### PR TITLE
mco: remove osimageurl logging from sync() to make mco logs readable

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -267,7 +267,6 @@ func (optr *Operator) sync(key string) error {
 	}
 
 	osimageurl, err := optr.getOsImageURL(namespace)
-	glog.Infof("using osimageurl: %s", osimageurl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary: PR #305 added logging to operator.go func sync(), which fills the MCO logs (as seen in `oc logs -f ...` ) with line output similar to `I0125 23:24:27.865406       1 operator.go:273] using osimageurl: registry.svc.ci.openshift.org/openshift/origin-v4.0-2019-01-25-191847@sha256:61dc83d62cfb5054c4c5532bd2478742a0711075ef5151572e63f94babeacc1a` approx 4 times every minute. 

This makes it difficult to read/watch the logs for other alerts/messages from the MCO.

Closes: #345 
