### PR TITLE
install: Use generic image placeholders

### DIFF
--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -6,11 +6,11 @@ metadata:
 data:
   images.json: >
     {
-      "machineConfigController": "docker.io/openshift/origin-machine-config-controller:v4.0.0",
-      "machineConfigDaemon": "docker.io/openshift/origin-machine-config-daemon:v4.0.0",
-      "machineConfigServer": "docker.io/openshift/origin-machine-config-server:v4.0.0",
-      "etcd": "registry.svc.ci.openshift.org/openshift/origin-v4.0:etcd",
-      "setupEtcdEnv": "registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment",
-      "infraImage": "quay.io/openshift/origin-pod:v4.0",
-      "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift/origin-v4.0:kube-client-agent"
+      "machineConfigController": "registry.svc.ci.openshift.org/openshift:machine-config-controller",
+      "machineConfigDaemon": "registry.svc.ci.openshift.org/openshift:machine-config-daemon",
+      "machineConfigServer": "registry.svc.ci.openshift.org/openshift:machine-config-server",
+      "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
+      "setupEtcdEnv": "registry.svc.ci.openshift.org/openshift:setup-etcd-environment",
+      "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
+      "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift:kube-client-agent"
     }

--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: machine-config-operator
-        image: docker.io/openshift/origin-machine-config-operator:v4.0.0
+        image: registry.svc.ci.openshift.org/openshift:machine-config-operator
         args:
         - "start"
         - "--images-json=/etc/mco/images/images.json"

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   # The OS payload, managed by the daemon + pivot + rpm-ostree
   # https://github.com/openshift/machine-config-operator/issues/183
-  osImageURL: "registry.svc.ci.openshift.org/rhcos/maipo@sha256:61dc83d62cfb5054c4c5532bd2478742a0711075ef5151572e63f94babeacc1a"
+  osImageURL: "registry.svc.ci.openshift.org/openshift:machine-os-content"

--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -49,7 +49,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-      - image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
+      - image: registry.svc.ci.openshift.org/openshift:cli
         imagePullPolicy: IfNotPresent
         name: guard
         volumeMounts:

--- a/install/image-references
+++ b/install/image-references
@@ -6,43 +6,43 @@ spec:
   - name: machine-config-operator
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-machine-config-operator:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:machine-config-operator
   - name: machine-config-controller
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-machine-config-controller:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:machine-config-controller
   - name: machine-config-server
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-machine-config-server:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:machine-config-server
   - name: machine-config-daemon
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-machine-config-daemon:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:machine-config-daemon
   - name: etcd
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:etcd
+      name: registry.svc.ci.openshift.org/openshift:etcd
   - name: pod
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-pod:v4.0
+      name: registry.svc.ci.openshift.org/openshift:pod
   - name: setup-etcd-environment
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:setup-etcd-environment
+      name: registry.svc.ci.openshift.org/openshift:setup-etcd-environment
   # This one is special, it's the OS payload
   # https://github.com/openshift/machine-config-operator/issues/183
   # See the machine-config-osimageurl configmap.
   - name: machine-os-content
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/rhcos/maipo@sha256:61dc83d62cfb5054c4c5532bd2478742a0711075ef5151572e63f94babeacc1a
+      name: registry.svc.ci.openshift.org/openshift:machine-os-content
   - name: kube-client-agent
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:kube-client-agent
+      name: registry.svc.ci.openshift.org/openshift:kube-client-agent
   - name: cli
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
+      name: registry.svc.ci.openshift.org/openshift:cli


### PR DESCRIPTION
These get [replaced by the release-creation tooling][1], so there's no point in using more specific names referencing v4.0 or particular digests.  This commit moves us to generic placeholders, where the pattern is:

```
registry.svc.ci.openshift.org/openshift:{name-in-image-references}
```

You can't pull any of them directly, but that makes it more obvious that these are placeholders.

[1]: https://github.com/openshift/cluster-version-operator/blob/33079c7732b99394f78c4fecb8d7d277c87ef02c/docs/dev/operators.md#how-do-i-ensure-the-right-images-get-used-by-my-manifests