### PR TITLE
hack: change override env for version in build-go.sh

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -15,12 +15,12 @@ GOARCH=${GOACH:-${GOHOSTARCH}}
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)"
 
-if [ -z ${VERSION+a} ]; then
+if [ -z ${VERSION_OVERRIDE+a} ]; then
 	echo "Using version from git..."
-	VERSION=$(git describe --abbrev=8 --dirty --always)
+	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
-GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION}"
+GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
 
 eval $(go env)
 


### PR DESCRIPTION
One of the CI runs shows `1.10.3` as the version chosen for build of machine config operator
```console
Pulling image "docker-registry.default.svc:5000/ci-op-39bh1qy5/pipeline@sha256:daa33010e3225f7abefc2358aaff9891353e86b3d7dde7257982fb487a298e6b" ...
Replaced Dockerfile FROM image registry.svc.ci.openshift.org/openshift/origin-v4.0:base

Pulling image docker-registry.default.svc:5000/ci-op-39bh1qy5/pipeline@sha256:02b13d581ad7d92b43d0557a26e804c06f7f35261cbed17ac91b21a468483ff9 ...

Pulling image registry.svc.ci.openshift.org/openshift/release:golang-1.10 ...
--> FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 as builder
--> WORKDIR /go/src/github.com/openshift/machine-config-operator
--> COPY . .
--> RUN WHAT=machine-config-operator ./hack/build-go.sh
Building github.com/openshift/machine-config-operator/cmd/machine-config-operator (1.10.3)
--> FROM docker-registry.default.svc:5000/ci-op-39bh1qy5/pipeline@sha256:02b13d581ad7d92b43d0557a26e804c06f7f35261cbed17ac91b21a468483ff9 as 1
--> COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /usr/bin/
--> COPY install /manifests
--> ENTRYPOINT ["/usr/bin/machine-config-operator"]
--> LABEL io.openshift.release.operator=true
--> ENV "OPENSHIFT_BUILD_NAME"="machine-config-operator" "OPENSHIFT_BUILD_NAMESPACE"="ci-op-39bh1qy5"
--> LABEL "io.openshift.build.name"="machine-config-operator" "io.openshift.build.namespace"="ci-op-39bh1qy5" "vcs-ref"="" "vcs-url"="" "io.openshift.build.commit.id"="" "io.openshift.build.commit.message"="" "io.openshift.build.commit.author"="" "io.openshift.build.source-location"="" "io.openshift.build.source-context-dir"="" "vcs-type"="" "io.openshift.build.name"="" "io.openshift.build.namespace"="" "io.openshift.build.commit.ref"="" "io.openshift.build.commit.date"=""
--> Committing changes to temp.builder.openshift.io/ci-op-39bh1qy5/machine-config-operator:b2d8da48 ...
--> Done

Pushing image docker-registry.default.svc:5000/ci-op-39bh1qy5/pipeline:machine-config-operator ...
Pushed 2/3 layers, 71% complete
Pushed 3/3 layers, 100% complete
Push successful
```
`Building github.com/openshift/machine-config-operator/cmd/machine-config-operator (1.10.3)`

Turns out `registry.svc.ci.openshift.org/openshift/release:golang-1.10` has `VERSION` env set to golang's version. So switching to `VERSION_OVERRIDE` prevents conflicts.

/cc @jlebon @ashcrow 