### PR TITLE
BUG 1670700: *: add etcd-metric-ca flag

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -25,6 +25,7 @@ var (
 
 	bootstrapOpts struct {
 		etcdCAFile           string
+		etcdMetricCAFile     string
 		rootCAFile           string
 		kubeCAFile           string
 		pullSecretFile       string
@@ -47,6 +48,7 @@ var (
 func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdCAFile, "etcd-ca", "/etc/ssl/etcd/ca.crt", "path to etcd CA certificate")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdMetricCAFile, "etcd-metric-ca", "/assets/tls/etcd-metric-ca-bundle.crt", "path to etcd metric CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.rootCAFile, "root-ca", "/etc/ssl/kubernetes/ca.crt", "path to root CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeCAFile, "kube-ca", "", "path to kube CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "/assets/manifests/pull.json", "path to secret manifest that contains pull secret.")
@@ -95,7 +97,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	if err := operator.RenderBootstrap(
 		bootstrapOpts.configFile,
 		bootstrapOpts.infraConfigFile, bootstrapOpts.networkConfigFile,
-		bootstrapOpts.etcdCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
+		bootstrapOpts.etcdCAFile, bootstrapOpts.etcdMetricCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
 		imgs,
 		bootstrapOpts.destinationDir,
 	); err != nil {

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -60,6 +60,7 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
 
 	setBytesIfSet(modified, &existing.EtcdCAData, required.EtcdCAData)
+	setBytesIfSet(modified, &existing.EtcdMetricCAData, required.EtcdMetricCAData)
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)
 
 	if required.PullSecret != nil && !equality.Semantic.DeepEqual(existing.PullSecret, required.PullSecret) {

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -118,8 +118,9 @@ type ControllerConfigSpec struct {
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
 
 	// CAs
-	EtcdCAData []byte `json:"etcdCAData"`
-	RootCAData []byte `json:"rootCAData"`
+	EtcdCAData       []byte `json:"etcdCAData"`
+	EtcdMetricCAData []byte `json:"etcdMetricCAData"`
+	RootCAData       []byte `json:"rootCAData"`
 
 	// PullSecret is the default pull secret that needs to be installed
 	// on all machines.

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -23,7 +23,7 @@ import (
 func RenderBootstrap(
 	clusterConfigConfigMapFile string,
 	infraFile, networkFile string,
-	etcdCAFile, rootCAFile string, kubeCAFile string, pullSecretFile string,
+	etcdCAFile, etcdMetricCAFile string, rootCAFile string, kubeCAFile string, pullSecretFile string,
 	imgs Images,
 	destinationDir string,
 ) error {
@@ -79,6 +79,7 @@ func RenderBootstrap(
 	}
 
 	spec.EtcdCAData = filesData[etcdCAFile]
+	spec.EtcdMetricCAData = filesData[etcdMetricCAFile]
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.SSHKey = ic.SSHKey

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -283,6 +283,10 @@ func (optr *Operator) sync(key string) error {
 	if err != nil {
 		return err
 	}
+	etcdMetricCA, err := optr.getCAsFromConfigMap("openshift-config", "etcd-metric-serving-ca", "ca-bundle.crt")
+	if err != nil {
+		return err
+	}
 	rootCA, err := optr.getCAsFromConfigMap("kube-system", "root-ca", "ca.crt")
 	if err != nil {
 		return err
@@ -318,6 +322,7 @@ func (optr *Operator) sync(key string) error {
 	}
 
 	spec.EtcdCAData = etcdCA
+	spec.EtcdMetricCAData = etcdMetricCA
 	spec.RootCAData = bundle
 	spec.PullSecret = &v1.ObjectReference{Namespace: "kube-system", Name: "coreos-pull-secret"}
 	spec.SSHKey = ic.SSHKey


### PR DESCRIPTION
This PR is the first of 2 the default is set for chicken and egg with the installer. Adding the metric ca is part of a series of PRs to add etcd metric support.

Depends on https://github.com/openshift/installer/pull/1477

/hold