### PR TITLE
hack/build-go: strip debuginfo from binaries

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -36,4 +36,4 @@ if [[ $WHAT == "machine-config-daemon" ]]; then
 fi
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
-CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}
+CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}


### PR DESCRIPTION
This saves about ~20MB for the resulting daemon image (we've been doing this in CRI-O and other Runtimes tools for a while now)

Signed-off-by: Antonio Murdaca <runcom@linux.com>