### PR TITLE
pkg/daemon: abstract NodeWriter to an interface

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -89,7 +89,7 @@ type Daemon struct {
 
 	installedSigterm bool
 
-	nodeWriter *NodeWriter
+	nodeWriter NodeWriter
 
 	// channel used by callbacks to signal Run() of an error
 	exitCh chan<- error
@@ -179,7 +179,7 @@ func New(
 	kubeClient kubernetes.Interface,
 	kubeletHealthzEnabled bool,
 	kubeletHealthzEndpoint string,
-	nodeWriter *NodeWriter,
+	nodeWriter NodeWriter,
 	exitCh chan<- error,
 	stopCh <-chan struct{},
 ) (*Daemon, error) {
@@ -234,7 +234,7 @@ func NewClusterDrivenDaemon(
 	nodeInformer coreinformersv1.NodeInformer,
 	kubeletHealthzEnabled bool,
 	kubeletHealthzEndpoint string,
-	nodeWriter *NodeWriter,
+	nodeWriter NodeWriter,
 	exitCh chan<- error,
 	stopCh <-chan struct{},
 ) (*Daemon, error) {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -209,7 +209,7 @@ func (f *fixture) newController() *Daemon {
 		k8sI.Core().V1().Nodes(),
 		false,
 		"",
-		nil,
+		newFakeNodeWriter(),
 		nil,
 		nil,
 	)

--- a/pkg/daemon/fake_writer.go
+++ b/pkg/daemon/fake_writer.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+)
+
+// fakeNodeWriter is a fake single writer to Kubernetes to prevent race conditions
+type fakeNodeWriter struct {
+}
+
+// newFakeNodeWriter Create a new NodeWriter
+func newFakeNodeWriter() NodeWriter {
+	return &fakeNodeWriter{}
+}
+
+// Run reads from the writer channel and sets the node annotation. It will
+// return if the stop channel is closed. Intended to be run via a goroutine.
+func (nw *fakeNodeWriter) Run(stop <-chan struct{}) {
+}
+
+// SetDone sets the state to Done.
+func (nw *fakeNodeWriter) SetDone(client corev1.NodeInterface, lister corelisterv1.NodeLister, node string, dcAnnotation string) error {
+	return nil
+}
+
+// SetWorking sets the state to Working.
+func (nw *fakeNodeWriter) SetWorking(client corev1.NodeInterface, lister corelisterv1.NodeLister, node string) error {
+	return nil
+}
+
+// SetUnreconcilable sets the state to Unreconcilable.
+func (nw *fakeNodeWriter) SetUnreconcilable(err error, client corev1.NodeInterface, lister corelisterv1.NodeLister, node string) error {
+	return nil
+}
+
+// SetDegraded logs the error and sets the state to Degraded.
+// Returns an error if it couldn't set the annotation.
+func (nw *fakeNodeWriter) SetDegraded(err error, client corev1.NodeInterface, lister corelisterv1.NodeLister, node string) error {
+	return nil
+}
+
+// SetSSHAccessed sets the ssh annotation to accessed
+func (nw *fakeNodeWriter) SetSSHAccessed(client corev1.NodeInterface, lister corelisterv1.NodeLister, node string) error {
+	return nil
+}


### PR DESCRIPTION
Current units are broken on master on linux since the NodeWriter is nil
in fixtures (sorry I didn't catch that on osx).
Anyway, this patch finally abstract NodeWriter behing an interface so
it's easy to use it in tests as well. I've created a fakeNodeWriter
which can also be expanted in the future to make assertions if needed
(like counting actions and stuff like that).

cc @LorbusChris since you spotted this one