### PR TITLE
Pass ssh keys from clusterconfig to machineconfig

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -57,7 +57,7 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setStringIfSet(modified, &existing.ClusterName, required.ClusterName)
 	setStringIfSet(modified, &existing.Platform, required.Platform)
 	setStringIfSet(modified, &existing.BaseDomain, required.BaseDomain)
-	setStringIfSet(modified, &existing.Platform, required.Platform)
+	setStringIfSet(modified, &existing.SSHKey, required.SSHKey)
 
 	setBytesIfSet(modified, &existing.EtcdCAData, required.EtcdCAData)
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -58,6 +58,8 @@ type MCOConfigSpec struct {
 	Platform string `json:"platform"`
 
 	BaseDomain string `json:"baseDomain"`
+
+	SSHKey string `json:"sshKey"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -129,6 +131,9 @@ type ControllerConfigSpec struct {
 	// PullSecret is the default pull secret that needs to be installed
 	// on all machines.
 	PullSecret *corev1.ObjectReference `json:"pullSecret,omitempty"`
+
+	// Public SSH
+	SSHKey string `json:"sshKey"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -56,6 +56,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 		return err
 	}
 
+	if err = dn.updateSSHKeys(newConfig.Spec.Config.Passwd.Users); err != nil {
+		return err
+	}
+
 	// TODO: Change the logic to be clearer
 	// We need to skip draining of the node when we are running once
 	// and there is no cluster.
@@ -93,7 +97,9 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 // we can only update machine configs that have changes to the files,
 // directories, links, and systemd units sections of the included ignition
 // config currently.
+
 func (dn *Daemon) reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) *string {
+	glog.Info("Checking if configs are reconcilable")
 	// We skip out of reconcilable if there is no Kind and we are in runOnce mode. The
 	// reason is that there is a good chance a previous state is not available to match against.
 	if oldConfig.Kind == "" && dn.onceFrom != "" {
@@ -131,8 +137,25 @@ func (dn *Daemon) reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) *stri
 	// we don't currently configure groups or users in place. we can't fix it if
 	// something changed here.
 	if !reflect.DeepEqual(oldIgn.Passwd, newIgn.Passwd) {
-		msg := "Ignition passwd section contains changes"
-		return &msg
+		if !reflect.DeepEqual(oldIgn.Passwd.Groups, newIgn.Passwd.Groups) {
+			msg := "Ignition Passwd Groups section contains changes"
+			return &msg
+		}
+		// check if the prior config is empty and that this is the first time running.
+		// if so, the SSHKey from the cluster config and user "core" must be added to machine config,.
+		if !reflect.DeepEqual(oldIgn.Passwd.Users, newIgn.Passwd.Users) {
+			if len(oldIgn.Passwd.Users) == 0 && len(newIgn.Passwd.Users) == 1 {
+				if newIgn.Passwd.Users[0].Name == "core" && len(newIgn.Passwd.Users[0].SSHAuthorizedKeys) > 0 {
+					glog.Info("SSH Keys reconcilable")
+				} else {
+					msg := "Ignition passwd user section contains unsupported changes"
+					return &msg
+				}
+			}
+		} else {
+			msg := "Ignition passwd section contains unsupported changes"
+			return &msg
+		}
 	}
 
 	// Storage section
@@ -462,6 +485,37 @@ func getFileOwnership(file ignv2_2types.File) (int, int, error) {
 		}
 	}
 	return uid, gid, nil
+}
+
+// Update a given PasswdUser's SSHKey
+func (dn *Daemon) updateSSHKeys(newUsers []ignv2_2types.PasswdUser) error {
+	// Keys should only be written to "/home/core/.ssh"
+	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
+	if newUsers[0].Name != "core" {
+		// Double checking that we are only writing SSH Keys for user "core"
+		return fmt.Errorf("Expecting user core. Got %s instead", newUsers[0].Name)
+	}
+	sshDirPath := filepath.Join("/home", newUsers[0].Name, ".ssh")
+	// we are only dealing with the "core" User at this time, so only dealing with the first entry in Users[]
+	glog.Infof("Writing SSHKeys at %q:", sshDirPath)
+	if err := dn.fileSystemClient.MkdirAll(filepath.Dir(sshDirPath), os.FileMode(0600)); err != nil {
+		return fmt.Errorf("Failed to create directory %q: %v", filepath.Dir(sshDirPath), err)
+	}
+	glog.V(2).Infof("Created directory: %s", sshDirPath)
+
+	authkeypath := filepath.Join(sshDirPath, "authorized_keys")
+	var concatSSHKeys string
+	for _, k := range newUsers[0].SSHAuthorizedKeys {
+		concatSSHKeys = concatSSHKeys + string(k) + "\n"
+	}
+
+	if err := dn.fileSystemClient.WriteFile(authkeypath, []byte(concatSSHKeys), os.FileMode(0600)); err != nil {
+		return fmt.Errorf("Failed to write ssh key: %v", err)
+	}
+
+	glog.V(2).Infof("Wrote SSHKeys at %s", sshDirPath)
+
+	return nil
 }
 
 // updateOS updates the system OS to the one specified in newConfig

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	configclientset "github.com/openshift/client-go/config/clientset/versioned"
-	installertypes "github.com/openshift/installer/pkg/types"
+
 	"k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextinformersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
@@ -28,7 +27,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-
+	
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	installertypes "github.com/openshift/installer/pkg/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/scheme"
@@ -310,6 +311,7 @@ func getRenderConfig(mc *mcfgv1.MCOConfig, etcdCAData, rootCAData []byte, ps *v1
 		EtcdCAData:          etcdCAData,
 		RootCAData:          rootCAData,
 		PullSecret:          ps,
+		SSHKey:              mc.Spec.SSHKey,
 	}
 	return renderConfig{
 		TargetNamespace:  mc.GetNamespace(),

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -10,7 +10,6 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/ghodss/yaml"
 	installertypes "github.com/openshift/installer/pkg/types"
-
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/operator/assets"
 )
@@ -58,7 +57,6 @@ func discoverMCOConfig(f installConfigGetter) (*mcfgv1.MCOConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	dnsIP, err := clusterDNSIP(ic.Networking.ServiceCIDR.String())
 	if err != nil {
 		return nil, err
@@ -71,6 +69,7 @@ func discoverMCOConfig(f installConfigGetter) (*mcfgv1.MCOConfig, error) {
 			ClusterName:         ic.ObjectMeta.Name,
 			Platform:            platformFromInstallConfig(ic),
 			BaseDomain:          ic.BaseDomain,
+			SSHKey:              ic.SSHKey,
 		},
 	}, nil
 }


### PR DESCRIPTION
Closes https://github.com/openshift/installer/issues/578

Summary of issue: the ClusterConfig has the SSH key and while that key is being passed into the MCO, the MCO isn't properly adding it to the MachineConfig. This prevents us from being able add functionality to MCD updating existing SSH keys in a MachineConfig's Spec.Config.Passwd.Users.

Comments & feedback welcome!
cc: @abhinavdahiya @wking 