### PR TITLE
DR: pkg/daemon: reconcile current on disk on boot

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -212,6 +212,18 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		}
 	}()
 
+	if err := dn.storeCurrentConfigOnDisk(newConfig); err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			if err := dn.storeCurrentConfigOnDisk(oldConfig); err != nil {
+				retErr = errors.Wrapf(retErr, "error rolling back current config on disk %v", err)
+				return
+			}
+		}
+	}()
+
 	return dn.updateOSAndReboot(newConfig)
 }
 


### PR DESCRIPTION
We are checking and reconciling any skew once we're actively running as
a controller in prepUpdateFromCluster already.
This patch enhance that so that we reconcile any drift directly when we
bring up the MCD on a node.
This has the advantage of an easy trigger when, for instance, we want to
kick a reconcile after an etcd backup has been restored: we simple
restart the MCD (or we find a way to automate that or whatever, not in
scope for this PR).