### PR TITLE
Fix MCD status reporting, retry loop and max unavailable progress

### DIFF
--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -16,10 +16,6 @@ spec:
     description: When at least one of machine is not either not updated or is in the process of updating to the desired machine config.
     name: Updating
     type: string
-  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
-    description: When the update for one of the machine is not progressig due to an error.
-    name: Degraded
-    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
@@ -26,17 +26,9 @@ var (
 		}
 	}
 
-	condDegraded = func() MachineConfigPoolCondition {
-		return MachineConfigPoolCondition{
-			Type:   MachineConfigPoolDegraded,
-			Status: corev1.ConditionTrue,
-			Reason: "ForSomeReason",
-		}
-	}
-
 	status = func() *MachineConfigPoolStatus {
 		return &MachineConfigPoolStatus{
-			Conditions: []MachineConfigPoolCondition{condUpdatedFalse(), condDegraded()},
+			Conditions: []MachineConfigPoolCondition{condUpdatedFalse()},
 		}
 	}
 )
@@ -84,11 +76,6 @@ func TestSetMachineConfigPoolCondition(t *testing.T) {
 		expectedStatus: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatedTrue()}},
 	}, {
 		status: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatedFalse()}},
-		cond:   condDegraded(),
-
-		expectedStatus: status(),
-	}, {
-		status: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatedFalse()}},
 		cond:   condUpdatedTrue(),
 
 		expectedStatus: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatedTrue()}},
@@ -111,12 +98,6 @@ func TestRemoveMachineConfigPoolCondition(t *testing.T) {
 
 		expectedStatus *MachineConfigPoolStatus
 	}{
-		{
-			status:   &MachineConfigPoolStatus{},
-			condType: MachineConfigPoolDegraded,
-
-			expectedStatus: &MachineConfigPoolStatus{},
-		},
 		{
 			status:   &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatedTrue()}},
 			condType: MachineConfigPoolUpdated,

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -324,10 +324,6 @@ type MachineConfigPoolStatus struct {
 	// A node is marked unavailable if it is in updating state or NodeReady condition is false.
 	UnavailableMachineCount int32 `json:"unavailableMachineCount"`
 
-	// Total number of machines marked degraded.
-	// A node is marked degraded if applying a configuration failed..
-	DegradedMachineCount int32 `json:"degradedMachineCount"`
-
 	// Represents the latest available observations of current state.
 	Conditions []MachineConfigPoolCondition `json:"conditions"`
 }
@@ -374,9 +370,6 @@ const (
 	// When at least one of machine is not either not updated or is in the process of updating
 	// to the desired machine config.
 	MachineConfigPoolUpdating MachineConfigPoolConditionType = "Updating"
-	// MachineConfigPoolDegraded means the update for one of the machine is not progressing
-	// due to an error
-	MachineConfigPoolDegraded MachineConfigPoolConditionType = "Degraded"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -59,6 +59,7 @@ func newNode(name string, currentConfig, desiredConfig string) *corev1.Node {
 		annos = map[string]string{}
 		annos[daemonconsts.CurrentMachineConfigAnnotationKey] = currentConfig
 		annos[daemonconsts.DesiredMachineConfigAnnotationKey] = desiredConfig
+		annos[daemonconsts.MachineConfigDaemonStateAnnotationKey] = daemonconsts.MachineConfigDaemonStateDone
 	}
 
 	return &corev1.Node{
@@ -318,21 +319,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -369,21 +361,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -420,21 +403,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -471,21 +445,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -522,21 +487,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -573,21 +529,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -624,21 +571,12 @@ func TestCalculateStatus(t *testing.T) {
 				t.Fatal("updated condition not found")
 			}
 
-			conddegrad := mcfgv1.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
-				t.Fatal("updated condition not found")
-			}
-
 			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
 			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
-
-			if got, want := conddegrad.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegrad.Status: got %s want: %s", got, want)
 			}
 		},
 	}}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -387,6 +387,7 @@ func (dn *Daemon) syncNode(key string) error {
 				return err
 			}
 		}
+		glog.V(2).Infof("Node %s is already synced", node.Name)
 	}
 	return nil
 }
@@ -880,9 +881,13 @@ func (dn *Daemon) prepUpdateFromCluster() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	state, err := getNodeAnnotation(dn.node, constants.MachineConfigDaemonStateAnnotationKey)
+	if err != nil {
+		return false, err
+	}
 
 	// Detect if there is an update
-	if desiredConfigName == currentConfigName {
+	if desiredConfigName == currentConfigName && state == constants.MachineConfigDaemonStateDone {
 		// No actual update to the config
 		glog.V(2).Info("No updating is required")
 		return false, nil

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -764,10 +764,6 @@ spec:
     description: When at least one of machine is not either not updated or is in the process of updating to the desired machine config.
     name: Updating
     type: string
-  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
-    description: When the update for one of the machine is not progressig due to an error.
-    name: Degraded
-    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -240,8 +240,6 @@ func (optr *Operator) handleErr(err error, key interface{}) {
 		return
 	}
 
-	optr.syncFailingStatus(err)
-
 	if optr.queue.NumRequeues(key) < maxRetries {
 		glog.V(2).Infof("Error syncing operator %v: %v", key, err)
 		optr.queue.AddRateLimited(key)
@@ -251,6 +249,7 @@ func (optr *Operator) handleErr(err error, key interface{}) {
 	utilruntime.HandleError(err)
 	glog.V(2).Infof("Dropping operator %q out of the queue: %v", key, err)
 	optr.queue.Forget(key)
+	optr.queue.AddAfter(key, 1*time.Minute)
 }
 
 func (optr *Operator) sync(key string) error {

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -279,9 +279,6 @@ func isMachineConfigPoolConfigurationValid(pool *mcfgv1.MachineConfigPool, versi
 
 func machineConfigPoolStatus(pool *mcfgv1.MachineConfigPool) string {
 	switch {
-	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolDegraded):
-		cond := mcfgv1.GetMachineConfigPoolCondition(pool.Status, mcfgv1.MachineConfigPoolDegraded)
-		return fmt.Sprintf("pool is degraded because of %s", cond.Reason)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdated):
 		return fmt.Sprintf("all %d nodes are at latest configuration %s", pool.Status.MachineCount, pool.Status.Configuration.Name)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating):

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -338,7 +338,7 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 		if pool.Generation <= pool.Status.ObservedGeneration && pool.Status.MachineCount == pool.Status.UpdatedMachineCount && pool.Status.UnavailableMachineCount == 0 {
 			continue
 		}
-		return fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d, degraded: %d)", pool.Name, pool.Status.MachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount, pool.Status.DegradedMachineCount)
+		return fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d)", pool.Name, pool.Status.MachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This PR is a follow up from #548 which accounts for the change in behavior that we introduced with that. Most notably:

- we are never in a permanent Degraded state anymore, we flip Working and Degraded but the logic for determining the updated/unavailable machines rely only on current/desired annotation. I'm going to fix that and remove Degraded
- progressing on applying a machineconfig is currently broken because of the above, so max unavailable isn't respected
- with #548, we can now delete a bad machineconfig which is erroring out in a loop, and just reapply the old one which is going to just stabilize the machine again
- probably something else I'm still not aware of but I'm actively testing

This PR includes https://github.com/openshift/machine-config-operator/pull/552 as well
so, close #552

**- How to verify it**

I'll add e2e(s) + the CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
