### PR TITLE
HACKING.md: add paragraph to turn verbose on

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -110,6 +110,21 @@ This [guide](https://golang.github.io/dep/docs/daily-dep.html) a great source to
 
 For the sake of your fellow reviewers, commit vendored code separately from any other changes.
 
+# Turn on verbose for development
+
+Given you already have a cluster up and running, you can turn verbose on (level 4)
+for any given component with:
+
+```sh
+oc patch daemonset/machine-config-daemon --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--v=4"}]'
+```
+
+You can replace `daemonset/machine-config-daemon` with any other MCO component.
+If the componenet already has a `--v=` flag set, the command above still adds
+verbose and ignores the previous one already set.
+If you watch the pods, you'll notice your component restarting as well.
+Note this still requires [disabling the CVO](https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusterversion.md#disabling-the-cluster-version-operator).
+
 # Developing the MCD without building images
 
 It is possible to iterate on the MCD without having to rebuild images


### PR DESCRIPTION
Add a paragraph about turning debugging on using `oc patch` for any
given component.

Signed-off-by: Antonio Murdaca <runcom@linux.com>