### PR TITLE
Bug 1720771 : pkg/operator: wait for all pools

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -413,7 +413,7 @@ func (optr *Operator) sync(key string) error {
 		{"mcc", optr.syncMachineConfigController},
 		{"mcs", optr.syncMachineConfigServer},
 		{"mcd", optr.syncMachineConfigDaemon},
-		{"required-pools", optr.syncRequiredMachineConfigPools},
+		{"pools", optr.waitForMachineConfigPools},
 	}
 	return optr.syncAll(rc, syncFuncs)
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

It seems clear that it's expected that we wait for all pools before flipping Progressing=False at the end an upgrade so this patch just does that. I've increased the pool timeout to 15 mins also but we give back feedback anyway.

I still suspect the CVO is gonna just timeout and report a failed upgrade but we'll see how that goes during the BZ testing with more than 3 workers.

**- How to verify it**

Install a cluster and run an upgrade

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
