### PR TITLE
pkg/operator: keep calling sync functions for MCP

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -240,8 +240,6 @@ func (optr *Operator) handleErr(err error, key interface{}) {
 		return
 	}
 
-	optr.syncFailingStatus(err)
-
 	if optr.queue.NumRequeues(key) < maxRetries {
 		glog.V(2).Infof("Error syncing operator %v: %v", key, err)
 		optr.queue.AddRateLimited(key)
@@ -251,6 +249,7 @@ func (optr *Operator) handleErr(err error, key interface{}) {
 	utilruntime.HandleError(err)
 	glog.V(2).Infof("Dropping operator %q out of the queue: %v", key, err)
 	optr.queue.Forget(key)
+	optr.queue.AddAfter(key, 1*time.Minute)
 }
 
 func (optr *Operator) sync(key string) error {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -322,37 +322,19 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 	if err != nil {
 		return err
 	}
-	var lastErr error
-	if err := wait.Poll(time.Second, 10*time.Minute, func() (bool, error) {
-		pools, err := optr.mcpLister.List(sel)
-		if apierrors.IsNotFound(err) {
-			return false, err
-		}
-		if err != nil {
-			lastErr = err
-			return false, nil
-		}
-
-		for _, pool := range pools {
-			p := pool.DeepCopy()
-			err := isMachineConfigPoolConfigurationValid(p, version.Version.String(), optr.mcLister.Get)
-			if err != nil {
-				lastErr = fmt.Errorf("pool %s has not progressed to latest configuration: %v", p.Name, err)
-				return false, nil
-			}
-
-			if p.Generation <= p.Status.ObservedGeneration && p.Status.MachineCount == p.Status.UpdatedMachineCount && p.Status.UnavailableMachineCount == 0 {
-				continue
-			}
-			lastErr = fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d, degraded: %d)", p.Name, p.Status.MachineCount, p.Status.UpdatedMachineCount, p.Status.UnavailableMachineCount, p.Status.DegradedMachineCount)
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
-		if err == wait.ErrWaitTimeout {
-			return fmt.Errorf("%v during syncRequiredMachineConfigPools: %v", err, lastErr)
-		}
+	pools, err := optr.mcpLister.List(sel)
+	if err != nil {
 		return err
+	}
+
+	for _, pool := range pools {
+		if err := isMachineConfigPoolConfigurationValid(pool, version.Version.String(), optr.mcLister.Get); err != nil {
+			return fmt.Errorf("pool %s has not progressed to latest configuration: %v", pool.Name, err)
+		}
+		if pool.Generation <= pool.Status.ObservedGeneration && pool.Status.MachineCount == pool.Status.UpdatedMachineCount && pool.Status.UnavailableMachineCount == 0 {
+			continue
+		}
+		return fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d, degraded: %d)", pool.Name, pool.Status.MachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount, pool.Status.DegradedMachineCount)
 	}
 	return nil
 }


### PR DESCRIPTION
instead of polling for that long...

Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

handle point number 2 from https://github.com/openshift/machine-config-operator/issues/550

close #550

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
