### PR TITLE
controller/template: put the cloudconf for kubelet behind platform gate

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -365,14 +365,22 @@ func cloudProvider(cfg RenderConfig) (interface{}, error) {
 // Process the {{cloudConfigFlag .}}
 // If the CloudProviderConfig field is set and not empty, this
 // returns the cloud conf flag for kubelet [1] pointing the kubelet to use
-// /etc/kubernetes/cloud.conf for configuring the cloud provider.
+// /etc/kubernetes/cloud.conf for configuring the cloud provider for select platforms.
+// By default even if CloudProviderConfig fields is set, the kubelet will be configured to used for
+// select platforms only.
 //
 // [1]: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options
 func cloudConfigFlag(cfg RenderConfig) interface{} {
-	if len(cfg.CloudProviderConfig) > 0 {
-		return "--cloud-config=/etc/kubernetes/cloud.conf"
+	if len(cfg.CloudProviderConfig) == 0 {
+		return ""
 	}
-	return ""
+	flag := "--cloud-config=/etc/kubernetes/cloud.conf"
+	switch cfg.Platform {
+	case platformAzure, platformOpenstack:
+		return flag
+	default:
+		return ""
+	}
 }
 
 // existsDir returns true if path exists and is a directory, false if the path

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
@@ -25,7 +25,7 @@ contents: |
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=vsphere \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
-        --cloud-config=/etc/kubernetes/cloud.conf \
+         \
         --anonymous-auth=false \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
 

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
@@ -24,7 +24,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --client-ca-file=/etc/kubernetes/ca.crt \
         --cloud-provider=vsphere \
-        --cloud-config=/etc/kubernetes/cloud.conf \
+         \
         --anonymous-auth=false \
 
   Restart=always


### PR DESCRIPTION
Previously, the assumption was that all platforms that had CloudProviderConfig set can have kubelet configured to
use the config file. But this created a regression for user-provided-infrastructure VSphere case, as everybody like kube-controller-manager etc. except kubelet can use the cloud conf
file from API for vSphere

/cc @staebler 