### PR TITLE
WIP: Add RHCOS oscontainer into payload, render to 00-$role-osimageurl MC

### DIFF
--- a/docs/MachineConfigServer.md
+++ b/docs/MachineConfigServer.md
@@ -36,6 +36,10 @@ It performs the following extra actions on the Ignition config defined in the Ma
 
    The new machines that come up, will need a KubeConfig file which will be added as an Ignition file. 
 
+* *Early pivot* - `/etc/rhcos-initial-pivot-target`
+
+    While the Ignition content configures the node, it may actually be booted into an older OS image than is specified by the release payload managed by the [Cluster Version Operator](https://github.com/openshift/cluster-version-operator/).  The MCS writes out the `osImageURL` to this file, and the system will (if necessary) performs an "early pivot" before the node has actually joined the cluster.  This then ensures that when the MachineConfigDaemon starts, it will validate the `currentConfig` (including files written by Ignition and the `osImageURL`).
+
 ### Running MachineConfigServer
 
 It is recommended that the MachineConfigServer is run as a DaemonSet on all `master` machines with the pods running in host network. So machines can access the Ignition endpoint through load balancer setup for control plane.

--- a/pkg/controller/template/test_data/templates/master/00-master/aws/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/master/00-master/none/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/units/rhcos-initial-pivot.service
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/units/rhcos-initial-pivot.service
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: rhcos-initial-pivot.service

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -96,7 +96,7 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, err
 		return nil, fmt.Errorf("server: could not unmarshal file %s, err: %v", fileName, err)
 	}
 
-	appenders := getAppenders(cr, currConf, bsc.kubeconfigFunc)
+	appenders := getAppenders(cr, currConf, bsc.kubeconfigFunc, "")
 	for _, a := range appenders {
 		if err := a(&mc.Spec.Config); err != nil {
 			return nil, err

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -70,7 +70,7 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, error)
 		return nil, fmt.Errorf("could not fetch config %s, err: %v", currConf, err)
 	}
 
-	appenders := getAppenders(cr, currConf, cs.kubeconfigFunc)
+	appenders := getAppenders(cr, currConf, cs.kubeconfigFunc, mc.Spec.OSImageURL)
 	for _, a := range appenders {
 		if err := a(&mc.Spec.Config); err != nil {
 			return nil, err

--- a/templates/master/00-master/_base/units/rhcos-initial-pivot.yaml
+++ b/templates/master/00-master/_base/units/rhcos-initial-pivot.yaml
@@ -1,0 +1,19 @@
+name: "rhcos-initial-pivot.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/00-worker/_base/units/rhcos-initial-pivot.yaml
+++ b/templates/worker/00-worker/_base/units/rhcos-initial-pivot.yaml
@@ -1,0 +1,19 @@
+name: "rhcos-initial-pivot.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=RHCOS initial pivot
+  # Before we join the cluster
+  Before=kubelet.service
+  # But be sure that we've finished Ignition before we reboot
+  After=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/rhcos-initial-pivot-target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/sh -c 'pivot --reboot $(cat /etc/rhcos-initial-pivot-target) && rm /etc/rhcos-initial-pivot-target'
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+const (
+	namespace = "openshift-machine-config-operator"
+)
+
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }

--- a/test/e2e/sanity_test.go
+++ b/test/e2e/sanity_test.go
@@ -2,10 +2,16 @@ package e2e_test
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/informers"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/openshift/machine-config-operator/cmd/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon"
 )
 
 // Test case for https://github.com/openshift/machine-config-operator/pull/288/commits/44d5c5215b5450fca32806f796b50a3372daddc2
@@ -24,5 +30,46 @@ func TestOperatorLabel(t *testing.T) {
 	osSelector := d.Spec.Template.Spec.NodeSelector["beta.kubernetes.io/os"]
 	if osSelector != "linux" {
 		t.Errorf("Expected node selector 'linux', not '%s'", osSelector)
+	}
+}
+
+func TestNoDegraded(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil{
+		t.Errorf("%#v", err)
+	}
+	k := cb.KubeClientOrDie("sanity-test")
+
+	kubeSharedInformer := informers.NewSharedInformerFactory(k, 20 * time.Minute)
+	nodeInformer := kubeSharedInformer.Core().V1().Nodes()
+	nodeLister := nodeInformer.Lister()
+	nodeListerSynced := nodeInformer.Informer().HasSynced
+
+	stopCh := make(chan struct{})
+	kubeSharedInformer.Start(stopCh)
+	cache.WaitForCacheSync(stopCh, nodeListerSynced)
+
+	nodes, err := nodeLister.List(labels.Everything())
+	if err != nil {
+		t.Errorf("listing nodes: %v", err)
+	}
+
+	var degraded []*corev1.Node
+	for _, node := range nodes {
+		if node.Annotations == nil {
+			continue
+		}
+		dstate, ok := node.Annotations[daemon.MachineConfigDaemonStateAnnotationKey]
+		if !ok || dstate == "" {
+			continue
+		}
+
+		if dstate == daemon.MachineConfigDaemonStateDegraded {
+			degraded = append(degraded, node)
+		}
+	}
+
+	if len(degraded) > 0 {
+		t.Errorf("%d degraded nodes found", len(degraded))
 	}
 }


### PR DESCRIPTION
PR Status:
---

 - [ ] Fix https://github.com/openshift/machine-config-operator/issues/301
 - [ ] Figure out whether or not we need special handling for the *first* master

---

This closes the gap in getting the RHCOS oscontainer into the update
payload, and having the MCO then render that down into the MachineConfigs.
    
Introduce a new ConfigMap `machine-config-osimageurl` that points to
the oscontainer and is applied by the CVO.  Then, the controller
renders that into `machineconfigs/00-$role-osimageurl` which then finally
goes into the rendered config, and should be applied by the daemon.


Closes: #183

