### PR TITLE
Add validation for blocked registries

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1186,6 +1186,7 @@
     "github.com/openshift/client-go/config/clientset/versioned",
     "github.com/openshift/client-go/config/clientset/versioned/fake",
     "github.com/openshift/client-go/config/clientset/versioned/scheme",
+    "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1",
     "github.com/openshift/client-go/config/informers/externalversions",
     "github.com/openshift/client-go/config/informers/externalversions/config/v1",
     "github.com/openshift/client-go/config/listers/config/v1",

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -112,6 +112,7 @@ func createControllers(ctx *controllercommon.ControllerContext) []controllercomm
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 			ctx.ConfigInformerFactory.Config().V1().Images(),
+			ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 			ctx.ClientBuilder.KubeClientOrDie("container-runtime-config-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("container-runtime-config-controller"),
 			ctx.ClientBuilder.ConfigClientOrDie("container-runtime-config-controller"),

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -14,5 +14,5 @@ rules:
   resources: ["configmaps", "secrets"]
   verbs: ["*"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["images"]
+  resources: ["images", "clusterversions"]
   verbs: ["*"]

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -333,7 +333,7 @@ rules:
   resources: ["configmaps", "secrets"]
   verbs: ["*"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["images"]
+  resources: ["images", "clusterversions"]
   verbs: ["*"]
 `)
 


### PR DESCRIPTION
We don't want users to add the registry being used by the payload
to the list of blocked registries in /etc/containers/registries.conf.
Doing so will basically bring the whole cluster down. So we add a check
to ensure that doesn't happen and only add the registries that don't
match the payload one.
Added a validation test for this as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686509

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
