### PR TITLE
sign for the local etcd service name that cluster-network apiservers use

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -302,6 +302,8 @@ func etcdServerCertDNSNames(cfg renderConfig) (interface{}, error) {
 		"localhost",
 		"*.kube-etcd.kube-system.svc.cluster.local",
 		"kube-etcd-client.kube-system.svc.cluster.local",
+		"etcd.kube-system.svc",               // sign for the local etcd service name that cluster-network apiservers use to communicate
+		"etcd.kube-system.svc.cluster.local", // sign for the local etcd service name that cluster-network apiservers use to communicate
 	}
 
 	for i := 0; i < cfg.EtcdInitialCount; i++ {

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -251,7 +251,7 @@ func TestEtcdServerCertDNSNames(t *testing.T) {
 		clusterName: "test-cluster",
 		baseDomain:  "tt.testing",
 		etcdCount:   3,
-		url:         "localhost,*.kube-etcd.kube-system.svc.cluster.local,kube-etcd-client.kube-system.svc.cluster.local,test-cluster-etcd-0.tt.testing,test-cluster-etcd-1.tt.testing,test-cluster-etcd-2.tt.testing",
+		url:         "localhost,*.kube-etcd.kube-system.svc.cluster.local,kube-etcd-client.kube-system.svc.cluster.local,etcd.kube-system.svc,etcd.kube-system.svc.cluster.local,test-cluster-etcd-0.tt.testing,test-cluster-etcd-1.tt.testing,test-cluster-etcd-2.tt.testing",
 		err:         false,
 	}}
 	for idx, c := range cases {

--- a/pkg/controller/template/test_data/templates/aws/master/units/etcd-member.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/etcd-member.service
@@ -28,7 +28,7 @@ contents: |
             --cacrt=/etc/ssl/etcd/root-ca.crt \
             --assetsdir=/etc/ssl/etcd \
             --address=https://my-test-cluster-api.installer.team.coreos.systems:6443 \
-            --dnsnames=localhost,*.kube-etcd.kube-system.svc.cluster.local,kube-etcd-client.kube-system.svc.cluster.local,my-test-cluster-etcd-0.installer.team.coreos.systems,my-test-cluster-etcd-1.installer.team.coreos.systems,my-test-cluster-etcd-2.installer.team.coreos.systems \
+            --dnsnames=localhost,*.kube-etcd.kube-system.svc.cluster.local,kube-etcd-client.kube-system.svc.cluster.local,etcd.kube-system.svc,etcd.kube-system.svc.cluster.local,my-test-cluster-etcd-0.installer.team.coreos.systems,my-test-cluster-etcd-1.installer.team.coreos.systems,my-test-cluster-etcd-2.installer.team.coreos.systems \
             --commonname=system:etcd-server:my-test-cluster-etcd-{{.etcd_index}}.installer.team.coreos.systems \
             --ipaddrs=127.0.0.1 \
   "

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/etcd-member.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/etcd-member.service
@@ -28,7 +28,7 @@ contents: |
             --cacrt=/etc/ssl/etcd/root-ca.crt \
             --assetsdir=/etc/ssl/etcd \
             --address=https://my-test-cluster-api.installer.team.coreos.systems:6443 \
-            --dnsnames=localhost,*.kube-etcd.kube-system.svc.cluster.local,kube-etcd-client.kube-system.svc.cluster.local,my-test-cluster-etcd-0.installer.team.coreos.systems,my-test-cluster-etcd-1.installer.team.coreos.systems,my-test-cluster-etcd-2.installer.team.coreos.systems \
+            --dnsnames=localhost,*.kube-etcd.kube-system.svc.cluster.local,kube-etcd-client.kube-system.svc.cluster.local,etcd.kube-system.svc,etcd.kube-system.svc.cluster.local,my-test-cluster-etcd-0.installer.team.coreos.systems,my-test-cluster-etcd-1.installer.team.coreos.systems,my-test-cluster-etcd-2.installer.team.coreos.systems \
             --commonname=system:etcd-server:my-test-cluster-etcd-{{.etcd_index}}.installer.team.coreos.systems \
             --ipaddrs=127.0.0.1 \
   "


### PR DESCRIPTION
the clusternetwork apiservers like openshift-apiserver use the `etcd.kube-system.svc` to get at etcd.  The cert needs to be signed for that name

/assign @abhinavdahiya 