### PR TITLE
test/e2e: roll out new MCs more than just once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ images.rhel7: $(imc7)
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	GOCACHE=off go test -timeout 20m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	GOCACHE=off go test -timeout 50m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
 
 # And this one dumps debugging stuff
 test-e2e-prow:


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Modified the e2e MC test to roll out MCs more than just once to understand if rolling MCs just goes ok

**- How to verify it**

run e2e or wait CI reports

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
