### PR TITLE
systemd: install systemd.conf to enable CPU Accounting

### DIFF
--- a/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/vpshere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/vpshere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/vpshere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/vpshere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-systemd-system.conf.d-kubelet-cgroups.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23%20Turning%20on%20Accounting%20helps%20track%20down%20performance%20issues.%0A%5BManager%5D%0ADefaultCPUAccounting%3Dyes%0ADefaultMemoryAccounting%3Dyes%0ADefaultBlockIOAccounting%3Dyes%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/systemd/system.conf.d/kubelet-cgroups.conf

--- a/templates/master/00-master/_base/files/kubelet-cgroups.yaml
+++ b/templates/master/00-master/_base/files/kubelet-cgroups.yaml
@@ -1,0 +1,10 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/system.conf.d/kubelet-cgroups.conf"
+contents:
+ inline: |
+    # Turning on Accounting helps track down performance issues.
+    [Manager]
+    DefaultCPUAccounting=yes
+    DefaultMemoryAccounting=yes
+    DefaultBlockIOAccounting=yes

--- a/templates/worker/00-worker/_base/files/kubelet-cgroups.yaml
+++ b/templates/worker/00-worker/_base/files/kubelet-cgroups.yaml
@@ -1,0 +1,10 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/system.conf.d/kubelet-cgroups.conf"
+contents:
+  inline: |
+    # Turning on Accounting helps track down performance issues.
+    [Manager]
+    DefaultCPUAccounting=yes
+    DefaultMemoryAccounting=yes
+    DefaultBlockIOAccounting=yes


### PR DESCRIPTION
Install system.conf to enable CPU Accounting.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1692131

**- What I did**
Install a custom system.conf file enabling CPU, BlockIO, and Memory accounting.

ref: https://github.com/openshift/origin/blob/master/contrib/systemd/origin-accounting.conf

**- Description for the changelog**
Enable CPU Accounting within systemd

/cc @sjenning @derekwaynecarr 