### PR TITLE
pkg/daemon: add more events and logging

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -341,6 +341,7 @@ func (dn *Daemon) handleErr(err error, key interface{}) {
 	}
 
 	dn.updateErrorState(err)
+	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeWarning, "MCDSyncFailure", err.Error())
 
 	if dn.queue.NumRequeues(key) < maxRetries {
 		glog.V(2).Infof("Error syncing node %v: %v", key, err)
@@ -789,8 +790,10 @@ func (dn *Daemon) CheckStateOnBoot() error {
 	// a once-a-day or week cron job.
 	var expectedConfig *mcfgv1.MachineConfig
 	if state.pendingConfig != nil {
+		glog.Infof("Validating against pending config %s", state.pendingConfig.GetName())
 		expectedConfig = state.pendingConfig
 	} else {
+		glog.Infof("Validating against current config %s", state.currentConfig.GetName())
 		expectedConfig = state.currentConfig
 	}
 	if isOnDiskValid := dn.validateOnDiskState(expectedConfig); !isOnDiskValid {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -139,6 +139,9 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) error {
 	if err := dn.writePendingState(newConfig); err != nil {
 		return errors.Wrapf(err, "writing pending state")
 	}
+	if dn.recorder != nil {
+		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "PendingConfig", fmt.Sprintf("Written pending config %s", newConfig.GetName()))
+	}
 
 	// reboot. this function shouldn't actually return.
 	return dn.reboot(fmt.Sprintf("Node will reboot into config %v", newConfig.GetName()), defaultRebootTimeout, exec.Command(defaultRebootCommand))


### PR DESCRIPTION
making it easier to debug stuff like https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/22653/pull-ci-openshift-origin-master-e2e-aws-upgrade/89 

I believe we failed to reboot, but we lost logs since we keep writing only the last error and overriding the previous so we're left with just "unexpected on-disk state".

This patch fires some more events which are persisted anyway during a job.