### PR TITLE
templates: switch kubelet systemd unit to type notify

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/kubelet.service
@@ -4,6 +4,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/aws/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/aws/worker/units/kubelet.service
@@ -4,6 +4,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/kubelet.service
@@ -4,6 +4,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/libvirt/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/units/kubelet.service
@@ -4,6 +4,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/openstack/master/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/openstack/master/units/kubelet.service
@@ -4,6 +4,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/openstack/worker/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/openstack/worker/units/kubelet.service
@@ -4,6 +4,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/_base/master/units/kubelet.yaml
+++ b/templates/_base/master/units/kubelet.yaml
@@ -6,6 +6,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/_base/worker/units/kubelet.yaml
+++ b/templates/_base/worker/units/kubelet.yaml
@@ -6,6 +6,7 @@ contents: |
   Wants=rpc-statd.service
 
   [Service]
+  Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env


### PR DESCRIPTION
kubelet supports running as systemd unit and sends READY=1 signal when running.
https://github.com/kubernetes/kubernetes/blob/12cf5451952c8425a47334465f3e03d7ca181956/cmd/kubelet/app/server.go#L761-L762

/cc @crawford @sjenning @rphillips 