### PR TITLE
pkg/operator: expose more resources to must-gather

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -207,6 +207,9 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 	// RelatedObjects are consumed by https://github.com/openshift/must-gather
 	co.Status.RelatedObjects = []configv1.ObjectReference{
 		{Resource: "namespaces", Name: "openshift-machine-config-operator"},
+		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "master"},
+		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "worker"},
+		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "cluster"},
 	}
 	// During an installation we report the RELEASE_VERSION as soon as the component is created
 	// whether for normal runs and upgrades this code isn't hit and we get the right version every


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

added collection of master,worker MCP and CC

**- How to verify it**

run must-gather

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
