### PR TITLE
pkg/server: Clean up typos and comments

### DIFF
--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -41,8 +41,7 @@ func NewBootstrapServer(dir, kubeconfig string) (Server, error) {
 
 // GetConfig fetches the machine config(type - Ignition) from the bootstrap server,
 // based on the pool request.
-// It returns nil for conf, error if the config isn't found. It returns a formatted
-// error if any other error is encountered during its operations.
+// If a config cannot be found or parsed, it returns a nil conf, along with an error.
 //
 // The method does the following:
 //

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -40,8 +40,8 @@ type clusterServer struct {
 // NewClusterServer is used to initialize the machine config
 // server that will be used to fetch the requested MachineConfigPool
 // objects from within the cluster.
-// It accepts the kubeConfig which is not required when it's
-// run from within the cluster(useful in testing).
+// It accepts a kubeConfig, which is not required when it's
+// run from within a cluster(useful in testing).
 // It accepts the apiserverURL which is the location of the KubeAPIServer.
 func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 	restConfig, err := getClientConfig(kubeConfig)
@@ -90,9 +90,11 @@ func getClientConfig(path string) (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func kubeconfigFromSecret(secertDir, apiserverURL string) ([]byte, []byte, error) {
-	caFile := filepath.Join(secertDir, corev1.ServiceAccountRootCAKey)
-	tokenFile := filepath.Join(secertDir, corev1.ServiceAccountTokenKey)
+// kubeconfigFromSecret creates a kubeconfig with the certificate
+// and token files in secretDir
+func kubeconfigFromSecret(secretDir, apiserverURL string) ([]byte, []byte, error) {
+	caFile := filepath.Join(secretDir, corev1.ServiceAccountRootCAKey)
+	tokenFile := filepath.Join(secretDir, corev1.ServiceAccountTokenKey)
 	caData, err := ioutil.ReadFile(caFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to read %s: %v", caFile, err)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed some typos in `pkg/server/cluster_server.go` (`secert` -> `secret`) and cleaned up some other comments in `pkg/server/bootstrap_server.go`
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix typos and comments in pkg/server