### PR TITLE
daemon: error out early if we can't talk to rpm-ostree

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -79,6 +79,9 @@ func New(
 	}
 
 	osImageURL, osVersion, err := nodeUpdaterClient.GetBootedOSImageURL(rootMount)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading osImageURL from rpm-ostree: %v", err)
+	}
 	glog.Infof("Booted osImageURL: %s (%s)", osImageURL, osVersion)
 
 	return &Daemon{


### PR DESCRIPTION
Otherwise, there's no sane way to check the OS version.