### PR TITLE
pkg/apis:  controllerconfig needs to be cluster-scoped 

### DIFF
--- a/lib/resourceapply/machineconfig.go
+++ b/lib/resourceapply/machineconfig.go
@@ -52,9 +52,9 @@ func ApplyMachineConfigPool(client mcfgclientv1.MachineConfigPoolsGetter, requir
 
 // ApplyControllerConfig applies the required machineconfig to the cluster.
 func ApplyControllerConfig(client mcfgclientv1.ControllerConfigsGetter, required *mcfgv1.ControllerConfig) (*mcfgv1.ControllerConfig, bool, error) {
-	existing, err := client.ControllerConfigs(required.GetNamespace()).Get(required.GetName(), metav1.GetOptions{})
+	existing, err := client.ControllerConfigs().Get(required.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ControllerConfigs(required.GetNamespace()).Create(required)
+		actual, err := client.ControllerConfigs().Create(required)
 		return actual, true, err
 	}
 	if err != nil {
@@ -67,6 +67,6 @@ func ApplyControllerConfig(client mcfgclientv1.ControllerConfigsGetter, required
 		return existing, false, nil
 	}
 
-	actual, err := client.ControllerConfigs(required.GetNamespace()).Update(existing)
+	actual, err := client.ControllerConfigs().Update(existing)
 	return actual, true, err
 }

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -14,7 +14,7 @@ spec:
       # One and only one version must be marked as the storage version.
       storage: true
   # either Namespaced or Cluster
-  scope: Namespaced
+  scope: Cluster
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: controllerconfigs

--- a/manifests/machineconfigcontroller/controllerconfig.yaml
+++ b/manifests/machineconfigcontroller/controllerconfig.yaml
@@ -2,6 +2,5 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: ControllerConfig
 metadata:
   name: machine-config-controller
-  namespace: {{.TargetNamespace}}
 spec:
 {{toYAML .ControllerConfig | toString | indent 2}}

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -101,6 +101,7 @@ type MCOConfigList struct {
 
 // +genclient
 // +genclient:noStatus
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ControllerConfig describes configuration for MachineConfigController.

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -182,10 +182,6 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 	oldNode := old.(*corev1.Node)
 	curNode := cur.(*corev1.Node)
 
-	if oldNode.ResourceVersion == curNode.ResourceVersion {
-		return
-	}
-
 	if !nodeChanged(oldNode, curNode) {
 		return
 	}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -176,9 +176,6 @@ func (ctrl *Controller) addMachineConfig(obj interface{}) {
 func (ctrl *Controller) updateMachineConfig(old, cur interface{}) {
 	oldMC := old.(*mcfgv1.MachineConfig)
 	curMC := cur.(*mcfgv1.MachineConfig)
-	if oldMC.ResourceVersion == curMC.ResourceVersion {
-		return
-	}
 
 	curControllerRef := metav1.GetControllerOf(curMC)
 	oldControllerRef := metav1.GetControllerOf(oldMC)

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -54,7 +54,7 @@ func newFixture(t *testing.T) *fixture {
 func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 	return &mcfgv1.ControllerConfig{
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: mcfgv1.ControllerConfigSpec{
 			ClusterDNSIP: "10.3.0.1/16",
 			ClusterName:  name,

--- a/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/controllerconfig.go
+++ b/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/controllerconfig.go
@@ -14,7 +14,7 @@ import (
 // ControllerConfigsGetter has a method to return a ControllerConfigInterface.
 // A group's client should implement this interface.
 type ControllerConfigsGetter interface {
-	ControllerConfigs(namespace string) ControllerConfigInterface
+	ControllerConfigs() ControllerConfigInterface
 }
 
 // ControllerConfigInterface has methods to work with ControllerConfig resources.
@@ -33,14 +33,12 @@ type ControllerConfigInterface interface {
 // controllerConfigs implements ControllerConfigInterface
 type controllerConfigs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newControllerConfigs returns a ControllerConfigs
-func newControllerConfigs(c *MachineconfigurationV1Client, namespace string) *controllerConfigs {
+func newControllerConfigs(c *MachineconfigurationV1Client) *controllerConfigs {
 	return &controllerConfigs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -48,7 +46,6 @@ func newControllerConfigs(c *MachineconfigurationV1Client, namespace string) *co
 func (c *controllerConfigs) Get(name string, options metav1.GetOptions) (result *v1.ControllerConfig, err error) {
 	result = &v1.ControllerConfig{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -61,7 +58,6 @@ func (c *controllerConfigs) Get(name string, options metav1.GetOptions) (result 
 func (c *controllerConfigs) List(opts metav1.ListOptions) (result *v1.ControllerConfigList, err error) {
 	result = &v1.ControllerConfigList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -73,7 +69,6 @@ func (c *controllerConfigs) List(opts metav1.ListOptions) (result *v1.Controller
 func (c *controllerConfigs) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -83,7 +78,6 @@ func (c *controllerConfigs) Watch(opts metav1.ListOptions) (watch.Interface, err
 func (c *controllerConfigs) Create(controllerConfig *v1.ControllerConfig) (result *v1.ControllerConfig, err error) {
 	result = &v1.ControllerConfig{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		Body(controllerConfig).
 		Do().
@@ -95,7 +89,6 @@ func (c *controllerConfigs) Create(controllerConfig *v1.ControllerConfig) (resul
 func (c *controllerConfigs) Update(controllerConfig *v1.ControllerConfig) (result *v1.ControllerConfig, err error) {
 	result = &v1.ControllerConfig{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		Name(controllerConfig.Name).
 		Body(controllerConfig).
@@ -107,7 +100,6 @@ func (c *controllerConfigs) Update(controllerConfig *v1.ControllerConfig) (resul
 // Delete takes name of the controllerConfig and deletes it. Returns an error if one occurs.
 func (c *controllerConfigs) Delete(name string, options *metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		Name(name).
 		Body(options).
@@ -118,7 +110,6 @@ func (c *controllerConfigs) Delete(name string, options *metav1.DeleteOptions) e
 // DeleteCollection deletes a collection of objects.
 func (c *controllerConfigs) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -130,7 +121,6 @@ func (c *controllerConfigs) DeleteCollection(options *metav1.DeleteOptions, list
 func (c *controllerConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ControllerConfig, err error) {
 	result = &v1.ControllerConfig{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("controllerconfigs").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/fake/fake_controllerconfig.go
+++ b/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/fake/fake_controllerconfig.go
@@ -15,7 +15,6 @@ import (
 // FakeControllerConfigs implements ControllerConfigInterface
 type FakeControllerConfigs struct {
 	Fake *FakeMachineconfigurationV1
-	ns   string
 }
 
 var controllerconfigsResource = schema.GroupVersionResource{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "controllerconfigs"}
@@ -25,8 +24,7 @@ var controllerconfigsKind = schema.GroupVersionKind{Group: "machineconfiguration
 // Get takes name of the controllerConfig, and returns the corresponding controllerConfig object, and an error if there is any.
 func (c *FakeControllerConfigs) Get(name string, options v1.GetOptions) (result *machineconfigurationopenshiftiov1.ControllerConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(controllerconfigsResource, c.ns, name), &machineconfigurationopenshiftiov1.ControllerConfig{})
-
+		Invokes(testing.NewRootGetAction(controllerconfigsResource, name), &machineconfigurationopenshiftiov1.ControllerConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -36,8 +34,7 @@ func (c *FakeControllerConfigs) Get(name string, options v1.GetOptions) (result 
 // List takes label and field selectors, and returns the list of ControllerConfigs that match those selectors.
 func (c *FakeControllerConfigs) List(opts v1.ListOptions) (result *machineconfigurationopenshiftiov1.ControllerConfigList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(controllerconfigsResource, controllerconfigsKind, c.ns, opts), &machineconfigurationopenshiftiov1.ControllerConfigList{})
-
+		Invokes(testing.NewRootListAction(controllerconfigsResource, controllerconfigsKind, opts), &machineconfigurationopenshiftiov1.ControllerConfigList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,15 +55,13 @@ func (c *FakeControllerConfigs) List(opts v1.ListOptions) (result *machineconfig
 // Watch returns a watch.Interface that watches the requested controllerConfigs.
 func (c *FakeControllerConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(controllerconfigsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(controllerconfigsResource, opts))
 }
 
 // Create takes the representation of a controllerConfig and creates it.  Returns the server's representation of the controllerConfig, and an error, if there is any.
 func (c *FakeControllerConfigs) Create(controllerConfig *machineconfigurationopenshiftiov1.ControllerConfig) (result *machineconfigurationopenshiftiov1.ControllerConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(controllerconfigsResource, c.ns, controllerConfig), &machineconfigurationopenshiftiov1.ControllerConfig{})
-
+		Invokes(testing.NewRootCreateAction(controllerconfigsResource, controllerConfig), &machineconfigurationopenshiftiov1.ControllerConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,8 +71,7 @@ func (c *FakeControllerConfigs) Create(controllerConfig *machineconfigurationope
 // Update takes the representation of a controllerConfig and updates it. Returns the server's representation of the controllerConfig, and an error, if there is any.
 func (c *FakeControllerConfigs) Update(controllerConfig *machineconfigurationopenshiftiov1.ControllerConfig) (result *machineconfigurationopenshiftiov1.ControllerConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(controllerconfigsResource, c.ns, controllerConfig), &machineconfigurationopenshiftiov1.ControllerConfig{})
-
+		Invokes(testing.NewRootUpdateAction(controllerconfigsResource, controllerConfig), &machineconfigurationopenshiftiov1.ControllerConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -87,14 +81,13 @@ func (c *FakeControllerConfigs) Update(controllerConfig *machineconfigurationope
 // Delete takes name of the controllerConfig and deletes it. Returns an error if one occurs.
 func (c *FakeControllerConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(controllerconfigsResource, c.ns, name), &machineconfigurationopenshiftiov1.ControllerConfig{})
-
+		Invokes(testing.NewRootDeleteAction(controllerconfigsResource, name), &machineconfigurationopenshiftiov1.ControllerConfig{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeControllerConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(controllerconfigsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(controllerconfigsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &machineconfigurationopenshiftiov1.ControllerConfigList{})
 	return err
@@ -103,8 +96,7 @@ func (c *FakeControllerConfigs) DeleteCollection(options *v1.DeleteOptions, list
 // Patch applies the patch and returns the patched controllerConfig.
 func (c *FakeControllerConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *machineconfigurationopenshiftiov1.ControllerConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(controllerconfigsResource, c.ns, name, data, subresources...), &machineconfigurationopenshiftiov1.ControllerConfig{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(controllerconfigsResource, name, data, subresources...), &machineconfigurationopenshiftiov1.ControllerConfig{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/fake/fake_machineconfiguration.openshift.io_client.go
+++ b/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/fake/fake_machineconfiguration.openshift.io_client.go
@@ -12,8 +12,8 @@ type FakeMachineconfigurationV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeMachineconfigurationV1) ControllerConfigs(namespace string) v1.ControllerConfigInterface {
-	return &FakeControllerConfigs{c, namespace}
+func (c *FakeMachineconfigurationV1) ControllerConfigs() v1.ControllerConfigInterface {
+	return &FakeControllerConfigs{c}
 }
 
 func (c *FakeMachineconfigurationV1) MCOConfigs(namespace string) v1.MCOConfigInterface {

--- a/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/machineconfiguration.openshift.io_client.go
+++ b/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/machineconfiguration.openshift.io_client.go
@@ -22,8 +22,8 @@ type MachineconfigurationV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *MachineconfigurationV1Client) ControllerConfigs(namespace string) ControllerConfigInterface {
-	return newControllerConfigs(c, namespace)
+func (c *MachineconfigurationV1Client) ControllerConfigs() ControllerConfigInterface {
+	return newControllerConfigs(c)
 }
 
 func (c *MachineconfigurationV1Client) MCOConfigs(namespace string) MCOConfigInterface {

--- a/pkg/generated/informers/externalversions/machineconfiguration.openshift.io/v1/controllerconfig.go
+++ b/pkg/generated/informers/externalversions/machineconfiguration.openshift.io/v1/controllerconfig.go
@@ -25,33 +25,32 @@ type ControllerConfigInformer interface {
 type controllerConfigInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewControllerConfigInformer constructs a new informer for ControllerConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewControllerConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredControllerConfigInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewControllerConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredControllerConfigInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredControllerConfigInformer constructs a new informer for ControllerConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredControllerConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredControllerConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.MachineconfigurationV1().ControllerConfigs(namespace).List(options)
+				return client.MachineconfigurationV1().ControllerConfigs().List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.MachineconfigurationV1().ControllerConfigs(namespace).Watch(options)
+				return client.MachineconfigurationV1().ControllerConfigs().Watch(options)
 			},
 		},
 		&machineconfigurationopenshiftiov1.ControllerConfig{},
@@ -61,7 +60,7 @@ func NewFilteredControllerConfigInformer(client versioned.Interface, namespace s
 }
 
 func (f *controllerConfigInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredControllerConfigInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredControllerConfigInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *controllerConfigInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/generated/informers/externalversions/machineconfiguration.openshift.io/v1/interface.go
+++ b/pkg/generated/informers/externalversions/machineconfiguration.openshift.io/v1/interface.go
@@ -31,7 +31,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // ControllerConfigs returns a ControllerConfigInformer.
 func (v *version) ControllerConfigs() ControllerConfigInformer {
-	return &controllerConfigInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &controllerConfigInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // MCOConfigs returns a MCOConfigInformer.

--- a/pkg/generated/listers/machineconfiguration.openshift.io/v1/controllerconfig.go
+++ b/pkg/generated/listers/machineconfiguration.openshift.io/v1/controllerconfig.go
@@ -13,8 +13,8 @@ import (
 type ControllerConfigLister interface {
 	// List lists all ControllerConfigs in the indexer.
 	List(selector labels.Selector) (ret []*v1.ControllerConfig, err error)
-	// ControllerConfigs returns an object that can list and get ControllerConfigs.
-	ControllerConfigs(namespace string) ControllerConfigNamespaceLister
+	// Get retrieves the ControllerConfig from the index for a given name.
+	Get(name string) (*v1.ControllerConfig, error)
 	ControllerConfigListerExpansion
 }
 
@@ -36,38 +36,9 @@ func (s *controllerConfigLister) List(selector labels.Selector) (ret []*v1.Contr
 	return ret, err
 }
 
-// ControllerConfigs returns an object that can list and get ControllerConfigs.
-func (s *controllerConfigLister) ControllerConfigs(namespace string) ControllerConfigNamespaceLister {
-	return controllerConfigNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ControllerConfigNamespaceLister helps list and get ControllerConfigs.
-type ControllerConfigNamespaceLister interface {
-	// List lists all ControllerConfigs in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1.ControllerConfig, err error)
-	// Get retrieves the ControllerConfig from the indexer for a given namespace and name.
-	Get(name string) (*v1.ControllerConfig, error)
-	ControllerConfigNamespaceListerExpansion
-}
-
-// controllerConfigNamespaceLister implements the ControllerConfigNamespaceLister
-// interface.
-type controllerConfigNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ControllerConfigs in the indexer for a given namespace.
-func (s controllerConfigNamespaceLister) List(selector labels.Selector) (ret []*v1.ControllerConfig, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.ControllerConfig))
-	})
-	return ret, err
-}
-
-// Get retrieves the ControllerConfig from the indexer for a given namespace and name.
-func (s controllerConfigNamespaceLister) Get(name string) (*v1.ControllerConfig, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ControllerConfig from the index for a given name.
+func (s *controllerConfigLister) Get(name string) (*v1.ControllerConfig, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generated/listers/machineconfiguration.openshift.io/v1/expansion_generated.go
+++ b/pkg/generated/listers/machineconfiguration.openshift.io/v1/expansion_generated.go
@@ -6,10 +6,6 @@ package v1
 // ControllerConfigLister.
 type ControllerConfigListerExpansion interface{}
 
-// ControllerConfigNamespaceListerExpansion allows custom methods to be added to
-// ControllerConfigNamespaceLister.
-type ControllerConfigNamespaceListerExpansion interface{}
-
 // MCOConfigListerExpansion allows custom methods to be added to
 // MCOConfigLister.
 type MCOConfigListerExpansion interface{}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -165,7 +165,7 @@ spec:
       # One and only one version must be marked as the storage version.
       storage: true
   # either Namespaced or Cluster
-  scope: Namespaced
+  scope: Cluster
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: controllerconfigs
@@ -296,7 +296,6 @@ var _manifestsMachineconfigcontrollerControllerconfigYaml = []byte(`apiVersion: 
 kind: ControllerConfig
 metadata:
   name: machine-config-controller
-  namespace: {{.TargetNamespace}}
 spec:
 {{toYAML .ControllerConfig | toString | indent 2}}
 `)


### PR DESCRIPTION
MachineConfig and MachineConfigPools were made cluster scoped in #25

But I missed that ControllerConfig used by the machineconfigcontroller to create the OpenShift mananged MachineConfigs have to be owned by the ControllerConfig.
And ControllerConfig being a namespaced resource owning a cluster scoped resource MachineConfig does not make sense.

Also since MachineConfigController controls resources at cluster scope (MachineConfigs, MachineConfigPools, NodeUpdates), it makes sense to make it cluster scoped too.