### PR TITLE
image: MCD depends on util-linux (mount) which is being removed from base

### DIFF
--- a/Dockerfile.machine-config-daemon
+++ b/Dockerfile.machine-config-daemon
@@ -5,4 +5,5 @@ RUN WHAT=machine-config-daemon ./hack/build-go.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
+RUN yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*
 ENTRYPOINT ["/usr/bin/machine-config-daemon"]

--- a/Dockerfile.machine-config-daemon.rhel7
+++ b/Dockerfile.machine-config-daemon.rhel7
@@ -5,4 +5,5 @@ RUN WHAT=machine-config-daemon ./hack/build-go.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
+RUN yum install -y util-linux && yum clean all && rb -rf /var/cache/yum/*
 ENTRYPOINT ["/usr/bin/machine-config-daemon"]


### PR DESCRIPTION
As part of the general cleanup we are moving to UBI based Docker images
and util-linux is being removed from the base image. Add an explicit
dependency here.