### PR TITLE
Work around bz1571183

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -77,6 +77,7 @@ spec:
                 declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print -quit)"
                 declare -r key="${cert%.crt}.key"
                 declare -r cacert="$croot/ca.crt"
+                export NSS_SDB_USE_CACHE=no
                 [[ -z $cert || -z $key ]] && exit 1
                 curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
             initialDelaySecond: 5


### PR DESCRIPTION
`curl` results in heavy dentry cache pollution that gets charged to the eqg's cgroup.  The underlying bug is https://bugzilla.redhat.com/show_bug.cgi?id=1571183.

Fixes 1706625.