### PR TITLE
daemon: Look for pivot.service unit file instead of binary

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -126,13 +126,14 @@ func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 
 	service := "machine-config-daemon-host.service"
 	// We need to use pivot if it's there, because machine-config-daemon-host.service
-	// currently has a ConditionPathExists=!/usr/bin/pivot.  This code can be dropped
+	// currently has a ConditionPathExists=!/usr/lib/systemd/system/pivot.service to
+	// avoid having *both* pivot and MCD try to update.  This code can be dropped
 	// once we don't need to care about compat with older RHCOS.
 	var err error
-	_, err = os.Stat("/usr/bin/pivot")
+	_, err = os.Stat("/usr/lib/systemd/system/pivot.service")
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "stat(/usr/bin/pivot)")
+			return errors.Wrapf(err, "checking pivot service")
 		}
 	} else {
 		service = "pivot.service"

--- a/templates/common/_base/units/machine-config-daemon-host.service
+++ b/templates/common/_base/units/machine-config-daemon-host.service
@@ -4,8 +4,8 @@ contents: |
   [Unit]
   Description=Machine Config Daemon Initial
   ConditionPathExists=/etc/pivot/image-pullspec
-  # If pivot exists, defer to it
-  ConditionPathExists=!/usr/bin/pivot
+  # If pivot exists, defer to it.  Note similar code in update.go
+  ConditionPathExists=!/usr/lib/systemd/system/pivot.service
   After=ignition-firstboot-complete.service
   Before=kubelet.service
 


### PR DESCRIPTION
Since we merged a change to add `/usr/bin/pivot` redirecting
to the MCD, we need to fix this compat code.  Checking for the unit
file gives us the semantics we need here.
