### PR TITLE
[cleanup] pkg/daemon: do not use pointers to strings for errors + unexport consts

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -807,7 +807,7 @@ func checkUnits(units []ignv2_2types.Unit) bool {
 	for _, u := range units {
 		for j := range u.Dropins {
 			path := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
-			if status := checkFileContentsAndMode(path, []byte(u.Dropins[j].Contents), DefaultFilePermissions); !status {
+			if status := checkFileContentsAndMode(path, []byte(u.Dropins[j].Contents), defaultFilePermissions); !status {
 				return false
 			}
 		}
@@ -828,7 +828,7 @@ func checkUnits(units []ignv2_2types.Unit) bool {
 				return false
 			}
 		}
-		if status := checkFileContentsAndMode(path, []byte(u.Contents), DefaultFilePermissions); !status {
+		if status := checkFileContentsAndMode(path, []byte(u.Contents), defaultFilePermissions); !status {
 			return false
 		}
 
@@ -846,7 +846,7 @@ func checkFiles(files []ignv2_2types.File) bool {
 		if _, ok := checkedFiles[f.Path]; ok {
 			continue
 		}
-		mode := DefaultFilePermissions
+		mode := defaultFilePermissions
 		if f.Mode != nil {
 			mode = os.FileMode(*f.Mode)
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	// DefaultDirectoryPermissions houses the default mode to use when no directory permissions are provided
-	DefaultDirectoryPermissions os.FileMode = 0755
-	// DefaultFilePermissions houses the default mode to use when no file permissions are provided
-	DefaultFilePermissions os.FileMode = 0644
+	// defaultDirectoryPermissions houses the default mode to use when no directory permissions are provided
+	defaultDirectoryPermissions os.FileMode = 0755
+	// defaultFilePermissions houses the default mode to use when no file permissions are provided
+	defaultFilePermissions os.FileMode = 0644
 )
 
 // Someone please tell me this actually lives in the stdlib somewhere
@@ -426,7 +426,7 @@ func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
 		for i := range u.Dropins {
 			glog.Infof("Writing systemd unit dropin %q", u.Dropins[i].Name)
 			path = filepath.Join(pathSystemd, u.Name+".d", u.Dropins[i].Name)
-			if err := dn.fileSystemClient.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions); err != nil {
+			if err := dn.fileSystemClient.MkdirAll(filepath.Dir(path), defaultDirectoryPermissions); err != nil {
 				return fmt.Errorf("Failed to create directory %q: %v", filepath.Dir(path), err)
 			}
 			glog.V(2).Infof("Created directory: %s", path)
@@ -444,7 +444,7 @@ func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
 
 		glog.Infof("Writing systemd unit %q", u.Name)
 		path = filepath.Join(pathSystemd, u.Name)
-		if err := dn.fileSystemClient.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions); err != nil {
+		if err := dn.fileSystemClient.MkdirAll(filepath.Dir(path), defaultDirectoryPermissions); err != nil {
 			return fmt.Errorf("Failed to create directory %q: %v", filepath.Dir(path), err)
 		}
 		glog.V(2).Infof("Created directory: %s", path)
@@ -467,7 +467,7 @@ func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
 		}
 
 		// write the unit to disk
-		err := ioutil.WriteFile(path, []byte(u.Contents), DefaultFilePermissions)
+		err := ioutil.WriteFile(path, []byte(u.Contents), defaultFilePermissions)
 		if err != nil {
 			return fmt.Errorf("Failed to write systemd unit %q: %v", u.Name, err)
 		}
@@ -510,7 +510,7 @@ func (dn *Daemon) writeFiles(files []ignv2_2types.File) error {
 	for _, f := range files {
 		glog.Infof("Writing file %q", f.Path)
 		// create any required directories for the file
-		if err := dn.fileSystemClient.MkdirAll(filepath.Dir(f.Path), DefaultDirectoryPermissions); err != nil {
+		if err := dn.fileSystemClient.MkdirAll(filepath.Dir(f.Path), defaultDirectoryPermissions); err != nil {
 			return fmt.Errorf("Failed to create directory %q: %v", filepath.Dir(f.Path), err)
 		}
 
@@ -533,7 +533,7 @@ func (dn *Daemon) writeFiles(files []ignv2_2types.File) error {
 		w.Flush()
 
 		// chmod and chown
-		mode := DefaultFilePermissions
+		mode := defaultFilePermissions
 		if f.Mode != nil {
 			mode = os.FileMode(*f.Mode)
 		}

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -325,16 +325,14 @@ func TestUpdateSSHKeys(t *testing.T) {
 }
 
 // checkReconcilableResults is a shortcut for verifying results that should be reconcilable
-func checkReconcilableResults(t *testing.T, key string, reconcilableError *string) {
-
+func checkReconcilableResults(t *testing.T, key string, reconcilableError error) {
 	if reconcilableError != nil {
-		t.Errorf("Expected the same %s values would be reconcilable. Received error: %v", key, *reconcilableError)
+		t.Errorf("Expected the same %s values would be reconcilable. Received error: %v", key, reconcilableError)
 	}
 }
 
 // checkIrreconcilableResults is a shortcut for verifing results that should be irreconcilable
-func checkIrreconcilableResults(t *testing.T, key string, reconcilableError *string) {
-
+func checkIrreconcilableResults(t *testing.T, key string, reconcilableError error) {
 	if reconcilableError == nil {
 		t.Errorf("Expected different %s values would not be reconcilable.", key)
 	}


### PR DESCRIPTION
Pointer to strings in Golang as used rarely and almost only for struct
properties when deserializing json or yaml (or anything) into a structure.
Else, the idiomatic way of informing something isn't right it's through
errors only. Errors in Go do also have an handy `.Error()` which represents
the error as a string for our use cases.

Second commit unexports consts not used outside the daemon package.

Signed-off-by: Antonio Murdaca <runcom@linux.com>