### PR TITLE
MCD: fix another panic in onceFrom with Ignition

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/machine-config-operator/internal/clients"
 	controllercommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
+	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -109,9 +110,12 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	// If we are asked to run once and it's a valid file system path use
 	// the bare Daemon
 	if startOpts.onceFrom != "" {
-		mcClient, err := cb.MachineConfigClient(componentName)
-		if err != nil {
-			glog.Info("Cannot initialize MC client, likely in onceFrom mode with Ignition")
+		var mcClient mcfgclientset.Interface
+		if cb != nil {
+			mcClient, err = cb.MachineConfigClient(componentName)
+			if err != nil {
+				glog.Info("Cannot initialize MC client, likely in onceFrom mode with Ignition")
+			}
 		}
 		dn, err = daemon.New(
 			startOpts.rootMount,


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

follow up to #483 cause there's still a panic in rhel scaleup job

**- How to verify it**

rhel scaleup job

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
