### PR TITLE
Bug 1711879 : templates/master/00-master: resolve empty var when ETCD_CONNSTRING is not passed

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
@@ -4,12 +4,12 @@ path: "/usr/local/bin/etcd-member-recover.sh"
 contents:
   inline: |
     #!/usr/bin/env bash
-    
+
     # example
     # export SETUP_ETCD_ENVIRONMENT=$(oc adm release info --image-for setup-etcd-environment --registry-config=./config.json)
     # export KUBE_CLIENT_AGENT=$(oc adm release info --image-for kube-client-agent --registry-config=./config.json)
     # sudo -E ./etcd-member-recover.sh 192.168.1.100
-    
+
     if [[ $EUID -ne 0 ]]; then
       echo "This script must be run as root"
       exit 1
@@ -17,36 +17,36 @@ contents:
 
     : ${SETUP_ETCD_ENVIRONMENT:?"Need to set SETUP_ETCD_ENVIRONMENT"}
     : ${KUBE_CLIENT_AGENT:?"Need to set KUBE_CLIENT_AGENT"}
-    
+
     usage () {
         echo 'Recovery server IP address required: ./etcd-member-recover.sh 192.168.1.100'
         exit
     }
-    
+
     if [ "$1" == "" ]; then
         usage
     fi
-    
+
     RECOVERY_SERVER_IP=$1
-    
+
     ASSET_DIR=./assets
     ASSET_DIR_TMP="$ASSET_DIR/tmp"
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
     MANIFEST_STOPPED_DIR=/etc/kubernetes/manifests-stopped
-    
+
     ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
     ETCD_CONFIG=/etc/etcd/etcd.conf
     ETCDCTL=$ASSET_DIR/bin/etcdctl
     ETCD_VERSION=v3.3.10
     ETCD_DATA_DIR=/var/lib/etcd
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
-    
+
     SHARED=/usr/local/share/openshift-recovery
     TEMPLATE="$SHARED/template/etcd-generate-certs.yaml.template"
-    
+
     source "/usr/local/bin/openshift-recovery-tools"
-    
+
     function run {
       init
       dl_etcdctl
@@ -58,7 +58,6 @@ contents:
       backup_certs
       remove_certs
       gen_config
-      download_cert_recover_template
       DISCOVERY_DOMAIN=$(grep -oP '(?<=discovery-srv=).*[^"]' $ASSET_DIR/backup/etcd-member.yaml )
       if [ -z "$DISCOVERY_DOMAIN" ]; then
         echo "Discovery domain can not be extracted from $ASSET_DIR/backup/etcd-member.yaml"
@@ -75,5 +74,5 @@ contents:
       etcd_member_add
       start_etcd
     }
-    
+
     run

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -142,11 +142,12 @@ contents:
       HOSTNAME=$(hostname)
       HOSTDOMAIN=$(hostname -d)
       ETCD_NAME=etcd-member-${HOSTNAME}.${HOSTDOMAIN}
+
+      source /run/etcd/environment
+
       if [ -z "${ETCD_CONNSTRING}" ]; then
         ETCD_CONNSTRING="${ETCD_NAME}=https://${ETCD_DNS_NAME}:2380"
       fi
-
-      source /run/etcd/environment
 
       if [ ! -f "$SNAPSHOT_FILE" ]; then
         echo "Snapshot file not found, restore failed: $SNAPSHOT_FILE."
@@ -229,10 +230,6 @@ contents:
     start_etcd() {
       echo "Starting etcd.."
       mv ${MANIFEST_STOPPED_DIR}/etcd-member.yaml $MANIFEST_DIR
-    }
-
-    download_cert_recover_template() {
-      curl -s https://raw.githubusercontent.com/hexfusion/openshift-recovery/master/manifests/etcd-generate-certs.yaml.template -o $ASSET_DIR/templates/etcd-generate-certs.yaml.template
     }
 
     populate_template() {


### PR DESCRIPTION
This PR resolves an issue where we sourced `/run/etcd/environment` after we were populating $ETCD_CONNSTRING which if not passed as a param would result in ${ETCD_DNS_NAME} having no value. Also removed `download_cert_recover_template` function which is no longer used.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1711879

**NOTE: This will fall in 4.1.z and is not blocking for 4.1**