### PR TITLE
MCC: drop memory limit

### DIFF
--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         - "--resourcelock-namespace={{.TargetNamespace}}"
         - "--v=2"
         resources:
-          limits:
-            memory: 50Mi
           requests:
             cpu: 20m
             memory: 50Mi

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -426,8 +426,6 @@ spec:
         - "--resourcelock-namespace={{.TargetNamespace}}"
         - "--v=2"
         resources:
-          limits:
-            memory: 50Mi
           requests:
             cpu: 20m
             memory: 50Mi


### PR DESCRIPTION
Drop the memory limit of 50Mi from the MCC deployment since it doesn't
really make sense for the component to have a limit. The MCC deals with
informers and MCs as well and it really makes little sense to cap on
memory, and 50Mi is really low as seen in other PRs.

On top of that, setting memory limits for core component on the
control plan is something that we are recommended NOT to do as this test
in origin says: https://github.com/openshift/origin/pull/22095/files#diff-bf7568debb85800236085e7e6de8cb07R67

So, comply with that test and avoid bad OOMs that can cause issues once
we're deployed for real and people have huge MCs and objects from
informers to deal with.

Signed-off-by: Antonio Murdaca <runcom@linux.com>

/cc @derekwaynecarr @abhinavdahiya 