### PR TITLE
Add pod image to image-references

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -23,6 +23,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/coreos/etcd:v3.3.10
+  - name: pod
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/pod:v4.0
   - name: setup-etcd-environment
     from:
       kind: DockerImage


### PR DESCRIPTION
This is to ensure that the image is injected when the
installer is run.
This from an already approved & lgtm'ed PR #417

Installer PR: https://github.com/openshift/installer/pull/1292

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
