### PR TITLE
templates: Add proxy conf for systemd user sessions as well

### DIFF
--- a/templates/common/_base/files/etc-systemd-user.conf.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-user.conf.d-10-default-env.conf.yaml
@@ -1,0 +1,17 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/user.conf.d/10-default-env.conf"
+contents:
+  inline: |
+    {{if .Proxy -}}
+    [Manager]
+    {{if .Proxy.HTTPProxy -}}
+    DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+    {{end -}}
+    {{end -}}


### PR DESCRIPTION
Followup from: https://github.com/openshift/machine-config-operator/pull/901
We want the proxies to be set up for systemd user sessions as well, as it's
quite valid to do e.g. `systemd-run --user podman ...` even if not a primary
OpenShift use case today.
