### PR TITLE
Tolerate every taint

### DIFF
--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -29,6 +29,4 @@ spec:
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
-      - key: "node-role.kubernetes.io/master"
         operator: "Exists"
-        effect: "NoSchedule"

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -29,4 +29,4 @@ spec:
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
-        operator: "Exists"
+      - operator: "Exists"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -51,12 +51,7 @@ spec:
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 300
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/etcd
-          operator: Exists
-          effect: NoSchedule
+        operator: Exists
       nodeSelector:
         beta.kubernetes.io/os: linux
       priorityClassName: "system-node-critical"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 300
       tolerations:
-        operator: Exists
+      - operator: Exists
       nodeSelector:
         beta.kubernetes.io/os: linux
       priorityClassName: "system-node-critical"

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
-        operator: Exists
+      - operator: Exists
       volumes:
       - name: node-bootstrap-token
         secret:

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -34,9 +34,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+        operator: Exists
       volumes:
       - name: node-bootstrap-token
         secret:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -436,9 +436,8 @@ spec:
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"`)
+      - operator: "Exists"
+`)
 
 func manifestsMachineconfigcontrollerDeploymentYamlBytes() ([]byte, error) {
 	return _manifestsMachineconfigcontrollerDeploymentYaml, nil
@@ -597,12 +596,7 @@ spec:
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 300
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/etcd
-          operator: Exists
-          effect: NoSchedule
+      - operator: Exists
       nodeSelector:
         beta.kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
@@ -992,9 +986,7 @@ spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      - operator: Exists
       volumes:
       - name: node-bootstrap-token
         secret:


### PR DESCRIPTION

As of now, we are tolerating only `node-role.kubernetes.io/master` taint during scheduling stage. If we don't have the blanket toleration, there is a very good chance that these pods won't tolerate other taints that got added to the node, for example `disk-pressure` etc. The side-effect is that we will tolerate `NoExecute` taints as well

Please feel free to close this PR, if you think, you just need to tolerate the current taint(s) you have.

/cc @sjenning @derekwaynecarr 
