### PR TITLE
daemon: Uninstall SIGTERM handler just before rebooting

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -718,6 +718,12 @@ func (dn *Daemon) reboot(rationale string) error {
 	}
 	dn.logSystem("machine-config-daemon initiating reboot: %s", rationale)
 
+	// Now that everything is done, avoid delaying shutdown.
+	if dn.installedSigterm {
+		signal.Reset(syscall.SIGTERM)
+		dn.installedSigterm = false
+	}
+
 	// reboot
 	dn.loginClient.Reboot(false)
 


### PR DESCRIPTION
This way we're not delaying shutdown.

Closes: https://github.com/openshift/machine-config-operator/issues/486
