### PR TITLE
Bug 1720872: Add coreos-growpart systemd dependency to kubelet

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -3,8 +3,9 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service crio.service
-  After=crio.service
+  Wants=rpc-statd.service crio.service coreos-growpart.service
+  After=crio.service coreos-growpart.service
+
 
   [Service]
   Type=notify

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -3,8 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service crio.service
-  After=crio.service
+  Wants=rpc-statd.service crio.service coreos-growpart.service
+  After=crio.service coreos-growpart.service
 
   [Service]
   Type=notify


### PR DESCRIPTION
**- What I did**
Two part series to fix. 1. Adds a dependency to the kubelet unit file to
start after coreos-growpart.service. 2. RHCOS needs a tweak in the unit
file for coreos-growpart to add `Type=oneshot` to wait for the
coreos-growpart service to complete.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1720872

**- How to verify it**

**- Description for the changelog**
<!--
Add dependency to kubelet unit file to wait for coreos-growpart to complete
-->
