### PR TITLE
update etcd servicing-ca location for api freeze

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -316,7 +316,7 @@ func (optr *Operator) sync(key string) error {
 	}
 
 	// sync up CAs
-	etcdCA, err := optr.getCAsFromConfigMap("kube-system", "etcd-serving-ca", "ca-bundle.crt")
+	etcdCA, err := optr.getCAsFromConfigMap("openshift-config", "etcd-serving-ca", "ca-bundle.crt")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
API freeze doc wants user managed resources in openshift-config.  The installer already moved this one.  This updates the location for the MCO

