### PR TITLE
 test/e2e: New test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPONENTS = daemon controller server operator
 # vim: noexpandtab ts=8
 export GOPATH=$(shell echo $${GOPATH:-$$HOME/go})
 
-.PHONY: clean test test-unit verify update
+.PHONY: clean test test-unit test-e2e verify update
 # Remove build artifaces
 # Example:
 #    make clean
@@ -31,7 +31,7 @@ _deploy-%:
 	WHAT=$* hack/cluster-push.sh
 
 # Run tests
-test: test-unit
+test: test-unit test-e2e
 
 # Unit tests only (no active cluster required)
 test-unit:
@@ -92,3 +92,7 @@ images: $(imc)
 # Example:
 #    make images.rhel7
 images.rhel7: $(imc7)
+
+# This was copied from https://github.com/openshift/cluster-image-registry-operato
+test-e2e:
+	go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/

--- a/cmd/common/client_builder.go
+++ b/cmd/common/client_builder.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"os"
+
 	"github.com/golang/glog"
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	cvoclientset "github.com/openshift/cluster-version-operator/pkg/generated/clientset/versioned"
@@ -49,6 +51,10 @@ func (cb *ClientBuilder) ClusterversionClientOrDie(name string) cvoclientset.Int
 func NewClientBuilder(kubeconfig string) (*ClientBuilder, error) {
 	var config *rest.Config
 	var err error
+
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
 
 	if kubeconfig != "" {
 		glog.V(4).Infof("Loading kube client config from path %q", kubeconfig)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,10 @@
+package e2e_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/test/e2e/sanity_test.go
+++ b/test/e2e/sanity_test.go
@@ -1,0 +1,28 @@
+package e2e_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/machine-config-operator/cmd/common"
+)
+
+// Test case for https://github.com/openshift/machine-config-operator/pull/288/commits/44d5c5215b5450fca32806f796b50a3372daddc2
+func TestOperatorLabel(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil{
+		t.Errorf("%#v", err)
+	}
+	k := cb.KubeClientOrDie("sanity-test")
+
+	d, err := k.AppsV1().DaemonSets("openshift-machine-config-operator").Get("machine-config-daemon", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("%#v", err)
+	}
+
+	osSelector := d.Spec.Template.Spec.NodeSelector["beta.kubernetes.io/os"]
+	if osSelector != "linux" {
+		t.Errorf("Expected node selector 'linux', not '%s'", osSelector)
+	}
+}


### PR DESCRIPTION

Add a basic test suite, targeting a test case for
44d5c52

This is inspired by the cluster-image-registry-operator tests:
https://github.com/openshift/cluster-image-registry-operator/blob/e6c7544903d2826d171be45cdde5a83a58d97383/test/e2e/main_test.go

Next step is to try hooking this up to Prow.

Related: #257
Replaces: #298