### PR TITLE
kubelet: always delete cpu_manager_state

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -6,6 +6,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -6,6 +6,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -6,6 +6,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -6,6 +6,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -6,6 +6,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -6,6 +6,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -8,6 +8,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -8,6 +8,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 


### PR DESCRIPTION
Talked to @sjenning about cpu_manager_state.

When a node is drained there is not any cpu state to preserve. Preserving
this file also causes the kubelet to fail to startup when the
cpu_manager_state has changed from none to static (or vice versa).

ref: https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy

/cc @jeremyeder 

related to: https://github.com/openshift/machine-config-operator/issues/332