### PR TITLE
daemon: Only print status if os == RHCOS

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -154,12 +154,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 
 	if startOpts.onceFrom == "" {
-		status, err := dn.NodeUpdaterClient.GetStatus()
-		if err != nil {
-			glog.Fatalf("unable to get rpm-ostree status: %s", err)
-		}
-		glog.Info(status)
-
 		err = dn.CheckStateOnBoot()
 		if err != nil {
 			dn.EnterDegradedState(errors.Wrapf(err, "Checking initial state"))

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -560,6 +560,15 @@ func (dn *Daemon) getPendingConfig() (string, error) {
 //
 // Some more background in this PR: https://github.com/openshift/machine-config-operator/pull/245
 func (dn *Daemon) CheckStateOnBoot() error {
+	// Print status if available
+	if dn.OperatingSystem == machineConfigDaemonOSRHCOS {
+		status, err := dn.NodeUpdaterClient.GetStatus()
+		if err != nil {
+			glog.Fatalf("unable to get rpm-ostree status: %s", err)
+		}
+		glog.Info(status)
+	}
+
 	pendingConfigName, err := dn.getPendingConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
Don't crash on non-rpm-ostree based systems.

