### PR TITLE
daemon: Create a new watcher on error

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -28,10 +28,12 @@ func waitUntilUpdate(client corev1.NodeInterface, node string) error {
 		return err
 	}
 
-	watcher, err := client.Watch(metav1.ListOptions{
+	options := metav1.ListOptions{
 		FieldSelector:   fields.OneTermEqualSelector("metadata.name", node).String(),
 		ResourceVersion: n.ResourceVersion,
-	})
+	}
+
+	watcher, err := client.Watch(options)
 	if err != nil {
 		return fmt.Errorf("Failed to watch self node (%q): %v", node, err)
 	}
@@ -57,6 +59,8 @@ func waitUntilUpdate(client corev1.NodeInterface, node string) error {
 		if _, err := watch.Until(0, watcher, updateWatcher); err != nil {
 			// if the watch was closed, watch again
 			if err == watch.ErrWatchClosed {
+				// we must reset the watcher on error
+				watcher, err = client.Watch(options)
 				continue
 			}
 			// any other error should return


### PR DESCRIPTION
/cc @sjenning @sdemos 

Hopefully resolves #79 

**Notes**:
- Even if this does resolve #79 we likely still will want to record the updated `ResourceVersion` for the next watcher in a follow on.
- I was not able to test this patch properly to verify it fixed the issue
