### PR TITLE
pkg/daemon: backup the initial node annotations file

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -28,6 +28,8 @@ const (
 	// InitialNodeAnnotationsFilePath defines the path at which it will find the node annotations it needs to set on the node once it comes up for the first time.
 	// The Machine Config Server writes the node annotations to this path.
 	InitialNodeAnnotationsFilePath = "/etc/machine-config-daemon/node-annotations.json"
+	// InitialNodeAnnotationsBakPath defines the path of InitialNodeAnnotationsFilePath when the initial bootstrap is done. We leave it around for debugging and reconciling.
+	InitialNodeAnnotationsBakPath = "/etc/machine-config-daemon/node-annotation.json.bak"
 
 	// EtcPivotFile is used by the `pivot` command
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -839,11 +839,11 @@ func (dn *Daemon) CheckStateOnBoot() error {
 		}
 		glog.Info("No bootstrap pivot required; unlinking bootstrap node annotations")
 
-		// Delete the bootstrap node annotations; the
+		// Rename the bootstrap node annotations; the
 		// currentConfig's osImageURL should now be *truth*.
 		// In other words if it drifts somehow, we go degraded.
-		if err := os.Remove(constants.InitialNodeAnnotationsFilePath); err != nil {
-			return errors.Wrapf(err, "removing initial node annotations file")
+		if err := os.Rename(constants.InitialNodeAnnotationsFilePath, constants.InitialNodeAnnotationsBakPath); err != nil {
+			return errors.Wrap(err, "renaming initial node annotation file")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

Trying to understand something about https://bugzilla.redhat.com/show_bug.cgi?id=1702626

Let's check if that file is at all around. This isn't really changing any logic but the rename vs delete of the initial node annotation file.