### PR TITLE
 daemon: Add a m-c-d-firstboot.service that handles encapsulated MC

### DIFF
--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var firstbootCompleteMachineconfig = &cobra.Command{
+	Use:                   "firstboot-complete-machineconfig",
+	DisableFlagsInUseLine: true,
+	Short:                 "Complete the host's initial boot into a MachineConfig",
+	Args:                  cobra.MaximumNArgs(0),
+	Run:                   executeFirstbootCompleteMachineConfig,
+}
+
+// init executes upon import
+func init() {
+	rootCmd.AddCommand(firstbootCompleteMachineconfig)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+}
+
+func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	exitCh := make(chan error)
+	defer close(exitCh)
+
+	dn, err := daemon.New(daemon.NewNodeUpdaterClient(), exitCh)
+	if err != nil {
+		return err
+	}
+
+	err = dn.RunFirstbootCompleteMachineconfig()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func executeFirstbootCompleteMachineConfig(cmd *cobra.Command, args []string) {
+	err := runFirstBootCompleteMachineConfig(cmd, args)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -36,12 +36,7 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	err = dn.RunFirstbootCompleteMachineconfig()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return dn.RunFirstbootCompleteMachineconfig()
 }
 
 func executeFirstbootCompleteMachineConfig(cmd *cobra.Command, args []string) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -459,12 +459,12 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 
 	// Start with an empty config, then add our *booted* osImageURL to
 	// it, reflecting the current machine state.
-	oldConfig := canonicalizeEmptyConfig(nil)
+	oldConfig := canonicalizeEmptyMC(nil)
 	oldConfig.Spec.OSImageURL = dn.bootedOSImageURL
 	// Currently, we generally expect the bootimage to be older, but in the special
 	// case of having bootimage == machine-os-content, and no kernel arguments
 	// specified, then we don't need to do anything here.
-	if !dn.checkUpdateDiff(oldConfig, &mc) {
+	if !dn.compareMachineConfig(oldConfig, &mc) {
 		// Removing this file signals completion of the initial MC processing.
 		if err := os.Remove(constants.MachineConfigEncapsulatedPath); err != nil {
 			return errors.Wrapf(err, "failed to remove %s", constants.MachineConfigEncapsulatedPath)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -444,6 +444,49 @@ func (dn *Daemon) RunOnceFrom(onceFrom string, skipReboot bool) error {
 	return errors.New("unsupported onceFrom type provided")
 }
 
+// RunFirstbootCompleteMachineconfig is run via systemd on the first boot
+// to complete processing of the target MachineConfig.
+func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
+	data, err := ioutil.ReadFile(constants.MachineConfigEncapsulatedPath)
+	if err != nil {
+		return err
+	}
+	var mc mcfgv1.MachineConfig
+	err = json.Unmarshal(data, &mc)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse MachineConfig")
+	}
+
+	// Start with an empty config, then add our *booted* osImageURL to
+	// it, reflecting the current machine state.
+	oldConfig := canonicalizeEmptyConfig(nil)
+	oldConfig.Spec.OSImageURL = dn.bootedOSImageURL
+	// Currently, we generally expect the bootimage to be older, but in the special
+	// case of having bootimage == machine-os-content, and no kernel arguments
+	// specified, then we don't need to do anything here.
+	if !dn.checkUpdateDiff(oldConfig, &mc) {
+		// Removing this file signals completion of the initial MC processing.
+		if err := os.Remove(constants.MachineConfigEncapsulatedPath); err != nil {
+			return errors.Wrapf(err, "failed to remove %s", constants.MachineConfigEncapsulatedPath)
+		}
+		return nil
+	}
+
+	dn.skipReboot = true
+	err = dn.update(nil, &mc)
+	if err != nil {
+		return err
+	}
+
+	// Removing this file signals completion of the initial MC processing.
+	if err := os.Remove(constants.MachineConfigEncapsulatedPath); err != nil {
+		return errors.Wrapf(err, "failed to remove %s", constants.MachineConfigEncapsulatedPath)
+	}
+
+	dn.skipReboot = false
+	return dn.reboot(fmt.Sprintf("Completing firstboot provisioning to %s", mc.GetName()))
+}
+
 // InstallSignalHandler installs the handler for the signals the daemon should act on
 func (dn *Daemon) InstallSignalHandler(signaled chan struct{}) {
 	termChan := make(chan os.Signal, 2048)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -333,13 +333,21 @@ type MachineConfigDiff struct {
 	units    bool
 }
 
+// See if this was Rust we wouldn't have nullable pointers by default...
+func canonicalizeStringArray(a []string) []string {
+	if a == nil {
+		return []string{}
+	}
+	return a
+}
+
 // NewMachineConfigDiff compares two MachineConfig objects.
 func NewMachineConfigDiff(oldConfig, newConfig *mcfgv1.MachineConfig) *MachineConfigDiff {
 	oldIgn := oldConfig.Spec.Config
 	newIgn := newConfig.Spec.Config
 	return &MachineConfigDiff{
 		osUpdate: oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL,
-		kargs:    !reflect.DeepEqual(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments),
+		kargs:    !reflect.DeepEqual(canonicalizeStringArray(oldConfig.Spec.KernelArguments), canonicalizeStringArray(newConfig.Spec.KernelArguments)),
 		fips:     oldConfig.Spec.FIPS != newConfig.Spec.FIPS,
 		passwd:   !reflect.DeepEqual(oldIgn.Passwd, newIgn.Passwd),
 		files:    !reflect.DeepEqual(oldIgn.Storage.Files, newIgn.Storage.Files),

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -9,9 +9,9 @@ import (
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -197,8 +197,8 @@ func TestMachineConfigDiff(t *testing.T) {
 	assert.False(t, diff.IsEmpty())
 	assert.True(t, diff.osUpdate)
 
-	emptyMc := canonicalizeEmptyConfig(nil)
-	otherEmptyMc := canonicalizeEmptyConfig(nil)
+	emptyMc := canonicalizeEmptyMC(nil)
+	otherEmptyMc := canonicalizeEmptyMC(nil)
 	emptyMc.Spec.KernelArguments = nil
 	otherEmptyMc.Spec.KernelArguments = []string{}
 	diff = NewMachineConfigDiff(emptyMc, otherEmptyMc)

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -196,6 +196,13 @@ func TestMachineConfigDiff(t *testing.T) {
 	diff = NewMachineConfigDiff(oldConfig, newConfig)
 	assert.False(t, diff.IsEmpty())
 	assert.True(t, diff.osUpdate)
+
+	emptyMc := canonicalizeEmptyConfig(nil)
+	otherEmptyMc := canonicalizeEmptyConfig(nil)
+	emptyMc.Spec.KernelArguments = nil
+	otherEmptyMc.Spec.KernelArguments = []string{}
+	diff = NewMachineConfigDiff(emptyMc, otherEmptyMc)
+	assert.True(t, diff.IsEmpty())
 }
 
 func newTestIgnitionFile(i uint) igntypes.File {

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service
@@ -3,10 +3,13 @@ enabled: true
 contents: |
   [Unit]
   Description=Machine Config Daemon Firstboot
-  # This effectively disables this unit unit we patch the MCS, so
-  # we can land this code and then get it built into the host.
+  # Make sure it runs only on OSTree booted system
+  ConditionPathExists=/run/ostree-booted
+  # This effectively disables this unit unitl we get latest
+  # machine-config-daemon package into bootimage
   ConditionPathExists=!/etc/pivot/image-pullspec
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
+  BindsTo=ignition-firstboot-complete.service
   After=ignition-firstboot-complete.service
   Before=kubelet.service
 

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service
@@ -1,0 +1,19 @@
+name: "machine-config-daemon-firstboot.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Machine Config Daemon Firstboot
+  # This effectively disables this unit unit we patch the MCS, so
+  # we can land this code and then get it built into the host.
+  ConditionPathExists=!/etc/pivot/image-pullspec
+  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
+  After=ignition-firstboot-complete.service
+  Before=kubelet.service
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  ExecStart=/usr/libexec/machine-config-daemon firstboot-complete-machineconfig
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION

The saga of adding "firstboot MachineConfig" in
#798
is getting closer.  This is a small amount of code that builds on
a lot of prep work that landed to add a systemd service + entrypoint
in the MCD that reads the
`/etc/ignition-machine-config-encapsulated.json` file.  You
could think of this a lot like a variant of "once-from".

However, it doesn't run by default right now because the MCS still
serves `/etc/pivot/image-pullspec`, and this gives us a way to
"ratchet" the change as we need this new MCD code to land in RHCOS
before we can use it.