### PR TITLE
Makefile: add bindata generation to update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test-unit:
 #    make update
 update:
 	hack/update-codegen.sh
+	hack/update-generated-bindata.sh
 
 # Run verification steps
 # Example:


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

added bindata generation to `make update`. This came out from #503 where we also noticed that a previous PR didn't correctly generated bindata https://github.com/openshift/machine-config-operator/pull/503/files#diff-180d80e1c6d7634b2dd083e60c06459bR598

**- How to verify it**

run make update and make sure bindata is correctly (re)generated

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
