### PR TITLE
README.md: fix link to HACKING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ a single MC apply to multiple labels, inline file encoding, etc.
 
 # Developing the MCO
 
-See [HACKING.md](HACKING.md).
+See [HACKING.md](docs/HACKING.md).


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fixed broken link in README.md to HACKING.md now that it resides under docs/

**- How to verify it**

check the README.md from this PR

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
