### PR TITLE
JIRA PROD-1027: templates/master/00-master: add a script to make etcd snapshot

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -1,0 +1,45 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/etcd-snapshot-backup.sh"
+contents:
+  inline: |
+    #!/usr/bin/env bash
+
+    set -o errexit
+    set -o pipefail
+
+    # example
+    # etcd-snapshot-backup.sh $path-to-snapshot
+
+    if [[ $EUID -ne 0 ]]; then
+      echo "This script must be run as root"
+      exit 1
+    fi
+
+    ASSET_DIR=./assets
+    SNAPSHOT_FILE="${ASSET_DIR}/backup/etcd/member/snap/db"
+
+    if [ "$1" != "" ]; then
+      SNAPSHOT_FILE="$1"
+    fi
+
+    CONFIG_FILE_DIR=/etc/kubernetes
+    MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
+    MANIFEST_STOPPED_DIR="${CONFIG_FILE_DIR}/manifests-stopped"
+    ETCD_VERSION=v3.3.10
+    ETCDCTL="${ASSET_DIR}/bin/etcdctl"
+    ETCD_DATA_DIR=/var/lib/etcd
+    ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
+    ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
+    STOPPED_STATIC_PODS="${ASSET_DIR}/tmp/stopped-static-pods"
+
+    source "/usr/local/bin/openshift-recovery-tools"
+
+    function run {
+      init
+      dl_etcdctl
+      backup_manifest
+      snapshot_data_dir
+    }
+
+    run

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -79,12 +79,16 @@ contents:
         cp -rap ${ETCD_DATA_DIR} $ASSET_DIR/backup/
       fi
     }
-    
+
+    snapshot_data_dir() {
+      ETCDCTL_API=3 ${ETCDCTL} snapshot save ${SNAPSHOT_FILE}
+    }
+
     # backup etcd peer, server and metric certs
     backup_certs() {
       COUNT=$(ls $ETCD_STATIC_RESOURCES/system\:etcd-* 2>/dev/null | wc -l)
       BACKUP_COUNT=$(ls $ASSET_DIR/backup/system\:etcd-* 2>/dev/null | wc -l)
-    
+
       if [ "$BACKUP_COUNT" -gt 1 ]; then
         echo "etcd TLS certificate backups found in $ASSET_DIR/backup.."
       elif [ "$COUNT" -eq 0 ]; then


### PR DESCRIPTION

This adds a new script on master which snapshots existing etcd state. 
This scriptis not yet used by DR scenarios (a few more PRs are required 
for that)

/cc @hexfusion @runcom 
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new script 

**- How to verify it**
* Setup a master using this release
* Run `/usr/local/bin/etcd-snapshot-backup.sh`
* Check that `/root/assets/backup/etcd/member/snap/db` has been created
* Check that `/usr/local/bin/etcd-snapshot-restore.sh` restores the etcd snapshot

**- Description for the changelog**

