### PR TITLE
Remove amd64 from dockerfile copy path to support Mulit-Arch Builds.

### DIFF
--- a/Dockerfile.machine-config-controller.rhel7
+++ b/Dockerfile.machine-config-controller.rhel7
@@ -1,9 +1,11 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN WHAT=machine-config-controller ./hack/build-go.sh
+RUN WHAT=machine-config-controller ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-controller /tmp/build/machine-config-controller
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-controller /usr/bin/
+COPY --from=builder /tmp/build/machine-config-controller /usr/bin/
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-controller"]

--- a/Dockerfile.machine-config-daemon.rhel7
+++ b/Dockerfile.machine-config-daemon.rhel7
@@ -1,9 +1,11 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN WHAT=machine-config-daemon ./hack/build-go.sh
+RUN WHAT=machine-config-daemon ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-daemon /tmp/build/machine-config-daemon
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
+COPY --from=builder /tmp/build/machine-config-daemon /usr/bin/
 RUN yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*
 ENTRYPOINT ["/usr/bin/machine-config-daemon"]

--- a/Dockerfile.machine-config-operator.rhel7
+++ b/Dockerfile.machine-config-operator.rhel7
@@ -1,10 +1,12 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN WHAT=machine-config-operator ./hack/build-go.sh
+RUN WHAT=machine-config-operator ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-operator /tmp/build/machine-config-operator
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /usr/bin/
+COPY --from=builder /tmp/build/machine-config-operator /usr/bin/
 COPY install /manifests
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.machine-config-server.rhel7
+++ b/Dockerfile.machine-config-server.rhel7
@@ -1,8 +1,10 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN WHAT=machine-config-server ./hack/build-go.sh
+RUN WHAT=machine-config-server ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-server /tmp/build/machine-config-server
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /usr/bin/
+COPY --from=builder /tmp/build/machine-config-server /usr/bin/
 ENTRYPOINT ["/usr/bin/machine-config-server"]

--- a/Dockerfile.setup-etcd-environment.rhel7
+++ b/Dockerfile.setup-etcd-environment.rhel7
@@ -1,8 +1,10 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN WHAT=setup-etcd-environment ./hack/build-go.sh
+RUN WHAT=setup-etcd-environment ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/setup-etcd-environment /tmp/build/setup-etcd-environment
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/setup-etcd-environment /usr/bin/
+COPY --from=builder /tmp/build/setup-etcd-environment /usr/bin/
 ENTRYPOINT ["/usr/bin/setup-etcd-environment"]


### PR DESCRIPTION
**- What I did**
Removed hardcoded 'amd64' in build path from the .rhel7 Dockerfiles so we can start building these containers on other architectures.

**- How to verify it**
 Build the containers locally (with doozer or some other method).

**- Description for the changelog**
Remove amd64 from dockerfile copy path to support Mulit-Arch Builds.
