### PR TITLE
Makefile: fix io redirection for image targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ _build-%:
 # Example:
 #    make _image-machine-config-daemon
 _image-%:
-	@which podman 2> /dev/null &>1 || { echo "podman must be installed to build an image";  exit 1; }
+	@which podman 2> /dev/null >&1 || { echo "podman must be installed to build an image";  exit 1; }
 	WHAT=$* hack/build-image.sh
 
 # Build + push + deploy image for a component. Intended to be called via another target.


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

`make images` and the other targets were just creating this file named `1` because the redirection is inverted

**- How to verify it**

run `make images` and watch it not creating a file named `1`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
