### PR TITLE
*: include 127.0.0.1 and localhost in etcd peer SAN

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -331,6 +331,7 @@ func etcdPeerCertDNSNames(cfg RenderConfig) (interface{}, error) {
 	}
 
 	var dnsNames = []string{
+		"localhost",
 		"${ETCD_DNS_NAME}",
 		fmt.Sprintf("%s.%s", cfg.ClusterName, cfg.BaseDomain), // https://github.com/etcd-io/etcd/blob/583763261f1c843e07c1bf7fea5fb4cfb684fe87/Documentation/op-guide/clustering.md#dns-discovery
 	}

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -55,7 +55,7 @@ contents:
                 --assetsdir=/etc/ssl/etcd \
                 --dnsnames={{etcdPeerCertDNSNames .}} \
                 --commonname=system:etcd-peer:${ETCD_DNS_NAME} \
-                --ipaddrs=${ETCD_IPV4_ADDRESS} \
+                --ipaddrs=${ETCD_IPV4_ADDRESS},127.0.0.1 \
           
         securityContext:
           priviledged: true


### PR DESCRIPTION
The etcd peer SAN does not include localhost/127.0.0.1 this is a problem if you would like to use this cert as a client from say inside the container.

As the peer is the only cert with `TLS Web Client Authentication` we really need to include this.

peer
```
 X509v3 Extended Key Usage: 
                TLS Web Client Authentication, TLS Web Server Authentication

X509v3 Subject Alternative Name: 
                DNS:sbatsche-etcd-0.devcluster.openshift.com, DNS:sbatsche.devcluster.openshift.com, IP Address:10.0.15.187

```
server
```
X509v3 Extended Key Usage: 
              TLS Web Server Authentication

X509v3 Subject Alternative Name: 
                DNS:localhost, DNS:etcd.kube-system.svc, DNS:etcd.kube-system.svc.cluster.local, DNS:sbatsche-etcd-0.devcluster.openshift.com, IP Address:10.0.15.187, IP Address:127.0.0.1
```
Separate issue also I am seeing what appears to be a client attempting to use the server cert
```
2019-01-17T13:10:11.150313341+00:00 stderr F 2019-01-17 13:10:11.150277 I | embed: rejected connection from "127.0.0.1:37686" (error "tls: failed to verify client's certificate: x509: certificate specifies an incompatible key usage", ServerName "")
```