### PR TITLE
daemon: Fix inverted conditional for `logger --journald` check

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -810,7 +810,7 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig) error {
 
 // RHEL 7.6 logger (util-linux) doesn't have the --journald flag
 func (dn *Daemon) isLoggingToJournalSupported() bool {
-	if dn.OperatingSystem == machineConfigDaemonOSRHEL {
+	if dn.OperatingSystem == machineConfigDaemonOSRHCOS {
 		return true
 	}
 	loggerOutput, err := exec.Command("logger", "--help").CombinedOutput()


### PR DESCRIPTION
We know RHCOS has it being RHEL8.
Split out of https://github.com/openshift/machine-config-operator/pull/866
