### PR TITLE
WIP: templates: Add node.openshift.io/rhelmajor label, drop os_version one

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -20,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -20,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -20,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vpshere/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vpshere/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -20,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=vsphere \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vpshere/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vpshere/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet-rhelmajor.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet-rhelmajor.service
@@ -1,0 +1,16 @@
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+name: kubelet-rhelmajor.service

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
@@ -8,6 +8,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/templates/master/01-master-kubelet/_base/units/kubelet-rhelmajor.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet-rhelmajor.yaml
@@ -1,0 +1,16 @@
+name: "kubelet-rhelmajor.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -10,6 +10,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -22,7 +23,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet-rhelmajor.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet-rhelmajor.yaml
@@ -1,0 +1,16 @@
+name: "kubelet-rhelmajor.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Generate rhelmajor version for kubelet
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/os-release
+  # Really we should fix VERSION_ID in rhcos but that requires rpm-ostree changes
+  ExecStart=/bin/sh -c '(echo -n RHELMAJOR= && if [ "${ID}" = rhcos ]; then echo ${VERSION} | cut -d . -f 2; else echo ${VERSION_ID} | cut -d . -f 1; fi) > /run/kubelet-rhelmajor'
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -10,6 +10,7 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   EnvironmentFile=/etc/os-release
+  EnvironmentFile=/run/kubelet-rhelmajor
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -21,7 +22,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/rhelmajor=${RHELMAJOR},node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \


### PR DESCRIPTION

This removes the functionality added in
#514
which I don't think really worked for what people needed; a node
selector can't parse the value.

All we care about is currently 7 or 8; this signals things like
`iptables` vs `nftables`.

And the presence of this label also signals "RHEL" too;
though we keep the `os_id` label in case e.g. a daemonset should only
run on RHCOS (or traditional RHEL).

Closes: #582