### PR TITLE
install: Fix reference to pod image

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -85,7 +85,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		MachineOSContent:        bootstrapOpts.oscontentImage,
 		Etcd:                    bootstrapOpts.etcdImage,
 		SetupEtcdEnv:            bootstrapOpts.setupEtcdEnvImage,
-		InfraImage:              bootstrapOpts.infraImage,
+		InfraImage:              "quay.io/openshift/origin-pod:v4.0",
 	}
 
 	if err := operator.RenderBootstrap(

--- a/install/0000_30_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_30_machine-config-operator_02_images.configmap.yaml
@@ -11,5 +11,6 @@ data:
       "machineConfigServer": "docker.io/openshift/origin-machine-config-server:v4.0.0",
       "etcd": "quay.io/coreos/etcd:v3.3.10",
       "setupEtcdEnv": "registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment",
+      "dummyImage": "quay.io/tectonicshift/pod:42",
       "infraImage": "quay.io/openshift/origin-pod:v4.0"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -26,7 +26,7 @@ spec:
   - name: pod
     from:
       kind: DockerImage
-      name: quay.io/openshift/pod:v4.0
+      name: quay.io/tectonicshift/pod:42
   - name: setup-etcd-environment
     from:
       kind: DockerImage


### PR DESCRIPTION
The name needs to *exactly* match that in `image-references`
in order to be substituted.
