### PR TITLE
pkg/operator: fix log messages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,8 @@ metadata:
   name: 50-examplecorp-chrony
 spec:
   config:
+    ignition:
+      version: 2.2.0
     storage:
       files:
       - contents:
@@ -82,21 +84,22 @@ spec:
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
-  creationTimestamp: 2019-02-03T16:51:18Z
+  creationTimestamp: 2019-03-25T18:25:39Z
   generation: 1
   labels:
     machineconfiguration.openshift.io/role: worker
   name: 50-examplecorp-chrony
-  resourceVersion: "24634"
+  resourceVersion: "186713"
   selfLink: /apis/machineconfiguration.openshift.io/v1/machineconfigs/50-examplecorp-chrony
-  uid: ed13afd1-27d3-11e9-a281-067ebaf71038
+  uid: 6445154f-4f2b-11e9-91e1-021aaf2ce4c0
 spec:
   config:
+    ignition:
+      version: 2.2.0
     storage:
       files:
       - contents:
           source: data:,server%20foo.example.net%20maxdelay%200.4%20offline%0Aserver%20bar.example.net%20maxdelay%200.4%20offline%0Aserver%20baz.example.net%20maxdelay%200.4%20offline
-          verification: {}
         filesystem: root
         mode: 420
         path: /etc/chrony.conf

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -324,12 +324,12 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 
 	for _, pool := range pools {
 		if err := isMachineConfigPoolConfigurationValid(pool, version.Version.String(), optr.mcLister.Get); err != nil {
-			return fmt.Errorf("pool %s has not progressed to latest configuration: %v", pool.Name, err)
+			return fmt.Errorf("pool %s has not progressed to latest configuration: %v, retrying", pool.Name, err)
 		}
 		if pool.Generation <= pool.Status.ObservedGeneration && pool.Status.MachineCount == pool.Status.UpdatedMachineCount && pool.Status.UnavailableMachineCount == 0 {
 			continue
 		}
-		return fmt.Errorf("error pool %s is not ready. status: (total: %d, updated: %d, unavailable: %d)", pool.Name, pool.Status.MachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount)
+		return fmt.Errorf("error pool %s is not ready, retrying. Status: (total: %d, updated: %d, unavailable: %d)", pool.Name, pool.Status.MachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount)
 	}
 	return nil
 }


### PR DESCRIPTION
`syncRequiredMachineConfigPools` is continuosly called and can error out
flipping the operator status to Failing. Clarify that we're going to
retry in logs w/o having users think it's a fatal error.

Signed-off-by: Antonio Murdaca <runcom@linux.com>