### PR TITLE
cmd/machine-config-operator: add mco image flag to bootstrap.go

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -38,6 +38,7 @@ var (
 		mccImage             string
 		mcdImage             string
 		mcsImage             string
+		mcoImage             string
 		networkConfigFile    string
 		oscontentImage       string
 		pullSecretFile       string
@@ -61,6 +62,7 @@ func init() {
 	bootstrapCmd.MarkFlagRequired("machine-config-server-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcdImage, "machine-config-daemon-image", "", "Image for Machine Config Daemon.")
 	bootstrapCmd.MarkFlagRequired("machine-config-daemon-image")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcoImage, "machine-config-operator-image", "", "Image for Machine Config Operator.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oscontentImage, "machine-config-oscontent-image", "", "Image for osImageURL")
 	bootstrapCmd.MarkFlagRequired("machine-config-oscontent-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdImage, "etcd-image", "", "Image for Etcd.")


### PR DESCRIPTION
**- What I did**
This is a prep step for folding all mco component images into one mco image.
This flag will also be added to the installer.

Related-to: #739

**- How to verify it**
This should not affect anything right now.

cc: @runcom 