### PR TITLE
append kube-ca to root-ca for mco config

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -26,6 +26,7 @@ var (
 	bootstrapOpts struct {
 		etcdCAFile          string
 		rootCAFile          string
+		kubeCAFile          string
 		pullSecretFile      string
 		configFile          string
 		oscontentImage      string
@@ -45,6 +46,7 @@ func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdCAFile, "etcd-ca", "/etc/ssl/etcd/ca.crt", "path to etcd CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.rootCAFile, "root-ca", "/etc/ssl/kubernetes/ca.crt", "path to root CA certificate")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeCAFile, "kube-ca", "/assets/tls/kube-ca.crt", "path to kube CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "/assets/manifests/pull.json", "path to secret manifest that contains pull secret.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
 	bootstrapCmd.MarkFlagRequired("dest-dir")
@@ -85,7 +87,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	if err := operator.RenderBootstrap(
 		bootstrapOpts.configFile,
 		bootstrapOpts.infraConfigFile, bootstrapOpts.networkConfigFile,
-		bootstrapOpts.etcdCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.pullSecretFile,
+		bootstrapOpts.etcdCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
 		imgs,
 		bootstrapOpts.destinationDir,
 	); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -288,6 +288,13 @@ func (optr *Operator) sync(key string) error {
 	if err != nil {
 		return err
 	}
+	kubeCA, err := optr.getCAsFromConfigMap("openshift-config", "initial-client-ca", "ca-bundle.crt")
+	if err != nil {
+		return err
+	}
+	bundle := make([]byte, 0)
+	bundle = append(bundle, rootCA...)
+	bundle = append(bundle, kubeCA...)
 
 	// sync up os image url
 	// TODO: this should probably be part of the imgs
@@ -311,7 +318,7 @@ func (optr *Operator) sync(key string) error {
 		return err
 	}
 	spec.EtcdCAData = etcdCA
-	spec.RootCAData = rootCA
+	spec.RootCAData = bundle
 	spec.PullSecret = &v1.ObjectReference{Namespace: "kube-system", Name: "coreos-pull-secret"}
 	spec.SSHKey = ic.SSHKey
 	spec.OSImageURL = imgs.MachineOSContent


### PR DESCRIPTION
For https://github.com/openshift/installer/pull/1179 it's necessary to include the now self-signed kube-ca in the /etc/kubernetes/ca.crt file for kubelets, since the PR makes root-ca no longer a valid trust anchor for the API server certs. I think this is the correct spot to modify to change /etc/kubernetes/ca.crt, and I'm opting to append it rather than replace the root CA for now to make sure nothing else breaks. (There might be a different configmap that it would be better to grab kube-ca from.)
/cc @abhinavdahiya @deads2k @openshift/sig-auth 