### PR TITLE
templates: update default etcd conf on Azure

### DIFF
--- a/templates/master/00-master/azure/files/etc-etcd-etcd-conf.yaml
+++ b/templates/master/00-master/azure/files/etc-etcd-etcd-conf.yaml
@@ -1,0 +1,18 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/etcd/etcd.conf"
+contents:
+  inline: |
+    #[member]
+    ETCD_SNAPSHOT_COUNT=100000
+    ETCD_HEARTBEAT_INTERVAL=500
+    ETCD_ELECTION_TIMEOUT=2500
+
+    #[storage]
+    ETCD_QUOTA_BACKEND_BYTES=7516192768
+
+    #[logging]
+    ETCD_DEBUG=false
+
+    #[profiling]
+    ETCD_ENABLE_PPROF=false


### PR DESCRIPTION
on Azure, it seems like 40%+ of peer round trips are over 25ms. Therefore etcd team has made a recommendation for

```
current: ETCD_ELECTION_TIMEOUT=1000

We would want to bump that to 2500

current: ETCD_HEARTBEAT_INTERVAL=100

500
```

/cc @hexfusion @crawford 