### PR TITLE
pkg/apis: avoid a double call in getting the cc

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -201,14 +201,14 @@ func IsControllerConfigStatusConditionPresentAndEqual(conditions []ControllerCon
 }
 
 // IsControllerConfigCompleted checks whether a ControllerConfig is completed by the Template Controller
-func IsControllerConfigCompleted(cc *ControllerConfig, ccGetter func(string) (*ControllerConfig, error)) error {
-	cur, err := ccGetter(cc.GetName())
+func IsControllerConfigCompleted(ccName string, ccGetter func(string) (*ControllerConfig, error)) error {
+	cur, err := ccGetter(ccName)
 	if err != nil {
 		return err
 	}
 
 	if cur.Generation != cur.Status.ObservedGeneration {
-		return fmt.Errorf("status for ControllerConfig %s is being reported for %d, expecting it for %d", cc.GetName(), cur.Status.ObservedGeneration, cur.Generation)
+		return fmt.Errorf("status for ControllerConfig %s is being reported for %d, expecting it for %d", ccName, cur.Status.ObservedGeneration, cur.Generation)
 	}
 
 	completed := IsControllerConfigStatusConditionTrue(cur.Status.Conditions, TemplateContollerCompleted)

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
@@ -172,7 +172,7 @@ func TestIsControllerConfigCompleted(t *testing.T) {
 				}, nil
 			}
 
-			err := IsControllerConfigCompleted(&ControllerConfig{ObjectMeta: metav1.ObjectMeta{Generation: 1, Name: "dummy"}}, getter)
+			err := IsControllerConfigCompleted("dummy", getter)
 			if !reflect.DeepEqual(err, test.err) {
 				t.Fatalf("expected %v got %v", test.err, err)
 			}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -425,7 +425,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	}
 
 	// TODO(runcom): add tests in render_controller_test.go for this condition
-	if err := ctrl.isControllerConfigCompleted(); err != nil {
+	if err := mcfgv1.IsControllerConfigCompleted(common.ControllerConfigName, ctrl.ccLister.Get); err != nil {
 		return err
 	}
 
@@ -438,14 +438,6 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	}
 
 	return ctrl.syncGeneratedMachineConfig(pool, mcs)
-}
-
-func (ctrl *Controller) isControllerConfigCompleted() error {
-	cc, err := ctrl.ccLister.Get(common.ControllerConfigName)
-	if err != nil {
-		return fmt.Errorf("could not get ControllerConfig %v", err)
-	}
-	return mcfgv1.IsControllerConfigCompleted(cc, ctrl.ccLister.Get)
 }
 
 // This function will eventually contain a sane garbage collection policy for rendered MachineConfigs;

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -442,7 +442,7 @@ func (optr *Operator) waitForDaemonsetRollout(resource *appsv1.DaemonSet) error 
 func (optr *Operator) waitForControllerConfigToBeCompleted(resource *mcfgv1.ControllerConfig) error {
 	var lastErr error
 	if err := wait.Poll(controllerConfigCompletedInterval, controllerConfigCompletedTimeout, func() (bool, error) {
-		if err := mcfgv1.IsControllerConfigCompleted(resource, optr.ccLister.Get); err != nil {
+		if err := mcfgv1.IsControllerConfigCompleted(resource.GetName(), optr.ccLister.Get); err != nil {
 			lastErr = fmt.Errorf("controllerconfig is not completed: %v", err)
 			return false, nil
 		}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

we were always getting the ControllerConfig before passing it down for a new `ccLister.Get` - this patch avoids that and we just get the CC once inside the check code.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
