### PR TITLE
pkg/daemon: write bytes, use buffered writer and compare bytes

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -52,7 +52,7 @@ func TestOverwrittenFile(t *testing.T) {
 		},
 	}
 
-	if status := checkFiles(files); status != true {
+	if status := checkFiles(files); !status {
 		t.Errorf("Invalid files")
 	}
 
@@ -82,7 +82,7 @@ func TestOverwrittenFile(t *testing.T) {
 		},
 	}
 
-	if status := checkFiles(files); status != true {
+	if status := checkFiles(files); !status {
 		t.Errorf("Validating an overwritten file failed")
 	}
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -537,9 +538,11 @@ func (dn *Daemon) writeFiles(files []ignv2_2types.File) error {
 		if err != nil {
 			return err
 		}
-		if _, err = file.WriteString(string(contents.Data)); err != nil {
+		w := bufio.NewWriter(file)
+		if _, err := w.Write(contents.Data); err != nil {
 			return fmt.Errorf("Failed to write inline contents to file %q: %v", f.Path, err)
 		}
+		w.Flush()
 
 		// chmod and chown
 		mode := DefaultFilePermissions


### PR DESCRIPTION
`contents.Data` is a byte slice and can be anything (i.e. a binary after
    deconding). Use a bytes writer to prevent misbehaves in such scenarios.
    Along with that, use a buffered writer around the file in case we're
    dealing with big files. Also, compare byte slices as well instead of
    using strings.
    
    Signed-off-by: Antonio Murdaca <runcom@linux.com>