### PR TITLE
Bug 1707212: Rework controller progress

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -44,10 +44,10 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 	readyMachines := getReadyMachines(pool.Status.Configuration.Name, nodes)
 	readyMachineCount := int32(len(readyMachines))
 
-	unavailableMachines := getUnavailableMachines(pool.Status.Configuration.Name, nodes)
+	unavailableMachines := getUnavailableMachines(nodes)
 	unavailableMachineCount := int32(len(unavailableMachines))
 
-	degradedMachines := getDegradedMachines(pool.Status.Configuration.Name, nodes)
+	degradedMachines := getDegradedMachines(nodes)
 	degradedReasons := []string{}
 	for _, n := range degradedMachines {
 		reason, ok := n.Annotations[daemonconsts.MachineConfigDaemonReasonAnnotationKey]
@@ -129,29 +129,54 @@ func isNodeManaged(node *corev1.Node) bool {
 	return true
 }
 
-// getUpdatedMachines filters the provided nodes to ones whose current == desired
+/// isNodeDone returns true if the current == desired and the MCD has marked done.
+func isNodeDone(node *corev1.Node) bool {
+	if node.Annotations == nil {
+		return false
+	}
+	cconfig, ok := node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey]
+	if !ok || cconfig == "" {
+		return false
+	}
+	dconfig, ok := node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]
+	if !ok || dconfig == "" {
+		return false
+	}
+
+	return cconfig == dconfig && isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDone)
+}
+
+// isNodeDoneAt checks whether a node is fully updated to a targetConfig
+func isNodeDoneAt(node *corev1.Node, targetConfig string) bool {
+	return isNodeDone(node) && node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] == targetConfig
+}
+
+// isNodeMCDDone checks the MCD state
+func isNodeMCDState(node *corev1.Node, state string) bool {
+	dstate, ok := node.Annotations[daemonconsts.MachineConfigDaemonStateAnnotationKey]
+	if !ok || dstate == "" {
+		return false
+	}
+
+	return dstate == state
+}
+
+// isNodeMCDFailing says whether the MCD has unsuccessfully applied an update
+func isNodeMCDFailing(node *corev1.Node) bool {
+	if node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] == node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] {
+		return false
+	}	
+	return isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDegraded) ||
+		isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateUnreconcilable)
+}
+
+// getUpdatedMachines filters the provided nodes to ones whose current config
+// matches the desired config, which also matches the target config.
 // and the "done" flag is set.
-func getUpdatedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
+func getUpdatedMachines(poolTargetConfig string, nodes []*corev1.Node) []*corev1.Node {
 	var updated []*corev1.Node
 	for _, node := range nodes {
-		if node.Annotations == nil {
-			continue
-		}
-		cconfig, ok := node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey]
-		if !ok || cconfig == "" {
-			continue
-		}
-		dconfig, ok := node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]
-		if !ok || cconfig == "" {
-			continue
-		}
-
-		dstate, ok := node.Annotations[daemonconsts.MachineConfigDaemonStateAnnotationKey]
-		if !ok || dstate == "" {
-			continue
-		}
-
-		if cconfig == currentConfig && dconfig == currentConfig && dstate == daemonconsts.MachineConfigDaemonStateDone {
+		if isNodeDoneAt(node, poolTargetConfig) {
 			updated = append(updated, node)
 		}
 	}
@@ -199,31 +224,43 @@ func isNodeReady(node *corev1.Node) bool {
 	return checkNodeReady(node) == nil
 }
 
-func getUnavailableMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
+// isNodeUnavailable is the backend for getUnavailableMachines;
+// see the docs for that for more information.
+func isNodeUnavailable(node *corev1.Node) bool {
+	// Unready nodes are unavailable
+	if !isNodeReady(node) {
+		return true
+	}
+	// Ready nodes are not unavailable
+	if isNodeDone(node) {
+		return false
+	}
+	// Now we know the node isn't ready - the current config must not
+	// equal target.  We want to further filter down on the MCD state.
+	// If a MCD is in a terminal (failing) state then we can safely retarget it.
+	// to a different config.  Or to say it another way, a node is unavailable
+	// if the MCD is working, or hasn't started work but the configs differ.
+	return !isNodeMCDFailing(node)
+}
+
+// getUnavailableMachines returns the set of nodes which are
+// either marked unscheduleable, or have a MCD actively working.
+// The reason for checking the MCD state is that if the MCD is actively
+// working (or hasn't started) then the node *may* go unschedulable in the future, so we
+// don't want to potentially start another node update exceeding our
+// maxUnavailable.
+// Somewhat the opposite of getReadyNodes().
+func getUnavailableMachines(nodes []*corev1.Node) []*corev1.Node {
 	var unavail []*corev1.Node
 	for _, node := range nodes {
-		if node.Annotations == nil {
-			continue
-		}
-		dconfig, ok := node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]
-		if !ok || dconfig == "" {
-			continue
-		}
-		cconfig, ok := node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey]
-		if !ok || cconfig == "" {
-			continue
-		}
-
-		nodeNotReady := !isNodeReady(node)
-		if dconfig == currentConfig && (dconfig != cconfig || nodeNotReady) {
+		if isNodeUnavailable(node) {
 			unavail = append(unavail, node)
-			glog.V(2).Infof("Node %s unavailable: different configs (desired: %s, current %s) or node not ready %v", node.Name, dconfig, cconfig, nodeNotReady)
 		}
 	}
 	return unavail
 }
 
-func getDegradedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.Node {
+func getDegradedMachines(nodes []*corev1.Node) []*corev1.Node {
 	var degraded []*corev1.Node
 	for _, node := range nodes {
 		if node.Annotations == nil {
@@ -238,8 +275,7 @@ func getDegradedMachines(currentConfig string, nodes []*corev1.Node) []*corev1.N
 			continue
 		}
 
-		if dconfig == currentConfig &&
-			(dstate == daemonconsts.MachineConfigDaemonStateDegraded || dstate == daemonconsts.MachineConfigDaemonStateUnreconcilable) {
+		if dstate == daemonconsts.MachineConfigDaemonStateDegraded || dstate == daemonconsts.MachineConfigDaemonStateUnreconcilable {
 			degraded = append(degraded, node)
 		}
 	}

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -396,12 +396,12 @@ func TestReconcileAfterBadMC(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
-		if mcp.Status.UnavailableMachineCount >= 1 {
+		if mcv1.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcv1.MachineConfigPoolDegraded) && mcp.Status.DegradedMachineCount >= 1 {
 			return true, nil
 		}
 		return false, nil
 	}); err != nil {
-		t.Errorf("MCP isn't reporting unavailable with a bad MC: %v", err)
+		t.Errorf("worker pool isn't reporting degraded with a bad MC: %v", err)
 	}
 
 	// now delete the bad MC and watch the nodes reconciling as expected


### PR DESCRIPTION
Bigger rewrite for #699

This should ensure that the node controller avoids exceeding maxUnavailable,
by changing the notion of "unavailable" to mean nodes which are either
not ready, *or* may become not ready as they're working on an update.

That list is also further filtered by nodes which are degraded/unreconcilable.