### PR TITLE
controller: don't set cloud provider for baremetal

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -369,7 +369,7 @@ func cloudProvider(cfg RenderConfig) (interface{}, error) {
 	// FIXME Explicitly disable (remove) the cloud provider on OpenStack for now
 	// Don't forget to turn the test case back on as well
 	switch cfg.Platform {
-	case platformAWS, platformBaremetal, platformAzure, platformVSphere:
+	case platformAWS, platformAzure, platformVSphere:
 		return cfg.Platform, nil
 	default:
 		return "", nil

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -34,7 +34,7 @@ func TestCloudProvider(t *testing.T) {
 		//res:      "openstack",
 	}, {
 		platform: "baremetal",
-		res:      "baremetal",
+		res:      "",
 	}, {
 		platform: "libvirt",
 		res:      "",


### PR DESCRIPTION
This causes an error during installation:

```
Jun 18 16:39:30 master-0 hyperkube[2223]: F0618 16:39:30.475150    2223
server.go:267] failed to run Kubelet: unknown cloud provider "baremetal"
```
