### PR TITLE
controller/render: fix ownerRef deletion error-handling

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -475,15 +475,17 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// If the machineconfig no longer exists, ignore it.
-				return nil
+				continue
 			}
 			if errors.IsInvalid(err) {
 				// Invalid error will be returned in two cases: 1. the machineconfig
 				// has no owner reference, 2. the uid of the machineconfig doesn't
 				// match.
 				// In both cases, the error can be ignored.
-				return nil
+				continue
 			}
+			// Let's not make it fatal for now
+			glog.Warningf("Failed to delete ownerReference from %s: %v", gmc.Name, err)
 		}
 	}
 


### PR DESCRIPTION
We were immediately returning from the function when ignoring an error
instead of moving on to the next MachineConfig in the list. Also, we
were completely ignoring errors we *shouldn't* ignore. For now, I've
just made this a warning rather than a hard failure pending discussions
re. garbage collection.