### PR TITLE
manifests/machineconfig: Print osImageURL last

### DIFF
--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -13,13 +13,13 @@ spec:
     description: Version of the Ignition Config defined in the machineconfig.
     name: IgnitionVersion
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Created
+    type: date
   - JSONPath: .spec.osImageURL
     description: URL for the RPM OS-tree image. This is optional and can be empty.
     name: OSImageURL
     type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Created
-    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition


### PR DESCRIPTION
Since it's long, and the `Age` column is interesting and we don't
want to obscure it.

Ref: https://github.com/openshift/machine-config-operator/pull/287#discussion_r247128766