### PR TITLE
kubeletconfig_features: fix ignition object creation

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/vincent-petithory/dataurl"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,6 @@ import (
 )
 
 func createNewKubeletIgnition(ymlconfig []byte) ignv2_2types.Config {
-	var tempIgnConfig ignv2_2types.Config
 	mode := 0644
 	du := dataurl.New(ymlconfig, "text/plain")
 	du.Encoding = dataurl.EncodingASCII
@@ -34,6 +34,7 @@ func createNewKubeletIgnition(ymlconfig []byte) ignv2_2types.Config {
 			},
 		},
 	}
+	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	tempIgnConfig.Storage.Files = append(tempIgnConfig.Storage.Files, tempFile)
 	return tempIgnConfig
 }

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -457,7 +457,8 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 			return ctrl.syncStatusOnly(cfg, err, "could not encode YAML: %v", err)
 		}
 		if isNotFound {
-			mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignv2_2types.Config{})
+			ignConfig := ctrlcommon.NewIgnConfig()
+			mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignConfig)
 		}
 		mc.Spec.Config = createNewKubeletIgnition(cfgYAML)
 		mc.ObjectMeta.Annotations = map[string]string{

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"time"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 	"github.com/vincent-petithory/dataurl"
@@ -88,7 +87,8 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		}
 		isNotFound := errors.IsNotFound(err)
 		if isNotFound {
-			mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignv2_2types.Config{})
+			ignConfig := ctrlcommon.NewIgnConfig()
+			mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignConfig)
 		}
 		// Generate the original KubeletConfig
 		originalKubeletIgn, err := ctrl.generateOriginalKubeletConfig(role)


### PR DESCRIPTION
**- What I did**
FeatureGates creates a brand new ignition object, and the ignition
subsystem validates the Version field is a valid Semver. This fix uses
the common constructor to create a valid ignition object.

Note: This patch also changes the kubelet_config_controller to make it consistent
with how the featuregates controller constructs the ignition object.

**- How to verify it**

**- Description for the changelog**
None