### PR TITLE
pkg/controller/node: add tests for multiple pools

### DIFF
--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -67,11 +67,23 @@ func newNode(name string, currentConfig, desiredConfig string) *corev1.Node {
 		annos[daemonconsts.DesiredMachineConfigAnnotationKey] = desiredConfig
 		annos[daemonconsts.MachineConfigDaemonStateAnnotationKey] = state
 	}
+	return newNodeWithAnnotations(name, annos)
+}
 
+func newNodeWithLabels(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+func newNodeWithAnnotations(name string, annotations map[string]string) *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: annos,
+			Annotations: annotations,
 		},
 	}
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Add tests for `getNodesForPool` - the e2e version of this is going to QE directly for now but I'm hoping we can add it to our suite eventually.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
