### PR TITLE
DR: use param to populate etcd name

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
@@ -8,7 +8,7 @@ contents:
     # example
     # export SETUP_ETCD_ENVIRONMENT=$(oc adm release info --image-for setup-etcd-environment --registry-config=./config.json)
     # export KUBE_CLIENT_AGENT=$(oc adm release info --image-for kube-client-agent --registry-config=./config.json)
-    # sudo -E ./etcd-member-recover.sh 192.168.1.100
+    # sudo -E ./etcd-member-recover.sh 192.168.1.100 $etcd_name
 
     if [[ $EUID -ne 0 ]]; then
       echo "This script must be run as root"
@@ -19,15 +19,16 @@ contents:
     : ${KUBE_CLIENT_AGENT:?"Need to set KUBE_CLIENT_AGENT"}
 
     usage () {
-        echo 'Recovery server IP address required: ./etcd-member-recover.sh 192.168.1.100'
-        exit
+        echo 'Recovery server IP address and etcd name required: ./etcd-member-recover.sh 192.168.1.100 $etcd_name'
+        exit 1
     }
 
-    if [ "$1" == "" ]; then
+    if [ "$1" == "" ] || [ "$2" == "" ]; then
         usage
     fi
 
     RECOVERY_SERVER_IP=$1
+    ETCD_NAME=$2
 
     ASSET_DIR=./assets
     ASSET_DIR_TMP="$ASSET_DIR/tmp"
@@ -58,6 +59,7 @@ contents:
         exit 1
       fi
       validate_environment
+      source  /run/etcd/environment
       backup_etcd_conf
       backup_etcd_client_certs
       stop_etcd

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -9,7 +9,7 @@ contents:
     set -o pipefail
 
     # example
-    # etcd-snapshot-restore.sh $path-to-snapshot $etcd-connection-string
+    # ./etcd-snapshot-restore.sh $path-to-snapshot $inital_cluster
 
     if [[ $EUID -ne 0 ]]; then
       echo "This script must be run as root"
@@ -17,20 +17,16 @@ contents:
     fi
 
     usage () {
-        echo 'Path to snapshot is required: ./etcd-member-recover.sh $path-to-snapshot'
-        exit
+        echo 'Path to snapshot and initial cluster are required: ./etcd-snapshot-restore.sh $path-to-snapshot $initial_cluster'
+        exit 1
     }
 
-    if [ "$1" == "" ]; then
+    if [ "$1" == "" ] || [ "$2" == "" ]; then
         usage
     fi
 
     SNAPSHOT_FILE="$1"
-    ETCD_CONNSTRING=""
-    if [ "$2" != "" ]; then
-      ETCD_CONNSTRING="$2"
-    fi
-
+    ETCD_INITIAL_CLUSTER="$2"
     ASSET_DIR=./assets
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
@@ -56,6 +52,8 @@ contents:
         exit 1
       fi
       validate_environment
+      source /run/etcd/environment
+      ETCD_NAME=$(validate_etcd_name)
       stop_static_pods
       stop_etcd
       stop_kubelet

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -139,28 +139,15 @@ contents:
     }
 
     restore_snapshot() {
-      HOSTNAME=$(hostname)
-      HOSTDOMAIN=$(hostname -d)
-      ETCD_NAME=etcd-member-${HOSTNAME}.${HOSTDOMAIN}
-
-      source /run/etcd/environment
-
-      if [ -z "${ETCD_CONNSTRING}" ]; then
-        ETCD_CONNSTRING="${ETCD_NAME}=https://${ETCD_DNS_NAME}:2380"
-      fi
-
       if [ ! -f "$SNAPSHOT_FILE" ]; then
         echo "Snapshot file not found, restore failed: $SNAPSHOT_FILE."
         exit 1
       fi
 
-      sleep 2
-
       echo "Restoring etcd member $ETCD_NAME from snapshot.."
-
       env ETCDCTL_API=3 ${ETCDCTL} snapshot restore $SNAPSHOT_FILE \
         --name $ETCD_NAME \
-        --initial-cluster ${ETCD_CONNSTRING} \
+        --initial-cluster ${ETCD_INITIAL_CLUSTER} \
         --initial-cluster-token etcd-cluster-1 \
         --skip-hash-check=true \
         --initial-advertise-peer-urls https://${ETCD_IPV4_ADDRESS}:2380 \
@@ -203,16 +190,11 @@ contents:
 
     # add member cluster
     etcd_member_add() {
-      source  /run/etcd/environment
-      HOSTNAME=$(hostname)
-      HOSTDOMAIN=$(hostname -d)
-      ETCD_NAME=etcd-member-${HOSTNAME}.${HOSTDOMAIN}
-
+      echo "Updating etcd membership.."
       if [ -d "$ETCD_DATA_DIR" ]; then
+        echo "Removing etcd data_dir $ETCD_DATA_DIR.."
         rm -rf $ETCD_DATA_DIR
       fi
-
-      echo "Updating etcd membership.."
 
       RESPONSE=$(env ETCDCTL_API=3 $ETCDCTL --cert $ASSET_DIR/backup/etcd-client.crt --key $ASSET_DIR/backup/etcd-client.key --cacert $ASSET_DIR/backup/etcd-ca-bundle.crt \
         --endpoints ${RECOVERY_SERVER_IP}:2379 member add $ETCD_NAME --peer-urls=https://${ETCD_DNS_NAME}:2380)
@@ -359,4 +341,14 @@ contents:
       done
       echo "SRV query failed no matching records found"
       exit 1
+    }
+
+    # validate_etcd_name uses regex to return the etcd member name key from ETCD_INITIAL_CLUSTER matching the local ETCD_DNS_NAME.
+    validate_etcd_name() {
+      ETCD_NAME=$(echo ${ETCD_INITIAL_CLUSTER} | grep -oP "(?<=)[^,,\s]*(?==[^=]*${ETCD_DNS_NAME}\b)")
+      if [ -z "$ETCD_NAME" ]; then
+        echo "${ETCD_DNS_NAME} is not found in ${ETCD_INITIAL_CLUSTER}"
+        exit 1
+      fi
+      echo "$ETCD_NAME"
     }


### PR DESCRIPTION
The PR resolves a few issues.

* `ETCD_NAME` is currently populated from `hostname` but this is not always valid. For example, `hostname` in AWS returns the hostname of the node. But in baremetal hostname returns FQDN. Because we can no longer assume how etcd name is formatted we will ask for it as a mandatory param for `etcd-member-recover.sh`. With the addition of `validate_etcd_name function,` we can now extract the ETCD_NAME from `ETCD_INITIAL_CLUSTER` for `etcd-snapshot-restore.sh`.

* ETCD_CONNSTRING is now renamed ETCD_INTIAL_CLUSTER to more accurately reflect value.

* Fail early if SNAPSHOT_FILE does not actually exist.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1714457

/hold

