### PR TITLE
 Add KernelArguments to MachineConfig

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -48,11 +48,9 @@ type MachineConfig struct {
 }
 
 type MachineConfigSpec struct {
-    // OSImageURL specifies the remote location that will be used to
-    // fetch the OS. This must be in the canonical $name@$digest format.
-    OSImageURL string `json:"osImageURL"`
     // Config is a Ignition Config object.
     Config ign.Config `json:"config"`
+    KernelArguments []string `json:"kernelArguments"`
 }
 ```
 
@@ -74,13 +72,11 @@ spec:
         filesystem: root
         mode: 384
         path: /root/myfile
-  osImageURL: quay.io/openshift/rhcos@sha256:...
 ```
 
-(Notice how it's the usual Ignition config object *inplace*, not as a JSON
-string -- also note the `config` and `osImageURL` casing follow the
-`json:` markers in the definition above, of course this follows for the
-Ignition config keys as well).
+Notice how it's the usual Ignition config object *inplace*, not as a JSON
+string -- also note the casing follows the `json:` markers in the definition above, of course this follows for the
+Ignition config keys as well.
 
 ### How to create generated MachineConfig
 
@@ -94,8 +90,11 @@ Ignition config keys as well).
 
     * Use the openshift defined Ignition config as base and append all the other Ignition configs in a pre-defined order.
 
+### KernelArguments
+
+This extends the host's kernel arguments.  Use this for e.g. [nosmt](https://access.redhat.com/solutions/rhel-smt).
+
 ### OSImageURL
 
-The operating system used to first boot a machine is platform dependent. For example, on AWS AMIs are used to bring up EC2Instances. But for day-2 updates of the cluster, the MachineConfigDaemon uses the `OSImageURL` to fetch new operating system during updates. An example for OSImageURL is `quay.io/openshift/$CONTAINER@sha256:$DIGEST`. The digest is required to ensure there are no race conditions.
-
+You should not attempt to set this field; it is controlled by the operator and injected directly into the final `rendered-` config.
 For more information, see [OSUpgrades.md].

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -45,6 +45,10 @@ func EnsureMachineConfigPool(modified *bool, existing *mcfgv1.MachineConfigPool,
 
 func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec, required mcfgv1.MachineConfigSpec) {
 	setStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
+	if !equality.Semantic.DeepEqual(existing.KernelArguments, required.KernelArguments) {
+		*modified = true
+		(*existing).KernelArguments = required.KernelArguments
+	}
 	if !equality.Semantic.DeepEqual(existing.Config, required.Config) {
 		*modified = true
 		(*existing).Config = required.Config

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -11,7 +11,8 @@ import (
 
 // MergeMachineConfigs combines multiple machineconfig objects into one object.
 // It sorts all the configs in increasing order of their name.
-// It uses the Ign config from first object as base and appends all the rest.
+// It uses the Ignition config from first object as base and appends all the rest.
+// Kernel arguments are concatenated.
 // It uses only the OSImageURL provided by the CVO and ignores any MC provided OSImageURL.
 func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineConfig {
 	if len(configs) == 0 {
@@ -23,10 +24,15 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 	for idx := 1; idx < len(configs); idx++ {
 		outIgn = ign.Append(outIgn, configs[idx].Spec.Config)
 	}
+	kargs := []string{}
+	for _, cfg := range configs {
+		kargs = append(kargs, cfg.Spec.KernelArguments...)
+	}
 
 	return &MachineConfig{
 		Spec: MachineConfigSpec{
 			OSImageURL: osImageURL,
+			KernelArguments: kargs,
 			Config:     outIgn,
 		},
 	}

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -229,6 +229,8 @@ type MachineConfigSpec struct {
 	OSImageURL string `json:"osImageURL"`
 	// Config is a Ignition Config object.
 	Config igntypes.Config `json:"config"`
+
+	KernelArguments []string `json:"kernelArguments"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
We need to support things like adding `nosmt` to the kernel
commandline, for users that want to choose security over performance;
this is particularly relevant for multi-tenant clusters.
There are a lot of other "tuning" features that are expressed as
kernel cmdline args; down the line we want `node-tuning-operator`
to write something like `machineconfig/05-node-tuning-operator`.

Per discussion in the PR, we down the line probably want to add
an `operatingsystem` type or so that would be a high level wrapper
for this, but today everything else is expressed in `MachineConfig`,
so we need to extend this type.

There have also been some discussions about extending Ignition,
but that's not likely to land soon, and even if it did we still
need to handle "early pivot" pulling `machine-os-content`, and
scoping both OS updates and kargs into Ignition is too far out.

This is the first step which will support "day 2" configuration.
After this lands, we have further work to have the MCS provide
`MachineConfig` and not just Ignition, so that we can replace
the "early pivot" with MCD code.

Closes: https://github.com/openshift/machine-config-operator/issues/388
