### PR TITLE
hack/build-image.sh: Add script to build images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ Tests can be executed on a per package basis with `go test` like so:
 All tests can be executed with:
 
 `go test -v ./...`
+
+## Building Images
+**NOTE**: To build images you will need [`podman`](https://github.com/containers/libpod/) installed.
+
+Images can be built locally via the `hack/build-image.sh` script. This script uses the
+`WHAT` variable similarly to the `hack/build-go.sh` script.
+
+```console
+$ ./hack/build-image.sh
+ERROR: Note: Building unprivileged may fail due to permissions
+ERROR: WHAT must be set to one of the following:
+ERROR: - all
+ERROR: - machine-config-controller
+ERROR: - machine-config-daemon
+ERROR: - machine-config-operator
+$ WHAT=machine-config-daemon ./hack/build-image.sh
+[...]
+```

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Print errors to stderr
+function print_error {
+	echo "ERROR: $1" >&2
+}
+
+function print_info {
+	echo "INFO: $1" >&2
+}
+
+# Warn when unprivileged
+if [ `id --user` -ne 0 ]; then
+	print_error "Note: Building unprivileged may fail due to permissions"
+fi
+
+# Record all images files
+ALL_IMAGES=Dockerfile.*
+
+# To build will hold a list of all image files to build
+TOBUILD=""
+
+# WHAT should be defined. If not, give a list and exit
+if [ -z ${WHAT+a} ]; then
+	print_error "WHAT must be set to one of the following:"
+	print_error "- all"
+	for x in $ALL_IMAGES ; do
+		print_error "- ${x#Dockerfile.}"
+	done
+
+	exit 1
+fi
+
+
+# If all is the WHAT target then set TOBUILD to all the images found
+if [ ${WHAT} == "all" ]; then
+	TOBUILD=$ALL_IMAGES
+	print_info "Building all images"
+else
+	# Otherwise WHAT should be valid at this point
+	TOBUILD="Dockerfile.${WHAT}"
+fi
+
+# Check that the target is valid
+for IMAGE_TO_BUILD in $TOBUILD; do
+  if ! test -f "${IMAGE_TO_BUILD}"
+  then
+    print_error "no build file named '${IMAGE_TO_BUILD}'"
+    print_error "WHAT may be invalid: '${WHAT}'"
+    exit 1
+  fi
+done
+
+
+if [ -z ${VERSION+a} ]; then
+        print_info "Using version from git..."
+        VERSION=$(git describe --abbrev=8 --dirty --always)
+fi
+
+# Build all images requested
+for IMAGE_TO_BUILD in $TOBUILD; do
+	NAME="${IMAGE_TO_BUILD#Dockerfile.}"
+	set -x
+	podman build -t "${NAME}:${VERSION}" -f "${IMAGE_TO_BUILD}"
+done


### PR DESCRIPTION
hack script to build images quickly.

```
$ sudo  ./hack/build-image.sh 
WHAT must be set to one of the following:
- all
- machine-config-controller
- machine-config-daemon
- machine-config-operator
```

## Full Example
```
$ sudo WHAT=asd ./hack/build-image.sh 
asd is not a valid build target
$ sudo WHAT=machine-config-daemon ./hack/build-image.sh 
Using version from git...
---
Building machine-config-daemon
    Executing: podman build -t machine-config-daemon:v0.0.0-68-g57ceadb3 -f Dockerfile.machine-config-daemon
---
STEP 1: FROM golang:1.10.3
STEP 2: COPY . /go/src/github.com/openshift/machine-config-operator
STEP 3: WORKDIR /go/src/github.com/openshift/machine-config-operator
STEP 4: RUN WHAT=machine-config-daemon ./hack/build-go.sh
Using version from git...
Building github.com/openshift/machine-config-operator/cmd/machine-config-daemon (v0.0.0-68-g57ceadb3)
STEP 5: FROM scratch
STEP 6: COPY --from=build-env /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /bin/machine-config-daemon
STEP 7: COPY templates /etc/templates
STEP 8: ENTRYPOINT ["/bin/machine-config-daemon"]
STEP 9: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.mountopt=nodev,overlay.override_kernel_check=true]localhost/machine-config-daemon:v0.0.0-68-g57ceadb3
Getting image source signatures
Copying blob sha256:3868fd5a663c3f153c8f325bdcce83fde0bc22fd62fd299bb2ab1c0c300794d5
 8.65 MB / 8.65 MB [========================================================] 0s
Copying config sha256:f16a4582dcf7929aee5d541f3614fd6caead1369405fb70cd240c9386632b032
 399 B / 399 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
--> f16a4582dcf7929aee5d541f3614fd6caead1369405fb70cd240c9386632b032
```