### PR TITLE
install: use origin-v4.0 etcd image

### DIFF
--- a/install/0000_30_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_30_machine-config-operator_02_images.configmap.yaml
@@ -9,7 +9,7 @@ data:
       "machineConfigController": "docker.io/openshift/origin-machine-config-controller:v4.0.0",
       "machineConfigDaemon": "docker.io/openshift/origin-machine-config-daemon:v4.0.0",
       "machineConfigServer": "docker.io/openshift/origin-machine-config-server:v4.0.0",
-      "etcd": "quay.io/coreos/etcd:v3.3.10",
+      "etcd": "registry.svc.ci.openshift.org/openshift/origin-v4.0:etcd",
       "setupEtcdEnv": "registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment",
       "infraImage": "quay.io/openshift/origin-pod:v4.0"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -22,7 +22,7 @@ spec:
   - name: etcd
     from:
       kind: DockerImage
-      name: quay.io/coreos/etcd:v3.3.10
+      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:etcd
   - name: pod
     from:
       kind: DockerImage


### PR DESCRIPTION
We are currently using upstream etcd image which is based on Alpine Linux OS. This PR updates this to the correct origin-v4.0 etcd image build.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1679834

/cc @abhinavdahiya 

