### PR TITLE
controller: Log when a node has been updated

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -200,7 +200,14 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 	if pool == nil {
 		return
 	}
-	glog.V(4).Infof("Node %s updated", curNode.Name)
+
+	// Specifically log when a node has completed an update so the MCC logs are a useful central aggregate of state changes
+	if oldNode.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] != oldNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] &&
+		curNode.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] == curNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] {
+		glog.Infof("Pool %s: node %s has completed update to %s", pool.Name, curNode.Name, curNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
+	} else {
+		glog.V(4).Infof("Node %s updated", curNode.Name)
+	}
 	ctrl.enqueueMachineConfigPool(pool)
 }
 

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -111,6 +111,8 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 	return status
 }
 
+// getUpdatedMachines filters the provided nodes to ones whose current == desired
+// and the "done" flag is set.
 func getUpdatedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	var updated []*corev1.Node
 	for _, node := range nodes {
@@ -138,6 +140,8 @@ func getUpdatedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.No
 	return updated
 }
 
+// getReadyMachines filters the provided nodes to ones which are updated
+// and marked ready.
 func getReadyMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	updated := getUpdatedMachines(currentConfig, nodes)
 	var ready []*corev1.Node
@@ -177,6 +181,9 @@ func isNodeReady(node *corev1.Node) bool {
 	return true
 }
 
+// getUnavailableMachines is the opposite of getReadyNodes - it filters the provided
+// set of nodes to ones which are either not ready, or whose current config does
+// not match the target.
 func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
 	var unavail []*corev1.Node
 	for _, node := range nodes {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -976,7 +976,7 @@ func (dn *Daemon) completeUpdate(node *corev1.Node, desiredConfigName string) er
 		return err
 	}
 
-	dn.logSystem("machine-config-daemon: completed update for config %s", desiredConfigName)
+	dn.logSystem("completed update for config %s", desiredConfigName)
 
 	return nil
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -266,7 +266,7 @@ func NewClusterDrivenDaemon(
 	eventBroadcaster.StartRecordingToSink(&clientsetcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	dn.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigdaemon", Host: nodeName})
 
-	glog.Infof("Managing node: %s", nodeName)
+	dn.logSystem("Starting to manage node: %s", nodeName)
 
 	go dn.runLoginMonitor(dn.stopCh, dn.exitCh)
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -218,6 +218,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		dn.logSystem(wrappedErr.Error())
 		return errors.Wrapf(errUnreconcilable, "%v", wrappedErr)
 	}
+	dn.logSystem("Starting update from %s to %s", oldConfigName, newConfigName)
 
 	// update files on disk that need updating
 	if err := dn.updateFiles(oldConfig, newConfig); err != nil {


### PR DESCRIPTION
The MCC logs show when we tell a node to start, but don't show us
when it's done.  This helps the MCC logs be a centralized
aggregate of events.

Doing this now to aid debugging slowness in updates in our `e2e-aws-op`
test suite.
