### PR TITLE
pkg/daemon: implement OS version validation

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -38,6 +38,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+      hostNetwork: true
+      hostPID: true
       serviceAccountName: machine-config-daemon
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -195,8 +195,14 @@ func (dn *Daemon) isDesiredMachineState() (bool, error) {
 		return false, err
 	}
 
+	isDesiredOS, err := dn.checkOS(desiredConfig.Spec.OSImageURL)
+	if err != nil {
+		return false, err
+	}
+
 	if dn.checkFiles(desiredConfig.Spec.Config.Storage.Files) &&
-		dn.checkUnits(desiredConfig.Spec.Config.Systemd.Units) {
+		dn.checkUnits(desiredConfig.Spec.Config.Systemd.Units) &&
+		isDesiredOS {
 		return true, nil
 	}
 
@@ -204,8 +210,19 @@ func (dn *Daemon) isDesiredMachineState() (bool, error) {
 	return false, nil
 }
 
-// checkUnits validates the contents of  all the units in the
-// target config.
+// checkOS validates the OS image URL and returns true if they match.
+func (dn *Daemon) checkOS(osImageURL string) (bool, error) {
+	bootedOSImageURL, bootedOSTreeVersion, err := getBootedOSImageURL()
+	if err != nil {
+		return false, err
+	}
+	glog.Infof("Current osImageURL: %v (%s)", bootedOSImageURL, bootedOSTreeVersion)
+
+	return bootedOSImageURL == osImageURL, nil
+}
+
+// checkUnits validates the contents of all the units in the
+// target config and retursn true if they match.
 func (dn *Daemon) checkUnits(units []ignv2_2types.Unit) bool {
 	for _, u := range units {
 		for j := range u.Dropins {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -216,8 +216,17 @@ func (dn *Daemon) checkOS(osImageURL string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	glog.Infof("Current osImageURL: %v (%s)", bootedOSImageURL, bootedOSTreeVersion)
 
+	// XXX: the installer doesn't pivot yet so for now, just make "" equivalent
+	// to "://dummy" so that we don't immediately try to pivot to this dummy
+	// URL. See also
+	// https://github.com/openshift/machine-config-operator/pull/60#issuecomment-421489272
+	if bootedOSImageURL == "" {
+		bootedOSImageURL = "://dummy"
+		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
+	}
+
+	glog.Infof("Current osImageURL: %v (%s)", bootedOSImageURL, bootedOSTreeVersion)
 	return bootedOSImageURL == osImageURL, nil
 }
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -1,0 +1,67 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Subset of `rpm-ostree status --json`
+// https://github.com/projectatomic/rpm-ostree/blob/bce966a9812df141d38e3290f845171ec745aa4e/src/daemon/rpmostreed-deployment-utils.c#L227
+type RpmOstreeState struct {
+	Deployments []RpmOstreeDeployment
+}
+
+type RpmOstreeDeployment struct {
+	Id           string   `json:"id"`
+	OSName       string   `json:"osname"`
+	Serial       int32    `json:"serial"`
+	Checksum     string   `json:"checksum"`
+	Version      string   `json:"version"`
+	Timestamp    uint64   `json:"timestamp"`
+	Booted       bool     `json:"booted"`
+	Origin       string   `json:"origin"`
+	CustomOrigin []string `json:"custom-origin"`
+}
+
+func getBootedDeployment() (*RpmOstreeDeployment, error) {
+	var rosState RpmOstreeState
+	output, err := RunGetOut("rpm-ostree", "status", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(output, &rosState); err != nil {
+		return nil, fmt.Errorf("Failed to parse `rpm-ostree status --json` output: %v", err)
+	}
+
+	for _, deployment := range rosState.Deployments {
+		if deployment.Booted {
+			return &deployment, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Not currently booted in a deployment")
+}
+
+// getBootedOSImageURL returns the image URL as well as the OSTree version (for logging)
+func getBootedOSImageURL() (string, string, error) {
+	bootedDeployment, err := getBootedDeployment()
+	if err != nil {
+		return "", "", err
+	}
+
+	// the canonical image URL is stored in the custom origin field by the pivot tool
+	osImageURL := ""
+	if len(bootedDeployment.CustomOrigin) > 0 {
+		if strings.HasPrefix(bootedDeployment.CustomOrigin[0], "pivot://") {
+			osImageURL = bootedDeployment.CustomOrigin[0][len("pivot://"):]
+		}
+	}
+
+	return osImageURL, bootedDeployment.Version, nil
+}
+
+func runPivot(osImageURL string) error {
+	return Run("/bin/pivot", osImageURL)
+}

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -1,0 +1,30 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// Run executes a command, logging it.
+func Run(command string, args ...string) error {
+	glog.Infof("Running: %s %s\n", command, strings.Join(args, " "))
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// RunGetOut executes a command, logging it, and return the stdout output.
+func RunGetOut(command string, args ...string) ([]byte, error) {
+	glog.Infof("Running captured: %s %s\n", command, strings.Join(args, " "))
+	cmd := exec.Command(command, args...)
+	cmd.Stderr = os.Stderr
+	rawOut, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return rawOut, nil
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -411,6 +411,11 @@ func (dn *Daemon) updateOS(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 		return err
 	}
 
+	// see similar block in checkOS()
+	if bootedOSImageURL == "" {
+		bootedOSImageURL = "://dummy"
+	}
+
 	if newConfig.Spec.OSImageURL == bootedOSImageURL {
 		return nil
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -501,6 +501,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+      hostNetwork: true
+      hostPID: true
       serviceAccountName: machine-config-daemon
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Teach the MCD to check the current OS version and upgrade the host. This
essentially implements the 'OSImageURL` part of the `MachineConfig`
spec.

Since we're in a chroot anyway, I just took the easy path of exec'ing
`rpm-ostree` and `pivot` directly. Which is good, because right now only
`pivot` knows how to upgrade RHCOS from an oscontainer image pull spec.