### PR TITLE
controller: Prefix generated configs with pool type

### DIFF
--- a/pkg/controller/render/hash.go
+++ b/pkg/controller/render/hash.go
@@ -20,7 +20,9 @@ var (
 	}
 )
 
-func getMachineConfigHashedName(config *mcfgv1.MachineConfig) (string, error) {
+// Given a config from a pool, generate a name for the config
+// of the form <poolname>-<hash>
+func getMachineConfigHashedName(pool *mcfgv1.MachineConfigPool, config *mcfgv1.MachineConfig) (string, error) {
 	if config == nil {
 		return "", fmt.Errorf("empty machineconfig object")
 	}
@@ -34,7 +36,7 @@ func getMachineConfigHashedName(config *mcfgv1.MachineConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", h), nil
+	return fmt.Sprintf("%s-%x", pool.GetName(), h), nil
 }
 
 func hashData(data []byte) ([]byte, error) {

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -470,7 +470,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 
 func generateMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) (*mcfgv1.MachineConfig, error) {
 	merged := mcfgv1.MergeMachineConfigs(configs)
-	hashedName, err := getMachineConfigHashedName(merged)
+	hashedName, err := getMachineConfigHashedName(pool, merged)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This way it's easy to see at a glance where a given
config came from.  Now looks like:

```
$ oc get machineconfig
NAME                                      AGE
00-master                                 6h
00-worker                                 6h
...
master-e92af7e0bdc0591dc11405aeabb57ccd   1m
worker-50748faa54f9cc70af13c8686c2c7a28   1m
```