### PR TITLE
ContainerRuntimeConfig: Enable "info" debug level

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -289,10 +289,11 @@ func validateUserContainerRuntimeConfig(cfg *mcfgv1.ContainerRuntimeConfig) erro
 			"fatal": true,
 			"panic": true,
 			"warn":  true,
+			"info":  true,
 			"debug": true,
 		}
 		if !validLogLevels[ctrcfg.LogLevel] {
-			return fmt.Errorf("invalid LogLevel %q, must be one of error, fatal, panic, warn, or debug", ctrcfg.LogLevel)
+			return fmt.Errorf("invalid LogLevel %q, must be one of error, fatal, panic, warn, info, or debug", ctrcfg.LogLevel)
 		}
 	}
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added support for the "info" log level for ContainerRunetimeConfig.

**- Description for the changelog**
The "info" log level for ContainerRunetimeConfig is now supported
