### PR TITLE
pkg/daemon: check channel closing

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -279,7 +279,11 @@ func (dn *Daemon) runLoginMonitor(stopCh <-chan struct{}, exitCh chan<- error) {
 		select {
 		case <-stopCh:
 			return
-		case msg := <-sessionNewCh:
+		case msg, ok := <-sessionNewCh:
+			if !ok {
+				glog.V(4).Info("Not adding the ssh accessed annotation because the logind SessionNew channel is closed")
+				return
+			}
 			glog.Infof("Detected a new login session: %v", msg)
 			glog.Infof("Login access is discouraged! Applying annotation: %v", MachineConfigDaemonSSHAccessAnnotationKey)
 			if err := dn.nodeWriter.SetSSHAccessed(dn.kubeClient.CoreV1().Nodes(), dn.name); err != nil {


### PR DESCRIPTION
Fix #372, after this patch, no ssh/accessed annotation is applied on a machine config addition.

On reboot, the SessionNew subscribed channel gets closed
causing the node ssh/accessed annotation to be added.
This patch fixes that by checking if the channel is indeed
closing before going ahead and add the annotation.

Haven't added an e2e cause watching for something _not to_ happen is gonna be the best flake ever, I'll defer to add proper testing around ssh/accessed being added on real login in a follow up.

Signed-off-by: Antonio Murdaca <runcom@linux.com>