### PR TITLE
MCO/MCD: sync deployment before controllerconfig, roll out MCDs before MCC and remove pivot's reboot-needed file

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -921,6 +921,13 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 				return err
 			}
 		}
+		// if we're degraded here, it means we got an error likely on startup and we retried
+		// if it's the case, clear it out
+		if state.state == constants.MachineConfigDaemonStateDegraded {
+			if err := dn.nodeWriter.SetDone(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, state.currentConfig.GetName()); err != nil {
+				return errors.Wrap(err, "error setting node's state to Done")
+			}
+		}
 
 		glog.Infof("In desired config %s", state.currentConfig.GetName())
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -124,6 +124,11 @@ func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 	defer close(journalStopCh)
 	go followPivotJournalLogs(journalStopCh)
 
+	// This is written by code injected by the MCS, but we always want the MCD to be in control of reboots
+	if err := os.Remove("/run/pivot/reboot-needed"); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "deleting pivot reboot-needed file")
+	}
+
 	service := "machine-config-daemon-host.service"
 	// We need to use pivot if it's there, because machine-config-daemon-host.service
 	// currently has a ConditionPathExists=!/usr/bin/pivot.  This code can be dropped

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -410,9 +410,9 @@ func (optr *Operator) sync(key string) error {
 	// any error marks sync as failure but continues to next syncFunc
 	var syncFuncs = []syncFunc{
 		{"pools", optr.syncMachineConfigPools},
+		{"mcd", optr.syncMachineConfigDaemon},
 		{"mcc", optr.syncMachineConfigController},
 		{"mcs", optr.syncMachineConfigServer},
-		{"mcd", optr.syncMachineConfigDaemon},
 		{"required-pools", optr.syncRequiredMachineConfigPools},
 	}
 	return optr.syncAll(rc, syncFuncs)


### PR DESCRIPTION
This patch set takes care of mainly three issues we've spotted:

- an osimageurl change from an upgrade can race with the old MCC
- we can still be running the old MCDs on nodes once the new MCC creates the new rendered
- if the node has never rebooted and ConditionFirstBoot is thus True, pivot reboots the node causing an upgrade failure

The above have been fixed by:

- rolling out the new MCC before applying the new osimageurl ConfigMap that is then templated by the new MCC
- roll out the MCDs before the MCC
- always remove `/etc/pivot/reboot-needed` when running pivot from the MCD