### PR TITLE
Remove reference to etcd-quorum-guard image, and use cli instead

### DIFF
--- a/install/0000_30_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_30_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -56,9 +56,9 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-      - image: registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+      - image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
         imagePullPolicy: IfNotPresent
-        name: etcd-quorum-guard-container
+        name: guard
         volumeMounts:
         - mountPath: /mnt/kube
           name: kubecerts

--- a/install/image-references
+++ b/install/image-references
@@ -42,7 +42,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift/origin-v4.0:kube-client-agent
-  - name: etcd-quorum-guard
+  - name: cli
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:cli


### PR DESCRIPTION
The quorum guard image does not exist in OCP and agreement was not
to create a new one. Use the CLI image which is required to have
bash. Simplify the container name to be easier to input when debugging.