### PR TITLE
Bug 1691660: pkg/controller: always use the OSImageURL from the CVO

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -12,26 +12,21 @@ import (
 // MergeMachineConfigs combines multiple machineconfig objects into one object.
 // It sorts all the configs in increasing order of their name.
 // It uses the Ign config from first object as base and appends all the rest.
-// It uses the first non-empty OSImageURL.
-func MergeMachineConfigs(configs []*MachineConfig) *MachineConfig {
+// It uses only the OSImageURL provided by the CVO and ignores any MC provided OSImageURL.
+func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineConfig {
 	if len(configs) == 0 {
 		return nil
 	}
 	sort.Slice(configs, func(i, j int) bool { return configs[i].Name < configs[j].Name })
 
-	outOSImageURL := configs[0].Spec.OSImageURL
 	outIgn := configs[0].Spec.Config
 	for idx := 1; idx < len(configs); idx++ {
-		config := configs[idx]
-		if outOSImageURL == "" {
-			outOSImageURL = config.Spec.OSImageURL
-		}
-		outIgn = ignv2_2.Append(outIgn, config.Spec.Config)
+		outIgn = ignv2_2.Append(outIgn, configs[idx].Spec.Config)
 	}
 
 	return &MachineConfig{
 		Spec: MachineConfigSpec{
-			OSImageURL: outOSImageURL,
+			OSImageURL: osImageURL,
 			Config:     outIgn,
 		},
 	}

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
@@ -122,51 +122,6 @@ func TestRemoveMachineConfigPoolCondition(t *testing.T) {
 		})
 	}
 }
-
-func TestMergeMachineConfigs(t *testing.T) {
-	var configs []*MachineConfig
-	configs = append(configs, &MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: "4"},
-		Spec: MachineConfigSpec{
-			OSImageURL: "",
-		},
-	})
-
-	configs = append(configs, &MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: "3"},
-		Spec: MachineConfigSpec{
-			OSImageURL: "example.com/os@sha256:notthetarget",
-		},
-	})
-
-	configs = append(configs, &MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: "0"},
-		Spec: MachineConfigSpec{
-			OSImageURL: "",
-		},
-	})
-
-	targetOSImageURL := "example.com/os@sha256:thetarget"
-	configs = append(configs, &MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: "1"},
-		Spec: MachineConfigSpec{
-			OSImageURL: targetOSImageURL,
-		},
-	})
-
-	configs = append(configs, &MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: "2"},
-		Spec: MachineConfigSpec{
-			OSImageURL: "",
-		},
-	})
-
-	merged := MergeMachineConfigs(configs)
-	if merged.Spec.OSImageURL != targetOSImageURL {
-		t.Errorf("OSImageURL expected: %s, received: %s", targetOSImageURL, merged.Spec.OSImageURL)
-	}
-}
-
 func TestIsControllerConfigCompleted(t *testing.T) {
 	tests := []struct {
 		obsrvdGen int64

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -97,7 +97,7 @@ func (b *Bootstrap) Run(destDir string) error {
 	}
 	configs = append(configs, iconfigs...)
 
-	fpools, gconfigs, err := render.RunBootstrap(pools, configs)
+	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Always use the osimageurl coming from the CVO. 

close #465 

**- How to verify it**

Added a unit test to cover this change 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
