### PR TITLE
pkg/operator: update LastTransitionTime when flipping conditions

### DIFF
--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -501,6 +501,9 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 	optr.vStore.Set("operator", "test-version")
 	optr.mcpLister = &mockMCPLister{}
 	co := &configv1.ClusterOperator{}
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse})
 	optr.configClient = fakeconfigclientset.NewSimpleClientset(co)
 	optr.inClusterBringup = true
 


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Update `LastTransitionTime` when flipping progressing
xref: https://github.com/openshift/cluster-version-operator/pull/154

as done in https://github.com/openshift/cluster-version-operator/pull/153

**- How to verify it**

There's gonna be a test in origin covering this

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
