### PR TITLE
server: update healthz to return 200 instead of 204

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -134,7 +134,7 @@ type healthHandler struct{}
 func (h *healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", "0")
 	if r.Method == http.MethodGet || r.Method == http.MethodHead {
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -106,7 +106,7 @@ func TestHealthzHandler(t *testing.T) {
 				return new(ignv2_2types.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
-				checkStatus(t, response, http.StatusNoContent)
+				checkStatus(t, response, http.StatusOK)
 				checkContentLength(t, response, 0)
 				checkBodyLength(t, response, 0)
 			},
@@ -118,7 +118,7 @@ func TestHealthzHandler(t *testing.T) {
 				return new(ignv2_2types.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
-				checkStatus(t, response, http.StatusNoContent)
+				checkStatus(t, response, http.StatusOK)
 				checkContentLength(t, response, 0)
 				checkBodyLength(t, response, 0)
 			},
@@ -260,7 +260,7 @@ func TestAPIServer(t *testing.T) {
 				return new(ignv2_2types.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
-				checkStatus(t, response, http.StatusNoContent)
+				checkStatus(t, response, http.StatusOK)
 				checkContentLength(t, response, 0)
 				checkBodyLength(t, response, 0)
 			},
@@ -272,7 +272,7 @@ func TestAPIServer(t *testing.T) {
 				return new(ignv2_2types.Config), nil
 			},
 			checkResponse: func(t *testing.T, response *http.Response) {
-				checkStatus(t, response, http.StatusNoContent)
+				checkStatus(t, response, http.StatusOK)
 				checkContentLength(t, response, 0)
 				checkBodyLength(t, response, 0)
 			},


### PR DESCRIPTION
**- What I did**

Returning 204 `StatusNoContent` for `/healthz` is technically the correct response. And on AWS [1] the health checks treat 200 to 399 as Healthy.
But on Azure, the health checks on treat 200 `StatusOK` [2] as the healthy response. :shake_fist:

This moves the ign server to return 200 for `/heathz`

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html
[2]: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview#httpprobe


**- How to verify it**

Updates the unit tests

**- Description for the changelog**
`update healthz to return 200 instead of 204`

/cc @wking @runcom 