### PR TITLE
daemon: just sit quietly if node is degraded

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -107,7 +107,14 @@ func (dn *Daemon) Run(stop <-chan struct{}) error {
 		glog.Errorf("Marking degraded due to: %v", err)
 		return setUpdateDegraded(dn.kubeClient.CoreV1().Nodes(), dn.name)
 	} else if state == MachineConfigDaemonStateDegraded {
-		return fmt.Errorf("Node is degraded; exiting loudly...")
+		// just sleep so that we don't clobber output of previous run which
+		// probably contains the real reason why we marked the node as degraded
+		// in the first place
+		glog.Info("Node is degraded; going to sleep")
+		select {
+		case <-stop:
+			return nil
+		}
 	}
 
 	if err := dn.process(); err != nil {


### PR DESCRIPTION
An issue with immediately exiting if the node is degraded is that we
then clobber the logs of the previous MCD containers, which means that
the logs from the MCD instance that actually set the node to degraded is
lost in the ether.

Let's just block on `poll()` so we don't exit and don't waste any CPU
resources. The stop channel here isn't actually being written/closed by
any other goroutine so this just sits there.

See also #127.