### PR TITLE
Match image reference in osimageurl configmap

### DIFF
--- a/install/0000_30_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_30_machine-config-operator_05_osimageurl.yaml
@@ -6,4 +6,7 @@ metadata:
 data:
   # The OS payload, managed by the daemon + pivot + rpm-ostree
   # https://github.com/openshift/machine-config-operator/issues/183
-  osImageURL: "registry.svc.ci.openshift.org/rhcos/maipo@sha256:61dc83d62cfb5054c4c5532bd2478742a0711075ef5151572e63f94babeacc1a"
+  # This gets substituted in at release payload creation time by the
+  # machine-os-content imagestream specified in image-references (the string
+  # here must match exactly).
+  osImageURL: "registry.svc.ci.openshift.org/rhcos/maipo@sha256:83a6d461628380f1dcc057ffef4909992f593b72c5aa4db2e01c0b130004afea"

--- a/install/image-references
+++ b/install/image-references
@@ -27,9 +27,9 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment
-  # This one is special, it's the OS payload
+  # This one is special, it's the OS payload.
   # https://github.com/openshift/machine-config-operator/issues/183
-  # See the machine-config-osimageurl configmap.
+  # See the machine-config-osimageurl configmap (which must match exactly).
   - name: machine-os-content
     from:
       kind: DockerImage


### PR DESCRIPTION
Minor regression from #404. For the substitution to take place, the
pullspec has to match exactly.

---

I'm still confirming it, but I think this is the root of my issues in https://github.com/openshift/machine-config-operator/pull/363#issuecomment-463705911. The masters are getting their `osImageURL` from the bootstrap path (which gets it from the image-references file in the payload), while the controller gets it from the configmap, so the mismatch was causing a checksum diff.

I think the `e2e-aws` tests didn't fail on this because it follows a slightly different path? https://github.com/openshift/origin/pull/21919