### PR TITLE
controller/bootstrap: use files with multiple yaml documents

### DIFF
--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -1,0 +1,119 @@
+package bootstrap
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestParseManifests(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []manifest
+	}{{
+		name: "ingress",
+		raw: `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: test-namespace
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: test
+          servicePort: 80
+`,
+		want: []manifest{{
+			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
+		}},
+	}, {
+		name: "two-resources",
+		raw: `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: test-namespace
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: test
+          servicePort: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-config
+  namespace: default
+data:
+  color: "red"
+  multi-line: |
+    hello world
+    how are you?
+`,
+		want: []manifest{{
+			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
+		}, {
+			Raw: []byte(`{"apiVersion":"v1","data":{"color":"red","multi-line":"hello world\nhow are you?\n"},"kind":"ConfigMap","metadata":{"name":"a-config","namespace":"default"}}`),
+		}},
+	}, {
+		name: "two-resources-with-empty",
+		raw: `
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: test-namespace
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: test
+          servicePort: 80
+---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-config
+  namespace: default
+data:
+  color: "red"
+  multi-line: |
+    hello world
+    how are you?
+---
+`,
+		want: []manifest{{
+			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
+		}, {
+			Raw: []byte(`{"apiVersion":"v1","data":{"color":"red","multi-line":"hello world\nhow are you?\n"},"kind":"ConfigMap","metadata":{"name":"a-config","namespace":"default"}}`),
+		}},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseManifests("dummy-file-name", strings.NewReader(test.raw))
+			if err != nil {
+				t.Fatalf("failed to parse manifest: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("mismatch found %s", diff.ObjectDiff(got, test.want))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
**- What I did**
Users can push manifests during bootstrap that of the form:

```yaml
---
```

Especially for the installer: setting authorizes_keys [1] and setting hyperthreading [2] will push a manifest that includes multiple machineconfig objects for
control-plane (master) and compute (worker) roles.

Single file with multiple k8s objects separated by `---` is also a supported structure for `oc create|apply` ie. there is a high chance that users trying to push machineconfigs at
install time might create such files.

This commit allows bootstrap controller to read all k8s objects, even ones described above to find all the `machineconfiguration.openshift.io` Objects.

[1]: https://github.com/openshift/installer/pull/1150
[2]: https://github.com/openshift/installer/pull/1392

**- How to verify it**

Added a unit test.

**- Description for the changelog**

`Allow bootstrap controller to read multi object yaml files`
