### PR TITLE
pkg/operator Filter out non-MCO CRDs when re-syncing modified MCO CRDs

### DIFF
--- a/manifests/containerruntimeconfig.crd.yaml
+++ b/manifests/containerruntimeconfig.crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: containerruntimeconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   group: machineconfiguration.openshift.io
   names:

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: controllerconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io

--- a/manifests/kubeletconfig.crd.yaml
+++ b/manifests/kubeletconfig.crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kubeletconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   group: machineconfiguration.openshift.io
   names:

--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   additionalPrinterColumns:
   - JSONPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version

--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigpools.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.configuration.name

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -155,6 +155,8 @@ var _manifestsContainerruntimeconfigCrdYaml = []byte(`apiVersion: apiextensions.
 kind: CustomResourceDefinition
 metadata:
   name: containerruntimeconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   group: machineconfiguration.openshift.io
   names:
@@ -193,6 +195,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: controllerconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
@@ -235,6 +239,8 @@ var _manifestsKubeletconfigCrdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubeletconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   group: machineconfiguration.openshift.io
   names:
@@ -271,6 +277,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   additionalPrinterColumns:
   - JSONPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
@@ -739,6 +747,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: machineconfigpools.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.configuration.name


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
Please provide the following information:
-->
Fixes #815 

**- What I did**
Following #817, added a label for `mco-built-in/crd` to MCO CRDs in the `manifests/` directory.  
Then modified `apiExtSharedInformer` to filter based on this label.
Tested on an AWS cluster to be working.

**- How to verify it**
Add logging statements to the `enqueue` function in `pkg/operator/operator.go` and watch `machine-config-operator` pod logs in kube and verify that non-MCO CRDs are not being re-synced (when they don't need to be, as seen in the issue, #815 ).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Filter out object changes not pertaining to MCO when re-syncing MCO CRDs.

