### PR TITLE
machineconfig: Drop osimageurl from `oc get machineconfigs`

### DIFF
--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -16,10 +16,6 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Created
     type: date
-  - JSONPath: .spec.osImageURL
-    description: URL for the RPM OS-tree image. This is optional and can be empty.
-    name: OSImageURL
-    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -283,10 +283,6 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Created
     type: date
-  - JSONPath: .spec.osImageURL
-    description: URL for the RPM OS-tree image. This is optional and can be empty.
-    name: OSImageURL
-    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition


### PR DESCRIPTION
We really want this driven by the CVO; people should look at
`oc get clusterversion`.

See also https://github.com/openshift/os/issues/377
