### PR TITLE
kubelet-config: prevent changing the ConfigMap and Secret Changing Strategy

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -63,6 +63,10 @@ var blacklistKubeletConfigurationFields = []string{
 	"CgroupDriver",
 	"ClusterDNS",
 	"ClusterDomain",
+	// Bugfix to force cache based configmap and secret watches. This should be
+	// removed with Kubernetes 1.14.
+	//   https://github.com/kubernetes/kubernetes/issues/74412
+	"ConfigMapAndSecretChangeDetectionStrategy",
 	"RuntimeRequestTimeout",
 	"StaticPodPath",
 }


### PR DESCRIPTION
Blacklists `ConfigMapAndSecretChangeDetectionStrategy` from being user changeable.

ref: https://github.com/openshift/machine-config-operator/issues/520
ref: https://github.com/openshift/origin/pull/22236

**- Description for the changelog**
None