### PR TITLE
controller/node: Support master/worker combined, and 1 custom role

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -233,8 +233,8 @@ func TestGetPoolForNode(t *testing.T) {
 		err      bool
 	}{{
 		pools: []*mcfgv1.MachineConfigPool{
-			newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
-			newMachineConfigPool("test-cluster-worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), nil, "v0"),
+			newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
+			newMachineConfigPool("worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), nil, "v0"),
 		},
 		nodeLabel: map[string]string{"node-role": ""},
 
@@ -242,14 +242,55 @@ func TestGetPoolForNode(t *testing.T) {
 		err:      false,
 	}, {
 		pools: []*mcfgv1.MachineConfigPool{
-			newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
-			newMachineConfigPool("test-cluster-worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), nil, "v0"),
+			newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
+			newMachineConfigPool("worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), nil, "v0"),
 		},
 		nodeLabel: map[string]string{"node-role": "master"},
 
-		expected: newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
+		expected: newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
 		err:      false,
 	}, {
+		pools: []*mcfgv1.MachineConfigPool{
+			newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/master", ""), nil, "v0"),
+			newMachineConfigPool("worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/worker", ""), nil, "v0"),
+		},
+		nodeLabel: map[string]string{"node-role/master": "", "node-role/worker": ""},
+
+		expected: newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/master", ""), nil, "v0"),
+		err:      false,
+	}, {
+		pools: []*mcfgv1.MachineConfigPool{
+			newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/master", ""), nil, "v0"),
+			newMachineConfigPool("worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/worker", ""), nil, "v0"),
+			newMachineConfigPool("infra", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra", ""), nil, "v0"),
+		},
+		nodeLabel: map[string]string{"node-role/worker": "", "node-role/infra": ""},
+
+		expected: newMachineConfigPool("infra", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra", ""), nil, "v0"),
+		err:      false,
+	}, {
+		pools: []*mcfgv1.MachineConfigPool{
+			newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/master", ""), nil, "v0"),
+			newMachineConfigPool("worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/worker", ""), nil, "v0"),
+			newMachineConfigPool("infra", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra", ""), nil, "v0"),
+		},
+		nodeLabel: map[string]string{"node-role/master": "", "node-role/infra": ""},
+
+		expected: nil,
+		err:      true,
+	}, {
+		pools: []*mcfgv1.MachineConfigPool{
+			newMachineConfigPool("master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/master", ""), nil, "v0"),
+			newMachineConfigPool("worker", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/worker", ""), nil, "v0"),
+			newMachineConfigPool("infra", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra", ""), nil, "v0"),
+			newMachineConfigPool("infra2", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra2", ""), nil, "v0"),
+		},
+		nodeLabel: map[string]string{"node-role/infra": "", "node-role/infra2": ""},
+
+		expected: nil,
+		err:      true,
+	}, {
+
 		pools: []*mcfgv1.MachineConfigPool{
 			newMachineConfigPool("test-cluster-pool-1", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),
 			newMachineConfigPool("test-cluster-pool-2", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), nil, "v0"),


### PR DESCRIPTION
For CodeReady Containers and general single-node testing cases,
we need to support having a single node with both master/worker
labels.  In this case, it should fall under the master pool.

We also want to support users defining custom pools that conceptually
"derive" from worker.  If we find both `node-role/worker` and
`node-role/$x`, choose `$x`.  But we don't support more than one
custom role.

Closes: https://github.com/openshift/machine-config-operator/issues/571
