### PR TITLE
Use cluo style restart again

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -49,22 +49,13 @@ func waitUntilUpdate(client corev1.NodeInterface, node string) error {
 		return nil
 	}
 
-	// Loop over watches to ensure that if the watch is closed before changes we
-	// start up a new watch.
-	// See: https://github.com/openshift/machine-config-operator/issues/68
-	for {
-		// for now, we wait forever. that might not be the best long-term strategy.
-		if _, err := watch.Until(0, watcher, updateWatcher); err != nil {
-			// if the watch was closed, watch again
-			if err == watch.ErrWatchClosed {
-				continue
-			}
-			// any other error should return
-			return fmt.Errorf("Failed to watch for update request: %v", err)
-		}
-		// no error received so none returned
-		return nil
+	// for now, we wait forever. that might not be the best long-term strategy.
+	_, err = watch.Until(0, watcher, updateWatcher)
+	if err != nil {
+		return fmt.Errorf("Failed to watch for update request: %v", err)
 	}
+
+	return nil
 }
 
 // setConfig sets the given annotation key, value pair.

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -28,12 +28,10 @@ func waitUntilUpdate(client corev1.NodeInterface, node string) error {
 		return err
 	}
 
-	options := metav1.ListOptions{
+	watcher, err := client.Watch(metav1.ListOptions{
 		FieldSelector:   fields.OneTermEqualSelector("metadata.name", node).String(),
 		ResourceVersion: n.ResourceVersion,
-	}
-
-	watcher, err := client.Watch(options)
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to watch self node (%q): %v", node, err)
 	}
@@ -59,8 +57,6 @@ func waitUntilUpdate(client corev1.NodeInterface, node string) error {
 		if _, err := watch.Until(0, watcher, updateWatcher); err != nil {
 			// if the watch was closed, watch again
 			if err == watch.ErrWatchClosed {
-				// we must reset the watcher on error
-				watcher, err = client.Watch(options)
 				continue
 			}
 			// any other error should return


### PR DESCRIPTION
This reverts us back to the restarting of MCD when the watch fails. As found by @sdemos this was actually a feature rather than a bug in the original implementation. However, we should look at how to do this better in the near future. 

/cc @sjenning @rphillips @sdemos