### PR TITLE
server: Support denying serving Ignition to active nodes and pods 

### DIFF
--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -4,6 +4,12 @@ metadata:
   name: machine-config-server
   namespace: {{.TargetNamespace}}
 rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["networks"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2536,9 +2536,15 @@ metadata:
   name: machine-config-server
   namespace: {{.TargetNamespace}}
 rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["networks"]
+  verbs: ["get", "list", "watch"]
 `)
 
 func manifestsMachineconfigserverClusterroleYamlBytes() ([]byte, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,27 @@ type kubeconfigFunc func() (kubeconfigData []byte, rootCAData []byte, err error)
 // appenderFunc appends Config.
 type appenderFunc func(*mcfgv1.MachineConfig) error
 
+// configError is returned by the GetConfig API
+type configError struct {
+	msg       string
+	forbidden bool
+}
+
+// configError returns the string
+func (e *configError) Error() string {
+	return e.msg
+}
+
+// IsForbidden says if err is an configError with forbidden set
+func IsForbidden(err error) bool {
+	switch t := err.(type) {
+	case *configError:
+		return t.forbidden
+	default:
+		return false
+	}
+}
+
 // Server defines the interface that is implemented by different
 // machine config server implementations.
 type Server interface {


### PR DESCRIPTION
Ignition may contain secret data; pods running on the cluster
shouldn't have access.

This PR closes of access to any IP that responds on port 22, as that
is a port that is:

 - Known to be active by default
 - Not firewalled

A previous attempt at this was to have an [auth token](#736);
but this fix doesn't require changing the installer and people's PXE setups.

In the future we may reserve a port in the 9xxx range and have the
MCD respond on it so that admins who disable/firewall SSH don't
have indirectly reduced security.