### PR TITLE
install: EQG: tolerate all taints

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -34,27 +34,7 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-        operator: Exists
-      - key: node.kubernetes.io/memory-pressure
-        effect: NoSchedule
-        operator: Exists
-      - key: node.kubernetes.io/disk-pressure
-        effect: NoSchedule
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        effect: NoExecute
-        operator: Exists
-      - key: node.kubernetes.io/unreachable
-        effect: NoExecute
-        operator: Exists
-      - key: node.kubernetes.io/unschedulable
-        effect: NoExecute
-        operator: Exists
-      - key: node-role.kubernetes.io/etcd
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
       containers:
       - image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Rather than listing out all known taints and potentially breaking when a new one pops up, just tolerate all taints.

I think this is causing this gridlock in the MCC/MCD during upgrades
https://search.svc.ci.openshift.org/?search=failed+to+reboot&maxAge=48h&context=2&type=all

@runcom @RobertKrawitz 