### PR TITLE
Makefile: Also support specifying just e.g. `make controller`

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -37,15 +37,15 @@ You will likely get an error about needing to add the registry to your `/etc/hos
 While you're still in the mode of testing builds, use `make`:
 
 ```
-$ make machine-config-daemon
+$ make daemon
 ```
 
-You can also `make machine-config-controller` and `make machine-config-operator`.
+You can also `make controller` and `make operator`.
 
 When you want to push to the cluster, use the `deploy-` prefix, e.g.:
 
 ```
-make deploy-machine-config-daemon
+make deploy-daemon
 ```
 
 (Like above, you can use `operator` or `controller` in place of `daemon`).


### PR DESCRIPTION
Since we're in the machine-config-operator repository, typing
`machine-config-` is redundant.  Now one can just type e.g.
`make daemon` or `make controller`.  But we still support
`make machine-config-daemon` for backwards compat.