### PR TITLE
pkg/daemon: fix oncefrom panic

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -433,9 +433,6 @@ func (dn *Daemon) detectEarlySSHAccessesFromBoot() error {
 // responsible for triggering callbacks to handle updates. Successful
 // updates shouldn't return, and should just reboot the node.
 func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
-	defer utilruntime.HandleCrash()
-	defer dn.queue.ShutDown()
-
 	if dn.kubeletHealthzEnabled {
 		glog.Info("Enabling Kubelet Healthz Monitor")
 		go dn.runKubeletHealthzMonitor(stopCh, dn.exitCh)
@@ -460,6 +457,9 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 			return dn.runOnceFromMachineConfig(*mcConfig, contentFrom)
 		}
 	}
+
+	defer utilruntime.HandleCrash()
+	defer dn.queue.ShutDown()
 
 	if !cache.WaitForCacheSync(stopCh, dn.nodeListerSynced, dn.mcListerSynced) {
 		return errors.New("failed to sync initial listers cache")


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

we were panicking in onceFrom since the dn.queue isn't initialized in
onceFrom.

**- How to verify it**

rhel scaleup CI

/cc @vrutkovs 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
