### PR TITLE
daemon: Drop all dependency on cgo and external shlibs

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -31,9 +31,6 @@ fi
 mkdir -p ${BIN_PATH}
 
 CGO_ENABLED=0
-if [[ $WHAT == "machine-config-daemon" ]]; then
-    CGO_ENABLED=1
-fi
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
 CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -31,7 +31,6 @@ func TestUpdateOS(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
-		loginClient:       nil, // set to nil as it will not be used within tests
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		rootMount:         "/",
 		bootedOSImageURL:  "test",
@@ -64,7 +63,6 @@ func TestReconcilable(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: nil,
-		loginClient:       nil,
 		kubeClient:        nil,
 		rootMount:         "/",
 		bootedOSImageURL:  "test",
@@ -204,7 +202,6 @@ func TestReconcilableSSH(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
-		loginClient:       nil, // set to nil as it will not be used within tests
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		rootMount:         "/",
 		bootedOSImageURL:  "test",
@@ -295,7 +292,6 @@ func TestUpdateSSHKeys(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
-		loginClient:       nil, // set to nil as it will not be used within tests
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		rootMount:         "/",
 		bootedOSImageURL:  "test",
@@ -349,7 +345,6 @@ func TestInvalidIgnConfig(t *testing.T) {
 		name:              "nodeName",
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
-		loginClient:       nil, // set to nil as it will not be used within tests
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		rootMount:         "/",
 		bootedOSImageURL:  "test",


### PR DESCRIPTION
The way the MCD today chroots into the host is problematic
for major OS version updates and creates a hidden dependency.

Eventually we need to stop chrooting, see:
https://github.com/openshift/machine-config-operator/issues/543

