### PR TITLE
Add a Spec.Configuration to MachineConfigPool

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -299,6 +299,9 @@ type MachineConfigPoolSpec struct {
 	// MaxUnavailable specifies the percentage or constant number of machines that can be updating at any given time.
 	// default is 1.
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable"`
+
+	// The targeted MachineConfig object for the machine config pool.
+	Configuration MachineConfigPoolStatusConfiguration `json:"configuration"`
 }
 
 // MachineConfigPoolStatus is the status for MachineConfigPool resource.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -633,6 +633,7 @@ func (in *MachineConfigPoolSpec) DeepCopyInto(out *MachineConfigPoolSpec) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
+	in.Configuration.DeepCopyInto(&out.Configuration)
 	return
 }
 

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -118,6 +118,7 @@ func newMachineConfigPool(name string, labels map[string]string, selector *metav
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			MachineConfigSelector: selector,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -128,6 +128,7 @@ func newMachineConfigPool(name string, labels map[string]string, selector *metav
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			MachineConfigSelector: selector,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -425,7 +425,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return err
 	}
 
-	if machineconfigpool.Status.Configuration.Name == "" {
+	if machineconfigpool.Spec.Configuration.Name == "" {
 		// Previously we spammed the logs about empty pools.
 		// Let's just pause for a bit here to let the renderer
 		// initialize them.
@@ -468,7 +468,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 
 	candidates := getCandidateMachines(pool, nodes, maxunavail)
 	for _, node := range candidates {
-		if err := ctrl.setDesiredMachineConfigAnnotation(node.Name, pool.Status.Configuration.Name); err != nil {
+		if err := ctrl.setDesiredMachineConfigAnnotation(node.Name, pool.Spec.Configuration.Name); err != nil {
 			return err
 		}
 	}
@@ -510,7 +510,7 @@ func (ctrl *Controller) setDesiredMachineConfigAnnotation(nodeName, currentConfi
 }
 
 func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) []*corev1.Node {
-	targetConfig := pool.Status.Configuration.Name
+	targetConfig := pool.Spec.Configuration.Name
 
 	unavail := getUnavailableMachines(nodesInPool)
 	// If we're at capacity, there's nothing to do.

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -63,6 +63,7 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, maxUnavai
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			NodeSelector:   selector,
 			MaxUnavailable: maxUnavail,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
@@ -524,7 +525,7 @@ func TestGetCandidateMachines(t *testing.T) {
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
 			pool := &mcfgv1.MachineConfigPool{
-				Status: mcfgv1.MachineConfigPoolStatus{
+				Spec: mcfgv1.MachineConfigPoolSpec{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: "v1"}},
 				},
 			}

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -598,7 +598,7 @@ func TestCalculateStatus(t *testing.T) {
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
 			pool := &mcfgv1.MachineConfigPool{
-				Status: mcfgv1.MachineConfigPoolStatus{
+				Spec: mcfgv1.MachineConfigPoolSpec{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.currentConfig}},
 				},
 			}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -255,8 +255,11 @@ func (optr *Operator) allMachineConfigPoolStatus() (map[string]string, error) {
 // isMachineConfigPoolConfigurationValid returns nil error when the configuration of a `pool` is created by the controller at version `version`.
 func isMachineConfigPoolConfigurationValid(pool *mcfgv1.MachineConfigPool, version string, machineConfigGetter func(string) (*mcfgv1.MachineConfig, error)) error {
 	// both .status.configuration.name and .status.configuration.source must be set.
+	if len(pool.Spec.Configuration.Name) == 0 {
+		return fmt.Errorf("configuration spec for pool %s is empty", pool.GetName())
+	}
 	if len(pool.Status.Configuration.Name) == 0 {
-		return fmt.Errorf("configuration for pool %s is empty", pool.GetName())
+		return fmt.Errorf("configuration status for pool %s is empty", pool.GetName())
 	}
 	if len(pool.Status.Configuration.Source) == 0 {
 		return fmt.Errorf("list of MachineConfigs that were used to generate configuration for pool %s is empty", pool.GetName())

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -35,7 +35,7 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 
 		err error
 	}{{
-		err: errors.New("configuration for pool dummy-pool is empty"),
+		err: errors.New("configuration spec for pool dummy-pool is empty"),
 	}, {
 		generated: "g",
 		err:       errors.New("list of MachineConfigs that were used to generate configuration for pool dummy-pool is empty"),
@@ -115,6 +115,9 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 			err := isMachineConfigPoolConfigurationValid(&mcfgv1.MachineConfigPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dummy-pool",
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.generated}, Source: source},
 				},
 				Status: mcfgv1.MachineConfigPoolStatus{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.generated}, Source: source},

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -101,9 +101,9 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 		if err != nil {
 			return false, err
 		}
-		for _, mc := range mcp.Status.Configuration.Source {
+		for _, mc := range mcp.Spec.Configuration.Source {
 			if mc.Name == mcName {
-				renderedConfig = mcp.Status.Configuration.Name
+				renderedConfig = mcp.Spec.Configuration.Name
 				return true, nil
 			}
 		}
@@ -117,8 +117,6 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 
 // waitForPoolComplete polls a pool until it has completed an update to target
 func waitForPoolComplete(t *testing.T, cs *framework.ClientSet, pool, target string) error {
-	// We need a spec and status separation https://github.com/openshift/machine-config-operator/pull/765#issuecomment-493136113
-	time.Sleep(time.Second * 13)
 	startTime := time.Now()
 	if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
 		mcp, err := cs.MachineConfigPools().Get(pool, metav1.GetOptions{})


### PR DESCRIPTION
See https://github.com/openshift/machine-config-operator/pull/765#issuecomment-493136113

MachineConfigPool needs a `Spec.Configuration` and `Status.Configuration`
[just like other objects][1] so that we can properly detect state.
Currently there's a race because the render controler may set `Status.Configuration`
while the pool's `Status` still has `Updated`, so one can't check whether the
pool is at a given config.

[1] https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
