### PR TITLE
DR start_static_pods: reread a list of static pods when starting them

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
@@ -33,8 +33,8 @@ contents:
     ASSET_DIR_TMP="$ASSET_DIR/tmp"
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
-    MANIFEST_STOPPED_DIR=/etc/kubernetes/manifests-stopped
-
+    
+    MANIFEST_STOPPED_DIR="$ASSET_DIR/manifests-stopped"
     ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
     ETCD_CONFIG=/etc/etcd/etcd.conf
     ETCDCTL=$ASSET_DIR/bin/etcdctl

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -25,7 +25,7 @@ contents:
 
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
-    MANIFEST_STOPPED_DIR="${CONFIG_FILE_DIR}/manifests-stopped"
+    MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
     ETCD_VERSION=v3.3.10
     ETCDCTL="${ASSET_DIR}/bin/etcdctl"
     ETCD_DATA_DIR=/var/lib/etcd

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -31,7 +31,7 @@ contents:
 
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
-    MANIFEST_STOPPED_DIR="${CONFIG_FILE_DIR}/manifests-stopped"
+    MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
     ETCD_VERSION=v3.3.10
     ETCDCTL="${ASSET_DIR}/bin/etcdctl"
     ETCD_DATA_DIR=/var/lib/etcd

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -299,6 +299,7 @@ contents:
 
     start_static_pods() {
       echo "Starting static pods.."
+      find ${MANIFEST_STOPPED_DIR} -maxdepth 1 -type f -printf "%f\n" > $STOPPED_STATIC_PODS
       while read STATIC_POD; do
         echo "..starting $STATIC_POD"
         mv ${MANIFEST_STOPPED_DIR}/${STATIC_POD} $MANIFEST_DIR


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Updated DR scripts to start all stopped pods.

Script won't start all stopped pods if it was terminated and restarted.
This may happen when pod-based ssh bastion is used and connection may break 
when other masters are starting.

Instead `start_static_pods` function should re-read a list of pods in MANIFEST_STOPPED_DIR.

**- How to verify it**
* Follow snapshot restore DR procedure and stop the script when master is being restored.
* Stop the script in the middle
* Restart the script
* Verify all pods from `/etc/kubernetes/manifests-stopped` were started

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
