### PR TITLE
mcc: add ignition validation to render controller

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -439,7 +439,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		return nil
 	}
 
-	generated, err := generateMachineConfig(pool, configs)
+	generated, err := generateRenderedMachineConfig(pool, configs)
 	if err != nil {
 		return err
 	}
@@ -477,7 +477,8 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	return nil
 }
 
-func generateMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) (*mcfgv1.MachineConfig, error) {
+// generateRenderedMachineConfig takes all MCs for a given pool and returns a single rendered MC. For ex master-XXXX or worker-XXXX
+func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) (*mcfgv1.MachineConfig, error) {
 	merged := mcfgv1.MergeMachineConfigs(configs)
 	hashedName, err := getMachineConfigHashedName(pool, merged)
 	if err != nil {
@@ -509,7 +510,7 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 			return nil, nil, err
 		}
 
-		generated, err := generateMachineConfig(pool, pcs)
+		generated, err := generateRenderedMachineConfig(pool, pcs)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -521,7 +522,7 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 	return opools, oconfigs, nil
 }
 
-// getMachineConfigsForPool returns configs that match label from configs for a pool.
+// getMachineConfigsForPool is called by RunBootstrap and returns configs that match label from configs for a pool.
 func getMachineConfigsForPool(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) ([]*mcfgv1.MachineConfig, error) {
 	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.MachineConfigSelector)
 	if err != nil {

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -263,7 +263,7 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
 		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
 	}
-	gmc, err := generateMachineConfig(mcp, mcs)
+	gmc, err := generateRenderedMachineConfig(mcp, mcs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 	f.mcLister = append(f.mcLister, gmc)
 	f.objects = append(f.objects, gmc)
 
-	expmc, err := generateMachineConfig(mcp, mcs)
+	expmc, err := generateRenderedMachineConfig(mcp, mcs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ func TestDoNothing(t *testing.T) {
 		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
 		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
 	}
-	gmc, err := generateMachineConfig(mcp, mcs)
+	gmc, err := generateRenderedMachineConfig(mcp, mcs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -17,8 +17,8 @@ import (
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/lib/resourcemerge"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +41,7 @@ const (
 	platformBase      = "_base"
 )
 
-// generateMachineConfigs returns MachineConfig objects from the templateDir and a config object
+// generateTemplateMachineConfigs returns MachineConfig objects from the templateDir and a config object
 // expected directory structure for correctly templating machine configs: <templatedir>/<role>/<name>/<platform>/<type>/<tmpl_file>
 //
 // All files from platform _base are always included, and may be overridden or
@@ -55,7 +55,7 @@ const (
 //                /master/00-master/_base/units/kubelet.tmpl
 //                                    /files/hostname.tmpl
 //
-func generateMachineConfigs(config *RenderConfig, templateDir string) ([]*mcfgv1.MachineConfig, error) {
+func generateTemplateMachineConfigs(config *RenderConfig, templateDir string) ([]*mcfgv1.MachineConfig, error) {
 	infos, err := ioutil.ReadDir(templateDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dir %q: %v", templateDir, err)

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -209,14 +209,14 @@ func TestInvalidPlatform(t *testing.T) {
 
 	// we must treat unrecognized constants as "none"
 	controllerConfig.Spec.Platform = "_bad_"
-	_, err = generateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 	if err != nil {
 		t.Errorf("expect nil error, got: %v", err)
 	}
 
 	// explicitly blocked
 	controllerConfig.Spec.Platform = "_base"
-	_, err = generateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 	expectErr(err, "failed to create MachineConfig for role master: platform _base unsupported")
 }
 
@@ -227,7 +227,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 			t.Fatalf("failed to get controllerconfig config: %v", err)
 		}
 
-		cfgs, err := generateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 		if err != nil {
 			t.Fatalf("failed to generate machine configs: %v", err)
 		}
@@ -261,7 +261,7 @@ func TestGenerateMachineConfigsSSH(t *testing.T) {
 		}
 
 		controllerConfig.Spec.SSHKey = "1234"
-		cfgs, err := generateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 
 		if err != nil {
 			t.Fatalf("failed to generate machine configs: %v", err)

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -377,7 +377,7 @@ func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.Co
 		ControllerConfigSpec: &config.Spec,
 		PullSecret:           string(buf.Bytes()),
 	}
-	mcs, err := generateMachineConfigs(rc, templatesDir)
+	mcs, err := generateTemplateMachineConfigs(rc, templatesDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- Add check in render_controller.go to ensure that all machineconfigs to be merged in
getRenderedMachineConfig() contain valid ignition configs.
- Add unit test for getRenderedMachineConfig() to test ign validation
- Add missing unit test for GetMachineConfigsForPool()
- Rename confusing function names in controller which caused problems while working on this PR: 
generateMachineConfig() -> generateRenderedMachineConfig()
generateMachineConfigs() -> generateTemplateMachineConfigs() 

Closes: #502 
Related-to: #505 
