### PR TITLE
operator: fix bindata

### DIFF
--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -527,6 +527,8 @@ spec:
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoSchedule
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       volumes:
         - name: rootfs
           hostPath:


### PR DESCRIPTION
37599e13 added node selector to run only on linux, but did not update the operator bindata using `./hack/update-generated-bindata.sh`.

/assign @cgwalters 