### PR TITLE
Revert "kubelet-config: prevent changing the ConfigMap and Secret Cha…

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -72,10 +72,6 @@ var blacklistKubeletConfigurationFields = []string{
 	"CgroupDriver",
 	"ClusterDNS",
 	"ClusterDomain",
-	// Bugfix to force cache based configmap and secret watches. This should be
-	// removed with Kubernetes 1.14.
-	//   https://github.com/kubernetes/kubernetes/issues/74412
-	"ConfigMapAndSecretChangeDetectionStrategy",
 	"FeatureGates",
 	"RuntimeRequestTimeout",
 	"StaticPodPath",


### PR DESCRIPTION
…nging Strategy"

Close https://github.com/openshift/machine-config-operator/issues/534

This is not needed anymore now that we've bumped to go1.12 and kube1.14

This reverts commit 2c640ae716540519c9a5266162fc56be80f80f0f.