### PR TITLE
typo fix and better bash variable handling

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -9,8 +9,8 @@ GLDFLAGS=${GLDFLAGS:-}
 
 eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
 
-GOOS=${GOOS:-${GOHOSTOS}}
-GOARCH=${GOACH:-${GOHOSTARCH}}
+: "${GOOS:=${GOHOSTOS}}"
+: "${GOARCH:=${GOHOSTARCH}}"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)"


### PR DESCRIPTION
Using `: "${GOARCH:=${GOHOSTARCH}}"` since:
- it is DRY 
- avoids subsequent typos.
- The : will only apply the value if GOARCH is unset.

Also it is fixing a typo.