### PR TITLE
templates: set sysctl net.ipv4.tcp_keepalive_time to 30sec

### DIFF
--- a/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-sysctl.d-tcp_keepalive.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-sysctl.d-tcp_keepalive.conf
@@ -1,0 +1,6 @@
+contents:
+  source: data:,net.ipv4.tcp_keepalive_time%20%3D%2030%0A
+  verification: {}
+filesystem: root
+mode: 420
+path: /etc/sysctl.d/tcp_keepalive.conf

--- a/templates/master/00-master/_base/files/sysctl-keepalive.yaml
+++ b/templates/master/00-master/_base/files/sysctl-keepalive.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/tcp_keepalive.conf"
+contents:
+  inline: |
+    net.ipv4.tcp_keepalive_time = 30
+

--- a/templates/worker/00-worker/_base/files/sysctl-keepalive.yaml
+++ b/templates/worker/00-worker/_base/files/sysctl-keepalive.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/tcp_keepalive.conf"
+contents:
+  inline: |
+    net.ipv4.tcp_keepalive_time = 30
+


### PR DESCRIPTION
This sets the interval for which the kernel will send TCP keepalives, in
seconds. The default, 7200, is too high and causes idle but alive
connections to be dropped by middleboxes and load balancers.

**- How to verify it**
```
$ sysctl net.ipv4.tcp_keepalive_time
net.ipv4.tcp_keepalive_time = 30
```

**- Description for the changelog**
Update tcp_keepalive_time to 30 seconds.
