### PR TITLE
Bug 1697644: operator: use openshift-config/pull-secret to fetch the pull secret for images.

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -318,7 +318,7 @@ func (optr *Operator) sync(key string) error {
 	spec.EtcdCAData = etcdCA
 	spec.EtcdMetricCAData = etcdMetricCA
 	spec.RootCAData = bundle
-	spec.PullSecret = &v1.ObjectReference{Namespace: "kube-system", Name: "coreos-pull-secret"}
+	spec.PullSecret = &v1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
 		templatectrl.EtcdImageKey:            imgs.Etcd,


### PR DESCRIPTION
**- What I did**

The operator should be using the `openshift-config/pull-secret` as the `kube-system/coreos-pull-secret` has been marked deprecated.

**- Description for the changelog**

`Use openshift-config/pull-secret as source for pull secret for images`

requires: https://github.com/openshift/installer/pull/1554
/cc @smarterclayton 