### PR TITLE
daemon: Use pivot/machine-config-daemon-host.service as needed

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-host.service
+++ b/templates/common/_base/units/machine-config-daemon-host.service
@@ -1,4 +1,4 @@
-name: "machine-config-daemon-initial.service"
+name: "machine-config-daemon-host.service"
 enabled: true
 contents: |
   [Unit]


### PR DESCRIPTION
RHCOS will soon drop `pivot` entirely and I only tested the
bootimage pivot, but as soon as that lands in `machine-os-content`
we need this fix too.

Also this reveals the `-initial` nomenclature in the service
is wrong; I was originally thinking this was just for the first
boot.  But I'd forgotten about the whole saga around why we always
execute on the host because of SELinux.  I fleshed out some of
the comments there.

Rename the systemd unit to make that clearer too.
