### PR TITLE
operator: add mco cli flags to mco bootstrap

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io/ioutil"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/openshift/machine-config-operator/pkg/operator"
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -21,6 +27,9 @@ var (
 	bootstrapOpts struct {
 		configFile          string
 		imagesConfigMapFile string
+		mccImage            string
+		mcsImage            string
+		mcdImage            string
 		destinationDir      string
 	}
 )
@@ -29,6 +38,9 @@ func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.imagesConfigMapFile, "images-json-configmap", "", "ConfigMap that contains images.json for MCO.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mccImage, "machine-config-controller-image", "", "Image for Machine Config Controller. (this cannot be set if --images-json-configmap is set)")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcsImage, "machine-config-server-image", "", "Image for Machine Config Server. (this cannot be set if --images-json-configmap is set)")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcdImage, "machine-config-daemon-image", "", "Image for Machine Config Daemon. (this cannot be set if --images-json-configmap is set)")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
 }
 
@@ -47,16 +59,49 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		glog.Fatal("--config-file cannot be empty")
 	}
 
-	if bootstrapOpts.imagesConfigMapFile == "" {
-		glog.Fatal("--images-json-configmap cannot be empty")
+	if bootstrapOpts.imagesConfigMapFile != "" &&
+		(bootstrapOpts.mccImage != "" ||
+			bootstrapOpts.mcsImage != "" ||
+			bootstrapOpts.mcdImage != "") {
+		glog.Fatal("both --images-json-configmap and --machine-config-{controller,server,daemon}-image flags cannot be set")
 	}
 
+	imgs := operator.DefaultImages()
+	if bootstrapOpts.imagesConfigMapFile != "" {
+		imgsRaw, err := rawImagesFromConfigMapOnDisk(bootstrapOpts.imagesConfigMapFile)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		if err := json.Unmarshal([]byte(imgsRaw), &imgs); err != nil {
+			glog.Fatal(err)
+		}
+	} else {
+		imgs.MachineConfigController = bootstrapOpts.mccImage
+		imgs.MachineConfigServer = bootstrapOpts.mcsImage
+		imgs.MachineConfigDaemon = bootstrapOpts.mcdImage
+	}
 	if err := operator.RenderBootstrap(
 		bootstrapOpts.configFile,
 		rootOpts.etcdCAFile, rootOpts.rootCAFile,
-		bootstrapOpts.imagesConfigMapFile,
+		imgs,
 		bootstrapOpts.destinationDir,
 	); err != nil {
 		glog.Fatalf("error rendering bootstrap manifests: %v", err)
 	}
+}
+
+func rawImagesFromConfigMapOnDisk(file string) ([]byte, error) {
+	data, err := ioutil.ReadFile(bootstrapOpts.imagesConfigMapFile)
+	if err != nil {
+		return nil, err
+	}
+	obji, err := runtime.Decode(scheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion), data)
+	if err != nil {
+		return nil, err
+	}
+	cm, ok := obji.(*corev1.ConfigMap)
+	if !ok {
+		return nil, fmt.Errorf("expected *corev1.ConfigMap found %T", obji)
+	}
+	return []byte(cm.Data["images.json"]), nil
 }

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -1,8 +1,17 @@
 package operator
 
-// images allows build systems to inject images for MCO components.
-type images struct {
+// Images allows build systems to inject images for MCO components.
+type Images struct {
 	MachineConfigController string `json:"machineConfigController"`
 	MachineConfigDaemon     string `json:"machineConfigDaemon"`
 	MachineConfigServer     string `json:"machineConfigServer"`
+}
+
+// DefaultImages returns default set of images for operator.
+func DefaultImages() Images {
+	return Images{
+		MachineConfigController: "docker.io/openshift/origin-machine-config-controller:v4.0.0",
+		MachineConfigDaemon:     "docker.io/openshift/origin-machine-config-daemon:v4.0.0",
+		MachineConfigServer:     "docker.io/openshift/origin-machine-config-server:v4.0.0",
+	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -240,7 +240,6 @@ func (optr *Operator) sync(key string) error {
 	if err != nil {
 		return err
 	}
-
 	mcoconfig := obj.DeepCopy()
 
 	filesData := map[string][]byte{}
@@ -257,7 +256,7 @@ func (optr *Operator) sync(key string) error {
 		filesData[file] = data
 	}
 
-	var imgs images
+	imgs := DefaultImages()
 	if err := json.Unmarshal(filesData[optr.imagesFile], &imgs); err != nil {
 		return err
 	}
@@ -294,7 +293,7 @@ func icFromClusterConfig(cm *v1.ConfigMap) (installertypes.InstallConfig, error)
 	return ic, nil
 }
 
-func getRenderConfig(mc *mcfgv1.MCOConfig, etcdCAData, rootCAData []byte, imgs images) renderConfig {
+func getRenderConfig(mc *mcfgv1.MCOConfig, etcdCAData, rootCAData []byte, imgs Images) renderConfig {
 	controllerconfig := mcfgv1.ControllerConfigSpec{
 		ClusterDNSIP:        mc.Spec.ClusterDNSIP,
 		CloudProviderConfig: mc.Spec.CloudProviderConfig,

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -18,7 +18,7 @@ type renderConfig struct {
 	TargetNamespace  string
 	Version          string
 	ControllerConfig mcfgv1.ControllerConfigSpec
-	Images           images
+	Images           Images
 }
 
 func renderAsset(config renderConfig, path string) ([]byte, error) {


### PR DESCRIPTION
This will allow us remove the hardcoded config map in installer for bootstrap mco.
/cc @crawford 