### PR TITLE
disable swappiness on workers and master

### DIFF
--- a/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-sysctl.d-swappiness.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-sysctl.d-swappiness.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,vm.swappiness%3D0%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/swappiness.conf

--- a/templates/master/00-master/_base/files/sysctl-swappiness-conf.yaml
+++ b/templates/master/00-master/_base/files/sysctl-swappiness-conf.yaml
@@ -1,0 +1,6 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/swappiness.conf"
+contents:
+  inline: |
+    vm.swappiness=0

--- a/templates/worker/00-worker/_base/files/sysctl-swappiness-conf.yaml
+++ b/templates/worker/00-worker/_base/files/sysctl-swappiness-conf.yaml
@@ -1,0 +1,6 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/swappiness.conf"
+contents:
+  inline: |
+    vm.swappiness=0


### PR DESCRIPTION
Disable swappiness to hint to the kernel there is not any swap.

**- What I did**

I'm looking into a [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1679585) regarding performance and noticed the swappiness level set to 60 on masters and workers. My test cluster started having high cpu+memory in kswapd when the cluster was overloaded.

**- How to verify it**
`sysctl vm.swappiness` on a node.

**- Description for the changelog**

set vm.swappiness=0 on masters and workers