### PR TITLE
e2e: add ssh mcd test

### DIFF
--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/openshift/machine-config-operator/test/e2e/framework"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -140,6 +142,112 @@ func TestMCDeployed(t *testing.T) {
 		}); err != nil {
 			t.Errorf("machine config didn't result in file being on any worker: %v", err)
 		}
+	}
+}
+
+func TestUpdateSSH(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	// create a dummy MC with an sshKey for user Core
+	mcName := fmt.Sprintf("sshkeys-worker-%s", uuid.NewUUID())
+	mcadd := &mcv1.MachineConfig{}
+	mcadd.ObjectMeta = metav1.ObjectMeta{
+		Name:   mcName,
+		Labels: mcLabelForWorkers(),
+	}
+	// create a new MC that adds a valid user & ssh keys
+	tempUser := ignv2_2types.PasswdUser{
+		Name: "core",
+		SSHAuthorizedKeys: []ignv2_2types.SSHAuthorizedKey{
+			"1234_test",
+			"abc_test",
+		},
+	}
+	mcadd.Spec = mcv1.MachineConfigSpec{
+		Config: ignv2_2types.Config{
+			Ignition: ignv2_2types.Ignition{
+				Version: "2.2.0",
+			},
+			Passwd: ignv2_2types.Passwd{
+				Users: []ignv2_2types.PasswdUser{tempUser},
+			},
+		},
+	}
+	_, err := cs.MachineConfigs().Create(mcadd)
+	if err != nil {
+		t.Errorf("failed to create machine config %v", err)
+	}
+
+	// grab the latest worker- MC
+	var newMCName string
+	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineConfigPools().Get("worker", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, mc := range mcp.Status.Configuration.Source {
+			if mc.Name == mcName {
+				newMCName = mcp.Status.Configuration.Name
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("machine config hasn't been picked by the pool: %v", err)
+	}
+
+	visited := make(map[string]bool)
+	if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
+		nodes, err := getNodesByRole(cs, "worker")
+		if err != nil {
+			return false, err
+		}
+		for _, node := range nodes {
+			if visited[node.Name] {
+				continue
+			}
+			// check that the new MC is in the annotations and that the MCD state is Done.
+			if node.Annotations[constants.CurrentMachineConfigAnnotationKey] == newMCName &&
+				node.Annotations[constants.MachineConfigDaemonStateAnnotationKey] == constants.MachineConfigDaemonStateDone {
+				// find the MCD pod that has spec.nodeNAME = node.Name and get its name:
+				listOptions := metav1.ListOptions{
+					FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
+				}
+				listOptions.LabelSelector = labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}).String()
+
+				mcdList, err := cs.Pods("openshift-machine-config-operator").List(listOptions)
+				if err != nil {
+					return false, nil
+				}
+				if len(mcdList.Items) != 1 {
+					t.Logf("did not find any mcd pods")
+					return false, nil
+				}
+				mcdName := mcdList.Items[0].ObjectMeta.Name
+
+				// now rsh into that daemon and grep the authorized key file to check if 1234_test was written
+				// must do both commands in same shell, combine commands into one exec.Command()
+				found, err := exec.Command("oc", "rsh", "-n", "openshift-machine-config-operator", mcdName,
+					"grep", "1234_test", "/rootfs/home/core/.ssh/authorized_keys").CombinedOutput()
+				if err != nil {
+					t.Logf("unable to read authorized_keys on daemon: %s got: %s got err: %v", mcdName, found, err)
+					return false, nil
+				}
+				if !strings.Contains(string(found), "1234_test") {
+					t.Logf("updated ssh keys not found in authorized_keys, got %s", found)
+					return false, nil
+				}
+
+				visited[node.Name] = true
+				if len(visited) == len(nodes) {
+					return true, nil
+				}
+				continue
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("machine config didn't result in ssh keys being on any worker: %v", err)
 	}
 }
 


### PR DESCRIPTION
Test verifies that MCD updates MCP, daemons and
writes new ssh keys to node filesystems.

Closes #546 
