### PR TITLE
daemon: Log degredation reason to journal and event too

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -526,11 +526,11 @@ func (dn *Daemon) isDesiredMachineState() (bool, string, error) {
 	// config, the machine is definitely not in its desired state. this function
 	// will return true (meaning they are reconcilable) if there aren't actually
 	// changes.
-	reconcilable, err := dn.reconcilable(currentConfig, desiredConfig)
+	reconcilableError, err := dn.reconcilable(currentConfig, desiredConfig)
 	if err != nil {
 		return false, "", err
 	}
-	if !reconcilable {
+	if reconcilableError != nil {
 		return false, "", nil
 	}
 

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -67,22 +67,22 @@ func TestUpdateOS(t *testing.T) {
 // reconcilable. Welcome to the longest unittest you've ever read.
 func TestReconcilable(t *testing.T) {
 	// checkReconcilableResults is a shortcut for verifying results that should be reconcilable
-	checkReconcilableResults := func(key string, err error, isReconcilable bool) {
+	checkReconcilableResults := func(key string, err error, reconcilableError *string) {
 		if err != nil {
 			t.Errorf("Expected no error. Got %s.", err)
 		}
-		if isReconcilable != true {
-			t.Errorf("Expected the same %s values would cause reconcilable. Received irreconcilable.", key)
+		if reconcilableError != nil {
+			t.Errorf("Expected the same %s values would be reconcilable. Received error: %v", key, *reconcilableError)
 		}
 	}
 
 	// checkIreconcilableResults is a shortcut for verifing results that should be ireconcilable
-	checkIreconcilableResults := func(key string, err error, isReconcilable bool) {
+	checkIreconcilableResults := func(key string, err error, reconcilableError *string) {
 		if err != nil {
 			t.Errorf("Expected no error. Got %s.", err)
 		}
-		if isReconcilable != false {
-			t.Errorf("Expected different %s values would cause irreconcilable. Received reconcilable.", key)
+		if reconcilableError == nil {
+			t.Errorf("Expected different %s values would not be reconcilable.", key)
 		}
 	}
 


### PR DESCRIPTION
We really want admins to know *why* a system is degraded, so let's
add the precise error to the event log, and also log it to the
systemd journal just like we do reboots.

This changes the internal core `reconcible()` method to
return its error message rather than logging it itself, so we can
append it when we e.g. send the event.