### PR TITLE
 render: Add `core` user explicitly to groups

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -152,7 +152,13 @@ func generateSSHConfig(sshKey string, role string) (*mcfgv1.MachineConfig, error
 	// validated Ignition Config (instead of creating one by hand) that is then added to a
 	// MachineConfig.
 	var tempctCfg cttypes.Config
-	tempUser := cttypes.User{Name: "core", SSHAuthorizedKeys: []string{sshKey}}
+
+	// Keep the set of groups here in sync with `coreos-useradd-core.service`
+	// from https://github.com/coreos/fedora-coreos-config
+	// This list is also referenced in the installer.
+	tempUser := cttypes.User{Name: "core",
+		Groups: []string{"wheel", "sudo", "adm", "systemd-journal"},
+		SSHAuthorizedKeys: []string{sshKey}}
 	tempctCfg.Passwd.Users = append(tempctCfg.Passwd.Users, tempUser)
 	tempIgnConfig, rep := ctconfig.Convert(tempctCfg, "", nil)
 	if rep.IsFatal() {

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -118,13 +118,15 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role string, path strin
 		return nil, fmt.Errorf("failed to read dir %q: %v", path, err)
 	}
 
-	sshMachineConfigForRole, err := generateSSHConfig(config.SSHKey, role)
-	if err != nil {
-		return nil, err
-	}
-
 	cfgs := []*mcfgv1.MachineConfig{}
-	cfgs = append(cfgs, sshMachineConfigForRole)
+
+	if config.SSHKey != "" {
+		sshMachineConfigForRole, err := generateSSHConfig(config.SSHKey, role)
+		if err != nil {
+			return nil, err
+		}
+		cfgs = append(cfgs, sshMachineConfigForRole)
+	}
 
 	for _, info := range infos {
 		if !info.IsDir() {


### PR DESCRIPTION
This is prep for increasing alignment with FCOS where we'd
like to not have the user hardcoded.

See also: openshift/installer#1445

This way the privileged user is only created if a SSH key is
provided.