### PR TITLE
manifests/mcd: add OWNERS file

### DIFF
--- a/manifests/machineconfigdaemon/OWNERS
+++ b/manifests/machineconfigdaemon/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - machine-config-daemon-approvers

--- a/pkg/operator/assets/OWNERS
+++ b/pkg/operator/assets/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - machine-config-daemon-approvers


### PR DESCRIPTION
So that MCD approvers can also approve changes to MCD related manifests.

Closes: #73