### PR TITLE
[release-4.1] Bug 1723327: sync deployment before controllerconfig, roll out MCDs before MCC and remove pivot's reboot-needed file

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -940,6 +940,13 @@ func (dn *Daemon) CheckStateOnBoot() error {
 				return err
 			}
 		}
+		// if we're degraded here, it means we got an error likely on startup and we retried
+		// if it's the case, clear it out
+		if state.state == constants.MachineConfigDaemonStateDegraded {
+			if err := dn.nodeWriter.SetDone(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, state.currentConfig.GetName()); err != nil {
+				return errors.Wrap(err, "error setting node's state to Done")
+			}
+		}
 
 		glog.Infof("In desired config %s", state.currentConfig.GetName())
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -122,6 +122,11 @@ func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 	defer close(journalStopCh)
 	go followPivotJournalLogs(journalStopCh)
 
+	// This is written by code injected by the MCS, but we always want the MCD to be in control of reboots
+	if err := os.Remove("/run/pivot/reboot-needed"); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "deleting pivot reboot-needed file")
+	}
+
 	err := exec.Command("systemctl", "start", "pivot.service").Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to start pivot.service")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -395,9 +395,9 @@ func (optr *Operator) sync(key string) error {
 	// any error marks sync as failure but continues to next syncFunc
 	var syncFuncs = []syncFunc{
 		{"pools", optr.syncMachineConfigPools},
+		{"mcd", optr.syncMachineConfigDaemon},
 		{"mcc", optr.syncMachineConfigController},
 		{"mcs", optr.syncMachineConfigServer},
-		{"mcd", optr.syncMachineConfigDaemon},
 		{"required-pools", optr.syncRequiredMachineConfigPools},
 	}
 	return optr.syncAll(rc, syncFuncs)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -143,16 +143,6 @@ func (optr *Operator) syncMachineConfigController(config renderConfig) error {
 		return err
 	}
 
-	ccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/controllerconfig.yaml")
-	if err != nil {
-		return err
-	}
-	cc := resourceread.ReadControllerConfigV1OrDie(ccBytes)
-	_, _, err = resourceapply.ApplyControllerConfig(optr.client.MachineconfigurationV1(), cc)
-	if err != nil {
-		return err
-	}
-
 	mccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/deployment.yaml")
 	if err != nil {
 		return err
@@ -164,13 +154,20 @@ func (optr *Operator) syncMachineConfigController(config renderConfig) error {
 		return err
 	}
 	if updated {
-		var waitErrs []error
-		waitErrs = append(waitErrs, optr.waitForDeploymentRollout(mcc))
-		waitErrs = append(waitErrs, optr.waitForControllerConfigToBeCompleted(cc))
-		agg := utilerrors.NewAggregate(waitErrs)
-		return agg
+		if err := optr.waitForDeploymentRollout(mcc); err != nil {
+			return err
+		}
 	}
-	return nil
+	ccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/controllerconfig.yaml")
+	if err != nil {
+		return err
+	}
+	cc := resourceread.ReadControllerConfigV1OrDie(ccBytes)
+	_, _, err = resourceapply.ApplyControllerConfig(optr.client.MachineconfigurationV1(), cc)
+	if err != nil {
+		return err
+	}
+	return optr.waitForControllerConfigToBeCompleted(cc)
 }
 
 func (optr *Operator) syncMachineConfigDaemon(config renderConfig) error {


### PR DESCRIPTION
Backport of https://github.com/openshift/machine-config-operator/pull/887

There's a simple reproducer for this but requires "bootimage == target oscontainer" to avoid an early pivot + reboot. Basically, at least on UPI, install 4.1.0 and upgrade to whatever this PR lands to (4.1.4?).