### PR TITLE
node_controller: mark unavailable if configs differ

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -452,13 +452,13 @@ func TestGetCandidateMachines(t *testing.T) {
 		expected: []*corev1.Node{newNodeWithReady("node-3", "v0", "v0", corev1.ConditionTrue)},
 	}, {
 		//progress on old stuck node
-		progress: 1,
+		progress: 0,
 		nodes: []*corev1.Node{
 			newNodeWithReady("node-0", "v1", "v1", corev1.ConditionTrue),
 			newNodeWithReady("node-1", "v0.1", "v0.2", corev1.ConditionFalse),
 			newNodeWithReady("node-2", "v0", "v0", corev1.ConditionTrue),
 		},
-		expected: []*corev1.Node{newNodeWithReady("node-1", "v0.1", "v0.2", corev1.ConditionFalse)},
+		expected: []*corev1.Node{},
 	}}
 
 	for idx, test := range tests {

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -239,7 +239,10 @@ func TestGetUnavailableMachines(t *testing.T) {
 			newNodeWithReady("node-2", "v0", "v2", corev1.ConditionTrue),
 		},
 		currentConfig: "v2",
-		unavail:       []*corev1.Node{newNodeWithReady("node-2", "v0", "v2", corev1.ConditionTrue)},
+		unavail: []*corev1.Node{
+			newNodeWithReady("node-0", "v0", "v1", corev1.ConditionTrue),
+			newNodeWithReady("node-2", "v0", "v2", corev1.ConditionTrue),
+		},
 	}, {
 		// 1 node updated, 1 updating, 1 updating but not v2 and is not ready
 		nodes: []*corev1.Node{
@@ -248,7 +251,10 @@ func TestGetUnavailableMachines(t *testing.T) {
 			newNodeWithReady("node-2", "v0", "v2", corev1.ConditionTrue),
 		},
 		currentConfig: "v2",
-		unavail:       []*corev1.Node{newNodeWithReady("node-2", "v0", "v2", corev1.ConditionTrue)},
+		unavail:       []*corev1.Node{
+			newNodeWithReady("node-0", "v0", "v1", corev1.ConditionFalse),
+			newNodeWithReady("node-2", "v0", "v2", corev1.ConditionTrue),
+		},
 	}, {
 		// 2 node updated, 1 updating
 		nodes: []*corev1.Node{


### PR DESCRIPTION
Skip Unreconcilable nodes to allow them to roll back though.
The NodeController shouldn't rely just on what it's syncing at that
moment to deduce that a node is unavailable. It may happen that the pool
is updating to a rendered-config-A but it's not done, and the code was
still going to apply a new rendered-config-B causing more than 1 node at
the time to go unschedulable. This patch should fix that.