### PR TITLE
pkg/apis: update generated deepcopy

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -226,6 +226,11 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.EtcdMetricCAData != nil {
+		in, out := &in.EtcdMetricCAData, &out.EtcdMetricCAData
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RootCAData != nil {
 		in, out := &in.RootCAData, &out.RootCAData
 		*out = make([]byte, len(*in))


### PR DESCRIPTION
This PR https://github.com/openshift/machine-config-operator/pull/590
didn't run `make update` and generated deepcopy hasn't been updated.
This PR just does that.

@hexfusion ptal

Signed-off-by: Antonio Murdaca <runcom@linux.com>