### PR TITLE
MCD: Fix once-from start

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -73,7 +73,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	// If we are asked to run once and it's a valid file system path use
 	// the bare Daemon
-	if startOpts.onceFrom != "" && daemon.ValidPath(startOpts.onceFrom) {
+	if startOpts.onceFrom != "" {
 		dn, err = daemon.New(
 			startOpts.rootMount,
 			startOpts.nodeName,


### PR DESCRIPTION
Currently, if an invalid path is provided to mcd with
once-from, mcd will attempt to start in normal mode.

We validate the path later in the process, this commit
ensures we don't start mcd in normal mode by mistake.