### PR TITLE
Disable Go Unit Test Cache in Go 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: test-unit test-e2e
 
 # Unit tests only (no active cluster required)
 test-unit:
-	go test -v ./cmd/... ./pkg/... ./lib/...
+	go test -count=1 -v ./cmd/... ./pkg/... ./lib/...
 
 # Run the code generation tasks.
 # Example:

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -84,6 +84,10 @@ package basis with `go test`:
 
 `go test -v github.com/openshift/machine-config-operator/pkg/apis`
 
+To disable go test caching in go > 1.10:
+
+`go test -count=1 ...`
+
 To execute all unit tests:
 
 `make test-unit`


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
In https://github.com/openshift/machine-config-operator/pull/818, the flag to disable `GOCACHE` was removed for go 1.12 compatibility.  Turns out, running unit tests with the cache enabled is frustrating.  For example, if a test asset (and not a test file itself) is updated, re-running `make test-unit` will pull test results from the test cache. Also, changing some parts of a unit test may not actually clear the entire test cache for that particular test (even though it should).

The _new_ way to disable the go testing cache is to use `-count=1` in the `go test` command.
(see https://github.com/golang/go/issues/24573)

**- How to verify it**
`make test-unit` and verify that no test were pulled from the cache (ie. look for `(cached)`)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Disable Go Cache for unit tests in Makefile