### PR TITLE
Bug 1698250: *: pt2 NodeSelector transition : remove all MachineSelector refs

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -33,15 +33,6 @@ func EnsureMachineConfigPool(modified *bool, existing *mcfgv1.MachineConfigPool,
 		existing.Spec.MachineConfigSelector = required.Spec.MachineConfigSelector
 	}
 
-	if existing.Spec.MachineSelector == nil {
-		*modified = true
-		existing.Spec.MachineSelector = required.Spec.MachineSelector
-	}
-	if !equality.Semantic.DeepEqual(existing.Spec.MachineSelector, required.Spec.MachineSelector) {
-		*modified = true
-		existing.Spec.MachineSelector = required.Spec.MachineSelector
-	}
-
 	if existing.Spec.NodeSelector == nil {
 		*modified = true
 		existing.Spec.NodeSelector = required.Spec.NodeSelector

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -289,10 +289,7 @@ type MachineConfigPoolSpec struct {
 	// Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ on how label and selectors work.
 	MachineConfigSelector *metav1.LabelSelector `json:"machineConfigSelector,omitempty"`
 
-	// Label selector for Machines.
-	MachineSelector *metav1.LabelSelector `json:"machineSelector,omitempty"`
-
-	// Node selector for Machines, to replace MachineSelector
+	// Node selector for Machines
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 
 	// If true, changes to this machine config pool should be stopped.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -623,11 +623,6 @@ func (in *MachineConfigPoolSpec) DeepCopyInto(out *MachineConfigPoolSpec) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.MachineSelector != nil {
-		in, out := &in.MachineSelector, &out.MachineSelector
-		*out = new(metav1.LabelSelector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = new(metav1.LabelSelector)

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -265,17 +265,9 @@ func (ctrl *Controller) getPoolForNode(node *corev1.Node) (*mcfgv1.MachineConfig
 
 	var pools []*mcfgv1.MachineConfigPool
 	for _, p := range pl {
-		// first get MachineSelector
-		selector, err := metav1.LabelSelectorAsSelector(p.Spec.MachineSelector)
+		selector, err := metav1.LabelSelectorAsSelector(p.Spec.NodeSelector)
 		if err != nil {
 			return nil, fmt.Errorf("invalid label selector: %v", err)
-		}
-		// if MachineSelector is empty, get and use NodeSelector
-		if p.Spec.MachineSelector == nil {
-			selector, err = metav1.LabelSelectorAsSelector(p.Spec.NodeSelector)
-			if err != nil {
-				return nil, fmt.Errorf("invalid label selector: %v", err)
-			}
 		}
 
 		// If a pool with a nil or empty selector creeps in, it should match nothing, not everything.
@@ -433,7 +425,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	pool := machineconfigpool.DeepCopy()
 	everything := metav1.LabelSelector{}
 
-	if reflect.DeepEqual(pool.Spec.MachineSelector, &everything) && reflect.DeepEqual(pool.Spec.NodeSelector, &everything) {
+	if reflect.DeepEqual(pool.Spec.NodeSelector, &everything) {
 		ctrl.eventRecorder.Eventf(pool, v1.EventTypeWarning, "SelectingAll", "This machineconfigpool is selecting all nodes. A non-empty selector is required.")
 		return nil
 	}
@@ -445,16 +437,10 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	if pool.Spec.Paused {
 		return ctrl.syncStatusOnly(pool)
 	}
-	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.MachineSelector)
+
+	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
 	if err != nil {
-		return err
-	}
-	// if MachineSelector is empty, get and use NodeSelector
-	if pool.Spec.MachineSelector == nil {
-		selector, err = metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
-		if err != nil {
-			return fmt.Errorf("invalid label selector: %v", err)
-		}
+		return fmt.Errorf("invalid label selector: %v", err)
 	}
 	nodes, err := ctrl.nodeLister.List(selector)
 	if err != nil {

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -61,9 +61,8 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, maxUnavai
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: mcfgv1.MachineConfigPoolSpec{
-			MachineSelector: selector,
-			NodeSelector:    selector,
-			MaxUnavailable:  maxUnavail,
+			NodeSelector:   selector,
+			MaxUnavailable: maxUnavail,
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -12,15 +12,9 @@ import (
 )
 
 func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
-	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.MachineSelector)
+	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
 	if err != nil {
 		return err
-	}
-	if pool.Spec.MachineSelector == nil {
-		selector, err = metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
-		if err != nil {
-			return err
-		}
 	}
 	nodes, err := ctrl.nodeLister.List(selector)
 	if err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This PR removes all references to MachineSelector. PR 625 added NodeSelector
in addition to MachineSelector to allow for users to transition. This PR fully
removes all references to MachineSelector to make the transition complete.

Related-to: #625
Related-to: BZ 1698250

**- How to verify it**
CI, nothing should change functionally.


