### PR TITLE
 pkg/controller: fix container runtime registries generation

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -567,8 +567,13 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 			isNotFound := errors.IsNotFound(err)
 			rci := createNewRegistriesConfigIgnition(registriesTOML)
 			if !isNotFound && equality.Semantic.DeepEqual(rci, mc.Spec.Config) {
-				applied = false
-				return nil
+				// if the configuration for the registries is equal, we still need to compare
+				// the generated controller version because during an upgrade we need a new one
+				mcCtrlVersion := mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey]
+				if mcCtrlVersion == version.Version.String() {
+					applied = false
+					return nil
+				}
 			}
 			if isNotFound {
 				mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignv2_2types.Config{})


### PR DESCRIPTION
The CRC (container runtime config) controller recently added a check to
avoid resyncing and recreating the very same registries config if
nothing has changed on the image crd side [1]. While that's correct,
during an upgrade, the controllers need to generate the MC fragments
using the controller version they're at. Since we weren't checking the
versions of the controller that generated the registries config, we
wrongly assumed the configurations were equal and never generated a new
one with the new controller.
This patch fixes that by adding a version check before skipping a
regeneration on equal content in the registries configs.
Fixes: https://github.com/openshift/machine-config-operator/issues/487

[1] https://github.com/openshift/machine-config-operator/pull/461

Signed-off-by: Antonio Murdaca <runcom@linux.com>