### PR TITLE
pkg/daemon: roll back pending config on error

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -157,17 +157,21 @@ func isNodeReady(node *corev1.Node) bool {
 		// - NodeOutOfDisk condition status is ConditionFalse,
 		// - NodeNetworkUnavailable condition status is ConditionFalse.
 		if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
+			glog.Infof("Node %s is reporting NotReady", node.Name)
 			return false
 		}
 		if cond.Type == corev1.NodeOutOfDisk && cond.Status != corev1.ConditionFalse {
+			glog.Infof("Node %s is reporting OutOfDisk", node.Name)
 			return false
 		}
 		if cond.Type == corev1.NodeNetworkUnavailable && cond.Status != corev1.ConditionFalse {
+			glog.Infof("Node %s is reporting NetworkUnavailable", node.Name)
 			return false
 		}
 	}
 	// Ignore nodes that are marked unschedulable
 	if node.Spec.Unschedulable {
+		glog.Infof("Node %s is reporting Unschedulable", node.Name)
 		return false
 	}
 	return true
@@ -191,7 +195,7 @@ func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev
 		nodeNotReady := !isNodeReady(node)
 		if dconfig == currentConfig && (dconfig != cconfig || nodeNotReady) {
 			unavail = append(unavail, node)
-			glog.V(2).Infof("Node %s unavailable: different configs %v or node not ready %v", node.Name, dconfig != cconfig, nodeNotReady)
+			glog.V(2).Infof("Node %s unavailable: different configs (desired: %s, current %s) or node not ready %v", node.Name, dconfig, cconfig, nodeNotReady)
 		}
 	}
 	return unavail

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -797,8 +797,8 @@ func (dn *Daemon) CheckStateOnBoot() error {
 		glog.Infof("Validating against current config %s", state.currentConfig.GetName())
 		expectedConfig = state.currentConfig
 	}
-	if isOnDiskValid := dn.validateOnDiskState(expectedConfig); !isOnDiskValid {
-		return errors.New("unexpected on-disk state")
+	if !dn.validateOnDiskState(expectedConfig) {
+		return fmt.Errorf("unexpected on-disk state validating against %s", expectedConfig.GetName())
 	}
 	glog.Info("Validated on-disk state")
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -810,7 +810,7 @@ func (dn *Daemon) CheckStateOnBoot() error {
 	// we don't uncordon and then immediately re-cordon)
 	if state.pendingConfig != nil {
 		if err := dn.nodeWriter.SetDone(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, state.pendingConfig.GetName()); err != nil {
-			return err
+			return errors.Wrap(err, "error setting node's state to Done")
 		}
 		// And remove the pending state file
 		if err := os.Remove(pathStateJSON); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -101,6 +101,21 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr err
 		return err
 	}
 
+	if err := dn.writePendingState(newConfig); err != nil {
+		return errors.Wrapf(err, "writing pending state")
+	}
+	defer func() {
+		if retErr != nil {
+			if err := os.Remove(pathStateJSON); err != nil {
+				retErr = errors.Wrapf(retErr, "error removing pending config file %v", err)
+				return
+			}
+		}
+	}()
+	if dn.recorder != nil {
+		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "PendingConfig", fmt.Sprintf("Written pending config %s", newConfig.GetName()))
+	}
+
 	// Skip draining of the node when we're not cluster driven
 	if dn.onceFrom == "" {
 		glog.Info("Update prepared; draining the node")
@@ -126,7 +141,6 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr err
 			lastErr = err
 			glog.Infof("Draining failed with: %v, retrying", err)
 			return false, nil
-
 		}); err != nil {
 			if err == wait.ErrWaitTimeout {
 				return errors.Wrapf(lastErr, "failed to drain node (%d tries): %v", backoff.Steps, err)
@@ -134,21 +148,6 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr err
 			return errors.Wrap(err, "failed to drain node")
 		}
 		glog.Info("Node successfully drained")
-	}
-
-	if err := dn.writePendingState(newConfig); err != nil {
-		return errors.Wrapf(err, "writing pending state")
-	}
-	defer func() {
-		if retErr != nil {
-			if err := os.Remove(pathStateJSON); err != nil {
-				retErr = errors.Wrapf(retErr, "error removing pending config file %v", err)
-				return
-			}
-		}
-	}()
-	if dn.recorder != nil {
-		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "PendingConfig", fmt.Sprintf("Written pending config %s", newConfig.GetName()))
 	}
 
 	// reboot. this function shouldn't actually return.
@@ -716,6 +715,9 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig) error {
 	if osMatch {
 		return nil
 	}
+	if dn.recorder != nil {
+		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "InClusterUpgrade", fmt.Sprintf("In cluster upgrade to %s", newURL))
+	}
 
 	glog.Infof("Updating OS to %s", newURL)
 	if err := dn.NodeUpdaterClient.RunPivot(newURL); err != nil {
@@ -782,7 +784,7 @@ func (dn *Daemon) reboot(rationale string, timeout time.Duration, rebootCmd *exe
 	// in the context of the host asynchronously from us
 	err := rebootCmd.Run()
 	if err != nil {
-		return errors.Wrapf(err, "Failed to reboot")
+		return errors.Wrapf(err, "failed to reboot")
 	}
 
 	// wait to be killed via SIGTERM from the kubelet shutting down

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -96,7 +96,7 @@ func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
 
 // updateOSAndReboot is the last step in an update(), and it can also
 // be called as a special case for the "bootstrap pivot".
-func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) error {
+func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr error) {
 	if err := dn.updateOS(newConfig); err != nil {
 		return err
 	}
@@ -139,6 +139,14 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) error {
 	if err := dn.writePendingState(newConfig); err != nil {
 		return errors.Wrapf(err, "writing pending state")
 	}
+	defer func() {
+		if retErr != nil {
+			if err := os.Remove(pathStateJSON); err != nil {
+				retErr = errors.Wrapf(retErr, "error removing pending config file %v", err)
+				return
+			}
+		}
+	}()
 	if dn.recorder != nil {
 		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "PendingConfig", fmt.Sprintf("Written pending config %s", newConfig.GetName()))
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -188,7 +188,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		}
 		if state != constants.MachineConfigDaemonStateDegraded && state != constants.MachineConfigDaemonStateUnreconcilable {
 			if err := dn.nodeWriter.SetWorking(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name); err != nil {
-				return err
+				return errors.Wrap(err, "error setting node's state to Working")
 			}
 		}
 	}


### PR DESCRIPTION
If we fail something after we write files to disk for desired config we
now roll back to files for current config.
In case we fail _after_ writing the pending config file, we still roll
back files but we never remove the pending config.
I was debugging
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/22653/pull-ci-openshift-origin-master-e2e-aws-upgrade/89
and what it looks like it's happening is that we wrote the pending
config but we then errored, rolling back files but leaving that pending
config file around which made the MCD restart fail (also hiding the real
failure error on reboot).