### PR TITLE
[wip] See what breaks when node-bootstrapper cannot use CSR

### DIFF
--- a/manifests/machineconfigserver/csr-approver-role-binding.yaml
+++ b/manifests/machineconfigserver/csr-approver-role-binding.yaml
@@ -7,10 +7,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system-bootstrap-approve-node-client-csr
-subjects:
-- kind: ServiceAccount
-  name: node-bootstrapper
-  namespace: openshift-machine-config-operator
 roleRef:
   kind: ClusterRole
   name: system:certificates.k8s.io:certificatesigningrequests:nodeclient

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -851,14 +851,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system-bootstrap-approve-node-client-csr
-subjects:
-- kind: ServiceAccount
-  name: node-bootstrapper
-  namespace: openshift-machine-config-operator
 roleRef:
   kind: ClusterRole
   name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 
 func manifestsMachineconfigserverCsrApproverRoleBindingYamlBytes() ([]byte, error) {
 	return _manifestsMachineconfigserverCsrApproverRoleBindingYaml, nil


### PR DESCRIPTION
@deads2k @sjenning @openshift/sig-auth 