### PR TITLE
*: set kube-client-agent-image flag as required

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -65,8 +65,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.setupEtcdEnvImage, "setup-etcd-env-image", "", "Image for Setup etcd Environment.")
 	bootstrapCmd.MarkFlagRequired("setup-etcd-env-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeClientAgentImage, "kube-client-agent-image", "", "Image for Kube Client Agent.")
-	// TODO hexfusion: uncomment after flag is merged from installer.
-	// bootstrapCmd.MarkFlagRequired("kube-client-agent-image")
+	bootstrapCmd.MarkFlagRequired("kube-client-agent-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "", "Image for Infra Containers.")
 	bootstrapCmd.MarkFlagRequired("infra-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
@@ -81,9 +80,6 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v", version.Version)
-
-	// TODO hexfusion: uncomment after flag is merged from installer.
-	bootstrapOpts.kubeClientAgentImage = "registry.svc.ci.openshift.org/openshift/origin-v4.0:kube-client-agent"
 
 	imgs := operator.Images{
 		MachineConfigController: bootstrapOpts.mccImage,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -318,9 +318,6 @@ func (optr *Operator) sync(key string) error {
 		return err
 	}
 
-	// TODO hexfusion: uncomment after flag is merged from installer.
-	imgs.KubeClientAgent = "registry.svc.ci.openshift.org/openshift/origin-v4.0:kube-client-agent"
-
 	spec.EtcdCAData = etcdCA
 	spec.RootCAData = bundle
 	spec.PullSecret = &v1.ObjectReference{Namespace: "kube-system", Name: "coreos-pull-secret"}


### PR DESCRIPTION
This PR is the final action to enable kube-client-agent to be part of the release payload.

depends on: https://github.com/openshift/installer/pull/1429
ref: https://github.com/openshift/machine-config-operator/pull/538

/hold

