### PR TITLE
daemon: Adapt to OS being pre-pivoted

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -321,6 +321,12 @@ func (dn *Daemon) isDesiredMachineState() (bool, string, error) {
 
 // checkOS validates the OS image URL and returns true if they match.
 func (dn *Daemon) checkOS(osImageURL string) (bool, error) {
+	// XXX: The installer doesn't pivot yet so for now, just make "://dummy"
+	// match anything. See also: https://github.com/openshift/installer/issues/281
+	if osImageURL == "://dummy" {
+		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
+		return true, nil
+	}
 	return dn.bootedOSImageURL == osImageURL, nil
 }
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/golang/glog"
 )
 
 // RpmOstreeState houses zero or more RpmOstreeDeployments
@@ -73,19 +71,11 @@ func (r *RpmOstreeClient) GetBootedOSImageURL(rootMount string) (string, string,
 	}
 
 	// the canonical image URL is stored in the custom origin field by the pivot tool
-	osImageURL := ""
+	osImageURL := "<not pivoted>"
 	if len(bootedDeployment.CustomOrigin) > 0 {
 		if strings.HasPrefix(bootedDeployment.CustomOrigin[0], "pivot://") {
 			osImageURL = bootedDeployment.CustomOrigin[0][len("pivot://"):]
 		}
-	}
-
-	// XXX: the installer doesn't pivot yet so for now, just make "" equivalent
-	// to "://dummy" so that we don't immediately try to pivot to this dummy
-	// URL. See also: https://github.com/openshift/installer/issues/281
-	if osImageURL == "" {
-		osImageURL = "://dummy"
-		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
 	}
 
 	return osImageURL, bootedDeployment.Version, nil

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -453,6 +453,12 @@ func getFileOwnership(file ignv2_2types.File) (int, int, error) {
 
 // updateOS updates the system OS to the one specified in newConfig
 func (dn *Daemon) updateOS(oldConfig, newConfig *mcfgv1.MachineConfig) error {
+	// see similar logic in checkOS()
+	if newConfig.Spec.OSImageURL == "://dummy" {
+		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
+		return nil
+	}
+
 	if newConfig.Spec.OSImageURL == dn.bootedOSImageURL {
 		return nil
 	}


### PR DESCRIPTION
Now that RHCOS is pre-pivoted (see
https://github.com/openshift/os/issues/307), we need to tweak the logic
here on how we handle `osImageURL`. Notably, we allow `://dummy` from
the installer to always match the current image, regardless of whether
we're pivoted or not. In fact, that should've been the logic from the
start.

Closes: #150