### PR TITLE
operator: fix logic setting version for progressing status

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -29,7 +29,7 @@ func (optr *Operator) syncVersion() error {
 	}
 
 	// keep the old version and progressing if we fail progressing
-	if cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorProgressing) && cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded) {
+	if cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorProgressing) || cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded) {
 		return nil
 	}
 


### PR DESCRIPTION
Background: in CI we are seeing a cluster that is in the middle of upgrading having a CVO status of Available in version target version as opposed to the expected status of progressing until the upgrade is completed.
