### PR TITLE
Dockerfiles: base off of origin-base

### DIFF
--- a/Dockerfile.machine-config-controller
+++ b/Dockerfile.machine-config-controller
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/openshift/machine-config-operator
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 RUN WHAT=machine-config-controller ./hack/build-go.sh
 
-FROM scratch
+FROM openshift/origin-base:v4.0.0
 COPY --from=build-env /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-controller /bin/machine-config-controller
 COPY templates /etc/mcc/templates
 

--- a/Dockerfile.machine-config-daemon
+++ b/Dockerfile.machine-config-daemon
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/openshift/machine-config-operator
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 RUN WHAT=machine-config-daemon ./hack/build-go.sh
 
-FROM scratch
+FROM openshift/origin-base:v4.0.0
 COPY --from=build-env /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /bin/machine-config-daemon
 
 ENTRYPOINT ["/bin/machine-config-daemon"]

--- a/Dockerfile.machine-config-operator
+++ b/Dockerfile.machine-config-operator
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/openshift/machine-config-operator
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 RUN WHAT=machine-config-operator ./hack/build-go.sh
 
-FROM scratch
+FROM openshift/origin-base:v4.0.0
 COPY --from=build-env /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /bin/machine-config-operator
 COPY install /manifests
 

--- a/Dockerfile.machine-config-server
+++ b/Dockerfile.machine-config-server
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/openshift/machine-config-operator
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 RUN WHAT=machine-config-server ./hack/build-go.sh
 
-FROM scratch
+FROM openshift/origin-base:v4.0.0
 COPY --from=build-env /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /bin/machine-config-server
 
 ENTRYPOINT ["/bin/machine-config-server"]


### PR DESCRIPTION
Be closer to production by using the same base that all origin images
use. Notably, this has a full rootfs, with utilities like `/sbin/chroot`
which is needed for the MCD.

Resolves: #137