### PR TITLE
Makefile: drop GOCACHE for go1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,4 +98,4 @@ images.rhel7: $(imc7)
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	GOCACHE=off go test -timeout 75m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -timeout 75m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

fix https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/813/pull-ci-openshift-machine-config-operator-master-e2e-aws-op/2316

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
