### PR TITLE
[release-4.1] Bug 1723327: pkg/operator: sync deployment before controllerconfig

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -122,6 +122,9 @@ func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 	defer close(journalStopCh)
 	go followPivotJournalLogs(journalStopCh)
 
+	if err := os.Remove("/etc/pivot/reboot-needed"); err != nil {
+		return errors.Wrap(err, "deleting pivot reboot-needed file")
+	}
 	err := exec.Command("systemctl", "start", "pivot.service").Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to start pivot.service")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -395,9 +395,9 @@ func (optr *Operator) sync(key string) error {
 	// any error marks sync as failure but continues to next syncFunc
 	var syncFuncs = []syncFunc{
 		{"pools", optr.syncMachineConfigPools},
+		{"mcd", optr.syncMachineConfigDaemon},
 		{"mcc", optr.syncMachineConfigController},
 		{"mcs", optr.syncMachineConfigServer},
-		{"mcd", optr.syncMachineConfigDaemon},
 		{"required-pools", optr.syncRequiredMachineConfigPools},
 	}
 	return optr.syncAll(rc, syncFuncs)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -143,16 +143,6 @@ func (optr *Operator) syncMachineConfigController(config renderConfig) error {
 		return err
 	}
 
-	ccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/controllerconfig.yaml")
-	if err != nil {
-		return err
-	}
-	cc := resourceread.ReadControllerConfigV1OrDie(ccBytes)
-	_, _, err = resourceapply.ApplyControllerConfig(optr.client.MachineconfigurationV1(), cc)
-	if err != nil {
-		return err
-	}
-
 	mccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/deployment.yaml")
 	if err != nil {
 		return err
@@ -164,13 +154,20 @@ func (optr *Operator) syncMachineConfigController(config renderConfig) error {
 		return err
 	}
 	if updated {
-		var waitErrs []error
-		waitErrs = append(waitErrs, optr.waitForDeploymentRollout(mcc))
-		waitErrs = append(waitErrs, optr.waitForControllerConfigToBeCompleted(cc))
-		agg := utilerrors.NewAggregate(waitErrs)
-		return agg
+		if err := optr.waitForDeploymentRollout(mcc); err != nil {
+			return err
+		}
 	}
-	return nil
+	ccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/controllerconfig.yaml")
+	if err != nil {
+		return err
+	}
+	cc := resourceread.ReadControllerConfigV1OrDie(ccBytes)
+	_, _, err = resourceapply.ApplyControllerConfig(optr.client.MachineconfigurationV1(), cc)
+	if err != nil {
+		return err
+	}
+	return optr.waitForControllerConfigToBeCompleted(cc)
 }
 
 func (optr *Operator) syncMachineConfigDaemon(config renderConfig) error {


### PR DESCRIPTION
and also rename the CM so the old version can't use the new osimageurl coming from an upgrade.

This should take care of clusters at 4.1.0 upgrading to 4.1.x+?