### PR TITLE
Dockerfile.*: bump to golang-1.12

### DIFF
--- a/Dockerfile.machine-config-controller
+++ b/Dockerfile.machine-config-controller
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-controller ./hack/build-go.sh

--- a/Dockerfile.machine-config-controller.rhel7
+++ b/Dockerfile.machine-config-controller.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-controller ./hack/build-go.sh; \

--- a/Dockerfile.machine-config-daemon
+++ b/Dockerfile.machine-config-daemon
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-daemon ./hack/build-go.sh

--- a/Dockerfile.machine-config-daemon.rhel7
+++ b/Dockerfile.machine-config-daemon.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-daemon ./hack/build-go.sh; \

--- a/Dockerfile.machine-config-daemon.upstream
+++ b/Dockerfile.machine-config-daemon.upstream
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-daemon ./hack/build-go.sh

--- a/Dockerfile.machine-config-operator
+++ b/Dockerfile.machine-config-operator
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-operator ./hack/build-go.sh

--- a/Dockerfile.machine-config-operator.rhel7
+++ b/Dockerfile.machine-config-operator.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-operator ./hack/build-go.sh; \

--- a/Dockerfile.machine-config-server
+++ b/Dockerfile.machine-config-server
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-server ./hack/build-go.sh

--- a/Dockerfile.machine-config-server.rhel7
+++ b/Dockerfile.machine-config-server.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-server ./hack/build-go.sh; \

--- a/Dockerfile.setup-etcd-environment
+++ b/Dockerfile.setup-etcd-environment
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=setup-etcd-environment ./hack/build-go.sh

--- a/Dockerfile.setup-etcd-environment.rhel7
+++ b/Dockerfile.setup-etcd-environment.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=setup-etcd-environment ./hack/build-go.sh; \


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

bump golang base images in Dockerfile(s) to 1.12, part of #796

/hold

Holding since we need openshift/release changes as well

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
