### PR TITLE
Bug 1698250: * : pt1 transition from MachineSelector to NodeSelector labels

### DIFF
--- a/docs/MachineConfigController.md
+++ b/docs/MachineConfigController.md
@@ -39,7 +39,7 @@ type MachineConfigPoolSpec struct {
     MachineConfigSelector *metav1.LabelSelector `json:"machineConfigSelector,omitempty"`
 
     // Label selector for Machines.
-    MachineSelector *metav1.LabelSelector `json:"machineSelector,omitempty"`
+    NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 
     // If true, changes to this machine config pool should be stopped.
     // This includes generating new desiredMachineConfig and update of machines.
@@ -81,7 +81,7 @@ type MachineConfigPoolStatus struct {
 
 - MachineConfigPool also allows users to configure how upgrades are rolled out to the machines in a pool.
 
-- MachineSelector can be replaced with reference to MachineSet.
+- NodeSelector can be replaced with reference to MachineSet.
 
 ## TemplateController
 

--- a/examples/etcd.machineconfigpool.yaml
+++ b/examples/etcd.machineconfigpool.yaml
@@ -7,6 +7,6 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "etcd"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/etcd: ""

--- a/examples/master.machineconfigpool.yaml
+++ b/examples/master.machineconfigpool.yaml
@@ -7,6 +7,6 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "master"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/master: ""

--- a/examples/worker.machineconfigpool.yaml
+++ b/examples/worker.machineconfigpool.yaml
@@ -7,6 +7,6 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "worker"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/worker: ""

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -41,6 +41,15 @@ func EnsureMachineConfigPool(modified *bool, existing *mcfgv1.MachineConfigPool,
 		*modified = true
 		existing.Spec.MachineSelector = required.Spec.MachineSelector
 	}
+
+	if existing.Spec.NodeSelector == nil {
+		*modified = true
+		existing.Spec.NodeSelector = required.Spec.NodeSelector
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec.NodeSelector, required.Spec.NodeSelector) {
+		*modified = true
+		existing.Spec.NodeSelector = required.Spec.NodeSelector
+	}
 }
 
 func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec, required mcfgv1.MachineConfigSpec) {

--- a/manifests/master.machineconfigpool.yaml
+++ b/manifests/master.machineconfigpool.yaml
@@ -8,6 +8,6 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "master"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/master: ""

--- a/manifests/worker.machineconfigpool.yaml
+++ b/manifests/worker.machineconfigpool.yaml
@@ -6,6 +6,6 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "worker"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/worker: ""

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -292,6 +292,9 @@ type MachineConfigPoolSpec struct {
 	// Label selector for Machines.
 	MachineSelector *metav1.LabelSelector `json:"machineSelector,omitempty"`
 
+	// Node selector for Machines, to replace MachineSelector
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+
 	// If true, changes to this machine config pool should be stopped.
 	// This includes generating new desiredMachineConfig and update of machines.
 	Paused bool `json:"paused"`

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -628,6 +628,11 @@ func (in *MachineConfigPoolSpec) DeepCopyInto(out *MachineConfigPoolSpec) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
 		*out = new(intstr.IntOrString)

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -61,6 +61,7 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, maxUnavai
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			MachineSelector: selector,
+			NodeSelector:    selector,
 			MaxUnavailable:  maxUnavail,
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -16,6 +16,12 @@ func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
 	if err != nil {
 		return err
 	}
+	if pool.Spec.MachineSelector == nil {
+		selector, err = metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
+		if err != nil {
+			return err
+		}
+	}
 	nodes, err := ctrl.nodeLister.List(selector)
 	if err != nil {
 		return err

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1095,7 +1095,7 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "master"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/master: ""`)
 
@@ -1122,7 +1122,7 @@ spec:
   machineConfigSelector:
     matchLabels:
       "machineconfiguration.openshift.io/role": "worker"
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/worker: ""`)
 

--- a/pkg/server/testdata/machine-pools/test-pool.yaml
+++ b/pkg/server/testdata/machine-pools/test-pool.yaml
@@ -7,7 +7,7 @@ spec:
   machineConfigSelector:
     matchLabels:
       machineconfiguration.openshift.io/role: test
-  machineSelector:
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/test: ""
   maxUnavailable: null


### PR DESCRIPTION
**- What I did**

MachineSelector will eventually be replaced with NodeSelector.
This PR allows all current MachineSelector values to be copied
into the NodeSelector label if MachineSelector is not nil, otherwise 
reads and uses NodeSelector value as part 1 of this process.

Closes: #619


**- How to verify it**


