### PR TITLE
Bug 1718421: templates: Add missing fields to crio.conf 

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,13 @@ contents:
     #storage_option = [
     #]
 
+    # file_locking is whether file-based locking will be used instead of
+    # in-memory locking
+    file_locking = false
+
+    # Path to the lock file.
+    file_locking_path = "/run/crio.lock"
+
     # The "crio.api" table contains settings for the kubelet/gRPC interface.
     [crio.api]
 
@@ -56,41 +63,24 @@ contents:
     # This file can change, and CRIO will automatically pick up the changes within 5 minutes.
     stream_tls_ca = ""
 
-    # file_locking is whether file-based locking will be used instead of
-    # in-memory locking
-    file_locking = false
-
     # The "crio.runtime" table contains settings pertaining to the OCI
     # runtime used and options for how to set up and manage the OCI runtime.
     [crio.runtime]
 
-    # runtime is the OCI compatible runtime used for trusted container workloads.
-    # This is a mandatory setting as this runtime will be the default one
-    # and will also be used for untrusted container workloads if
-    # runtime_untrusted_workload is not set.
-    runtime = "/usr/bin/runc"
+    # A list of ulimits to be set in containers by default, specified as
+    # "<ulimit name>=<soft limit>:<hard limit>", for example:
+    # "nofile=1024:2048"
+    # If nothing is set here, settings will be inherited from the CRI-O daemon
+    #default_ulimits = []
 
-    # runtime_untrusted_workload is the OCI compatible runtime used for untrusted
-    # container workloads. This is an optional setting, except if
-    # default_container_trust is set to "untrusted".
-    runtime_untrusted_workload = ""
+    # Path to the OCI compatible runtime used for trusted container workloads. This
+    # is a mandatory setting as this runtime will be the default and will also be
+    # used for untrusted container workloads if runtime_untrusted_workload is not
+    # set.
 
-    # default_workload_trust is the default level of trust crio puts in container
-    # workloads. It can either be "trusted" or "untrusted", and the default
-    # is "trusted".
-    # Containers can be run through different container runtimes, depending on
-    # the trust hints we receive from kubelet:
-    # - If kubelet tags a container workload as untrusted, crio will try first to
-    # run it through the untrusted container workload runtime. If it is not set,
-    # crio will use the trusted runtime.
-    # - If kubelet does not provide any information about the container workload trust
-    # level, the selected runtime will depend on the default_container_trust setting.
-    # If it is set to "untrusted", then all containers except for the host privileged
-    # ones, will be run by the runtime_untrusted_workload runtime. Host privileged
-    # containers are by definition trusted and will always use the trusted container
-    # runtime. If default_container_trust is set to "trusted", crio will use the trusted
-    # container runtime for all containers.
-    default_workload_trust = "trusted"
+    # default_runtime is the _name_ of the OCI runtime to be used as the default.
+    # The name is matched against the runtimes map below.
+    default_runtime = "runc"
 
     # no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
     no_pivot = false
@@ -139,6 +129,16 @@ contents:
       "SYS_CHROOT", 
       "KILL", 
     ]
+
+    # List of default sysctls. If it is empty or commented out, only the sysctls
+    # defined in the container json file by the user/kube will be added.
+    default_sysctls = []
+
+    # List of additional devices. specified as
+    # "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
+    #If it is empty or commented out, only the devices
+    # defined in the container json file by the user/kube will be added.
+    additional_devices = []
 
     # hooks_dir_path is the oci hooks directory for automatically executed hooks
     hooks_dir_path = "/usr/share/containers/oci/hooks.d"
@@ -195,6 +195,17 @@ contents:
     # A range is specified in the form containerGID:HostGID:Size.  Multiple
     # ranges are separed by comma.
     gid_mappings = ""
+
+    # The minimal amount of time in seconds to wait before issuing a timeout
+    # regarding the proper termination of the container.
+    ctr_stop_timeout = 10
+
+    # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
+    # The runtime to use is picked based on the runtime_handler provided by the CRI.
+    # If no runtime_handler is provided, the runtime will be picked based on the level
+    # of trust of the workload.
+    [crio.runtime.runtimes.runc]
+    runtime_path = "/usr/bin/runc"
 
     [crio.image]
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,13 @@ contents:
     #storage_option = [
     #]
 
+    # file_locking is whether file-based locking will be used instead of
+    # in-memory locking
+    file_locking = false
+
+    # Path to the lock file.
+    file_locking_path = "/run/crio.lock"
+
     # The "crio.api" table contains settings for the kubelet/gRPC interface.
     [crio.api]
 
@@ -56,41 +63,24 @@ contents:
     # This file can change, and CRIO will automatically pick up the changes within 5 minutes.
     stream_tls_ca = ""
 
-    # file_locking is whether file-based locking will be used instead of
-    # in-memory locking
-    file_locking = false
-
     # The "crio.runtime" table contains settings pertaining to the OCI
     # runtime used and options for how to set up and manage the OCI runtime.
     [crio.runtime]
 
-    # runtime is the OCI compatible runtime used for trusted container workloads.
-    # This is a mandatory setting as this runtime will be the default one
-    # and will also be used for untrusted container workloads if
-    # runtime_untrusted_workload is not set.
-    runtime = "/usr/bin/runc"
+    # A list of ulimits to be set in containers by default, specified as
+    # "<ulimit name>=<soft limit>:<hard limit>", for example:
+    # "nofile=1024:2048"
+    # If nothing is set here, settings will be inherited from the CRI-O daemon
+    #default_ulimits = []
 
-    # runtime_untrusted_workload is the OCI compatible runtime used for untrusted
-    # container workloads. This is an optional setting, except if
-    # default_container_trust is set to "untrusted".
-    runtime_untrusted_workload = ""
+    # Path to the OCI compatible runtime used for trusted container workloads. This
+    # is a mandatory setting as this runtime will be the default and will also be
+    # used for untrusted container workloads if runtime_untrusted_workload is not
+    # set.
 
-    # default_workload_trust is the default level of trust crio puts in container
-    # workloads. It can either be "trusted" or "untrusted", and the default
-    # is "trusted".
-    # Containers can be run through different container runtimes, depending on
-    # the trust hints we receive from kubelet:
-    # - If kubelet tags a container workload as untrusted, crio will try first to
-    # run it through the untrusted container workload runtime. If it is not set,
-    # crio will use the trusted runtime.
-    # - If kubelet does not provide any information about the container workload trust
-    # level, the selected runtime will depend on the default_container_trust setting.
-    # If it is set to "untrusted", then all containers except for the host privileged
-    # ones, will be run by the runtime_untrusted_workload runtime. Host privileged
-    # containers are by definition trusted and will always use the trusted container
-    # runtime. If default_container_trust is set to "trusted", crio will use the trusted
-    # container runtime for all containers.
-    default_workload_trust = "trusted"
+    # default_runtime is the _name_ of the OCI runtime to be used as the default.
+    # The name is matched against the runtimes map below.
+    default_runtime = "runc"
 
     # no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
     no_pivot = false
@@ -139,6 +129,16 @@ contents:
       "SYS_CHROOT", 
       "KILL", 
     ]
+
+    # List of default sysctls. If it is empty or commented out, only the sysctls
+    # defined in the container json file by the user/kube will be added.
+    default_sysctls = []
+
+    # List of additional devices. specified as
+    # "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
+    #If it is empty or commented out, only the devices
+    # defined in the container json file by the user/kube will be added.
+    additional_devices = []
 
     # hooks_dir_path is the oci hooks directory for automatically executed hooks
     hooks_dir_path = "/usr/share/containers/oci/hooks.d"
@@ -195,6 +195,17 @@ contents:
     # A range is specified in the form containerGID:HostGID:Size.  Multiple
     # ranges are separed by comma.
     gid_mappings = ""
+
+    # The minimal amount of time in seconds to wait before issuing a timeout
+    # regarding the proper termination of the container.
+    ctr_stop_timeout = 10
+
+    # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
+    # The runtime to use is picked based on the runtime_handler provided by the CRI.
+    # If no runtime_handler is provided, the runtime will be picked based on the level
+    # of trust of the workload.
+    [crio.runtime.runtimes.runc]
+    runtime_path = "/usr/bin/runc"
 
     [crio.image]
 


### PR DESCRIPTION
Certain options such as default_runtime were missing
from the crio.conf template in the MCO. This was causing
issues when upgrading cri-o from 1.13 to 1.14.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>