### PR TITLE
pkg/daemon: idiomatic Go cleanup

### DIFF
--- a/pkg/daemon/constants.go
+++ b/pkg/daemon/constants.go
@@ -31,7 +31,7 @@ const (
 	// MachineConfigOnceFromLocalConfig denotes that the config was found locally
 	MachineConfigOnceFromLocalConfig = "LOCAL"
 
-	// MachineConfigSSHAccessAnnotationKey is used to mark a node after it has been accessed via SSH
+	// MachineConfigDaemonSSHAccessAnnotationKey is used to mark a node after it has been accessed via SSH
 	MachineConfigDaemonSSHAccessAnnotationKey = "machineconfiguration.openshift.io/ssh"
 	// MachineConfigDaemonSSHAccessValue is the annotation value applied when ssh access is detected
 	MachineConfigDaemonSSHAccessValue = "accessed"

--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -20,14 +20,15 @@ func GetHostRunningOS(rootFs string) (string, error) {
 		return "", err
 	}
 	// See https://github.com/openshift/redhat-release-coreos/blob/master/redhat-release-coreos.spec
-	if or.ID == "rhcos" {
+	switch or.ID {
+	case "rhcos":
 		return MachineConfigDaemonOSRHCOS, nil
-	} else if or.ID == "rhel" {
+	case "rhel":
 		return MachineConfigDaemonOSRHEL, nil
-	} else if or.ID == "centos" {
+	case "centos":
 		return MachineConfigDaemonOSCENTOS, nil
+	default:
+		// default to unknown OS
+		return "", fmt.Errorf("An unsupported OS is being used: %s:%s", or.ID, or.VARIANT_ID)
 	}
-	// default to unknown OS
-	return "", fmt.Errorf(
-		"An unsupported OS is being used: %s:%s", or.ID, or.VARIANT_ID)
 }

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -103,9 +103,9 @@ func (nw *NodeWriter) SetUpdateDegraded(err error, client corev1.NodeInterface, 
 // node to degraded due to that error.
 func (nw *NodeWriter) SetUpdateDegradedIgnoreErr(err error, client corev1.NodeInterface, node string) error {
 	// log error here since the caller won't look at it
-	degraded_err := nw.SetUpdateDegraded(err, client, node)
-	if degraded_err != nil {
-		glog.Errorf("Error while setting degraded: %v", degraded_err)
+	degradedErr := nw.SetUpdateDegraded(err, client, node)
+	if degradedErr != nil {
+		glog.Errorf("Error while setting degraded: %v", degradedErr)
 	}
 	return err
 }
@@ -119,17 +119,17 @@ func (nw *NodeWriter) SetUpdateDegradedMsgIgnoreErr(msg string, client corev1.No
 
 // SetSSHAccessed sets the ssh annotation to accessed
 func (nw *NodeWriter) SetSSHAccessed(client corev1.NodeInterface, node string) error {
-        annos := map[string]string{
-                MachineConfigDaemonSSHAccessAnnotationKey: MachineConfigDaemonSSHAccessValue,
-        }
-        respChan := make(chan error, 1)
-        nw.writer <- message{
-                client:          client,
-                node:            node,
-                annos:           annos,
-                responseChannel: respChan,
-        }
-        return <-respChan
+	annos := map[string]string{
+		MachineConfigDaemonSSHAccessAnnotationKey: MachineConfigDaemonSSHAccessValue,
+	}
+	respChan := make(chan error, 1)
+	nw.writer <- message{
+		client:          client,
+		node:            node,
+		annos:           annos,
+		responseChannel: respChan,
+	}
+	return <-respChan
 }
 
 // updateNodeRetry calls f to update a node object in Kubernetes.


### PR DESCRIPTION
Went through a bunch of cleanup to be more idiomatic when writing Go
code (no else if previous return, default values, return on err, bool comparison etc etc)
(mainly went to read and learn the code)
There should be no functional change at all.

(so sorry for this PR :angel: )

Signed-off-by: Antonio Murdaca <runcom@linux.com>