### PR TITLE
pkg/operator: wait for cache on mcp/cc/mcp

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -67,6 +67,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.KubeNamespacedInformerFactory.Rbac().V1().ClusterRoles(),
 			ctrlctx.KubeNamespacedInformerFactory.Rbac().V1().ClusterRoleBindings(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
+			ctrlctx.KubeInformerFactory.Core().V1().ConfigMaps(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Networks(),
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie(componentName),

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -55,7 +55,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		controller := operator.New(
 			componentNamespace, componentName,
 			startOpts.imagesFile,
-			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().MCOConfigs(),
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().MachineConfigs(),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -145,17 +145,21 @@ func New(
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
 	}
 
-	mcoconfigInformer.Informer().AddEventHandler(optr.eventHandler())
-	controllerConfigInformer.Informer().AddEventHandler(optr.eventHandler())
-	serviceAccountInfomer.Informer().AddEventHandler(optr.eventHandler())
-	crdInformer.Informer().AddEventHandler(optr.eventHandler())
-	deployInformer.Informer().AddEventHandler(optr.eventHandler())
-	daemonsetInformer.Informer().AddEventHandler(optr.eventHandler())
-	clusterRoleInformer.Informer().AddEventHandler(optr.eventHandler())
-	clusterRoleBindingInformer.Informer().AddEventHandler(optr.eventHandler())
-	mcoCmInformer.Informer().AddEventHandler(optr.eventHandler())
-	infraInformer.Informer().AddEventHandler(optr.eventHandler())
-	networkInformer.Informer().AddEventHandler(optr.eventHandler())
+	for _, i := range []cache.SharedIndexInformer{
+		mcoconfigInformer.Informer(),
+		controllerConfigInformer.Informer(),
+		serviceAccountInfomer.Informer(),
+		crdInformer.Informer(),
+		deployInformer.Informer(),
+		daemonsetInformer.Informer(),
+		clusterRoleInformer.Informer(),
+		clusterRoleBindingInformer.Informer(),
+		mcoCmInformer.Informer(),
+		infraInformer.Informer(),
+		networkInformer.Informer(),
+	} {
+		i.AddEventHandler(optr.eventHandler())
+	}
 
 	optr.syncHandler = optr.sync
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -75,7 +75,6 @@ type Operator struct {
 	syncHandler func(ic string) error
 
 	crdLister       apiextlistersv1beta1.CustomResourceDefinitionLister
-	mcoconfigLister mcfglistersv1.MCOConfigLister
 	mcpLister       mcfglistersv1.MachineConfigPoolLister
 	ccLister        mcfglistersv1.ControllerConfigLister
 	mcLister        mcfglistersv1.MachineConfigLister
@@ -87,7 +86,6 @@ type Operator struct {
 	clusterCmLister corelisterv1.ConfigMapLister
 
 	crdListerSynced       cache.InformerSynced
-	mcoconfigListerSynced cache.InformerSynced
 	deployListerSynced    cache.InformerSynced
 	daemonsetListerSynced cache.InformerSynced
 	infraListerSynced     cache.InformerSynced
@@ -108,7 +106,6 @@ type Operator struct {
 func New(
 	namespace, name string,
 	imagesFile string,
-	mcoconfigInformer mcfginformersv1.MCOConfigInformer,
 	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	ccInformer mcfginformersv1.ControllerConfigInformer,
 	mcInformer mcfginformersv1.MachineConfigInformer,
@@ -146,7 +143,6 @@ func New(
 	}
 
 	for _, i := range []cache.SharedIndexInformer{
-		mcoconfigInformer.Informer(),
 		controllerConfigInformer.Informer(),
 		serviceAccountInfomer.Informer(),
 		crdInformer.Informer(),
@@ -169,8 +165,6 @@ func New(
 	optr.mcoCmListerSynced = mcoCmInformer.Informer().HasSynced
 	optr.crdLister = crdInformer.Lister()
 	optr.crdListerSynced = crdInformer.Informer().HasSynced
-	optr.mcoconfigLister = mcoconfigInformer.Lister()
-	optr.mcoconfigListerSynced = mcoconfigInformer.Informer().HasSynced
 	optr.mcpLister = mcpInformer.Lister()
 	optr.mcpListerSynced = mcpInformer.Informer().HasSynced
 	optr.ccLister = ccInformer.Lister()


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

added cache sync for the other listers we are using in the operator

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
