### PR TITLE
*: pre-transition ign refactor

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -52,7 +52,7 @@ type MachineConfigSpec struct {
     // fetch the OS. This must be in the canonical $name@$digest format.
     OSImageURL string `json:"osImageURL"`
     // Config is a Ignition Config object.
-    Config ignv2_2.Config `json:"config"`
+    Config ign.Config `json:"config"`
 }
 ```
 

--- a/lib/resourceapply/machineconfig_test.go
+++ b/lib/resourceapply/machineconfig_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/davecgh/go-spew/spew"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
@@ -175,9 +175,9 @@ func TestApplyMachineConfig(t *testing.T) {
 		input: &mcfgv1.MachineConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			Spec: mcfgv1.MachineConfigSpec{
-				Config: ignv2_2types.Config{
-					Passwd: ignv2_2types.Passwd{
-						Users: []ignv2_2types.PasswdUser{{
+				Config: igntypes.Config{
+					Passwd: igntypes.Passwd{
+						Users: []igntypes.PasswdUser{{
 							HomeDir: "/home/dummy",
 						}},
 					},
@@ -199,9 +199,9 @@ func TestApplyMachineConfig(t *testing.T) {
 			expected := &mcfgv1.MachineConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Spec: mcfgv1.MachineConfigSpec{
-					Config: ignv2_2types.Config{
-						Passwd: ignv2_2types.Passwd{
-							Users: []ignv2_2types.PasswdUser{{
+					Config: igntypes.Config{
+						Passwd: igntypes.Passwd{
+							Users: []igntypes.PasswdUser{{
 								HomeDir: "/home/dummy",
 							}},
 						},
@@ -218,9 +218,9 @@ func TestApplyMachineConfig(t *testing.T) {
 			&mcfgv1.MachineConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Spec: mcfgv1.MachineConfigSpec{
-					Config: ignv2_2types.Config{
-						Passwd: ignv2_2types.Passwd{
-							Users: []ignv2_2types.PasswdUser{{
+					Config: igntypes.Config{
+						Passwd: igntypes.Passwd{
+							Users: []igntypes.PasswdUser{{
 								HomeDir: "/home/dummy-prev",
 							}},
 						},
@@ -231,9 +231,9 @@ func TestApplyMachineConfig(t *testing.T) {
 		input: &mcfgv1.MachineConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			Spec: mcfgv1.MachineConfigSpec{
-				Config: ignv2_2types.Config{
-					Passwd: ignv2_2types.Passwd{
-						Users: []ignv2_2types.PasswdUser{{
+				Config: igntypes.Config{
+					Passwd: igntypes.Passwd{
+						Users: []igntypes.PasswdUser{{
 							HomeDir: "/home/dummy",
 						}},
 					},
@@ -255,9 +255,9 @@ func TestApplyMachineConfig(t *testing.T) {
 			expected := &mcfgv1.MachineConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Spec: mcfgv1.MachineConfigSpec{
-					Config: ignv2_2types.Config{
-						Passwd: ignv2_2types.Passwd{
-							Users: []ignv2_2types.PasswdUser{{
+					Config: igntypes.Config{
+						Passwd: igntypes.Passwd{
+							Users: []igntypes.PasswdUser{{
 								HomeDir: "/home/dummy",
 							}},
 						},

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	ignv2_2 "github.com/coreos/ignition/config/v2_2"
+	ign "github.com/coreos/ignition/config/v2_2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,7 +21,7 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 
 	outIgn := configs[0].Spec.Config
 	for idx := 1; idx < len(configs); idx++ {
-		outIgn = ignv2_2.Append(outIgn, configs[idx].Spec.Config)
+		outIgn = ign.Append(outIgn, configs[idx].Spec.Config)
 	}
 
 	return &MachineConfig{

--- a/pkg/apis/machineconfiguration.openshift.io/v1/machineconfig.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/machineconfig.deepcopy.go
@@ -1,8 +1,8 @@
 package v1
 
 import (
-	ignv2_2 "github.com/coreos/ignition/config/v2_2"
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	ign "github.com/coreos/ignition/config/v2_2"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -37,13 +37,13 @@ func (in *MachineConfigSpec) DeepCopyInto(out *MachineConfigSpec) {
 	return
 }
 
-func deepCopyIgnConfig(in ignv2_2types.Config) ignv2_2types.Config {
-	var out ignv2_2types.Config
+func deepCopyIgnConfig(in igntypes.Config) igntypes.Config {
+	var out igntypes.Config
 
 	// https://github.com/coreos/ignition/blob/d19b2021cf397de7c31774c13805bbc3aa655646/config/v2_2/append.go#L41
 	out.Ignition.Version = in.Ignition.Version
 
-	return ignv2_2.Append(out, in)
+	return ign.Append(out, in)
 }
 
 // DeepCopy copying the receiver, creating a new MachineConfigSpec.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -228,7 +228,7 @@ type MachineConfigSpec struct {
 	// fetch the OS.
 	OSImageURL string `json:"osImageURL"`
 	// Config is a Ignition Config object.
-	Config ignv2_2types.Config `json:"config"`
+	Config igntypes.Config `json:"config"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -1,14 +1,14 @@
 package common
 
 import (
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 )
 
-// NewIgnConfig returns an empty ignition config with version set as 2.2.0
-func NewIgnConfig() ignv2_2types.Config {
-	return ignv2_2types.Config{
-		Ignition: ignv2_2types.Ignition{
-			Version: "2.2.0",
+// NewIgnConfig returns an empty ignition config with version set as latest version
+func NewIgnConfig() igntypes.Config {
+	return igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
 		},
 	}
 }

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	"github.com/vincent-petithory/dataurl"
 	"k8s.io/api/core/v1"
@@ -345,7 +345,7 @@ func (ctrl *Controller) handleImgErr(err error, key interface{}) {
 }
 
 // generateOriginalContainerRuntimeConfigs returns rendered default storage, and crio config files
-func (ctrl *Controller) generateOriginalContainerRuntimeConfigs(role string) (*ignv2_2types.File, *ignv2_2types.File, *ignv2_2types.File, error) {
+func (ctrl *Controller) generateOriginalContainerRuntimeConfigs(role string) (*igntypes.File, *igntypes.File, *igntypes.File, error) {
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not get ControllerConfig %v", err)
@@ -359,7 +359,7 @@ func (ctrl *Controller) generateOriginalContainerRuntimeConfigs(role string) (*i
 	}
 	// Find generated storage.config, and crio.config
 	var (
-		config, gmcStorageConfig, gmcCRIOConfig, gmcRegistriesConfig *ignv2_2types.File
+		config, gmcStorageConfig, gmcCRIOConfig, gmcRegistriesConfig *igntypes.File
 		errStorage, errCRIO, errRegistries                           error
 	)
 	// Find storage config
@@ -504,7 +504,8 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 				}
 			}
 			if isNotFound {
-				mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignv2_2types.Config{})
+				tempIgnCfg := ctrlcommon.NewIgnConfig()
+				mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &tempIgnCfg)
 			}
 			mc.Spec.Config = createNewCtrRuntimeConfigIgnition(storageTOML, crioTOML)
 			mc.SetAnnotations(map[string]string{
@@ -536,7 +537,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 
 // mergeConfigChanges retrieves the original/default config data from the templates, decodes it and merges in the changes given by the Custom Resource.
 // It then encodes the new data and returns it.
-func (ctrl *Controller) mergeConfigChanges(origFile *ignv2_2types.File, cfg *mcfgv1.ContainerRuntimeConfig, mc *mcfgv1.MachineConfig, role, managedKey string, isNotFound bool, update updateConfig) ([]byte, error) {
+func (ctrl *Controller) mergeConfigChanges(origFile *igntypes.File, cfg *mcfgv1.ContainerRuntimeConfig, mc *mcfgv1.MachineConfig, role, managedKey string, isNotFound bool, update updateConfig) ([]byte, error) {
 	dataURL, err := dataurl.DecodeString(origFile.Contents.Source)
 	if err != nil {
 		return nil, ctrl.syncStatusOnly(cfg, err, "could not decode original Container Runtime config: %v", err)
@@ -631,7 +632,8 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 				}
 			}
 			if isNotFound {
-				mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &ignv2_2types.Config{})
+				tempIgnCfg := ctrlcommon.NewIgnConfig()
+				mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &tempIgnCfg)
 			}
 			mc.Spec.Config = registriesIgn
 			mc.ObjectMeta.Annotations = map[string]string{

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	fakeconfigv1client "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
@@ -86,7 +86,7 @@ func (f *fixture) validateActions() {
 	}
 }
 
-func newMachineConfig(name string, labels map[string]string, osurl string, files []ignv2_2types.File) *mcfgv1.MachineConfig {
+func newMachineConfig(name string, labels map[string]string, osurl string, files []igntypes.File) *mcfgv1.MachineConfig {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -95,7 +95,7 @@ func newMachineConfig(name string, labels map[string]string, osurl string, files
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigSpec{
 			OSImageURL: osurl,
-			Config:     ignv2_2types.Config{Storage: ignv2_2types.Storage{Files: files}},
+			Config:     igntypes.Config{Storage: igntypes.Storage{Files: files}},
 		},
 	}
 }
@@ -341,7 +341,7 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			mcp := newMachineConfigPool("master", map[string]string{"custom-crio": "my-config"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
 			mcp2 := newMachineConfigPool("worker", map[string]string{"custom-crio": "storage-config"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "custom-crio", "my-config"))
-			mcs1 := newMachineConfig(getManagedKeyCtrCfg(mcp, ctrcfg1), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
+			mcs1 := newMachineConfig(getManagedKeyCtrCfg(mcp, ctrcfg1), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -372,7 +372,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			mcp := newMachineConfigPool("master", map[string]string{"custom-crio": "my-config"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
 			mcp2 := newMachineConfigPool("worker", map[string]string{"custom-crio": "storage-config"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "custom-crio", "my-config"))
-			mcs := newMachineConfig(getManagedKeyCtrCfg(mcp, ctrcfg1), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
+			mcs := newMachineConfig(getManagedKeyCtrCfg(mcp, ctrcfg1), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -448,8 +448,8 @@ func TestImageConfigCreate(t *testing.T) {
 			mcp2 := newMachineConfigPool("worker", map[string]string{"custom-crio": "storage-config"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			imgcfg1 := newImageConfig("cluster", &apicfgv1.RegistrySources{InsecureRegistries: []string{"blah.io"}})
 			cvcfg1 := newClusterVersionConfig("version", "test.io/myuser/myimage:test")
-			mcs1 := newMachineConfig(getManagedKeyReg(mcp, imgcfg1), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
-			mcs2 := newMachineConfig(getManagedKeyReg(mcp2, imgcfg1), map[string]string{"node-role": "worker"}, "dummy://", []ignv2_2types.File{{}})
+			mcs1 := newMachineConfig(getManagedKeyReg(mcp, imgcfg1), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
+			mcs2 := newMachineConfig(getManagedKeyReg(mcp2, imgcfg1), map[string]string{"node-role": "worker"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -480,8 +480,8 @@ func TestImageConfigUpdate(t *testing.T) {
 			mcp2 := newMachineConfigPool("worker", map[string]string{"custom-crio": "storage-config"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			imgcfg1 := newImageConfig("cluster", &apicfgv1.RegistrySources{InsecureRegistries: []string{"blah.io"}})
 			cvcfg1 := newClusterVersionConfig("version", "test.io/myuser/myimage:test")
-			mcs1 := newMachineConfig(getManagedKeyReg(mcp, imgcfg1), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
-			mcs2 := newMachineConfig(getManagedKeyReg(mcp2, imgcfg1), map[string]string{"node-role": "worker"}, "dummy://", []ignv2_2types.File{{}})
+			mcs1 := newMachineConfig(getManagedKeyReg(mcp, imgcfg1), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
+			mcs2 := newMachineConfig(getManagedKeyReg(mcp2, imgcfg1), map[string]string{"node-role": "worker"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/pkg/sysregistriesv2"
 	storageconfig "github.com/containers/storage/pkg/config"
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	crioconfig "github.com/kubernetes-sigs/cri-o/pkg/config"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -61,21 +61,21 @@ type tomlConfigRegistries struct {
 
 type updateConfig func(data []byte, internal *mcfgv1.ContainerRuntimeConfiguration) ([]byte, error)
 
-func createNewCtrRuntimeConfigIgnition(storageTOMLConfig, crioTOMLConfig []byte) ignv2_2types.Config {
+func createNewCtrRuntimeConfigIgnition(storageTOMLConfig, crioTOMLConfig []byte) igntypes.Config {
 	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	mode := 0644
 	// Create storage.conf ignition
 	if storageTOMLConfig != nil {
 		storagedu := dataurl.New(storageTOMLConfig, "text/plain")
 		storagedu.Encoding = dataurl.EncodingASCII
-		storageTempFile := ignv2_2types.File{
-			Node: ignv2_2types.Node{
+		storageTempFile := igntypes.File{
+			Node: igntypes.Node{
 				Filesystem: "root",
 				Path:       storageConfigPath,
 			},
-			FileEmbedded1: ignv2_2types.FileEmbedded1{
+			FileEmbedded1: igntypes.FileEmbedded1{
 				Mode: &mode,
-				Contents: ignv2_2types.FileContents{
+				Contents: igntypes.FileContents{
 					Source: storagedu.String(),
 				},
 			},
@@ -87,14 +87,14 @@ func createNewCtrRuntimeConfigIgnition(storageTOMLConfig, crioTOMLConfig []byte)
 	if crioTOMLConfig != nil {
 		criodu := dataurl.New(crioTOMLConfig, "text/plain")
 		criodu.Encoding = dataurl.EncodingASCII
-		crioTempFile := ignv2_2types.File{
-			Node: ignv2_2types.Node{
+		crioTempFile := igntypes.File{
+			Node: igntypes.Node{
 				Filesystem: "root",
 				Path:       crioConfigPath,
 			},
-			FileEmbedded1: ignv2_2types.FileEmbedded1{
+			FileEmbedded1: igntypes.FileEmbedded1{
 				Mode: &mode,
-				Contents: ignv2_2types.FileContents{
+				Contents: igntypes.FileContents{
 					Source: criodu.String(),
 				},
 			},
@@ -105,21 +105,21 @@ func createNewCtrRuntimeConfigIgnition(storageTOMLConfig, crioTOMLConfig []byte)
 	return tempIgnConfig
 }
 
-func createNewRegistriesConfigIgnition(registriesTOMLConfig []byte) ignv2_2types.Config {
+func createNewRegistriesConfigIgnition(registriesTOMLConfig []byte) igntypes.Config {
 	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	mode := 0644
 	// Create Registries ignition
 	if registriesTOMLConfig != nil {
 		regdu := dataurl.New(registriesTOMLConfig, "text/plain")
 		regdu.Encoding = dataurl.EncodingASCII
-		regTempFile := ignv2_2types.File{
-			Node: ignv2_2types.Node{
+		regTempFile := igntypes.File{
+			Node: igntypes.Node{
 				Filesystem: "root",
 				Path:       registriesConfigPath,
 			},
-			FileEmbedded1: ignv2_2types.FileEmbedded1{
+			FileEmbedded1: igntypes.FileEmbedded1{
 				Mode: &mode,
-				Contents: ignv2_2types.FileContents{
+				Contents: igntypes.FileContents{
 					Source: regdu.String(),
 				},
 			},
@@ -129,7 +129,7 @@ func createNewRegistriesConfigIgnition(registriesTOMLConfig []byte) ignv2_2types
 	return tempIgnConfig
 }
 
-func findStorageConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {
+func findStorageConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	for _, c := range mc.Spec.Config.Storage.Files {
 		if c.Path == storageConfigPath {
 			return &c, nil
@@ -138,7 +138,7 @@ func findStorageConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {
 	return nil, fmt.Errorf("could not find Storage Config")
 }
 
-func findCRIOConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {
+func findCRIOConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	for _, c := range mc.Spec.Config.Storage.Files {
 		if c.Path == crioConfigPath {
 			return &c, nil
@@ -147,7 +147,7 @@ func findCRIOConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {
 	return nil, fmt.Errorf("could not find CRI-O Config")
 }
 
-func findRegistriesConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {
+func findRegistriesConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	for _, c := range mc.Spec.Config.Storage.Files {
 		if c.Path == registriesConfigPath {
 			return &c, nil

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	osev1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -19,18 +19,18 @@ import (
 	kubeletconfigscheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
 )
 
-func createNewKubeletIgnition(ymlconfig []byte) ignv2_2types.Config {
+func createNewKubeletIgnition(ymlconfig []byte) igntypes.Config {
 	mode := 0644
 	du := dataurl.New(ymlconfig, "text/plain")
 	du.Encoding = dataurl.EncodingASCII
-	tempFile := ignv2_2types.File{
-		Node: ignv2_2types.Node{
+	tempFile := igntypes.File{
+		Node: igntypes.Node{
 			Filesystem: "root",
 			Path:       "/etc/kubernetes/kubelet.conf",
 		},
-		FileEmbedded1: ignv2_2types.FileEmbedded1{
+		FileEmbedded1: igntypes.FileEmbedded1{
 			Mode: &mode,
-			Contents: ignv2_2types.FileContents{
+			Contents: igntypes.FileContents{
 				Source: du.String(),
 			},
 		},
@@ -48,7 +48,7 @@ func createNewDefaultFeatureGate() *osev1.FeatureGate {
 	}
 }
 
-func findKubeletConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {
+func findKubeletConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	for _, c := range mc.Spec.Config.Storage.Files {
 		if c.Path == "/etc/kubernetes/kubelet.conf" {
 			return &c, nil

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 	"github.com/vincent-petithory/dataurl"
@@ -320,7 +320,7 @@ func (ctrl *Controller) handleFeatureErr(err error, key interface{}) {
 	ctrl.featureQueue.AddAfter(key, 1*time.Minute)
 }
 
-func (ctrl *Controller) generateOriginalKubeletConfig(role string) (*ignv2_2types.File, error) {
+func (ctrl *Controller) generateOriginalKubeletConfig(role string) (*igntypes.File, error) {
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
 		return nil, fmt.Errorf("could not get ControllerConfig %v", err)

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -25,7 +25,7 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	oseinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	oseconfigfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -85,7 +85,7 @@ func (f *fixture) validateActions() {
 	}
 }
 
-func newMachineConfig(name string, labels map[string]string, osurl string, files []ignv2_2types.File) *mcfgv1.MachineConfig {
+func newMachineConfig(name string, labels map[string]string, osurl string, files []igntypes.File) *mcfgv1.MachineConfig {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -94,7 +94,7 @@ func newMachineConfig(name string, labels map[string]string, osurl string, files
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigSpec{
 			OSImageURL: osurl,
-			Config:     ignv2_2types.Config{Storage: ignv2_2types.Storage{Files: files}},
+			Config:     igntypes.Config{Storage: igntypes.Storage{Files: files}},
 		},
 	}
 }
@@ -340,7 +340,7 @@ func TestKubeletConfigCreate(t *testing.T) {
 			mcp := newMachineConfigPool("master", map[string]string{"kubeletType": "small-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
 			mcp2 := newMachineConfigPool("worker", map[string]string{"kubeletType": "large-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
-			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
+			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -367,7 +367,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			mcp := newMachineConfigPool("master", map[string]string{"kubeletType": "small-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
 			mcp2 := newMachineConfigPool("worker", map[string]string{"kubeletType": "large-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
-			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
+			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -512,7 +512,7 @@ func TestKubeletFeatureExists(t *testing.T) {
 			mcp := newMachineConfigPool("master", map[string]string{"kubeletType": "small-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
 			mcp2 := newMachineConfigPool("worker", map[string]string{"kubeletType": "large-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
-			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
+			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/vincent-petithory/dataurl"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -44,8 +44,8 @@ func TestFeaturesDefault(t *testing.T) {
 			cc := newControllerConfig(common.ControllerConfigName, platform)
 			mcp := newMachineConfigPool("master", map[string]string{"kubeletType": "small-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
 			mcp2 := newMachineConfigPool("worker", map[string]string{"kubeletType": "large-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
-			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
-			mcs2 := newMachineConfig(getManagedKubeletConfigKey(mcp2), map[string]string{"node-role": "worker"}, "dummy://", []ignv2_2types.File{{}})
+			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
+			mcs2 := newMachineConfig(getManagedKubeletConfigKey(mcp2), map[string]string{"node-role": "worker"}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
@@ -69,7 +69,7 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, currentMa
 	return mcp
 }
 
-func newMachineConfig(name string, labels map[string]string, osurl string, files []ignv2_2types.File) *mcfgv1.MachineConfig {
+func newMachineConfig(name string, labels map[string]string, osurl string, files []igntypes.File) *mcfgv1.MachineConfig {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -261,18 +261,18 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 func TestCreatesGeneratedMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
-	files := []ignv2_2types.File{{
-		Node: ignv2_2types.Node{
+	files := []igntypes.File{{
+		Node: igntypes.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: ignv2_2types.Node{
+		Node: igntypes.Node{
 			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
-		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
+		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{files[0]}),
+		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []igntypes.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -289,18 +289,18 @@ func TestCreatesGeneratedMachineConfig(t *testing.T) {
 // generateRenderedMachineConfig should return an error when one of the MCs in configs contains an invalid ignconfig.
 func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
-	files := []ignv2_2types.File{{
-		Node: ignv2_2types.Node{
+	files := []igntypes.File{{
+		Node: igntypes.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: ignv2_2types.Node{
+		Node: igntypes.Node{
 			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
-		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
+		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{files[0]}),
+		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []igntypes.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -319,18 +319,18 @@ func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
-	files := []ignv2_2types.File{{
-		Node: ignv2_2types.Node{
+	files := []igntypes.File{{
+		Node: igntypes.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: ignv2_2types.Node{
+		Node: igntypes.Node{
 			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
-		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
+		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{files[0]}),
+		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []igntypes.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -366,8 +366,8 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 func TestGenerateMachineConfigNoOverrideOSImageURL(t *testing.T) {
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
 	mcs := []*mcfgv1.MachineConfig{
-		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy-test-1", []ignv2_2types.File{}),
-		newMachineConfig("00-test-cluster-master-0", map[string]string{"node-role": "master"}, "dummy-change", []ignv2_2types.File{}),
+		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy-test-1", []igntypes.File{}),
+		newMachineConfig("00-test-cluster-master-0", map[string]string{"node-role": "master"}, "dummy-change", []igntypes.File{}),
 	}
 
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
@@ -382,18 +382,18 @@ func TestGenerateMachineConfigNoOverrideOSImageURL(t *testing.T) {
 func TestDoNothing(t *testing.T) {
 	f := newFixture(t)
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
-	files := []ignv2_2types.File{{
-		Node: ignv2_2types.Node{
+	files := []igntypes.File{{
+		Node: igntypes.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: ignv2_2types.Node{
+		Node: igntypes.Node{
 			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
-		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
+		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{files[0]}),
+		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []igntypes.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -421,23 +421,23 @@ func TestDoNothing(t *testing.T) {
 
 func TestGetMachineConfigsForPool(t *testing.T) {
 	masterPool := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
-	files := []ignv2_2types.File{{
-		Node: ignv2_2types.Node{
+	files := []igntypes.File{{
+		Node: igntypes.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: ignv2_2types.Node{
+		Node: igntypes.Node{
 			Path: "/dummy/1",
 		},
 	}, {
-		Node: ignv2_2types.Node{
+		Node: igntypes.Node{
 			Path: "/dummy/2",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{files[0]}),
-		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []ignv2_2types.File{files[1]}),
-		newMachineConfig("00-test-cluster-worker", map[string]string{"node-role": "worker"}, "dummy://2", []ignv2_2types.File{files[2]}),
+		newMachineConfig("00-test-cluster-master", map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{files[0]}),
+		newMachineConfig("05-extra-master", map[string]string{"node-role": "master"}, "dummy://1", []igntypes.File{files[1]}),
+		newMachineConfig("00-test-cluster-worker", map[string]string{"node-role": "worker"}, "dummy://2", []igntypes.File{files[2]}),
 	}
 	masterConfigs, err := getMachineConfigsForPool(masterPool, mcs)
 	if err != nil {
@@ -467,7 +467,7 @@ func getKey(config *mcfgv1.MachineConfigPool, t *testing.T) string {
 
 func TestMachineConfigsNoBailWithoutPool(t *testing.T) {
 	f := newFixture(t)
-	mc := newMachineConfig("00-test-cluster-worker", map[string]string{"node-role": "worker"}, "dummy://2", []ignv2_2types.File{})
+	mc := newMachineConfig("00-test-cluster-worker", map[string]string{"node-role": "worker"}, "dummy://2", []igntypes.File{})
 	oref := metav1.NewControllerRef(newControllerConfig("test"), mcfgv1.SchemeGroupVersion.WithKind("ControllerConfig"))
 	mc.SetOwnerReferences([]metav1.OwnerReference{*oref})
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "")

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Masterminds/sprig"
 	ctconfig "github.com/coreos/container-linux-config-transpiler/config"
 	cttypes "github.com/coreos/container-linux-config-transpiler/config/types"
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -241,7 +241,7 @@ const (
 )
 
 // MachineConfigFromIgnConfig creates a MachineConfig with the provided Ignition config
-func MachineConfigFromIgnConfig(role string, name string, ignCfg *ignv2_2types.Config) *mcfgv1.MachineConfig {
+func MachineConfigFromIgnConfig(role string, name string, ignCfg *igntypes.Config) *mcfgv1.MachineConfig {
 	labels := map[string]string{
 		machineConfigRoleLabelKey: role,
 	}
@@ -257,7 +257,7 @@ func MachineConfigFromIgnConfig(role string, name string, ignCfg *ignv2_2types.C
 	}
 }
 
-func transpileToIgn(files, units []string) (*ignv2_2types.Config, error) {
+func transpileToIgn(files, units []string) (*igntypes.Config, error) {
 	var ctCfg cttypes.Config
 
 	// Convert data to Ignition resources

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -321,7 +321,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 		}
 		if !foundKubeletUnitWorker {
 			t.Errorf("Failed to find kubelet unit")
-		}		
+		}
 	}
 }
 
@@ -341,7 +341,7 @@ func controllerConfigFromFile(path string) (*mcfgv1.ControllerConfig, error) {
 	return cc, nil
 }
 
-func findIgnFile(files []ignv2_2types.File, path string, t *testing.T) bool {
+func findIgnFile(files []igntypes.File, path string, t *testing.T) bool {
 	for _, f := range files {
 		if f.Path == path {
 			return true
@@ -350,7 +350,7 @@ func findIgnFile(files []ignv2_2types.File, path string, t *testing.T) bool {
 	return false
 }
 
-func findIgnUnit(units []ignv2_2types.Unit, name string, t *testing.T) bool {
+func findIgnUnit(units []igntypes.Unit, name string, t *testing.T) bool {
 	for _, u := range units {
 		if u.Name == name {
 			return true

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
 	coreinformersv1 "k8s.io/client-go/informers"
@@ -371,7 +371,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	//update machineconfig
-	mcs[len(mcs)-1].Spec.Config = ignv2_2types.Config{}
+	mcs[len(mcs)-1].Spec.Config = ctrlcommon.NewIgnConfig()
 
 	f.ccLister = append(f.ccLister, cc)
 	f.kubeobjects = append(f.kubeobjects, ps)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	imgref "github.com/containers/image/docker/reference"
-	ignv2 "github.com/coreos/ignition/config/v2_2"
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	ign "github.com/coreos/ignition/config/v2_2"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	drain "github.com/openshift/kubernetes-drain"
 	"github.com/openshift/machine-config-operator/lib/resourceread"
@@ -105,7 +105,7 @@ type Daemon struct {
 	node *corev1.Node
 
 	// remove the funcs below once proper e2e testing is done for updating ssh keys
-	atomicSSHKeysWriter func(ignv2_2types.PasswdUser, string) error
+	atomicSSHKeysWriter func(igntypes.PasswdUser, string) error
 
 	queue       workqueue.RateLimitingInterface
 	enqueueNode func(*corev1.Node)
@@ -441,9 +441,9 @@ func (dn *Daemon) runOnceFrom() error {
 		return err
 	}
 	switch configi.(type) {
-	case ignv2_2types.Config:
+	case igntypes.Config:
 		glog.V(2).Info("Daemon running directly from Ignition")
-		return dn.runOnceFromIgnition(configi.(ignv2_2types.Config))
+		return dn.runOnceFromIgnition(configi.(igntypes.Config))
 	case mcfgv1.MachineConfig:
 		glog.V(2).Info("Daemon running directly from MachineConfig")
 		return dn.runOnceFromMachineConfig(configi.(mcfgv1.MachineConfig), contentFrom)
@@ -969,7 +969,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 }
 
 // runOnceFromIgnition executes MCD's subset of Ignition functionality in onceFrom mode
-func (dn *Daemon) runOnceFromIgnition(ignConfig ignv2_2types.Config) error {
+func (dn *Daemon) runOnceFromIgnition(ignConfig igntypes.Config) error {
 	// Execute update without hitting the cluster
 	if err := dn.writeFiles(ignConfig.Storage.Files); err != nil {
 		return err
@@ -1166,7 +1166,7 @@ func (dn *Daemon) checkOS(osImageURL string) (bool, error) {
 
 // checkUnits validates the contents of all the units in the
 // target config and retursn true if they match.
-func checkUnits(units []ignv2_2types.Unit) bool {
+func checkUnits(units []igntypes.Unit) bool {
 	for _, u := range units {
 		for j := range u.Dropins {
 			path := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
@@ -1201,7 +1201,7 @@ func checkUnits(units []ignv2_2types.Unit) bool {
 
 // checkFiles validates the contents of  all the files in the
 // target config.
-func checkFiles(files []ignv2_2types.File) bool {
+func checkFiles(files []igntypes.File) bool {
 	checkedFiles := make(map[string]bool)
 	for i := len(files) - 1; i >= 0; i-- {
 		f := files[i]
@@ -1303,7 +1303,7 @@ func (dn *Daemon) senseAndLoadOnceFrom() (interface{}, onceFromOrigin, error) {
 	}
 
 	// Try each supported parser
-	ignConfig, _, err := ignv2.Parse(content)
+	ignConfig, _, err := ign.Parse(content)
 	if err == nil && ignConfig.Ignition.Version != "" {
 		glog.V(2).Info("onceFrom file is of type Ignition")
 		return ignConfig, contentFrom, nil

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
@@ -57,13 +57,13 @@ func TestOverwrittenFile(t *testing.T) {
 	fileMode := int(fi.Mode().Perm())
 
 	// validate single file
-	files := []ignv2_2types.File{
+	files := []igntypes.File{
 		{
-			Node: ignv2_2types.Node{
+			Node: igntypes.Node{
 				Path: "fixtures/test1.txt",
 			},
-			FileEmbedded1: ignv2_2types.FileEmbedded1{
-				Contents: ignv2_2types.FileContents{
+			FileEmbedded1: igntypes.FileEmbedded1{
+				Contents: igntypes.FileContents{
 					Source: dataurl.EncodeBytes([]byte("hello world\n")),
 				},
 				Mode: &fileMode,
@@ -76,24 +76,24 @@ func TestOverwrittenFile(t *testing.T) {
 	}
 
 	// validate overwritten file
-	files = []ignv2_2types.File{
+	files = []igntypes.File{
 		{
-			Node: ignv2_2types.Node{
+			Node: igntypes.Node{
 				Path: "fixtures/test1.txt",
 			},
-			FileEmbedded1: ignv2_2types.FileEmbedded1{
-				Contents: ignv2_2types.FileContents{
+			FileEmbedded1: igntypes.FileEmbedded1{
+				Contents: igntypes.FileContents{
 					Source: dataurl.EncodeBytes([]byte("hello\n")),
 				},
 				Mode: &fileMode,
 			},
 		},
 		{
-			Node: ignv2_2types.Node{
+			Node: igntypes.Node{
 				Path: "fixtures/test1.txt",
 			},
-			FileEmbedded1: ignv2_2types.FileEmbedded1{
-				Contents: ignv2_2types.FileContents{
+			FileEmbedded1: igntypes.FileEmbedded1{
+				Contents: igntypes.FileContents{
 					Source: dataurl.EncodeBytes([]byte("hello world\n")),
 				},
 				Mode: &fileMode,

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/coreos/ignition/config/validate"
 	"github.com/golang/glog"
 	"github.com/google/renameio"
@@ -366,8 +366,8 @@ func Reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) (*MachineConfigDif
 // Otherwise, an error will be returned and the proposed config will not be reconcilable.
 // At this time we do not support non-"core" users or any changes to the "core" user
 // outside of SSHAuthorizedKeys.
-func verifyUserFields(pwdUser ignv2_2types.PasswdUser) error {
-	emptyUser := ignv2_2types.PasswdUser{}
+func verifyUserFields(pwdUser igntypes.PasswdUser) error {
+	emptyUser := igntypes.PasswdUser{}
 	tempUser := pwdUser
 	if tempUser.Name == coreUserName && len(tempUser.SSHAuthorizedKeys) >= 1 {
 		tempUser.Name = ""
@@ -489,7 +489,7 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) er
 }
 
 // enableUnit enables a systemd unit via symlink
-func (dn *Daemon) enableUnit(unit ignv2_2types.Unit) error {
+func (dn *Daemon) enableUnit(unit igntypes.Unit) error {
 	// The link location
 	wantsPath := filepath.Join(wantsPathSystemd, unit.Name)
 	// sanity check that we don't return an error when the link already exists
@@ -510,7 +510,7 @@ func (dn *Daemon) enableUnit(unit ignv2_2types.Unit) error {
 }
 
 // disableUnit disables a systemd unit via symlink removal
-func (dn *Daemon) disableUnit(unit ignv2_2types.Unit) error {
+func (dn *Daemon) disableUnit(unit igntypes.Unit) error {
 	// The link location
 	wantsPath := filepath.Join(wantsPathSystemd, unit.Name)
 	// sanity check so we don't return an error when the unit was already disabled
@@ -524,7 +524,7 @@ func (dn *Daemon) disableUnit(unit ignv2_2types.Unit) error {
 }
 
 // writeUnits writes the systemd units to disk
-func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
+func (dn *Daemon) writeUnits(units []igntypes.Unit) error {
 	for _, u := range units {
 		// write the dropin to disk
 		for i := range u.Dropins {
@@ -600,7 +600,7 @@ func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
 
 // writeFiles writes the given files to disk.
 // it doesn't fetch remote files and expects a flattened config file.
-func (dn *Daemon) writeFiles(files []ignv2_2types.File) error {
+func (dn *Daemon) writeFiles(files []igntypes.File) error {
 	for _, file := range files {
 		glog.Infof("Writing file %q", file.Path)
 
@@ -630,7 +630,7 @@ func (dn *Daemon) writeFiles(files []ignv2_2types.File) error {
 }
 
 // This is essentially ResolveNodeUidAndGid() from Ignition; XXX should dedupe
-func getFileOwnership(file ignv2_2types.File) (int, int, error) {
+func getFileOwnership(file igntypes.File) (int, int, error) {
 	uid, gid := 0, 0 // default to root
 	if file.User != nil {
 		if file.User.ID != nil {
@@ -659,7 +659,7 @@ func getFileOwnership(file ignv2_2types.File) (int, int, error) {
 	return uid, gid, nil
 }
 
-func (dn *Daemon) atomicallyWriteSSHKey(newUser ignv2_2types.PasswdUser, keys string) error {
+func (dn *Daemon) atomicallyWriteSSHKey(newUser igntypes.PasswdUser, keys string) error {
 	authKeyPath := filepath.Join(coreUserSSHPath, "authorized_keys")
 
 	// Keys should only be written to "/home/core/.ssh"
@@ -676,7 +676,7 @@ func (dn *Daemon) atomicallyWriteSSHKey(newUser ignv2_2types.PasswdUser, keys st
 }
 
 // Update a given PasswdUser's SSHKey
-func (dn *Daemon) updateSSHKeys(newUsers []ignv2_2types.PasswdUser) error {
+func (dn *Daemon) updateSSHKeys(newUsers []igntypes.PasswdUser) error {
 	if len(newUsers) == 0 {
 		return nil
 	}

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -7,14 +7,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 )
 
 type mockServer struct {
-	GetConfigFn func(poolRequest) (*ignv2_2types.Config, error)
+	GetConfigFn func(poolRequest) (*igntypes.Config, error)
 }
 
-func (ms *mockServer) GetConfig(pr poolRequest) (*ignv2_2types.Config, error) {
+func (ms *mockServer) GetConfig(pr poolRequest) (*igntypes.Config, error) {
 	return ms.GetConfigFn(pr)
 }
 
@@ -23,7 +23,7 @@ type checkResponse func(t *testing.T, response *http.Response)
 type scenario struct {
 	name          string
 	request       *http.Request
-	serverFunc    func(poolRequest) (*ignv2_2types.Config, error)
+	serverFunc    func(poolRequest) (*igntypes.Config, error)
 	checkResponse checkResponse
 }
 
@@ -32,8 +32,8 @@ func TestAPIHandler(t *testing.T) {
 		{
 			name:    "get config path that does not exist",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/config/does-not-exist", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), fmt.Errorf("not acceptable")
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), fmt.Errorf("not acceptable")
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusInternalServerError)
@@ -44,8 +44,8 @@ func TestAPIHandler(t *testing.T) {
 		{
 			name:    "get config path that exists",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/config/master", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -57,8 +57,8 @@ func TestAPIHandler(t *testing.T) {
 		{
 			name:    "head config path that exists",
 			request: httptest.NewRequest(http.MethodHead, "http://testrequest/config/master", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -70,8 +70,8 @@ func TestAPIHandler(t *testing.T) {
 		{
 			name:    "post config path that exists",
 			request: httptest.NewRequest(http.MethodPost, "http://testrequest/config/master", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusMethodNotAllowed)
@@ -102,8 +102,8 @@ func TestHealthzHandler(t *testing.T) {
 		{
 			name:    "get healthz",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/healthz", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -114,8 +114,8 @@ func TestHealthzHandler(t *testing.T) {
 		{
 			name:    "head healthz",
 			request: httptest.NewRequest(http.MethodHead, "http://testrequest/healthz", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -126,8 +126,8 @@ func TestHealthzHandler(t *testing.T) {
 		{
 			name:    "post healthz",
 			request: httptest.NewRequest(http.MethodPost, "http://testrequest/healthz", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusMethodNotAllowed)
@@ -154,8 +154,8 @@ func TestDefaultHandler(t *testing.T) {
 		{
 			name:    "get root",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusNotFound)
@@ -166,8 +166,8 @@ func TestDefaultHandler(t *testing.T) {
 		{
 			name:    "head root",
 			request: httptest.NewRequest(http.MethodHead, "http://testrequest/", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusNotFound)
@@ -178,8 +178,8 @@ func TestDefaultHandler(t *testing.T) {
 		{
 			name:    "post root",
 			request: httptest.NewRequest(http.MethodPost, "http://testrequest/", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusMethodNotAllowed)
@@ -206,8 +206,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "get config path that does not exist",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/config/does-not-exist", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), fmt.Errorf("not acceptable")
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), fmt.Errorf("not acceptable")
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusInternalServerError)
@@ -218,8 +218,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "get config path that exists",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/config/master", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -231,8 +231,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "head config path that exists",
 			request: httptest.NewRequest(http.MethodHead, "http://testrequest/config/master", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -244,8 +244,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "post config path that exists",
 			request: httptest.NewRequest(http.MethodPost, "http://testrequest/config/master", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusMethodNotAllowed)
@@ -256,8 +256,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "get healthz",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/healthz", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -268,8 +268,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "head healthz",
 			request: httptest.NewRequest(http.MethodHead, "http://testrequest/healthz", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusOK)
@@ -280,8 +280,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "post healthz",
 			request: httptest.NewRequest(http.MethodPost, "http://testrequest/healthz", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusMethodNotAllowed)
@@ -292,8 +292,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "get root",
 			request: httptest.NewRequest(http.MethodGet, "http://testrequest/", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusNotFound)
@@ -304,8 +304,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "head root",
 			request: httptest.NewRequest(http.MethodHead, "http://testrequest/", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusNotFound)
@@ -316,8 +316,8 @@ func TestAPIServer(t *testing.T) {
 		{
 			name:    "post root",
 			request: httptest.NewRequest(http.MethodPost, "http://testrequest/", nil),
-			serverFunc: func(poolRequest) (*ignv2_2types.Config, error) {
-				return new(ignv2_2types.Config), nil
+			serverFunc: func(poolRequest) (*igntypes.Config, error) {
+				return new(igntypes.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
 				checkStatus(t, response, http.StatusMethodNotAllowed)

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	yaml "github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	clientcmd "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -56,7 +56,7 @@ func NewBootstrapServer(dir, kubeconfig string) (Server, error) {
 // 3. Load the machine config.
 // 4. Append the machine annotations file.
 // 5. Append the KubeConfig file.
-func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, error) {
+func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*igntypes.Config, error) {
 
 	// 1. Read the Machine Config Pool object.
 	fileName := path.Join(bsc.serverBaseDir, "machine-pools", cr.machineConfigPool+".yaml")

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	yaml "github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,7 +57,7 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 
 // GetConfig fetches the machine config(type - Ignition) from the cluster,
 // based on the pool request.
-func (cs *clusterServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, error) {
+func (cs *clusterServer) GetConfig(cr poolRequest) (*igntypes.Config, error) {
 	mp, err := cs.machineClient.MachineConfigPools().Get(cr.machineConfigPool, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch pool. err: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/url"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/vincent-petithory/dataurl"
 )
@@ -29,22 +29,22 @@ const (
 type kubeconfigFunc func() (kubeconfigData []byte, rootCAData []byte, err error)
 
 // appenderFunc appends Config.
-type appenderFunc func(*ignv2_2types.Config) error
+type appenderFunc func(*igntypes.Config) error
 
 // Server defines the interface that is implemented by different
 // machine config server implementations.
 type Server interface {
-	GetConfig(poolRequest) (*ignv2_2types.Config, error)
+	GetConfig(poolRequest) (*igntypes.Config, error)
 }
 
 func getAppenders(cr poolRequest, currMachineConfig string, f kubeconfigFunc, osimageurl string) []appenderFunc {
 	appenders := []appenderFunc{
 		// append machine annotations file.
-		func(config *ignv2_2types.Config) error { return appendNodeAnnotations(config, currMachineConfig) },
+		func(config *igntypes.Config) error { return appendNodeAnnotations(config, currMachineConfig) },
 		// append pivot
-		func(config *ignv2_2types.Config) error { return appendInitialPivot(config, osimageurl) },
+		func(config *igntypes.Config) error { return appendInitialPivot(config, osimageurl) },
 		// append kubeconfig.
-		func(config *ignv2_2types.Config) error { return appendKubeConfig(config, f) },
+		func(config *igntypes.Config) error { return appendKubeConfig(config, f) },
 	}
 	return appenders
 }
@@ -54,21 +54,21 @@ func boolToPtr(b bool) *bool {
 	return &b
 }
 
-func appendInitialPivot(conf *ignv2_2types.Config, osimageurl string) error {
+func appendInitialPivot(conf *igntypes.Config, osimageurl string) error {
 	if osimageurl == "" {
 		return nil
 	}
 
 	// Tell pivot.service to pivot early
-	appendFileToIgnition(conf, daemonconsts.EtcPivotFile, osimageurl + "\n")
+	appendFileToIgnition(conf, daemonconsts.EtcPivotFile, osimageurl+"\n")
 	// Awful hack to create a file in /run
 	// https://github.com/openshift/machine-config-operator/pull/363#issuecomment-463397373
 	// "So one gotcha here is that Ignition will actually write `/run/pivot/image-pullspec` to the filesystem rather than the `/run` tmpfs"
 	if len(conf.Systemd.Units) == 0 {
-		conf.Systemd.Units = make([]ignv2_2types.Unit, 0)
+		conf.Systemd.Units = make([]igntypes.Unit, 0)
 	}
-	unit := ignv2_2types.Unit {
-		Name: "mcd-write-pivot-reboot.service",
+	unit := igntypes.Unit{
+		Name:    "mcd-write-pivot-reboot.service",
 		Enabled: boolToPtr(true),
 		Contents: `[Unit]
 Before=pivot.service
@@ -77,12 +77,12 @@ ConditionFirstBoot=true
 ExecStart=/bin/sh -c 'mkdir /run/pivot && touch /run/pivot/reboot-needed'
 [Install]
 WantedBy=multi-user.target
-`,}
+`}
 	conf.Systemd.Units = append(conf.Systemd.Units, unit)
 	return nil
 }
 
-func appendKubeConfig(conf *ignv2_2types.Config, f kubeconfigFunc) error {
+func appendKubeConfig(conf *igntypes.Config, f kubeconfigFunc) error {
 	kcData, _, err := f()
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func appendKubeConfig(conf *ignv2_2types.Config, f kubeconfigFunc) error {
 	return nil
 }
 
-func appendNodeAnnotations(conf *ignv2_2types.Config, currConf string) error {
+func appendNodeAnnotations(conf *igntypes.Config, currConf string) error {
 	anno, err := getNodeAnnotation(currConf)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func getNodeAnnotation(conf string) (string, error) {
 	return string(contents), nil
 }
 
-func copyFileToIgnition(conf *ignv2_2types.Config, outPath, srcPath string) error {
+func copyFileToIgnition(conf *igntypes.Config, outPath, srcPath string) error {
 	contents, err := ioutil.ReadFile(srcPath)
 	if err != nil {
 		return fmt.Errorf("could not read file from: %s, err: %v", srcPath, err)
@@ -122,22 +122,22 @@ func copyFileToIgnition(conf *ignv2_2types.Config, outPath, srcPath string) erro
 	return nil
 }
 
-func appendFileToIgnition(conf *ignv2_2types.Config, outPath, contents string) {
+func appendFileToIgnition(conf *igntypes.Config, outPath, contents string) {
 	fileMode := int(420)
-	file := ignv2_2types.File{
-		Node: ignv2_2types.Node{
+	file := igntypes.File{
+		Node: igntypes.Node{
 			Filesystem: defaultFileSystem,
 			Path:       outPath,
 		},
-		FileEmbedded1: ignv2_2types.FileEmbedded1{
-			Contents: ignv2_2types.FileContents{
+		FileEmbedded1: igntypes.FileEmbedded1{
+			Contents: igntypes.FileContents{
 				Source: getEncodedContent(contents),
 			},
 			Mode: &fileMode,
 		},
 	}
 	if len(conf.Storage.Files) == 0 {
-		conf.Storage.Files = make([]ignv2_2types.File, 0)
+		conf.Storage.Files = make([]igntypes.File, 0)
 	}
 	conf.Storage.Files = append(conf.Storage.Files, file)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	yaml "github.com/ghodss/yaml"
 	"github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -187,7 +187,7 @@ func getKubeConfigContent(t *testing.T) ([]byte, []byte, error) {
 	return []byte("dummy-kubeconfig"), []byte("dummy-root-ca"), nil
 }
 
-func validateIgnitionFiles(t *testing.T, exp, got []ignv2_2types.File) {
+func validateIgnitionFiles(t *testing.T, exp, got []igntypes.File) {
 	expMap := createFileMap(exp)
 	gotMap := createFileMap(got)
 
@@ -202,7 +202,7 @@ func validateIgnitionFiles(t *testing.T, exp, got []ignv2_2types.File) {
 	}
 }
 
-func validateIgnitionSystemd(t *testing.T, exp, got []ignv2_2types.Unit) {
+func validateIgnitionSystemd(t *testing.T, exp, got []igntypes.Unit) {
 	expMap := createUnitMap(exp)
 	gotMap := createUnitMap(got)
 
@@ -217,16 +217,16 @@ func validateIgnitionSystemd(t *testing.T, exp, got []ignv2_2types.Unit) {
 	}
 }
 
-func createUnitMap(units []ignv2_2types.Unit) map[string]ignv2_2types.Unit {
-	m := make(map[string]ignv2_2types.Unit)
+func createUnitMap(units []igntypes.Unit) map[string]igntypes.Unit {
+	m := make(map[string]igntypes.Unit)
 	for i := range units {
 		m[units[i].Name] = units[i]
 	}
 	return m
 }
 
-func createFileMap(files []ignv2_2types.File) map[string]ignv2_2types.File {
-	m := make(map[string]ignv2_2types.File)
+func createFileMap(files []igntypes.File) map[string]igntypes.File {
+	m := make(map[string]igntypes.File)
 	for i := range files {
 		file := path.Join(files[i].Filesystem, files[i].Path)
 		m[file] = files[i]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Now that we have more time, I am breaking up PR #583 . This PR is removing the changes from #583 that can go into the code-base now to make the future transition easier. 

This PR makes the following changes:
- update helpers.go NewIgnConfig() to use MaxVersion and sub igntypes for ignv2_2types as package alias
- for all non-test files, substitute igntypes for ignv2_2types as package alias (these changes are trivial but take up a lot of space in the PR, let's do it now!)
- in test files, make the above substitution, and also refactor to use NewIgnConfig() instead of generating empty config and hardcoding version.
- minor doc update to reflect above changes

After this lands, the future subtantive ignition change PR should be clearer and easier to test and evaluate.

**- How to verify it**
This PR makes no functional changes and everything should work exactly the same as before.

