### PR TITLE
kubeletconfig: add support for observedgeneration

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -99,7 +99,7 @@ func newMachineConfigPool(name string, labels map[string]string, selector *metav
 func newKubeletConfig(name string, kubeconf *kubeletconfigv1beta1.KubeletConfiguration, selector *metav1.LabelSelector) *mcfgv1.KubeletConfig {
 	return &mcfgv1.KubeletConfig{
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5)), Generation: 1},
 		Spec: mcfgv1.KubeletConfigSpec{
 			KubeletConfig:             kubeconf,
 			MachineConfigPoolSelector: selector,


### PR DESCRIPTION
ObservedObservations and Generations were a new concept to me...

Adds support for KubeletConfig Status updates and generations comparisons. Fixes KubeletConfig Updates where the status will get updated causing the watch to trigger an unlimited amount of times.