### PR TITLE
kubelet: use cache configMap and secrets change strategy

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -63,6 +63,9 @@ var blacklistKubeletConfigurationFields = []string{
 	"CgroupDriver",
 	"ClusterDNS",
 	"ClusterDomain",
+	// Bugfix to force cache based configmap and secret watches
+	//   https://github.com/kubernetes/kubernetes/issues/74412
+	"ConfigMapAndSecretChangeDetectionStrategy",
 	"RuntimeRequestTimeout",
 	"StaticPodPath",
 }

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0A%23%201.12%2C%201.13%20ConfigMap%20watch%20fix%20https%3A%2F%2Fgithub.com%2Fkubernetes%2Fkubernetes%2Fissues%2F74412%23issuecomment-468437599%0AconfigMapAndSecretChangeDetectionStrategy%3A%20%22Cache%22%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -9,6 +9,8 @@ contents:
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
+    # 1.12, 1.13 ConfigMap watch fix https://github.com/kubernetes/kubernetes/issues/74412#issuecomment-468437599
+    configMapAndSecretChangeDetectionStrategy: "Cache"
     maxPods: 250
     runtimeRequestTimeout: 10m
     serializeImagePulls: false

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -9,6 +9,8 @@ contents:
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
+    # 1.12, 1.13 ConfigMap watch fix https://github.com/kubernetes/kubernetes/issues/74412#issuecomment-468437599
+    configMapAndSecretChangeDetectionStrategy: "Cache"
     maxPods: 250
     rotateCertificates: true
     runtimeRequestTimeout: 10m


### PR DESCRIPTION
**Bug fix for 4.0**

Watched based strategy for ConfigMaps and Secrets has a couple bugs, 1) golang http2 max
streams blocking when the stream limit is reached and 2) the kubelet not
cleaning up watches for terminated pods.

This patch configures the cache based strategy. Once golang 1.12 is in
use, and the kubelet patch is merged we can use the watch based
strategy.

ref: https://github.com/kubernetes/kubernetes/issues/74412
ref: https://github.com/kubernetes/kubernetes/issues/74412#issuecomment-468437599

**- How to verify it**

**- Description for the changelog**

```Use Cache based watched strategy in Kubelet for ConfigMaps and Secrets```