### PR TITLE
update hack/push-image.sh to rename images

### DIFF
--- a/hack/push-image.sh
+++ b/hack/push-image.sh
@@ -55,7 +55,6 @@ fi
 for IMAGE_TO_PUSH in $TOPUSH; do
 	NAME="${IMAGE_TO_PUSH#Dockerfile.}"
 	set -x
-	podman push "${NAME}:${VERSION}" "${REPO}/origin-${NAME}:${VERSION}"
-	podman push "${NAME}:${VERSION}" "${REPO}/origin-${NAME}:latest"
+	podman push "localhost/${NAME}:latest" "${REPO}/origin-${NAME}:latest"
 	set +x
 done


### PR DESCRIPTION

**- What I did**
PR #474 broke hack/push-image.sh (and my workflow) by renaming the generated
images.  This PR fixes the names used in this script, so the
latest can be pushed to a remote repo like dockerhub.

I'd like to eventually re-add VERSION support, but I don't have time, so it's commented out for now.

**- How to verify it**
try using the push-image.sh note how it doesn't work. update to use this pr and now it successfully pushes like it did pre-474


