### PR TITLE
 Inject OSImageURL from CVO into templated MachineConfigs

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -33,4 +33,4 @@ spec:
   - name: machine-os-content
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/rhcos/maipo@sha256:83a6d461628380f1dcc057ffef4909992f593b72c5aa4db2e01c0b130004afea
+      name: registry.svc.ci.openshift.org/rhcos/maipo@sha256:61dc83d62cfb5054c4c5532bd2478742a0711075ef5151572e63f94babeacc1a

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -239,7 +239,11 @@ func generateMachineConfigForName(config *RenderConfig, role, name, path string)
 		return nil, fmt.Errorf("error transpiling ct config to Ignition config: %v", err)
 	}
 
-	return MachineConfigFromIgnConfig(role, name, ignCfg), nil
+	mcfg := MachineConfigFromIgnConfig(role, name, ignCfg)
+	// And inject the osimageurl here
+	mcfg.Spec.OSImageURL = config.OSImageURL
+
+	return mcfg, nil
 }
 
 const (

--- a/test/e2e/osimageurl_test.go
+++ b/test/e2e/osimageurl_test.go
@@ -1,0 +1,46 @@
+package e2e_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/machine-config-operator/cmd/common"
+)
+
+func TestOSImageURL(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+	mcClient := cb.MachineConfigClientOrDie("mc-file-add")
+
+	// grab the latest worker- MC
+	mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get("worker", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	mc, err := mcClient.MachineconfigurationV1().MachineConfigs().Get(mcp.Status.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	if mc.Spec.OSImageURL == "" {
+		t.Fatalf("Empty OSImageURL for %s", mc.Name)
+	}
+
+	// grab the latest master- MC
+	mcp, err = mcClient.MachineconfigurationV1().MachineConfigPools().Get("master", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+	mc, err = mcClient.MachineconfigurationV1().MachineConfigs().Get(mcp.Status.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	if mc.Spec.OSImageURL == "" {
+		t.Fatalf("Empty OSImageURL for %s", mc.Name)
+	}
+}


### PR DESCRIPTION

This injects the `OSImageURL` into the "base"
config (e.g. `00-worker`, `00-master`).  This differs from
previous pull requests which made it a separate MC, but that
adds visual noise and will exacerbate renderer race conditions.