### PR TITLE
daemon: fix overwritten files

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	mcfgclientv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
 	"github.com/vincent-petithory/dataurl"
+	fsnotify "gopkg.in/fsnotify.v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,7 +33,6 @@ import (
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	fsnotify "gopkg.in/fsnotify.v1"
 )
 
 // Daemon is the dispatch point for the functions of the agent on the
@@ -505,11 +505,11 @@ func (dn *Daemon) setupFileWatcher(watcher *fsnotify.Watcher) error {
 // applySSHTaint calls nodewriter to apply the specified ssh taint
 func (dn *Daemon) applySSHTaint() error {
 	glog.Infof("Detected ssh! The node is being tainted with: %v=%v:%v",
-	MachineConfigDaemonSSHTaintKey, MachineConfigDaemonSSHTaintValue, corev1.TaintEffectNoSchedule)
+		MachineConfigDaemonSSHTaintKey, MachineConfigDaemonSSHTaintValue, corev1.TaintEffectNoSchedule)
 
-	taint := &corev1.Taint {
-		Key: MachineConfigDaemonSSHTaintKey,
-		Value: MachineConfigDaemonSSHTaintValue,
+	taint := &corev1.Taint{
+		Key:    MachineConfigDaemonSSHTaintKey,
+		Value:  MachineConfigDaemonSSHTaintValue,
 		Effect: corev1.TaintEffectNoSchedule,
 	}
 	return dn.nodeWriter.SetTaint(dn.kubeClient.CoreV1().Nodes(), dn.name, taint)

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,8 +1,12 @@
 package daemon
 
 import (
+	"os"
 	"strconv"
 	"testing"
+
+	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/vincent-petithory/dataurl"
 )
 
 var pathtests = []struct {
@@ -23,5 +27,62 @@ func TestValidPath(t *testing.T) {
 		if isValid != tt.isValid {
 			t.Errorf("%s isValid should be %s, found %s", tt.path, strconv.FormatBool(tt.isValid), strconv.FormatBool(isValid))
 		}
+	}
+}
+
+func TestOverwrittenFile(t *testing.T) {
+	fi, err := os.Lstat("fixtures/test1.txt")
+	if err != nil {
+		t.Errorf("Could not Lstat file: %v", err)
+	}
+	fileMode := int(fi.Mode().Perm())
+
+	// validate single file
+	files := []ignv2_2types.File{
+		{
+			Node: ignv2_2types.Node{
+				Path: "fixtures/test1.txt",
+			},
+			FileEmbedded1: ignv2_2types.FileEmbedded1{
+				Contents: ignv2_2types.FileContents{
+					Source: dataurl.EncodeBytes([]byte("hello world\n")),
+				},
+				Mode: &fileMode,
+			},
+		},
+	}
+
+	if status := checkFiles(files); status != true {
+		t.Errorf("Invalid files")
+	}
+
+	// validate overwritten file
+	files = []ignv2_2types.File{
+		{
+			Node: ignv2_2types.Node{
+				Path: "fixtures/test1.txt",
+			},
+			FileEmbedded1: ignv2_2types.FileEmbedded1{
+				Contents: ignv2_2types.FileContents{
+					Source: dataurl.EncodeBytes([]byte("hello\n")),
+				},
+				Mode: &fileMode,
+			},
+		},
+		{
+			Node: ignv2_2types.Node{
+				Path: "fixtures/test1.txt",
+			},
+			FileEmbedded1: ignv2_2types.FileEmbedded1{
+				Contents: ignv2_2types.FileContents{
+					Source: dataurl.EncodeBytes([]byte("hello world\n")),
+				},
+				Mode: &fileMode,
+			},
+		},
+	}
+
+	if status := checkFiles(files); status != true {
+		t.Errorf("Validating an overwritten file failed")
 	}
 }

--- a/pkg/daemon/fixtures/test1.txt
+++ b/pkg/daemon/fixtures/test1.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
Files within ignition can be overwritten by later entries. This fixes
the validation to check all ignition written files for validity instead
of checking only the first.

This fixes an issue where the MCD marks a node as degraded when a file within ignition has overwritten a default config (ie: KubeletConfig)

/cc @jeremyeder @sjenning 