### PR TITLE
pkg/controller: resync on unavailable 

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -784,7 +784,7 @@ func TestShouldMakeProgress(t *testing.T) {
 	expMcp.Status = expStatus
 	f.expectUpdateMachineConfigPoolStatus(expMcp)
 
-	f.run(getKey(mcp, t))
+	f.runExpectError(getKey(mcp, t))
 }
 
 func TestEmptyCurrentMachineConfig(t *testing.T) {
@@ -816,7 +816,7 @@ func TestPaused(t *testing.T) {
 	expMcp.Status = expStatus
 	f.expectUpdateMachineConfigPoolStatus(expMcp)
 
-	f.run(getKey(mcp, t))
+	f.runExpectError(getKey(mcp, t))
 }
 
 func TestShouldUpdateStatusOnlyUpdated(t *testing.T) {
@@ -858,11 +858,12 @@ func TestShouldUpdateStatusOnlyNoProgress(t *testing.T) {
 	}
 
 	expStatus := calculateStatus(mcp, nodes)
+	t.Logf("expStatus: %v", expStatus)
 	expMcp := mcp.DeepCopy()
 	expMcp.Status = expStatus
 	f.expectUpdateMachineConfigPoolStatus(expMcp)
 
-	f.run(getKey(mcp, t))
+	f.runExpectError(getKey(mcp, t))
 }
 
 func TestShouldDoNothing(t *testing.T) {

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -29,7 +29,15 @@ func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
 	newPool := pool
 	newPool.Status = newStatus
 	_, err = ctrl.client.MachineconfigurationV1().MachineConfigPools().UpdateStatus(newPool)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if newPool.Status.UnavailableMachineCount != 0 ||
+		newPool.Status.UpdatedMachineCount != newPool.Status.MachineCount {
+		return fmt.Errorf("resync needed: unavailable machines or un-updated machine present")
+	}
+	return nil
 }
 
 func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv1.MachineConfigPoolStatus {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- add check to syncStatusOnly to allow for resync of status when
an unavailable machine or unupdated machines are found.
- update unit tests to account for new error generated in syncStatusOnly 

Closes BZ 1695721

**- How to verify it**
CI runs should now pass without the error.