### PR TITLE
daemon: allow no state label to be set on node

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -102,7 +102,7 @@ func (dn *Daemon) Run(stop <-chan struct{}) error {
 	defer glog.Info("Shutting down MachineConfigDaemon")
 
 	// sanity check we're not already in a degraded state
-	if state, err := getNodeAnnotation(dn.kubeClient.CoreV1().Nodes(), dn.name, MachineConfigDaemonStateAnnotationKey); err != nil {
+	if state, err := getNodeAnnotationExt(dn.kubeClient.CoreV1().Nodes(), dn.name, MachineConfigDaemonStateAnnotationKey, true); err != nil {
 		// try to set to degraded... because we failed to check if we're degraded
 		glog.Errorf("Marking degraded due to: %v", err)
 		return setUpdateDegraded(dn.kubeClient.CoreV1().Nodes(), dn.name)

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -96,7 +96,13 @@ func loadNodeAnnotations(client corev1.NodeInterface, node string) error {
 	return nil
 }
 
+// getNodeAnnotation gets the node annotation, unsurprisingly
 func getNodeAnnotation(client corev1.NodeInterface, node string, k string) (string, error) {
+	return getNodeAnnotationExt(client, node, k, false)
+}
+
+// getNodeAnnotationExt is like getNodeAnnotation, but allows one to customize ENOENT handling
+func getNodeAnnotationExt(client corev1.NodeInterface, node string, k string, allow_noent bool) (string, error) {
 	n, err := client.Get(node, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -104,7 +110,11 @@ func getNodeAnnotation(client corev1.NodeInterface, node string, k string) (stri
 
 	v, ok := n.Annotations[k]
 	if !ok {
-		return "", fmt.Errorf("%s annotation not found in %s", k, node)
+		if !allow_noent {
+			return "", fmt.Errorf("%s annotation not found in %s", k, node)
+		} else {
+			return "", nil
+		}
 	}
 
 	return v, nil


### PR DESCRIPTION
Regression from #121: we would fail at retrieving the annotation on the
first run since it wasn't set yet. Except... that annotation gets set by
us normally.

Tweak this by adding an `Ext` version of `getNodeAnnotation` which
doesn't error out if the annotation is not yet set. So now, we exit
early only if the label is set *and* its value is set to "Degraded".

Fixes: #127