### PR TITLE
mcc: refactor node controller to use error check helper function 

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -205,17 +205,10 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 	var changed bool
 	oldReadyErr := checkNodeReady(oldNode)
 	newReadyErr := checkNodeReady(curNode)
-	var oldReady, newReady string
-	if oldReadyErr != nil {
-		oldReady = oldReadyErr.Error()
-	} else {
-		oldReady = ""
-	}
-	if newReadyErr != nil {
-		newReady = newReadyErr.Error()
-	} else {
-		newReady = ""
-	}
+
+	oldReady := getErrorString(oldReadyErr)
+	newReady := getErrorString(newReadyErr)
+
 	if oldReady != newReady {
 		changed = true
 		if newReadyErr != nil {
@@ -471,7 +464,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	maxunavail, err := maxUnavailable(pool, nodes)
 	if err != nil {
 		return err
-	}	
+	}
 
 	candidates := getCandidateMachines(pool, nodes, maxunavail)
 	for _, node := range candidates {
@@ -572,4 +565,12 @@ func maxUnavailable(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) (int, 
 		maxunavail = 1
 	}
 	return maxunavail, nil
+}
+
+// getErrorString returns error string if not nil and empty string if error is nil
+func getErrorString(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -165,7 +165,7 @@ func isNodeMCDState(node *corev1.Node, state string) bool {
 func isNodeMCDFailing(node *corev1.Node) bool {
 	if node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] == node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] {
 		return false
-	}	
+	}
 	return isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDegraded) ||
 		isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateUnreconcilable)
 }
@@ -204,18 +204,18 @@ func checkNodeReady(node *corev1.Node) error {
 		// - NodeOutOfDisk condition status is ConditionFalse,
 		// - NodeNetworkUnavailable condition status is ConditionFalse.
 		if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
-			return fmt.Errorf("Node %s is reporting NotReady", node.Name)
+			return fmt.Errorf("node %s is reporting NotReady", node.Name)
 		}
 		if cond.Type == corev1.NodeOutOfDisk && cond.Status != corev1.ConditionFalse {
-			return fmt.Errorf("Node %s is reporting OutOfDisk", node.Name)
+			return fmt.Errorf("node %s is reporting OutOfDisk", node.Name)
 		}
 		if cond.Type == corev1.NodeNetworkUnavailable && cond.Status != corev1.ConditionFalse {
-			return fmt.Errorf("Node %s is reporting NetworkUnavailable", node.Name)
+			return fmt.Errorf("node %s is reporting NetworkUnavailable", node.Name)
 		}
 	}
 	// Ignore nodes that are marked unschedulable
 	if node.Spec.Unschedulable {
-		return fmt.Errorf("Node %s is reporting Unschedulable", node.Name)
+		return fmt.Errorf("node %s is reporting Unschedulable", node.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
**- What I did**
small updates:
- replace repetitive error checks with helper function in updateNode()
mentioned in comment here: https://github.com/openshift/machine-config-operator/pull/718/files/ad37518f2374b2742ad51e492eb8f811d2e21be9#r282160740
- fix errorf caps in status.go

**- How to verify it**
e2e & unit tests
