### PR TITLE
Bug 1708602:  pkg/daemon: workaround old util-linux logger in rhel7.6

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -117,6 +117,8 @@ type Daemon struct {
 	booting bool
 
 	currentConfigPath string
+
+	loggerSupportsJournal bool
 }
 
 const (
@@ -217,6 +219,7 @@ func New(
 	}
 	dn.currentConfigPath = currentConfigPath
 	dn.atomicSSHKeysWriter = dn.atomicallyWriteSSHKey
+	dn.loggerSupportsJournal = dn.isLoggingToJournalSupported()
 	return dn, nil
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -913,7 +913,7 @@ func (dn *Daemon) CheckStateOnBoot() error {
 		}
 	}
 
-	inDesiredConfig := state.currentConfig == state.desiredConfig
+	inDesiredConfig := state.currentConfig.GetName() == state.desiredConfig.GetName()
 	if inDesiredConfig {
 		if state.pendingConfig != nil {
 			// Great, we've successfully rebooted for the desired config,

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -95,6 +95,9 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr err
 	}
 	defer func() {
 		if retErr != nil {
+			if dn.recorder != nil {
+				dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "PendingConfigRollBack", fmt.Sprintf("Rolling back pending config %s: %v", newConfig.GetName(), retErr))
+			}
 			if out, err := dn.storePendingState(newConfig, 0); err != nil {
 				retErr = errors.Wrapf(retErr, "error rolling back pending config %v: %s", err, string(out))
 				return


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

RHEL7.6 has an old util-linux's logger which doesn't support the `--journald` flag to log to journal in a structured way. Work that around by logging a json directly and fall back to that if we're on rhel7.6 then.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
