### PR TITLE
Bug 1704706: remove openshift-sdn and multus CNI configuration files on boot

### DIFF
--- a/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Forigin%2Fopenvswitch%2Fconf.db%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/templates/master/00-master/_base/files/cleanup-cni-conf.yaml
+++ b/templates/master/00-master/_base/files/cleanup-cni-conf.yaml
@@ -3,6 +3,6 @@ mode: 0644
 path: "/etc/tmpfiles.d/cleanup-cni.conf"
 contents:
   inline: |
-    r /etc/origin/openvswitch/conf.db
-    r /etc/cni/net.d/80-openshift-network.conf
-    r /etc/cni/net.d/10-ovn-kubernetes.conf
+    r /etc/kubernetes/cni/net.d/80-openshift-network.conf
+    r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
+    r /etc/kubernetes/cni/net.d/00-multus.conf

--- a/templates/worker/00-worker/_base/files/cleanup-cni-conf.yaml
+++ b/templates/worker/00-worker/_base/files/cleanup-cni-conf.yaml
@@ -3,6 +3,6 @@ mode: 0644
 path: "/etc/tmpfiles.d/cleanup-cni.conf"
 contents:
   inline: |
-    r /etc/origin/openvswitch/conf.db
-    r /etc/cni/net.d/80-openshift-network.conf
-    r /etc/cni/net.d/10-ovn-kubernetes.conf
+    r /etc/kubernetes/cni/net.d/80-openshift-network.conf
+    r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
+    r /etc/kubernetes/cni/net.d/00-multus.conf


### PR DESCRIPTION
Discovered in BZ1704706 that we weren't actually cleaning these files
up, leading to failed deletions.

Fixes: rhbz1704706