### PR TITLE
templates: add flannel-dns-hack.service for masters

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/units/flannel-dns-hack.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/flannel-dns-hack.service
@@ -1,0 +1,15 @@
+contents: |
+  [Unit]
+  Description=Flannel DNS Hack
+  Documentation=https://github.com/openshift/installer/issues/440
+  After=network-online.target
+  Wants=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+
+  ExecStartPre=-/sbin/modprobe br_netfilter
+  ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+enabled: true
+name: flannel-dns-hack.service

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/flannel-dns-hack.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/flannel-dns-hack.service
@@ -1,0 +1,15 @@
+contents: |
+  [Unit]
+  Description=Flannel DNS Hack
+  Documentation=https://github.com/openshift/installer/issues/440
+  After=network-online.target
+  Wants=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+
+  ExecStartPre=-/sbin/modprobe br_netfilter
+  ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+enabled: true
+name: flannel-dns-hack.service

--- a/pkg/controller/template/test_data/templates/openstack/master/units/flannel-dns-hack.service
+++ b/pkg/controller/template/test_data/templates/openstack/master/units/flannel-dns-hack.service
@@ -1,0 +1,15 @@
+contents: |
+  [Unit]
+  Description=Flannel DNS Hack
+  Documentation=https://github.com/openshift/installer/issues/440
+  After=network-online.target
+  Wants=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+
+  ExecStartPre=-/sbin/modprobe br_netfilter
+  ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+enabled: true
+name: flannel-dns-hack.service

--- a/templates/_base/master/units/flannel-dns-hack.yaml
+++ b/templates/_base/master/units/flannel-dns-hack.yaml
@@ -1,0 +1,15 @@
+name: "flannel-dns-hack.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Flannel DNS Hack
+  Documentation=https://github.com/openshift/installer/issues/440
+  After=network-online.target
+  Wants=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+
+  ExecStartPre=-/sbin/modprobe br_netfilter
+  ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1


### PR DESCRIPTION
when pod requesting dns resolution is located on the same node as the dns pod,
the dns query fails with error
```console
nslookup test1-etcd-0.tt.testing
;; reply from unexpected source: 10.2.0.6#53, expected 10.3.0.10#53
```

@rchopra found that the cause is flannel using the bridge to route pod traffic and
the bridge does not participate in iptables if routed locally. The fix is to force
the cni0 bridge to use iptables.

https://github.com/openshift/installer/issues/440
/cc @crawford 