### PR TITLE
Bootstrap modes for MCO and MCC

### DIFF
--- a/cmd/machine-config-controller/bootstrap.go
+++ b/cmd/machine-config-controller/bootstrap.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/bootstrap"
+	"github.com/openshift/machine-config-operator/pkg/version"
+)
+
+var (
+	bootstrapCmd = &cobra.Command{
+		Use:   "boostrap",
+		Short: "Starts Machine Config Controller in bootstrap mode",
+		Long:  "",
+		Run:   runbootstrapCmd,
+	}
+
+	bootstrapOpts struct {
+		manifestsDir   string
+		destinationDir string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(bootstrapCmd)
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination dir where MCC writes the generated machineconfigs and machineconfigpools.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.manifestsDir, "mainfest-dir", "", "The dir where MCC reads the controllerconfig, machineconfigpools and user-defined machineconfigs.")
+
+}
+
+func runbootstrapCmd(cmd *cobra.Command, args []string) {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	// To help debugging, immediately log version
+	glog.Infof("Version: %+v", version.Version)
+
+	if bootstrapOpts.manifestsDir == "" || bootstrapOpts.destinationDir == "" {
+		glog.Fatalf("--dest-dir or --mainfest-dir not set")
+	}
+
+	if err := bootstrap.New(rootOpts.templates, bootstrapOpts.manifestsDir).Run(bootstrapOpts.destinationDir); err != nil {
+		glog.Fatalf("error running MCC[BOOTSTRAP]: %v", err)
+	}
+}

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/machine-config-operator/pkg/operator"
+	"github.com/openshift/machine-config-operator/pkg/version"
+)
+
+var (
+	bootstrapCmd = &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Machine Config Operator in bootstrap mode",
+		Long:  "",
+		Run:   runBootstrapCmd,
+	}
+
+	bootstrapOpts struct {
+		destinationDir string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(bootstrapCmd)
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
+
+}
+
+func runBootstrapCmd(cmd *cobra.Command, args []string) {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	// To help debugging, immediately log version
+	glog.Infof("Version: %+v", version.Version)
+
+	if bootstrapOpts.destinationDir == "" {
+		glog.Fatal("--dest-dir cannot be empty")
+	}
+
+	if err := operator.RenderBootstrap(bootstrapOpts.destinationDir); err != nil {
+		glog.Fatalf("error rendering bootstrap manifests: %v", err)
+	}
+}

--- a/manifests/machineconfigcontroller/bootstrap-pod.yaml
+++ b/manifests/machineconfigcontroller/bootstrap-pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-machine-config-controller
+spec:
+  containers:
+  - name: machine-config-controller
+    image: quay.io/abhinavdahiya/machine-config-controller:v0.0.0-69-gcf692f4e-dirty
+    args:
+    - "bootstrap"
+    - "--manifest-dir=/etc/mcc/bootstrap/manifests"
+    - "--dest-dir=/etc/mcc/bootstrap/server"
+    resources:
+      limits:
+        cpu: 20m
+        memory: 50Mi
+      requests:
+        cpu: 20m
+        memory: 50Mi
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: bootstrap-manifests
+      mountPath: /etc/mcc/bootstrap/manifests
+    - name: bootstrap-server
+      mountPath: /etc/mcc/bootstrap/server
+  restartPolicy: OnFailure
+  hostNetwork: true
+  volumes:
+  - name: bootstrap-manifests
+    hostPath:
+      path: /etc/mcc/bootstrap/manifests
+  - name: bootstrap-server
+    hostPath:
+      path: /etc/mcs/bootstrap

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: machine-config-controller
-        image: quay.io/abhinavdahiya/machine-config-controller:v0.0.0-66-g61fa2e7d
+        image: quay.io/abhinavdahiya/machine-config-controller:v0.0.0-69-gcf692f4e-dirty
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: machine-config-daemon
-          image: quay.io/abhinavdahiya/machine-config-daemon:v0.0.0-66-g61fa2e7d
+          image: quay.io/abhinavdahiya/machine-config-daemon:v0.0.0-69-gcf692f4e-dirty
           args:
             - "start"
           volumeMounts:

--- a/manifests/machineconfigserver/bootstrap-pod.yaml
+++ b/manifests/machineconfigserver/bootstrap-pod.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bootstrap-machine-config-server
+  namespace: {{.TargetNamespace}}
+spec:
+  containers:
+    - name: machine-config-server
+      image: quay.io/abhinavdahiya/machine-config-server:v0.0.0-69-gcf692f4e-dirty
+      args:
+        - "bootstrap"
+      volumeMounts:
+      - name: certs
+        mountPath: /etc/ssl/mcs
+      - name: etc-kubernetes
+        mountPath: /etc/kubernetes/kubeconfig
+      - name: server-basedir
+        mountPath: /etc/mcs/boostrap
+      - name:  etcd-certs
+        mountPath: /etc/ssl/etcd
+  hostNetwork: true
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  restartPolicy: Always
+  volumes:
+  - name: certs
+    hostPath:
+      path: /etc/ssl/mcs
+  - name: etc-kubernetes
+    hostPath:
+      path: /etc/kubernetes/kubeconfig
+  - name: server-basedir
+    hostPath:
+      path: /etc/mcs/boostrap
+  - name: etcd-certs
+    hostPath:
+      path: /etc/ssl/etcd

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -1,0 +1,117 @@
+package bootstrap
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/controller/render"
+	"github.com/openshift/machine-config-operator/pkg/controller/template"
+	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/scheme"
+)
+
+// Bootstrap defines boostrap mode for Machine Config Controller
+type Bootstrap struct {
+	// dir used by template controller to render internal machineconfigs.
+	templatesDir string
+	// dir used to read pools and user defined machineconfigs.
+	manifestDir string
+}
+
+// New returns controller for bootstrap
+func New(templatesDir, manifestDir string) *Bootstrap {
+	return &Bootstrap{
+		templatesDir: templatesDir,
+		manifestDir:  manifestDir,
+	}
+}
+
+// Run runs boostrap for Machine Config Controller
+// It writes all the assets to destDir
+func (b *Bootstrap) Run(destDir string) error {
+	infos, err := ioutil.ReadDir(b.manifestDir)
+	if err != nil {
+		return err
+	}
+
+	var cconfig *v1.ControllerConfig
+	var pools []*v1.MachineConfigPool
+	var configs []*v1.MachineConfig
+	for _, info := range infos {
+		if info.IsDir() {
+			continue
+		}
+
+		path := filepath.Join(b.manifestDir, info.Name())
+		raw, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		obji, err := runtime.Decode(scheme.Codecs.UniversalDecoder(v1.SchemeGroupVersion), raw)
+		if err != nil {
+			glog.V(4).Infof("skipping path because of error: %v", err)
+			// don't care
+			continue
+		}
+
+		switch obj := obji.(type) {
+		case *v1.MachineConfigPool:
+			pools = append(pools, obj)
+		case *v1.MachineConfig:
+			configs = append(configs, obj)
+		case *v1.ControllerConfig:
+			cconfig = obj
+		default:
+			glog.Infof("skipping %T", path, obji)
+		}
+	}
+
+	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig)
+	if err != nil {
+		return err
+	}
+	configs = append(configs, iconfigs...)
+
+	fpools, gconfigs, err := render.RunBootstrap(pools, configs)
+	if err != nil {
+		return err
+	}
+
+	poolsdir := filepath.Join(destDir, "machine-pools")
+	if err := os.MkdirAll(poolsdir, 0664); err != nil {
+		return err
+	}
+	for _, p := range fpools {
+		b, err := yaml.Marshal(p)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(poolsdir, fmt.Sprintf("%s.yaml", p.Name))
+		if err := ioutil.WriteFile(path, b, 0664); err != nil {
+			return err
+		}
+	}
+
+	configdir := filepath.Join(destDir, "machine-configs")
+	if err := os.MkdirAll(poolsdir, 0664); err != nil {
+		return err
+	}
+	for _, c := range gconfigs {
+		b, err := yaml.Marshal(c)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(configdir, fmt.Sprintf("%s.yaml", c.Name))
+		if err := ioutil.WriteFile(path, b, 0664); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -365,3 +365,8 @@ func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.Co
 	sort.Slice(mcs, func(i, j int) bool { return mcs[i].Name < mcs[j].Name })
 	return mcs, nil
 }
+
+// RunBootstrap runs the tempate controller in boostrap mode.
+func RunBootstrap(templatesDir string, config *mcfgv1.ControllerConfig) ([]*mcfgv1.MachineConfig, error) {
+	return getMachineConfigsForControllerConfig(templatesDir, config)
+}

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -1,0 +1,58 @@
+package operator
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/golang/glog"
+)
+
+// RenderBootstrap writes to destinationDir static Pods.
+func RenderBootstrap(destinationDir string) error {
+	config := getRenderConfig()
+
+	manifests := []struct {
+		name     string
+		filename string
+	}{{
+		name:     "manifests/machineconfigcontroller/controllerconfig.yaml",
+		filename: "machineconfigcontroller-controllerconfig.yaml",
+	}, {
+		name:     "manifests/machineconfigcontroller/bootstrap-pod.yaml",
+		filename: "machineconfigcontroller-bootstrap-pod.yaml",
+	}, {
+		name:     "manifests/master.machineconfigpool.yaml",
+		filename: "master.machineconfigpool.yaml",
+	}, {
+		name:     "manifests/worker.machineconfigpool.yaml",
+		filename: "worker.machineconfigpool.yaml",
+	}, {
+		name:     "manifests/etcd.machineconfigpool.yaml",
+		filename: "etcd.machineconfigpool.yaml",
+	}, {
+		name:     "manifests/machineconfigserver/bootstrap-pod.yaml",
+		filename: "machineconfigserver-bootstrap-pod.yaml",
+	}, {
+		name:     "manifests/controllerconfig.crd.yaml",
+		filename: "controllerconfig.crd.yaml",
+	}, {
+		name:     "manifests/machineconfig.crd.yaml",
+		filename: "machineconfig.crd.yaml",
+	}, {
+		name:     "manifests/machineconfigpool.crd.yaml",
+		filename: "machineconfigpool.crd.yaml",
+	}}
+	for _, m := range manifests {
+		glog.Info(m)
+		b, err := renderAsset(*config, m.name)
+		if err != nil {
+			return err
+		}
+
+		path := filepath.Join(destinationDir, m.filename)
+		if err := ioutil.WriteFile(path, b, 0655); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
1. Add bootstrap mode for MCC. MCC now reads ControllerConfig, Pools, user-defined Machineconfigs to seed the MCS with correct Pools and generated Machineconfigs

2. MCO renders pods for MCC and MCS, ControllerConfig and Pools to disk in bootstrap phse

/cc @yifan-gu 
/assign @yifan-gu 