### PR TITLE
MCD: Possible test pattern

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -62,6 +62,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		cb.ClientOrDie(componentName),
 		cb.KubeClientOrDie(componentName),
 		daemon.LoadNodeAnnotations,
+		nil, // allow New to make the dbus connection itself
 	)
 	if err != nil {
 		glog.Fatalf("failed to initialize daemon: %v", err)

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -61,6 +61,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		startOpts.nodeName,
 		cb.ClientOrDie(componentName),
 		cb.KubeClientOrDie(componentName),
+		daemon.LoadNodeAnnotations,
 	)
 	if err != nil {
 		glog.Fatalf("failed to initialize daemon: %v", err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	drain "github.com/wking/kubernetes-drain"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	kubernetescorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // Daemon is the dispatch point for the functions of the agent on the
@@ -42,6 +43,10 @@ const (
 	pathDevNull = "/dev/null"
 )
 
+// NodeAnnotationLoader is the function type that loads annotations from the cluster.
+// It is required when creating a new Daemon object via it's constructor.
+type NodeAnnotationLoader func(kubernetescorev1.NodeInterface, string) error
+
 // New sets up the systemd and kubernetes connections needed to update the
 // machine.
 func New(
@@ -49,6 +54,7 @@ func New(
 	nodeName string,
 	client mcfgclientset.Interface,
 	kubeClient kubernetes.Interface,
+	loadNodeAnnotations NodeAnnotationLoader,
 ) (*Daemon, error) {
 	loginClient, err := login1.New()
 	if err != nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,7 +16,7 @@ import (
 	drain "github.com/wking/kubernetes-drain"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	kubernetescorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // Daemon is the dispatch point for the functions of the agent on the
@@ -45,7 +45,7 @@ const (
 
 // NodeAnnotationLoader is the function type that loads annotations from the cluster.
 // It is required when creating a new Daemon object via it's constructor.
-type NodeAnnotationLoader func(kubernetescorev1.NodeInterface, string) error
+type NodeAnnotationLoader func(coreclientv1.NodeInterface, string) error
 
 // New sets up the systemd and kubernetes connections needed to update the
 // machine.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -55,12 +55,16 @@ func New(
 	client mcfgclientset.Interface,
 	kubeClient kubernetes.Interface,
 	loadNodeAnnotations NodeAnnotationLoader,
+	loginClient *login1.Conn,
 ) (*Daemon, error) {
-	loginClient, err := login1.New()
-	if err != nil {
-		return nil, fmt.Errorf("Error establishing connection to logind dbus: %v", err)
+	// Default to creating our own connection to the system dbus
+	if loginClient == nil {
+		var err error
+		loginClient, err = login1.New()
+		if err != nil {
+			return nil, fmt.Errorf("Error establishing connection to logind dbus: %v", err)
+		}
 	}
-
 	if err := loadNodeAnnotations(kubeClient.CoreV1().Nodes(), nodeName); err != nil {
 		return nil, err
 	}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	kubernetes "k8s.io/client-go/kubernetes/fake"
+	kubernetescorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// mockLoadNodeAnnotations returns an implementation of NodeAnnotationLoader.
+// If succeed is true the NodeAnnotationLoader implementation will return nil error.
+// If succeed is false the NodeAnnotationLoader implementation will return an error.
+func mockLoadNodeAnnotations(succeed bool) func(kubernetescorev1.NodeInterface, string) error {
+	return func(kubernetescorev1.NodeInterface, string) error {
+		if succeed == true {
+			return nil
+		}
+		return errors.New("mock failure")
+	}
+}
+
+// TestNew ensures that proper Daemon instances are created
+func TestNew(t *testing.T) {
+	clientSet := mcfgclientset.NewSimpleClientset()
+	kubeClient := kubernetes.NewSimpleClientset()
+	rootFS := "/"
+	nodeName := "node"
+
+	// Verify a successful creation
+	daemon, err := New(rootFS, nodeName, clientSet, kubeClient, mockLoadNodeAnnotations(true))
+	if err != nil {
+		t.Fatalf("unable to create Daemon: %s", err)
+	}
+	if daemon == nil {
+		t.Fatalf("expected daemon to be of type daemon.Daemon, found nil")
+	}
+
+	// There should be no Daemon if loadNodeAnnotations doesn't work
+	daemon, err = New(rootFS, nodeName, clientSet, kubeClient, mockLoadNodeAnnotations(false))
+	if daemon != nil {
+		t.Fatalf("expected daemon=nil, found daemon=%+v", daemon)
+	}
+	if err == nil {
+		t.Fatalf("expected err to be returned, instead got nil")
+	}
+}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/coreos/go-systemd/login1"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	kubernetes "k8s.io/client-go/kubernetes/fake"
 	kubernetescorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -27,9 +28,10 @@ func TestNew(t *testing.T) {
 	kubeClient := kubernetes.NewSimpleClientset()
 	rootFS := "/"
 	nodeName := "node"
+	loginCon := &login1.Conn{}
 
 	// Verify a successful creation
-	daemon, err := New(rootFS, nodeName, clientSet, kubeClient, mockLoadNodeAnnotations(true))
+	daemon, err := New(rootFS, nodeName, clientSet, kubeClient, mockLoadNodeAnnotations(true), loginCon)
 	if err != nil {
 		t.Fatalf("unable to create Daemon: %s", err)
 	}
@@ -38,7 +40,7 @@ func TestNew(t *testing.T) {
 	}
 
 	// There should be no Daemon if loadNodeAnnotations doesn't work
-	daemon, err = New(rootFS, nodeName, clientSet, kubeClient, mockLoadNodeAnnotations(false))
+	daemon, err = New(rootFS, nodeName, clientSet, kubeClient, mockLoadNodeAnnotations(false), loginCon)
 	if daemon != nil {
 		t.Fatalf("expected daemon=nil, found daemon=%+v", daemon)
 	}

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -67,7 +67,10 @@ func setNodeAnnotations(client corev1.NodeInterface, node string, m map[string]s
 	})
 }
 
-func loadNodeAnnotations(client corev1.NodeInterface, node string) error {
+// LoadNodeAnnotations loads annotations from the cluster via a providec client. This is used when
+// creating a new Daemon instance via it's constructor.
+// This function implements NodeAnnotationLoader
+func LoadNodeAnnotations(client corev1.NodeInterface, node string) error {
 	ccAnnotation, err := getNodeAnnotation(client, node, CurrentMachineConfigAnnotationKey)
 
 	// we need to load the annotations from the file only for the


### PR DESCRIPTION
Looking through the MCD code I found trying to write unittests a bit harder than normal. One pattern I've seen in the past is to pass functions (or structs, etc..) that have network requests/side effects as part of the design of the system. This unbinds said side effects at the unit level and, in theory, can provide a foundation for different execution paths chosen at runtime. 

**Note**: `New` probably wasn't example to use to test with since it's pretty simple, but I think the idea still is shown.

This is a quick example of:

- making a type of `NodeAnnotationLoader`
- renaming `loadNodeAnnotations` to `LoadNodeAnnotations`
- passing `LoadNodeAnnotations` to `New`
- optional passing of `login1.Conn` to `New`. If passed `nil` one will be created inside of `New`.
- creating a mocked function for testing that also implements `NodeAnnotationLoader` for unittesting

```console
$ cd pkg/daemon/
$ go test -v -run ^TestNew$
=== RUN   TestNew
--- PASS: TestNew (0.00s)
PASS
ok      github.com/openshift/machine-config-operator/pkg/daemon 0.009s
```