### PR TITLE
pkg/operator: link related objects to clusteroperator

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -150,6 +150,10 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse})
+	// RelatedObjects are consumed by https://github.com/openshift/must-gather
+	co.Status.RelatedObjects = []configv1.ObjectReference{
+		{Resource: "namespaces", Name: "openshift-machine-config-operator"},
+	}
 	return optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 }
 

--- a/test/e2e/mco_test.go
+++ b/test/e2e/mco_test.go
@@ -1,0 +1,32 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/openshift/machine-config-operator/cmd/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClusterOperatorRelatedObjects(t *testing.T) {
+	cb, err := common.NewClientBuilder("")
+	if err != nil {
+		t.Errorf("%#v", err)
+	}
+	configClient := cb.ConfigClientOrDie("test-co-related-objects")
+	co, err := configClient.ConfigV1().ClusterOperators().Get("machine-config", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("couldn't get clusteroperator %v", err)
+	}
+	if len(co.Status.RelatedObjects) == 0 {
+		t.Error("expected RelatedObjects to be populated but it was not")
+	}
+	var foundNS bool
+	for _, ro := range co.Status.RelatedObjects {
+		if ro.Resource == "namespaces" && ro.Name == "openshift-machine-config-operator" {
+			foundNS = true
+		}
+	}
+	if !foundNS {
+		t.Error("ClusterOperator.RelatedObjects should contain the MCO namespace")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This patch populates the RelatedObjects field of the MCO ClusterOperator
so openshift/must-gather can consume it. We're just exposing our own
namespace for the tool to scrape.

**- How to verify it**

Build a custom payload from this PR, create a cluster with it, run `oc describe clusteroperator machine-config` and confirm the "Related Objects" section is populated with our namespace

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
