### PR TITLE
pkg: add GCP support

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -113,7 +113,7 @@ type ControllerConfigSpec struct {
 	ClusterDNSIP        string `json:"clusterDNSIP"`
 	CloudProviderConfig string `json:"cloudProviderConfig"`
 
-	// The openshift platform, e.g. "libvirt", "openstack", "baremetal", "aws", or "none"
+	// The openshift platform, e.g. "libvirt", "openstack", "gcp", "baremetal", "aws", or "none"
 	Platform string `json:"platform"`
 
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -37,6 +37,7 @@ const (
 	platformAWS       = "aws"
 	platformAzure     = "azure"
 	platformBaremetal = "baremetal"
+	platformGCP       = "gcp"
 	platformOpenstack = "openstack"
 	platformLibvirt   = "libvirt"
 	platformNone      = "none"
@@ -126,7 +127,7 @@ func platformFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, 
 		return "", fmt.Errorf("cannot generate MachineConfigs with an empty platform field")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case platformAWS, platformAzure, platformBaremetal, platformOpenstack, platformLibvirt, platformNone:
+	case platformAWS, platformAzure, platformBaremetal, platformGCP, platformOpenstack, platformLibvirt, platformNone:
 		return ic.Platform, nil
 	default:
 		glog.Warningf("Warning: the controller config referenced an unsupported platform: %s", ic.Platform)
@@ -369,7 +370,7 @@ func cloudProvider(cfg RenderConfig) (interface{}, error) {
 	// FIXME Explicitly disable (remove) the cloud provider on OpenStack for now
 	// Don't forget to turn the test case back on as well
 	switch cfg.Platform {
-	case platformAWS, platformAzure, platformVSphere:
+	case platformAWS, platformAzure, platformGCP, platformVSphere:
 		return cfg.Platform, nil
 	default:
 		return "", nil

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -36,6 +36,9 @@ func TestCloudProvider(t *testing.T) {
 		platform: "baremetal",
 		res:      "",
 	}, {
+		platform: "gcp",
+		res:      "gcp",
+	}, {
 		platform: "libvirt",
 		res:      "",
 	}, {
@@ -232,6 +235,7 @@ var (
 	configs = map[string]string{
 		"aws":       "./test_data/controller_config_aws.yaml",
 		"baremetal": "./test_data/controller_config_baremetal.yaml",
+		"gcp":    "./test_data/controller_config_gcp.yaml",
 		"openstack": "./test_data/controller_config_openstack.yaml",
 		"libvirt":   "./test_data/controller_config_libvirt.yaml",
 		"none":      "./test_data/controller_config_none.yaml",

--- a/pkg/controller/template/test_data/controller_config_gcp.yaml
+++ b/pkg/controller/template/test_data/controller_config_gcp.yaml
@@ -1,0 +1,17 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
+  etcdInitialCount: 3
+  platform: "gcp"
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -76,6 +76,8 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		platform = "azure"
 	case configv1.BareMetalPlatformType:
 		platform = "baremetal"
+	case configv1.GCPPlatformType:
+		platform = "gcp"
 	case configv1.OpenStackPlatformType:
 		platform = "openstack"
 	case configv1.LibvirtPlatformType:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Allow the operator so understand `GCP` platform as suported.

Allow the template controller to create a kubelet service with cloud provider flag set to `gcp`

**- How to verify it**

**- Description for the changelog**

`add GCP support`

