### PR TITLE
Fix upgrades/pivoting

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -185,6 +185,9 @@ func updateTuningArgs(tuningFilePath, cmdLinePath string) (bool, error) {
 }
 
 func run(_ *cobra.Command, args []string) error {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
 	var container string
 	if fromEtcPullSpec || len(args) == 0 {
 		fromEtcPullSpec = true

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -335,7 +335,8 @@ func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 func followPivotJournalLogs(stopCh <-chan time.Time) {
 	cmd := exec.Command("journalctl", "-f", "-b", "-o", "cat",
 		"-u", "rpm-ostreed",
-		"-u", "pivot")
+		"-u", "pivot",
+		"-u", "machine-config-daemon-host")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
 daemon: Fix pivoting by trimming trailing newlines

Subtle API difference in the `runGetOut` that was duplicated
between the pivot and MCD codebases.  The trailing newline
wasn't expected by podman in further commands obviously.
My bad for not testing this, and doubly bad for not having CI coverage.