### PR TITLE
Sync OpenStack kubelet config and everyone else's kubelet config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ verify:
 	@which go-bindata 2> /dev/null >&1 || { echo "go-bindata must be installed to verify generated code";  exit 1; }
 	hack/verify-codegen.sh
 	hack/verify-generated-bindata.sh
+	hack/verify-kubelet-template-diff.sh
 
 # Template for defining build targets for binaries.
 define target_template =

--- a/hack/verify-kubelet-template-diff.sh
+++ b/hack/verify-kubelet-template-diff.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+count=$(diff -U 0 "${REPO_ROOT}/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml" "${REPO_ROOT}/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml" | grep -v ^@ | grep -v '^---' | grep -v '^+++' | wc -l || /bin/true)
+if [[ $count -ne 1 ]]; then
+	echo "Too many differences in the worker template"
+	exit 1
+fi
+count=$(diff -U 0 "${REPO_ROOT}/templates/master/01-master-kubelet/openstack/units/kubelet.yaml" "${REPO_ROOT}/templates/master/01-master-kubelet/_base/units/kubelet.yaml" | grep -v ^@ | grep -v '^---' | grep -v '^+++' | wc -l || /bin/true)
+if [[ $count -ne 1 ]]; then
+	echo "Too many differences in the master template"
+	exit 1
+fi

--- a/templates/master/01-master-kubelet/openstack/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/openstack/units/kubelet.yaml
@@ -3,11 +3,14 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service
+  Wants=rpc-statd.service crio.service
+  After=crio.service
 
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -19,10 +22,12 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --node-labels=node-role.kubernetes.io/master \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --v=3 \
 
   Restart=always
   RestartSec=10

--- a/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml
@@ -3,11 +3,14 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service
+  Wants=rpc-statd.service crio.service
+  After=crio.service
 
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -18,9 +21,11 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --node-labels=node-role.kubernetes.io/worker \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
-        {{cloudConfigFlag . }}
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        {{cloudConfigFlag . }} \
+        --v=3 \
 
   Restart=always
   RestartSec=10


### PR DESCRIPTION
It appears OpenStack added their own kubelet config without cloudconfig set. The pod team updated the _base kubelet config but never updated the OpenStack version. This re-sync's the files and it creates an (extremely hacky) verify script to hopefully keep them in sync.

I think the existence of this PR means we're doing it wrong. And probably shouldn't allow these per platform file overwrites. We should find a better way to templatize such differences.