### PR TITLE
templates: remove How I did it section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,11 @@
 <!--
-If this is a bug fix, make sure your description includes "fixes #xxxx", or
-"closes #xxxx"
+If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
+"Closes: #xxxx"
 
 Please provide the following information:
 -->
 
 **- What I did**
-
-**- How I did it**
 
 **- How to verify it**
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Discussed with @runcom and decided to remove the How I did it section to keep this template simple.

**- How I did it**

**- How to verify it**
remove template section --> template section removed!

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
n/a