### PR TITLE
kubelet: add script to generate bootstrap recovery kubeconfig

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-kubeconfig-gen.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-kubeconfig-gen.yaml
@@ -1,0 +1,27 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/recover-kubeconfig.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    
+    set -eou pipefail
+    
+    # context
+    intapi=$(oc get infrastructures.config.openshift.io cluster -o "jsonpath={.status.apiServerURL}")
+    context="$(oc config current-context)"
+    # cluster
+    cluster="$(oc config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.cluster}")"
+    server="$(oc config view -o "jsonpath={.clusters[?(@.name==\"$cluster\")].cluster.server}")"
+    # token
+    ca_crt_data="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.ca\.crt}" | base64 --decode)"
+    namespace="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token  -o "jsonpath={.data.namespace}" | base64 --decode)"
+    token="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.token}" | base64 --decode)"
+    
+    export KUBECONFIG="$(mktemp)"
+    kubectl config set-credentials "kubelet" --token="$token" >/dev/null
+    ca_crt="$(mktemp)"; echo "$ca_crt_data" > $ca_crt
+    kubectl config set-cluster $cluster --server="$intapi" --certificate-authority="$ca_crt" --embed-certs >/dev/null
+    kubectl config set-context kubelet --cluster="$cluster" --user="kubelet" >/dev/null
+    kubectl config use-context kubelet >/dev/null
+    cat "$KUBECONFIG"


### PR DESCRIPTION
**- What I did**
Adds a recovery script to generate a bootstrap kubeconfig for use in kubelet disaster recovery scenarios.

**- Description for the changelog**
```
Add a script to generate a bootstrap kubeconfig for disaster recovery scenarios.
```

/cc @hexfusion @sjenning 