### PR TITLE
server: Add optional auth token

### DIFF
--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -7,3 +7,6 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -796,6 +796,9 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
 `)
 
 func manifestsMachineconfigserverClusterroleYamlBytes() ([]byte, error) {

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -56,7 +56,8 @@ func NewBootstrapServer(dir, kubeconfig string) (Server, error) {
 // 3. Load the machine config.
 // 4. Append the machine annotations file.
 // 5. Append the KubeConfig file.
-func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*ignv2_2types.Config, error) {
+func (bsc *bootstrapServer) GetConfig(cr poolRequest, auth string) (*ignv2_2types.Config, error) {
+	// Note we explicitly ignore auth for bootstrap.
 
 	// 1. Read the Machine Config Pool object.
 	fileName := path.Join(bsc.serverBaseDir, "machine-pools", cr.machineConfigPool+".yaml")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,10 +31,30 @@ type kubeconfigFunc func() (kubeconfigData []byte, rootCAData []byte, err error)
 // appenderFunc appends Config.
 type appenderFunc func(*ignv2_2types.Config) error
 
+// configError is returned by the GetConfig API
+type configError struct {
+	msg			string
+	forbidden	bool
+}
+
+// configError returns the string
+func (e *configError) Error() string {
+	return e.msg
+}
+
+// IsForbidden says if err is an configError with forbidden set
+func IsForbidden(err error) bool {
+	switch t := err.(type) {
+	case *configError:
+		return t.forbidden
+	}
+	return false
+}
+
 // Server defines the interface that is implemented by different
 // machine config server implementations.
 type Server interface {
-	GetConfig(poolRequest) (*ignv2_2types.Config, error)
+	GetConfig(cr poolRequest, auth string) (*ignv2_2types.Config, error)
 }
 
 func getAppenders(cr poolRequest, currMachineConfig string, f kubeconfigFunc, osimageurl string) []appenderFunc {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	yaml "github.com/ghodss/yaml"
 	"github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 )
 
@@ -99,7 +100,7 @@ func TestBootstrapServer(t *testing.T) {
 	}
 	res, err := bs.GetConfig(poolRequest{
 		machineConfigPool: testPool,
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected err to be nil, received: %v", err)
 	}
@@ -151,6 +152,7 @@ func TestClusterServer(t *testing.T) {
 	}
 
 	csc := &clusterServer{
+		kubeClient:     k8sfake.NewSimpleClientset(),
 		machineClient:  cs.MachineconfigurationV1(),
 		kubeconfigFunc: func() ([]byte, []byte, error) { return getKubeConfigContent(t) },
 	}
@@ -174,7 +176,7 @@ func TestClusterServer(t *testing.T) {
 
 	res, err := csc.GetConfig(poolRequest{
 		machineConfigPool: testPool,
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected err to be nil, received: %v", err)
 	}


### PR DESCRIPTION
Since the bootstrap node serves Ignition to master, and today we
don't support scaling up/down masters, just disable access to
the master Ignition config in the in-cluster MCS by default.
