### PR TITLE
pkg/daemon: don't flip Degraded/Working and add an Unreconcilable state

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -18,8 +18,11 @@ const (
 	MachineConfigDaemonStateWorking = "Working"
 	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.
 	MachineConfigDaemonStateDone = "Done"
-	// MachineConfigDaemonStateDegraded is set by daemon when update cannot be applied.
+	// MachineConfigDaemonStateDegraded is set by daemon when an error not caused by a bad MachineConfig
+	// is thrown during an udpate.
 	MachineConfigDaemonStateDegraded = "Degraded"
+	// MachineConfigDaemonStateUnreconcilable is set by the daemon when a MachineConfig cannot be applied.
+	MachineConfigDaemonStateUnreconcilable = "Unreconcilable"
 	// InitialNodeAnnotationsFilePath defines the path at which it will find the node annotations it needs to set on the node once it comes up for the first time.
 	// The Machine Config Server writes the node annotations to this path.
 	InitialNodeAnnotationsFilePath = "/etc/machine-config-daemon/node-annotations.json"


### PR DESCRIPTION
pkg/daemon: keep degraded state after failure

Now that the Degraded state is just a state with the only scope of being
informative, keep it instead of just flipping between Working->Degraded
when we fail. When an MC degrades the machine, it still keeps retrying
to reconcile but at least administrators know that something is wrong
instantly.

Signed-off-by: Antonio Murdaca <runcom@linux.com>

pkg/daemon: add an Unreconcilable state

This new state is, like Degraded, the way we communicate to
administrators that something went specifically wrong with their
MachineConfigs. A natural follow up to this would be going ahead and
expose the real error on the object itself. With this state admins can also
just delete the bad MC and roll back.

Signed-off-by: Antonio Murdaca <runcom@linux.com>