### PR TITLE
setup-etcd-environment: wait for all etcd members to be resolvable

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -128,20 +128,25 @@ func reverseLookupSelf(service, proto, name, self string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	selfTarget := ""
 	for _, srv := range srvs {
 		glog.V(4).Infof("checking against %s", srv.Target)
 		addrs, err := net.LookupHost(srv.Target)
 		if err != nil {
-			continue // don't care
+			return "", fmt.Errorf("could not resolve member %q", srv.Target)
 		}
 
 		for _, addr := range addrs {
 			if addr == self {
-				return strings.Trim(srv.Target, "."), nil
+				selfTarget = strings.Trim(srv.Target, ".")
+				break
 			}
 		}
 	}
-	return "", fmt.Errorf("could not find self")
+	if selfTarget == "" {
+		return "", fmt.Errorf("could not find self")
+	}
+	return selfTarget, nil
 }
 
 func writeEnvironmentFile(m map[string]string, w io.Writer) error {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Modified the `setup-etcd-environment` component so that it continues to wait if any of the targets in the discovery SRV cannot be resolved.

**- How to verify it**
1) Run the setup-etcd-environment component.
2) Create an SRV record with two targets, A and B.
3) Create an A record to point target A to the IP address of the local host.
4) Verify that the setup-etcd-environment compoent logs errors about not being able to resolve target B.
5) Create an A record to point target B to some other IP address.
6) Verify that the setup-etcd-environment component exits successfully.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Wait for the names of all of the etcd members in the SRV to be resolvable before exiting discovery