### PR TITLE
mcc: add ignition version for ssh & registries machineconfigs

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+)
+
+// NewIgnConfig returns an empty ignition config with version set as 2.2.0
+func NewIgnConfig() ignv2_2types.Config {
+	return ignv2_2types.Config{
+		Ignition: ignv2_2types.Ignition{
+			Version: "2.2.0",
+		},
+	}
+}

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -14,6 +14,7 @@ import (
 	crioconfig "github.com/kubernetes-sigs/cri-o/pkg/config"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/vincent-petithory/dataurl"
 
 	"k8s.io/api/core/v1"
@@ -59,7 +60,7 @@ type tomlConfigRegistries struct {
 type updateConfig func(data []byte, internal *mcfgv1.ContainerRuntimeConfiguration) ([]byte, error)
 
 func createNewCtrRuntimeConfigIgnition(storageTOMLConfig, crioTOMLConfig []byte) ignv2_2types.Config {
-	var tempIgnConfig ignv2_2types.Config
+	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	mode := 0644
 	// Create storage.conf ignition
 	if storageTOMLConfig != nil {
@@ -103,7 +104,7 @@ func createNewCtrRuntimeConfigIgnition(storageTOMLConfig, crioTOMLConfig []byte)
 }
 
 func createNewRegistriesConfigIgnition(registriesTOMLConfig []byte) ignv2_2types.Config {
-	var tempIgnConfig ignv2_2types.Config
+	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	mode := 0644
 	// Create Registries ignition
 	if registriesTOMLConfig != nil {

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -8,10 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/coreos/ignition/config/validate"
 	"github.com/ghodss/yaml"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -295,6 +297,12 @@ func validateSSHConfig(t *testing.T, mc *mcfgv1.MachineConfig) {
 	if mc.Spec.Config.Passwd.Users[0].Name != "core" && mc.Spec.Config.Passwd.Users[0].SSHAuthorizedKeys[0] != "1234" {
 		t.Fatalf("Failed to create SSH machine config with user core and sshkey 1234, Got: %v", mc.Spec.Config.Passwd.Users[0])
 	}
+
+	rpt := validate.ValidateWithoutSource(reflect.ValueOf(mc.Spec.Config))
+	if rpt.IsFatal() {
+		t.Fatalf("Invalid Ignition config found: %v", rpt)
+	}
+
 }
 
 func controllerConfigFromFile(path string) (*mcfgv1.ControllerConfig, error) {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- [x] add ignition version for ssh machineconfig

- [x] add ignition version for 99-xxx-xxxx-registries

Closes: #498 
Pre-req for: #502 

**- How to verify it**
`oc get machineconfigs` should have a version for both.
also `e2e-aws` and `e2e-aws-op` in `artifacts/e2e-aws/machineconfigs.json` should show the ssh configs & registry configs as having version numbers.

