### PR TITLE
Bug 1677198: pkg/daemon: allow empty new links section

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -330,7 +330,12 @@ func (dn *Daemon) reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) error
 		return errors.New("ignition directories section contains changes")
 	}
 	if !reflect.DeepEqual(oldIgn.Storage.Links, newIgn.Storage.Links) {
-		return errors.New("ignition links section contains changes")
+		// This means links have been added, as opposed as being removed as it happened with
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1677198. This doesn't really change behavior
+		// since we still don't support links but we allow old MC to remove links when upgrading.
+		if len(newIgn.Storage.Links) != 0 {
+			return errors.New("ignition links section contains changes")
+		}
 	}
 
 	// Special case files append: if the new config wants us to append, then we


### PR DESCRIPTION
This PR is further fixing https://bugzilla.redhat.com/show_bug.cgi?id=1677198 by
allowing an old cluster to contain links (coming from #535) which are
then removed when upgrading to post #540.

What's happening to QE is that:

1) they're starting a cluster with an MCO version which contains #535
2) they're upgrading to a payload which doesn't have #535 cause it has #540 which reverts #535

The above means that point 1) generates MachineConfigs with an unsupported symlink and when
upgrading to 2), the symlink is removed causing drift and an unreconcilable error.

QE can start testing with a newer MCO version to avoid this, but for
ease of testing, let's add this snippet to make sure getting rid of
links, which we don't support anyway, just works.

Signed-off-by: Antonio Murdaca <runcom@linux.com>