### PR TITLE
Make use of /dev/termination-log

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/pkg/errors"
 	"context"
 	"flag"
 
@@ -50,7 +51,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	cb, err := clients.NewBuilder(startOpts.kubeconfig)
 	if err != nil {
-		glog.Fatalf("error creating clients: %v", err)
+		controllercommon.WriteTerminationError(errors.Wrapf(err, "Creating clients"))
 	}
 	run := func(ctx context.Context) {
 		ctrlctx := controllercommon.CreateControllerContext(cb, ctx.Done(), componentName)

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -217,6 +217,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	dn.InstallSignalHandler(signaled)
 
 	if err := dn.Run(stopCh, signaled, exitCh); err != nil {
-		glog.Fatalf("Failed to run: %v", err)
+		controllercommon.WriteTerminationError(err)
 	}
 }

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
+	controllercommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/server"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
@@ -42,7 +43,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	cs, err := server.NewClusterServer(startOpts.kubeconfig, startOpts.apiserverURL)
 	if err != nil {
-		glog.Exitf("Machine Config Server exited with error: %v", err)
+		controllercommon.WriteTerminationError(err)
 	}
 
 	apiHandler := server.NewServerAPIHandler(cs)

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"io/ioutil"
+	"github.com/golang/glog"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 )
 
@@ -11,4 +13,11 @@ func NewIgnConfig() igntypes.Config {
 			Version: igntypes.MaxVersion.String(),
 		},
 	}
+}
+
+// WriteTerminationError writes to the Kubernetes termination log.
+func WriteTerminationError(err error) {
+	msg := err.Error()
+	ioutil.WriteFile("/dev/termination-log", []byte(msg), 0644)
+	glog.Fatal(msg)
 }


### PR DESCRIPTION
Debugging things is easier if we use the termination log, since
it ends up in the pod data which we can see directly in CI, etc.

Note since the daemon runs chrooted we can't quite make use of this
without doing e.g. `openat()` and holding a dfd for the real root
or so, but golang has an ergonomic hit for that.  May do it later.
