### PR TITLE
migrate to kubelet config file

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/aws/master/files/-etc-kubernetes-kubelet.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/kubernetes/kubelet.conf

--- a/pkg/controller/template/test_data/templates/aws/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/kubelet.service
@@ -5,33 +5,25 @@ contents: |
 
   [Service]
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
   ExecStart=/usr/bin/hyperkube \
       kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-        --kubeconfig=/var/lib/kubelet/kubeconfig \
         --rotate-certificates \
-        --serialize-image-pulls=false \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
-        --lock-file=/var/run/lock/kubelet.lock \
-        --exit-on-lock-contention \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
         --minimum-container-ttl-duration=6m0s \
-        --cluster-dns=10.3.0.10 \
-        --cluster-domain=cluster.local \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \
-         \
+        \
         --anonymous-auth=false \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-      --cgroup-driver=systemd \
 
   Restart=always
   RestartSec=10

--- a/pkg/controller/template/test_data/templates/aws/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/aws/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/kubernetes/kubelet.conf

--- a/pkg/controller/template/test_data/templates/aws/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/aws/worker/units/kubelet.service
@@ -5,32 +5,23 @@ contents: |
 
   [Service]
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
   ExecStart=/usr/bin/hyperkube \
       kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --rotate-certificates \
-        --serialize-image-pulls=false \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
-        --lock-file=/var/run/lock/kubelet.lock \
-        --exit-on-lock-contention \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
-        --cluster-dns=10.3.0.10 \
-        --cluster-domain=cluster.local \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \
-         \
+        \
         --anonymous-auth=false \
-      --cgroup-driver=systemd \
 
   Restart=always
   RestartSec=10

--- a/pkg/controller/template/test_data/templates/libvirt/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/libvirt/master/files/-etc-kubernetes-kubelet.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/kubernetes/kubelet.conf

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/kubelet.service
@@ -5,33 +5,25 @@ contents: |
 
   [Service]
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
   ExecStart=/usr/bin/hyperkube \
       kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-        --kubeconfig=/var/lib/kubelet/kubeconfig \
         --rotate-certificates \
-        --serialize-image-pulls=false \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
-        --lock-file=/var/run/lock/kubelet.lock \
-        --exit-on-lock-contention \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
         --minimum-container-ttl-duration=6m0s \
-        --cluster-dns=10.3.0.10 \
-        --cluster-domain=cluster.local \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \
-         \
+        \
         --anonymous-auth=false \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-      --cgroup-driver=systemd \
 
   Restart=always
   RestartSec=10

--- a/pkg/controller/template/test_data/templates/libvirt/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/kubernetes/kubelet.conf

--- a/pkg/controller/template/test_data/templates/libvirt/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/units/kubelet.service
@@ -5,32 +5,23 @@ contents: |
 
   [Service]
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
   ExecStart=/usr/bin/hyperkube \
       kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --rotate-certificates \
-        --serialize-image-pulls=false \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
-        --lock-file=/var/run/lock/kubelet.lock \
-        --exit-on-lock-contention \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
-        --cluster-dns=10.3.0.10 \
-        --cluster-domain=cluster.local \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \
-         \
+        \
         --anonymous-auth=false \
-      --cgroup-driver=systemd \
 
   Restart=always
   RestartSec=10

--- a/templates/_base/master/files/kubelet.yaml
+++ b/templates/_base/master/files/kubelet.yaml
@@ -1,0 +1,14 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/kubelet.conf"
+contents:
+  inline: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDns:
+      - {{.ClusterDNSIP}}
+    clusterDomain: cluster.local
+    runtimeRequestTimeout: 10m
+    serializeImagePulls: false
+    staticPodPath: /etc/kubernetes/manifests

--- a/templates/_base/master/units/kubelet.yaml
+++ b/templates/_base/master/units/kubelet.yaml
@@ -7,33 +7,25 @@ contents: |
 
   [Service]
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
   ExecStart=/usr/bin/hyperkube \
       kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-        --kubeconfig=/var/lib/kubelet/kubeconfig \
         --rotate-certificates \
-        --serialize-image-pulls=false \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
-        --lock-file=/var/run/lock/kubelet.lock \
-        --exit-on-lock-contention \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
         --minimum-container-ttl-duration=6m0s \
-        --cluster-dns={{.ClusterDNSIP}} \
-        --cluster-domain=cluster.local \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \
-        {{.CloudProviderConfig}} \
+        {{.CloudProviderConfig -}} \
         --anonymous-auth=false \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-      --cgroup-driver=systemd \
 
   Restart=always
   RestartSec=10

--- a/templates/_base/worker/files/kubelet.yaml
+++ b/templates/_base/worker/files/kubelet.yaml
@@ -1,0 +1,15 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/kubelet.conf"
+contents:
+  inline: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDns:
+      - {{.ClusterDNSIP}}
+    clusterDomain: cluster.local
+    rotateCertificates: true
+    runtimeRequestTimeout: 10m
+    serializeImagePulls: false
+    staticPodPath: /etc/kubernetes/manifests

--- a/templates/_base/worker/units/kubelet.yaml
+++ b/templates/_base/worker/units/kubelet.yaml
@@ -7,32 +7,23 @@ contents: |
 
   [Service]
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
   ExecStart=/usr/bin/hyperkube \
       kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --rotate-certificates \
-        --serialize-image-pulls=false \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
-        --lock-file=/var/run/lock/kubelet.lock \
-        --exit-on-lock-contention \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
-        --cluster-dns={{.ClusterDNSIP}} \
-        --cluster-domain=cluster.local \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \
-        {{.CloudProviderConfig}} \
+        {{.CloudProviderConfig -}} \
         --anonymous-auth=false \
-      --cgroup-driver=systemd \
 
   Restart=always
   RestartSec=10


### PR DESCRIPTION
Migrates the kubelet to a kubelet.conf file.

The customer typically had to set configuration settings within the kubelet unit file and pass command-line flags to reconfigure the Kubelet. With this patch, the configuration file will allow a subset of options to be set by the customer.