### PR TITLE
daemon/update: retry pivot 5 times on failed rc

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
 	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +84,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	var dn *daemon.Daemon
 	var ctx *common.ControllerContext
-
 
 	glog.Info("starting node writer")
 	nodeWriter := daemon.NewNodeWriter()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2,16 +2,15 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/coreos/go-systemd/login1"
 	ignv2 "github.com/coreos/ignition/config/v2_2"
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
@@ -21,6 +20,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	mcfgclientv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
+	"github.com/pkg/errors"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -323,7 +323,6 @@ func (dn *Daemon) getHealth() error {
 	return nil
 }
 
-
 // EnterDegradedState causes the MCD to update the annotations
 // to note that we're degraded, and sleep forever.
 func (dn *Daemon) EnterDegradedState(err error) {
@@ -340,7 +339,7 @@ func (dn *Daemon) EnterDegradedState(err error) {
 //
 // If any of the object names are the same, they will be pointer-equal.
 type stateAndConfigs struct {
-	state          string
+	state         string
 	currentConfig *mcfgv1.MachineConfig
 	pendingConfig *mcfgv1.MachineConfig
 	desiredConfig *mcfgv1.MachineConfig
@@ -396,7 +395,7 @@ func (dn *Daemon) getStateAndConfigs(pendingConfigName string) (*stateAndConfigs
 		currentConfig: currentConfig,
 		pendingConfig: pendingConfig,
 		desiredConfig: desiredConfig,
-		state: state,
+		state:         state,
 	}, nil
 }
 

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -3,13 +3,13 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 	"io/ioutil"
+	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"syscall"
 	"time"
 
 	errors "github.com/pkg/errors"
@@ -22,6 +23,7 @@ import (
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -599,7 +601,26 @@ func (dn *Daemon) updateOS(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 	}
 
 	glog.Infof("Updating OS to %s", newConfig.Spec.OSImageURL)
-	return dn.NodeUpdaterClient.RunPivot(newConfig.Spec.OSImageURL)
+
+	// try to run pivot 5 times; in the future we'd make the tool smarter
+	// so it can always retry things it knows are transient
+	return wait.ExponentialBackoff(wait.Backoff{
+		Steps:    5,               // times to retry
+		Duration: 5 * time.Second, // sleep between tries
+		Factor:   2,               // factor by which to increase sleep
+	}, func() (bool, error) {
+		var err error
+		if err = dn.NodeUpdaterClient.RunPivot(newConfig.Spec.OSImageURL); err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				rc := exitError.Sys().(syscall.WaitStatus).ExitStatus()
+				if rc != 0 {
+					glog.Warningf("pivot exited with rc=%d; retrying...", rc)
+					return false, nil
+				}
+			}
+		}
+		return true, err
+	})
 }
 
 // Log a message to the systemd journal as well as our stdout

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -15,11 +15,11 @@ import (
 	"syscall"
 	"time"
 
-	errors "github.com/pkg/errors"
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	drain "github.com/openshift/kubernetes-drain"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	errors "github.com/pkg/errors"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +56,7 @@ func replaceFileContentsAtomically(fpath string, b []byte) error {
 func (dn *Daemon) writePendingState(desiredConfig *mcfgv1.MachineConfig) error {
 	t := &pendingConfigState{
 		PendingConfig: desiredConfig.GetName(),
-		BootID: dn.bootID,
+		BootID:        dn.bootID,
 	}
 	b, err := json.Marshal(t)
 	if err != nil {


### PR DESCRIPTION
In the spirit of retrying all the things that could fail transiently,
just wrap the `/bin/pivot` call in a retry loop.

Closes: #276 