### PR TITLE
daemon: Reboot via systemd-run, not logind DBus API

### DIFF
--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -32,7 +32,6 @@ func TestUpdateOS(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   MachineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
-		loginClient:       nil, // set to nil as it will not be used within tests
 		client:            fake.NewSimpleClientset(),
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		rootMount:         "/",
@@ -90,7 +89,6 @@ func TestReconcilable(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   MachineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: nil,
-		loginClient:       nil,
 		client:            nil,
 		kubeClient:        nil,
 		rootMount:         "/",


### PR DESCRIPTION
Today, the operator uses:

```
drain.Drain(..., IgnoreDaemonsets:   true, ...)
```

The problem is this leaves e.g. the mcd lying around
from Kube's perspective; it takes a while for it to conclude the mcd
is dead and make a new one on next reboot.  We really want to drain
the node fully for other daemonsets too for similar reasons.

To fix this, we do a two-phase drain; first we drain all of the
non-daemonsets.  Then, we *queue* a reboot by creating a new systemd
unit that waits for us to unlock a file in `/run`.  Once our process
dies (because our pod is drained), we'll unlock the file and the
reboot will commence.