### PR TITLE
*: create a single MCO image containing all MC* binaries

### DIFF
--- a/Dockerfile.machine-config-operator
+++ b/Dockerfile.machine-config-operator
@@ -2,9 +2,19 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN WHAT=machine-config-operator ./hack/build-go.sh
+RUN WHAT=machine-config-daemon ./hack/build-go.sh
+RUN WHAT=machine-config-controller ./hack/build-go.sh
+RUN WHAT=machine-config-server ./hack/build-go.sh
+RUN WHAT=setup-etcd-environment ./hack/build-go.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /usr/bin/
 COPY install /manifests
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
+RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-controller /usr/bin/
+COPY templates /etc/mcc/templates
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/setup-etcd-environment /usr/bin/
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.machine-config-operator.rhel7
+++ b/Dockerfile.machine-config-operator.rhel7
@@ -4,9 +4,27 @@ COPY . .
 RUN WHAT=machine-config-operator ./hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-operator /tmp/build/machine-config-operator
+RUN WHAT=machine-config-daemon ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-daemon /tmp/build/machine-config-daemon
+RUN WHAT=machine-config-controller ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-controller /tmp/build/machine-config-controller
+RUN WHAT=machine-config-server ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-server /tmp/build/machine-config-server
+RUN WHAT=setup-etcd-environment ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/setup-etcd-environment /tmp/build/setup-etcd-environment
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /tmp/build/machine-config-operator /usr/bin/
 COPY install /manifests
+COPY --from=builder /tmp/build/machine-config-daemon /usr/bin/
+RUN yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*
+COPY --from=builder /tmp/build/machine-config-controller /usr/bin/
+COPY templates /etc/mcc/templates
+COPY --from=builder /tmp/build/machine-config-server /usr/bin/
+COPY --from=builder /tmp/build/setup-etcd-environment /usr/bin/
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -58,6 +58,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcdImage, "machine-config-daemon-image", "", "Image for Machine Config Daemon.")
 	bootstrapCmd.MarkFlagRequired("machine-config-daemon-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcoImage, "machine-config-operator-image", "", "Image for Machine Config Operator.")
+	bootstrapCmd.MarkFlagRequired("machine-config-operator-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oscontentImage, "machine-config-oscontent-image", "", "Image for osImageURL")
 	bootstrapCmd.MarkFlagRequired("machine-config-oscontent-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdImage, "etcd-image", "", "Image for Etcd.")
@@ -83,6 +84,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
 
 	imgs := operator.Images{
+		MachineConfigOperator:   bootstrapOpts.mcoImage,
 		MachineConfigController: bootstrapOpts.mccImage,
 		MachineConfigDaemon:     bootstrapOpts.mcdImage,
 		MachineConfigServer:     bootstrapOpts.mcsImage,

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   images.json: >
     {
+      "machineConfigOperator": "registry.svc.ci.openshift.org/openshift:machine-config-operator",
       "machineConfigController": "registry.svc.ci.openshift.org/openshift:machine-config-controller",
       "machineConfigDaemon": "registry.svc.ci.openshift.org/openshift:machine-config-daemon",
       "machineConfigServer": "registry.svc.ci.openshift.org/openshift:machine-config-server",

--- a/install/image-references
+++ b/install/image-references
@@ -2,7 +2,9 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  # These are the 4 components of the MCO
+  # machine-config-operator is the new master mco image that contains all of the 
+  # component images:mco, mcc, mcs, mcd & setup etcd
+  # TO-DO: in future PR other component images will be deleted
   - name: machine-config-operator
     from:
       kind: DockerImage

--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   initContainers:
   - name: machine-config-controller
-    image: {{.Images.MachineConfigController}}
+    image: {{.Images.MachineConfigOperator}}
+    command: ["/usr/bin/machine-config-controller"]
     args:
     - "bootstrap"
     - "--manifest-dir=/etc/mcc/bootstrap"
@@ -27,7 +28,8 @@ spec:
       mountPath: /etc/mcs/bootstrap
   containers:
   - name: machine-config-server
-    image: {{.Images.MachineConfigServer}}
+    image: {{.Images.MachineConfigOperator}}
+    command: ["/usr/bin/machine-config-server"]
     args:
       - "bootstrap"
     volumeMounts:

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -14,7 +14,8 @@ spec:
     spec:
       containers:
       - name: machine-config-controller
-        image: {{.Images.MachineConfigController}}
+        image: {{.Images.MachineConfigOperator}}
+        command: ["/usr/bin/machine-config-controller"]
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -15,7 +15,8 @@ spec:
     spec:
       containers:
       - name: machine-config-daemon
-        image: {{.Images.MachineConfigDaemon}}
+        image: {{.Images.MachineConfigOperator}}
+        command: ["/usr/bin/machine-config-daemon"]
         args:
           - "start"
         resources:

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -15,7 +15,8 @@ spec:
     spec:
       containers:
       - name: machine-config-server
-        image: {{.Images.MachineConfigServer}}
+        image: {{.Images.MachineConfigOperator}}
+        command: ["/usr/bin/machine-config-server"]
         args:
           - "start"
           - "--apiserver-url={{.APIServerURL}}"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -80,7 +80,8 @@ metadata:
 spec:
   initContainers:
   - name: machine-config-controller
-    image: {{.Images.MachineConfigController}}
+    image: {{.Images.MachineConfigOperator}}
+    command: ["/usr/bin/machine-config-controller"]
     args:
     - "bootstrap"
     - "--manifest-dir=/etc/mcc/bootstrap"
@@ -101,7 +102,8 @@ spec:
       mountPath: /etc/mcs/bootstrap
   containers:
   - name: machine-config-server
-    image: {{.Images.MachineConfigServer}}
+    image: {{.Images.MachineConfigOperator}}
+    command: ["/usr/bin/machine-config-server"]
     args:
       - "bootstrap"
     volumeMounts:
@@ -423,7 +425,8 @@ spec:
     spec:
       containers:
       - name: machine-config-controller
-        image: {{.Images.MachineConfigController}}
+        image: {{.Images.MachineConfigOperator}}
+        command: ["/usr/bin/machine-config-controller"]
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"
@@ -572,7 +575,8 @@ spec:
     spec:
       containers:
       - name: machine-config-daemon
-        image: {{.Images.MachineConfigDaemon}}
+        image: {{.Images.MachineConfigOperator}}
+        command: ["/usr/bin/machine-config-daemon"]
         args:
           - "start"
         resources:
@@ -928,7 +932,8 @@ spec:
     spec:
       containers:
       - name: machine-config-server
-        image: {{.Images.MachineConfigServer}}
+        image: {{.Images.MachineConfigOperator}}
+        command: ["/usr/bin/machine-config-server"]
         args:
           - "start"
           - "--apiserver-url={{.APIServerURL}}"

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -8,6 +8,7 @@ package operator
 // Change the installer to pass that arg with the image from the CVO
 // (some time later) Change the option to required and drop the default
 type Images struct {
+	MachineConfigOperator   string `json:"machineConfigOperator"`
 	MachineConfigController string `json:"machineConfigController"`
 	MachineConfigDaemon     string `json:"machineConfigDaemon"`
 	MachineConfigServer     string `json:"machineConfigServer"`

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -56,9 +56,9 @@ func TestRenderAsset(t *testing.T) {
 		RenderConfig: &renderConfig{
 			TargetNamespace: "testing-namespace",
 			Images: &Images{
-				MachineConfigController: "{MCC: PLACEHOLDER}"},
+				MachineConfigOperator: "{MCO: PLACEHOLDER}"},
 		},
-		FindExpected: "image: {MCC: PLACEHOLDER}",
+		FindExpected: "image: {MCO: PLACEHOLDER}",
 	}, {
 		// Render same template as previous test
 		// But with a template field missing
@@ -96,7 +96,7 @@ func TestRenderAsset(t *testing.T) {
 			// Verify that any FindExpected values are actually in the string
 			if test.FindExpected != "" {
 				if !strings.Contains(str, test.FindExpected) {
-					t.Fatalf("Rendered template does not contain expected values")
+					t.Fatalf("Rendered template does not contain expected values: %s, \nGot: %s", test.FindExpected, str)
 				}
 			}
 		})


### PR DESCRIPTION
This is the 3rd pr in a series to fold all MC* images into one.
PR does the following as step 3:
- update dockerfile.machine-config-operator to generates all component
images (mco/mcc/mcd/mcs/setup-etcd-env)
- update dockerfile.machine-config-operator.rhel7 the same as sbove
- update image-references, configmap and manifests to use MCO image
- update MCO image flag in bootstrap.go to be required

TO-DO in follow-on prs:
- removes other dockerfiles to have 1 dockerfile generating image
- make another PR in release to only reference the above dockerfile
- make another PR in installer later to remove individual refs in bootkube
- make another PR here to remove the component image refs
- remove component image refs in ART(??)

Related-to: #847 (merged)
Requires: openshift/installer#1847 (merged)
Related-to: #739 (issue will only close when final installer pr merges)
