### PR TITLE
initial pass at populating the os version label

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -18,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -18,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -18,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -9,6 +9,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -21,7 +22,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -9,6 +9,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -20,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \


### PR DESCRIPTION
**- What I did**

Enumerates the OS version from /etc/os-release and creates a `node.openshift.io/os_version={OS_VERSION}` label.

**- How to verify it**
oc get node [node name] -o yaml

**- Description for the changelog**
Add an initial OS Version to label (`node.openshift.io/os_version={OS_VERSION}`) to nodes.

**- Some background info**
Kubelet --node-labels only get created on kubelet registration, so changes will need to happen with a daemonset. Liggit has a [number](https://github.com/kubernetes/kubernetes/issues/59314) of [comments](https://github.com/kubernetes/kubernetes/issues/59314#issuecomment-362869655) in upstream saying the kubelet should not update labels, so a custom patch would probably never be merged upstream (IMO). There are differing opinions on the ticket.

This PR is phase 1) create the label with the starting version. The second phase will be to create a daemonset to update the label on RHEL7->RHEL8 upgrades. A final third phase, when RHEL7 is not supported anymore, we can retire the daemonset and delete the code/daemonset.

/cc @jeremyeder @sjenning @smarterclayton @derekwaynecarr 