### PR TITLE
daemon: Only check osImageURL on RHCOS

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -439,9 +439,17 @@ func (dn *Daemon) isDesiredMachineState() (bool, string, error) {
 		return false, "", nil
 	}
 
-	isDesiredOS, err := dn.checkOS(desiredConfig.Spec.OSImageURL)
-	if err != nil {
-		return false, "", err
+	isDesiredOS := false
+	// We only deal with operating system management on RHCOS
+	if dn.OperatingSystem != MachineConfigDaemonOSRHCOS {
+		// If we are on anything but RHCOS we set to True as there
+		// is nothing to updated.
+		isDesiredOS = true
+	} else {
+		isDesiredOS, err = dn.checkOS(desiredConfig.Spec.OSImageURL)
+		if err != nil {
+			return false, "", err
+		}
 	}
 
 	if dn.checkFiles(desiredConfig.Spec.Config.Storage.Files) &&

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -85,13 +85,15 @@ func New(
 		return nil, fmt.Errorf("Error establishing connection to logind dbus: %v", err)
 	}
 
-	osImageURL, osVersion, err := nodeUpdaterClient.GetBootedOSImageURL(rootMount)
-	if err != nil {
-		return nil, fmt.Errorf("Error reading osImageURL from rpm-ostree: %v", err)
+	osImageURL := ""
+	// Only pull the osImageURL from OSTree when we are on RHCOS
+	if operatingSystem == MachineConfigDaemonOSRHCOS {
+		osImageURL, osVersion, err := nodeUpdaterClient.GetBootedOSImageURL(rootMount)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading osImageURL from rpm-ostree: %v", err)
+		}
+		glog.Infof("Booted osImageURL: %s (%s)", osImageURL, osVersion)
 	}
-
-	glog.Infof("Booted osImageURL: %s (%s)", osImageURL, osVersion)
-
 	dn := &Daemon{
 		name:              nodeName,
 		OperatingSystem:   operatingSystem,

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -465,6 +465,10 @@ func getFileOwnership(file ignv2_2types.File) (int, int, error) {
 
 // updateOS updates the system OS to the one specified in newConfig
 func (dn *Daemon) updateOS(oldConfig, newConfig *mcfgv1.MachineConfig) error {
+	if dn.OperatingSystem != MachineConfigDaemonOSRHCOS {
+		glog.V(2).Infof("Updating of non RHCOS nodes are not supported")
+		return nil
+	}
 	// see similar logic in checkOS()
 	if newConfig.Spec.OSImageURL == "://dummy" {
 		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)


### PR DESCRIPTION
This will get past the `ostree` hit that @michaelgugino found on RHEL. I'm looking to see if there are any other hits that may cause an error on non RHCOS nodes just incase.