### PR TITLE
Bug 1712507: etcdquorumguard: Respond correctly to TERM when pod shut down

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -33,6 +33,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
+      terminationGracePeriodSeconds: 3
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -49,16 +50,21 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-      - image: registry.svc.ci.openshift.org/openshift:cli
+      - image: quay.io/openshift/origin-cli:latest
         imagePullPolicy: IfNotPresent
         name: guard
         volumeMounts:
         - mountPath: /mnt/kube
           name: kubecerts
         command:
-        - "/bin/sleep"
+        - /bin/bash
         args:
-        - "infinity"
+        - -c
+        - |
+          # properly handle TERM and exit as soon as it is signaled
+          set -euo pipefail
+          trap 'jobs -p | xargs -r kill; exit 0' TERM
+          sleep infinity & wait
         readinessProbe:
           exec:
             command:

--- a/install/image-references
+++ b/install/image-references
@@ -45,4 +45,4 @@ spec:
   - name: cli
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:cli
+      name: quay.io/openshift/origin-cli:latest


### PR DESCRIPTION
sleep, when run as pid 1, does not correctly exit on TERM and so stays
running. Correct that by running a small shim that terminates on TERM,
lower the graceful deletion period (the minimum is 3s in practice).

Correct the image reference to be a real image so that this can be
tested against a working cluster.

Also, the etcd quorum guard test does not correctly make nodes unschedulable, resulting in occasional failures when the quorum guard exits more quickly.

@hexfusion @smarterclayton 