### PR TITLE
daemon: Move chroot to very early on

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -57,6 +59,18 @@ func getBootID() (string, error) {
 	return strings.TrimSpace(string(currentBootIDBytes)), nil
 }
 
+// bindPodMounts ensures that the daemon can still see e.g. /run/secrets/kubernetes.io
+// service account tokens after chrooting.  This function must be called before chroot.
+func bindPodMounts(rootMount string) error {
+       targetSecrets := filepath.Join(rootMount, "/run/secrets")
+       if err := os.MkdirAll(targetSecrets, 0755); err != nil {
+               return err
+       }
+       // This will only affect our mount namespace, not the host
+       mnt := exec.Command("mount", "--rbind", "/run/secrets", targetSecrets)
+       return mnt.Run()
+}
+
 func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
@@ -66,7 +80,25 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
 
-	operatingSystem, err := daemon.GetHostRunningOS(startOpts.rootMount)
+	onceFromMode := startOpts.onceFrom != ""
+	if !onceFromMode {
+		// in the daemon case
+		if err := bindPodMounts(startOpts.rootMount); err != nil {
+			glog.Fatalf("Binding pod mounts: %s", err)
+		}
+	}
+
+	glog.Infof(`Calling chroot("%s")`, startOpts.rootMount)
+	if err := syscall.Chroot(startOpts.rootMount); err != nil {
+		glog.Fatalf("Unable to chroot to %s: %s", startOpts.rootMount, err)
+	}
+
+	glog.V(2).Infof("Moving to / inside the chroot")
+	if err := os.Chdir("/"); err != nil {
+		glog.Fatalf("Unable to change directory to /: %s", err)
+	}
+
+	operatingSystem, err := daemon.GetHostRunningOS()
 	if err != nil {
 		glog.Fatalf("Error found when checking operating system: %s", err)
 	}
@@ -77,14 +109,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			glog.Fatalf("node-name is required")
 		}
 		startOpts.nodeName = name
-	}
-
-	// Ensure that the rootMount exists
-	if _, err := os.Stat(startOpts.rootMount); err != nil {
-		if os.IsNotExist(err) {
-			glog.Fatalf("rootMount %s does not exist", startOpts.rootMount)
-		}
-		glog.Fatalf("Unable to verify rootMount %s exists: %s", startOpts.rootMount, err)
 	}
 
 	// This channel is used to ensure all spawned goroutines exit when we exit.
@@ -136,7 +160,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			}
 		}
 		dn, err = daemon.New(
-			startOpts.rootMount,
 			startOpts.nodeName,
 			operatingSystem,
 			daemon.NewNodeUpdaterClient(),
@@ -163,7 +186,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		// create the daemon instance. this also initializes kube client items
 		// which need to come from the container and not the chroot.
 		dn, err = daemon.NewClusterDrivenDaemon(
-			startOpts.rootMount,
 			startOpts.nodeName,
 			operatingSystem,
 			daemon.NewNodeUpdaterClient(),
@@ -183,24 +205,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			glog.Fatalf("Failed to initialize daemon: %v", err)
 		}
 
-		// in the daemon case
-		if err := dn.BindPodMounts(); err != nil {
-			glog.Fatalf("Binding pod mounts: %s", err)
-		}
-
 		ctx.KubeInformerFactory.Start(stopCh)
 		ctx.InformerFactory.Start(stopCh)
 		close(ctx.InformersStarted)
-	}
-
-	glog.Infof(`Calling chroot("%s")`, startOpts.rootMount)
-	if err := syscall.Chroot(startOpts.rootMount); err != nil {
-		glog.Fatalf("Unable to chroot to %s: %s", startOpts.rootMount, err)
-	}
-
-	glog.V(2).Infof("Moving to / inside the chroot")
-	if err := os.Chdir("/"); err != nil {
-		glog.Fatalf("Unable to change directory to /: %s", err)
 	}
 
 	glog.Info("Starting MachineConfigDaemon")

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -165,7 +165,6 @@ func (f *fixture) newController() *Daemon {
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 
 	d, err := NewClusterDrivenDaemon(
-		"/",
 		"node_name_test",
 		"rhel",
 		NewNodeUpdaterClient(),

--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/ashcrow/osrelease"
 )
@@ -20,9 +19,9 @@ const (
 // OS variant the daemon is running on. If we are unable to read the
 // os-release file OR the information doesn't match MCD supported OS's
 // an error is returned.
-func GetHostRunningOS(rootFs string) (string, error) {
-	libPath := path.Join(rootFs, "usr", "lib", "os-release")
-	etcPath := path.Join(rootFs, "etc", "os-release")
+func GetHostRunningOS() (string, error) {
+	libPath := "/usr/lib/os-release"
+	etcPath := "/etc/os-release"
 
 	or, err := osrelease.NewWithOverrides(etcPath, libPath)
 	if err != nil {

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -45,7 +45,7 @@ type RpmOstreeDeployment struct {
 // around content deployment
 type NodeUpdaterClient interface {
 	GetStatus() (string, error)
-	GetBootedOSImageURL(string) (string, string, error)
+	GetBootedOSImageURL() (string, string, error)
 	RunPivot(string) error
 }
 
@@ -59,9 +59,9 @@ func NewNodeUpdaterClient() NodeUpdaterClient {
 }
 
 // getBootedDeployment returns the current deployment found
-func (r *RpmOstreeClient) getBootedDeployment(rootMount string) (*RpmOstreeDeployment, error) {
+func (r *RpmOstreeClient) getBootedDeployment() (*RpmOstreeDeployment, error) {
 	var rosState RpmOstreeState
-	output, err := RunGetOut("chroot", rootMount, "rpm-ostree", "status", "--json")
+	output, err := RunGetOut("rpm-ostree", "status", "--json")
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func (r *RpmOstreeClient) GetStatus() (string, error) {
 }
 
 // GetBootedOSImageURL returns the image URL as well as the OSTree version (for logging)
-func (r *RpmOstreeClient) GetBootedOSImageURL(rootMount string) (string, string, error) {
-	bootedDeployment, err := r.getBootedDeployment(rootMount)
+func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, error) {
+	bootedDeployment, err := r.getBootedDeployment()
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -23,7 +23,7 @@ type RpmOstreeClientMock struct {
 
 // GetBootedOSImageURL implements a test version of RpmOStreeClients GetBootedOSImageURL.
 // It returns an OsImageURL, Version, and Error as defined in GetBootedOSImageURLReturns in order.
-func (r RpmOstreeClientMock) GetBootedOSImageURL(string) (string, string, error) {
+func (r RpmOstreeClientMock) GetBootedOSImageURL() (string, string, error) {
 	returnValues := r.GetBootedOSImageURLReturns[0]
 	if len(r.GetBootedOSImageURLReturns) > 1 {
 		r.GetBootedOSImageURLReturns = r.GetBootedOSImageURLReturns[1:]

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -34,7 +34,6 @@ func TestUpdateOS(t *testing.T) {
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
-		rootMount:         "/",
 		bootedOSImageURL:  "test",
 	}
 
@@ -66,7 +65,6 @@ func TestReconcilable(t *testing.T) {
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: nil,
 		kubeClient:        nil,
-		rootMount:         "/",
 		bootedOSImageURL:  "test",
 	}
 
@@ -205,7 +203,6 @@ func TestReconcilableSSH(t *testing.T) {
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
-		rootMount:         "/",
 		bootedOSImageURL:  "test",
 	}
 
@@ -295,7 +292,6 @@ func TestUpdateSSHKeys(t *testing.T) {
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
-		rootMount:         "/",
 		bootedOSImageURL:  "test",
 	}
 	// Set up machineconfigs that are identical except for SSH keys
@@ -348,7 +344,6 @@ func TestInvalidIgnConfig(t *testing.T) {
 		OperatingSystem:   machineConfigDaemonOSRHCOS,
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
-		rootMount:         "/",
 		bootedOSImageURL:  "test",
 	}
 


### PR DESCRIPTION
Today at least `detectEarlySSHAccessesFromBoot()` was racing
as it was spawning a goroutine that was expecting the target root,
but we were only calling `chroot()` later on.

I think everything will be a lot clearer if the daemon code is
basically *always* chrooted from as early on as possible.
