### PR TITLE
OWNERS_ALIASES: add machine-config-daemon-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,7 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  machine-config-daemon-approvers:
+    - ashcrow
+    - sdemos
+    - jlebon

--- a/cmd/machine-config-daemon/OWNERS
+++ b/cmd/machine-config-daemon/OWNERS
@@ -1,6 +1,4 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - ashcrow
-  - sdemos
-  - jlebon
+  - machine-config-daemon-approvers

--- a/pkg/daemon/OWNERS
+++ b/pkg/daemon/OWNERS
@@ -1,6 +1,4 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - ashcrow
-  - sdemos
-  - jlebon
+  - machine-config-daemon-approvers


### PR DESCRIPTION
To DRY up our two sub-`OWNERS`.  The namespacing (vs. just `daemon-approvers`) is for when these are [slurped into openshift/release][1].  If we used `daemon-approvers` and another release upstream did as well, ours would be [namespaced to `openshift-machine-config-operator-daemon-approvers`][2].  That's not too bad, but I went with the middle-ground namespacing to keep things stable and relatively short ;).

[1]: https://github.com/openshift/release/blob/51ed98ca754e80618769eae5a3f8f602a30f8977/tools/populate-owners/README.md
[2]: https://github.com/openshift/release/blame/51ed98ca754e80618769eae5a3f8f602a30f8977/tools/populate-owners/README.md#L20