### PR TITLE
*: add resource sync for etcd-quorum-guard

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -337,6 +337,7 @@ func (optr *Operator) sync(key string) error {
 		{"mcs", optr.syncMachineConfigServer},
 		{"mcd", optr.syncMachineConfigDaemon},
 		{"required-pools", optr.syncRequiredMachineConfigPools},
+		{"required-resources", optr.syncRequiredMachineConfigResources},
 	}
 	return optr.syncAll(rc, syncFuncs)
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -334,6 +334,35 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 	return nil
 }
 
+// syncRequiredMachineConfigResources ensures that the ConfigMap and Secret resources are synced from source namespace to destination.
+func (optr *Operator) syncRequiredMachineConfigResources(config renderConfig) error {
+	sourceNamespace := "openshift-config"
+	destinationNamespace := "kube-system"
+
+	_, _, err := resourceapply.SyncConfigMap(
+		optr.kubeClient.CoreV1(),
+		sourceNamespace,
+		"etcd-metric-serving-ca",
+		destinationNamespace,
+		"etcd-metric-serving-ca",
+		[]metav1.OwnerReference{})
+	if err != nil {
+		return err
+	}
+
+	_, _, errs := resourceapply.SyncSecret(
+		optr.kubeClient.CoreV1(),
+		sourceNamespace,
+		"etcd-metric-client",
+		destinationNamespace,
+		"etcd-metric-client",
+		[]metav1.OwnerReference{})
+	if errs != nil {
+		return errs
+	}
+	return nil
+}
+
 const (
 	deploymentRolloutPollInterval = time.Second
 	deploymentRolloutTimeout      = 10 * time.Minute


### PR DESCRIPTION
This PR adds functionality which will sync ConfigMaps and Secrets from `openshift-config` namespace to `kube-system`. The result will be etcd TLS resources available for etcd-quorum-guard` to consume.

/cc @abhinavdahiya 

functionality assists https://github.com/openshift/machine-config-operator/pull/613