### PR TITLE
daemon: Run once mode

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -24,6 +24,7 @@ var (
 		kubeconfig string
 		nodeName   string
 		rootMount  string
+		onceFrom   string
 	}
 )
 
@@ -32,6 +33,7 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.nodeName, "node-name", "", "kubernetes node name daemon is managing.")
 	startCmd.PersistentFlags().StringVar(&startOpts.rootMount, "root-mount", "/rootfs", "where the nodes root filesystem is mounted for chroot and file manipulation.")
+	startCmd.PersistentFlags().StringVar(&startOpts.onceFrom, "once-from", "", "Runs the daemon once using a provided file path or URL endpoint as its machine config source")
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) {
@@ -82,6 +84,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		cb.KubeClientOrDie(componentName),
 		daemon.NewFileSystemClient(),
 		ctx.KubeInformerFactory.Core().V1().Nodes(),
+		startOpts.onceFrom,
 	)
 	if err != nil {
 		glog.Fatalf("failed to initialize daemon: %v", err)

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -105,6 +105,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		if err != nil {
 			glog.Fatalf("error checking initial state of node: %v", err)
 		}
+		if err = dn.StartInformer(stopCh, startOpts.nodeName, componentName, startOpts.kubeconfig); err != nil {
+			glog.Fatalf("error starting kubernetes informers: %v", err)
+		}
 	}
 
 	glog.Infof(`Calling chroot("%s")`, startOpts.rootMount)

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -6,7 +6,6 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
@@ -40,6 +39,8 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
+	glog.V(2).Infof("Options parsed: %+v", startOpts)
+
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v", version.Version)
 
@@ -56,11 +57,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		startOpts.nodeName = name
 	}
 
-	cb, err := common.NewClientBuilder(startOpts.kubeconfig)
-	if err != nil {
-		glog.Fatalf("error creating clients: %v", err)
-	}
-
 	// Ensure that the rootMount exists
 	if _, err := os.Stat(startOpts.rootMount); err != nil {
 		if os.IsNotExist(err) {
@@ -71,23 +67,44 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
+	var dn *daemon.Daemon
 
-	ctx := common.CreateControllerContext(cb, stopCh, componentName)
-	// create the daemon instance. this also initializes kube client items
-	// which need to come from the container and not the chroot.
-	daemon, err := daemon.New(
-		startOpts.rootMount,
-		startOpts.nodeName,
-		operatingSystem,
-		daemon.NewNodeUpdaterClient(),
-		cb.MachineConfigClientOrDie(componentName),
-		cb.KubeClientOrDie(componentName),
-		daemon.NewFileSystemClient(),
-		ctx.KubeInformerFactory.Core().V1().Nodes(),
-		startOpts.onceFrom,
-	)
-	if err != nil {
-		glog.Fatalf("failed to initialize daemon: %v", err)
+	// If we are asked to run once and it's a valid file system path use
+	// the bare Daemon
+	if startOpts.onceFrom != "" && daemon.ValidPath(startOpts.onceFrom) {
+		dn, err = daemon.New(
+			startOpts.rootMount,
+			startOpts.nodeName,
+			operatingSystem,
+			daemon.NewNodeUpdaterClient(),
+			daemon.NewFileSystemClient(),
+			startOpts.onceFrom,
+		)
+		if err != nil {
+			glog.Fatalf("failed to initialize single run daemon: %v", err)
+		}
+		// Else we use the cluster driven daemon
+	} else {
+		// create the daemon instance. this also initializes kube client items
+		// which need to come from the container and not the chroot.
+		dn, err = daemon.NewClusterDrivenDaemon(
+			startOpts.rootMount,
+			startOpts.nodeName,
+			operatingSystem,
+			daemon.NewNodeUpdaterClient(),
+			startOpts.kubeconfig,
+			daemon.NewFileSystemClient(),
+			startOpts.onceFrom,
+			stopCh,
+			componentName,
+		)
+		if err != nil {
+			glog.Fatalf("failed to initialize daemon: %v", err)
+		}
+		err = dn.CheckStateOnBoot(stopCh)
+		if err != nil {
+			glog.Fatalf("error checking initial state of node: %v", err)
+		}
 	}
 
 	glog.Infof(`Calling chroot("%s")`, startOpts.rootMount)
@@ -103,15 +120,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	glog.Info("Starting MachineConfigDaemon")
 	defer glog.Info("Shutting down MachineConfigDaemon")
 
-	err = daemon.CheckStateOnBoot(stopCh)
-	if err != nil {
-		glog.Fatalf("error checking initial state of node: %v", err)
-	}
-
-	ctx.KubeInformerFactory.Start(ctx.Stop)
-	close(ctx.KubeInformersStarted)
-
-	err = daemon.Run(stopCh)
+	err = dn.Run(stopCh)
 	if err != nil {
 		glog.Fatalf("failed to run: %v", err)
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -222,7 +222,7 @@ func (dn *Daemon) runOnce() error {
 		}
 		return nil
 
-	} else if validPath(dn.onceFrom) {
+	} else if ValidPath(dn.onceFrom) {
 		// NOTE: This case expects that the cluster is NOT CREATED YET.
 		// If we sense a local file has been provided parse it.
 		oldConfig = mcfgv1.MachineConfig{}
@@ -563,9 +563,9 @@ func getMachineConfig(client mcfgclientv1.MachineConfigInterface, name string) (
 	return client.Get(name, metav1.GetOptions{})
 }
 
-// validPath attempts to see if the path provided is indeed an acceptable
+// ValidPath attempts to see if the path provided is indeed an acceptable
 // filesystem path. This function does not check if the path exists.
-func validPath(path string) bool {
+func ValidPath(path string) bool {
 	path = filepath.Clean(path)
 	for _, validStart := range []string{".", "..", "/"} {
 		if strings.HasPrefix(path, validStart) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -136,17 +136,23 @@ func NewClusterDrivenDaemon(
 		glog.Fatalf("error creating clients: %v", err)
 	}
 
-	ctx := common.CreateControllerContext(cb, stopCh, componentName)
-
-	ctx.KubeInformerFactory.Start(ctx.Stop)
-	close(ctx.KubeInformersStarted)
-
 	dn.kubeClient = cb.KubeClientOrDie(componentName)
 	dn.client = cb.MachineConfigClientOrDie(componentName)
 
 	if err = loadNodeAnnotations(dn.kubeClient.CoreV1().Nodes(), nodeName); err != nil {
 		return nil, err
 	}
+	return dn, nil
+}
+
+// StartInformer initializes and starts the informers.
+func (dn *Daemon) StartInformer(stopCh chan (struct{}), nodeName, componentName, kubeconfig string) error {
+	cb, err := common.NewClientBuilder(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	ctx := common.CreateControllerContext(cb, stopCh, componentName)
 
 	nodeInformer := ctx.KubeInformerFactory.Core().V1().Nodes()
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -156,7 +162,10 @@ func NewClusterDrivenDaemon(
 	dn.nodeLister = nodeInformer.Lister()
 	dn.nodeListerSynced = nodeInformer.Informer().HasSynced
 
-	return dn, nil
+	ctx.KubeInformerFactory.Start(ctx.Stop)
+	close(ctx.KubeInformersStarted)
+
+	return nil
 }
 
 // Run finishes informer setup and then blocks, and the informer will be

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	drain "github.com/openshift/kubernetes-drain"
+	"github.com/openshift/machine-config-operator/lib/resourceread"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	mcfgclientv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
@@ -418,6 +420,38 @@ func checkFileContentsAndMode(filePath, expectedContent string, mode os.FileMode
 // Close closes all the connections the node agent has open for it's lifetime
 func (dn *Daemon) Close() {
 	dn.loginClient.Close()
+}
+
+// getMachineConfigFromFile parses a valid machine config file in yaml format and returns
+// a MachineConfig struct.
+func (dn *Daemon) getMachineConfigFromFile(filePath string) (*mcfgv1.MachineConfig, error) {
+	data, err := dn.fileSystemClient.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	config := resourceread.ReadMachineConfigV1OrDie(data)
+	return config, nil
+}
+
+// getMachineConfigFromURL reads a remote MC in yaml format and returns a MachineConfig struct.
+func (dn *Daemon) getMachineConfigFromURL(url string) (*mcfgv1.MachineConfig, error) {
+	// Make a request to the remote URL
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Read the body content from the request
+	body, err := dn.fileSystemClient.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the body into the machineConfig
+	config := resourceread.ReadMachineConfigV1OrDie(body)
+
+	return config, nil
 }
 
 func getMachineConfig(client mcfgclientv1.MachineConfigInterface, name string) (*mcfgv1.MachineConfig, error) {

--- a/pkg/daemon/fsclient.go
+++ b/pkg/daemon/fsclient.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 )
@@ -16,6 +17,7 @@ type FileSystemClient interface {
 	Chmod(string, os.FileMode) error
 	Chown(string, int, int) error
 	WriteFile(filename string, data []byte, perm os.FileMode) error
+	ReadAll(reader io.Reader) ([]byte, error)
 	ReadFile(filename string) ([]byte, error)
 }
 
@@ -70,6 +72,11 @@ func (f FsClient) WriteFile(filename string, data []byte, perm os.FileMode) erro
 // ReadFile implements ioutil.WriteFile
 func (f FsClient) ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename)
+}
+
+// ReadAll implements ioutil.ReadAll
+func (f FsClient) ReadAll(reader io.Reader) ([]byte, error) {
+	return ioutil.ReadAll(reader)
 }
 
 // NewFileSystemClient creates a new file system client using the default

--- a/pkg/daemon/fsclient_test.go
+++ b/pkg/daemon/fsclient_test.go
@@ -1,6 +1,9 @@
 package daemon
 
-import "os"
+import (
+	"io"
+	"os"
+)
 
 // CreateReturn is a structure used for testing. It holds a single return value
 // set for a mocked Create call.
@@ -34,6 +37,7 @@ type FsClientMock struct {
 	ChmodReturns     []error
 	ChownReturns     []error
 	WriteFileReturns []error
+	ReadAllReturns   []ReadFileReturn
 	ReadFileReturns  []ReadFileReturn
 }
 
@@ -99,6 +103,15 @@ func (f FsClientMock) Chown(name string, uid, gid int) error {
 // WriteFile provides a mocked implemention
 func (f FsClientMock) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	return updateErrorReturns(&f.WriteFileReturns)
+}
+
+// ReadAll provides a mocked implemention
+func (f FsClientMock) ReadAll(reader io.Reader) ([]byte, error) {
+	returnValues := f.ReadAllReturns[0]
+	if len(f.ReadAllReturns) > 1 {
+		f.ReadAllReturns = f.ReadAllReturns[1:]
+	}
+	return returnValues.Bytes, returnValues.Error
 }
 
 // ReadFile provides a mocked implemention

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -80,6 +80,12 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 func (dn *Daemon) reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) (bool, error) {
 	glog.Info("Checking if configs are reconcilable")
 
+	// We skip out of reconcilable if there is no Kind and we are in runOnce mode. The
+	// reason is that there is a good chance a previous state is not available to match against.
+	if oldConfig.Kind == "" && dn.onceFrom != "" {
+		glog.Infof("Missing kind in old config. Assuming reconcilable with new.")
+		return true, nil
+	}
 	oldIgn := oldConfig.Spec.Config
 	newIgn := newConfig.Spec.Config
 


### PR DESCRIPTION
Non RHCOS nodes will need to apply an MC once and exit.

Requires: https://github.com/openshift/machine-config-operator/pull/139

/cc @aaronlevy @dustymabe @sdodson 



Still todo:
- [x] Rebase on #130 
- [x] Update remote http(s) `onceFrom` to request resources from the cluster
- [x] Update local ignition file `onceFrom` to be able to run without making requests for state from the cluster
- [x] Ensure kubernetes client doesn't attempt connection when there is no cluster