### PR TITLE
Bug 1702626: pkg/daemon: reconcile if we lost annotations

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -28,6 +28,8 @@ const (
 	// InitialNodeAnnotationsFilePath defines the path at which it will find the node annotations it needs to set on the node once it comes up for the first time.
 	// The Machine Config Server writes the node annotations to this path.
 	InitialNodeAnnotationsFilePath = "/etc/machine-config-daemon/node-annotations.json"
+	// InitialNodeAnnotationsBakPath defines the path of InitialNodeAnnotationsFilePath when the initial bootstrap is done. We leave it around for debugging and reconciling.
+	InitialNodeAnnotationsBakPath = "/etc/machine-config-daemon/node-annotation.json.bak"
 
 	// EtcPivotFile is used by the `pivot` command
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -839,11 +839,11 @@ func (dn *Daemon) CheckStateOnBoot() error {
 		}
 		glog.Info("No bootstrap pivot required; unlinking bootstrap node annotations")
 
-		// Delete the bootstrap node annotations; the
+		// Rename the bootstrap node annotations; the
 		// currentConfig's osImageURL should now be *truth*.
 		// In other words if it drifts somehow, we go degraded.
-		if err := os.Remove(constants.InitialNodeAnnotationsFilePath); err != nil {
-			return errors.Wrapf(err, "removing initial node annotations file")
+		if err := os.Rename(constants.InitialNodeAnnotationsFilePath, constants.InitialNodeAnnotationsBakPath); err != nil {
+			return errors.Wrap(err, "renaming initial node annotation file")
 		}
 	}
 


### PR DESCRIPTION
~Builds on #806 for no good reason actually.~ brought it in here

Should take care of this one as well https://github.com/openshift/machine-config-operator/issues/660 but requires an MCD restart (we might want to drop `dn.booting` to have it automatically reconciles)

This is tricky, but the aim is to workaround missing annotations on node (best effort) - I haven't fully tested this just yet but reviews are highly appreciated.