### PR TITLE
cmd: fix typo and uppercase components names

### DIFF
--- a/cmd/machine-config-controller/main.go
+++ b/cmd/machine-config-controller/main.go
@@ -30,6 +30,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing mcc: %v", err)
+		glog.Exitf("Error executing MCC: %v", err)
 	}
 }

--- a/cmd/machine-config-daemon/main.go
+++ b/cmd/machine-config-daemon/main.go
@@ -25,6 +25,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing mcd: %v", err)
+		glog.Exitf("Error executing MCD: %v", err)
 	}
 }

--- a/cmd/machine-config-operator/main.go
+++ b/cmd/machine-config-operator/main.go
@@ -26,6 +26,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing mcc: %v", err)
+		glog.Exitf("Error executing MCO: %v", err)
 	}
 }

--- a/cmd/machine-config-server/main.go
+++ b/cmd/machine-config-server/main.go
@@ -36,6 +36,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing mcs: %v", err)
+		glog.Exitf("Error executing MCS: %v", err)
 	}
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

noticed the `mcc -> mco` typo, fixed that and uppercased all names as well

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
