### PR TITLE
MCS: remove legacy servers & ports

### DIFF
--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -9,13 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	// we are transitioning from legacy ports 49500/49501 -> 22623/22624
-	// this can be removed once fully transitioned in the installer.
-	legacySecurePort   = 49500
-	legacyInsecurePort = 49501
-)
-
 var (
 	bootstrapCmd = &cobra.Command{
 		Use:   "bootstrap",
@@ -52,14 +45,10 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	apiHandler := server.NewServerAPIHandler(bs)
 	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
 	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
-	legacySecureServer := server.NewAPIServer(apiHandler, legacySecurePort, false, rootOpts.cert, rootOpts.key)
-	legacyInsecureServer := server.NewAPIServer(apiHandler, legacyInsecurePort, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()
 	go insecureServer.Serve()
-	go legacySecureServer.Serve()
-	go legacyInsecureServer.Serve()
 	<-stopCh
 	panic("not possible")
 }

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -45,19 +45,13 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		glog.Exitf("Machine Config Server exited with error: %v", err)
 	}
 
-	// we are transitioning from legacy ports 49500/49501 -> 22623/22624
-	// legacySecureServer/legacyInsecureServer will be removed once the installer commits port changes.
 	apiHandler := server.NewServerAPIHandler(cs)
 	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
 	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
-	legacySecureServer := server.NewAPIServer(apiHandler, legacySecurePort, false, rootOpts.cert, rootOpts.key)
-	legacyInsecureServer := server.NewAPIServer(apiHandler, legacyInsecurePort, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()
 	go insecureServer.Serve()
-	go legacySecureServer.Serve()
-	go legacyInsecureServer.Serve()
 	<-stopCh
 	panic("not possible")
 }


### PR DESCRIPTION
legacySecureServer and legacyInsecureServer were added to accommodate the
installer port references when we transitioned the MCS ports from 49500/49501
to 22623/22624. The installer was updated via PR #1180 to use 22623/22624, so
we can now remove the legacy server/port references.

Clean-up step for: #166 
Related to: #368 
Related-to: [openshift/installer#1180](https://github.com/openshift/installer/pull/1180)