### PR TITLE
kubelet config deletions fix + example update

### DIFF
--- a/examples/kubeletconfig.crd.yaml
+++ b/examples/kubeletconfig.crd.yaml
@@ -3,5 +3,8 @@ kind: KubeletConfig
 metadata:
   name: set-max-pods
 spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: small-pods
   kubeletConfig:
     maxPods: 100

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -152,7 +152,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 func (ctrl *Controller) updateKubeletConfig(old, cur interface{}) {
 	oldConfig := old.(*mcfgv1.KubeletConfig)
 	newConfig := cur.(*mcfgv1.KubeletConfig)
-	if !reflect.DeepEqual(oldConfig.Spec, newConfig.Spec) {
+	if !reflect.DeepEqual(oldConfig, newConfig) {
 		glog.V(4).Infof("Update KubeletConfig %s", oldConfig.Name)
 		ctrl.enqueueKubeletConfig(newConfig)
 	}


### PR DESCRIPTION
@umohnani8 found out that KubeletConfigs were hanging on deletes caused by the reference not getting updated. This PR expands the comparison for the update event to look at the entire object instead of just the spec.

Additionally, a second commit fixes the kubeletconfig example within the examples folder.