### PR TITLE
Fix RHEL image typo

### DIFF
--- a/Dockerfile.machine-config-daemon.rhel7
+++ b/Dockerfile.machine-config-daemon.rhel7
@@ -5,5 +5,5 @@ RUN WHAT=machine-config-daemon ./hack/build-go.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
-RUN yum install -y util-linux && yum clean all && rb -rf /var/cache/yum/*
+RUN yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*
 ENTRYPOINT ["/usr/bin/machine-config-daemon"]


### PR DESCRIPTION
RHEL builds broke because this dockerfile was not also updated.