### PR TITLE
controller: Report number of degraded machines in pool

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -324,6 +324,10 @@ type MachineConfigPoolStatus struct {
 	// A node is marked unavailable if it is in updating state or NodeReady condition is false.
 	UnavailableMachineCount int32 `json:"unavailableMachineCount"`
 
+	// Total number of machines marked degraded.
+	// A node is marked degraded if applying a configuration failed..
+	DegradedMachineCount int32 `json:"degradedMachineCount"`
+
 	// Represents the latest available observations of current state.
 	Conditions []MachineConfigPoolCondition `json:"conditions"`
 }

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -44,6 +44,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 	unavailableMachineCount := int32(len(unavailableMachines))
 
 	degradedMachines := getDegradedMachines(pool.Status.Configuration.Name, nodes)
+	degradedMachineCount := int32(len(degradedMachines))
 
 	status := mcfgv1.MachineConfigPoolStatus{
 		ObservedGeneration:      pool.Generation,
@@ -51,6 +52,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 		UpdatedMachineCount:     updatedMachineCount,
 		ReadyMachineCount:       readyMachineCount,
 		UnavailableMachineCount: unavailableMachineCount,
+		DegradedMachineCount:    degradedMachineCount,
 	}
 
 	status.Configuration = pool.Status.Configuration

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -344,7 +344,7 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 			if p.Generation <= p.Status.ObservedGeneration && p.Status.MachineCount == p.Status.UpdatedMachineCount && p.Status.UnavailableMachineCount == 0 {
 				continue
 			}
-			lastErr = fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d)", p.Name, p.Status.MachineCount, p.Status.UpdatedMachineCount, p.Status.UnavailableMachineCount)
+			lastErr = fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d, degraded: %d)", p.Name, p.Status.MachineCount, p.Status.UpdatedMachineCount, p.Status.UnavailableMachineCount, p.Status.DegradedMachineCount)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
We want to get rid of "degraded" someday; but today is not that day.
In the meantime, let's make clear that there's a degraded node
in a pool status, as distinct from "unavailable".
