### PR TITLE
pkg/controller/node: fix controller to handle multiple roles

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -452,11 +452,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return ctrl.syncStatusOnly(pool)
 	}
 
-	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
-	if err != nil {
-		return fmt.Errorf("invalid label selector: %v", err)
-	}
-	nodes, err := ctrl.nodeLister.List(selector)
+	nodes, err := ctrl.getNodesForPool(pool)
 	if err != nil {
 		return err
 	}
@@ -473,6 +469,32 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		}
 	}
 	return ctrl.syncStatusOnly(pool)
+}
+
+func (ctrl *Controller) getNodesForPool(pool *mcfgv1.MachineConfigPool) ([]*corev1.Node, error) {
+	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid label selector: %v", err)
+	}
+
+	initialNodes, err := ctrl.nodeLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := []*corev1.Node{}
+	for _, n := range initialNodes {
+		p, err := ctrl.getPoolForNode(n)
+		if err != nil {
+			glog.Warningf("can't get pool for node %q: %v", n.Name, err)
+			continue
+		}
+		if p.Name != pool.Name {
+			continue
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
 }
 
 func (ctrl *Controller) setDesiredMachineConfigAnnotation(nodeName, currentConfig string) error {

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -9,15 +9,10 @@ import (
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
-	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)
-	if err != nil {
-		return err
-	}
-	nodes, err := ctrl.nodeLister.List(selector)
+	nodes, err := ctrl.getNodesForPool(pool)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the node belongs to more than 1 pool, run it through the same logic we use
to add it to the queue for a specific pool. This avoids including nodes in
multiple pools for status reporting and multiple desiredConfig swaps.

see https://github.com/openshift/machine-config-operator/issues/429#issuecomment-499458138 for testing. W/o this patch, the worker pool will show Updating with 6 nodes cause 3 nodes are both worker and infra. If you then add an MC for worker only, nodes go through reconciliation twice (which is super bad cause of reboot).

Close #429 
Close https://github.com/openshift/machine-config-operator/issues/294

Signed-off-by: Antonio Murdaca <runcom@linux.com>