### PR TITLE
Take ownership of the bootstrapping CSR cluster roles from KubeCoreOperator

### DIFF
--- a/manifests/machineconfigserver/csr-approver-role-binding.yaml
+++ b/manifests/machineconfigserver/csr-approver-role-binding.yaml
@@ -1,0 +1,17 @@
+# CSRApproverRoleBindingTemplate instructs the csrapprover controller to
+# automatically approve CSRs made by serviceaccount node-bootstrapper in openshift-machine-config-operator
+# for client credentials.
+#
+# This binding should be removed to disable CSR auto-approval.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-bootstrap-approve-node-client-csr
+subjects:
+- kind: ServiceAccount
+  name: node-bootstrapper
+  namespace: openshift-machine-config-operator
+roleRef:
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/machineconfigserver/csr-bootstrap-role-binding.yaml
+++ b/manifests/machineconfigserver/csr-bootstrap-role-binding.yaml
@@ -1,0 +1,13 @@
+# system-bootstrap-node-bootstrapper lets serviceaccount `openshift-machine-config-operator/node-bootstrapper` tokens and nodes request CSRs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-bootstrap-node-bootstrapper
+subjects:
+- kind: ServiceAccount
+  name: node-bootstrapper
+  namespace: openshift-machine-config-operator
+roleRef:
+  kind: ClusterRole
+  name: system:node-bootstrapper
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/machineconfigserver/csr-renewal-role-binding.yaml
+++ b/manifests/machineconfigserver/csr-renewal-role-binding.yaml
@@ -1,0 +1,19 @@
+# CSRRenewalRoleBindingTemplate instructs the csrapprover controller to
+# automatically approve all CSRs made by nodes to renew their client
+# certificates.
+#
+# This binding should be altered in the future to hold a list of node
+# names instead of targeting `system:nodes` so we can revoke invidivual
+# node's ability to renew its certs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-bootstrap-node-renewal
+subjects:
+- kind: Group
+  name: system:nodes
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -16,6 +16,9 @@
 // manifests/machineconfigpool.crd.yaml
 // manifests/machineconfigserver/clusterrole.yaml
 // manifests/machineconfigserver/clusterrolebinding.yaml
+// manifests/machineconfigserver/csr-approver-role-binding.yaml
+// manifests/machineconfigserver/csr-bootstrap-role-binding.yaml
+// manifests/machineconfigserver/csr-renewal-role-binding.yaml
 // manifests/machineconfigserver/daemonset.yaml
 // manifests/machineconfigserver/node-bootstrapper-sa.yaml
 // manifests/machineconfigserver/node-bootstrapper-token.yaml
@@ -685,6 +688,103 @@ func manifestsMachineconfigserverClusterrolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
+var _manifestsMachineconfigserverCsrApproverRoleBindingYaml = []byte(`# CSRApproverRoleBindingTemplate instructs the csrapprover controller to
+# automatically approve CSRs made by serviceaccount node-bootstrapper in openshift-machine-config-operator
+# for client credentials.
+#
+# This binding should be removed to disable CSR auto-approval.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-bootstrap-approve-node-client-csr
+subjects:
+- kind: ServiceAccount
+  name: node-bootstrapper
+  namespace: openshift-machine-config-operator
+roleRef:
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+  apiGroup: rbac.authorization.k8s.io`)
+
+func manifestsMachineconfigserverCsrApproverRoleBindingYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigserverCsrApproverRoleBindingYaml, nil
+}
+
+func manifestsMachineconfigserverCsrApproverRoleBindingYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigserverCsrApproverRoleBindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigserver/csr-approver-role-binding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _manifestsMachineconfigserverCsrBootstrapRoleBindingYaml = []byte(`# system-bootstrap-node-bootstrapper lets serviceaccount `+"`"+`openshift-machine-config-operator/node-bootstrapper`+"`"+` tokens and nodes request CSRs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-bootstrap-node-bootstrapper
+subjects:
+- kind: ServiceAccount
+  name: node-bootstrapper
+  namespace: openshift-machine-config-operator
+roleRef:
+  kind: ClusterRole
+  name: system:node-bootstrapper
+  apiGroup: rbac.authorization.k8s.io`)
+
+func manifestsMachineconfigserverCsrBootstrapRoleBindingYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigserverCsrBootstrapRoleBindingYaml, nil
+}
+
+func manifestsMachineconfigserverCsrBootstrapRoleBindingYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigserverCsrBootstrapRoleBindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigserver/csr-bootstrap-role-binding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _manifestsMachineconfigserverCsrRenewalRoleBindingYaml = []byte(`# CSRRenewalRoleBindingTemplate instructs the csrapprover controller to
+# automatically approve all CSRs made by nodes to renew their client
+# certificates.
+#
+# This binding should be altered in the future to hold a list of node
+# names instead of targeting `+"`"+`system:nodes`+"`"+` so we can revoke invidivual
+# node's ability to renew its certs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-bootstrap-node-renewal
+subjects:
+- kind: Group
+  name: system:nodes
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+  apiGroup: rbac.authorization.k8s.io`)
+
+func manifestsMachineconfigserverCsrRenewalRoleBindingYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigserverCsrRenewalRoleBindingYaml, nil
+}
+
+func manifestsMachineconfigserverCsrRenewalRoleBindingYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigserverCsrRenewalRoleBindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigserver/csr-renewal-role-binding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _manifestsMachineconfigserverDaemonsetYaml = []byte(`apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -934,6 +1034,9 @@ var _bindata = map[string]func() (*asset, error){
 	"manifests/machineconfigpool.crd.yaml": manifestsMachineconfigpoolCrdYaml,
 	"manifests/machineconfigserver/clusterrole.yaml": manifestsMachineconfigserverClusterroleYaml,
 	"manifests/machineconfigserver/clusterrolebinding.yaml": manifestsMachineconfigserverClusterrolebindingYaml,
+	"manifests/machineconfigserver/csr-approver-role-binding.yaml": manifestsMachineconfigserverCsrApproverRoleBindingYaml,
+	"manifests/machineconfigserver/csr-bootstrap-role-binding.yaml": manifestsMachineconfigserverCsrBootstrapRoleBindingYaml,
+	"manifests/machineconfigserver/csr-renewal-role-binding.yaml": manifestsMachineconfigserverCsrRenewalRoleBindingYaml,
 	"manifests/machineconfigserver/daemonset.yaml": manifestsMachineconfigserverDaemonsetYaml,
 	"manifests/machineconfigserver/node-bootstrapper-sa.yaml": manifestsMachineconfigserverNodeBootstrapperSaYaml,
 	"manifests/machineconfigserver/node-bootstrapper-token.yaml": manifestsMachineconfigserverNodeBootstrapperTokenYaml,
@@ -1004,6 +1107,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"machineconfigserver": &bintree{nil, map[string]*bintree{
 			"clusterrole.yaml": &bintree{manifestsMachineconfigserverClusterroleYaml, map[string]*bintree{}},
 			"clusterrolebinding.yaml": &bintree{manifestsMachineconfigserverClusterrolebindingYaml, map[string]*bintree{}},
+			"csr-approver-role-binding.yaml": &bintree{manifestsMachineconfigserverCsrApproverRoleBindingYaml, map[string]*bintree{}},
+			"csr-bootstrap-role-binding.yaml": &bintree{manifestsMachineconfigserverCsrBootstrapRoleBindingYaml, map[string]*bintree{}},
+			"csr-renewal-role-binding.yaml": &bintree{manifestsMachineconfigserverCsrRenewalRoleBindingYaml, map[string]*bintree{}},
 			"daemonset.yaml": &bintree{manifestsMachineconfigserverDaemonsetYaml, map[string]*bintree{}},
 			"node-bootstrapper-sa.yaml": &bintree{manifestsMachineconfigserverNodeBootstrapperSaYaml, map[string]*bintree{}},
 			"node-bootstrapper-token.yaml": &bintree{manifestsMachineconfigserverNodeBootstrapperTokenYaml, map[string]*bintree{}},

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -217,6 +217,9 @@ func (optr *Operator) syncMachineConfigServer(config renderConfig) error {
 
 	crbs := []string{
 		"manifests/machineconfigserver/clusterrolebinding.yaml",
+		"manifests/machineconfigserver/csr-approver-role-binding.yaml",
+		"manifests/machineconfigserver/csr-bootstrap-role-binding.yaml",
+		"manifests/machineconfigserver/csr-renewal-role-binding.yaml",
 	}
 	for _, crb := range crbs {
 		b, err := renderAsset(config, crb)


### PR DESCRIPTION
/cc @mfojtik 

This fixes the error where workers could not join the cluster in absence of KCO in https://github.com/openshift/installer/pull/420

Error from one of the worker
```console
failed to run Kubelet: cannot create certificate signing request: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper" cannot create certificatesigningrequests.certificates.k8s.io at the cluster scope: no RBAC policy matched
```