### PR TITLE
daemon: Write out pending state file just before reboot

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -105,6 +105,10 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) error {
 		glog.V(2).Info("Node successfully drained")
 	}
 
+	if err := dn.writePendingState(newConfig); err != nil {
+		return errors.Wrapf(err, "writing pending state")
+	}
+
 	// reboot. this function shouldn't actually return.
 	return dn.reboot(fmt.Sprintf("Node will reboot into config %v", newConfig.GetName()))
 }
@@ -139,10 +143,6 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 
 	if err := dn.updateSSHKeys(newConfig.Spec.Config.Passwd.Users); err != nil {
 		return err
-	}
-
-	if err := dn.writePendingState(newConfig); err != nil {
-		return errors.Wrapf(err, "writing pending state")
 	}
 
 	return dn.updateOSAndReboot(newConfig)


### PR DESCRIPTION
Saw
```
E0211 21:20:54.783163   68957 daemon.go:384] Fatal error checking initial state of node: Checking initial state: pending config master-e36ac826fbfdf3342e5579460c64658e bootID 4f94db9f-79a2-43be-8630-4fb276eb2e14 matches current! Failed to reboot?
E0211 21:20:54.783186   68957 writer.go:91] Marking degraded due to: Checking initial state: pending config master-e36ac826fbfdf3342e5579460c64658e bootID 4f94db9f-79a2-43be-8630-4fb276eb2e14 matches current! Failed to reboot?
```
on chat.  Thinking about this, we could hit this case if e.g.
the MCD was restarted during the drain (or more generally between
where we were writing the pending file and rebooting).

Let's write it just before reboot to reduce the chance of hitting
those cases.