### PR TITLE
Bug 1707162: machine-config-server: Bind to a specific address, not all

### DIFF
--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -43,8 +43,8 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	}
 
 	apiHandler := server.NewServerAPIHandler(bs)
-	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
-	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
+	secureServer := server.NewAPIServer(apiHandler, rootOpts.address, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
+	insecureServer := server.NewAPIServer(apiHandler, rootOpts.address, rootOpts.isport, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()

--- a/cmd/machine-config-server/main.go
+++ b/cmd/machine-config-server/main.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
 const (
@@ -19,12 +21,24 @@ var (
 	}
 
 	rootOpts struct {
-		sport  int
-		isport int
-		cert   string
-		key    string
+		address string
+		sport   int
+		isport  int
+		cert    string
+		key     string
 	}
 )
+
+// findDefaultAddress uses the k8s ChooseHostInterface to provide a default
+// address to bind to. This function panic's on ChooseHostInterface error.
+func findDefaultAddress() string {
+	ip, err := utilnet.ChooseHostInterface()
+	if err != nil {
+		panic(err)
+	}
+
+	return ip.String()
+}
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
@@ -32,6 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&rootOpts.cert, "cert", "/etc/ssl/mcs/tls.crt", "cert file for TLS")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.key, "key", "/etc/ssl/mcs/tls.key", "key file for TLS")
 	rootCmd.PersistentFlags().IntVar(&rootOpts.isport, "insecure-port", 22624, "insecure port to serve ignition configs")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.address, "address", findDefaultAddress(), "address to bind ports on")
 }
 
 func main() {

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -46,8 +46,8 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 
 	apiHandler := server.NewServerAPIHandler(cs)
-	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
-	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
+	secureServer := server.NewAPIServer(apiHandler, rootOpts.address, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
+	insecureServer := server.NewAPIServer(apiHandler, rootOpts.address, rootOpts.isport, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -17,6 +17,7 @@ type poolRequest struct {
 // for providing the machine configs.
 type APIServer struct {
 	handler  http.Handler
+	address  string
 	port     int
 	insecure bool
 	cert     string
@@ -26,7 +27,7 @@ type APIServer struct {
 // NewAPIServer initializes a new API server
 // that runs the Machine Config Server as a
 // handler.
-func NewAPIServer(a *APIHandler, p int, is bool, c, k string) *APIServer {
+func NewAPIServer(a *APIHandler, address string, p int, is bool, c, k string) *APIServer {
 	mux := http.NewServeMux()
 	mux.Handle("/config/", a)
 	mux.Handle("/healthz", &healthHandler{})
@@ -34,6 +35,7 @@ func NewAPIServer(a *APIHandler, p int, is bool, c, k string) *APIServer {
 
 	return &APIServer{
 		handler:  mux,
+		address:  address,
 		port:     p,
 		insecure: is,
 		cert:     c,

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -332,7 +332,7 @@ func TestAPIServer(t *testing.T) {
 			ms := &mockServer{
 				GetConfigFn: scenario.serverFunc,
 			}
-			server := NewAPIServer(NewServerAPIHandler(ms), 0, false, "", "")
+			server := NewAPIServer(NewServerAPIHandler(ms), "127.0.0.1", 0, false, "", "")
 			server.handler.ServeHTTP(w, scenario.request)
 
 			resp := w.Result()


### PR DESCRIPTION
**- What I did**
Use `k8s.io/apimachinery/pkg/util/net` to default to a specific network rather than `0.0.0.0`


**- Description for the changelog**
- Inclusion of `k8s.io/apimachinery/pkg/util/net` for finding the MCS default bind network
- New MCS root option of address
- NewAPIServer now takes an address

/cc @runcom @imcleod 