### PR TITLE
[release-4.1] Bug 1706082: Add Spec.Configuration to MachineConfigPool, render controller writes it

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -299,6 +299,9 @@ type MachineConfigPoolSpec struct {
 	// MaxUnavailable specifies the percentage or constant number of machines that can be updating at any given time.
 	// default is 1.
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable"`
+
+	// The targeted MachineConfig object for the machine config pool.
+	Configuration MachineConfigPoolStatusConfiguration `json:"configuration"`
 }
 
 // MachineConfigPoolStatus is the status for MachineConfigPool resource.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -633,6 +633,7 @@ func (in *MachineConfigPoolSpec) DeepCopyInto(out *MachineConfigPoolSpec) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
+	in.Configuration.DeepCopyInto(&out.Configuration)
 	return
 }
 

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -118,6 +118,7 @@ func newMachineConfigPool(name string, labels map[string]string, selector *metav
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			MachineConfigSelector: selector,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -128,6 +128,7 @@ func newMachineConfigPool(name string, labels map[string]string, selector *metav
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			MachineConfigSelector: selector,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -432,7 +432,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return err
 	}
 
-	if machineconfigpool.Status.Configuration.Name == "" {
+	if machineconfigpool.Spec.Configuration.Name == "" {
 		// Previously we spammed the logs about empty pools.
 		// Let's just pause for a bit here to let the renderer
 		// initialize them.
@@ -475,7 +475,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 
 	candidates := getCandidateMachines(pool, nodes, maxunavail)
 	for _, node := range candidates {
-		if err := ctrl.setDesiredMachineConfigAnnotation(node.Name, pool.Status.Configuration.Name); err != nil {
+		if err := ctrl.setDesiredMachineConfigAnnotation(node.Name, pool.Spec.Configuration.Name); err != nil {
 			return err
 		}
 	}
@@ -517,7 +517,7 @@ func (ctrl *Controller) setDesiredMachineConfigAnnotation(nodeName, currentConfi
 }
 
 func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) []*corev1.Node {
-	targetConfig := pool.Status.Configuration.Name
+	targetConfig := pool.Spec.Configuration.Name
 
 	unavail := getUnavailableMachines(nodesInPool)
 	// If we're at capacity, there's nothing to do.

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -63,6 +63,7 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, maxUnavai
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			NodeSelector:   selector,
 			MaxUnavailable: maxUnavail,
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
@@ -502,7 +503,7 @@ func TestGetCandidateMachines(t *testing.T) {
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
 			pool := &mcfgv1.MachineConfigPool{
-				Status: mcfgv1.MachineConfigPoolStatus{
+				Spec: mcfgv1.MachineConfigPoolSpec{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: "v1"}},
 				},
 			}

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -598,7 +598,7 @@ func TestCalculateStatus(t *testing.T) {
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
 			pool := &mcfgv1.MachineConfigPool{
-				Status: mcfgv1.MachineConfigPoolStatus{
+				Spec: mcfgv1.MachineConfigPoolSpec{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.currentConfig}},
 				},
 			}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -258,8 +258,11 @@ func (optr *Operator) allMachineConfigPoolStatus() (map[string]string, error) {
 // isMachineConfigPoolConfigurationValid returns nil error when the configuration of a `pool` is created by the controller at version `version`.
 func isMachineConfigPoolConfigurationValid(pool *mcfgv1.MachineConfigPool, version string, machineConfigGetter func(string) (*mcfgv1.MachineConfig, error)) error {
 	// both .status.configuration.name and .status.configuration.source must be set.
+	if len(pool.Spec.Configuration.Name) == 0 {
+		return fmt.Errorf("configuration spec for pool %s is empty", pool.GetName())
+	}
 	if len(pool.Status.Configuration.Name) == 0 {
-		return fmt.Errorf("configuration for pool %s is empty", pool.GetName())
+		return fmt.Errorf("configuration status for pool %s is empty", pool.GetName())
 	}
 	if len(pool.Status.Configuration.Source) == 0 {
 		return fmt.Errorf("list of MachineConfigs that were used to generate configuration for pool %s is empty", pool.GetName())

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -35,7 +35,7 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 
 		err error
 	}{{
-		err: errors.New("configuration for pool dummy-pool is empty"),
+		err: errors.New("configuration spec for pool dummy-pool is empty"),
 	}, {
 		generated: "g",
 		err:       errors.New("list of MachineConfigs that were used to generate configuration for pool dummy-pool is empty"),
@@ -115,6 +115,9 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 			err := isMachineConfigPoolConfigurationValid(&mcfgv1.MachineConfigPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dummy-pool",
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.generated}, Source: source},
 				},
 				Status: mcfgv1.MachineConfigPoolStatus{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.generated}, Source: source},

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/stretchr/testify/assert"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/test/e2e/framework"
@@ -99,7 +100,8 @@ func createMCToAddFile(name, filename, data, fs string) *mcv1.MachineConfig {
 // included the given mcName in its config, and returns the new
 // rendered config name.
 func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName string) (string, error) {
-	var newMCName string
+	var renderedConfig string
+	startTime := time.Now()
 	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
 		mcp, err := cs.MachineConfigPools().Get(pool, metav1.GetOptions{})
 		if err != nil {
@@ -107,7 +109,7 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 		}
 		for _, mc := range mcp.Status.Configuration.Source {
 			if mc.Name == mcName {
-				newMCName = mcp.Status.Configuration.Name
+				renderedConfig = mcp.Status.Configuration.Name
 				return true, nil
 			}
 		}
@@ -115,7 +117,32 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 	}); err != nil {
 		return "", errors.Wrapf(err, "machine config %s hasn't been picked by pool %s", mcName, pool)
 	}
-	return newMCName, nil
+	t.Logf("Pool %s has rendered config %s with %s (waited %v)", pool, mcName, renderedConfig, time.Since(startTime))
+	return renderedConfig, nil
+}
+
+// waitForPoolComplete polls a pool until it has completed an update to target
+func waitForPoolComplete(t *testing.T, cs *framework.ClientSet, pool, target string) error {
+	// We need a spec and status separation https://github.com/openshift/machine-config-operator/pull/765#issuecomment-493136113
+	time.Sleep(time.Second * 13)
+	startTime := time.Now()
+	if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineConfigPools().Get(pool, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if mcp.Status.Configuration.Name != target {
+			return false, nil
+		}
+		if mcv1.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcv1.MachineConfigPoolUpdated) {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return errors.Wrapf(err, "pool %s didn't report updated to %s", pool, target)
+	}
+	t.Logf("Pool %s has completed %s (waited %v)", pool, target, time.Since(startTime))
+	return nil
 }
 
 func TestMCDeployed(t *testing.T) {
@@ -124,6 +151,7 @@ func TestMCDeployed(t *testing.T) {
 
 	// TODO: bring this back to 10
 	for i := 0; i < 5; i++ {
+		startTime := time.Now()
 		mcadd := createMCToAddFile("add-a-file", fmt.Sprintf("/etc/mytestconf%d", i), "test", "root")
 
 		// create the dummy MC now
@@ -132,33 +160,23 @@ func TestMCDeployed(t *testing.T) {
 			t.Errorf("failed to create machine config %v", err)
 		}
 
-		newMCName, err := waitForRenderedConfig(t, cs, "worker", mcadd.Name)
+		t.Logf("Created %s", mcadd.Name)
+		renderedConfig, err := waitForRenderedConfig(t, cs, "worker", mcadd.Name)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
-
-		visited := make(map[string]bool)
-		if err := wait.Poll(2*time.Second, 30*time.Minute, func() (bool, error) {
-			nodes, err := getNodesByRole(cs, "worker")
-			if err != nil {
-				return false, nil
-			}
-			for _, node := range nodes {
-				if visited[node.Name] {
-					continue
-				}
-				if node.Annotations[constants.CurrentMachineConfigAnnotationKey] == newMCName && node.Annotations[constants.MachineConfigDaemonStateAnnotationKey] == constants.MachineConfigDaemonStateDone {
-					visited[node.Name] = true
-					if len(visited) == len(nodes) {
-						return true, nil
-					}
-					continue
-				}
-			}
-			return false, nil
-		}); err != nil {
-			t.Errorf("machine config didn't result in file being on any worker: %v", err)
+		if err := waitForPoolComplete(t, cs, "worker", renderedConfig); err != nil {
+			t.Fatal(err)
 		}
+		nodes, err := getNodesByRole(cs, "worker")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, node := range nodes {
+			assert.Equal(t, renderedConfig, node.Annotations[constants.CurrentMachineConfigAnnotationKey])
+			assert.Equal(t, constants.MachineConfigDaemonStateDone, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey])
+		}
+		t.Logf("All nodes updated with %s (%s elapsed)", mcadd.Name, time.Since(startTime))
 	}
 }
 
@@ -210,65 +228,49 @@ func TestUpdateSSH(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create machine config %v", err)
 	}
+	t.Logf("Created %s", mcadd.Name)
 
 	// grab the latest worker- MC
-	newMCName, err := waitForRenderedConfig(t, cs, "worker", mcadd.Name)
+	renderedConfig, err := waitForRenderedConfig(t, cs, "worker", mcadd.Name)
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Fatal(err)
 	}
+	if err := waitForPoolComplete(t, cs, "worker", renderedConfig); err != nil {
+		t.Fatal(err)
+	}
+	nodes, err := getNodesByRole(cs, "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, node := range nodes {
+		assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
+		assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+		// find the MCD pod that has spec.nodeNAME = node.Name and get its name:
+		listOptions := metav1.ListOptions{
+			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
+		}
+		listOptions.LabelSelector = labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}).String()
 
-	visited := make(map[string]bool)
-	if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
-		nodes, err := getNodesByRole(cs, "worker")
+		mcdList, err := cs.Pods("openshift-machine-config-operator").List(listOptions)
 		if err != nil {
-			return false, err
+			t.Fatal(err)
 		}
-		for _, node := range nodes {
-			if visited[node.Name] {
-				continue
-			}
-			// check that the new MC is in the annotations and that the MCD state is Done.
-			if node.Annotations[constants.CurrentMachineConfigAnnotationKey] == newMCName &&
-				node.Annotations[constants.MachineConfigDaemonStateAnnotationKey] == constants.MachineConfigDaemonStateDone {
-				// find the MCD pod that has spec.nodeNAME = node.Name and get its name:
-				listOptions := metav1.ListOptions{
-					FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
-				}
-				listOptions.LabelSelector = labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}).String()
-
-				mcdList, err := cs.Pods("openshift-machine-config-operator").List(listOptions)
-				if err != nil {
-					return false, nil
-				}
-				if len(mcdList.Items) != 1 {
-					t.Logf("did not find any mcd pods")
-					return false, nil
-				}
-				mcdName := mcdList.Items[0].ObjectMeta.Name
-
-				// now rsh into that daemon and grep the authorized key file to check if 1234_test was written
-				// must do both commands in same shell, combine commands into one exec.Command()
-				found, err := exec.Command("oc", "rsh", "-n", "openshift-machine-config-operator", mcdName,
-					"grep", "1234_test", "/rootfs/home/core/.ssh/authorized_keys").CombinedOutput()
-				if err != nil {
-					t.Logf("unable to read authorized_keys on daemon: %s got: %s got err: %v", mcdName, found, err)
-					return false, nil
-				}
-				if !strings.Contains(string(found), "1234_test") {
-					t.Logf("updated ssh keys not found in authorized_keys, got %s", found)
-					return false, nil
-				}
-
-				visited[node.Name] = true
-				if len(visited) == len(nodes) {
-					return true, nil
-				}
-				continue
-			}
+		if len(mcdList.Items) != 1 {
+			t.Fatalf("Failed to find MCD for node %s", node.Name)
 		}
-		return false, nil
-	}); err != nil {
-		t.Errorf("machine config didn't result in ssh keys being on any worker: %v", err)
+		mcdName := mcdList.Items[0].ObjectMeta.Name
+
+		// now rsh into that daemon and grep the authorized key file to check if 1234_test was written
+		// must do both commands in same shell, combine commands into one exec.Command()
+		found, err := exec.Command("oc", "rsh", "-n", "openshift-machine-config-operator", mcdName,
+			"grep", "1234_test", "/rootfs/home/core/.ssh/authorized_keys").CombinedOutput()
+		if err != nil {
+			t.Fatalf("unable to read authorized_keys on daemon: %s got: %s got err: %v", mcdName, found, err)
+		}
+		if !strings.Contains(string(found), "1234_test") {
+			t.Fatalf("updated ssh keys not found in authorized_keys, got %s", found)
+		}
+		t.Logf("Node %s has SSH key", node.Name)
 	}
 }
 
@@ -351,7 +353,7 @@ func TestReconcileAfterBadMC(t *testing.T) {
 		t.Errorf("failed to create machine config %v", err)
 	}
 
-	newMCName, err := waitForRenderedConfig(t, cs, "worker", mcadd.Name)
+	renderedConfig, err := waitForRenderedConfig(t, cs, "worker", mcadd.Name)
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -363,7 +365,8 @@ func TestReconcileAfterBadMC(t *testing.T) {
 			return false, err
 		}
 		for _, node := range nodes {
-			if node.Annotations[constants.DesiredMachineConfigAnnotationKey] == newMCName && node.Annotations[constants.MachineConfigDaemonStateAnnotationKey] != constants.MachineConfigDaemonStateDone {
+			if node.Annotations[constants.DesiredMachineConfigAnnotationKey] == renderedConfig &&
+				node.Annotations[constants.MachineConfigDaemonStateAnnotationKey] != constants.MachineConfigDaemonStateDone {
 				// just check that we have the annotation here, w/o strings checking anything that can flip fast causing flakes
 				if node.Annotations[constants.MachineConfigDaemonReasonAnnotationKey] != "" {
 					return true, nil
@@ -395,17 +398,8 @@ func TestReconcileAfterBadMC(t *testing.T) {
 	}
 
 	// wait for the mcp to go back to previous config
-	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
-		mcp, err := cs.MachineConfigPools().Get("worker", metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if mcp.Status.Configuration.Name == workerOldMc {
-			return true, nil
-		}
-		return false, nil
-	}); err != nil {
-		t.Errorf("old machine config hasn't been picked by the pool: %v", err)
+	if err := waitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+		t.Fatal(err)
 	}
 
 	visited := make(map[string]bool)

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -93,6 +93,7 @@ func createMCToAddFile(name, filename, data, fs string) *mcv1.MachineConfig {
 			},
 		},
 	}
+
 	return mcadd
 }
 
@@ -107,9 +108,9 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 		if err != nil {
 			return false, err
 		}
-		for _, mc := range mcp.Status.Configuration.Source {
+		for _, mc := range mcp.Spec.Configuration.Source {
 			if mc.Name == mcName {
-				renderedConfig = mcp.Status.Configuration.Name
+				renderedConfig = mcp.Spec.Configuration.Name
 				return true, nil
 			}
 		}
@@ -123,8 +124,6 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 
 // waitForPoolComplete polls a pool until it has completed an update to target
 func waitForPoolComplete(t *testing.T, cs *framework.ClientSet, pool, target string) error {
-	// We need a spec and status separation https://github.com/openshift/machine-config-operator/pull/765#issuecomment-493136113
-	time.Sleep(time.Second * 13)
 	startTime := time.Now()
 	if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
 		mcp, err := cs.MachineConfigPools().Get(pool, metav1.GetOptions{})


### PR DESCRIPTION
Cherry-picked from 37e8466a1a5d809b31a1e7782aeecb8abf62752b

See https://github.com/openshift/machine-config-operator/pull/765#issuecomment-493136113

MachineConfigPool needs a `Spec.Configuration` and `Status.Configuration`
[just like other objects][1] so that we can properly detect state.
Currently there's a race because the render controller may set `Status.Configuration`
while the pool's `Status` still has `Updated`, so one can't reliably check whether the
pool is at a given config.

With this, ownership is clear: the render controller sets the spec, and the node controller
updates the status.

[1] https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)
