### PR TITLE
Update MCO to use images.json from ConfigMap for image resolution

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -19,14 +19,16 @@ var (
 	}
 
 	bootstrapOpts struct {
-		configFile     string
-		destinationDir string
+		configFile          string
+		imagesConfigMapFile string
+		destinationDir      string
 	}
 )
 
 func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.imagesConfigMapFile, "images-json-configmap", "", "ConfigMap that contains images.json for MCO.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "MCOConfig file.")
 }
 
@@ -45,9 +47,14 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		glog.Fatal("--config-file cannot be empty")
 	}
 
+	if bootstrapOpts.imagesConfigMapFile == "" {
+		glog.Fatal("--images-json-configmap cannot be empty")
+	}
+
 	if err := operator.RenderBootstrap(
 		bootstrapOpts.configFile,
 		rootOpts.etcdCAFile, rootOpts.rootCAFile,
+		bootstrapOpts.imagesConfigMapFile,
 		bootstrapOpts.destinationDir,
 	); err != nil {
 		glog.Fatalf("error rendering bootstrap manifests: %v", err)

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -21,12 +21,14 @@ var (
 
 	startOpts struct {
 		kubeconfig string
+		imagesFile string
 	}
 )
 
 func init() {
 	rootCmd.AddCommand(startCmd)
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
+	startCmd.PersistentFlags().StringVar(&startOpts.imagesFile, "images-json", "", "images.json file for MCO.")
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) {
@@ -35,6 +37,10 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v", version.Version)
+
+	if startOpts.imagesFile == "" {
+		glog.Fatal("--images-json cannot be empty")
+	}
 
 	cb, err := common.NewClientBuilder(startOpts.kubeconfig)
 	if err != nil {
@@ -77,6 +83,7 @@ func startControllers(ctx *common.ControllerContext) error {
 	go operator.New(
 		componentNamespace, componentName,
 		rootOpts.etcdCAFile, rootOpts.rootCAFile,
+		startOpts.imagesFile,
 		ctx.NamespacedInformerFactory.Machineconfiguration().V1().MCOConfigs(),
 		ctx.NamespacedInformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 		ctx.KubeInformerFactory.Core().V1().ConfigMaps(),

--- a/install/mco.images.yaml
+++ b/install/mco.images.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machine-config-operator-images
+  namespace: machine-config-operator
+data:
+  images.json: '{"machineConfigController": "openshift/origin-machine-config-controller:latest", "machineConfigDaemon": "openshift/origin-machine-config-daemon:latest", "machineConfigServer": "openshift/origin-machine-config-server:latest"}'

--- a/manifests/machineconfigcontroller/bootstrap-pod.yaml
+++ b/manifests/machineconfigcontroller/bootstrap-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: machine-config-controller
-    image: quay.io/abhinavdahiya/machine-config-controller:{{.Version}}
+    image: {{.Images.MachineConfigController}}
     args:
     - "bootstrap"
     - "--manifest-dir=/etc/mcc/bootstrap/manifests"

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: machine-config-controller
-        image: quay.io/abhinavdahiya/machine-config-controller:{{.Version}}
+        image: {{.Images.MachineConfigController}}
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: machine-config-daemon
-          image: quay.io/abhinavdahiya/machine-config-daemon:{{.Version}}
+          image: {{.Images.MachineConfigDaemon}}
           args:
             - "start"
           volumeMounts:

--- a/manifests/machineconfigserver/bootstrap-pod.yaml
+++ b/manifests/machineconfigserver/bootstrap-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: machine-config-server
-      image: quay.io/abhinavdahiya/machine-config-server:{{.Version}}
+      image: {{.Images.MachineConfigServer}}
       args:
         - "bootstrap"
       volumeMounts:

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: machine-config-server
-          image: quay.io/abhinavdahiya/machine-config-server:{{.Version}}
+          image: {{.Images.MachineConfigServer}}
           args:
             - "start"
             - "--apiserver-url=https://{{.ControllerConfig.ClusterName}}-api.{{.ControllerConfig.BaseDomain}}:6443"

--- a/pkg/apis/machineconfiguration.openshift.io/v1/register.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/register.go
@@ -39,6 +39,7 @@ func init() {
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
+		&MCOConfig{},
 		&ControllerConfig{},
 		&ControllerConfigList{},
 		&MachineConfig{},

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -25,6 +25,8 @@
 // manifests/scc.yaml
 // manifests/worker.machineconfigpool.yaml
 // install/.gitkeep
+// install/images.json
+// install/mco.images.yaml
 // install/mcoconfig.crd.yaml
 // install/mcoconfig.yaml
 // DO NOT EDIT!
@@ -186,7 +188,7 @@ metadata:
 spec:
   containers:
   - name: machine-config-controller
-    image: quay.io/abhinavdahiya/machine-config-controller:{{.Version}}
+    image: {{.Images.MachineConfigController}}
     args:
     - "bootstrap"
     - "--manifest-dir=/etc/mcc/bootstrap/manifests"
@@ -339,7 +341,7 @@ spec:
     spec:
       containers:
       - name: machine-config-controller
-        image: quay.io/abhinavdahiya/machine-config-controller:{{.Version}}
+        image: {{.Images.MachineConfigController}}
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"
@@ -471,7 +473,7 @@ spec:
     spec:
       containers:
         - name: machine-config-daemon
-          image: quay.io/abhinavdahiya/machine-config-daemon:{{.Version}}
+          image: {{.Images.MachineConfigDaemon}}
           args:
             - "start"
           volumeMounts:
@@ -606,7 +608,7 @@ metadata:
 spec:
   containers:
     - name: machine-config-server
-      image: quay.io/abhinavdahiya/machine-config-server:{{.Version}}
+      image: {{.Images.MachineConfigServer}}
       args:
         - "bootstrap"
       volumeMounts:
@@ -726,7 +728,7 @@ spec:
     spec:
       containers:
         - name: machine-config-server
-          image: quay.io/abhinavdahiya/machine-config-server:{{.Version}}
+          image: {{.Images.MachineConfigServer}}
           args:
             - "start"
             - "--apiserver-url=https://{{.ControllerConfig.ClusterName}}-api.{{.ControllerConfig.BaseDomain}}:6443"
@@ -953,6 +955,50 @@ func installGitkeep() (*asset, error) {
 	return a, nil
 }
 
+var _installImagesJson = []byte(`{
+    "machineConfigController": "quay.io/abhinavdahiya/machine-config-controller:latest",
+    "machineConfigDaemon": "quay.io/abhinavdahiya/machine-config-daemon:latest",
+    "machineConfigServer": "quay.io/abhinavdahiya/machine-config-server:latest"
+}`)
+
+func installImagesJsonBytes() ([]byte, error) {
+	return _installImagesJson, nil
+}
+
+func installImagesJson() (*asset, error) {
+	bytes, err := installImagesJsonBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/images.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installMcoImagesYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machine-config-operator-images
+  namespace: machine-config-operator
+data:
+  images.json: '{"machineConfigController": "quay.io/abhinavdahiya/machine-config-controller:latest", "machineConfigDaemon": "quay.io/abhinavdahiya/machine-config-daemon:latest", "machineConfigServer": "quay.io/abhinavdahiya/machine-config-server:latest"}'`)
+
+func installMcoImagesYamlBytes() ([]byte, error) {
+	return _installMcoImagesYaml, nil
+}
+
+func installMcoImagesYaml() (*asset, error) {
+	bytes, err := installMcoImagesYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/mco.images.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installMcoconfigCrdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -1101,6 +1147,8 @@ var _bindata = map[string]func() (*asset, error){
 	"manifests/scc.yaml": manifestsSccYaml,
 	"manifests/worker.machineconfigpool.yaml": manifestsWorkerMachineconfigpoolYaml,
 	"install/.gitkeep": installGitkeep,
+	"install/images.json": installImagesJson,
+	"install/mco.images.yaml": installMcoImagesYaml,
 	"install/mcoconfig.crd.yaml": installMcoconfigCrdYaml,
 	"install/mcoconfig.yaml": installMcoconfigYaml,
 }
@@ -1147,6 +1195,8 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"install": &bintree{nil, map[string]*bintree{
 		".gitkeep": &bintree{installGitkeep, map[string]*bintree{}},
+		"images.json": &bintree{installImagesJson, map[string]*bintree{}},
+		"mco.images.yaml": &bintree{installMcoImagesYaml, map[string]*bintree{}},
 		"mcoconfig.crd.yaml": &bintree{installMcoconfigCrdYaml, map[string]*bintree{}},
 		"mcoconfig.yaml": &bintree{installMcoconfigYaml, map[string]*bintree{}},
 	}},

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -1,0 +1,8 @@
+package operator
+
+// images allows build systems to inject images for MCO components.
+type images struct {
+	MachineConfigController string `json:"machineConfigController"`
+	MachineConfigDaemon     string `json:"machineConfigDaemon"`
+	MachineConfigServer     string `json:"machineConfigServer"`
+}

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -15,6 +15,7 @@ type renderConfig struct {
 	TargetNamespace  string
 	Version          string
 	ControllerConfig mcfgv1.ControllerConfigSpec
+	Images           images
 }
 
 func renderAsset(config renderConfig, path string) ([]byte, error) {


### PR DESCRIPTION
In preparation for https://docs.google.com/document/d/1CGZVEyuloZ9oD4NUArW6dnEpi0WFc6BP2tqPSwFZTCY/edit#heading=h.1qxlffn2dsyu

bootstrap mode mco reads a config map with images.json key
long running mode mco reads the images.json directly as the configmap
will be mounted as a volume
mco doesn't load images.json at startup rather continuously reads the file
so that it can reconcile state if the configmap changes at runtime.

/cc @yifan-gu 
/assign @yifan-gu 