### PR TITLE
add permissions to the cluster-reader role

### DIFF
--- a/install/0000_30_machine-config-operator-00_clusterreader_clusterrole.yaml
+++ b/install/0000_30_machine-config-operator-00_clusterreader_clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:machine-config-operator:cluster-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - containerruntimeconfigs
+      - controllerconfigs
+      - kubeletconfigs
+      - machineconfigpools
+      - mcoconfigs
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Adds permissions to non-sensitive API resources for cluster-reader.

The general rule is that they can read all non-escalating resources, so not things like secrets, oauthtokens