### PR TITLE
Take over `/usr/bin/pivot` too

### DIFF
--- a/cmd/machine-config-daemon/pivot.sh
+++ b/cmd/machine-config-daemon/pivot.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/sh
+exec /usr/libexec/machine-config-daemon pivot "$@"

--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -28,8 +28,10 @@ env VERSION_OVERRIDE=%{version} SOURCE_GIT_COMMIT=%{commit} make daemon
 
 %install
 install -D -m 0755 _output/linux/*/%{name} $RPM_BUILD_ROOT/usr/libexec/%{name}
+install -D -m 0755 cmd/machine-config-daemon/pivot.sh $RPM_BUILD_ROOT/%{_bindir}/pivot
 
 %files
 %license LICENSE
 %doc README.md
 %{_libexecdir}/%{name}
+%{_bindir}/pivot


### PR DESCRIPTION
Since it exists in the docs, and there's already a nontrivial amount
of "muscle memory" around it.
