### PR TITLE
Turn rpm-ostree code into a client

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -73,6 +73,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		startOpts.rootMount,
 		startOpts.nodeName,
 		operatingSystem,
+		daemon.NewNodeUpdaterClient(),
 		cb.MachineConfigClientOrDie(componentName),
 		cb.KubeClientOrDie(componentName),
 	)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -27,6 +27,9 @@ type Daemon struct {
 	// OperatingSystem the operating system the MCD is running on
 	OperatingSystem string
 
+	// NodeUpdaterClient an instance of the client which interfaces with host content deployments
+	NodeUpdaterClient NodeUpdaterClient
+
 	// bootedOSImageURL is the currently booted URL of the operating system
 	bootedOSImageURL string
 
@@ -57,6 +60,7 @@ func New(
 	rootMount string,
 	nodeName string,
 	operatingSystem string,
+	nodeUpdaterClient NodeUpdaterClient,
 	client mcfgclientset.Interface,
 	kubeClient kubernetes.Interface,
 ) (*Daemon, error) {
@@ -69,17 +73,18 @@ func New(
 		return nil, err
 	}
 
-	osImageURL, osVersion, err := getBootedOSImageURL(rootMount)
+	osImageURL, osVersion, err := nodeUpdaterClient.GetBootedOSImageURL(rootMount)
 	glog.Infof("Booted osImageURL: %s (%s)", osImageURL, osVersion)
 
 	return &Daemon{
-		name:             nodeName,
-		OperatingSystem:  operatingSystem,
-		loginClient:      loginClient,
-		client:           client,
-		kubeClient:       kubeClient,
-		rootMount:        rootMount,
-		bootedOSImageURL: osImageURL,
+		name:              nodeName,
+		OperatingSystem:   operatingSystem,
+		NodeUpdaterClient: nodeUpdaterClient,
+		loginClient:       loginClient,
+		client:            client,
+		kubeClient:        kubeClient,
+		rootMount:         rootMount,
+		bootedOSImageURL:  osImageURL,
 	}, nil
 }
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -28,7 +28,24 @@ type RpmOstreeDeployment struct {
 	CustomOrigin []string `json:"custom-origin"`
 }
 
-func getBootedDeployment(rootMount string) (*RpmOstreeDeployment, error) {
+// NodeUpdaterClient is an interface describing how to interact with the host
+// around content deployment
+type NodeUpdaterClient interface {
+	GetBootedOSImageURL(string) (string, string, error)
+	RunPivot(string) error
+}
+
+// RpmOstreeClient provides all RpmOstree related methods in one structure.
+// This structure implements DeploymentClient
+type RpmOstreeClient struct{}
+
+// NewNodeUpdaterClient returns a new instance of the default DeploymentClient (RpmOstreeClient)
+func NewNodeUpdaterClient() NodeUpdaterClient {
+	return &RpmOstreeClient{}
+}
+
+// getBootedDeployment returns the current deployment found
+func (r *RpmOstreeClient) getBootedDeployment(rootMount string) (*RpmOstreeDeployment, error) {
 	var rosState RpmOstreeState
 	output, err := RunGetOut("chroot", rootMount, "rpm-ostree", "status", "--json")
 	if err != nil {
@@ -48,9 +65,9 @@ func getBootedDeployment(rootMount string) (*RpmOstreeDeployment, error) {
 	return nil, fmt.Errorf("Not currently booted in a deployment")
 }
 
-// getBootedOSImageURL returns the image URL as well as the OSTree version (for logging)
-func getBootedOSImageURL(rootMount string) (string, string, error) {
-	bootedDeployment, err := getBootedDeployment(rootMount)
+// GetBootedOSImageURL returns the image URL as well as the OSTree version (for logging)
+func (r *RpmOstreeClient) GetBootedOSImageURL(rootMount string) (string, string, error) {
+	bootedDeployment, err := r.getBootedDeployment(rootMount)
 	if err != nil {
 		return "", "", err
 	}
@@ -74,6 +91,8 @@ func getBootedOSImageURL(rootMount string) (string, string, error) {
 	return osImageURL, bootedDeployment.Version, nil
 }
 
-func runPivot(osImageURL string) error {
+// RunPivot executes a pivot from one deployment to another as found in the referenced
+// osImageURL. See https://github.com/openshift/pivot.
+func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 	return Run("/bin/pivot", osImageURL)
 }

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+/*
+ * This file contains test code for the rpm-ostree client. It is meant to be used when
+ * testing the daemon and mocking the responses that would normally be executed by the
+ * client.
+ */
+
+// GetBootedOSImageURLReturn is a structure used for testing. The fields correspond with the
+// return values in GetBootedOSImageURL implementations.
+type GetBootedOSImageURLReturn struct {
+	OsImageURL string
+	Version    string
+	Error      error
+}
+
+// RpmOstreeClientMock is a testing implementation of NodeUpdaterClient. Fields presented here
+// hold return values that will be returned when their corresponding methods are called.
+type RpmOstreeClientMock struct {
+	GetBootedOSImageURLReturns []GetBootedOSImageURLReturn
+	RunPivotReturns            []error
+}
+
+// GetBootedOSImageURL implements a test version of RpmOStreeClients GetBootedOSImageURL.
+// It returns an OsImageURL, Version, and Error as defined in GetBootedOSImageURLReturns in order.
+func (r RpmOstreeClientMock) GetBootedOSImageURL(string) (string, string, error) {
+	returnValues := r.GetBootedOSImageURLReturns[0]
+	if len(r.GetBootedOSImageURLReturns) > 0 {
+		r.GetBootedOSImageURLReturns = r.GetBootedOSImageURLReturns[1:]
+	}
+	return returnValues.OsImageURL, returnValues.Version, returnValues.Error
+}
+
+// RunPivot implements a test version of RpmOstreeClients RunPivot. It returns errors as defined
+// in the instances RunPivotReturns field in order.
+func (r RpmOstreeClientMock) RunPivot(string) error {
+	err := r.RunPivotReturns[0]
+	if len(r.RunPivotReturns) > 0 {
+		r.RunPivotReturns = r.RunPivotReturns[1:]
+	}
+	return err
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -443,7 +443,7 @@ func (dn *Daemon) updateOS(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 	}
 
 	glog.Infof("Updating OS to %s", newConfig.Spec.OSImageURL)
-	return runPivot(newConfig.Spec.OSImageURL)
+	return dn.NodeUpdaterClient.RunPivot(newConfig.Spec.OSImageURL)
 }
 
 // reboot is the final step. it tells systemd-logind to reboot the machine,

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestUpdateOS verifies the return errors from attempting to update the OS follow expectations
+func TestUpdateOS(t *testing.T) {
+	// expectedError is the error we will use when expecting an error to return
+	expectedError := fmt.Errorf("broken")
+
+	// testClient is the NodeUpdaterClient mock instance that will front
+	// calls to update the host.
+	testClient := RpmOstreeClientMock{
+		GetBootedOSImageURLReturns: []GetBootedOSImageURLReturn{},
+		RunPivotReturns: []error{
+			// First run will return no error
+			nil,
+			// Second rrun will return our expected error
+			expectedError},
+	}
+
+	// Create a Daemon instance with mocked clients
+	d := Daemon{
+		name:              "nodeName",
+		OperatingSystem:   MachineConfigDaemonOSRHCOS,
+		NodeUpdaterClient: testClient,
+		loginClient:       nil, // set to nil as it will not be used within tests
+		client:            fake.NewSimpleClientset(),
+		kubeClient:        k8sfake.NewSimpleClientset(),
+		rootMount:         "/",
+		bootedOSImageURL:  "test",
+	}
+
+	// Set up machineconfigs to pass to updateOS.
+	mcfg := &mcfgv1.MachineConfig{}
+	// differentMcfg has a different OSImageURL so it will force Daemon.UpdateOS
+	// to trigger an update of the operatingsystem (as fronted by our testClient)
+	differentMcfg := &mcfgv1.MachineConfig{
+		Spec: mcfgv1.MachineConfigSpec{
+			OSImageURL: "somethingDifferent",
+		},
+	}
+
+	// Test when the machine configs match. No operation should occur
+	if err := d.updateOS(mcfg, mcfg); err != nil {
+		t.Errorf("Expected no error. Got %s.", err)
+	}
+	// When machine configs differ but pivot succeeds we should get no error.
+	if err := d.updateOS(mcfg, mcfg); err != nil {
+		t.Errorf("Expected no error. Got %s.", err)
+	}
+	// When machine configs differ but pivot fails we should get the expected error.
+	if err := d.updateOS(mcfg, differentMcfg); err == expectedError {
+		t.Error("Expected an error. Got none.")
+	}
+}


### PR DESCRIPTION
This change allows for modification of rpm-ostree related code so
unittesting can occur. Instead of the functionality being spread
through private functions within the daemon package, a structure
which implements DeploymentClient is used and is passed in to
the Daemon at creation.

Part of https://github.com/openshift/machine-config-operator/issues/101

/cc @jlebon @sdemos @kikisdeliveryservice 