### PR TITLE
cmd/setup-etcd-environment: fix flag bug

### DIFF
--- a/cmd/setup-etcd-environment/main.go
+++ b/cmd/setup-etcd-environment/main.go
@@ -50,7 +50,6 @@ func main() {
 
 func runRootCmd(cmd *cobra.Command, args []string) error {
 	flag.Set("logtostderr", "true")
-	flag.Parse()
 
 	if rootOpts.discoverySRV == "" {
 		return errors.New("--discovery-srv cannot be empty")


### PR DESCRIPTION
seeing this error:
```console
sudo podman run --rm -ti registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment --discovery-srv=origin-ci-int-aws.dev.rhcloud.com
flag provided but not defined: -discovery-srv
Usage of /bin/setup-etcd-environment:
  -alsologtostderr
        log to standard error as well as files
  -log_backtrace_at value
        when logging hits line file:N, emit a stack trace
  -log_dir string
        If non-empty, write log files in this directory
  -logtostderr
        log to standard error instead of files
  -stderrthreshold value
        logs at or above this threshold go to stderr
  -v value
        log level for V logs
  -vmodule value
        comma-separated list of pattern=N settings for file-filtered logging
```