### PR TITLE
pkg/operator: correctly sync status for the CVO

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -47,7 +47,6 @@ func (optr *Operator) syncAll(rconfig renderConfig) error {
 		if optr.inClusterBringup {
 			glog.Infof("[init mode] synced %s in %v", sf.name, time.Since(startTime))
 		}
-		optr.syncProgressingStatus()
 	}
 
 	agg := utilerrors.NewAggregate(errs)
@@ -55,7 +54,8 @@ func (optr *Operator) syncAll(rconfig renderConfig) error {
 		errs = append(errs, optr.syncFailingStatus(agg))
 		agg = utilerrors.NewAggregate(errs)
 		return fmt.Errorf("error syncing: %v", agg.Error())
-	} else if optr.inClusterBringup {
+	}
+	if optr.inClusterBringup {
 		glog.Infof("Initialization complete")
 		optr.inClusterBringup = false
 	}


### PR DESCRIPTION
Based on:

- https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#conditions
- Slack conversation with Clayton

We should correctly report Progressing only when really progressing towards something. Re-syncing, reconciling, drift detections verifying everything is still where you left it is not _changing_ something, thus is not progressing.

closes #346

/cc @smarterclayton @abhinavdahiya ptal

Signed-off-by: Antonio Murdaca <runcom@linux.com>