### PR TITLE
daemon: Drop unnecessary logSystem

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -778,7 +778,6 @@ func (dn *Daemon) getPendingConfig() (string, error) {
 		if !os.IsNotExist(err) {
 			return "", errors.Wrapf(err, "loading transient state")
 		}
-		dn.logSystem("error loading pending config %v", err)
 		return "", nil
 	}
 	var p pendingConfigState


### PR DESCRIPTION
We show this log in the normal case where the file exists.
I don't think we need to `logSystem` this anyways.
