### PR TITLE
MCS: change machine-config-server ports

### DIFF
--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -9,6 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// we are transitioning from legacy ports 49500/49501 -> 22623/22624
+	// this can be removed once fully transitioned in the installer.
+	legacySecurePort   = 49500
+	legacyInsecurePort = 49501
+)
+
 var (
 	bootstrapCmd = &cobra.Command{
 		Use:   "bootstrap",
@@ -45,10 +52,14 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	apiHandler := server.NewServerAPIHandler(bs)
 	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
 	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
+	legacySecureServer := server.NewAPIServer(apiHandler, legacySecurePort, false, rootOpts.cert, rootOpts.key)
+	legacyInsecureServer := server.NewAPIServer(apiHandler, legacyInsecurePort, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()
 	go insecureServer.Serve()
+	go legacySecureServer.Serve()
+	go legacyInsecureServer.Serve()
 	<-stopCh
 	panic("not possible")
 }

--- a/cmd/machine-config-server/main.go
+++ b/cmd/machine-config-server/main.go
@@ -28,10 +28,10 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-	rootCmd.PersistentFlags().IntVar(&rootOpts.sport, "secure-port", 49500, "secure port to serve ignition configs")
+	rootCmd.PersistentFlags().IntVar(&rootOpts.sport, "secure-port", 22623, "secure port to serve ignition configs")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.cert, "cert", "/etc/ssl/mcs/tls.crt", "cert file for TLS")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.key, "key", "/etc/ssl/mcs/tls.key", "key file for TLS")
-	rootCmd.PersistentFlags().IntVar(&rootOpts.isport, "insecure-port", 49501, "insecure port to serve ignition configs")
+	rootCmd.PersistentFlags().IntVar(&rootOpts.isport, "insecure-port", 22624, "insecure port to serve ignition configs")
 }
 
 func main() {

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -45,13 +45,19 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		glog.Exitf("Machine Config Server exited with error: %v", err)
 	}
 
+	// we are transitioning from legacy ports 49500/49501 -> 22623/22624
+	// legacySecureServer/legacyInsecureServer will be removed once the installer commits port changes.
 	apiHandler := server.NewServerAPIHandler(cs)
 	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
 	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
+	legacySecureServer := server.NewAPIServer(apiHandler, legacySecurePort, false, rootOpts.cert, rootOpts.key)
+	legacyInsecureServer := server.NewAPIServer(apiHandler, legacyInsecurePort, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()
 	go insecureServer.Serve()
+	go legacySecureServer.Serve()
+	go legacyInsecureServer.Serve()
 	<-stopCh
 	panic("not possible")
 }


### PR DESCRIPTION
Change machine-config-server ports from 49500/49501 -> 22623/22624
to avoid conflict with local port and node port ranges.

Closes: #166
Related-to: https://github.com/openshift/installer/pull/1180