### PR TITLE
*: add resource sync for etcd-quorum-guard

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -399,6 +399,7 @@ func (optr *Operator) sync(key string) error {
 		{"mcs", optr.syncMachineConfigServer},
 		{"mcd", optr.syncMachineConfigDaemon},
 		{"required-pools", optr.syncRequiredMachineConfigPools},
+		{"required-resources", optr.syncRequiredMachineConfigResources},
 	}
 	return optr.syncAll(rc, syncFuncs)
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -345,6 +345,35 @@ func (optr *Operator) syncRequiredMachineConfigPools(config renderConfig) error 
 	return nil
 }
 
+// syncRequiredMachineConfigResources ensures that the ConfigMap and Secret resources are synced from source namespace to destination.
+func (optr *Operator) syncRequiredMachineConfigResources(config renderConfig) error {
+	sourceNamespace := "openshift-config"
+	destinationNamespace := "openshift-etcd"
+
+	_, _, err := resourceapply.SyncConfigMap(
+		optr.kubeClient.CoreV1(),
+		sourceNamespace,
+		"etcd-metric-serving-ca",
+		destinationNamespace,
+		"etcd-metric-serving-ca",
+		[]metav1.OwnerReference{})
+	if err != nil {
+		return err
+	}
+
+	_, _, errs := resourceapply.SyncSecret(
+		optr.kubeClient.CoreV1(),
+		sourceNamespace,
+		"etcd-metric-client",
+		destinationNamespace,
+		"etcd-metric-client",
+		[]metav1.OwnerReference{})
+	if errs != nil {
+		return errs
+	}
+	return nil
+}
+
 const (
 	deploymentRolloutPollInterval = time.Second
 	deploymentRolloutTimeout      = 10 * time.Minute


### PR DESCRIPTION
This PR adds functionality which will sync ConfigMaps and Secrets from `openshift-config` namespace to `openshift-etcd`. The result will be etcd TLS resources available for etcd-quorum-guard to consume.

Note: although etcd-quorum-guard is solo it still requires the same assets.