### PR TITLE
WIP: server: Add /pointerconfig API

### DIFF
--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +17,9 @@ type mockServer struct {
 
 func (ms *mockServer) GetConfig(pr poolRequest) (*ignv2_2types.Config, error) {
 	return ms.GetConfigFn(pr)
+}
+func (ms *mockServer) GetPointerConfig(pr poolRequest) (*ignv2_2types.Config, error) {
+	return nil, errors.New("Not implemented")
 }
 
 type checkResponse func(t *testing.T, response *http.Response)

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -39,6 +39,11 @@ func NewBootstrapServer(dir, kubeconfig string) (Server, error) {
 	}, nil
 }
 
+// GetPointerConfig is not implemented yet - currently the installer generates this
+func (bsc *bootstrapServer) GetPointerConfig(cr poolRequest) (*ignv2_2types.Config, error) {
+	return nil, fmt.Errorf("Not implemented")
+}
+
 // GetConfig fetches the machine config(type - Ignition) from the bootstrap server,
 // based on the pool request.
 // It returns nil for conf, error if the config isn't found. It returns a formatted

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,6 +34,7 @@ type appenderFunc func(*ignv2_2types.Config) error
 // Server defines the interface that is implemented by different
 // machine config server implementations.
 type Server interface {
+	GetPointerConfig(poolRequest) (*ignv2_2types.Config, error)
 	GetConfig(poolRequest) (*ignv2_2types.Config, error)
 }
 


### PR DESCRIPTION
This is prep for fixing
https://github.com/openshift/machine-config-operator/issues/683

Today the installer generates this "pointer Ignition" which ends up
as e.g. user-data in AWS, which is just a pair of (MCS URL, root CA).
We need to do this because of size limitations on AWS user data.

It makes a lot of sense for the MCO to be in control of generating
the pointer ignition config too, as it helps centralize knowledge
of Ignition.

Ultimately, the goal here is tighter integration between machineAPI
and the the MCO; e.g. the machineAPI asks to generate the pointer
Ignition config, rather than having it stored as a static secret.
This could then unlock the ability for the MCO to inject e.g.
one time auth tokens.
