### PR TITLE
mcd: fix race condition for annotation updates

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -157,12 +157,7 @@ func updateNodeRetry(client corev1.NodeInterface, node string, f func(*v1.Node))
 	return nil
 }
 
-func setUpdateDone(client corev1.NodeInterface, node string) error {
-	dcAnnotation, err := getNodeAnnotation(client, node, DesiredMachineConfigAnnotationKey)
-	if err != nil {
-		return err
-	}
-
+func setUpdateDone(client corev1.NodeInterface, node string, dcAnnotation string) error {
 	annos := map[string]string{
 		MachineConfigDaemonStateAnnotationKey: MachineConfigDaemonStateDone,
 		CurrentMachineConfigAnnotationKey:     dcAnnotation,


### PR DESCRIPTION
Currently when we finish an update, we re-check the desired config
and indiscriminately set the current config to it. This can cause
an update to be lost since the desired config may have changed
inbetween the isDesired check and when the map is updated. Instead
we should be updating the config to the one we checked for in
isDesired.

Tested the update process, seems fine to work.