### PR TITLE
mcd: use GA kubelet OS label

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
       volumes:
         - name: rootfs

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -598,7 +598,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
       volumes:
         - name: rootfs

--- a/test/e2e/sanity_test.go
+++ b/test/e2e/sanity_test.go
@@ -16,7 +16,7 @@ func TestOperatorLabel(t *testing.T) {
 		t.Errorf("%#v", err)
 	}
 
-	osSelector := d.Spec.Template.Spec.NodeSelector["beta.kubernetes.io/os"]
+	osSelector := d.Spec.Template.Spec.NodeSelector["kubernetes.io/os"]
 	if osSelector != "linux" {
 		t.Errorf("Expected node selector 'linux', not '%s'", osSelector)
 	}


### PR DESCRIPTION
**- What I did**
Kubelet now has support for GA OS label as of 1.14.0. Bump MCD to use the new label.

ref: https://jira.coreos.com/browse/POD-114
ref: https://github.com/kubernetes/kubernetes/pull/73048

**- How to verify it**

**- Description for the changelog**
```
Change MCD to use the generally available OS label `kubernetes.io/os` as a selector.
```
