### PR TITLE
Fix kubelet stats summary endpoint with cri-o

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/kubelet.service
@@ -16,7 +16,7 @@ contents: |
         --rotate-certificates \
         --serialize-image-pulls=false \
         --container-runtime=remote \
-        --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
         --lock-file=/var/run/lock/kubelet.lock \
         --exit-on-lock-contention \

--- a/pkg/controller/template/test_data/templates/aws/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/aws/worker/units/kubelet.service
@@ -16,7 +16,7 @@ contents: |
         --rotate-certificates \
         --serialize-image-pulls=false \
         --container-runtime=remote \
-        --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
         --lock-file=/var/run/lock/kubelet.lock \
         --exit-on-lock-contention \

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/kubelet.service
@@ -16,7 +16,7 @@ contents: |
         --rotate-certificates \
         --serialize-image-pulls=false \
         --container-runtime=remote \
-        --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
         --lock-file=/var/run/lock/kubelet.lock \
         --exit-on-lock-contention \

--- a/pkg/controller/template/test_data/templates/libvirt/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/units/kubelet.service
@@ -16,7 +16,7 @@ contents: |
         --rotate-certificates \
         --serialize-image-pulls=false \
         --container-runtime=remote \
-        --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
         --lock-file=/var/run/lock/kubelet.lock \
         --exit-on-lock-contention \

--- a/templates/_base/master/units/kubelet.yaml
+++ b/templates/_base/master/units/kubelet.yaml
@@ -18,7 +18,7 @@ contents: |
         --rotate-certificates \
         --serialize-image-pulls=false \
         --container-runtime=remote \
-        --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
         --lock-file=/var/run/lock/kubelet.lock \
         --exit-on-lock-contention \

--- a/templates/_base/worker/units/kubelet.yaml
+++ b/templates/_base/worker/units/kubelet.yaml
@@ -18,7 +18,7 @@ contents: |
         --rotate-certificates \
         --serialize-image-pulls=false \
         --container-runtime=remote \
-        --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
         --lock-file=/var/run/lock/kubelet.lock \
         --exit-on-lock-contention \


### PR DESCRIPTION
See https://github.com/openshift/installer/pull/303

See https://github.com/openshift/openshift-ansible/pull/10177

kubelet won't use cAdvisor with cri-o to return pod stats summary data if prefixed with unix:// for historical reasons.
