### PR TITLE
kubelet: use openshift pod image

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -19,6 +19,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -19,6 +19,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -19,6 +19,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -17,6 +17,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -17,6 +17,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -17,6 +17,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -21,6 +21,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
         --node-labels=node-role.kubernetes.io/master \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -19,6 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
+        --pod-infra-container-image=quay.io/openshift/origin-pod:v4.0 \
         --node-labels=node-role.kubernetes.io/worker \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \


### PR DESCRIPTION
Use the OpenShift container pod within the kubelet. Images are not passed to the template rendering engine... yet. There are various other templates that hard-code images for now with a TODO to fix. 

/cc @smarterclayton @sjenning 