### PR TITLE
Centralize test helpers for NewMachineConfig{,Pool}

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -6,9 +6,9 @@ import (
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/vincent-petithory/dataurl"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
 func TestFeatureGateDrift(t *testing.T) {
@@ -42,10 +42,10 @@ func TestFeaturesDefault(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(common.ControllerConfigName, platform)
-			mcp := newMachineConfigPool("master", map[string]string{"kubeletType": "small-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "v0")
-			mcp2 := newMachineConfigPool("worker", map[string]string{"kubeletType": "large-pods"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "worker"), "v0")
-			mcs := newMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role": "master"}, "dummy://", []igntypes.File{{}})
-			mcs2 := newMachineConfig(getManagedKubeletConfigKey(mcp2), map[string]string{"node-role": "worker"}, "dummy://", []igntypes.File{{}})
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcs := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcs2 := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp2), map[string]string{"node-role/worker": ""}, "dummy://", []igntypes.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -10,10 +10,6 @@ import (
 	"time"
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
-	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
-	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
-	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +22,12 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
+	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
 var pathtests = []struct {
@@ -348,14 +350,6 @@ func newNode(annotations map[string]string) *corev1.Node {
 	}
 }
 
-func newMachineConfig(name string) *mcfgv1.MachineConfig {
-	return &mcfgv1.MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-}
-
 func TestPrepUpdateFromClusterOnDiskDrift(t *testing.T) {
 	tmpCurrentConfig, err := ioutil.TempFile("", "currentconfig")
 	require.Nil(t, err)
@@ -363,15 +357,15 @@ func TestPrepUpdateFromClusterOnDiskDrift(t *testing.T) {
 
 	// 1: onDisk matches what on the node, so we now have currentFromNode == currentOnDisk, desiredFromNode
 	f := newFixture(t)
-	onDiskMC := newMachineConfig("test1")
+	onDiskMC := helpers.NewMachineConfig("test1", nil, "", nil)
 	annotations := map[string]string{
 		constants.CurrentMachineConfigAnnotationKey:     "test1",
 		constants.DesiredMachineConfigAnnotationKey:     "test2",
 		constants.MachineConfigDaemonStateAnnotationKey: "",
 	}
 	node := newNode(annotations)
-	f.objects = append(f.objects, newMachineConfig("test1"))
-	f.objects = append(f.objects, newMachineConfig("test2"))
+	f.objects = append(f.objects, helpers.NewMachineConfig("test1", nil, "", nil))
+	f.objects = append(f.objects, helpers.NewMachineConfig("test2", nil, "", nil))
 	tmpCurrentConfig.Truncate(0)
 	tmpCurrentConfig.Seek(0, 0)
 	require.Nil(t, json.NewEncoder(tmpCurrentConfig).Encode(onDiskMC))
@@ -388,15 +382,15 @@ func TestPrepUpdateFromClusterOnDiskDrift(t *testing.T) {
 	//    so we now have currentFromNode == currentOnDisk == desiredFromNode
 	//    so no update required
 	f = newFixture(t)
-	onDiskMC = newMachineConfig("test1")
+	onDiskMC = helpers.NewMachineConfig("test1", nil, "", nil)
 	annotations = map[string]string{
 		constants.CurrentMachineConfigAnnotationKey:     "test1",
 		constants.DesiredMachineConfigAnnotationKey:     "test1",
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateDone,
 	}
 	node = newNode(annotations)
-	f.objects = append(f.objects, newMachineConfig("test1"))
-	f.objects = append(f.objects, newMachineConfig("test2"))
+	f.objects = append(f.objects, helpers.NewMachineConfig("test1", nil, "", nil))
+	f.objects = append(f.objects, helpers.NewMachineConfig("test2", nil, "", nil))
 	tmpCurrentConfig.Truncate(0)
 	tmpCurrentConfig.Seek(0, 0)
 	require.Nil(t, json.NewEncoder(tmpCurrentConfig).Encode(onDiskMC))
@@ -411,15 +405,15 @@ func TestPrepUpdateFromClusterOnDiskDrift(t *testing.T) {
 	// 3: onDisk doesn't what on the node and current == desired,
 	//    so we now have currentFromNode != currentOnDisk, desiredFromNode
 	f = newFixture(t)
-	onDiskMC = newMachineConfig("test3")
+	onDiskMC = helpers.NewMachineConfig("test3", nil, "", nil)
 	annotations = map[string]string{
 		constants.CurrentMachineConfigAnnotationKey:     "test1",
 		constants.DesiredMachineConfigAnnotationKey:     "test2",
 		constants.MachineConfigDaemonStateAnnotationKey: "",
 	}
 	node = newNode(annotations)
-	f.objects = append(f.objects, newMachineConfig("test1"))
-	f.objects = append(f.objects, newMachineConfig("test2"))
+	f.objects = append(f.objects, helpers.NewMachineConfig("test1", nil, "", nil))
+	f.objects = append(f.objects, helpers.NewMachineConfig("test2", nil, "", nil))
 	tmpCurrentConfig.Truncate(0)
 	tmpCurrentConfig.Seek(0, 0)
 	require.Nil(t, json.NewEncoder(tmpCurrentConfig).Encode(onDiskMC))

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -1,0 +1,82 @@
+package helpers
+
+import (
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+var (
+	MasterSelector = metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/master", "")
+	WorkerSelector = metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/worker", "")
+	InfraSelector  = metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra", "")
+)
+
+func NewMachineConfig(name string, labels map[string]string, osurl string, files []igntypes.File) *mcfgv1.MachineConfig {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcfgv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+			UID:    types.UID(utilrand.String(5)),
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			OSImageURL: osurl,
+			Config: igntypes.Config{
+				Ignition: igntypes.Ignition{
+					Version: igntypes.MaxVersion.String(),
+				},
+				Storage: igntypes.Storage{
+					Files: files,
+				},
+			},
+		},
+	}
+}
+
+func NewMachineConfigPool(name string, mcSelector *metav1.LabelSelector, nodeSelector *metav1.LabelSelector, currentMachineConfig string) *mcfgv1.MachineConfigPool {
+	return &mcfgv1.MachineConfigPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcfgv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{},
+			UID:    types.UID(utilrand.String(5)),
+		},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			NodeSelector:          nodeSelector,
+			MachineConfigSelector: mcSelector,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+				ObjectReference: corev1.ObjectReference{
+					Name: currentMachineConfig,
+				},
+			},
+		},
+		Status: mcfgv1.MachineConfigPoolStatus{
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+				ObjectReference: corev1.ObjectReference{
+					Name: currentMachineConfig,
+				},
+			},
+			Conditions: []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:               mcfgv1.MachineConfigPoolRenderDegraded,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: metav1.Unix(0, 0),
+					Reason:             "",
+					Message:            "",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
We had at least 4 different _test helper functions to create these. Just make 1 helper and use those.

Even though this PR along doesn't make a huge difference to the code base, at least I know where to look for the tests I'm writing in another PR...