### PR TITLE
kubelet: fix the clusterDNS property within the config

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/aws/master/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/aws/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/aws/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/libvirt/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/libvirt/master/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/libvirt/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDns%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/templates/_base/master/files/kubelet.yaml
+++ b/templates/_base/master/files/kubelet.yaml
@@ -6,7 +6,7 @@ contents:
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
-    clusterDns:
+    clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
     runtimeRequestTimeout: 10m

--- a/templates/_base/worker/files/kubelet.yaml
+++ b/templates/_base/worker/files/kubelet.yaml
@@ -6,7 +6,7 @@ contents:
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
-    clusterDns:
+    clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
     rotateCertificates: true


### PR DESCRIPTION
case matters in yaml and kubelet configuration. clusterDNS was not being propagated into the config.

/cc @abhinavdahiya 