### PR TITLE
pkg/daemon: ensure /home/core/.ssh is there, not just /home/core

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -34,7 +34,7 @@ const (
 	// coreUser is "core" and currently the only permissible user name
 	coreUserName = "core"
 	// SSH Keys for user "core" will only be written at /home/core/.ssh
-	coreUserSSHPath = "/home/core/.ssh"
+	coreUserSSHPath = "/home/core/.ssh/"
 )
 
 // Someone please tell me this actually lives in the stdlib somewhere
@@ -608,9 +608,8 @@ func (dn *Daemon) updateSSHKeys(newUsers []ignv2_2types.PasswdUser) error {
 	// Keys should only be written to "/home/core/.ssh"
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
 	glog.Infof("Writing SSHKeys at %q", coreUserSSHPath)
-
-	if err := dn.fileSystemClient.MkdirAll(filepath.Dir(coreUserSSHPath), os.FileMode(0600)); err != nil {
-		return fmt.Errorf("Failed to create directory %q: %v", filepath.Dir(coreUserSSHPath), err)
+	if err := dn.fileSystemClient.MkdirAll(coreUserSSHPath, os.FileMode(0600)); err != nil {
+		return fmt.Errorf("Failed to create directory %q: %v", coreUserSSHPath, err)
 	}
 	glog.V(2).Infof("Created directory: %s", coreUserSSHPath)
 


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

The code was just checking `/home/core` but we later try to write to `/home/core/.ssh` (that folder is surely there but this needs to be fixed anyway).

I've centralized file writes in https://github.com/openshift/machine-config-operator/pull/401 as well to reduce the chances of doing this again.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
