### PR TITLE
 pkg/controller: add osimageurl to base ssh MC as well

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -33,4 +33,4 @@ spec:
   - name: machine-os-content
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/rhcos/maipo@sha256:83a6d461628380f1dcc057ffef4909992f593b72c5aa4db2e01c0b130004afea
+      name: registry.svc.ci.openshift.org/rhcos/maipo@sha256:61dc83d62cfb5054c4c5532bd2478742a0711075ef5151572e63f94babeacc1a

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -239,7 +239,11 @@ func generateMachineConfigForName(config *RenderConfig, role, name, path string)
 		return nil, fmt.Errorf("error transpiling ct config to Ignition config: %v", err)
 	}
 
-	return MachineConfigFromIgnConfig(role, name, ignCfg), nil
+	mcfg := MachineConfigFromIgnConfig(role, name, ignCfg)
+	// And inject the osimageurl here
+	mcfg.Spec.OSImageURL = config.OSImageURL
+
+	return mcfg, nil
 }
 
 const (

--- a/test/e2e/osimageurl_test.go
+++ b/test/e2e/osimageurl_test.go
@@ -1,0 +1,46 @@
+package e2e_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/machine-config-operator/cmd/common"
+)
+
+func TestOSImageURL(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+	mcClient := cb.MachineConfigClientOrDie("mc-file-add")
+
+	// grab the latest worker- MC
+	mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get("worker", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	mc, err := mcClient.MachineconfigurationV1().MachineConfigs().Get(mcp.Status.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	if mc.Spec.OSImageURL == "" {
+		t.Fatalf("Empty OSImageURL for %s", mc.Name)
+	}
+
+	// grab the latest master- MC
+	mcp, err = mcClient.MachineconfigurationV1().MachineConfigPools().Get("master", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+	mc, err = mcClient.MachineconfigurationV1().MachineConfigs().Get(mcp.Status.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	if mc.Spec.OSImageURL == "" {
+		t.Fatalf("Empty OSImageURL for %s", mc.Name)
+	}
+}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

builds on top of #363, cause I don't want to block that from merging right now, if you guys want instead, I'll close this and, _assuming this is needed_ we'll modify #363 directly.

@cgwalters ptal I'm not entirely sure we need this but I saw the ssh MCs were missing the osimageurl so I've added it (check only last commit)

**- How I did it**

vim

**- How to verify it**

test this PR with a custom payload and verify the `-ssh` MCs do have the osimageurl populated as well

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
