### PR TITLE
pkg/controller: calculate fault tolerance for the master pool

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -471,7 +471,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	maxunavail, err := maxUnavailable(pool, nodes)
 	if err != nil {
 		return err
-	}	
+	}
 
 	candidates := getCandidateMachines(pool, nodes, maxunavail)
 	for _, node := range candidates {
@@ -554,22 +554,25 @@ func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.
 }
 
 func maxUnavailable(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) (int, error) {
-	// Hardcoded for now per discussion in
-	// https://github.com/openshift/machine-config-operator/pull/701
-	if pool.Name == "master" {
-		return 1, nil
-	}
 	intOrPercent := intstrutil.FromInt(1)
 	if pool.Spec.MaxUnavailable != nil {
 		intOrPercent = *pool.Spec.MaxUnavailable
 	}
-
 	maxunavail, err := intstrutil.GetValueFromIntOrPercent(&intOrPercent, len(nodes), false)
 	if err != nil {
 		return 0, err
 	}
 	if maxunavail == 0 {
 		maxunavail = 1
+	}
+	if pool.Name == "master" {
+		// calculate the fault tolerance dynamically for the master pool
+		// to avoid risking losing etcd quorum.
+		tolerance := len(nodes) - ((len(nodes) / 2) + 1)
+		if maxunavail > tolerance {
+			glog.Warningf("Refusing to honor master pool maxUnavailable %d to prevent losing etcd quorum, using %d instead", maxunavail, tolerance)
+			return tolerance, nil
+		}
 	}
 	return maxunavail, nil
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Calculate the maxUnavailable for the master pool based also on the etcd fault tolerance and thus removing the hardcoded 1.

**- How to verify it**

added units

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
