### PR TITLE
templates: fix missing Install section for flannel-dns-hac.service

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/units/flannel-dns-hack.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/flannel-dns-hack.service
@@ -11,5 +11,8 @@ contents: |
 
   ExecStartPre=-/sbin/modprobe br_netfilter
   ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+
+  [Install]
+  WantedBy=multi-user.target
 enabled: true
 name: flannel-dns-hack.service

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/flannel-dns-hack.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/flannel-dns-hack.service
@@ -11,5 +11,8 @@ contents: |
 
   ExecStartPre=-/sbin/modprobe br_netfilter
   ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+
+  [Install]
+  WantedBy=multi-user.target
 enabled: true
 name: flannel-dns-hack.service

--- a/pkg/controller/template/test_data/templates/openstack/master/units/flannel-dns-hack.service
+++ b/pkg/controller/template/test_data/templates/openstack/master/units/flannel-dns-hack.service
@@ -11,5 +11,8 @@ contents: |
 
   ExecStartPre=-/sbin/modprobe br_netfilter
   ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+
+  [Install]
+  WantedBy=multi-user.target
 enabled: true
 name: flannel-dns-hack.service

--- a/templates/_base/master/units/flannel-dns-hack.yaml
+++ b/templates/_base/master/units/flannel-dns-hack.yaml
@@ -13,3 +13,6 @@ contents: |
 
   ExecStartPre=-/sbin/modprobe br_netfilter
   ExecStart=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
https://github.com/openshift/machine-config-operator/pull/118 added this service
which is not started by systemd on boot because of the missing Install section