### PR TITLE
daemon: Tweak logging during updates

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -348,6 +348,7 @@ func (dn *Daemon) handleErr(err error, key interface{}) {
 	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeWarning, "MCDSyncFailure", err.Error())
 
 	if dn.queue.NumRequeues(key) < maxRetries {
+		// This is at V(2) since the updateErrorState() call above ends up logging too
 		glog.V(2).Infof("Error syncing node %v: %v", key, err)
 		dn.queue.AddRateLimited(key)
 		return
@@ -408,7 +409,6 @@ func (dn *Daemon) syncNode(key string) error {
 		}
 		if current != nil || desired != nil {
 			if err := dn.triggerUpdateWithMachineConfig(current, desired); err != nil {
-				glog.Infof("Unable to apply update: %s", err)
 				return err
 			}
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -191,7 +191,6 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 			}
 			dn.recorder.Eventf(mcRef, corev1.EventTypeWarning, "FailedToReconcile", wrappedErr.Error())
 		}
-		dn.logSystem(wrappedErr.Error())
 		return errors.Wrapf(errUnreconcilable, "%v", wrappedErr)
 	}
 	dn.logSystem("Starting update from %s to %s", oldConfigName, newConfigName)
@@ -236,7 +235,6 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 // config currently.
 
 func (dn *Daemon) reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) error {
-	glog.Info("Checking if configs are reconcilable")
 	// We skip out of reconcilable if there is no Kind and we are in runOnce mode. The
 	// reason is that there is a good chance a previous state is not available to match against.
 	if oldConfig.Kind == "" && dn.onceFrom != "" {


### PR DESCRIPTION
We were printing errors 3 times, reduce that to 1.
Also strip out an extra reconciliation log.
