### PR TITLE
test/e2e: wait longer for reboots

### DIFF
--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -119,7 +119,7 @@ func TestMCDeployed(t *testing.T) {
 		}
 
 		visited := make(map[string]bool)
-		if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
 			nodes, err := getNodesByRole(cs, "worker")
 			if err != nil {
 				return false, err


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

bumped timeout to 10 mins as we're doing many reboots which might slow things down (observed in #549 )

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
