### PR TITLE
daemon: Catch SIGTERM and ignore it if we're doing an update

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
+      terminationGracePeriodSeconds: 300
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -82,6 +82,8 @@ type Daemon struct {
 	kubeletHealthzEnabled  bool
 	kubeletHealthzEndpoint string
 
+	installedSigterm bool
+
 	nodeWriter *NodeWriter
 
 	// channel used by callbacks to signal Run() of an error


### PR DESCRIPTION
Ref: https://github.com/openshift/machine-config-operator/issues/407

The MCD is not ready to be killed at any arbitrary point.  Bump
the termination timeout to 5 minutes, and ignore `SIGTERM` if we're
in the middle of performing an update.
