### PR TITLE
*: Update "MachinePool" -> "MachineConfigPool" and similar

### DIFF
--- a/docs/MachineConfigController.md
+++ b/docs/MachineConfigController.md
@@ -22,18 +22,18 @@
 
 4. `KubeletConfigController` is responsible for wrapping custom Kubelet configurations within a CRD. The available options are documented within the KubeletConfiguration (https://github.com/kubernetes/kubernetes/blob/release-1.11/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go#L45).
 
-## MachinePool
+## MachineConfigPool
 
 ```go
-type MachinePool struct {
+type MachineConfigPool struct {
     metav1.TypeMeta `json:",inline"`
     metav1.ObjectMeta `json:"metadata,omitempty"`
 
-    Spec MachinePoolSpec `json:"spec"`
-    Status MachinePoolStatus `json:"status"`
+    Spec MachineConfigPoolSpec `json:"spec"`
+    Status MachineConfigPoolStatus `json:"status"`
 }
 
-type MachinePoolSpec struct {
+type MachineConfigPoolSpec struct {
     // Label selector for MachineConfigs.
     // Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ on how label and selectors work.
     MachineConfigSelector *metav1.LabelSelector `json:"machineConfigSelector,omitempty"`
@@ -41,7 +41,7 @@ type MachinePoolSpec struct {
     // Label selector for Machines.
     MachineSelector *metav1.LabelSelector `json:"machineSelector,omitempty"`
 
-    // If true, changes to this machine pool should be stopped.
+    // If true, changes to this machine config pool should be stopped.
     // This includes generating new desiredMachineConfig and update of machines.
     Paused bool `json:"paused"`
 
@@ -50,14 +50,14 @@ type MachinePoolSpec struct {
     MaxUnavailable *intstr.IntOrString `json:"maxUnavailable"`
 }
 
-type MachinePoolStatus struct {
+type MachineConfigPoolStatus struct {
     // The generation observed by the controller.
     ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-    // The current MachineConfig object for the machine pool.
+    // The current MachineConfig object for the machine config pool.
     CurrentMachineConfig string `json:"currentMachineConfig"`
 
-    // Total number of machines in the machine pool.
+    // Total number of machines in the machine config pool.
     MachineCount int32 `json:"machineCount"`
 
     // Total number of machines targeted by the pool that have the CurrentMachineConfig as their config.
@@ -71,15 +71,15 @@ type MachinePoolStatus struct {
     UnavailableMachineCount int32 `json:"unavailableMachines"`
 
     // Represents the latest available observations of current state.
-    Conditions []MachinePoolConditions `json:"conditions"`
+    Conditions []MachineConfigPoolConditions `json:"conditions"`
 }
 ```
 
-## MachineSets vs MachinePool
+## MachineSets vs MachineConfigPool
 
-- MachineSets describe nodes with respect to cloud / machine provider. MachinePool allows MachineConfigController components to define and provide status of machines in context of upgrades.
+- MachineSets describe nodes with respect to cloud / machine provider. MachineConfigPool allows MachineConfigController components to define and provide status of machines in context of upgrades.
 
-- MachinePool also allows users to configure how upgrades are rolled out to the machines in a pool.
+- MachineConfigPool also allows users to configure how upgrades are rolled out to the machines in a pool.
 
 - MachineSelector can be replaced with reference to MachineSet.
 
@@ -95,11 +95,11 @@ The TemplateController uses `internal templates` and a `configuration object` to
 
 ## RenderController
 
-The RenderController generates the desired MachineConfig object based on the MachineConfigSelector defined in MachinePool.
+The RenderController generates the desired MachineConfig object based on the MachineConfigSelector defined in MachineConfigPool.
 
-- RenderController watches for changes on MachinePool object to find all the MachineConfig objects using `MachineConfigSelector` and updating the `CurrentMachineConfig` with the generated MachineConfig.
+- RenderController watches for changes on MachineConfigPool object to find all the MachineConfig objects using `MachineConfigSelector` and updating the `CurrentMachineConfig` with the generated MachineConfig.
 
-- RenderController watches for changes on all the MachineConfig objects and syncs all the MachinePool objects with new `CurrentMachineConfig`.
+- RenderController watches for changes on all the MachineConfig objects and syncs all the MachineConfigPool objects with new `CurrentMachineConfig`.
 
 ### Finding MachineConfigs
 
@@ -115,9 +115,9 @@ The render controller sorts all the other MachineConfigs based on the lexicograp
 
 ## UpdateController
 
-The UpdateController coordinates upgrade for machines in a machine pool. UpdateController uses annotations on node objects to coordinate with the `MachineConfigDaemon` running on each machine to upgrade each machine to the desired Machine Configuration.
+The UpdateController coordinates upgrade for machines in a MachineConfigPool. UpdateController uses annotations on node objects to coordinate with the `MachineConfigDaemon` running on each machine to upgrade each machine to the desired Machine Configuration.
 
-UpdateController watches for changes on MachinePool and runs update if,
+UpdateController watches for changes on MachineConfigPool and runs update if,
 
 1. If the `.Status.CurrentMachineConfig` has been updated.
 

--- a/docs/MachineConfigServer.md
+++ b/docs/MachineConfigServer.md
@@ -16,11 +16,11 @@ The machine can request specific configuration by pointing Ignition to MachineCo
 
 ### Endpoint
 
-MachineConfigServer serves Ignition at `/config/<machine-pool-name>` endpoint.
+MachineConfigServer serves Ignition at `/config/<machine-config-pool-name>` endpoint.
 
-* If the server finds the machine pool requested in the URL, it returns the Ignition config stored in the MachineConfig object referenced at `.status.currentMachineConfig` in the MachinePool object.
+* If the server finds the machine config pool requested in the URL, it returns the Ignition config stored in the MachineConfig object referenced at `.status.currentMachineConfig` in the MachineConfigPool object.
 
-* If the server cannot find the machine pool requested in the URL, the server returns HTTP Status Code 404 with an empty response.
+* If the server cannot find the machine config pool requested in the URL, the server returns HTTP Status Code 404 with an empty response.
 
 ### Ignition config from MachineConfig
 

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -294,7 +294,7 @@ type MachineConfigPoolSpec struct {
 	// Label selector for Machines.
 	MachineSelector *metav1.LabelSelector `json:"machineSelector,omitempty"`
 
-	// If true, changes to this machine pool should be stopped.
+	// If true, changes to this machine config pool should be stopped.
 	// This includes generating new desiredMachineConfig and update of machines.
 	Paused bool `json:"paused"`
 
@@ -308,10 +308,10 @@ type MachineConfigPoolStatus struct {
 	// The generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// The current MachineConfig object for the machine pool.
+	// The current MachineConfig object for the machine config pool.
 	Configuration MachineConfigPoolStatusConfiguration `json:"configuration"`
 
-	// Total number of machines in the machine pool.
+	// Total number of machines in the machine config pool.
 	MachineCount int32 `json:"machineCount"`
 
 	// Total number of machines targeted by the pool that have the CurrentMachineConfig as their config.

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -10,7 +10,7 @@ import (
 )
 
 type poolRequest struct {
-	machinePool string
+	machineConfigPool string
 }
 
 // APIServer provides the HTTP(s) endpoint
@@ -91,7 +91,7 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cr := poolRequest{
-		machinePool: path.Base(r.URL.Path),
+		machineConfigPool: path.Base(r.URL.Path),
 	}
 
 	conf, err := sh.server.GetConfig(cr)

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -21,7 +21,7 @@ var _ = Server(&bootstrapServer{})
 type bootstrapServer struct {
 
 	// serverBaseDir is the root, relative to which
-	// the machine pool, configs will be picked
+	// the MachineConfigPool configs will be picked
 	serverBaseDir string
 
 	kubeconfigFunc kubeconfigFunc
@@ -59,7 +59,7 @@ func NewBootstrapServer(dir, kubeconfig string) (Server, error) {
 func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, error) {
 
 	// 1. Read the Machine Config Pool object.
-	fileName := path.Join(bsc.serverBaseDir, "machine-pools", cr.machinePool+".yaml")
+	fileName := path.Join(bsc.serverBaseDir, "machine-pools", cr.machineConfigPool+".yaml")
 	glog.Infof("reading file %q", fileName)
 	data, err := ioutil.ReadFile(fileName)
 	if os.IsNotExist(err) {

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -37,7 +37,7 @@ type clusterServer struct {
 }
 
 // NewClusterServer is used to initialize the machine config
-// server that will be used to fetch the requested machine pool
+// server that will be used to fetch the requested MachineConfigPool
 // objects from within the cluster.
 // It accepts the kubeConfig which is not required when it's
 // run from within the cluster(useful in testing).
@@ -58,7 +58,7 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 // GetConfig fetches the machine config(type - Ignition) from the cluster,
 // based on the pool request.
 func (cs *clusterServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, error) {
-	mp, err := cs.machineClient.MachineConfigPools().Get(cr.machinePool, metav1.GetOptions{})
+	mp, err := cs.machineClient.MachineConfigPools().Get(cr.machineConfigPool, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch pool. err: %v", err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -50,17 +50,17 @@ func TestStringEncode(t *testing.T) {
 // when it's running in bootstrap mode.
 // The test does the following:
 //
-// 1. Fetch the machine-pool from the testdata.
-// 2. Fetch the machine-config from the testdata.
+// 1. Fetch the MachineConfigPool from the testdata.
+// 2. Fetch the MachineConfig from the testdata.
 // 3. Manually update the ignition config from Step 2 by adding
-//    the node-annotations file, the kubeconfig file(which is read
-//    from the testdata). This ignition config is then
+//    the NodeAnnotations file, the kubeconfig file (which is read
+//    from the testdata). This Ignition config is then
 //    labeled as expected Ignition config.
 // 4. Call the Bootstrap GetConfig method by passing the reference to the
-//    machine pool present in the testdata folder.
+//    MachineConfigPool present in the testdata folder.
 // 5. Compare the Ignition configs from Step 3 and Step 4.
 func TestBootstrapServer(t *testing.T) {
-	mp, err := getTestMachinePool()
+	mp, err := getTestMachineConfigPool()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestBootstrapServer(t *testing.T) {
 		t.Fatal(err)
 	}
 	res, err := bs.GetConfig(poolRequest{
-		machinePool: testPool,
+		machineConfigPool: testPool,
 	})
 	if err != nil {
 		t.Fatalf("expected err to be nil, received: %v", err)
@@ -113,18 +113,18 @@ func TestBootstrapServer(t *testing.T) {
 // when it's running within the cluster.
 // The test does the following:
 //
-// 1. Fetch the machine-pool from the testdata.
-// 2. Fetch the machine-config from the testdata, call this origMC.
+// 1. Fetch the MachineConfigPool from the testdata.
+// 2. Fetch the MachineConfig from the testdata, call this origMC.
 // 3. Manually update the ignition config from Step 2 by adding
-//    the node-annotations file, the kubeconfig file(which is read
-//    from the testdata). This ignition config is then
+//    the NodeAnnotations file, the kubeconfig file (which is read
+//    from the testdata). This Ignition config is then
 //    labeled as expected Ignition config (mc).
-// 4. Use the Kubernetes fake client to Create the machine pool and the config
-//    objects from Step 1, 2 inside the cluster.
+// 4. Use the Kubernetes fake client to Create the MachineConfigPool
+//    and the MachineConfig objects from Step 1, 2 inside the cluster.
 // 5. Call the Cluster GetConfig method.
 // 6. Compare the Ignition configs from Step 3 and Step 5.
 func TestClusterServer(t *testing.T) {
-	mp, err := getTestMachinePool()
+	mp, err := getTestMachineConfigPool()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestClusterServer(t *testing.T) {
 	appendFileToIgnition(&mc.Spec.Config, daemonconsts.InitialNodeAnnotationsFilePath, anno)
 
 	res, err := csc.GetConfig(poolRequest{
-		machinePool: testPool,
+		machineConfigPool: testPool,
 	})
 	if err != nil {
 		t.Fatalf("expected err to be nil, received: %v", err)
@@ -234,7 +234,7 @@ func createFileMap(files []ignv2_2types.File) map[string]ignv2_2types.File {
 	return m
 }
 
-func getTestMachinePool() (*v1.MachineConfigPool, error) {
+func getTestMachineConfigPool() (*v1.MachineConfigPool, error) {
 	mpPath := path.Join(testDir, "machine-pools", testPool+".yaml")
 	mpData, err := ioutil.ReadFile(mpPath)
 	if err != nil {


### PR DESCRIPTION
There seems to have been some initial uncertainty about what this would be called, with `MachinePool` first landing in 30d522f9 and `MachineConfigPool` first landing in cfc9660e (#2).  This commit consolidates us around `MachineConfigPool`, except for the `machine-pools/` bootstrap path (since changing that would require consumer updates).