### PR TITLE
pkg/operator: fix bootstrap logging

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -27,8 +27,12 @@ func RenderBootstrap(
 	filesData := map[string][]byte{}
 	files := []string{
 		clusterConfigConfigMapFile,
-		infraFile, networkFile,
-		rootCAFile, etcdCAFile, etcdMetricCAFile, pullSecretFile,
+		infraFile,
+		networkFile,
+		rootCAFile,
+		etcdCAFile,
+		etcdMetricCAFile,
+		pullSecretFile,
 	}
 	if kubeCAFile != "" {
 		files = append(files, kubeCAFile)
@@ -112,11 +116,10 @@ func RenderBootstrap(
 		filename: "manifests/csr-bootstrap-role-binding.yaml",
 	}}
 	for _, m := range manifests {
-		glog.Info(m.name)
-
 		var b []byte
 		var err error
 		if len(m.name) > 0 {
+			glog.Info(m.name)
 			b, err = renderAsset(config, m.name)
 			if err != nil {
 				return err


### PR DESCRIPTION
During bootkube we can see an empty line in there:

```
Apr 09 17:19:18 ip-10-0-7-150 bootkube.sh[1341]: Rendering MCO manifests...
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.779505       1 bootstrap.go:84] Version: 4.0.0-alpha.0-164-gfc43ad02-dirty
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.781728       1 bootstrap.go:115] manifests/machineconfigcontroller/controllerconfig.yaml
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.784134       1 bootstrap.go:115] manifests/master.machineconfigpool.yaml
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.784863       1 bootstrap.go:115] manifests/worker.machineconfigpool.yaml
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.785079       1 bootstrap.go:115] manifests/bootstrap-pod-v2.yaml
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.785306       1 bootstrap.go:115]
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.785414       1 bootstrap.go:115] manifests/machineconfigserver/csr-approver-role-binding.yaml
Apr 09 17:19:20 ip-10-0-7-150 bootkube.sh[1341]: I0409 17:19:20.785801       1 bootstrap.go:115] manifests/machineconfigserver/csr-bootstrap-role-binding.yaml
```

This patch fixes the above by skipping files w/o a filename to log...
Just my OCD kicking in lol

Signed-off-by: Antonio Murdaca <runcom@linux.com>
