### PR TITLE
manifests/daemon: add note about other mountpoints

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -27,6 +27,10 @@ spec:
         volumeMounts:
           - mountPath: /rootfs
             name: rootfs
+          # For now, we chroot into /rootfs, so we're not really making use of
+          # these mount points below (it works transparently right now because
+          # the mounted path is the same as the host path). They're mostly kept
+          # for documentation purposes, and in case we stop chroot'ing.
           - mountPath: /var/run/dbus
             name: var-run-dbus
           - mountPath: /run/systemd


### PR DESCRIPTION
Make it clear in the manifest file that we don't actually make use of
the other mount points right now since we chroot early on.