### PR TITLE
Update SSH keys via MCD

### DIFF
--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -65,22 +65,6 @@ func TestUpdateOS(t *testing.T) {
 // TestReconcilable attempts to verify the conditions in which configs would and would not be
 // reconcilable. Welcome to the longest unittest you've ever read.
 func TestReconcilable(t *testing.T) {
-	// checkReconcilableResults is a shortcut for verifying results that should be reconcilable
-	checkReconcilableResults := func(key string, reconcilableError *string) {
-
-		if reconcilableError != nil {
-			t.Errorf("Expected the same %s values would be reconcilable. Received error: %v", key, *reconcilableError)
-		}
-	}
-
-	// checkIreconcilableResults is a shortcut for verifing results that should be ireconcilable
-	checkIreconcilableResults := func(key string, reconcilableError *string) {
-
-		if reconcilableError == nil {
-			t.Errorf("Expected different %s values would not be reconcilable.", key)
-		}
-	}
-
 	d := Daemon{
 		name:              "nodeName",
 		OperatingSystem:   MachineConfigDaemonOSRHCOS,
@@ -116,12 +100,12 @@ func TestReconcilable(t *testing.T) {
 
 	// Verify Ignition version changes react as expected
 	isReconcilable := d.reconcilable(oldConfig, newConfig)
-	checkIreconcilableResults("ignition", isReconcilable)
+	checkIrreconcilableResults(t, "ignition", isReconcilable)
 
 	// Match ignition versions
 	oldConfig.Spec.Config.Ignition.Version = "1.0"
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkReconcilableResults("ignition", isReconcilable)
+	checkReconcilableResults(t, "ignition", isReconcilable)
 
 	// Verify Networkd unit changes react as expected
 	oldConfig.Spec.Config.Networkd = ignv2_2types.Networkd{}
@@ -133,13 +117,13 @@ func TestReconcilable(t *testing.T) {
 		},
 	}
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkIreconcilableResults("networkd", isReconcilable)
+	checkIrreconcilableResults(t, "networkd", isReconcilable)
 
 	// Match Networkd
 	oldConfig.Spec.Config.Networkd = newConfig.Spec.Config.Networkd
 
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkReconcilableResults("networkd", isReconcilable)
+	checkReconcilableResults(t, "networkd", isReconcilable)
 
 	// Verify Disk changes react as expected
 	oldConfig.Spec.Config.Storage.Disks = []ignv2_2types.Disk{
@@ -149,12 +133,12 @@ func TestReconcilable(t *testing.T) {
 	}
 
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkIreconcilableResults("disk", isReconcilable)
+	checkIrreconcilableResults(t, "disk", isReconcilable)
 
 	// Match storage disks
 	newConfig.Spec.Config.Storage.Disks = oldConfig.Spec.Config.Storage.Disks
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkReconcilableResults("disk", isReconcilable)
+	checkReconcilableResults(t, "disk", isReconcilable)
 
 	// Verify Filesystems changes react as expected
 	oldConfig.Spec.Config.Storage.Filesystems = []ignv2_2types.Filesystem{
@@ -164,12 +148,12 @@ func TestReconcilable(t *testing.T) {
 	}
 
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkIreconcilableResults("filesystem", isReconcilable)
+	checkIrreconcilableResults(t, "filesystem", isReconcilable)
 
 	// Match Storage filesystems
 	newConfig.Spec.Config.Storage.Filesystems = oldConfig.Spec.Config.Storage.Filesystems
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkReconcilableResults("filesystem", isReconcilable)
+	checkReconcilableResults(t, "filesystem", isReconcilable)
 
 	// Verify Raid changes react as expected
 	oldConfig.Spec.Config.Storage.Raid = []ignv2_2types.Raid{
@@ -179,12 +163,105 @@ func TestReconcilable(t *testing.T) {
 	}
 
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkIreconcilableResults("raid", isReconcilable)
+	checkIrreconcilableResults(t, "raid", isReconcilable)
 
 	// Match storage raid
 	newConfig.Spec.Config.Storage.Raid = oldConfig.Spec.Config.Storage.Raid
 	isReconcilable = d.reconcilable(oldConfig, newConfig)
-	checkReconcilableResults("raid", isReconcilable)
+	checkReconcilableResults(t, "raid", isReconcilable)
+
+	// Verify Passwd Groups changes unsupported
+	oldConfig = &mcfgv1.MachineConfig{}
+	tempGroup := ignv2_2types.PasswdGroup{Name: "testGroup"}
+	newMcfg := &mcfgv1.MachineConfig{
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: ignv2_2types.Config{
+				Passwd: ignv2_2types.Passwd{
+					Groups: []ignv2_2types.PasswdGroup{tempGroup},
+				},
+			},
+		},
+	}
+	isReconcilable = d.reconcilable(oldConfig, newMcfg)
+	checkIrreconcilableResults(t, "passwdGroups", isReconcilable)
+
+}
+
+func TestReconcilableSSH(t *testing.T) {
+	// expectedError is the error we will use when expecting an error to return
+	expectedError := fmt.Errorf("broken")
+
+	// testClient is the NodeUpdaterClient mock instance that will front
+	// calls to update the host.
+	testClient := RpmOstreeClientMock{
+		GetBootedOSImageURLReturns: []GetBootedOSImageURLReturn{},
+		RunPivotReturns: []error{
+			// First run will return no error
+			nil,
+			// Second rrun will return our expected error
+			expectedError},
+	}
+
+	// Create a Daemon instance with mocked clients
+	d := Daemon{
+		name:              "nodeName",
+		OperatingSystem:   MachineConfigDaemonOSRHCOS,
+		NodeUpdaterClient: testClient,
+		loginClient:       nil, // set to nil as it will not be used within tests
+		client:            fake.NewSimpleClientset(),
+		kubeClient:        k8sfake.NewSimpleClientset(),
+		rootMount:         "/",
+		bootedOSImageURL:  "test",
+	}
+
+	// Check that updating SSH Key of user core supported
+	//tempUser1 := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"1234"}}
+	oldMcfg := &mcfgv1.MachineConfig{}
+	tempUser1 := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"5678", "abc"}}
+	newMcfg := &mcfgv1.MachineConfig{
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: ignv2_2types.Config{
+				Passwd: ignv2_2types.Passwd{
+					Users: []ignv2_2types.PasswdUser{tempUser1},
+				},
+			},
+		},
+	}
+
+	errMsg := d.reconcilable(oldMcfg, newMcfg)
+	checkReconcilableResults(t, "ssh", errMsg)
+
+	// 	Check that updating User with User that is not core is not supported
+	tempUser2 := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"1234"}}
+	oldMcfg.Spec.Config.Passwd.Users = append(oldMcfg.Spec.Config.Passwd.Users, tempUser2)
+	tempUser3 := ignv2_2types.PasswdUser{Name: "another user", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"5678"}}
+	newMcfg.Spec.Config.Passwd.Users[0] = tempUser3
+
+	errMsg = d.reconcilable(oldMcfg, newMcfg)
+	checkIrreconcilableResults(t, "ssh", errMsg)
+
+	// check that we cannot make updates if any other Passwd.User field is changed.
+	tempUser4 := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"5678"}, HomeDir: "somedir"}
+	newMcfg.Spec.Config.Passwd.Users[0] = tempUser4
+
+	errMsg = d.reconcilable(oldMcfg, newMcfg)
+	checkIrreconcilableResults(t, "ssh", errMsg)
+
+	// check that we cannot add a user or have len(Passwd.Users)> 1
+	tempUser5 := ignv2_2types.PasswdUser{Name: "some user", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"5678"}}
+	newMcfg.Spec.Config.Passwd.Users = append(newMcfg.Spec.Config.Passwd.Users, tempUser5)
+
+	errMsg = d.reconcilable(oldMcfg, newMcfg)
+	checkIrreconcilableResults(t, "ssh", errMsg)
+
+	// check that user is not attempting to remove the only sshkey from core user
+	tempUser6 := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{}}
+	newMcfg.Spec.Config.Passwd.Users[0] = tempUser6
+	newMcfg.Spec.Config.Passwd.Users = newMcfg.Spec.Config.Passwd.Users[:len(newMcfg.Spec.Config.Passwd.Users)-1]
+
+	errMsg = d.reconcilable(oldMcfg, newMcfg)
+	checkIrreconcilableResults(t, "ssh", errMsg)
+
 }
 
 func TestUpdateSSHKeys(t *testing.T) {
@@ -214,7 +291,7 @@ func TestUpdateSSHKeys(t *testing.T) {
 		fileSystemClient:  mockFS,
 	}
 	// Set up machineconfigs that are identical except for SSH keys
-	tempUser := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"1234"}}
+	tempUser := ignv2_2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{"1234", "4567"}}
 
 	newMcfg := &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
@@ -235,5 +312,21 @@ func TestUpdateSSHKeys(t *testing.T) {
 	err = d.updateSSHKeys(newMcfg.Spec.Config.Passwd.Users)
 	if err == nil {
 		t.Errorf("Expected error, user is not core")
+	}
+}
+
+// checkReconcilableResults is a shortcut for verifying results that should be reconcilable
+func checkReconcilableResults(t *testing.T, key string, reconcilableError *string) {
+
+	if reconcilableError != nil {
+		t.Errorf("Expected the same %s values would be reconcilable. Received error: %v", key, *reconcilableError)
+	}
+}
+
+// checkIrreconcilableResults is a shortcut for verifing results that should be irreconcilable
+func checkIrreconcilableResults(t *testing.T, key string, reconcilableError *string) {
+
+	if reconcilableError == nil {
+		t.Errorf("Expected different %s values would not be reconcilable.", key)
 	}
 }


### PR DESCRIPTION
Allow MCD to update SSH Keys.  

We are only allowing one user named "core" and only updating the field SSHAuthorizedKeys for this user.
