### PR TITLE
pkg/daemon: roll back kargs on error and ignore kargs update on non-RHCOS

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -237,6 +237,14 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 	if err := dn.updateKernelArguments(oldConfig, newConfig); err != nil {
 		return err
 	}
+	defer func() {
+		if retErr != nil {
+			if err := dn.updateKernelArguments(newConfig, oldConfig); err != nil {
+				retErr = errors.Wrapf(retErr, "error rolling back kernel arguments %v", err)
+				return
+			}
+		}
+	}()
 
 	return dn.updateOSAndReboot(newConfig)
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed some late review comments that I've just noticed over at https://github.com/openshift/machine-config-operator/pull/762/files#diff-13f28de2a32e0dab8f73b67aa5af9803R24

- roll back kargs on error
- do not bail when trying to update kargs on non-RHOS, just log it as we're doing for OS upgrades

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
