### PR TITLE
mcd: remove unnecessary checks and simplify updateSSHKeys

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -601,13 +601,9 @@ func (dn *Daemon) updateSSHKeys(newUsers []ignv2_2types.PasswdUser) error {
 
 	// Keys should only be written to "/home/core/.ssh"
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
-	if newUsers[0].Name != "core" {
-		// Double checking that we are only writing SSH Keys for user "core"
-		return fmt.Errorf("Expecting user core. Got %s instead", newUsers[0].Name)
-	}
-	sshDirPath := filepath.Join("/home", newUsers[0].Name, ".ssh")
-	// we are only dealing with the "core" User at this time, so only dealing with the first entry in Users[]
+	sshDirPath := filepath.Join("/home", "core", ".ssh")
 	glog.Infof("Writing SSHKeys at %q", sshDirPath)
+
 	if err := dn.fileSystemClient.MkdirAll(filepath.Dir(sshDirPath), os.FileMode(0600)); err != nil {
 		return fmt.Errorf("Failed to create directory %q: %v", filepath.Dir(sshDirPath), err)
 	}

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -309,12 +309,6 @@ func TestUpdateSSHKeys(t *testing.T) {
 		t.Errorf("Expected no error. Got %s.", err)
 
 	}
-	// Until users are supported should not be writing keys for any user not named "core"
-	newMcfg.Spec.Config.Passwd.Users[0].Name = "not_core"
-	err = d.updateSSHKeys(newMcfg.Spec.Config.Passwd.Users)
-	if err == nil {
-		t.Errorf("Expected error, user is not core")
-	}
 
 	// if Users is empty, nothing should happen and no error should ever be generated
 	newMcfg2 := &mcfgv1.MachineConfig{}


### PR DESCRIPTION
Minor updates that I wanted to fix/cleanup since my last ssh pr:
1. remove user.name check this is already done in reconcilable() and is unnecessary here
2. use consts for "core" and core's filepath "/home/core/ssh" to make it more consistent and maintainable.