### PR TITLE
 operator: Add bootstrap arg --osimg-config-file

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -24,6 +24,7 @@ var (
 		rootCAFile          string
 		pullSecretFile      string
 		configFile          string
+		osimgConfigMapFile  string
 		imagesConfigMapFile string
 		mccImage            string
 		mcsImage            string
@@ -43,6 +44,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcsImage, "machine-config-server-image", "", "Image for Machine Config Server. (this cannot be set if --images-json-configmap is set)")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcdImage, "machine-config-daemon-image", "", "Image for Machine Config Daemon. (this cannot be set if --images-json-configmap is set)")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.osimgConfigMapFile, "osimg-config-file", "", "ConfigMap containing osImageURL")
 }
 
 func runBootstrapCmd(cmd *cobra.Command, args []string) {
@@ -81,10 +83,11 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		imgs.MachineConfigServer = bootstrapOpts.mcsImage
 		imgs.MachineConfigDaemon = bootstrapOpts.mcdImage
 	}
+
 	if err := operator.RenderBootstrap(
 		bootstrapOpts.configFile,
 		bootstrapOpts.etcdCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.pullSecretFile,
-		imgs,
+		imgs, bootstrapOpts.osimgConfigMapFile,
 		bootstrapOpts.destinationDir,
 	); err != nil {
 		glog.Fatalf("error rendering bootstrap manifests: %v", err)

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -3,14 +3,9 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
-	"io/ioutil"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/openshift/machine-config-operator/pkg/operator"
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -97,17 +92,9 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 }
 
 func rawImagesFromConfigMapOnDisk(file string) ([]byte, error) {
-	data, err := ioutil.ReadFile(bootstrapOpts.imagesConfigMapFile)
+	cm, err := operator.DecodeConfigMap(file)
 	if err != nil {
 		return nil, err
-	}
-	obji, err := runtime.Decode(scheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion), data)
-	if err != nil {
-		return nil, err
-	}
-	cm, ok := obji.(*corev1.ConfigMap)
-	if !ok {
-		return nil, fmt.Errorf("expected *corev1.ConfigMap found %T", obji)
 	}
 	return []byte(cm.Data["images.json"]), nil
 }

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -17,7 +17,7 @@ import (
 func RenderBootstrap(
 	clusterConfigConfigMapFile string,
 	etcdCAFile, rootCAFile string, pullSecretFile string,
-	imgs Images,
+	imgs Images, osimgConfigMapFile string,
 	destinationDir string,
 ) error {
 	filesData := map[string][]byte{}
@@ -37,12 +37,21 @@ func RenderBootstrap(
 		filesData[file] = data
 	}
 
+	var osimageurl string
+	if osimgConfigMapFile != "" {
+		cm, err := DecodeConfigMap(osimgConfigMapFile)
+		if err != nil {
+			return err
+		}
+		osimageurl = cm.Data["osImageURL"]
+	}
+
 	mcoconfig, err := discoverMCOConfig(getInstallConfigFromFile(filesData[clusterConfigConfigMapFile]))
 	if err != nil {
 		return fmt.Errorf("error discovering MCOConfig from %q: %v", clusterConfigConfigMapFile, err)
 	}
 
-	config := getRenderConfig(mcoconfig, filesData[etcdCAFile], filesData[rootCAFile], nil, imgs, "")
+	config := getRenderConfig(mcoconfig, filesData[etcdCAFile], filesData[rootCAFile], nil, imgs, osimageurl)
 
 	manifests := []struct {
 		name     string

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -98,6 +98,23 @@ func RenderBootstrap(
 	return nil
 }
 
+/// DecodeConfigMap converts a file on disk into a ConfigMap
+func DecodeConfigMap(file string) (*corev1.ConfigMap, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	obji, err := runtime.Decode(scheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion), data)
+	if err != nil {
+		return nil, err
+	}
+	cm, ok := obji.(*corev1.ConfigMap)
+	if !ok {
+		return nil, fmt.Errorf("expected *corev1.ConfigMap found %T", obji)
+	}
+	return cm, nil
+}
+
 func getInstallConfigFromFile(cmData []byte) installConfigGetter {
 	return func() (installertypes.InstallConfig, error) {
 		obji, err := runtime.Decode(scheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion), cmData)


### PR DESCRIPTION

This will allow the installer to render the payload's osImageURL
ConfigMap in the initial MachineConfig as well.

Closes: #334