### PR TITLE
[WIP] pkg/daemon: add onceFrom unit test

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/vincent-petithory/dataurl"
 )
 
@@ -85,4 +86,29 @@ func TestOverwrittenFile(t *testing.T) {
 	if status := checkFiles(files); !status {
 		t.Errorf("Validating an overwritten file failed")
 	}
+}
+
+func TestDaemonOnceFromNoPanic(t *testing.T) {
+	exitCh := make(chan error)
+	defer close(exitCh)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// This is how a onceFrom daemon is initialized
+	// and it shouldn't panic assuming kubeClient is there
+	dn, err := New(
+		"/",
+		"testnodename",
+		"testos",
+		NewNodeUpdaterClient(),
+		NewFileSystemClient(),
+		"test",
+		false,
+		"",
+		NewNodeWriter(),
+		exitCh,
+		stopCh,
+	)
+	assert.Nil(t, err)
+	assert.NotPanics(t, func() { dn.triggerUpdateWithMachineConfig(nil, nil) })
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Daemon in onceFrom mode can panic if it goes by a `dn.kubeClient.Something` call, this is an example that the daemon in onceFrom mode assume a kubeClient...

**- How to verify it**

run units, it shouldn't panic...

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
