### PR TITLE
pkg/server/api: Return 405s for non-GET requests

### DIFF
--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,50 +18,134 @@ func (ms *mockServer) GetConfig(pr poolRequest) (*ignv2_2types.Config, error) {
 	return ms.GetConfigFn(pr)
 }
 
+type checkResponse func(t *testing.T, response *http.Response)
+
 type scenario struct {
-	name           string
-	expectedStatus int
-	serverFunc     func(poolRequest) (*ignv2_2types.Config, error)
+	name          string
+	request       *http.Request
+	serverFunc    func(poolRequest) (*ignv2_2types.Config, error)
+	checkResponse checkResponse
 }
 
 func TestAPIHandler(t *testing.T) {
 	scenarios := []scenario{
 		{
-			name:           "not-found",
-			expectedStatus: http.StatusNotFound,
+			name:    "get non-config path that does not exist",
+			request: httptest.NewRequest(http.MethodGet, "http://testrequest/does-not-exist", nil),
 			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
 				return nil, nil
 			},
-		},
-		{
-			name:           "internal-server",
-			expectedStatus: http.StatusInternalServerError,
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), fmt.Errorf("not acceptable")
+			checkResponse: func(t *testing.T, response *http.Response) {
+				checkStatus(t, response, http.StatusNotFound)
+				checkContentLength(t, response, 0)
+				checkBodyLength(t, response, 0)
 			},
 		},
 		{
-			name:           "success",
-			expectedStatus: http.StatusOK,
+			name:    "get config path that does not exist",
+			request: httptest.NewRequest(http.MethodGet, "http://testrequest/config/does-not-exist", nil),
+			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
+				return new(ignv2_2types.Config), fmt.Errorf("not acceptable")
+			},
+			checkResponse: func(t *testing.T, response *http.Response) {
+				checkStatus(t, response, http.StatusInternalServerError)
+				checkContentLength(t, response, 0)
+				checkBodyLength(t, response, 0)
+			},
+		},
+		{
+			name:    "get config path that exists",
+			request: httptest.NewRequest(http.MethodGet, "http://testrequest/config/master", nil),
 			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
 				return new(ignv2_2types.Config), nil
+			},
+			checkResponse: func(t *testing.T, response *http.Response) {
+				checkStatus(t, response, http.StatusOK)
+				checkContentType(t, response, "application/json")
+				checkContentLength(t, response, 114)
+				checkBodyLength(t, response, 114)
+			},
+		},
+		{
+			name:    "head config path that exists",
+			request: httptest.NewRequest(http.MethodHead, "http://testrequest/config/master", nil),
+			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
+				return new(ignv2_2types.Config), nil
+			},
+			checkResponse: func(t *testing.T, response *http.Response) {
+				checkStatus(t, response, http.StatusOK)
+				checkContentType(t, response, "application/json")
+				checkContentLength(t, response, 114)
+				checkBodyLength(t, response, 0)
+			},
+		},
+		{
+			name:    "post non-config path that does not exist",
+			request: httptest.NewRequest(http.MethodPost, "http://testrequest/post", nil),
+			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
+				return nil, nil
+			},
+			checkResponse: func(t *testing.T, response *http.Response) {
+				checkStatus(t, response, http.StatusMethodNotAllowed)
+				checkContentLength(t, response, 0)
+				checkBodyLength(t, response, 0)
+			},
+		},
+		{
+			name:    "post config path that exists",
+			request: httptest.NewRequest(http.MethodPost, "http://testrequest/config/master", nil),
+			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
+				return new(ignv2_2types.Config), nil
+			},
+			checkResponse: func(t *testing.T, response *http.Response) {
+				checkStatus(t, response, http.StatusMethodNotAllowed)
+				checkContentLength(t, response, 0)
+				checkBodyLength(t, response, 0)
 			},
 		},
 	}
 
-	for i := range scenarios {
-		req := httptest.NewRequest("GET", "http://testrequest/", nil)
-		w := httptest.NewRecorder()
-		ms := &mockServer{
-			GetConfigFn: scenarios[i].serverFunc,
-		}
-		handler := NewServerAPIHandler(ms)
-		handler.ServeHTTP(w, req)
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			ms := &mockServer{
+				GetConfigFn: scenario.serverFunc,
+			}
+			handler := NewServerAPIHandler(ms)
+			handler.ServeHTTP(w, scenario.request)
 
-		resp := w.Result()
+			resp := w.Result()
+			defer resp.Body.Close()
+			scenario.checkResponse(t, resp)
+		})
+	}
+}
 
-		if resp.StatusCode != scenarios[i].expectedStatus {
-			t.Errorf("API Handler test failed for: %s, expected: %d, received: %d", scenarios[i].name, scenarios[i].expectedStatus, resp.StatusCode)
-		}
+func checkStatus(t *testing.T, response *http.Response, expected int) {
+	if response.StatusCode != expected {
+		t.Errorf("expected response status %d, received %d", expected, response.StatusCode)
+	}
+}
+
+func checkContentType(t *testing.T, response *http.Response, expected string) {
+	actual := response.Header.Get("Content-Type")
+	if actual != expected {
+		t.Errorf("expected response Content-Type %q, received %q", expected, actual)
+	}
+}
+
+func checkContentLength(t *testing.T, response *http.Response, l int) {
+	if int(response.ContentLength) != l {
+		t.Errorf("expected response Content-Length %d, received %d", l, int(response.ContentLength))
+	}
+}
+
+func checkBodyLength(t *testing.T, response *http.Response, l int) {
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != l {
+		t.Errorf("expected response body length %d, received %d", l, len(body))
 	}
 }


### PR DESCRIPTION
We don't want folks `POST`ing, etc. to this server.  With this pull-request, we'll return the appropriate response status code if they do.