### PR TITLE
mcd: Allow enabling units even if no content was provided

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -541,12 +541,6 @@ func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
 			glog.V(2).Infof("Wrote systemd unit dropin at %s", dpath)
 		}
 
-		if u.Contents == "" {
-			continue
-		}
-
-		glog.Infof("Writing systemd unit %q", u.Name)
-
 		fpath := filepath.Join(pathSystemd, u.Name)
 
 		// check if the unit is masked. if it is, we write a symlink to
@@ -566,12 +560,16 @@ func (dn *Daemon) writeUnits(units []ignv2_2types.Unit) error {
 			continue
 		}
 
-		// write the unit to disk
-		if err := writeFileAtomicallyWithDefaults(fpath, []byte(u.Contents)); err != nil {
-			return fmt.Errorf("failed to write systemd unit %q: %v", u.Name, err)
-		}
+		if u.Contents != "" {
+			glog.Infof("Writing systemd unit %q", u.Name)
 
-		glog.V(2).Infof("Successfully wrote systemd unit %q: ", u.Name)
+			// write the unit to disk
+			if err := writeFileAtomicallyWithDefaults(fpath, []byte(u.Contents)); err != nil {
+				return fmt.Errorf("failed to write systemd unit %q: %v", u.Name, err)
+			}
+
+			glog.V(2).Infof("Successfully wrote systemd unit %q: ", u.Name)
+		}
 
 		// if the unit doesn't note if it should be enabled or disabled then
 		// skip all linking.


### PR DESCRIPTION
Closes: #679

**- What I did**
when dealing with systemd units, the MCD used to check the "content"
section. If no content was provided, it would skip the unit. This
doesn't work for built-in units, which we could merely enable without
writing anything. This allows that.

**- How to verify it**

**- Description for the changelog**
Allows enabling built-in systemd units without providing the "content" section.
