### PR TITLE
pkg/daemon: remove annotation equality test from validation

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -282,11 +282,6 @@ func (dn *Daemon) isDesiredMachineState() (bool, string, error) {
 	if err != nil {
 		return false, "", err
 	}
-	// if the current annotation is equal to the desired annotation,
-	// system state is valid.
-	if strings.Compare(dcAnnotation, ccAnnotation) == 0 {
-		return true, dcAnnotation, nil
-	}
 
 	currentConfig, err := getMachineConfig(dn.client.MachineconfigurationV1().MachineConfigs(), ccAnnotation)
 	if err != nil {


### PR DESCRIPTION
the node state validation function had a test right at the beginning
that checked if the values of the current annotation and the desired
annotation were equal. if they were, it returned, under the assumption
that because the annotations were equal the node was in the state we
wanted it to be in.

with the way that we try to behave, in general that would be true.
however, we instead opt for more rigorous testing of the node - every
time the validation function is called, it does a full validation of the
node state. if something changed, we attempt to reconcile the state back
to the desired. this also reflects the fact that nobody should be
modifying the node outside of the daemon, and if they do they should
expect to get clobbered.

also, my editor ran gofmt on the file and fixed the import ordering.

fixes #98

/cc @ashcrow @jlebon 