### PR TITLE
 hack/cluster-push-prep.sh: override only needed objects

### DIFF
--- a/hack/cluster-push-prep.sh
+++ b/hack/cluster-push-prep.sh
@@ -15,7 +15,7 @@ if ! oc get -n openshift-image-registry route/image-registry &>/dev/null; then
 fi
 oc patch -n openshift-image-registry route/image-registry -p '{"spec": {"tls": {"insecureEdgeTerminationPolicy": "Redirect", "termination": "reencrypt"}}}'
 registry=$(oc get -n openshift-image-registry -o json route/image-registry | jq -r ".spec.host")
-if ! curl -k --head https://"${registry}" >/dev/null; then
+if ! curl -k -s --head https://"${registry}" >/dev/null; then
     if ! grep -q "${registry}" /etc/hosts; then
         set +x
         echo "error: Failed to contact the registry"

--- a/hack/cluster-push-prep.sh
+++ b/hack/cluster-push-prep.sh
@@ -9,7 +9,11 @@
 
 set -xeuo pipefail
 
-oc -n openshift-cluster-version scale --replicas=0 deploy/cluster-version-operator
+# XXX: --type merge completely overrides any previous "overrides" array
+#      find a way to just append? json op: add isn't working at all
+#      if there's not an overrides array already, that's why we use merge
+oc patch clusterversions.config.openshift.io/version --type merge -p '{"spec":{"overrides": [{"kind": "Deployment","name": "machine-config-operator", "namespace": "openshift-machine-config-operator", "unmanaged": true}, {"kind": "ConfigMap","name": "machine-config-operator-images", "namespace": "openshift-machine-config-operator", "unmanaged": true}]}}'
+
 if ! oc get -n openshift-image-registry route/image-registry &>/dev/null; then
     oc expose -n openshift-image-registry svc/image-registry
 fi

--- a/hack/cluster-push.sh
+++ b/hack/cluster-push.sh
@@ -14,7 +14,7 @@ if [ "${1:-}" = "-n" ]; then
 fi
 
 registry=$(oc get -n openshift-image-registry -o json route/image-registry | jq -r ".spec.host")
-curl -k --head https://"${registry}" >/dev/null
+curl -k -s --head https://"${registry}" >/dev/null
 
 WHAT=${WHAT:-machine-config-daemon}
 LOCAL_IMGNAME=localhost/${WHAT}


### PR DESCRIPTION
Close https://github.com/openshift/machine-config-operator/issues/259

First and third commits are auxiliary, the second one is the one actually adding overrides for the CVO in the `hack/cluster-push-*` scripts.

Could you test it out? It works fine on AWS.