### PR TITLE
Sync pull secret from `kube-system/coreos-pull-secret` to disk

### DIFF
--- a/cmd/machine-config-controller/bootstrap.go
+++ b/cmd/machine-config-controller/bootstrap.go
@@ -21,6 +21,7 @@ var (
 	bootstrapOpts struct {
 		manifestsDir   string
 		destinationDir string
+		pullSecretFile string
 	}
 )
 
@@ -28,7 +29,7 @@ func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination dir where MCC writes the generated machineconfigs and machineconfigpools.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.manifestsDir, "manifest-dir", "", "The dir where MCC reads the controllerconfig, machineconfigpools and user-defined machineconfigs.")
-
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "", "The pull secret file.")
 }
 
 func runbootstrapCmd(cmd *cobra.Command, args []string) {
@@ -42,7 +43,7 @@ func runbootstrapCmd(cmd *cobra.Command, args []string) {
 		glog.Fatalf("--dest-dir or --mainfest-dir not set")
 	}
 
-	if err := bootstrap.New(rootOpts.templates, bootstrapOpts.manifestsDir).Run(bootstrapOpts.destinationDir); err != nil {
+	if err := bootstrap.New(rootOpts.templates, bootstrapOpts.manifestsDir, bootstrapOpts.pullSecretFile).Run(bootstrapOpts.destinationDir); err != nil {
 		glog.Fatalf("error running MCC[BOOTSTRAP]: %v", err)
 	}
 }

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -27,6 +27,7 @@ var (
 	bootstrapOpts struct {
 		etcdCAFile          string
 		rootCAFile          string
+		pullSecretFile      string
 		configFile          string
 		imagesConfigMapFile string
 		mccImage            string
@@ -40,6 +41,7 @@ func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdCAFile, "etcd-ca", "/etc/ssl/etcd/ca.crt", "path to etcd CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.rootCAFile, "root-ca", "/etc/ssl/kubernetes/ca.crt", "path to root CA certificate")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "/assets/manifests/pull.json", "path to secret manifest that contains pull secret.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.imagesConfigMapFile, "images-json-configmap", "", "ConfigMap that contains images.json for MCO.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mccImage, "machine-config-controller-image", "", "Image for Machine Config Controller. (this cannot be set if --images-json-configmap is set)")
@@ -86,7 +88,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	}
 	if err := operator.RenderBootstrap(
 		bootstrapOpts.configFile,
-		bootstrapOpts.etcdCAFile, bootstrapOpts.rootCAFile,
+		bootstrapOpts.etcdCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.pullSecretFile,
 		imgs,
 		bootstrapOpts.destinationDir,
 	); err != nil {

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -58,4 +58,12 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setStringIfSet(modified, &existing.Platform, required.Platform)
 	setStringIfSet(modified, &existing.BaseDomain, required.BaseDomain)
 	setStringIfSet(modified, &existing.Platform, required.Platform)
+
+	setBytesIfSet(modified, &existing.EtcdCAData, required.EtcdCAData)
+	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)
+
+	if required.PullSecret != nil && !equality.Semantic.DeepEqual(existing.PullSecret, required.PullSecret) {
+		existing.PullSecret = required.PullSecret
+		*modified = true
+	}
 }

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -25,6 +25,16 @@ func setStringIfSet(modified *bool, existing *string, required string) {
 	}
 }
 
+func setBytesIfSet(modified *bool, existing *[]byte, required []byte) {
+	if len(required) == 0 {
+		return
+	}
+	if string(required) != string(*existing) {
+		*existing = required
+		*modified = true
+	}
+}
+
 func mergeMap(modified *bool, existing *map[string]string, required map[string]string) {
 	if *existing == nil {
 		*existing = map[string]string{}

--- a/manifests/bootstrap-pod.yaml
+++ b/manifests/bootstrap-pod.yaml
@@ -11,6 +11,7 @@ spec:
     - "bootstrap"
     - "--manifest-dir=/etc/mcc/bootstrap/manifests"
     - "--dest-dir=/etc/mcc/bootstrap/server"
+    - "--pull-secret=/etc/mcc/bootstrap/manifests/machineconfigcontroller-pull-secret"
     resources:
       limits:
         cpu: 20m

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -11,5 +11,5 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"]
   verbs: ["*"]

--- a/manifests/machineconfigcontroller/controllerconfig.yaml
+++ b/manifests/machineconfigcontroller/controllerconfig.yaml
@@ -4,10 +4,4 @@ metadata:
   name: machine-config-controller
   namespace: {{.TargetNamespace}}
 spec:
-  clusterDNSIP: {{.ControllerConfig.ClusterDNSIP}}
-  cloudProviderConfig: {{.ControllerConfig.CloudProviderConfig}}
-  clusterName: {{.ControllerConfig.ClusterName}}
-  platform: {{.ControllerConfig.Platform}}
-  baseDomain: {{.ControllerConfig.BaseDomain}}
-  etcdCAData: {{.ControllerConfig.EtcdCAData | toString | b64enc}}
-  rootCAData: {{.ControllerConfig.RootCAData | toString | b64enc}}
+{{toYAML .ControllerConfig | toString | indent 2}}

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -125,6 +125,10 @@ type ControllerConfigSpec struct {
 	// CAs
 	EtcdCAData []byte `json:"etcdCAData"`
 	RootCAData []byte `json:"rootCAData"`
+
+	// PullSecret is the default pull secret that needs to be installed
+	// on all machines.
+	PullSecret *corev1.ObjectReference `json:"pullSecret,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -82,6 +83,11 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		in, out := &in.RootCAData, &out.RootCAData
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
+	}
+	if in.PullSecret != nil {
+		in, out := &in.PullSecret, &out.PullSecret
+		*out = new(corev1.ObjectReference)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -24,6 +24,7 @@ import (
 // renderConfig is wrapper around ControllerConfigSpec.
 type renderConfig struct {
 	*mcfgv1.ControllerConfigSpec
+	PullSecret string
 }
 
 const (

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -50,7 +50,7 @@ func TestCloudProvider(t *testing.T) {
 					Platform: c.platform,
 				},
 			}
-			got, err := renderTemplate(renderConfig{&config.Spec}, name, dummyTemplate)
+			got, err := renderTemplate(renderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -96,7 +96,7 @@ func TestAPIServerURL(t *testing.T) {
 					ClusterName: c.clusterName,
 				},
 			}
-			got, err := renderTemplate(renderConfig{&config.Spec}, name, dummyTemplate)
+			got, err := renderTemplate(renderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
 			if err != nil && !c.err {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -147,7 +147,7 @@ func TestEtcdPeerCertDNSNames(t *testing.T) {
 					BaseDomain:  c.baseDomain,
 				},
 			}
-			got, err := renderTemplate(renderConfig{&config.Spec}, name, dummyTemplate)
+			got, err := renderTemplate(renderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
 			if err != nil && !c.err {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -184,7 +184,7 @@ func TestEtcdServerCertDNSNames(t *testing.T) {
 					BaseDomain: c.baseDomain,
 				},
 			}
-			got, err := renderTemplate(renderConfig{&config.Spec}, name, dummyTemplate)
+			got, err := renderTemplate(renderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
 			if err != nil && !c.err {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -271,11 +271,11 @@ func TestInvalidPlatform(t *testing.T) {
 	}
 
 	controllerConfig.Spec.Platform = "_bad_"
-	_, err = generateMachineConfigs(&renderConfig{&controllerConfig.Spec}, templateDir)
+	_, err = generateMachineConfigs(&renderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 	expectErr(err, "platform _bad_ unsupported")
 
 	controllerConfig.Spec.Platform = "_base"
-	_, err = generateMachineConfigs(&renderConfig{&controllerConfig.Spec}, templateDir)
+	_, err = generateMachineConfigs(&renderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 	expectErr(err, "platform _base unsupported")
 }
 
@@ -286,7 +286,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 			t.Fatalf("failed to get controllerconfig config: %v", err)
 		}
 
-		cfgs, err := generateMachineConfigs(&renderConfig{&controllerConfig.Spec}, templateDir)
+		cfgs, err := generateMachineConfigs(&renderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 		if err != nil {
 			t.Fatalf("failed to generate machine configs: %v", err)
 		}

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -203,7 +203,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 	f.ccLister = append(f.ccLister, cc)
 	f.objects = append(f.objects, cc)
 
-	expMCs, err := getMachineConfigsForControllerConfig(templateDir, cc)
+	expMCs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 func TestDoNothing(t *testing.T) {
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc)
+	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestDoNothing(t *testing.T) {
 func TestRecreateMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc)
+	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 func TestUpdateMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc)
+	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 		f.objects = append(f.objects, mcs[idx])
 	}
 
-	expmcs, err := getMachineConfigsForControllerConfig(templateDir, cc)
+	expmcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/template/test_data/controller_config_aws.yaml
+++ b/pkg/controller/template/test_data/controller_config_aws.yaml
@@ -9,3 +9,5 @@ spec:
   platform: "aws"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_libvirt.yaml
+++ b/pkg/controller/template/test_data/controller_config_libvirt.yaml
@@ -9,3 +9,5 @@ spec:
   platform: "libvirt"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_openstack.yaml
+++ b/pkg/controller/template/test_data/controller_config_openstack.yaml
@@ -9,3 +9,5 @@ spec:
   platform: "openstack"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/templates/aws/master/files/-var-lib-kubelet-config.json
+++ b/pkg/controller/template/test_data/templates/aws/master/files/-var-lib-kubelet-config.json
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%7B%22dummy%22%3A%22dummy%22%7D%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /var/lib/kubelet/config.json

--- a/pkg/controller/template/test_data/templates/aws/worker/files/-var-lib-kubelet-config.json
+++ b/pkg/controller/template/test_data/templates/aws/worker/files/-var-lib-kubelet-config.json
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%7B%22dummy%22%3A%22dummy%22%7D%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /var/lib/kubelet/config.json

--- a/pkg/controller/template/test_data/templates/libvirt/master/files/-var-lib-kubelet-config.json
+++ b/pkg/controller/template/test_data/templates/libvirt/master/files/-var-lib-kubelet-config.json
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%7B%22dummy%22%3A%22dummy%22%7D%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /var/lib/kubelet/config.json

--- a/pkg/controller/template/test_data/templates/libvirt/worker/files/-var-lib-kubelet-config.json
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/files/-var-lib-kubelet-config.json
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%7B%22dummy%22%3A%22dummy%22%7D%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /var/lib/kubelet/config.json

--- a/pkg/controller/template/test_data/templates/openstack/master/files/-var-lib-kubelet-config.json
+++ b/pkg/controller/template/test_data/templates/openstack/master/files/-var-lib-kubelet-config.json
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%7B%22dummy%22%3A%22dummy%22%7D%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /var/lib/kubelet/config.json

--- a/pkg/controller/template/test_data/templates/openstack/worker/files/-var-lib-kubelet-config.json
+++ b/pkg/controller/template/test_data/templates/openstack/worker/files/-var-lib-kubelet-config.json
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%7B%22dummy%22%3A%22dummy%22%7D%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /var/lib/kubelet/config.json

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -81,6 +81,7 @@ spec:
     - "bootstrap"
     - "--manifest-dir=/etc/mcc/bootstrap/manifests"
     - "--dest-dir=/etc/mcc/bootstrap/server"
+    - "--pull-secret=/etc/mcc/bootstrap/manifests/machineconfigcontroller-pull-secret"
     resources:
       limits:
         cpu: 20m
@@ -245,7 +246,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"]
   verbs: ["*"]
 `)
 
@@ -299,13 +300,7 @@ metadata:
   name: machine-config-controller
   namespace: {{.TargetNamespace}}
 spec:
-  clusterDNSIP: {{.ControllerConfig.ClusterDNSIP}}
-  cloudProviderConfig: {{.ControllerConfig.CloudProviderConfig}}
-  clusterName: {{.ControllerConfig.ClusterName}}
-  platform: {{.ControllerConfig.Platform}}
-  baseDomain: {{.ControllerConfig.BaseDomain}}
-  etcdCAData: {{.ControllerConfig.EtcdCAData | toString | b64enc}}
-  rootCAData: {{.ControllerConfig.RootCAData | toString | b64enc}}
+{{toYAML .ControllerConfig | toString | indent 2}}
 `)
 
 func manifestsMachineconfigcontrollerControllerconfigYamlBytes() ([]byte, error) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -256,7 +256,7 @@ func (optr *Operator) sync(key string) error {
 		return err
 	}
 
-	rc := getRenderConfig(mcoconfig, etcdCA, rootCA, imgs)
+	rc := getRenderConfig(mcoconfig, etcdCA, rootCA, &v1.ObjectReference{Namespace: "kube-system", Name: "coreos-pull-secret"}, imgs)
 	return optr.syncAll(rc)
 }
 
@@ -306,7 +306,7 @@ func icFromClusterConfig(cm *v1.ConfigMap) (installertypes.InstallConfig, error)
 	return ic, nil
 }
 
-func getRenderConfig(mc *mcfgv1.MCOConfig, etcdCAData, rootCAData []byte, imgs Images) renderConfig {
+func getRenderConfig(mc *mcfgv1.MCOConfig, etcdCAData, rootCAData []byte, ps *v1.ObjectReference, imgs Images) renderConfig {
 	controllerconfig := mcfgv1.ControllerConfigSpec{
 		ClusterDNSIP:        mc.Spec.ClusterDNSIP,
 		CloudProviderConfig: mc.Spec.CloudProviderConfig,
@@ -315,6 +315,7 @@ func getRenderConfig(mc *mcfgv1.MCOConfig, etcdCAData, rootCAData []byte, imgs I
 		BaseDomain:          mc.Spec.BaseDomain,
 		EtcdCAData:          etcdCAData,
 		RootCAData:          rootCAData,
+		PullSecret:          ps,
 	}
 	return renderConfig{
 		TargetNamespace:  mc.GetNamespace(),

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/apparentlymart/go-cidr/cidr"
+	"github.com/ghodss/yaml"
 	installertypes "github.com/openshift/installer/pkg/types"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -28,6 +29,7 @@ func renderAsset(config renderConfig, path string) ([]byte, error) {
 	}
 
 	funcs := sprig.TxtFuncMap()
+	funcs["toYAML"] = toYAML
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(objBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse asset %s: %v", path, err)
@@ -39,6 +41,14 @@ func renderAsset(config renderConfig, path string) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func toYAML(i interface{}) []byte {
+	out, err := yaml.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	return out
 }
 
 type installConfigGetter func() (installertypes.InstallConfig, error)

--- a/templates/_base/master/files/pull-secret.yaml
+++ b/templates/_base/master/files/pull-secret.yaml
@@ -1,0 +1,6 @@
+filesystem: "root"
+mode: 0644
+path: "/var/lib/kubelet/config.json"
+contents:
+  inline: |
+    {{.PullSecret}}

--- a/templates/_base/worker/files/pull-secret.yaml
+++ b/templates/_base/worker/files/pull-secret.yaml
@@ -1,0 +1,6 @@
+filesystem: "root"
+mode: 0644
+path: "/var/lib/kubelet/config.json"
+contents:
+  inline: |
+    {{.PullSecret}}


### PR DESCRIPTION
Updates the MCC to read pull-secret from `Secret` (used in cluster) or `Inline data` (used during bootstrapping).

This reads the `kube-system/coreos-pull-secret` Secret from the api.