### PR TITLE
Add support for baremetal platform

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -112,7 +112,7 @@ type ControllerConfigSpec struct {
 	ClusterDNSIP        string `json:"clusterDNSIP"`
 	CloudProviderConfig string `json:"cloudProviderConfig"`
 
-	// The openshift platform, e.g. "libvirt", "openstack", "aws", or "none"
+	// The openshift platform, e.g. "libvirt", "openstack", "baremetal", "aws", or "none"
 	Platform string `json:"platform"`
 
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -36,6 +36,7 @@ const (
 	// TODO: these constants are wrong, they should match what is reported by the infrastructure provider
 	platformAWS       = "aws"
 	platformAzure     = "azure"
+	platformBaremetal = "baremetal"
 	platformOpenstack = "openstack"
 	platformLibvirt   = "libvirt"
 	platformNone      = "none"
@@ -125,7 +126,7 @@ func platformFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, 
 		return "", fmt.Errorf("cannot generate MachineConfigs with an empty platform field")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case platformAWS, platformAzure, platformOpenstack, platformLibvirt, platformNone:
+	case platformAWS, platformAzure, platformBaremetal, platformOpenstack, platformLibvirt, platformNone:
 		return ic.Platform, nil
 	default:
 		glog.Warningf("Warning: the controller config referenced an unsupported platform: %s", ic.Platform)
@@ -368,7 +369,7 @@ func cloudProvider(cfg RenderConfig) (interface{}, error) {
 	// FIXME Explicitly disable (remove) the cloud provider on OpenStack for now
 	// Don't forget to turn the test case back on as well
 	switch cfg.Platform {
-	case platformAWS, platformAzure, platformVSphere:
+	case platformAWS, platformBaremetal, platformAzure, platformVSphere:
 		return cfg.Platform, nil
 	default:
 		return "", nil

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -33,6 +33,9 @@ func TestCloudProvider(t *testing.T) {
 		//platform: "openstack",
 		//res:      "openstack",
 	}, {
+		platform: "baremetal",
+		res:      "baremetal",
+	}, {
 		platform: "libvirt",
 		res:      "",
 	}, {
@@ -228,6 +231,7 @@ const (
 var (
 	configs = map[string]string{
 		"aws":       "./test_data/controller_config_aws.yaml",
+		"baremetal": "./test_data/controller_config_baremetal.yaml",
 		"openstack": "./test_data/controller_config_openstack.yaml",
 		"libvirt":   "./test_data/controller_config_libvirt.yaml",
 		"none":      "./test_data/controller_config_none.yaml",

--- a/pkg/controller/template/test_data/controller_config_baremetal.yaml
+++ b/pkg/controller/template/test_data/controller_config_baremetal.yaml
@@ -1,0 +1,17 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
+  etcdInitialCount: 3
+  platform: "baremetal"
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -73,6 +73,8 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		platform = "aws"
 	case configv1.AzurePlatformType:
 		platform = "azure"
+	case configv1.BareMetalPlatformType:
+		platform = "baremetal"
 	case configv1.OpenStackPlatformType:
 		platform = "openstack"
 	case configv1.LibvirtPlatformType:

--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
@@ -1,0 +1,36 @@
+name: "kubelet.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service crio.service
+  After=crio.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+
+  ExecStart=/usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --rotate-certificates \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --minimum-container-ttl-duration=6m0s \
+        --cloud-provider={{cloudProvider .}} \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        {{cloudConfigFlag . }} \
+        --v=3 \
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
For IPI baremetal, we need to support the platform in MCO. This PR also overrides the kubelet config to remove the NoSchedule taint.

Currently in the baremetal IPI installer fork, [we have to bail out of the installer early](https://github.com/openshift-metal3/kni-installer/blob/master/cmd/kni-install/create.go#L111) to take care of some things  - one of those things is disabling NoSchedule taints: https://github.com/openshift-metal3/dev-scripts/blob/master/06_create_cluster.sh#L82-L83

We are anxious to get an experimental version of this platform into openshift/installer, but need to resolve this issue first. This adds the barematel platform to MCO, and overrides the kubelet config. 

Once #763 is resolved, this can move to the new mechanism, or alternatively once we have workers being deployed (currently work in progress) we won't need the override at all .

See #722 for additional background.  GitHub won't let me re-open that PR.  