### PR TITLE
templates/mco: update template to replace setupetcdenv image with MCO image

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -112,7 +112,7 @@ func RenderBootstrap(
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
 		templatectrl.EtcdImageKey:            imgs.Etcd,
-		templatectrl.SetupEtcdEnvKey:         imgs.SetupEtcdEnv,
+		templatectrl.SetupEtcdEnvKey:         imgs.MachineConfigOperator,
 		templatectrl.InfraImageKey:           imgs.InfraImage,
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -406,7 +406,7 @@ func (optr *Operator) sync(key string) error {
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
 		templatectrl.EtcdImageKey:            imgs.Etcd,
-		templatectrl.SetupEtcdEnvKey:         imgs.SetupEtcdEnv,
+		templatectrl.SetupEtcdEnvKey:         imgs.MachineConfigOperator,
 		templatectrl.InfraImageKey:           imgs.InfraImage,
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 	}

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -14,6 +14,7 @@ contents:
       initContainers:
       - name: discovery
         image: "{{.Images.setupEtcdEnv}}"
+        command: ["/usr/bin/setup-etcd-environment"]
         args:
         - "run"
         - "--discovery-srv={{.EtcdDiscoveryDomain}}"


### PR DESCRIPTION
Operator.go & bootstrap.go need to reference the MCO image instead of the
old setupetcdenv image.

Update template to add setupetcdenv entrypoint for MCO image.

Required-for: openshift/installer#1875
Related-to: #850
Related-to: #739 (issue will only close when final installer pr merges)

cc: @runcom 