### PR TITLE
DR: backup etcd env file during snapshot restore

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -45,6 +45,7 @@ contents:
       init
       dl_etcdctl
       backup_manifest
+      backup_etcd_environment
       stop_static_pods
       stop_etcd
       stop_kubelet

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -69,6 +69,16 @@ contents:
       fi
     }
 
+    # backup etcd environment
+    backup_etcd_environment() {
+      if [ -e "${ASSET_DIR}/backup/etcd.environment" ]; then
+        echo "etcd.environment backup upready exists $ASSET_DIR/backup/etcd.environment"
+      else
+        echo "Backing up /run/etcd/environment to ${ASSET_DIR}/backup/"
+        cp /run/etcd/environment ${ASSET_DIR}/backup/etcd.environment
+      fi
+    }
+
     backup_data_dir() {
       if [ -f "$ASSET_DIR/backup/etcd/member/snap/db" ]; then
         echo "etcd data-dir backup found $ASSET_DIR/backup/etcd.."
@@ -143,7 +153,7 @@ contents:
       HOSTDOMAIN=$(hostname -d)
       ETCD_NAME=etcd-member-${HOSTNAME}.${HOSTDOMAIN}
 
-      source /run/etcd/environment
+      source ${ASSET_DIR}/backup/etcd.environment
 
       if [ -z "${ETCD_CONNSTRING}" ]; then
         ETCD_CONNSTRING="${ETCD_NAME}=https://${ETCD_DNS_NAME}:2380"


### PR DESCRIPTION
During snapshot restore this file may be deleted when pods are stopped, 
so restore_snapshot should use backed up copy of this file

/cc @hexfusion @runcom 