### PR TITLE
[cleanup] pkg/controller: don't use index in ranges, use int instead of int32

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -303,7 +303,7 @@ func TestMaxUnavailable(t *testing.T) {
 	tests := []struct {
 		maxUnavail *intstr.IntOrString
 
-		expected int32
+		expected int
 		err      bool
 	}{{
 		maxUnavail: nil,
@@ -359,7 +359,7 @@ func TestMaxUnavailable(t *testing.T) {
 func TestGetCandidateMachines(t *testing.T) {
 	tests := []struct {
 		nodes    []*corev1.Node
-		progress int32
+		progress int
 
 		expected []*corev1.Node
 	}{{
@@ -443,7 +443,7 @@ func TestMakeProgress(t *testing.T) {
 		nodes []*corev1.Node
 		max   intstr.IntOrString
 
-		expected int32
+		expected int
 	}{{
 		// no progress can be made
 		nodes: []*corev1.Node{

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -87,7 +87,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 
 func getUpdatedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	var updated []*corev1.Node
-	for idx, node := range nodes {
+	for _, node := range nodes {
 		if node.Annotations == nil {
 			continue
 		}
@@ -97,7 +97,7 @@ func getUpdatedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.No
 		}
 
 		if cconfig == currentConfig {
-			updated = append(updated, nodes[idx])
+			updated = append(updated, node)
 		}
 	}
 	return updated
@@ -106,9 +106,9 @@ func getUpdatedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.No
 func getReadyMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	updated := getUpdatedMachines(currentConfig, nodes)
 	var ready []*corev1.Node
-	for idx, node := range updated {
+	for _, node := range updated {
 		if isNodeReady(node) {
-			ready = append(ready, updated[idx])
+			ready = append(ready, node)
 		}
 	}
 	return ready
@@ -140,7 +140,7 @@ func isNodeReady(node *corev1.Node) bool {
 
 func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	var unavail []*corev1.Node
-	for idx, node := range nodes {
+	for _, node := range nodes {
 		if node.Annotations == nil {
 			continue
 		}
@@ -154,7 +154,7 @@ func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev
 		}
 
 		if dconfig == currentConfig && (dconfig != cconfig || !isNodeReady(node)) {
-			unavail = append(unavail, nodes[idx])
+			unavail = append(unavail, node)
 		}
 	}
 	return unavail
@@ -162,7 +162,7 @@ func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev
 
 func getDegradedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	var degraded []*corev1.Node
-	for idx, node := range nodes {
+	for _, node := range nodes {
 		if node.Annotations == nil {
 			continue
 		}
@@ -176,7 +176,7 @@ func getDegradedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.N
 		}
 
 		if dconfig == currentConfig && dstate == daemonconsts.MachineConfigDaemonStateDegraded {
-			degraded = append(degraded, nodes[idx])
+			degraded = append(degraded, node)
 		}
 	}
 	return degraded

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -504,8 +504,7 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 		opools   []*mcfgv1.MachineConfigPool
 		oconfigs []*mcfgv1.MachineConfig
 	)
-	for idx := range pools {
-		pool := pools[idx]
+	for _, pool := range pools {
 		pcs, err := getMachineConfigsForPool(pool, configs)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -78,8 +78,7 @@ func generateMachineConfigs(config *RenderConfig, templateDir string) ([]*mcfgv1
 
 	// tag all the machineconfigs with version of the controller.
 	ctrlv := version.Version
-	for idx := range cfgs {
-		cfg := cfgs[idx]
+	for _, cfg := range cfgs {
 		if cfg.Annotations == nil {
 			cfg.Annotations = map[string]string{}
 		}

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -355,13 +355,13 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		return ctrl.syncFailingStatus(cfg, err)
 	}
 
-	for idx := range mcs {
-		_, updated, err := resourceapply.ApplyMachineConfig(ctrl.client.MachineconfigurationV1(), mcs[idx])
+	for _, mc := range mcs {
+		_, updated, err := resourceapply.ApplyMachineConfig(ctrl.client.MachineconfigurationV1(), mc)
 		if err != nil {
 			return ctrl.syncFailingStatus(cfg, err)
 		}
 		if updated {
-			glog.V(4).Infof("Machineconfig %s was updated", mcs[idx].Name)
+			glog.V(4).Infof("Machineconfig %s was updated", mc.Name)
 		}
 	}
 
@@ -382,9 +382,9 @@ func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.Co
 		return nil, err
 	}
 
-	for i := range mcs {
+	for _, mc := range mcs {
 		oref := metav1.NewControllerRef(config, controllerKind)
-		mcs[i].SetOwnerReferences([]metav1.OwnerReference{*oref})
+		mc.SetOwnerReferences([]metav1.OwnerReference{*oref})
 	}
 
 	sort.Slice(mcs, func(i, j int) bool { return mcs[i].Name < mcs[j].Name })


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- use the object given by range directly, no reason to access the array by index, slices in Golang are guaranteed to be ordered as well
- use int instead of int32 to remove unnecessary casts

**- How I did it**

vscode

**- How to verify it**

CI I guess

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
