### PR TITLE
 daemon: fix deletion of stale config files 

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -280,7 +280,9 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) {
 	for _, f := range oldConfig.Spec.Config.Storage.Files {
 		if _, ok := newFileSet[f.Path]; !ok {
 			glog.V(2).Infof("Deleting stale config file: %s", f.Path)
-			dn.fileSystemClient.RemoveAll(f.Path)
+			if err := dn.fileSystemClient.Remove(f.Path); err != nil {
+				glog.Warningf("Unable to delete %s: %s", f.Path, err);
+			}
 		}
 	}
 
@@ -300,7 +302,9 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) {
 			path := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
 			if _, ok := newDropinSet[path]; !ok {
 				glog.V(2).Infof("Deleting stale systemd dropin file: %s", path)
-				dn.fileSystemClient.RemoveAll(path)
+				if err := dn.fileSystemClient.Remove(path); err != nil {
+					glog.Warningf("Unable to delete %s: %s", path, err);
+				}
 			}
 		}
 		path := filepath.Join(pathSystemd, u.Name)
@@ -309,7 +313,9 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) {
 				glog.Warningf("Unable to disable %s: %s", u.Name, err)
 			}
 			glog.V(2).Infof("Deleting stale systemd unit file: %s", path)
-			dn.fileSystemClient.RemoveAll(path)
+			if err := dn.fileSystemClient.Remove(path); err != nil {
+				glog.Warningf("Unable to delete %s: %s", path, err);
+			}
 		}
 	}
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -271,7 +271,6 @@ func (dn *Daemon) updateFiles(oldConfig, newConfig *mcfgv1.MachineConfig) error 
 // this function doesn't cause the agent to stop on failures and logs any errors
 // it encounters.
 func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) {
-	var path string
 	glog.Info("Deleting stale data")
 	newFileSet := make(map[string]struct{})
 	for _, f := range newConfig.Spec.Config.Storage.Files {
@@ -290,21 +289,21 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) {
 	newDropinSet := make(map[string]struct{})
 	for _, u := range newConfig.Spec.Config.Systemd.Units {
 		for j := range u.Dropins {
-			path = filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
+			path := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
 			newDropinSet[path] = struct{}{}
 		}
-		path = filepath.Join(pathSystemd, u.Name)
+		path := filepath.Join(pathSystemd, u.Name)
 		newUnitSet[path] = struct{}{}
 	}
 
 	for _, u := range oldConfig.Spec.Config.Systemd.Units {
 		for j := range u.Dropins {
-			path = filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
+			path := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
 			if _, ok := newDropinSet[path]; !ok {
 				dn.fileSystemClient.RemoveAll(path)
 			}
 		}
-		path = filepath.Join(pathSystemd, u.Name)
+		path := filepath.Join(pathSystemd, u.Name)
 		if _, ok := newUnitSet[path]; !ok {
 			if err := dn.disableUnit(u); err != nil {
 				glog.Warningf("Unable to disable %s: %s", u.Name, err)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -281,7 +281,7 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) {
 	glog.V(2).Info("Removing stale config storage files")
 	for _, f := range oldConfig.Spec.Config.Storage.Files {
 		if _, ok := newFileSet[f.Path]; !ok {
-			dn.fileSystemClient.RemoveAll(path)
+			dn.fileSystemClient.RemoveAll(f.Path)
 		}
 	}
 


### PR DESCRIPTION
Minor regression from 1d14b2a. We weren't passing the right variable to
`RemoveAll()`.

Closes: #268