### PR TITLE
* : remove refs to component images & dockerfiles

### DIFF
--- a/Dockerfile.machine-config-controller
+++ b/Dockerfile.machine-config-controller
@@ -1,9 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY . .
-RUN WHAT=machine-config-controller ./hack/build-go.sh
-
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-controller /usr/bin/
-COPY templates /etc/mcc/templates
-ENTRYPOINT ["/usr/bin/machine-config-controller"]

--- a/Dockerfile.machine-config-daemon
+++ b/Dockerfile.machine-config-daemon
@@ -1,9 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY . .
-RUN WHAT=machine-config-daemon ./hack/build-go.sh
-
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
-RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
-ENTRYPOINT ["/usr/bin/machine-config-daemon"]

--- a/Dockerfile.machine-config-operator
+++ b/Dockerfile.machine-config-operator
@@ -1,1 +1,0 @@
-Dockerfile

--- a/Dockerfile.machine-config-server
+++ b/Dockerfile.machine-config-server
@@ -1,8 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY . .
-RUN WHAT=machine-config-server ./hack/build-go.sh
-
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /usr/bin/
-ENTRYPOINT ["/usr/bin/machine-config-server"]

--- a/Dockerfile.setup-etcd-environment
+++ b/Dockerfile.setup-etcd-environment
@@ -1,8 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY . .
-RUN WHAT=setup-etcd-environment ./hack/build-go.sh
-
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/setup-etcd-environment /usr/bin/
-ENTRYPOINT ["/usr/bin/setup-etcd-environment"]

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -30,15 +30,11 @@ var (
 		infraImage           string
 		kubeCAFile           string
 		kubeClientAgentImage string
-		mccImage             string
-		mcdImage             string
-		mcsImage             string
 		mcoImage             string
 		networkConfigFile    string
 		oscontentImage       string
 		pullSecretFile       string
 		rootCAFile           string
-		setupEtcdEnvImage    string
 		proxyConfigFile      string
 	}
 )
@@ -52,16 +48,12 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "/assets/manifests/pull.json", "path to secret manifest that contains pull secret.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")
 	bootstrapCmd.MarkFlagRequired("dest-dir")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mccImage, "machine-config-controller-image", "", "Image for Machine Config Controller.")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcsImage, "machine-config-server-image", "", "Image for Machine Config Server.")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcdImage, "machine-config-daemon-image", "", "Image for Machine Config Daemon.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcoImage, "machine-config-operator-image", "", "Image for Machine Config Operator.")
 	bootstrapCmd.MarkFlagRequired("machine-config-operator-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oscontentImage, "machine-config-oscontent-image", "", "Image for osImageURL")
 	bootstrapCmd.MarkFlagRequired("machine-config-oscontent-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdImage, "etcd-image", "", "Image for Etcd.")
 	bootstrapCmd.MarkFlagRequired("etcd-image")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.setupEtcdEnvImage, "setup-etcd-env-image", "", "Image for Setup etcd Environment.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeClientAgentImage, "kube-client-agent-image", "", "Image for Kube Client Agent.")
 	bootstrapCmd.MarkFlagRequired("kube-client-agent-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "", "Image for Infra Containers.")
@@ -83,15 +75,11 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{
-			MachineConfigOperator:   bootstrapOpts.mcoImage,
-			MachineConfigController: bootstrapOpts.mccImage,
-			MachineConfigDaemon:     bootstrapOpts.mcdImage,
-			MachineConfigServer:     bootstrapOpts.mcsImage,
-			MachineOSContent:        bootstrapOpts.oscontentImage,
+			MachineConfigOperator: bootstrapOpts.mcoImage,
+			MachineOSContent:      bootstrapOpts.oscontentImage,
 		},
 		ControllerConfigImages: operator.ControllerConfigImages{
 			Etcd:            bootstrapOpts.etcdImage,
-			SetupEtcdEnv:    bootstrapOpts.setupEtcdEnvImage,
 			InfraImage:      bootstrapOpts.infraImage,
 			KubeClientAgent: bootstrapOpts.kubeClientAgentImage,
 		},

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -7,11 +7,7 @@ data:
   images.json: >
     {
       "machineConfigOperator": "registry.svc.ci.openshift.org/openshift:machine-config-operator",
-      "machineConfigController": "registry.svc.ci.openshift.org/openshift:machine-config-controller",
-      "machineConfigDaemon": "registry.svc.ci.openshift.org/openshift:machine-config-daemon",
-      "machineConfigServer": "registry.svc.ci.openshift.org/openshift:machine-config-server",
       "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
-      "setupEtcdEnv": "registry.svc.ci.openshift.org/openshift:setup-etcd-environment",
       "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
       "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift:kube-client-agent"
     }

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -14,17 +14,13 @@ type Images struct {
 
 // RenderConfigImages are image names used to render templates under ./manifests/
 type RenderConfigImages struct {
-	MachineConfigOperator   string `json:"machineConfigOperator"`
-	MachineConfigController string `json:"machineConfigController"`
-	MachineConfigDaemon     string `json:"machineConfigDaemon"`
-	MachineConfigServer     string `json:"machineConfigServer"`
-	MachineOSContent        string `json:"machineOSContent"`
+	MachineConfigOperator string `json:"machineConfigOperator"`
+	MachineOSContent      string `json:"machineOSContent"`
 }
 
 // ControllerConfigImages are image names used to render templates under ./templates/
 type ControllerConfigImages struct {
 	Etcd            string `json:"etcd"`
-	SetupEtcdEnv    string `json:"setupEtcdEnv"`
 	InfraImage      string `json:"infraImage"`
 	KubeClientAgent string `json:"kubeClientAgentImage"`
 }


### PR DESCRIPTION
Remove all references to mcc/mcd/mcs/setupetdenv images so that we rely on the new MCO mega image only.

Note: Dockerfile.rhel7 images will be removed in a followup PR pending ART merge

Requires: https://github.com/openshift/installer/pull/1875
Related-to: openshift/machine-config-operator#739