### PR TITLE
pkg/controller: avoid a patch call if the node is already at desired config

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -444,6 +444,9 @@ func (ctrl *Controller) setDesiredMachineConfigAnnotation(nodeName, currentConfi
 		if newNode.Annotations == nil {
 			newNode.Annotations = map[string]string{}
 		}
+		if newNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] == currentConfig {
+			return nil
+		}
 		newNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] = currentConfig
 		newData, err := json.Marshal(newNode)
 		if err != nil {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -480,14 +480,14 @@ func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node, 
 	acted := getReadyMachines(pool.Status.Configuration.Name, nodes)
 	acted = append(acted, getUnavailableMachines(pool.Status.Configuration.Name, nodes)...)
 
-	actedMap := map[string]struct{}{}
+	actedMap := map[string]bool{}
 	for _, node := range acted {
-		actedMap[node.Name] = struct{}{}
+		actedMap[node.Name] = true
 	}
 
 	var candidates []*corev1.Node
 	for _, node := range nodes {
-		if _, ok := actedMap[node.Name]; !ok {
+		if !actedMap[node.Name] {
 			candidates = append(candidates, node)
 		}
 	}

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -659,46 +659,24 @@ func TestSetDesiredMachineConfigAnnotation(t *testing.T) {
 	}, {
 		node: newNode("node-0", "v0", "v1"),
 		verify: func(actions []core.Action, t *testing.T) {
-			if len(actions) != 2 {
+			if len(actions) != 1 {
 				t.Fatal(actions)
 			}
 
 			if !actions[0].Matches("get", "nodes") || actions[0].(core.GetAction).GetName() != "node-0" {
 				t.Fatal(actions)
-			}
-
-			if !actions[1].Matches("patch", "nodes") {
-				t.Fatal(actions)
-			}
-
-			expected := []byte(`{}`)
-			actual := actions[1].(core.PatchAction).GetPatch()
-
-			if !reflect.DeepEqual(expected, actual) {
-				t.Fatal(diff.ObjectDiff(string(expected), string(actual)))
 			}
 		},
 	}, {
 		node:       newNode("node-0", "v0", "v1"),
 		extraannos: map[string]string{"test": "extra-annotation"},
 		verify: func(actions []core.Action, t *testing.T) {
-			if len(actions) != 2 {
+			if len(actions) != 1 {
 				t.Fatal(actions)
 			}
 
 			if !actions[0].Matches("get", "nodes") || actions[0].(core.GetAction).GetName() != "node-0" {
 				t.Fatal(actions)
-			}
-
-			if !actions[1].Matches("patch", "nodes") {
-				t.Fatal(actions)
-			}
-
-			expected := []byte(`{}`)
-			actual := actions[1].(core.PatchAction).GetPatch()
-
-			if !reflect.DeepEqual(expected, actual) {
-				t.Fatal(diff.ObjectDiff(string(expected), string(actual)))
 			}
 		},
 	}}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

There are a bunch of logs like these today:
```
I0301 14:49:44.146628       1 node_controller.go:432] Setting node ip-10-0-148-83.us-west-2.compute.internal to desired config worker-e854dfc4700db876403a02746b62bd99
I0301 14:49:49.164555       1 node_controller.go:432] Setting node ip-10-0-135-231.us-west-2.compute.internal to desired config worker-e854dfc4700db876403a02746b62bd99
I0301 14:50:05.687080       1 node_controller.go:432] Setting node ip-10-0-171-131.us-west-2.compute.internal to desired config worker-e854dfc4700db876403a02746b62bd99
I0301 14:50:10.697380       1 node_controller.go:432] Setting node ip-10-0-135-231.us-west-2.compute.internal to desired config worker-e854dfc4700db876403a02746b62bd99
I0301 14:50:16.916536       1 node_controller.go:432] Setting node ip-10-0-171-131.us-west-2.compute.internal to desired config worker-e854dfc4700db876403a02746b62bd99
I0301 14:50:21.954829       1 node_controller.go:432] Setting node ip-10-0-171-131.us-west-2.compute.internal to desired config worker-e854dfc4700db876403a02746b62bd99
```
The controller philosophy should always be (credits to Ben for this):

> observe X. generated desired state Y.  Apply Y to current state Z,which may be a no-op

This patch avoids a "patch" call if the node is already at desired config.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
