### PR TITLE
Bug 1706204: Fix tolerations

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -46,6 +46,14 @@ spec:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
       volumes:
       - name: images
         configMap:

--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -37,21 +37,14 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
         operator: Exists
-      - key: node.kubernetes.io/memory-pressure
-        effect: NoSchedule
-        operator: Exists
-      - key: node.kubernetes.io/disk-pressure
-        effect: NoSchedule
-        operator: Exists
       - key: node.kubernetes.io/not-ready
         effect: NoExecute
         operator: Exists
+        tolerationSeconds: 120
       - key: node.kubernetes.io/unreachable
         effect: NoExecute
         operator: Exists
-      - key: node.kubernetes.io/unschedulable
-        effect: NoExecute
-        operator: Exists
+        tolerationSeconds: 120
       - key: node-role.kubernetes.io/etcd
         operator: Exists
         effect: NoSchedule

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -29,6 +29,14 @@ spec:
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        operator: Exists
         effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -51,12 +51,12 @@ spec:
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 300
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/etcd
-          operator: Exists
-          effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/etcd
+        operator: Exists
+        effect: NoSchedule
       nodeSelector:
         beta.kubernetes.io/os: linux
       priorityClassName: "system-node-critical"

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -34,9 +34,12 @@ spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/etcd
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: node-bootstrap-token
         secret:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -436,9 +436,18 @@ spec:
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       tolerations:
-      - key: "node-role.kubernetes.io/master"
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
         operator: "Exists"
-        effect: "NoSchedule"`)
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+`)
 
 func manifestsMachineconfigcontrollerDeploymentYamlBytes() ([]byte, error) {
 	return _manifestsMachineconfigcontrollerDeploymentYaml, nil
@@ -597,12 +606,12 @@ spec:
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 300
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/etcd
-          operator: Exists
-          effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/etcd
+        operator: Exists
+        effect: NoSchedule
       nodeSelector:
         beta.kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
@@ -992,9 +1001,12 @@ spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: machine-config-server
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/etcd
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: node-bootstrap-token
         secret:


### PR DESCRIPTION
In 4.1, we have taint-based evictions enabled. This changes logic in the node lifecycle controller in the kube-controller-manager significantly.

Historically, the node lifecycle controller would directly evict pods from node that had a Ready condition of False or Unknown after a pod eviction timeout set by the --pod-eviction-timeout flag on the kube-controller-manager. This setting applied to all pods cluster-wide. The default was 5m.

With taint-based evictions, all the node lifecycle controller does is taint the node with node.kubernetes.io/unreachable and/or node.kubernetes.io/not-ready taint with NoExecute effect. This would normally result in the immediate eviction of all pods that don't tolerate those taints, breaking the old behavior with pod eviction timeouts. Enter DefaultTolerationSeconds mutating admission plugin.

https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds/admission.go

This plugin will add a default NoExecute toleration for node.kubernetes.io/unreachable and/or node.kubernetes.io/not-ready taints with a tolerationSeconds of 5m (300s) as long as no such toleration is already specified in the pod spec. This restores the old pod eviction tiemout behavior.

One of the intended effects of this change is the make the pod eviction timeout a pod-level property. Different applications require different timeouts depending on their design and having it controlled at a cluster level before was not optimal. The side-effect is that we won't allow pods to be scheduled onto nodes that have disk, memory, cpu pressure.

The DefaultTolerationSeconds plugin has a flag that allows adjusting the defaults for tolerationSeconds
https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds/admission.go#L34-L40

We might expose this tunable for user control in the future and do not want the cluster control plane components to be subject to it.

Thus, this PR explictly defines a NoExecute toleration for node.kubernetes.io/unreachable and/or node.kubernetes.io/not-ready taints with a tolerationSeconds generically appropriate for cluster components.

Once these changes are in across all components, this e2e will enforce it in the future
openshift/origin#22752


Please refer to this doc, if you have questions around what tolerations you can have:

https://docs.google.com/document/d/1W449BfB5la9NC7pcDxkovgzlBlHMy5Lkj0-WXWjdiTU/edit#

/cc @sjenning @smarterclayton @derekwaynecarr
