### PR TITLE
hack: Add cluster-push-*.sh scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ _image-%:
 	@which podman 2> /dev/null &>1 || { echo "podman must be installed to build an image";  exit 1; }
 	WHAT=$* $(my_p)/hack/build-image.sh
 
+# Build + push + deploy image for a component. Intended to be called via another target.
+# Example:
+#    make _deploy-machine-config-daemon
+_deploy-%:
+	WHAT=$* $(my_p)/hack/cluster-push.sh
+
 # Run unit tests
 # Example:
 #    make test
@@ -57,6 +63,7 @@ $(foreach P, $(patsubst cmd/%, %, $(shell find cmd -maxdepth 1 -mindepth 1 -type
 define image_template =
  .PHONY: image-$(1)
  image-$(1): _image-$(1) _build-$(1)
+ deploy-$(1): _deploy-$(1)
 
  imc += image-$(1)
 endef

--- a/hack/cluster-push-prep.sh
+++ b/hack/cluster-push-prep.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Scale the CVO down and set up podman with a secret ready to push
+# to the machine-config-operator namespace.
+
+# Assumptions: You have set KUBECONFIG to point to your local cluster,
+# and you have exposed the registry via e.g.
+# https://github.com/openshift/installer/issues/411#issuecomment-445165262
+
+set -xeuo pipefail
+
+oc -n openshift-cluster-version scale --replicas=0 deploy/cluster-version-operator
+if ! oc get -n openshift-image-registry route/image-registry &>/dev/null; then
+    oc expose -n openshift-image-registry svc/image-registry
+fi
+oc patch -n openshift-image-registry route/image-registry -p '{"spec": {"tls": {"insecureEdgeTerminationPolicy": "Redirect", "termination": "reencrypt"}}}'
+registry=$(oc get -n openshift-image-registry -o json route/image-registry | jq -r ".spec.host")
+if ! curl -k --head https://"${registry}" >/dev/null; then
+    if ! grep -q "${registry}" /etc/hosts; then
+        set +x
+        echo "error: Failed to contact the registry"
+        echo "The problem may be DNS; you can e.g. add the registry to your /etc/hosts - as root run:"
+        echo "  echo 127.0.0.1 ${registry} >> /etc/hosts"
+        exit 1
+    fi
+fi
+builder_secretid=$(oc get -n openshift-machine-config-operator secret | egrep '^builder-token-'| head -1 | cut -f 1 -d ' ')
+echo "podman login ${registry} ..."
+set +x
+secret="$(oc get -n openshift-machine-config-operator -o json secret/${builder_secretid} | jq -r '.data.token' | base64 -d)"
+podman login --tls-verify=false -u unused -p "${secret}" "${registry}"
+set -x
+
+# And allow everything to pull from our namespace
+oc -n openshift-machine-config-operator policy add-role-to-group registry-viewer system:unauthenticated

--- a/hack/cluster-push.sh
+++ b/hack/cluster-push.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Build an image and push it to the cluster registry.
+# You must have first run `cluster-push-prep.sh` once.
+# Assumptions: You have set KUBECONFIG to point to your local cluster,
+# and you have exposed the registry via e.g.
+# https://github.com/openshift/installer/issues/411#issuecomment-445165262
+
+set -xeuo pipefail
+
+do_build=1
+if [ "${1:-}" = "-n" ]; then
+    do_build=0
+fi
+
+registry=$(oc get -n openshift-image-registry -o json route/image-registry | jq -r ".spec.host")
+curl -k --head https://"${registry}" >/dev/null
+
+WHAT=${WHAT:-machine-config-daemon}
+LOCAL_IMGNAME=localhost/${WHAT}
+REMOTE_IMGNAME=openshift-machine-config-operator/${WHAT}
+if [ "${do_build}" = 1 ]; then
+    podman build -t "${LOCAL_IMGNAME}" -f Dockerfile.${WHAT}
+    podman push --tls-verify=false "${LOCAL_IMGNAME}" ${registry}/${REMOTE_IMGNAME}
+fi
+
+digest=$(skopeo inspect --tls-verify=false docker://${registry}/${REMOTE_IMGNAME} | jq -r .Digest)
+imageid=${REMOTE_IMGNAME}@${digest}
+
+oc project openshift-machine-config-operator
+
+IN_CLUSTER_NAME=image-registry.openshift-image-registry.svc:5000/${imageid}
+
+# Patch the images.json
+tmpf=$(mktemp)
+oc get -o json configmap/machine-config-operator-images > ${tmpf}
+outf=$(mktemp)
+python3 > ${outf} <<EOF
+import sys,json
+what="${WHAT}".split('-')[-1]
+cm=json.load(open("${tmpf}"))
+images = json.loads(cm['data']['images.json'])
+images["machineConfig"+what[0].upper()+what[1:]] = "${IN_CLUSTER_NAME}"
+cm['data']['images.json'] = json.dumps(images)
+json.dump(cm, sys.stdout)
+EOF
+oc replace -f ${outf}
+rm ${tmpf} ${outf}
+
+patch=$(mktemp)
+cat >${patch} <<EOF
+spec:
+  template:
+     spec:
+       containers:
+         - name: ${WHAT}
+           image: ${IN_CLUSTER_NAME}
+EOF
+
+# And for speed, patch the deployment directly
+case $WHAT in
+    machine-config-controller|machine-config-operator)
+        target=deploy/${WHAT}
+        ;;
+    machine-config-daemon)
+        target=daemonset/${WHAT}
+        ;;
+    *) echo "Unhandled WHAT=$WHAT" && exit 1
+esac
+
+oc patch -n openshift-machine-config-operator "${target}" -p "$(cat ${patch})"
+rm ${patch}


### PR DESCRIPTION
I *just* got this working but I am feeling it's going
to be a *dramatic* improvement in my development workflow.

To set up, run `hack/cluster-push-prep.sh` once after doing
an install.  Then run `hack/cluster-push.sh` to deploy a new
MCD.  Use `env WHAT=machine-config-controller hack/cluster-push.sh`
to update the controller.

(Yes, these don't integrate with the `Makefile` yet...)