### PR TITLE
manifests: set priority class

### DIFF
--- a/install/0000_30_machine-config-operator_04_deployment.yaml
+++ b/install/0000_30_machine-config-operator_04_deployment.yaml
@@ -34,6 +34,7 @@ spec:
           mountPath: /etc/mco/images
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       serviceAccountName: machine-config-controller
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
       - key: "node-role.kubernetes.io/master"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
           effect: NoSchedule
       nodeSelector:
         beta.kubernetes.io/os: linux
+      priorityClassName: "system-node-critical"
       volumes:
         - name: rootfs
           hostPath:

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -434,6 +434,7 @@ spec:
       serviceAccountName: machine-config-controller
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
       - key: "node-role.kubernetes.io/master"
@@ -605,6 +606,7 @@ spec:
           effect: NoSchedule
       nodeSelector:
         beta.kubernetes.io/os: linux
+      priorityClassName: "system-node-critical"
       volumes:
         - name: rootfs
           hostPath:
@@ -988,6 +990,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
**- What I did**
Add priorityClassName for machine-config-* related entities to guarantee scheduling.

**- How to verify it**
blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217

**- Description for the changelog**
Add priorityClassName for machine-config-* related entities to guarantee scheduling.