### PR TITLE
try to make MCD render more self-contained

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -50,7 +50,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdCAFile, "etcd-ca", "/etc/ssl/etcd/ca.crt", "path to etcd CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdMetricCAFile, "etcd-metric-ca", "/assets/tls/etcd-metric-ca-bundle.crt", "path to etcd metric CA certificate")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.rootCAFile, "root-ca", "/etc/ssl/kubernetes/ca.crt", "path to root CA certificate")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeCAFile, "kube-ca", "", "path to kube CA certificate")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeCAFile, "kube-ca", "", "path to kube-apiserver serving-ca bundle")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "/assets/manifests/pull.json", "path to secret manifest that contains pull secret.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
 	bootstrapCmd.MarkFlagRequired("dest-dir")

--- a/manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml
+++ b/manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: initial-kube-apiserver-server-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+{{.KubeAPIServerServingCA | indent 4}}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -24,6 +24,7 @@
 // manifests/machineconfigserver/csr-bootstrap-role-binding.yaml
 // manifests/machineconfigserver/csr-renewal-role-binding.yaml
 // manifests/machineconfigserver/daemonset.yaml
+// manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml
 // manifests/machineconfigserver/node-bootstrapper-sa.yaml
 // manifests/machineconfigserver/node-bootstrapper-token.yaml
 // manifests/machineconfigserver/sa.yaml
@@ -1016,6 +1017,31 @@ func manifestsMachineconfigserverDaemonsetYaml() (*asset, error) {
 	return a, nil
 }
 
+var _manifestsMachineconfigserverKubeApiserverServingCaConfigmapYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: initial-kube-apiserver-server-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+{{.KubeAPIServerServingCA | indent 4}}
+`)
+
+func manifestsMachineconfigserverKubeApiserverServingCaConfigmapYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigserverKubeApiserverServingCaConfigmapYaml, nil
+}
+
+func manifestsMachineconfigserverKubeApiserverServingCaConfigmapYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigserverKubeApiserverServingCaConfigmapYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _manifestsMachineconfigserverNodeBootstrapperSaYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -1217,6 +1243,7 @@ var _bindata = map[string]func() (*asset, error){
 	"manifests/machineconfigserver/csr-bootstrap-role-binding.yaml": manifestsMachineconfigserverCsrBootstrapRoleBindingYaml,
 	"manifests/machineconfigserver/csr-renewal-role-binding.yaml": manifestsMachineconfigserverCsrRenewalRoleBindingYaml,
 	"manifests/machineconfigserver/daemonset.yaml": manifestsMachineconfigserverDaemonsetYaml,
+	"manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml": manifestsMachineconfigserverKubeApiserverServingCaConfigmapYaml,
 	"manifests/machineconfigserver/node-bootstrapper-sa.yaml": manifestsMachineconfigserverNodeBootstrapperSaYaml,
 	"manifests/machineconfigserver/node-bootstrapper-token.yaml": manifestsMachineconfigserverNodeBootstrapperTokenYaml,
 	"manifests/machineconfigserver/sa.yaml": manifestsMachineconfigserverSaYaml,
@@ -1294,6 +1321,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"csr-bootstrap-role-binding.yaml": &bintree{manifestsMachineconfigserverCsrBootstrapRoleBindingYaml, map[string]*bintree{}},
 			"csr-renewal-role-binding.yaml": &bintree{manifestsMachineconfigserverCsrRenewalRoleBindingYaml, map[string]*bintree{}},
 			"daemonset.yaml": &bintree{manifestsMachineconfigserverDaemonsetYaml, map[string]*bintree{}},
+			"kube-apiserver-serving-ca-configmap.yaml": &bintree{manifestsMachineconfigserverKubeApiserverServingCaConfigmapYaml, map[string]*bintree{}},
 			"node-bootstrapper-sa.yaml": &bintree{manifestsMachineconfigserverNodeBootstrapperSaYaml, map[string]*bintree{}},
 			"node-bootstrapper-token.yaml": &bintree{manifestsMachineconfigserverNodeBootstrapperTokenYaml, map[string]*bintree{}},
 			"sa.yaml": &bintree{manifestsMachineconfigserverSaYaml, map[string]*bintree{}},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -328,13 +328,15 @@ func (optr *Operator) sync(key string) error {
 	if err != nil {
 		return err
 	}
-	kubeCA, err := optr.getCAsFromConfigMap("openshift-config", "initial-client-ca", "ca-bundle.crt")
+	// as described by the name this is essentially static, but it no worse than what was here before.  Since changes disrupt workloads
+	// and since must perfectly match what the installer creates, this is effectively frozen in time.
+	kubeAPIServerServingCABytes, err := optr.getCAsFromConfigMap("openshift-config", "initial-kube-apiserver-server-ca", "ca-bundle.crt")
 	if err != nil {
 		return err
 	}
 	bundle := make([]byte, 0)
 	bundle = append(bundle, rootCA...)
-	bundle = append(bundle, kubeCA...)
+	bundle = append(bundle, kubeAPIServerServingCABytes...)
 
 	// sync up os image url
 	// TODO: this should probably be part of the imgs
@@ -367,7 +369,7 @@ func (optr *Operator) sync(key string) error {
 	}
 
 	// create renderConfig
-	rc := getRenderConfig(namespace, spec, imgs, infra.Status.APIServerURL)
+	rc := getRenderConfig(namespace, string(kubeAPIServerServingCABytes), spec, imgs, infra.Status.APIServerURL)
 	// syncFuncs is the list of sync functions that are executed in order.
 	// any error marks sync as failure but continues to next syncFunc
 	var syncFuncs = []syncFunc{
@@ -422,12 +424,13 @@ func (optr *Operator) getGlobalConfig() (*configv1.Infrastructure, *configv1.Net
 	return infra, network, nil
 }
 
-func getRenderConfig(tnamespace string, ccSpec *mcfgv1.ControllerConfigSpec, imgs Images, apiServerURL string) renderConfig {
+func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs Images, apiServerURL string) renderConfig {
 	return renderConfig{
 		TargetNamespace:  tnamespace,
 		Version:          version.Raw,
 		ControllerConfig: *ccSpec,
 		Images:           imgs,
 		APIServerURL:     apiServerURL,
+		KubeAPIServerServingCA: kubeAPIServerServingCA,
 	}
 }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -22,6 +22,7 @@ type renderConfig struct {
 	ControllerConfig mcfgv1.ControllerConfigSpec
 	APIServerURL     string
 	Images           Images
+	KubeAPIServerServingCA string
 }
 
 func renderAsset(config renderConfig, path string) ([]byte, error) {


### PR DESCRIPTION
Trying to fix https://bugzilla.redhat.com/show_bug.cgi?id=1685704, we've bumped into MCD ghost dependencies to dead/broken resources.  In this case, it appears to be a dead configmap with ca-bundle.crt inside that cannot actually verify anything except a deprecated serving-cert.  However, we cannot fix the original here https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/bindata/bootkube/manifests/configmap-initial-kube-apiserver-client-ca.yaml#L1 (which was actually only working by a invalid coincidence of a client-ca validating a serving cert).

To avoid the ghost, the MCD can render out its own new configmap and then rely upon that.  Keep in mind that this still leaves it disconnected from the actual trust bundle because the actual values aren't known until after rotation starts and runs.  But if you depend on the new configmap, you end up getting invalid machine configs that prevent a cluster from ever moving forward.  See https://bugzilla.redhat.com/show_bug.cgi?id=1698007

@sjenning if this doesn't work, hopefully it moves you much closer.