### PR TITLE
pkg/operator: report available when failing to progress

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -29,11 +29,12 @@ func (optr *Operator) syncAvailableStatus() error {
 
 	optrVersion, _ := optr.vStore.Get("operator")
 	failing := cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorFailing)
+	progressing := cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorProgressing)
 	message := fmt.Sprintf("Cluster has deployed %s", optrVersion)
 
 	available := configv1.ConditionTrue
 
-	if failing {
+	if (failing && !progressing) || (failing && optr.inClusterBringup) {
 		available = configv1.ConditionFalse
 		message = fmt.Sprintf("Cluster not available for %s", optrVersion)
 	}

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -350,8 +350,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 				},
 			},
 		},
-		// 3. test that if progressing fails, we report available=false because state of the operator
-		//    might have changed in the various sync calls
+		// 3. test that if progressing fails, we report available=true for the current version
 		{
 			syncs: []syncCase{
 				{
@@ -390,7 +389,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						},
 						{
 							Type:   configv1.OperatorAvailable,
-							Status: configv1.ConditionFalse,
+							Status: configv1.ConditionTrue,
 						},
 						{
 							Type:   configv1.OperatorFailing,
@@ -402,6 +401,31 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							name: "fn1",
 							fn:   func(config renderConfig) error { return errors.New("mock error") },
+						},
+					},
+				},
+				{
+					// we mock the fact that we are at operator=test-version-2 after the previous sync
+					// so we don't provide any operatorVersions to mock that situation but in reality
+					// we are back at operator=test-version (we'll find a way to better do this...)
+					cond: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:   configv1.OperatorProgressing,
+							Status: configv1.ConditionFalse,
+						},
+						{
+							Type:   configv1.OperatorAvailable,
+							Status: configv1.ConditionTrue,
+						},
+						{
+							Type:   configv1.OperatorFailing,
+							Status: configv1.ConditionFalse,
+						},
+					},
+					syncFuncs: []syncFunc{
+						{
+							name: "fn1",
+							fn:   func(config renderConfig) error { return nil },
 						},
 					},
 				},


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This PR ~~builds on top of #442 and it~~ is the result of the conversation here: https://github.com/openshift/machine-config-operator/pull/442#discussion_r257516488

The CVO docs tell us that we may still report Available=True when we fail to progress to a newer version and this patch accounts for that case. The unit test change is the fix to my assumption that if we fail progressing, we do not need to report available cause state may have changed already and the MCO's components aren't good anymore.
The patch still accounts for reporting Available=False when we fail to bootstrap.

@abhinavdahiya @smarterclayton  ptal

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
