### PR TITLE
Bug 1699134: pkg/daemon: add reason annotation key for degraded/unreconcilable and bubble up errors from render controller

### DIFF
--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -16,6 +16,10 @@ spec:
     description: When at least one of machine is not either not updated or is in the process of updating to the desired machine config.
     name: Updating
     type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: When progress is blocked on updating one or more nodes, or the pool configuration is failing.
+    name: Degraded
+    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -322,6 +322,10 @@ type MachineConfigPoolStatus struct {
 	// A node is marked unavailable if it is in updating state or NodeReady condition is false.
 	UnavailableMachineCount int32 `json:"unavailableMachineCount"`
 
+	// Total number of machines marked degraded (or unreconcilable).
+	// A node is marked degraded if applying a configuration failed..
+	DegradedMachineCount int32 `json:"degradedMachineCount"`
+
 	// Represents the latest available observations of current state.
 	Conditions []MachineConfigPoolCondition `json:"conditions"`
 }
@@ -368,6 +372,10 @@ const (
 	// When at least one of machine is not either not updated or is in the process of updating
 	// to the desired machine config.
 	MachineConfigPoolUpdating MachineConfigPoolConditionType = "Updating"
+	// MachineConfigPoolDegraded means the update for one of the machine is not progressing
+	// the pool can't be configured due to an error
+	// Degraded == !render_went_well || Degraded == Updating_and_something_is_wrong_in_MCDs
+	MachineConfigPoolDegraded MachineConfigPoolConditionType = "Degraded"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -372,9 +372,11 @@ const (
 	// When at least one of machine is not either not updated or is in the process of updating
 	// to the desired machine config.
 	MachineConfigPoolUpdating MachineConfigPoolConditionType = "Updating"
-	// MachineConfigPoolDegraded means the update for one of the machine is not progressing
-	// the pool can't be configured due to an error
-	// Degraded == !render_went_well || Degraded == Updating_and_something_is_wrong_in_MCDs
+	// MachineConfigPoolNodeDegraded means the update for one of the machine is not progressing
+	MachineConfigPoolNodeDegraded MachineConfigPoolConditionType = "NodeDegraded"
+	// MachineConfigPoolRenderDegraded means the rendered configuration for the pool cannot be generated because of an error
+	MachineConfigPoolRenderDegraded MachineConfigPoolConditionType = "RenderDegraded"
+	// MachineConfigPoolDegraded is the overall status of the pool based, today, on whether we fail with NodeDegraded or RenderDegraded
 	MachineConfigPoolDegraded MachineConfigPoolConditionType = "Degraded"
 )
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -49,6 +49,11 @@ const (
 	maxRetries = 15
 )
 
+var (
+	// controllerKind contains the schema.GroupVersionKind for this controller type.
+	controllerKind = mcfgv1.SchemeGroupVersion.WithKind("ContainerRuntimeConfig")
+)
+
 var updateBackoff = wait.Backoff{
 	Steps:    5,
 	Duration: 100 * time.Millisecond,
@@ -468,17 +473,12 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 			mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignConfig)
 		}
 		mc.Spec.Config = createNewKubeletIgnition(cfgYAML)
-		mc.ObjectMeta.Annotations = map[string]string{
+		mc.SetAnnotations(map[string]string{
 			ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Version.String(),
-		}
-		mc.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			metav1.OwnerReference{
-				APIVersion: mcfgv1.SchemeGroupVersion.String(),
-				Kind:       "KubeletConfig",
-				Name:       cfg.Name,
-				UID:        cfg.UID,
-			},
-		}
+		})
+		oref := metav1.NewControllerRef(cfg, controllerKind)
+		mc.SetOwnerReferences([]metav1.OwnerReference{*oref})
+
 		// Create or Update, on conflict retry
 		if err := retry.RetryOnConflict(updateBackoff, func() error {
 			var err error

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -44,12 +45,23 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 	unavailableMachines := getUnavailableMachines(pool.Status.Configuration.Name, nodes)
 	unavailableMachineCount := int32(len(unavailableMachines))
 
+	degradedMachines := getDegradedMachines(pool.Status.Configuration.Name, nodes)
+	degradedReasons := make([]string, len(nodes))
+	for _, n := range degradedMachines {
+		reason, ok := n.Annotations[daemonconsts.MachineConfigDaemonReasonAnnotationKey]
+		if ok && reason != "" {
+			degradedReasons = append(degradedReasons, fmt.Sprintf("Node %s is reporting: %q", n.Name, reason))
+		}
+	}
+	degradedMachineCount := int32(len(degradedMachines))
+
 	status := mcfgv1.MachineConfigPoolStatus{
 		ObservedGeneration:      pool.Generation,
 		MachineCount:            machineCount,
 		UpdatedMachineCount:     updatedMachineCount,
 		ReadyMachineCount:       readyMachineCount,
 		UnavailableMachineCount: unavailableMachineCount,
+		DegradedMachineCount:    degradedMachineCount,
 	}
 
 	status.Configuration = pool.Status.Configuration
@@ -73,6 +85,20 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, fmt.Sprintf("All nodes are updating to %s", pool.Status.Configuration.Name), "")
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
 	}
+
+	if len(degradedMachines) > 0 {
+		sdegraded := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolDegraded, corev1.ConditionTrue, fmt.Sprintf("%d nodes are reporting degraded status on sync", len(degradedMachines)), strings.Join(degradedReasons, ","))
+		mcfgv1.SetMachineConfigPoolCondition(&status, *sdegraded)
+	} else {
+		// Do not clear out a possible degradation if everything is ok here but render_controller reported
+		// a failure in rendering
+		poolAlreadyDegraded := mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolDegraded)
+		if !poolAlreadyDegraded {
+			sdegraded := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolDegraded, corev1.ConditionFalse, "", "")
+			mcfgv1.SetMachineConfigPoolCondition(&status, *sdegraded)
+		}
+	}
+
 	return status
 }
 
@@ -160,4 +186,27 @@ func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev
 		}
 	}
 	return unavail
+}
+
+func getDegradedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
+	var degraded []*corev1.Node
+	for _, node := range nodes {
+		if node.Annotations == nil {
+			continue
+		}
+		dconfig, ok := node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]
+		if !ok || dconfig == "" {
+			continue
+		}
+		dstate, ok := node.Annotations[daemonconsts.MachineConfigDaemonStateAnnotationKey]
+		if !ok || dstate == "" {
+			continue
+		}
+
+		if dconfig == currentConfig &&
+			(dstate == daemonconsts.MachineConfigDaemonStateDegraded || dstate == daemonconsts.MachineConfigDaemonStateUnreconcilable) {
+			degraded = append(degraded, node)
+		}
+	}
+	return degraded
 }

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -54,7 +54,7 @@ func newFixture(t *testing.T) *fixture {
 }
 
 func newMachineConfigPool(name string, selector *metav1.LabelSelector, currentMachineConfig string) *mcfgv1.MachineConfigPool {
-	return &mcfgv1.MachineConfigPool{
+	mcp := &mcfgv1.MachineConfigPool{
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigPoolSpec{
@@ -64,6 +64,9 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, currentMa
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 	}
+	sdegraded := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolRenderDegraded, corev1.ConditionFalse, "", "")
+	mcfgv1.SetMachineConfigPoolCondition(&mcp.Status, *sdegraded)
+	return mcp
 }
 
 func newMachineConfig(name string, labels map[string]string, osurl string, files []ignv2_2types.File) *mcfgv1.MachineConfig {

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -23,6 +23,8 @@ const (
 	MachineConfigDaemonStateDegraded = "Degraded"
 	// MachineConfigDaemonStateUnreconcilable is set by the daemon when a MachineConfig cannot be applied.
 	MachineConfigDaemonStateUnreconcilable = "Unreconcilable"
+	// MachineConfigDaemonReasonAnnotationKey is set by the daemon when it needs to report a human readable reason for its state. E.g. when state flips to degraded/unreconcilable.
+	MachineConfigDaemonReasonAnnotationKey = "machineconfiguration.openshift.io/reason"
 	// InitialNodeAnnotationsFilePath defines the path at which it will find the node annotations it needs to set on the node once it comes up for the first time.
 	// The Machine Config Server writes the node annotations to this path.
 	InitialNodeAnnotationsFilePath = "/etc/machine-config-daemon/node-annotations.json"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -340,13 +340,13 @@ func (dn *Daemon) handleErr(err error, key interface{}) {
 		return
 	}
 
+	dn.updateErrorState(err)
+
 	if dn.queue.NumRequeues(key) < maxRetries {
 		glog.V(2).Infof("Error syncing node %v: %v", key, err)
 		dn.queue.AddRateLimited(key)
 		return
 	}
-
-	dn.updateErrorState(err)
 
 	utilruntime.HandleError(err)
 	glog.V(2).Infof("Dropping node %q out of the queue: %v", key, err)

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -64,6 +64,8 @@ func (nw *NodeWriter) SetDone(client corev1.NodeInterface, lister corelisterv1.N
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateDone,
 		constants.CurrentMachineConfigAnnotationKey:     dcAnnotation,
+		// clear out any Degraded/Unreconcilable reason
+		constants.MachineConfigDaemonReasonAnnotationKey: "",
 	}
 	respChan := make(chan error, 1)
 	nw.writer <- message{

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -97,6 +97,7 @@ func (nw *NodeWriter) SetUnreconcilable(err error, client corev1.NodeInterface, 
 	glog.Errorf("Marking Unreconcilable due to: %v", err)
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateUnreconcilable,
+		constants.MachineConfigDaemonReasonAnnotationKey: err.Error(),
 	}
 	respChan := make(chan error, 1)
 	nw.writer <- message{
@@ -119,6 +120,7 @@ func (nw *NodeWriter) SetDegraded(err error, client corev1.NodeInterface, lister
 	glog.Errorf("Marking Degraded due to: %v", err)
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateDegraded,
+		constants.MachineConfigDaemonReasonAnnotationKey: err.Error(),
 	}
 	respChan := make(chan error, 1)
 	nw.writer <- message{

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -763,6 +763,10 @@ spec:
     description: When at least one of machine is not either not updated or is in the process of updating to the desired machine config.
     name: Updating
     type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: When progress is blocked on updating one or more nodes, or the pool configuration is failing.
+    name: Degraded
+    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -155,6 +155,7 @@ func New(
 		mcoCmInformer.Informer(),
 		infraInformer.Informer(),
 		networkInformer.Informer(),
+		mcpInformer.Informer(),
 	} {
 		i.AddEventHandler(optr.eventHandler())
 	}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -262,9 +262,12 @@ func isMachineConfigPoolConfigurationValid(pool *mcfgv1.MachineConfigPool, versi
 
 func machineConfigPoolStatus(pool *mcfgv1.MachineConfigPool) string {
 	switch {
-	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolDegraded):
-		cond := mcfgv1.GetMachineConfigPoolCondition(pool.Status, mcfgv1.MachineConfigPoolDegraded)
-		return fmt.Sprintf("pool is degraded because of %q: %q", cond.Reason, cond.Message)
+	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolRenderDegraded):
+		cond := mcfgv1.GetMachineConfigPoolCondition(pool.Status, mcfgv1.MachineConfigPoolRenderDegraded)
+		return fmt.Sprintf("pool is degraded because rendering fails with %q", cond.Reason)
+	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolNodeDegraded):
+		cond := mcfgv1.GetMachineConfigPoolCondition(pool.Status, mcfgv1.MachineConfigPoolNodeDegraded)
+		return fmt.Sprintf("pool is degraded because rendering fails with %q: %q", cond.Reason, cond.Message)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdated):
 		return fmt.Sprintf("all %d nodes are at latest configuration %s", pool.Status.MachineCount, pool.Status.Configuration.Name)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating):

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -262,6 +262,9 @@ func isMachineConfigPoolConfigurationValid(pool *mcfgv1.MachineConfigPool, versi
 
 func machineConfigPoolStatus(pool *mcfgv1.MachineConfigPool) string {
 	switch {
+	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolDegraded):
+		cond := mcfgv1.GetMachineConfigPoolCondition(pool.Status, mcfgv1.MachineConfigPoolDegraded)
+		return fmt.Sprintf("pool is degraded because of %q: %q", cond.Reason, cond.Message)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdated):
 		return fmt.Sprintf("all %d nodes are at latest configuration %s", pool.Status.MachineCount, pool.Status.Configuration.Name)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating):

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -340,7 +340,7 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 			!degraded {
 			continue
 		}
-		return fmt.Errorf("error pool %s is not ready, retrying. Status: (total: %d, updated: %d, ready: %d, unavailable: %d, pool degraded: %v)", pool.Name, pool.Status.MachineCount, pool.Status.UpdatedMachineCount, pool.Status.ReadyMachineCount, pool.Status.UnavailableMachineCount, degraded)
+		return fmt.Errorf("error pool %s is not ready, retrying. Status: (pool degraded: %v total: %d, ready %d, updated: %d, unavailable: %d)", pool.Name, degraded, pool.Status.MachineCount, pool.Status.ReadyMachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount)
 	}
 	return nil
 }

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -309,12 +309,15 @@ func TestReconcileAfterBadMC(t *testing.T) {
 		}
 		for _, node := range nodes {
 			if node.Annotations[constants.DesiredMachineConfigAnnotationKey] == newMCName && node.Annotations[constants.MachineConfigDaemonStateAnnotationKey] != constants.MachineConfigDaemonStateDone {
-				return true, nil
+				// just check that we have the annotation here, w/o strings checking anything that can flip fast causing flakes
+				if node.Annotations[constants.MachineConfigDaemonReasonAnnotationKey] != "" {
+					return true, nil
+				}
 			}
 		}
 		return false, nil
 	}); err != nil {
-		t.Errorf("machine config didn't result in file being on any worker: %v", err)
+		t.Errorf("machine config hasn't been picked by any MCD: %v", err)
 	}
 
 	// verify that we got indeed an unavailable machine in the pool


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Close https://github.com/openshift/machine-config-operator/issues/234
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1699134

Added a new Reason annotation key set to the specific error we get when failing to reconcile + reintroduced degraded from https://github.com/runcom/machine-config-operator/commit/e753f108d3e0027500fb2c473ceb162c0fed74ae#diff-3bd49282ca65e5525da44a27caaa55c7L80 + bubbling up errors from pool

**- How to verify it**

added a check in one of the e2e

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
