### PR TITLE
pkg/operator: use fake clients in unit

### DIFF
--- a/cmd/common/client_builder.go
+++ b/cmd/common/client_builder.go
@@ -4,10 +4,8 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	configv1 "github.com/openshift/api/config/v1"
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -29,41 +27,6 @@ func (cb *ClientBuilder) MachineConfigClientOrDie(name string) mcfgclientset.Int
 // KubeClientOrDie returns the kubernetes client interface for general kubernetes objects.
 func (cb *ClientBuilder) KubeClientOrDie(name string) kubernetes.Interface {
 	return kubernetes.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
-}
-
-// clusterOperatorsClient is a wrapper around the ClusterOperators client
-// implementing the ClusterOperatorsClientInterface
-type clusterOperatorsClient struct {
-	innerConfigClient configclientset.Interface
-}
-
-// Create creates the cluster operator and returns it
-func (c *clusterOperatorsClient) Create(co *configv1.ClusterOperator) (*configv1.ClusterOperator, error) {
-	return c.innerConfigClient.ConfigV1().ClusterOperators().Create(co)
-}
-
-// UpdateStatus updates the status of the cluster operator and returns it
-func (c *clusterOperatorsClient) UpdateStatus(co *configv1.ClusterOperator) (*configv1.ClusterOperator, error) {
-	return c.innerConfigClient.ConfigV1().ClusterOperators().UpdateStatus(co)
-}
-
-// Get returns the cluster operator by name
-func (c *clusterOperatorsClient) Get(name string, options metav1.GetOptions) (*configv1.ClusterOperator, error) {
-	return c.innerConfigClient.ConfigV1().ClusterOperators().Get(name, options)
-}
-
-// ClusterOperatorsClientInterface is a controlled ClusterOperators client which is used
-// by the operator and allows us to mock it in tests.
-type ClusterOperatorsClientInterface interface {
-	Create(*configv1.ClusterOperator) (*configv1.ClusterOperator, error)
-	UpdateStatus(*configv1.ClusterOperator) (*configv1.ClusterOperator, error)
-	Get(name string, options metav1.GetOptions) (*configv1.ClusterOperator, error)
-}
-
-// ClusterOperatorsClientOrDie returns the controlleed ClusterOperators client used by the operator
-func (cb *ClientBuilder) ClusterOperatorsClientOrDie(name string) ClusterOperatorsClientInterface {
-	cc := configclientset.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
-	return &clusterOperatorsClient{innerConfigClient: cc}
 }
 
 // ConfigClientOrDie returns the kubernetes client interface for security related kubernetes objects

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -99,7 +99,7 @@ func startControllers(ctx *common.ControllerContext) error {
 		ctx.ClientBuilder.MachineConfigClientOrDie(componentName),
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.APIExtClientOrDie(componentName),
-		ctx.ClientBuilder.ClusterOperatorsClientOrDie(componentName),
+		ctx.ClientBuilder.ConfigClientOrDie(componentName),
 	).Run(2, ctx.Stop)
 
 	return nil

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextinformersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
@@ -33,8 +34,6 @@ import (
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	installertypes "github.com/openshift/installer/pkg/types"
 
-	// TODO(runcom): move to pkg
-	"github.com/openshift/machine-config-operator/cmd/common"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	templatectrl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
@@ -69,7 +68,7 @@ type Operator struct {
 	client        mcfgclientset.Interface
 	kubeClient    kubernetes.Interface
 	apiExtClient  apiextclientset.Interface
-	configClient  common.ClusterOperatorsClientInterface
+	configClient  configclientset.Interface
 	eventRecorder record.EventRecorder
 
 	syncHandler func(ic string) error
@@ -116,7 +115,7 @@ func New(
 	client mcfgclientset.Interface,
 	kubeClient kubernetes.Interface,
 	apiExtClient apiextclientset.Interface,
-	configClient common.ClusterOperatorsClientInterface,
+	configClient configclientset.Interface,
 ) *Operator {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -46,7 +46,7 @@ func (optr *Operator) syncAvailableStatus() error {
 
 	co.Status.Versions = optr.vStore.GetAll()
 	optr.setMachineConfigPoolStatuses(&co.Status)
-	_, err = optr.configClient.UpdateStatus(co)
+	_, err = optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 	return err
 }
 
@@ -80,7 +80,7 @@ func (optr *Operator) syncProgressingStatus() error {
 	})
 
 	optr.setMachineConfigPoolStatuses(&co.Status)
-	_, err = optr.configClient.UpdateStatus(co)
+	_, err = optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 	return err
 }
 
@@ -123,12 +123,12 @@ func (optr *Operator) syncFailingStatus(ierr error) (err error) {
 	})
 
 	optr.setMachineConfigPoolStatuses(&co.Status)
-	_, err = optr.configClient.UpdateStatus(co)
+	_, err = optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 	return err
 }
 
 func (optr *Operator) fetchClusterOperator() (*configv1.ClusterOperator, error) {
-	co, err := optr.configClient.Get(optr.name, metav1.GetOptions{})
+	co, err := optr.configClient.ConfigV1().ClusterOperators().Get(optr.name, metav1.GetOptions{})
 	if meta.IsNoMatchError(err) {
 		return nil, nil
 	}
@@ -142,7 +142,7 @@ func (optr *Operator) fetchClusterOperator() (*configv1.ClusterOperator, error) 
 }
 
 func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, error) {
-	co, err := optr.configClient.Create(&configv1.ClusterOperator{
+	co, err := optr.configClient.ConfigV1().ClusterOperators().Create(&configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: optr.name,
 		},
@@ -157,7 +157,7 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 	co.Status.RelatedObjects = []configv1.ObjectReference{
 		{Resource: "namespaces", Name: "openshift-machine-config-operator"},
 	}
-	return optr.configClient.UpdateStatus(co)
+	return optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 }
 
 func (optr *Operator) setMachineConfigPoolStatuses(status *configv1.ClusterOperatorStatus) {


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

I added a wrapper around the ClusterOperators client mainly for unit tests in #442  which turns out to be totally unnecessary since I've learned about fake clients in kube land. This PR removes that wrapper and turns the code back to its state and just use plain fake clients in unit tests which will reduce code and not needed abstractions.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
