### PR TITLE
Bug 1710626: kubelet: add crio dependency to systemd unit file

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -3,7 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service
+  Wants=rpc-statd.service crio.service
+  After=crio.service
 
   [Service]
   Type=notify

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -3,7 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service
+  Wants=rpc-statd.service crio.service
+  After=crio.service
 
   [Service]
   Type=notify


### PR DESCRIPTION
**- What I did**
Add a Wait= dependency for crio to start within the kubelet unit file. Prevents a race starting kubelet before crio has initialized.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1710626

**- Description for the changelog**
`Add crio dependency to Kubelet systemd unit file`