### PR TITLE
MCD: Fix ValidPath function

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -588,7 +588,6 @@ func getMachineConfig(client mcfgclientv1.MachineConfigInterface, name string) (
 // ValidPath attempts to see if the path provided is indeed an acceptable
 // filesystem path. This function does not check if the path exists.
 func ValidPath(path string) bool {
-	path = filepath.Clean(path)
 	for _, validStart := range []string{".", "..", "/"} {
 		if strings.HasPrefix(path, validStart) {
 			return true

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"strconv"
+	"testing"
+)
+
+var pathtests = []struct {
+	path    string
+	isValid bool
+}{
+	{".good", true},
+	{"./good", true},
+	{"/good", true},
+	{"../good", true},
+	{"bad", false},
+}
+
+func TestValidPath(t *testing.T) {
+	var isValid bool
+	for _, tt := range pathtests {
+		isValid = ValidPath(tt.path)
+		if isValid != tt.isValid {
+			t.Errorf("%s isValid should be %s, found %s", tt.path, strconv.FormatBool(tt.isValid), strconv.FormatBool(isValid))
+		}
+	}
+}


### PR DESCRIPTION
This commit corrects logic to ensure ValidPath works as intended.

ilepath.Clean strips leading '.' from path and should be removed.