### PR TITLE
manifests: include pretty column prints for some CRDs

### DIFF
--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -4,6 +4,22 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigs.machineconfiguration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
+    description: Version of the controller that generated the machineconfig. This will be empty if the machineconfig is not managed by a controller.
+    name: GeneratedByController
+    type: string
+  - JSONPath: .spec.config.ignition.version
+    description: Version of the Ignition Config defined in the machineconfig.
+    name: IgnitionVersion
+    type: string
+  - JSONPath: .spec.osImageURL
+    description: URL for the RPM OS-tree image. This is optional and can be empty.
+    name: OSImageURL
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Created
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -4,6 +4,22 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigpools.machineconfiguration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.configuration.name
+    name: Config
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Updated")].status
+    description: When all the machines in the pool are updated to the correct machine config.
+    name: Updated
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Updating")].status
+    description: When at least one of machine is not either not updated or is in the process of updating to the desired machine config.
+    name: Updating
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: When the update for one of the machine is not progressig due to an error.
+    name: Degraded
+    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -196,6 +196,22 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigs.machineconfiguration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
+    description: Version of the controller that generated the machineconfig. This will be empty if the machineconfig is not managed by a controller.
+    name: GeneratedByController
+    type: string
+  - JSONPath: .spec.config.ignition.version
+    description: Version of the Ignition Config defined in the machineconfig.
+    name: IgnitionVersion
+    type: string
+  - JSONPath: .spec.osImageURL
+    description: URL for the RPM OS-tree image. This is optional and can be empty.
+    name: OSImageURL
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Created
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition
@@ -672,6 +688,22 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigpools.machineconfiguration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.configuration.name
+    name: Config
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Updated")].status
+    description: When all the machines in the pool are updated to the correct machine config.
+    name: Updated
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Updating")].status
+    description: When at least one of machine is not either not updated or is in the process of updating to the desired machine config.
+    name: Updating
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: When the update for one of the machine is not progressig due to an error.
+    name: Degraded
+    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition


### PR DESCRIPTION
This makes the lists more informative
```console
$ oc get machineconfigpools
NAME      CONFIG                                    UPDATED   UPDATING   DEGRADED
master    master-49e4fc3d90841496575db504d606eb3c   True      False      False
worker    worker-e397e9633d67ced5bcbe3f4067715bff   True      False      False

oc get machineconfigs
NAME                                      GENERATEDBY                  IGNITIONVERSION   OSIMAGEURL
00-master                                 3.11.0-429-g9f6d7d5f-dirty   2.2.0
00-master-ssh                             3.11.0-429-g9f6d7d5f-dirty
00-worker                                 3.11.0-429-g9f6d7d5f-dirty   2.2.0
00-worker-ssh                             3.11.0-429-g9f6d7d5f-dirty
01-master-kubelet                         3.11.0-429-g9f6d7d5f-dirty   2.2.0
01-worker-kubelet                         3.11.0-429-g9f6d7d5f-dirty   2.2.0
master-49e4fc3d90841496575db504d606eb3c   3.11.0-429-g9f6d7d5f-dirty   2.2.0
worker-e397e9633d67ced5bcbe3f4067715bff   3.11.0-429-g9f6d7d5f-dirty   2.2.0
```

/cc @ashcrow @cgwalters 