### PR TITLE
WIP: kubelet: add disaster recovery for expired certificate

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/files/-usr-local-bin-kubelet_expiry_check
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/files/-usr-local-bin-kubelet_expiry_check
@@ -1,0 +1,6 @@
+contents:
+  source: data:,%23!%2Fbin%2Fbash%0A%0Aset%20-eou%20pipefail%0A%0AKUBELET_PEM_FILE%3D%2Fvar%2Flib%2Fkubelet%2Fpki%2Fkubelet-client-current.pem%0A%0Aerror()%20%7B%0A%20%20echo%20%22Error%3A%20Line%20%24(caller)%22%20%3E%262%0A%7D%0A%0Acleanup()%20%7B%0A%20%20rm%20-rf%20%2Fvar%2Flib%2Fkubelet%2Fpki%2F*%0A%20%20rm%20-f%20%2Fvar%2Flib%2Fkubelet%2Fkubeconfig%0A%20%20reboot%0A%7D%0A%0Atrap%20'error'%20ERR%0A%0A%5B%5B%20!%20-f%20%24KUBELET_PEM_FILE%20%5D%5D%20%26%26%20exit%200%0A%0Aexpiry_cert_date%3D%24(openssl%20x509%20-in%20%24%7BKUBELET_PEM_FILE%7D%20-enddate%20-noout%20%7C%20cut%20-d%3D%20-f%202)%0Aexpiry_date%3D%24(date%20-d%20%22%24%7Bexpiry_cert_date%7D%22%20%2B%25s)%0Anow_date%3D%24(date%20%2B%25s)%0A%0Aif%20%5B%20%24now_date%20-ge%20%24expiry_date%20%5D%20%3B%20then%0A%20%20echo%20%22Found%20expired%20certificate%22%0A%20%20cleanup%0Afi%0A
+  verification: {}
+filesystem: root
+mode: 493
+path: /usr/local/bin/kubelet_expiry_check

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service
@@ -7,6 +7,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/master/01-master-kubelet/_base/files/kubelet_expiry_check.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet_expiry_check.yaml
@@ -1,0 +1,33 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/kubelet_expiry_check"
+contents:
+  inline: |
+    #!/bin/bash
+    
+    set -eou pipefail
+    
+    KUBELET_PEM_FILE=/var/lib/kubelet/pki/kubelet-client-current.pem
+    
+    error() {
+      echo "Error: Line $(caller)" >&2
+    }
+    
+    cleanup() {
+      rm -rf /var/lib/kubelet/pki/*
+      rm -f /var/lib/kubelet/kubeconfig
+      reboot
+    }
+    
+    trap 'error' ERR
+    
+    [[ ! -f $KUBELET_PEM_FILE ]] && exit 0
+    
+    expiry_cert_date=$(openssl x509 -in ${KUBELET_PEM_FILE} -enddate -noout | cut -d= -f 2)
+    expiry_date=$(date -d "${expiry_cert_date}" +%s)
+    now_date=$(date +%s)
+    
+    if [ $now_date -ge $expiry_date ] ; then
+      echo "Found expired certificate"
+      cleanup
+    fi

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -9,6 +9,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet_expiry_check.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet_expiry_check.yaml
@@ -1,0 +1,33 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/kubelet_expiry_check"
+contents:
+  inline: |
+    #!/bin/bash
+    
+    set -eou pipefail
+    
+    KUBELET_PEM_FILE=/var/lib/kubelet/pki/kubelet-client-current.pem
+    
+    error() {
+      echo "Error: Line $(caller)" >&2
+    }
+    
+    cleanup() {
+      rm -rf /var/lib/kubelet/pki/*
+      rm -f /var/lib/kubelet/kubeconfig
+      reboot
+    }
+    
+    trap 'error' ERR
+    
+    [[ ! -f $KUBELET_PEM_FILE ]] && exit 0
+    
+    expiry_cert_date=$(openssl x509 -in ${KUBELET_PEM_FILE} -enddate -noout | cut -d= -f 2)
+    expiry_date=$(date -d "${expiry_cert_date}" +%s)
+    now_date=$(date +%s)
+    
+    if [ $now_date -ge $expiry_date ] ; then
+      echo "Found expired certificate"
+      cleanup
+    fi

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -9,6 +9,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet_expiry_check
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env


### PR DESCRIPTION
**- What I did**
If a cluster has been suspended for a period of time, then the Kubelet certificate may have expired. We need some way to re-bootstrap the machine if the expiry period has happened. This PR checks the expiry of the certificate, if expired, clears the required assets and reboots the machine.

**- How to verify it**

**- Description for the changelog**
