### PR TITLE
Drop os_version label on nodes

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=aws \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider= \

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
@@ -20,7 +20,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=vsphere \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
@@ -19,7 +19,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -22,7 +22,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -21,7 +21,7 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --allow-privileged \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_version=${VERSION_ID},node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \


### PR DESCRIPTION
It isn't useful today because most containers just want the RHEL major
which they can't get at without parsing it, and you can't do that
in a selector.

Also, it turns out that the label commandline is a one-shot.  We
need to move any label version updates into the MCD.
