### PR TITLE
daemon: tweak log message

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -100,7 +100,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	} else {
 		cb, err := common.NewClientBuilder(startOpts.kubeconfig)
 		if err != nil {
-			glog.Fatalf("failed to initialize daemon: %v", err)
+			glog.Fatalf("failed to initialize ClientBuilder: %v", err)
 		}
 		ctx = common.CreateControllerContext(cb, stopCh, componentName)
 		// create the daemon instance. this also initializes kube client items


### PR DESCRIPTION
We had two "failed to initialize daemon" log messages in the
`runStartCmd()` function. One can still distinguish which one was
emitted since glog does print the line number too, but really that first
one wasn't accurate, so tweak it.