### PR TITLE
Add infra-image flag to bootstrap.go as no-op

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -38,6 +38,7 @@ var (
 		mcdImage            string
 		etcdImage           string
 		setupEtcdEnvImage   string
+		infraImage          string
 		destinationDir      string
 	}
 )
@@ -62,6 +63,7 @@ func init() {
 	bootstrapCmd.MarkFlagRequired("etcd-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.setupEtcdEnvImage, "setup-etcd-env-image", "", "Image for Setup Etcd Environment.")
 	bootstrapCmd.MarkFlagRequired("setup-etcd-env-image")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "quay.io/openshift/origin-pod:v4.0", "Image for Infra Containers.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
 	bootstrapCmd.MarkFlagRequired("config-file")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraConfigFile, "infra-config-file", "/assets/manifests/cluster-infrastructure-02-config.yml", "File containing infrastructure.config.openshift.io manifest.")


### PR DESCRIPTION
Adding this, so we can get the installer PR https://github.com/openshift/installer/pull/1292 in first
before landing in #471.
This is from an approved and lgtm'ed PR #471.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>