### PR TITLE
Bug 1686117: pkg/controller: re-sync on pull secret change

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	controllercommon "github.com/openshift/machine-config-operator/pkg/controller/common"
-	"github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
-	"github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
+	containerruntimeconfig "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
+	kubeletconfig "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
 	"github.com/openshift/machine-config-operator/pkg/controller/node"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
@@ -95,6 +95,7 @@ func createControllers(ctx *controllercommon.ControllerContext) []controllercomm
 			rootOpts.templates,
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
+			ctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctx.ClientBuilder.KubeClientOrDie("template-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("template-controller"),
 		),

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -232,9 +232,9 @@ registry for this flow to still work as long as those images are pullable.
 Now that your have your custom component images, to build a custom release payload, run:
 
 ```
-oc adm release new -n openshift --server https://api.ci.openshift.org \
-                                --from-image-stream "origin-v4.0" \
-                                --to-image quay.io/user/origin-release:v4.0 \
+oc adm release new -n origin --server https://api.ci.openshift.org \
+                                --from-image-stream "4.1" \
+                                --to-image quay.io/user/origin-release:v4.1 \
                                 machine-config-{component}=quay.io/user/machine-config-{component}:{tag}
 ```
 
@@ -243,9 +243,9 @@ you from building a custom release payload using only a subset of the MCO compon
 creating a payload which contains all of them:
 
 ```
-oc adm release new -n openshift --server https://api.ci.openshift.org \
-                                --from-image-stream "origin-v4.0" \
-                                --to-image quay.io/user/origin-release:v4.0 \
+oc adm release new -n origin --server https://api.ci.openshift.org \
+                                --from-image-stream "4.1" \
+                                --to-image quay.io/user/origin-release:v4.1 \
                                 machine-config-operator=quay.io/user/machine-config-operator:latest \
                                 machine-config-controller=quay.io/user/machine-config-controller:latest \
                                 machine-config-daemon=quay.io/user/machine-config-daemon:latest \
@@ -268,5 +268,5 @@ In order to use your new custom release payload to install a new cluster, simply
 the `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` environment variable like so:
 
 ```
-OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/user/origin-release:v4.0 bin/openshift-install create cluster --log-level=debug
+OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/user/origin-release:v4.1 bin/openshift-install create cluster --log-level=debug
 ```

--- a/docs/PullSecret.md
+++ b/docs/PullSecret.md
@@ -1,0 +1,17 @@
+# Changing the payload pull secret
+
+The pull secret is used to pull the release payload image and it's currently stored as a secret in openshift-config/pull-secret.
+The ControllerConfig has an ObjectRefrence pointing to said secret and the Operator sets this up during its sync.
+The reference is then used by the TemplateController to grab the actual pull secret and generate the templates for MachineConfigs using it.
+That results in the pull secret being laid down on nodes, therefore nodes are now be able to pull the release payload image.
+
+The pull secret has an expiration, and when it expires you need to change it as follows:
+
+```
+oc edit secrets pull-secret -n openshift-config
+```
+
+Changing the `.dockerconfigjson` in the secret and saving it will result in the MCO syncing the new pull secret with the templates which then
+result in the new pull secret being laid down on nodes.
+
+Note that the `.dockerconfigjson` field is a base64 encoded JSON. 

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -27,12 +27,13 @@ func resyncPeriod() func() time.Duration {
 type ControllerContext struct {
 	ClientBuilder *clients.Builder
 
-	NamespacedInformerFactory     mcfginformers.SharedInformerFactory
-	InformerFactory               mcfginformers.SharedInformerFactory
-	KubeInformerFactory           informers.SharedInformerFactory
-	KubeNamespacedInformerFactory informers.SharedInformerFactory
-	APIExtInformerFactory         apiextinformers.SharedInformerFactory
-	ConfigInformerFactory         configinformers.SharedInformerFactory
+	NamespacedInformerFactory                    mcfginformers.SharedInformerFactory
+	InformerFactory                              mcfginformers.SharedInformerFactory
+	KubeInformerFactory                          informers.SharedInformerFactory
+	KubeNamespacedInformerFactory                informers.SharedInformerFactory
+	OpenShiftConfigKubeNamespacedInformerFactory informers.SharedInformerFactory
+	APIExtInformerFactory                        apiextinformers.SharedInformerFactory
+	ConfigInformerFactory                        configinformers.SharedInformerFactory
 
 	AvailableResources map[schema.GroupVersionResource]bool
 
@@ -53,19 +54,21 @@ func CreateControllerContext(cb *clients.Builder, stop <-chan struct{}, targetNa
 	sharedNamespacedInformers := mcfginformers.NewFilteredSharedInformerFactory(client, resyncPeriod()(), targetNamespace, nil)
 	kubeSharedInformer := informers.NewSharedInformerFactory(kubeClient, resyncPeriod()())
 	kubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), targetNamespace, nil)
+	openShiftConfigKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), "openshift-config", nil)
 	apiExtSharedInformer := apiextinformers.NewSharedInformerFactory(apiExtClient, resyncPeriod()())
 	configSharedInformer := configinformers.NewSharedInformerFactory(configClient, resyncPeriod()())
 
 	return &ControllerContext{
-		ClientBuilder:                 cb,
-		NamespacedInformerFactory:     sharedNamespacedInformers,
-		InformerFactory:               sharedInformers,
-		KubeInformerFactory:           kubeSharedInformer,
-		KubeNamespacedInformerFactory: kubeNamespacedSharedInformer,
-		APIExtInformerFactory:         apiExtSharedInformer,
-		ConfigInformerFactory:         configSharedInformer,
-		Stop:                          stop,
-		InformersStarted:              make(chan struct{}),
-		ResyncPeriod:                  resyncPeriod(),
+		ClientBuilder:                                cb,
+		NamespacedInformerFactory:                    sharedNamespacedInformers,
+		InformerFactory:                              sharedInformers,
+		KubeInformerFactory:                          kubeSharedInformer,
+		KubeNamespacedInformerFactory:                kubeNamespacedSharedInformer,
+		OpenShiftConfigKubeNamespacedInformerFactory: openShiftConfigKubeNamespacedSharedInformer,
+		APIExtInformerFactory:                        apiExtSharedInformer,
+		ConfigInformerFactory:                        configSharedInformer,
+		Stop:                                         stop,
+		InformersStarted:                             make(chan struct{}),
+		ResyncPeriod:                                 resyncPeriod(),
 	}
 }

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -28,7 +28,6 @@ const (
 )
 
 func (ctrl *Controller) featureWorker() {
-	glog.Infof("FeatureWorker")
 	for ctrl.processNextFeatureWorkItem() {
 	}
 }
@@ -47,7 +46,6 @@ func (ctrl *Controller) processNextFeatureWorkItem() bool {
 
 func (ctrl *Controller) syncFeatureHandler(key string) error {
 	startTime := time.Now()
-
 	glog.V(4).Infof("Started syncing feature handler %q (%v)", key, startTime)
 	defer func() {
 		glog.V(4).Infof("Finished syncing feature handler %q (%v)", key, time.Since(startTime))

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -13,6 +13,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
+	coreinformersv1 "k8s.io/client-go/informers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,9 +82,10 @@ func (f *fixture) newController() *Controller {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
 
+	cinformer := coreinformersv1.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 	c := New(templateDir,
-		i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(),
+		i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), cinformer.Core().V1().Secrets(),
 		f.kubeclient, f.client)
 
 	c.ccListerSynced = alwaysReady


### PR DESCRIPTION
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1686117

I've noticed, from code, that we don't trigger a resync when the
pull-secret changes. That leaves us with just a "oc delete pod
controller" to actually trigger a resync with a changed pull-secret.

Added an event handler for that particular secret to trigger a re-sync.

Also added a new doc explaining how to change the pull-secret (taking
care of the referenced BZ).

Signed-off-by: Antonio Murdaca <runcom@linux.com>