### PR TITLE
daemon: fix updateSSHKeys for MC with Users unset/empty

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -186,13 +186,7 @@ func (dn *Daemon) reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) *stri
 		if !reflect.DeepEqual(oldIgn.Passwd.Users, newIgn.Passwd.Users) {
 			// check if the prior config is empty and that this is the first time running.
 			// if so, the SSHKey from the cluster config and user "core" must be added to machine config.
-			if len(oldIgn.Passwd.Users) == 0 && len(newIgn.Passwd.Users) == 1 {
-				glog.Infof("user data sent to verify before ssh init: %v", newIgn.Passwd.Users[0])
-				msg := verifyUserFields(newIgn.Passwd.Users[0])
-				if msg != "" {
-					return &msg
-				}
-			} else if len(oldIgn.Passwd.Users) > 0 && len(newIgn.Passwd.Users) >= 1 {
+			if len(oldIgn.Passwd.Users) >= 0 && len(newIgn.Passwd.Users) >= 1 {
 				// there is an update to Users, we must verify that it is ONLY making an acceptable
 				// change to the SSHAuthorizedKeys for the user "core"
 				for _, user := range newIgn.Passwd.Users {
@@ -589,6 +583,10 @@ func getFileOwnership(file ignv2_2types.File) (int, int, error) {
 
 // Update a given PasswdUser's SSHKey
 func (dn *Daemon) updateSSHKeys(newUsers []ignv2_2types.PasswdUser) error {
+	if len(newUsers) == 0 {
+		return nil
+	}
+
 	// Keys should only be written to "/home/core/.ssh"
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
 	if newUsers[0].Name != "core" {

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -262,6 +262,12 @@ func TestReconcilableSSH(t *testing.T) {
 	errMsg = d.reconcilable(oldMcfg, newMcfg)
 	checkIrreconcilableResults(t, "ssh", errMsg)
 
+	//check that empty Users does not generate error/degrade node
+	newMcfg.Spec.Config.Passwd.Users = nil
+
+	errMsg = d.reconcilable(oldMcfg, newMcfg)
+	checkReconcilableResults(t, "ssh", errMsg)
+
 }
 
 func TestUpdateSSHKeys(t *testing.T) {
@@ -312,6 +318,13 @@ func TestUpdateSSHKeys(t *testing.T) {
 	err = d.updateSSHKeys(newMcfg.Spec.Config.Passwd.Users)
 	if err == nil {
 		t.Errorf("Expected error, user is not core")
+	}
+
+	// if Users is empty, nothing should happen and no error should ever be generated
+	newMcfg2 := &mcfgv1.MachineConfig{}
+	err = d.updateSSHKeys(newMcfg2.Spec.Config.Passwd.Users)
+	if err != nil {
+		t.Errorf("Expected no error. Got: %s", err)
 	}
 }
 


### PR DESCRIPTION
Add logic to updateSSH/reconcilable to account for machineconfigs where Passwd:Users is completely empty/unset.

Closes Issue: #292