### PR TITLE
render_controller: render on template MCs changes

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -15,7 +15,7 @@ import (
 	mcfginformersv1 "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions/machineconfiguration.openshift.io/v1"
 	mcfglistersv1 "github.com/openshift/machine-config-operator/pkg/generated/listers/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/version"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,14 +170,13 @@ func (ctrl *Controller) addMachineConfig(obj interface{}) {
 		return
 	}
 
-	if controllerRef := metav1.GetControllerOf(mc); controllerRef != nil {
-		pool := ctrl.resolveControllerRef(controllerRef)
-		if pool == nil {
+	controllerRef := metav1.GetControllerOf(mc)
+	if controllerRef != nil {
+		if pool := ctrl.resolveControllerRef(controllerRef); pool != nil {
+			glog.V(4).Infof("MachineConfig %s added", mc.Name)
+			ctrl.enqueueMachineConfigPool(pool)
 			return
 		}
-		glog.V(4).Infof("MachineConfig %s added", mc.Name)
-		ctrl.enqueueMachineConfigPool(pool)
-		return
 	}
 
 	pools, err := ctrl.getPoolsForMachineConfig(mc)
@@ -205,13 +204,11 @@ func (ctrl *Controller) updateMachineConfig(old, cur interface{}) {
 	}
 
 	if curControllerRef != nil {
-		pool := ctrl.resolveControllerRef(curControllerRef)
-		if pool == nil {
+		if pool := ctrl.resolveControllerRef(curControllerRef); pool != nil {
+			glog.V(4).Infof("MachineConfig %s updated", curMC.Name)
+			ctrl.enqueueMachineConfigPool(pool)
 			return
 		}
-		glog.V(4).Infof("MachineConfig %s updated", curMC.Name)
-		ctrl.enqueueMachineConfigPool(pool)
-		return
 	}
 
 	pools, err := ctrl.getPoolsForMachineConfig(curMC)
@@ -242,14 +239,13 @@ func (ctrl *Controller) deleteMachineConfig(obj interface{}) {
 		}
 	}
 
-	if controllerRef := metav1.GetControllerOf(mc); controllerRef != nil {
-		pool := ctrl.resolveControllerRef(controllerRef)
-		if pool == nil {
+	controllerRef := metav1.GetControllerOf(mc)
+	if controllerRef != nil {
+		if pool := ctrl.resolveControllerRef(controllerRef); pool != nil {
+			glog.V(4).Infof("MachineConfig %s deleted", mc.Name)
+			ctrl.enqueueMachineConfigPool(pool)
 			return
 		}
-		glog.V(4).Infof("MachineConfig %s deleted", mc.Name)
-		ctrl.enqueueMachineConfigPool(pool)
-		return
 	}
 
 	pools, err := ctrl.getPoolsForMachineConfig(mc)


### PR DESCRIPTION
I was working on triggering a resync when the pull-secret change and I
got to this:

- pull-secret changes
- template_controller runs and update 00-<role> with the new pull-secret
- stop, the new pull secret is now just in 00-<role> MCs and not on
nodes since there's no rendered MC which contains it

Now, the above isn't quite right since after an admin updates the
pull-secret, it must be rolled out to nodes to be able to pull images
(for e.g. an upgrade).
What's happening is that the template_controller sets an OwnerReference
of Kind: ControllerConfig, whether the render_controller only reacts to
a Kind: MachineConfigPool (and MCs that aren't controller at all, like
the template_controller tho).

This patch fixes the controller checks and we now enqueue an MCP for the
given MC if we have a pool anyway.

Signed-off-by: Antonio Murdaca <runcom@linux.com>