### PR TITLE
pkg/daemon: lock when checking if update is active

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -730,6 +730,8 @@ func (dn *Daemon) logSystem(format string, a ...interface{}) {
 }
 
 func (dn *Daemon) catchIgnoreSIGTERM() {
+	dn.updateActiveLock.Lock()
+	defer dn.updateActiveLock.Unlock()
 	if dn.updateActive {
 		return
 	}
@@ -737,6 +739,8 @@ func (dn *Daemon) catchIgnoreSIGTERM() {
 }
 
 func (dn *Daemon) cancelSIGTERM() {
+	dn.updateActiveLock.Lock()
+	defer dn.updateActiveLock.Unlock()
 	if dn.updateActive {
 		dn.updateActive = false
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added a lock to read/write `dn.updateActive` as we're reading/writing it from at least 2 goroutines concurrently

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
