### PR TITLE
client: add NewClientBuilderFromConfig API

### DIFF
--- a/cmd/common/client_builder.go
+++ b/cmd/common/client_builder.go
@@ -65,3 +65,10 @@ func NewClientBuilder(kubeconfig string) (*ClientBuilder, error) {
 		config: config,
 	}, nil
 }
+
+// NewClientBuilderFromConfig returns a *ClientBuilder given a rest.Config
+func NewClientBuilderFromConfig(config *rest.Config) (*ClientBuilder, error) {
+	return &ClientBuilder{
+		config: config,
+	}, nil
+}


### PR DESCRIPTION
operator-sdk uses a rest.Config passed to the controller. This change allows for easier construction of the ClientBuilder within operator-sdk controllers/operators.