### PR TITLE
WIP: test/e2e: Validate that no nodes went degraded

### DIFF
--- a/test/e2e/sanity_test.go
+++ b/test/e2e/sanity_test.go
@@ -2,10 +2,14 @@ package e2e_test
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/machine-config-operator/cmd/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon"
 )
 
 // Test case for https://github.com/openshift/machine-config-operator/pull/288/commits/44d5c5215b5450fca32806f796b50a3372daddc2
@@ -24,5 +28,42 @@ func TestOperatorLabel(t *testing.T) {
 	osSelector := d.Spec.Template.Spec.NodeSelector["beta.kubernetes.io/os"]
 	if osSelector != "linux" {
 		t.Errorf("Expected node selector 'linux', not '%s'", osSelector)
+	}
+}
+
+func TestNoDegraded(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil{
+		t.Errorf("%#v", err)
+	}
+	client := cb.KubeClientOrDie("sanity-test")
+
+	nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		t.Errorf("listing nodes: %v", err)
+	}
+
+	var degraded []*corev1.Node
+	for _, node := range nodes.Items {
+		err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+			if node.Annotations == nil {
+				return false, nil
+			}
+			dstate, ok := node.Annotations[daemon.MachineConfigDaemonStateAnnotationKey]
+			if !ok || dstate == "" {
+				return false, nil
+			}
+			if dstate == daemon.MachineConfigDaemonStateDegraded {
+				degraded = append(degraded, &node)
+			}
+			return true, nil
+		})
+		if err != nil {
+			t.Errorf("node annotation: %v", err)
+		}
+	}
+
+	if len(degraded) > 0 {
+		t.Errorf("%d degraded nodes found", len(degraded))
 	}
 }


### PR DESCRIPTION
I think we have this in CI but we're not noticing it.
If it's happening we need to fix it.

Ref: https://github.com/openshift/machine-config-operator/issues/301