### PR TITLE
controller: Add a 5s delay before rendering MCs

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -36,6 +36,10 @@ const (
 	//
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
+
+	// renderDelay is a pause to avoid churn in MachineConfigs; see
+	// https://github.com/openshift/machine-config-operator/issues/301
+	renderDelay = 5 * time.Second
 )
 
 var (
@@ -91,7 +95,7 @@ func New(
 	})
 
 	ctrl.syncHandler = ctrl.syncMachineConfigPool
-	ctrl.enqueueMachineConfigPool = ctrl.enqueue
+	ctrl.enqueueMachineConfigPool = ctrl.enqueueDefault
 
 	ctrl.mcpLister = mcpInformer.Lister()
 	ctrl.mcLister = mcInformer.Lister()
@@ -321,7 +325,7 @@ func (ctrl *Controller) enqueueRateLimited(pool *mcfgv1.MachineConfigPool) {
 }
 
 // enqueueAfter will enqueue a pool after the provided amount of time.
-func (ctrl *Controller) enqueueAfter(pool *mcfgv1.MachineConfig, after time.Duration) {
+func (ctrl *Controller) enqueueAfter(pool *mcfgv1.MachineConfigPool, after time.Duration) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pool)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", pool, err))
@@ -329,6 +333,11 @@ func (ctrl *Controller) enqueueAfter(pool *mcfgv1.MachineConfig, after time.Dura
 	}
 
 	ctrl.queue.AddAfter(key, after)
+}
+
+// enqueueDefault calls a default enqueue function
+func (ctrl *Controller) enqueueDefault(pool *mcfgv1.MachineConfigPool) {
+	ctrl.enqueueAfter(pool, renderDelay)
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.


### PR DESCRIPTION
To reduce churn if MCs are being created rapidly - both on general
principle, and also to reduce our exposure to the current bug
that a booting node may fail to find a GC'd MachineConfig:
https://github.com/openshift/machine-config-operator/issues/301