### PR TITLE
 server: Add /etc/ignition-machine-config-encapsulated.json

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -34,4 +34,10 @@ const (
 	// EtcPivotFile is used by the `pivot` command
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44
 	EtcPivotFile = "/etc/pivot/image-pullspec"
+
+	// MachineConfigEncapsulatedPath contains all of the data from a MachineConfig object
+	// except the Spec/Config object; this supports inverting+encapsulating a MachineConfig
+	// object so that Ignition can process it on first boot, and then the MCD can act on
+	// non-Ignition fields such as the osImageURL and kernelArguments.
+	MachineConfigEncapsulatedPath = "/etc/ignition-machine-config-encapsulated.json"
 )

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -101,7 +101,8 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*igntypes.Config, error) 
 			return nil, err
 		}
 	}
-	return &mc.Spec.Config, nil
+
+	return machineConfigToIgnition(mc), nil
 }
 
 func kubeconfigFromFile(path string) ([]byte, []byte, error) {

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -77,7 +77,7 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*igntypes.Config, error) {
 			return nil, err
 		}
 	}
-	return &mc.Spec.Config, nil
+	return machineConfigToIgnition(mc), nil
 }
 
 // getClientConfig returns a Kubernetes client Config.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/vincent-petithory/dataurl"
 )
@@ -48,6 +49,13 @@ func getAppenders(currMachineConfig string, f kubeconfigFunc, osimageurl string)
 
 // machineConfigToIgnition converts a MachineConfig object into Ignition.
 func machineConfigToIgnition(mccfg *mcfgv1.MachineConfig) *igntypes.Config {
+	tmpcfg := mccfg.DeepCopy()
+	tmpcfg.Spec.Config = ctrlcommon.NewIgnConfig()
+	serialized, err := json.Marshal(tmpcfg)
+	if err != nil {
+		panic(err.Error())
+	}
+	appendFileToIgnition(&mccfg.Spec.Config, daemonconsts.MachineConfigEncapsulatedPath, string(serialized))
 	return &mccfg.Spec.Config
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/vincent-petithory/dataurl"
 )
@@ -43,6 +44,11 @@ func getAppenders(currMachineConfig string, f kubeconfigFunc, osimageurl string)
 		func(config *igntypes.Config) error { return appendKubeConfig(config, f) },
 	}
 	return appenders
+}
+
+// machineConfigToIgnition converts a MachineConfig object into Ignition.
+func machineConfigToIgnition(mccfg *mcfgv1.MachineConfig) *igntypes.Config {
+	return &mccfg.Spec.Config
 }
 
 // Golang :cry:

--- a/pkg/server/testdata/machine-configs/test-config.yaml
+++ b/pkg/server/testdata/machine-configs/test-config.yaml
@@ -3,6 +3,10 @@ kind: MachineConfig
 metadata:
   name: test-config
 spec:
+  osImageURL: registry.example.com/oscontainer@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+  kernelArguments:
+    - foo=bar
+    - nosmt
   config:
     ignition:
     storage:

--- a/pkg/server/testdata/machine-pools/test-pool.yaml
+++ b/pkg/server/testdata/machine-pools/test-pool.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   name: test-pool
 spec:
+  configuration:
+    name: test-config
   machineConfigSelector:
     matchLabels:
       machineconfiguration.openshift.io/role: test


### PR DESCRIPTION

This effectively "inverts" a `MachineConfig` object so that
when it boots, Ignition processes the subset of MachineConfig
that is Ignition, and then we have the other stuff (`osImageURL`,
`kernelArguments` and in the future more) as a file on disk
that the MCD can read.

The way to think about this is we're aiming to have RHCOS boot
into `MachineConfig`, not just Ignition.