### PR TITLE
manifests: machine config daemon node selector for linux

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -48,6 +48,8 @@ spec:
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoSchedule
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       volumes:
         - name: rootfs
           hostPath:


### PR DESCRIPTION
Ensure that machine config daemon only runs on linux nodes.

This enables third-parties to explore Windows nodes on OpenShift.