### PR TITLE
bootstrap: Final switch to CVO pod image

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -63,7 +63,7 @@ func init() {
 	bootstrapCmd.MarkFlagRequired("etcd-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.setupEtcdEnvImage, "setup-etcd-env-image", "", "Image for Setup Etcd Environment.")
 	bootstrapCmd.MarkFlagRequired("setup-etcd-env-image")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "quay.io/openshift/origin-pod:v4.0", "Image for Infra Containers.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "", "Image for Infra Containers.")
 	bootstrapCmd.MarkFlagRequired("infra-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
 	bootstrapCmd.MarkFlagRequired("config-file")
@@ -85,7 +85,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		MachineOSContent:        bootstrapOpts.oscontentImage,
 		Etcd:                    bootstrapOpts.etcdImage,
 		SetupEtcdEnv:            bootstrapOpts.setupEtcdEnvImage,
-		InfraImage:              "quay.io/openshift/origin-pod:v4.0",
+		InfraImage:              bootstrapOpts.infraImage,
 	}
 
 	if err := operator.RenderBootstrap(

--- a/install/0000_30_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_30_machine-config-operator_02_images.configmap.yaml
@@ -11,6 +11,5 @@ data:
       "machineConfigServer": "docker.io/openshift/origin-machine-config-server:v4.0.0",
       "etcd": "registry.svc.ci.openshift.org/openshift/origin-v4.0:etcd",
       "setupEtcdEnv": "registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment",
-      "dummyImage": "quay.io/tectonicshift/pod:42",
       "infraImage": "quay.io/openshift/origin-pod:v4.0"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -26,7 +26,7 @@ spec:
   - name: pod
     from:
       kind: DockerImage
-      name: quay.io/tectonicshift/pod:42
+      name: quay.io/openshift/origin-pod:v4.0
   - name: setup-etcd-environment
     from:
       kind: DockerImage


### PR DESCRIPTION
When https://github.com/openshift/installer/pull/1292 lands
this will undo the hacks to enable the CVO-driven pod image.

