### PR TITLE
 controller/render: fix deleting ownerReference

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -503,6 +503,8 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 			}
 			// Let's not make it fatal for now
 			glog.Warningf("Failed to delete ownerReference from %s: %v", gmc.Name, err)
+		} else {
+			glog.Infof("Deleted ownerReference from %s", gmc.Name)
 		}
 	}
 

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -470,7 +470,26 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 			continue
 		}
 
-		deleteOwnerRefPatch := fmt.Sprintf(`{"metadata":{"ownerReferences":[{"$patch":"delete","uid":"%s"}],"uid":"%s"}}`, pool.UID, gmc.UID)
+		// we should be the only owners of the MC, but just in case, check the index
+		idx := -1
+		for i, owner := range gmc.OwnerReferences {
+			if owner.UID == pool.UID {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			// We don't have a ref on this object, done!
+			continue
+		}
+
+		// XXX: There is a race here if another ownerReference gets added
+		// (though they usually get appended so idx would still be valid), but
+		// that shouldn't happen since we should be the only owners.  Once CRDs
+		// support strategic merges, we can use the `$patch: delete` syntax.
+		glog.V(2).Infof("Attempting to delete ownerReference from %s", gmc.Name)
+		deleteOwnerRefPatch := fmt.Sprintf(`[{"op": "remove", "path": "/metadata/ownerReferences/%d"}]`, idx)
 		_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Patch(gmc.Name, types.JSONPatchType, []byte(deleteOwnerRefPatch))
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -478,10 +497,8 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 				continue
 			}
 			if errors.IsInvalid(err) {
-				// Invalid error will be returned in two cases: 1. the machineconfig
-				// has no owner reference, 2. the uid of the machineconfig doesn't
-				// match.
-				// In both cases, the error can be ignored.
+				// Invalid error will be returned if the machineconfig has no
+				// owner reference. Ignore it.
 				continue
 			}
 			// Let's not make it fatal for now


### PR DESCRIPTION
We weren't actually deleting the ownerReference because CRDs don't yet
support strategic merges[1], which have the fancy `$patch: delete`
syntax. We were also specifying the wrong PatchType argument.

For now, just drop down to the vanilla JSONPatch[2] to do this.

[1] https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch
[2] https://tools.ietf.org/html/rfc6902

Related: #301