### PR TITLE
daemon: exit early if node is degraded

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -211,7 +211,7 @@ func (dn *Daemon) triggerUpdate() error {
 // isDesiredMachineState confirms that the node is actually in the state that it
 // wants to be in. It does this by looking at the elements in the target config
 // and checks if all are present on the node. Returns true iff there are no
-// mismatches (e.g. files, units... XXX: but not yet OS version).
+// mismatches (e.g. files, units, OS version).
 func (dn *Daemon) isDesiredMachineState() (bool, error) {
 	ccAnnotation, err := getNodeAnnotation(dn.kubeClient.CoreV1().Nodes(), dn.name, CurrentMachineConfigAnnotationKey)
 	if err != nil {


### PR DESCRIPTION
As discussed in #109, if the node is marked degraded, then we don't want
the MCD to do anything at all. As a first step, just check for this on
start and exit right away if that's the case. Down the line, we should
investigate tainting the node to make sure we don't get scheduled in the
first place as was discussed in #109.