### PR TITLE
[wip] pkg/controller: Remove hard coded platform consts in controller template

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -17,6 +17,7 @@ import (
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
+	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -33,16 +34,16 @@ const (
 	filesDir = "files"
 	unitsDir = "units"
 
-	// TODO: these constants are wrong, they should match what is reported by the infrastructure provider
-	platformAWS       = "aws"
-	platformAzure     = "azure"
-	platformBaremetal = "baremetal"
-	platformGCP       = "gcp"
-	platformOpenstack = "openstack"
-	platformLibvirt   = "libvirt"
-	platformNone      = "none"
-	platformVSphere   = "vsphere"
-	platformBase      = "_base"
+	platformAWS       = string(configv1.AWSPlatformType)
+	platformAzure     = string(configv1.AzurePlatformType)
+	platformOpenstack = string(configv1.OpenStackPlatformType)
+	platformGCP       = string(configv1.GCPPlatformType)
+	platformLibvirt   = string(configv1.LibvirtPlatformType)
+	platformNone      = string(configv1.NonePlatformType)
+	platformVSphere   = string(configv1.VSpherePlatformType)
+	platformBareMetal = string(configv1.BareMetalPlatformType)
+	// TODO: Remove platformBase
+	platformBase = "_base"
 )
 
 // generateTemplateMachineConfigs returns MachineConfig objects from the templateDir and a config object
@@ -128,7 +129,7 @@ func platformFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, 
 		return "", fmt.Errorf("cannot generate MachineConfigs when no platform is set")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case platformAWS, platformAzure, platformBaremetal, platformGCP, platformOpenstack, platformLibvirt, platformNone:
+	case platformAWS, platformAzure, platformBareMetal, platformGCP, platformOpenstack, platformLibvirt, platformNone:
 		return ic.Platform, nil
 	default:
 		// platformNone is used for a non-empty, but currently unsupported platform.

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -26,23 +26,23 @@ func TestCloudProvider(t *testing.T) {
 		platform string
 		res      string
 	}{{
-		platform: "aws",
-		res:      "aws",
+		platform: platformAWS,
+		res:      platformAWS,
 		// OpenStack cloud config is disabled
 		//}, {
-		//platform: "openstack",
-		//res:      "openstack",
+		//platform: platformOpenstack,
+		//res:      platformOpenstack,
 	}, {
-		platform: "baremetal",
+		platform: platformBareMetal,
 		res:      "",
 	}, {
-		platform: "gcp",
+		platform: platformGCP,
 		res:      "gce",
 	}, {
-		platform: "libvirt",
+		platform: platformLibvirt,
 		res:      "",
 	}, {
-		platform: "none",
+		platform: platformNone,
 		res:      "",
 	}}
 	for idx, c := range cases {
@@ -73,22 +73,22 @@ func TestCloudConfigFlag(t *testing.T) {
 		content  string
 		res      string
 	}{{
-		platform: "aws",
+		platform: platformAWS,
 		content:  "",
 		res:      "",
 	}, {
-		platform: "azure",
+		platform: platformAzure,
 		content:  "",
 		res:      "",
 	}, {
-		platform: "aws",
+		platform: platformAWS,
 		content: `
 [dummy-config]
     option = a
 `,
 		res: "",
 	}, {
-		platform: "azure",
+		platform: platformAzure,
 		content: `
 [dummy-config]
     option = a
@@ -233,18 +233,18 @@ const (
 
 var (
 	configs = map[string]string{
-		"aws":       "./test_data/controller_config_aws.yaml",
-		"baremetal": "./test_data/controller_config_baremetal.yaml",
-		"gcp":    "./test_data/controller_config_gcp.yaml",
-		"openstack": "./test_data/controller_config_openstack.yaml",
-		"libvirt":   "./test_data/controller_config_libvirt.yaml",
-		"none":      "./test_data/controller_config_none.yaml",
-		"vsphere":   "./test_data/controller_config_vsphere.yaml",
+		platformAWS:       "./test_data/controller_config_aws.yaml",
+		platformBareMetal: "./test_data/controller_config_baremetal.yaml",
+		platformGCP:       "./test_data/controller_config_gcp.yaml",
+		platformOpenstack: "./test_data/controller_config_openstack.yaml",
+		platformLibvirt:   "./test_data/controller_config_libvirt.yaml",
+		platformNone:      "./test_data/controller_config_none.yaml",
+		platformVSphere:   "./test_data/controller_config_vsphere.yaml",
 	}
 )
 
 func TestInvalidPlatform(t *testing.T) {
-	controllerConfig, err := controllerConfigFromFile(configs["aws"])
+	controllerConfig, err := controllerConfigFromFile(configs[platformAWS])
 	if err != nil {
 		t.Fatalf("failed to get controllerconfig config: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestInvalidPlatform(t *testing.T) {
 	}
 
 	// explicitly blocked
-	controllerConfig.Spec.Platform = "_base"
+	controllerConfig.Spec.Platform = platformBase
 	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
 	expectErr(err, "failed to create MachineConfig for role master: platform _base unsupported")
 }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -68,19 +67,14 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		return nil, err
 	}
 
-	infraPlatformString := ""
+	platform := "none"
 	// The PlatformStatus field is set in cluster versions >= 4.2
 	// Otherwise use the Platform field
+	// nolint:staticcheck
 	if infra.Status.PlatformStatus != nil {
-		infraPlatformString = string(infra.Status.PlatformStatus.Type)
-	} else {
-		//nolint:staticcheck
-		infraPlatformString = string(infra.Status.Platform)
-	}
-
-	platform := "none"
-	if infraPlatformString != "" {
-		platform = strings.ToLower(infraPlatformString)
+		platform = string(infra.Status.PlatformStatus.Type)
+	} else if string(infra.Status.Platform) != "" {
+		platform = string(infra.Status.Platform)
 	}
 
 	ccSpec := &mcfgv1.ControllerConfigSpec{

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -138,7 +138,6 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 	}, {
 		Infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				PlatformStatus:      &configv1.PlatformStatus{},
 				EtcdDiscoveryDomain: "tt.testing",
 			}},
 		Network: &configv1.Network{


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Remove hard coded platform descriptors from `pkg/contrller/template/render.go`.
This PR depends on MCO #814 (which depends on https://github.com/openshift/installer/pull/1725).
This _may_ break upgrade testing. TBD.

**- How to verify it**
CI / run unit tests locally. 
ex. `go test -v github.com/openshift/machine-config-operator/pkg/controller/template`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove hard coded platform strings from controller template in pkg/controller