### PR TITLE
systemd enable/disable

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -38,7 +38,11 @@ type Daemon struct {
 }
 
 const (
+	// pathSystemd is the path systemd modifiable units, services, etc.. reside
 	pathSystemd = "/etc/systemd/system"
+	// wantsPathSystemd is the path where enabled units should be linked
+	wantsPathSystemd = "/etc/systemd/system/multi-user.target.wants/"
+	// pathDevNull is the systems path to and endless blackhole
 	pathDevNull = "/dev/null"
 )
 


### PR DESCRIPTION
This is pre-work for enabling/disabling units intelligently via incoming config.

- `enableUnit`:  Takes a `ignv2_2types.Unit` and attempts to link into the enabled path on the system. If it is already linked the function returns early.
- `disableUnit`: Takes a `ignv2_2types.Unit` and attempts to remove the link from the enabled path. If the link does not exist the function returns early.