### PR TITLE
Add shortnames for MachineConfig and MachineConfigPool CRDs

### DIFF
--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -34,3 +34,6 @@ spec:
     singular: machineconfig
     # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: MachineConfig
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mc

--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -40,3 +40,6 @@ spec:
     singular: machineconfigpool
     # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: MachineConfigPool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mcp

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -300,6 +300,9 @@ spec:
     singular: machineconfig
     # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: MachineConfig
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mc
 `)
 
 func manifestsMachineconfigCrdYamlBytes() ([]byte, error) {
@@ -769,6 +772,9 @@ spec:
     singular: machineconfigpool
     # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: MachineConfigPool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mcp
 `)
 
 func manifestsMachineconfigpoolCrdYamlBytes() ([]byte, error) {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added mc and mcd shortnames for MachineConfig and MachineConfigPool CRDs respectively.

**- How to verify it**
`oc describe mc` and `oc describe mcp`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added mc and mcd shortnames for MachineConfig and MachineConfigPool CRDs respectively.
