### PR TITLE
templates: Add a tmpfiles.d entry to delete CNI files at boot

### DIFF
--- a/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/tmpfiles.d/cleanup-cni.conf

--- a/templates/master/00-master/_base/files/cleanup-cni-conf.yaml
+++ b/templates/master/00-master/_base/files/cleanup-cni-conf.yaml
@@ -1,0 +1,8 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/tmpfiles.d/cleanup-cni.conf"
+contents:
+  inline: |
+    r /etc/origin/openvswitch/conf.db
+    r /etc/cni/net.d/80-openshift-network.conf
+    r /etc/cni/net.d/10-ovn-kubernetes.conf

--- a/templates/worker/00-worker/_base/files/cleanup-cni-conf.yaml
+++ b/templates/worker/00-worker/_base/files/cleanup-cni-conf.yaml
@@ -1,0 +1,8 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/tmpfiles.d/cleanup-cni.conf"
+contents:
+  inline: |
+    r /etc/origin/openvswitch/conf.db
+    r /etc/cni/net.d/80-openshift-network.conf
+    r /etc/cni/net.d/10-ovn-kubernetes.conf


### PR DESCRIPTION
The cluster considers a node "Ready" when the cni config file
is written. When the cni plugin fails the file was not deleted
so the node continued to be "Ready".

Further when the node is rebooted, the config file remained present
and the cluster set the node "Ready". The startup order of the pods in
the cluster is not sequenced and results are presented in bug 1654044

In addition when the node is rebooted the ovs database is completely
invalid and must be deleted.

This is part of the solution to
bug 1654044
https://bugzilla.redhat.com/show_bug.cgi?id=1654044
for 4.x. Part of the fix is in cluster-network-operator PR 137
https://github.com/openshift/cluster-network-operator/pull/137
And part is in ovn-kubernetes upstream pr 644
https://github.com/openvswitch/ovn-kubernetes/pull/664

The corresponding changes in 3.11 are in openshift-ansible PR 11409
https://github.com/openshift/openshift-ansible/pull/11409

Signed-off-by: Phil Cameron <pcameron@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
