### PR TITLE
pkg/operator: clarify pool status

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -265,7 +265,7 @@ func machineConfigPoolStatus(pool *mcfgv1.MachineConfigPool) string {
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdated):
 		return fmt.Sprintf("all %d nodes are at latest configuration %s", pool.Status.MachineCount, pool.Status.Configuration.Name)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating):
-		return fmt.Sprintf("%d out of %d nodes have updated to latest configuration %s", pool.Status.UpdatedMachineCount, pool.Status.MachineCount, pool.Status.Configuration.Name)
+		return fmt.Sprintf("%d (ready %d) out of %d nodes are updating to latest configuration %s", pool.Status.UpdatedMachineCount, pool.Status.ReadyMachineCount, pool.Status.MachineCount, pool.Status.Configuration.Name)
 	default:
 		return "<unknown>"
 	}


### PR DESCRIPTION
Saw this in a CI job:

```
extension: {
  master: "all 3 nodes are at latest configuration rendered-master-2637ad32a70f0618e20be6b9c53ac6d1",
  worker: "3 out of 3 nodes have updated to latest configuration rendered-worker-a48a1e135f36dc49e4c49aee5590ee72"
},
```

Which is confusing since 3/3 looks like everything is right so why that
if the pool is still updating? This patch fixes the above to have a
better status message for updating pools where we also take into
accounts ready machines.

Signed-off-by: Antonio Murdaca <runcom@linux.com>