### PR TITLE
build-go.sh: use SOURCE_GIT_COMMIT if available

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -20,7 +20,7 @@ if [ -z ${VERSION_OVERRIDE+a} ]; then
 	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
-HASH=$(git rev-parse --verify 'HEAD^{commit}')
+HASH=${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}
 
 GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE} -X ${REPO}/pkg/version.Hash=${HASH}"
 


### PR DESCRIPTION
This will be supplied in downstream builds to relay the commit from the source git repo.

Fixes: bz 1709365

**- How to verify it**
Check that the resulting OCP image built binary reports a commit from this github repo.

**- Description for the changelog**
build-go.sh: use SOURCE_GIT_COMMIT if available
