### PR TITLE
pkg/operator: set operator version to release payload version

### DIFF
--- a/install/0000_30_machine-config-operator_04_deployment.yaml
+++ b/install/0000_30_machine-config-operator_04_deployment.yaml
@@ -25,6 +25,9 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        env:
+          - name: RELEASE_VERSION
+            value: "0.0.1-snapshot"
         volumeMounts:
         - name: root-ca
           mountPath: /etc/ssl/kubernetes/ca.crt

--- a/install/0000_30_machine-config-operator_06_clusteroperator.yaml
+++ b/install/0000_30_machine-config-operator_06_clusteroperator.yaml
@@ -3,3 +3,7 @@ kind: ClusterOperator
 metadata:
   name: machine-config
 spec: {}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -434,7 +434,6 @@ func (ctrl *Controller) garbageCollectRenderedConfigs(pool *mcfgv1.MachineConfig
 	return nil
 }
 
-
 func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) error {
 	if len(configs) == 0 {
 		return nil

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -77,12 +77,11 @@ func generateMachineConfigs(config *RenderConfig, templateDir string) ([]*mcfgv1
 	}
 
 	// tag all the machineconfigs with version of the controller.
-	ctrlv := version.Version
 	for _, cfg := range cfgs {
 		if cfg.Annotations == nil {
 			cfg.Annotations = map[string]string{}
 		}
-		cfg.Annotations[common.GeneratedByControllerVersionAnnotationKey] = ctrlv.String()
+		cfg.Annotations[common.GeneratedByControllerVersionAnnotationKey] = version.Version.String()
 	}
 
 	return cfgs, nil

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -134,9 +135,6 @@ func New(
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
 	}
 
-	// set operator version in version store
-	optr.vStore.Set("operator", version.Version.String())
-
 	mcoconfigInformer.Informer().AddEventHandler(optr.eventHandler())
 	controllerConfigInformer.Informer().AddEventHandler(optr.eventHandler())
 	serviceAccountInfomer.Informer().AddEventHandler(optr.eventHandler())
@@ -166,6 +164,8 @@ func New(
 	optr.infraListerSynced = infraInformer.Informer().HasSynced
 	optr.networkLister = networkInformer.Lister()
 	optr.networkListerSynced = networkInformer.Informer().HasSynced
+
+	optr.vStore.Set("operator", os.Getenv("RELEASE_VERSION"))
 
 	return optr
 }

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -110,9 +110,9 @@ func (optr *Operator) syncFailingStatus(ierr error) (err error) {
 
 		// set progressing
 		if cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorProgressing) {
-			cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: fmt.Sprintf("Unable to apply %s", version.Version.String())})
+			cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: fmt.Sprintf("Unable to apply %s", optrVersion)})
 		} else {
-			cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: fmt.Sprintf("Error while reconciling %s", version.Version.String())})
+			cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: fmt.Sprintf("Error while reconciling %s", optrVersion)})
 		}
 	}
 	// set failing condition
@@ -157,6 +157,10 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 	co.Status.RelatedObjects = []configv1.ObjectReference{
 		{Resource: "namespaces", Name: "openshift-machine-config-operator"},
 	}
+	// During an installation we report the RELEASE_VERSION as soon as the component is created
+	// whether for normal runs and upgrades this code isn't hit and we get the right version every
+	// time. This also only contains the operator RELEASE_VERSION when we're here.
+	co.Status.Versions = optr.vStore.GetAll()
 	return optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 }
 


### PR DESCRIPTION
The other components versions can be left as they are to use the image
pullspec. This is not changing the version we report when starting every
component though for our debugging sanity.

This is a 4.0 requirement to pass https://github.com/openshift/origin/pull/22156

Signed-off-by: Antonio Murdaca <runcom@linux.com>