### PR TITLE
MCD: bump terminationGracePeriodSeconds

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 600
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -590,7 +590,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 600
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
This job https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_installer/1726/pull-ci-openshift-installer-master-e2e-aws-upgrade/319 is showing us an interesting pattern where:

1) we start a drain
2) we're asked to terminate
3) we exceed the termination grace period (currently 300s)
4) we get terminated
5) we don't reboot and fail the update

I'm still investigating why we're asked to terminate but drain's timeout (not counting the backoff on possible failures) is 600s so this PR is just bumping the DS termination to at least that.