### PR TITLE
clean up OWNERS file so that MCO team is always tagged

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - abhinavdahiya
   - ashcrow
   - cgwalters
-  - crawford
   - jlebon
-  - runcom
   - kikisdeliveryservice
-  - smarterclayton
-  - wking
-  - yuqi-zhang
+  - LorbusChris
+  - runcom


### PR DESCRIPTION
**- What I did**

Active members of the MCO group are not getting tagged onto MCO PRs quite frequently. As more development is done on this repo, we need to clean up this list so that active members always have the ability to be pinged, review and approve MCO repo PRs and are aware of all of the PRs that are merged.

This PR is also needed to clean-up the Owners file in release (https://github.com/openshift/release/issues/2980), where MCO team members are not being pinged.

