### PR TITLE
kubelet: quote values in node.openshift.io/os_id label, use VERSION_ID instead of VERSION

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vpshere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vpshere/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=vsphere \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vpshere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vpshere/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -22,7 +22,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -21,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \


### PR DESCRIPTION
Fixes https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/11343/pull-ci-openshift-openshift-ansible-devel-40-e2e-aws-scaleup/581/build-log.txt
Related to #514

**- What I did**
Quoted values for labels, assigned from /etc/os-release contents, replaced `VERSION` with `VERSION_ID`

**- How to verify it**
Run openshift-ansible's scaleup playbook on CentOS 7 nodes, check kubelet log:
`
kubelet_node_status.go:92] Unable to register node "ip-10-0-172-104.ec2.internal" with API server: Node "ip-10-0-172-104.ec2.internal" is invalid: metadata.labels: Invalid value: "7 (Core)": a valid label must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character (e.g. ''MyValue'',  or ''my_value'',  or ''12345'', regex used for validation is ''(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'')'
`

**- Description for the changelog**
Use `VERSION_ID` in `node.openshift.io/os_version` label
