### PR TITLE
Bug 1690707: MCO: report only operator version

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -65,7 +65,6 @@ func (optr *Operator) syncAvailableStatus() error {
 		Message: message,
 	})
 
-	co.Status.Versions = optr.vStore.GetAll()
 	optr.setMachineConfigPoolStatuses(&co.Status)
 	_, err = optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 	return err

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -157,9 +157,6 @@ func (optr *Operator) syncMachineConfigController(config renderConfig) error {
 	}
 	mcc := resourceread.ReadDeploymentV1OrDie(mccBytes)
 
-	// store version of machineconfigcontroller
-	optr.vStore.Set("machineconfigcontroller", imageForContainer("machine-config-controller", mcc.Spec.Template.Spec.Containers))
-
 	_, updated, err := resourceapply.ApplyDeployment(optr.kubeClient.AppsV1(), mcc)
 	if err != nil {
 		return err
@@ -230,9 +227,6 @@ func (optr *Operator) syncMachineConfigDaemon(config renderConfig) error {
 		return err
 	}
 	mcd := resourceread.ReadDaemonSetV1OrDie(mcdBytes)
-
-	// store version of machineconfigdaemon
-	optr.vStore.Set("machineconfigdaemon", imageForContainer("machine-config-daemon", mcd.Spec.Template.Spec.Containers))
 
 	_, updated, err := resourceapply.ApplyDaemonSet(optr.kubeClient.AppsV1(), mcd)
 	if err != nil {
@@ -305,9 +299,6 @@ func (optr *Operator) syncMachineConfigServer(config renderConfig) error {
 	}
 
 	mcs := resourceread.ReadDaemonSetV1OrDie(mcsBytes)
-
-	// store version of machineconfigserver
-	optr.vStore.Set("machineconfigserver", imageForContainer("machine-config-server", mcs.Spec.Template.Spec.Containers))
 
 	_, updated, err := resourceapply.ApplyDaemonSet(optr.kubeClient.AppsV1(), mcs)
 	if err != nil {

--- a/pkg/operator/version.go
+++ b/pkg/operator/version.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	configv1 "github.com/openshift/api/config/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // versionStore stores versions for important components.
@@ -65,13 +64,4 @@ func (vs *versionStore) Equal(opvs []configv1.OperandVersion) bool {
 		return false
 	}
 	return true
-}
-
-func imageForContainer(name string, containers []corev1.Container) string {
-	for _, c := range containers {
-		if c.Name == name {
-			return c.Image
-		}
-	}
-	return ""
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Fix BZ#1690707 - remove componenets versions, leave just the top level MCO one

**- How to verify it**

CI -> grab clusteroperators.json -> only `operator` is reported

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
