### PR TITLE
daemon: skip querying currentConfig if possible

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -100,7 +100,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 	// TODO: Change the logic to be clearer
 	// We need to skip draining of the node when we are running once
 	// and there is no cluster.
-	if dn.onceFrom != "" && !ValidPath(dn.onceFrom) {
+	if dn.onceFrom == "" {
 		glog.Info("Update prepared; draining the node")
 
 		node, err := dn.kubeClient.CoreV1().Nodes().Get(dn.name, metav1.GetOptions{})


### PR DESCRIPTION
The same way we pass the specific desiredConfig we "locked on" when
updating, also similarly pass the currentConfig. This is a minor
optimization so we avoid querying the cluster again for information we
already have, but it does also make the code more resilient to humans
meddling with node annotations.

Requires: #310