### PR TITLE
daemon: Remove workaround comparison to ://dummy

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -592,12 +592,6 @@ func (dn *Daemon) isDesiredMachineState() (bool, string, error) {
 
 // checkOS validates the OS image URL and returns true if they match.
 func (dn *Daemon) checkOS(osImageURL string) (bool, error) {
-	// XXX: The installer doesn't pivot yet so for now, just make "://dummy"
-	// match anything. See also: https://github.com/openshift/installer/issues/281
-	if osImageURL == "://dummy" {
-		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
-		return true, nil
-	}
 	return dn.bootedOSImageURL == osImageURL, nil
 }
 


### PR DESCRIPTION
The installer always pivots now.