### PR TITLE
templates: fix etcd discovery-srv endpoint

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -307,13 +307,13 @@ func etcdServerCertDNSNames(cfg renderConfig) (interface{}, error) {
 }
 
 func etcdPeerCertDNSNames(cfg renderConfig) (interface{}, error) {
-	if cfg.BaseDomain == "" {
+	if cfg.ClusterName == "" || cfg.BaseDomain == "" {
 		return nil, fmt.Errorf("invalid configuration")
 	}
 
 	var dnsNames = []string{
 		"${ETCD_DNS_NAME}",
-		cfg.BaseDomain, // https://github.com/etcd-io/etcd/blob/583763261f1c843e07c1bf7fea5fb4cfb684fe87/Documentation/op-guide/clustering.md#dns-discovery
+		fmt.Sprintf("%s.%s", cfg.ClusterName, cfg.BaseDomain), // https://github.com/etcd-io/etcd/blob/583763261f1c843e07c1bf7fea5fb4cfb684fe87/Documentation/op-guide/clustering.md#dns-discovery
 	}
 	return strings.Join(dnsNames, ","), nil
 }

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -112,25 +112,39 @@ func TestEtcdPeerCertDNSNames(t *testing.T) {
 	dummyTemplate := []byte(`{{etcdPeerCertDNSNames .}}`)
 
 	cases := []struct {
-		baseDomain string
+		clusterName string
+		baseDomain  string
 
 		url string
 		err bool
 	}{{
-		baseDomain: "",
-		url:        "",
-		err:        true,
+		clusterName: "",
+		baseDomain:  "",
+		url:         "",
+		err:         true,
 	}, {
-		baseDomain: "tt.testing",
-		url:        "${ETCD_DNS_NAME},tt.testing",
-		err:        false,
+		clusterName: "my-test-cluster",
+		baseDomain:  "",
+		url:         "",
+		err:         true,
+	}, {
+		clusterName: "",
+		baseDomain:  "tt.testing",
+		url:         "",
+		err:         true,
+	}, {
+		clusterName: "my-test-cluster",
+		baseDomain:  "tt.testing",
+		url:         "${ETCD_DNS_NAME},my-test-cluster.tt.testing",
+		err:         false,
 	}}
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)
 		t.Run(name, func(t *testing.T) {
 			config := &mcfgv1.ControllerConfig{
 				Spec: mcfgv1.ControllerConfigSpec{
-					BaseDomain: c.baseDomain,
+					ClusterName: c.clusterName,
+					BaseDomain:  c.baseDomain,
 				},
 			}
 			got, err := renderTemplate(renderConfig{&config.Spec}, name, dummyTemplate)

--- a/pkg/controller/template/test_data/templates/aws/master/units/etcd-member.service
+++ b/pkg/controller/template/test_data/templates/aws/master/units/etcd-member.service
@@ -52,7 +52,7 @@ contents: |
             --cacrt=/etc/ssl/etcd/root-ca.crt \
             --assetsdir=/etc/ssl/etcd \
             --address=https://my-test-cluster-api.installer.team.coreos.systems:6443 \
-            --dnsnames=${ETCD_DNS_NAME},installer.team.coreos.systems \
+            --dnsnames=${ETCD_DNS_NAME},my-test-cluster.installer.team.coreos.systems \
             --commonname=system:etcd-peer:${ETCD_DNS_NAME} \
             --ipaddrs=${ETCD_IPV4_ADDRESS} \
   "
@@ -82,7 +82,7 @@ contents: |
         '${ETCD_IMAGE}' \
           /usr/local/bin/etcd \
             --name ${ETCD_DNS_NAME} \
-            --discovery-srv installer.team.coreos.systems \
+            --discovery-srv my-test-cluster.installer.team.coreos.systems \
             --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \

--- a/pkg/controller/template/test_data/templates/libvirt/master/units/etcd-member.service
+++ b/pkg/controller/template/test_data/templates/libvirt/master/units/etcd-member.service
@@ -52,7 +52,7 @@ contents: |
             --cacrt=/etc/ssl/etcd/root-ca.crt \
             --assetsdir=/etc/ssl/etcd \
             --address=https://my-test-cluster-api.installer.team.coreos.systems:6443 \
-            --dnsnames=${ETCD_DNS_NAME},installer.team.coreos.systems \
+            --dnsnames=${ETCD_DNS_NAME},my-test-cluster.installer.team.coreos.systems \
             --commonname=system:etcd-peer:${ETCD_DNS_NAME} \
             --ipaddrs=${ETCD_IPV4_ADDRESS} \
   "
@@ -82,7 +82,7 @@ contents: |
         '${ETCD_IMAGE}' \
           /usr/local/bin/etcd \
             --name ${ETCD_DNS_NAME} \
-            --discovery-srv installer.team.coreos.systems \
+            --discovery-srv my-test-cluster.installer.team.coreos.systems \
             --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \

--- a/pkg/controller/template/test_data/templates/openstack/master/units/etcd-member.service
+++ b/pkg/controller/template/test_data/templates/openstack/master/units/etcd-member.service
@@ -52,7 +52,7 @@ contents: |
             --cacrt=/etc/ssl/etcd/root-ca.crt \
             --assetsdir=/etc/ssl/etcd \
             --address=https://my-test-cluster-api.installer.team.coreos.systems:6443 \
-            --dnsnames=${ETCD_DNS_NAME},installer.team.coreos.systems \
+            --dnsnames=${ETCD_DNS_NAME},my-test-cluster.installer.team.coreos.systems \
             --commonname=system:etcd-peer:${ETCD_DNS_NAME} \
             --ipaddrs=${ETCD_IPV4_ADDRESS} \
   "
@@ -82,7 +82,7 @@ contents: |
         '${ETCD_IMAGE}' \
           /usr/local/bin/etcd \
             --name ${ETCD_DNS_NAME} \
-            --discovery-srv installer.team.coreos.systems \
+            --discovery-srv my-test-cluster.installer.team.coreos.systems \
             --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \

--- a/templates/_base/master/units/etcd-member.yaml
+++ b/templates/_base/master/units/etcd-member.yaml
@@ -84,7 +84,7 @@ contents: |
         '${ETCD_IMAGE}' \
           /usr/local/bin/etcd \
             --name ${ETCD_DNS_NAME} \
-            --discovery-srv {{.BaseDomain}} \
+            --discovery-srv {{.ClusterName}}.{{.BaseDomain}} \
             --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \


### PR DESCRIPTION
https://github.com/openshift/machine-config-operator/pull/155 missed changing the
--discovery-srv flag on etcd to cluster-name.basedomain

/cc @crawford 