### PR TITLE
Use "" for "unspecified OS", tweak comments

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -203,10 +203,6 @@ func generateMachineConfigForRole(config *renderConfig, roleName string, roleDir
 const (
 	machineConfigNameTmpl     = "00-%s"
 	machineConfigRoleLabelKey = "machineconfiguration.openshift.io/role"
-
-	// DefaultOSImageURL is the value used for OSImageURL field.
-	// TODO: this might have to be configured using ControllerConfig.
-	DefaultOSImageURL = "://dummy"
 )
 
 func machineConfigFromIgnConfig(role string, ignCfg *ignv2_2types.Config) *mcfgv1.MachineConfig {
@@ -220,7 +216,7 @@ func machineConfigFromIgnConfig(role string, ignCfg *ignv2_2types.Config) *mcfgv
 			Name:   name,
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL: DefaultOSImageURL,
+			OSImageURL: "",
 			Config:     *ignCfg,
 		},
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -555,12 +555,19 @@ func (dn *Daemon) isDesiredMachineState() (bool, string, error) {
 	return false, "", nil
 }
 
+// isUnspecifiedOS says whether an osImageURL is "unspecified",
+// i.e. we should not try to change the current state.
+func (dn *Daemon) isUnspecifiedOS(osImageURL string) bool {
+	// The ://dummy syntax is legacy
+	return osImageURL == "" || osImageURL == "://dummy";
+}
+
 // checkOS validates the OS image URL and returns true if they match.
 func (dn *Daemon) checkOS(osImageURL string) (bool, error) {
-	// XXX: The installer doesn't pivot yet so for now, just make "://dummy"
-	// match anything. See also: https://github.com/openshift/installer/issues/281
-	if osImageURL == "://dummy" {
-		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
+	// XXX: The installer doesn't pivot yet so for now, just make ""
+	// mean "unset, don't pivot". See also: https://github.com/openshift/installer/issues/281
+	if dn.isUnspecifiedOS(osImageURL) {
+		glog.Infof(`No target osImageURL provided`)
 		return true, nil
 	}
 	return dn.bootedOSImageURL == osImageURL, nil

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -469,8 +469,8 @@ func (dn *Daemon) updateOS(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 		return nil
 	}
 	// see similar logic in checkOS()
-	if newConfig.Spec.OSImageURL == "://dummy" {
-		glog.Warningf(`Working around "://dummy" OS image URL until installer ➰ pivots`)
+	if dn.isUnspecifiedOS(newConfig.Spec.OSImageURL) {
+		glog.Infof(`No target osImageURL provided`)
 		return nil
 	}
 


### PR DESCRIPTION
The fact that `://dummy` is not a valid URL syntax was bothering me,
let's support (and default to) the empty string to mean unset.

Use a common function for handling this, and also change the comments
to clarify that we're not today "working around" the installer, it's
simply not specified.