### PR TITLE
pkg/daemon: support FIPS

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -51,6 +51,7 @@ type MachineConfigSpec struct {
     // Config is a Ignition Config object.
     Config ign.Config `json:"config"`
     KernelArguments []string `json:"kernelArguments"`
+    Fips bool `json:"fips"`
 }
 ```
 
@@ -93,6 +94,10 @@ Ignition config keys as well.
 ### KernelArguments
 
 This extends the host's kernel arguments.  Use this for e.g. [nosmt](https://access.redhat.com/solutions/rhel-smt).
+
+### FIPS
+
+This allows to enable/disable [FIPS mode](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations). If any of the configuration has FIPS enabled, it'll be set.
 
 ### OSImageURL
 

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -53,6 +53,10 @@ func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec,
 		*modified = true
 		(*existing).Config = required.Config
 	}
+	if existing.Fips != required.Fips {
+		*modified = true
+		(*existing).Fips = required.Fips
+	}
 }
 
 func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfigSpec, required mcfgv1.ControllerConfigSpec) {

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -20,8 +20,13 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 	}
 	sort.Slice(configs, func(i, j int) bool { return configs[i].Name < configs[j].Name })
 
+	var fips bool
 	outIgn := configs[0].Spec.Config
 	for idx := 1; idx < len(configs); idx++ {
+		// if any of the config has FIPS enabled, it'll be set
+		if configs[idx].Spec.Fips {
+			fips = true
+		}
 		outIgn = ign.Append(outIgn, configs[idx].Spec.Config)
 	}
 	kargs := []string{}
@@ -34,6 +39,7 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 			OSImageURL:      osImageURL,
 			KernelArguments: kargs,
 			Config:          outIgn,
+			Fips:            fips,
 		},
 	}
 }

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -231,6 +231,8 @@ type MachineConfigSpec struct {
 	Config igntypes.Config `json:"config"`
 
 	KernelArguments []string `json:"kernelArguments"`
+
+	Fips bool `json:"fips"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

resurrected from https://github.com/openshift/machine-config-operator/pull/826
close https://github.com/openshift/machine-config-operator/pull/800

Added a new FIPS field to MachineConfig to enable/disable FIPS on rhcos (disabled by default). This is, at this point, only intended as a day-2 operation.

FIPS would also greatly benefit a dedicated CRD (oc edit fips?) - I'm experimenting with that but it will ofc require a new controller.

**- How to verify it**

added an e2e and manually verified

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added FIPS support