### PR TITLE
 pkg/daemon: run login monitor for Degraded nodes

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -103,6 +103,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			startOpts.kubeletHealthzEndpoint,
 			nodeWriter,
 			exitCh,
+			stopCh,
 		)
 		if err != nil {
 			glog.Fatalf("failed to initialize single run daemon: %v", err)
@@ -130,6 +131,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			startOpts.kubeletHealthzEndpoint,
 			nodeWriter,
 			exitCh,
+			stopCh,
 		)
 		if err != nil {
 			glog.Fatalf("failed to initialize daemon: %v", err)


### PR DESCRIPTION
If there would ever be a way to reconcile a Degraded node, I believe it
would be worth to still learn if someone jumped on a node and messed up
with it so we can decide what to do.

Feel free to close this telling I'm dumb as well, I'm probably missing some context which led to this PR while playing around reading the code but it makes sense to me to still have something like this. This is also not fixing anything related to super early startup where someone can jump on a node _before_ the daemon is running and tracking accesses.

This PR builds on #373, I'll rebase it once that merges