### PR TITLE
templates: Make pull secret mode 0600

### DIFF
--- a/templates/common/_base/files/pull-secret.yaml
+++ b/templates/common/_base/files/pull-secret.yaml
@@ -1,5 +1,5 @@
 filesystem: "root"
-mode: 0644
+mode: 0600
 path: "/var/lib/kubelet/config.json"
 contents:
   inline: |


### PR DESCRIPTION
This is just generally a good idea; other processes on the host
besides kubelet have no business reading this.

Came out of discussion about supporting a pattern for *unprivileged*
pods that mount the host read-only, for inspection/tracing.
