### PR TITLE
 pkg: add migration for infrastructure api change

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -449,11 +449,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:036612b2822b84639a145eca16b59190e41f7eb9469bbfaa7f5fe2ecf9a9fef4"
+  digest = "1:1dd4900dc60a20a67c3d99f638bcdeb362faa83a62cd49d5cbde543daa87b2ba"
   name = "github.com/openshift/api"
   packages = ["config/v1"]
   pruneopts = "NUT"
-  revision = "e939c41e1a456ad24d7e86c66f48af9c12679d04"
+  revision = "10f647f62efca0c361334c29499f68ad1a37e266"
 
 [[projects]]
   branch = "master"
@@ -1191,6 +1191,7 @@
     "github.com/vincent-petithory/dataurl",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/policy/v1beta1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -106,7 +106,9 @@ func RenderBootstrap(
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 	}
 
-	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, imgs, infra.Status.APIServerURL)
+	// TODO(abhinavdahiya): remove this migration when https://github.com/openshift/installer/pull/1718 merges
+	apiServerURL := getAPIServerURL(infra)
+	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, imgs, apiServerURL)
 
 	manifests := []struct {
 		name     string

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -389,8 +389,11 @@ func (optr *Operator) sync(key string) error {
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 	}
 
+	// TODO(abhinavdahiya): remove this migration when https://github.com/openshift/installer/pull/1718 merges
+	apiServerURL := getAPIServerURL(infra)
+
 	// create renderConfig
-	rc := getRenderConfig(namespace, string(kubeAPIServerServingCABytes), spec, imgs, infra.Status.APIServerURL)
+	rc := getRenderConfig(namespace, string(kubeAPIServerServingCABytes), spec, imgs, apiServerURL)
 	// syncFuncs is the list of sync functions that are executed in order.
 	// any error marks sync as failure but continues to next syncFunc
 	var syncFuncs = []syncFunc{
@@ -466,4 +469,12 @@ func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.C
 		APIServerURL:           apiServerURL,
 		KubeAPIServerServingCA: kubeAPIServerServingCA,
 	}
+}
+
+func getAPIServerURL(infra *configv1.Infrastructure) string {
+	apiServerURL := infra.Status.APIServerInternalURL
+	if apiServerURL == "" {
+		apiServerURL = infra.Status.APIServerURL
+	}
+	return apiServerURL
 }

--- a/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
+++ b/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
@@ -158,6 +158,9 @@ type UpdateHistory struct {
 	// image is a container image location that contains the update. This value
 	// is always populated.
 	Image string `json:"image"`
+	// verified indicates whether the provided update was properly verified
+	// before it was installed. If this is false the cluster may not be trusted.
+	Verified bool `json:"verified"`
 }
 
 // ClusterID is string RFC4122 uuid.
@@ -202,6 +205,19 @@ type Update struct {
 	//
 	// +optional
 	Image string `json:"image"`
+	// force allows an administrator to update to an image that has failed
+	// verification, does not appear in the availableUpdates list, or otherwise
+	// would be blocked by normal protections on update. This option should only
+	// be used when the authenticity of the provided image has been verified out
+	// of band because the provided image will run with full administrative access
+	// to the cluster. Do not use this flag with images that comes from unknown
+	// or potentially malicious sources.
+	//
+	// This flag does not override other forms of consistency checking that are
+	// required before a new update is deployed.
+	//
+	// +optional
+	Force bool `json:"force"`
 }
 
 // RetrievedUpdates reports whether available updates have been retrieved from

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -52,10 +52,16 @@ type InfrastructureStatus struct {
 	// For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
 
-	// apiServerURL is a valid URL with scheme(http/https), address and port.
-	// apiServerURL can be used by components like kubelet on machines, to contact the `apisever`
-	// using the infrastructure provider rather than the kubernetes networking.
+	// apiServerURL is a valid URI with scheme(http/https), address and
+	// port.  apiServerURL can be used by components like the web console
+	// to tell users where to find the Kubernetes API.
 	APIServerURL string `json:"apiServerURL"`
+
+	// apiServerInternalURL is a valid URI with scheme(http/https),
+	// address and port.  apiServerInternalURL can be used by components
+	// like kubelets, to contact the Kubernetes API server using the
+	// infrastructure provider rather than Kubernetes networking.
+	APIServerInternalURL string `json:"apiServerInternalURI"`
 }
 
 // PlatformType is a specific supported infrastructure provider.

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -517,6 +517,7 @@ var map_Update = map[string]string{
 	"":        "Update represents a release of the ClusterVersionOperator, referenced by the Image member.",
 	"version": "version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.",
 	"image":   "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
+	"force":   "force allows an administrator to update to an image that has failed verification, does not appear in the availableUpdates list, or otherwise would be blocked by normal protections on update. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.\n\nThis flag does not override other forms of consistency checking that are required before a new update is deployed.",
 }
 
 func (Update) SwaggerDoc() map[string]string {
@@ -530,6 +531,7 @@ var map_UpdateHistory = map[string]string{
 	"completionTime": "completionTime, if set, is when the update was fully applied. The update that is currently being applied will have a null completion time. Completion time will always be set for entries that are not the current update (usually to the started time of the next update).",
 	"version":        "version is a semantic versioning identifying the update version. If the requested image does not define a version, or if a failure occurs retrieving the image, this value may be empty.",
 	"image":          "image is a container image location that contains the update. This value is always populated.",
+	"verified":       "verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted.",
 }
 
 func (UpdateHistory) SwaggerDoc() map[string]string {
@@ -727,11 +729,12 @@ func (InfrastructureSpec) SwaggerDoc() map[string]string {
 }
 
 var map_InfrastructureStatus = map[string]string{
-	"":                    "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
-	"infrastructureName":  "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
-	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
-	"etcdDiscoveryDomain": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
-	"apiServerURL":        "apiServerURL is a valid URL with scheme(http/https), address and port. apiServerURL can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.",
+	"":                     "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
+	"infrastructureName":   "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
+	"platform":             "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+	"etcdDiscoveryDomain":  "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
+	"apiServerURL":         "apiServerURL is a valid URI with scheme(http/https), address and port.  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
+	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme(http/https), address and port.  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
 }
 
 func (InfrastructureStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Catch up to the api change introduced in openshift/api#308
The migration is required until installer correctly sets up the infrastructure object in openshift/installer#1718

