### PR TITLE
Add a machine-config-daemon.spec

### DIFF
--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -1,0 +1,35 @@
+%define debug_package %{nil}
+%global commit          4e75a8f20e5cf44374fd1bf3b3df997b8689d3ff
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
+Name:           machine-config-daemon
+Version:        4.0.0
+Release:        1.rhaos4.2.git%{shortcommit}%{?dist}
+Summary:        https://github.com/openshift/machine-config-operator
+License:        ASL 2.0
+URL:            https://github.com/openshift/machine-config-operator
+Source0:        https://github.com/openshift/machine-config-operator/archive/%{commit}/machine-config-operator-%{shortcommit}.tar.gz
+
+BuildRequires:  git
+BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.6.2}
+
+%description
+%{summary}
+
+%prep
+%autosetup -Sgit -n machine-config-operator-%{commit}
+mkdir -p src/github.com/openshift/
+ln -sr . src/github.com/openshift/machine-config-operator
+
+%build
+export GOPATH=`pwd`
+cd src/github.com/openshift/machine-config-operator
+env VERSION_OVERRIDE=%{version} SOURCE_GIT_COMMIT=%{commit} make daemon
+
+%install
+install -D -m 0755 _output/linux/*/%{name} $RPM_BUILD_ROOT/usr/libexec/%{name}
+
+%files
+%license LICENSE
+%doc README.md
+%{_libexecdir}/%{name}


### PR DESCRIPTION
As we move towards having more things in MachineConfig, we also
in many cases need the functionality during "early pivot" before
the cluster is up.

Let's just ship the MCD as part of the host as well so we can use
the same code then.

Now of course we have the same code in two places.  I think
what we'd want to do after this is have the "pod-MCD" call out
to the "host-MCD" as a subprocess.  That would actually simplify
other things as well.
