### PR TITLE
Makefile: set GOCACHE=off in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ images.rhel7: $(imc7)
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	GOCACHE=off go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 
 # And this one dumps debugging stuff
 test-e2e-prow:
-	if ! go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/; then ./test/e2e/debuglog; exit 1; fi
+	if ! GOCACHE=off go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/; then ./test/e2e/debuglog; exit 1; fi


### PR DESCRIPTION
Since Go 1.10, test results get cached. This leads to the tests not being run
sometimes because Go has cached the results and just assumes it will get the
same results because the Go code hasn't changed.
Set GOCACHE=off to get clean results everytime (this is especially good
for us since we can poke at the cluster and rerun the test w/o having to
change go code).

Signed-off-by: Antonio Murdaca <runcom@linux.com>