### PR TITLE
controller: Take first non-empty osImageURL

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -11,7 +11,7 @@ import (
 // MergeMachineConfigs combines multiple machineconfig objects into one object.
 // It sorts all the configs in increasing order of their name.
 // It uses the Ign config from first object as base and appends all the rest.
-// It only uses the OSImageURL from first object and ignores it from rest.
+// It uses the first non-empty OSImageURL.
 func MergeMachineConfigs(configs []*MachineConfig) *MachineConfig {
 	if len(configs) == 0 {
 		return nil
@@ -21,7 +21,11 @@ func MergeMachineConfigs(configs []*MachineConfig) *MachineConfig {
 	outOSImageURL := configs[0].Spec.OSImageURL
 	outIgn := configs[0].Spec.Config
 	for idx := 1; idx < len(configs); idx++ {
-		outIgn = ignv2_2.Append(outIgn, configs[idx].Spec.Config)
+		config := configs[idx]
+		if outOSImageURL == "" {
+			outOSImageURL = config.Spec.OSImageURL
+		}
+		outIgn = ignv2_2.Append(outIgn, config.Spec.Config)
 	}
 
 	return &MachineConfig{

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -137,5 +138,49 @@ func TestRemoveMachineConfigPoolCondition(t *testing.T) {
 				t.Errorf("expected status: %v, got: %v", test.expectedStatus, test.status)
 			}
 		})
+	}
+}
+
+func TestMergeMachineConfigs(t *testing.T) {
+	var configs []*MachineConfig
+	configs = append(configs, &MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "4"},
+		Spec: MachineConfigSpec{
+			OSImageURL: "",
+		},
+	})
+
+	configs = append(configs, &MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "3"},
+		Spec: MachineConfigSpec{
+			OSImageURL:"example.com/os@sha256:notthetarget",
+		},
+	})
+
+	configs = append(configs, &MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "0"},
+		Spec: MachineConfigSpec{
+			OSImageURL: "",
+		},
+	})
+
+	targetOSImageURL := "example.com/os@sha256:thetarget"
+	configs = append(configs, &MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "1"},
+		Spec: MachineConfigSpec{
+			OSImageURL: targetOSImageURL,
+		},
+	})
+
+	configs = append(configs, &MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "2"},
+		Spec: MachineConfigSpec{
+			OSImageURL: "",
+		},
+	})
+
+	merged := MergeMachineConfigs(configs)
+	if merged.Spec.OSImageURL != targetOSImageURL {
+		t.Errorf("OSImageURL expected: %s, received: %s", targetOSImageURL, merged.Spec.OSImageURL)
 	}
 }


### PR DESCRIPTION
Today each MC will contain both an Ignition fragment and an
`osImageURL`.  Define "merging" as using the first
non-empty `osImageURL` so we don't have to be very picky about
ordering.

This is a smaller version of
https://github.com/openshift/machine-config-operator/pull/228

Prep for: https://github.com/openshift/machine-config-operator/pull/273