### PR TITLE
pkg/controller: disable kubelet readonly port

### DIFF
--- a/pkg/controller/template/test_data/templates/aws/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/aws/master/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AreadOnlyPort%3A%2010255%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/aws/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/aws/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AreadOnlyPort%3A%2010255%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/libvirt/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/libvirt/master/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AreadOnlyPort%3A%2010255%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/libvirt/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/libvirt/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AreadOnlyPort%3A%2010255%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/openstack/master/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/openstack/master/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AreadOnlyPort%3A%2010255%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/openstack/worker/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/openstack/worker/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AreadOnlyPort%3A%2010255%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/templates/_base/master/files/kubelet.yaml
+++ b/templates/_base/master/files/kubelet.yaml
@@ -9,7 +9,6 @@ contents:
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
-    readOnlyPort: 10255
     runtimeRequestTimeout: 10m
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests

--- a/templates/_base/worker/files/kubelet.yaml
+++ b/templates/_base/worker/files/kubelet.yaml
@@ -9,7 +9,6 @@ contents:
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
-    readOnlyPort: 10255
     rotateCertificates: true
     runtimeRequestTimeout: 10m
     serializeImagePulls: false


### PR DESCRIPTION
The readonly port is no longer needed since we do not depend on the pod checkpointer.

/cc @sjenning @rphillips 
