### PR TITLE
daemon: Bind /run/secrets/ in so we can see SA tokens

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -134,6 +134,11 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		if err != nil {
 			glog.Fatalf("failed to initialize daemon: %v", err)
 		}
+
+		// in the daemon case
+		if err := dn.BindPodMounts(); err != nil {
+			glog.Fatalf("binding pod mounts: %s", err)
+		}
 	}
 
 	glog.Infof(`Calling chroot("%s")`, startOpts.rootMount)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -271,6 +272,18 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 	err := <-exitCh
 
 	return dn.nodeWriter.SetUpdateDegradedIgnoreErr(err, dn.kubeClient.CoreV1().Nodes(), dn.name)
+}
+
+// BindPodMounts ensures that the daemon can still see e.g. /run/secrets/kubernetes.io
+// service account tokens after chrooting.  This function must be called before chroot.
+func (dn *Daemon) BindPodMounts() error {
+	targetSecrets := filepath.Join(dn.rootMount, "/run/secrets")
+	if err := os.MkdirAll(targetSecrets, 0755); err != nil {
+		return err
+	}
+	// This will only affect our mount namespace, not the host
+	mnt := exec.Command("mount", "--rbind", "/run/secrets", targetSecrets)
+	return mnt.Run()
 }
 
 func (dn *Daemon) runLoginMonitor(stopCh <-chan struct{}, exitCh chan<- error) {

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -1,0 +1,42 @@
+package e2e_test
+
+import (
+	"testing"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/openshift/machine-config-operator/cmd/common"
+)
+
+// Test case for https://github.com/openshift/machine-config-operator/issues/358
+func TestMCDToken(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil{
+		t.Errorf("%#v", err)
+	}
+	k := cb.KubeClientOrDie("sanity-test")
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}).String(),
+	}
+
+	mcdList, err := k.CoreV1().Pods("openshift-machine-config-operator").List(listOptions)
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	for _, pod := range mcdList.Items {
+		res, err := k.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{}).DoRaw()
+		if err != nil {
+			t.Errorf("%s", err)
+		}
+		for _, line := range strings.Split(string(res), "\n") {
+			if strings.Contains(line, "Unable to rotate token") {
+				t.Fatalf("found token rotation failure message: %s", line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Because we `chroot()` we need to ensure that we can still see
the service account tokens injected into our pod.

Closes: https://github.com/openshift/machine-config-operator/issues/358