### PR TITLE
featuregates: remove ownerref reference on managed feature gates

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	osev1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/vincent-petithory/dataurl"
@@ -37,6 +38,14 @@ func createNewKubeletIgnition(ymlconfig []byte) ignv2_2types.Config {
 	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	tempIgnConfig.Storage.Files = append(tempIgnConfig.Storage.Files, tempFile)
 	return tempIgnConfig
+}
+
+func createNewDefaultFeatureGate() *osev1.FeatureGate {
+	return &osev1.FeatureGate{
+		Spec: osev1.FeatureGateSpec{
+			FeatureSet: osev1.Default,
+		},
+	}
 }
 
 func findKubeletConfig(mc *mcfgv1.MachineConfig) (*ignv2_2types.File, error) {

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -406,12 +406,13 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 	}
 
 	features, err := ctrl.featLister.Get(clusterFeatureInstanceName)
-	if err != nil && !errors.IsNotFound(err) {
-		err := fmt.Errorf("could not fetch FeatureGates: %v", err)
+	if errors.IsNotFound(err) {
+		features = createNewDefaultFeatureGate()
+	} else if err != nil {
 		glog.V(2).Infof("%v", err)
+		err := fmt.Errorf("could not fetch FeatureGates: %v", err)
 		return ctrl.syncStatusOnly(cfg, err)
 	}
-	features = features.DeepCopy()
 	featureGates, err := ctrl.generateFeatureMap(features)
 	if err != nil {
 		err := fmt.Errorf("could not generate FeatureMap: %v", err)

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -193,6 +193,10 @@ func (f *fixture) run(mcpname string) {
 	f.runController(mcpname, false)
 }
 
+func (f *fixture) runFeature(featname string) {
+	f.runFeatureController(featname, false)
+}
+
 func (f *fixture) runExpectError(mcpname string) {
 	f.runController(mcpname, true)
 }
@@ -201,6 +205,19 @@ func (f *fixture) runController(mcpname string, expectError bool) {
 	c := f.newController()
 
 	err := c.syncHandler(mcpname)
+	if !expectError && err != nil {
+		f.t.Errorf("error syncing kubeletconfigs: %v", err)
+	} else if expectError && err == nil {
+		f.t.Error("expected error syncing kubeletconfigs, got nil")
+	}
+
+	f.validateActions()
+}
+
+func (f *fixture) runFeatureController(featname string, expectError bool) {
+	c := f.newController()
+
+	err := c.syncFeatureHandler(featname)
 	if !expectError && err != nil {
 		f.t.Errorf("error syncing kubeletconfigs: %v", err)
 	} else if expectError && err == nil {
@@ -515,6 +532,15 @@ func getKey(config *mcfgv1.KubeletConfig, t *testing.T) string {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(config)
 	if err != nil {
 		t.Errorf("Unexpected error getting key for config %v: %v", config.Name, err)
+		return ""
+	}
+	return key
+}
+
+func getKeyFromFeatureGate(gate *osev1.FeatureGate, t *testing.T) string {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(gate)
+	if err != nil {
+		t.Errorf("Unexpected error getting key for FeatureGate %v: %v", gate.Name, err)
 		return ""
 	}
 	return key

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -18,7 +18,6 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	osev1 "github.com/openshift/api/config/v1"
-	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	mtmpl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -120,14 +119,6 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		mc.ObjectMeta.Annotations = map[string]string{
 			ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Version.String(),
 		}
-		mc.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			metav1.OwnerReference{
-				APIVersion: mcfgv1.SchemeGroupVersion.String(),
-				Kind:       "Features",
-				Name:       features.Name,
-				UID:        features.UID,
-			},
-		}
 		// Create or Update, on conflict retry
 		if err := retry.RetryOnConflict(updateBackoff, func() error {
 			var err error
@@ -189,9 +180,6 @@ func (ctrl *Controller) deleteFeature(obj interface{}) {
 
 func (ctrl *Controller) generateFeatureMap(features *osev1.FeatureGate) (*map[string]bool, error) {
 	rv := make(map[string]bool)
-	if features == nil {
-		return &rv, nil
-	}
 	set, ok := osev1.FeatureSets[features.Spec.FeatureSet]
 	if !ok {
 		return &rv, fmt.Errorf("enabled FeatureSet %v does not have a corresponding config", features.Spec.FeatureSet)

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -1,0 +1,38 @@
+package kubeletconfig
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/openshift/machine-config-operator/pkg/controller/common"
+)
+
+func TestFeaturesDefault(t *testing.T) {
+	for _, platform := range []string{"aws", "none", "unrecognized"} {
+		t.Run(platform, func(t *testing.T) {
+			f := newFixture(t)
+
+			cc := newControllerConfig(common.ControllerConfigName, platform)
+			mcp := newMachineConfigPool("master", map[string]string{"kubeletType": "small-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
+			mcp2 := newMachineConfigPool("worker", map[string]string{"kubeletType": "large-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
+			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []ignv2_2types.File{{}})
+			mcs2 := newMachineConfig(getManagedKubeletConfigKey(mcp2), map[string]string{"node-role": "worker"}, "dummy://", []ignv2_2types.File{{}})
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+			f.mcpLister = append(f.mcpLister, mcp2)
+
+			features := createNewDefaultFeatureGate()
+			f.featLister = append(f.featLister, features)
+
+			f.expectGetMachineConfigAction(mcs)
+			f.expectCreateMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectCreateMachineConfigAction(mcs2)
+
+			f.runFeature(getKeyFromFeatureGate(features, t))
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**
* The ownerref is not needed on a featuregate change and causes issues
  on attempted deletions/modifications later.
* Add unit test
* [The line for the actual fix](https://github.com/openshift/machine-config-operator/pull/634/files#diff-7fdca55408b7882f7cf5d546eccb969eL123)

**- How to verify it**
* Unit test

**- Description for the changelog**
```
None
```

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1699353