### PR TITLE
Bump timeout for e2e-aws-op

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,4 +98,4 @@ images.rhel7: $(imc7)
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	GOCACHE=off go test -timeout 55m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	GOCACHE=off go test -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/


### PR DESCRIPTION
We seem to be taking longer here.
