### PR TITLE
pkg/controller: Shorten error Reasons by moving them to Messages

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -73,7 +73,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 	if allUpdated {
 		//TODO: update api to only have one condition regarding status of update.
 		updatedMsg := fmt.Sprintf("All nodes are updated with %s", pool.Spec.Configuration.Name)
-		supdated := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdated, corev1.ConditionTrue, updatedMsg, "")
+		supdated := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdated, corev1.ConditionTrue, "", updatedMsg)
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdated)
 
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", "")
@@ -85,7 +85,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 	} else {
 		supdated := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdated, corev1.ConditionFalse, "", "")
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdated)
-		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, fmt.Sprintf("All nodes are updating to %s", pool.Spec.Configuration.Name), "")
+		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("All nodes are updating to %s", pool.Spec.Configuration.Name))
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
 	}
 

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -453,7 +453,7 @@ func (ctrl *Controller) syncAvailableStatus(pool *mcfgv1.MachineConfigPool) erro
 }
 
 func (ctrl *Controller) syncFailingStatus(pool *mcfgv1.MachineConfigPool, err error) error {
-	sdegraded := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolRenderDegraded, corev1.ConditionTrue, fmt.Sprintf("Failed to render configuration for pool %s: %v", pool.Name, err), "")
+	sdegraded := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolRenderDegraded, corev1.ConditionTrue, "", fmt.Sprintf("Failed to render configuration for pool %s: %v", pool.Name, err))
 	mcfgv1.SetMachineConfigPoolCondition(&pool.Status, *sdegraded)
 	if _, updateErr := ctrl.client.MachineconfigurationV1().MachineConfigPools().UpdateStatus(pool); updateErr != nil {
 		glog.Errorf("Error updating MachineConfigPool %s: %v", pool.Name, updateErr)

--- a/pkg/controller/template/status.go
+++ b/pkg/controller/template/status.go
@@ -18,10 +18,10 @@ import (
 func (ctrl *Controller) syncRunningStatus(ctrlconfig *mcfgv1.ControllerConfig) error {
 	updateFunc := func(cfg *mcfgv1.ControllerConfig) error {
 		reason := fmt.Sprintf("syncing towards (%d) generation using controller version %s", cfg.GetGeneration(), version.Version)
-		rcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerRunning, corev1.ConditionTrue, reason, "")
+		rcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerRunning, corev1.ConditionTrue, "", reason)
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *rcond)
 		if cfg.GetGeneration() != cfg.Status.ObservedGeneration && mcfgv1.IsControllerConfigStatusConditionPresentAndEqual(cfg.Status.Conditions, mcfgv1.TemplateContollerCompleted, corev1.ConditionTrue) {
-			acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerCompleted, corev1.ConditionFalse, fmt.Sprintf("%s due to change in Generation", reason), "")
+			acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerCompleted, corev1.ConditionFalse, "", fmt.Sprintf("%s due to change in Generation", reason))
 			mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *acond)
 		}
 		cfg.Status.ObservedGeneration = ctrlconfig.GetGeneration()
@@ -38,9 +38,8 @@ func (ctrl *Controller) syncFailingStatus(ctrlconfig *mcfgv1.ControllerConfig, o
 		return nil
 	}
 	updateFunc := func(cfg *mcfgv1.ControllerConfig) error {
-		reason := oerr.Error()
 		message := fmt.Sprintf("failed to syncing towards (%d) generation using controller version %s: %v", cfg.GetGeneration(), version.Version, oerr)
-		fcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerFailing, corev1.ConditionTrue, reason, message)
+		fcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerFailing, corev1.ConditionTrue, "", message)
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *fcond)
 		acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerCompleted, corev1.ConditionFalse, "", "")
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *acond)
@@ -61,7 +60,7 @@ func (ctrl *Controller) syncFailingStatus(ctrlconfig *mcfgv1.ControllerConfig, o
 func (ctrl *Controller) syncCompletedStatus(ctrlconfig *mcfgv1.ControllerConfig) error {
 	updateFunc := func(cfg *mcfgv1.ControllerConfig) error {
 		reason := fmt.Sprintf("sync completed towards (%d) generation using controller version %s", cfg.GetGeneration(), version.Version)
-		acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerCompleted, corev1.ConditionTrue, reason, "")
+		acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerCompleted, corev1.ConditionTrue, "", reason)
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *acond)
 		rcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateContollerRunning, corev1.ConditionFalse, "", "")
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *rcond)

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -267,7 +267,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 	}
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Reason: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 
@@ -278,7 +278,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Reason: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateContollerFailing, Status: corev1.ConditionFalse},
 	}
@@ -306,7 +306,7 @@ func TestDoNothing(t *testing.T) {
 
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Reason: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 	for idx := range mcs {
@@ -315,7 +315,7 @@ func TestDoNothing(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Reason: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateContollerFailing, Status: corev1.ConditionFalse},
 	}
@@ -343,7 +343,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Reason: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 
@@ -354,7 +354,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Reason: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateContollerFailing, Status: corev1.ConditionFalse},
 	}
@@ -387,7 +387,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	}
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Reason: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 	for idx := range expmcs {
@@ -397,7 +397,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Reason: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateContollerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateContollerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateContollerFailing, Status: corev1.ConditionFalse},
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes #890.

**- What I did**
Found all instances of `MachineConfigPoolCondition` and `NewControllerConfigStatusCondition` in the repo and swapped the (left) Reason field with the (right) Message field, as described in #890.
**- How to verify it**
Unit testing / CI success
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
pkg/controller: Shorten error Reasons by moving them to Messages