### PR TITLE
Bug 1726296: pkg/operator: handle missing proxy object

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -476,7 +476,7 @@ func (optr *Operator) getGlobalConfig() (*configv1.Infrastructure, *configv1.Net
 		return nil, nil, nil, err
 	}
 	proxy, err := optr.proxyLister.Get("cluster")
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, nil, err
 	}
 	return infra, network, proxy, nil

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -86,13 +86,19 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		platform = "vsphere"
 	}
 
-	return &mcfgv1.ControllerConfigSpec{
+	ccSpec := &mcfgv1.ControllerConfigSpec{
 		ClusterDNSIP:        dnsIP,
 		CloudProviderConfig: "",
 		EtcdDiscoveryDomain: infra.Status.EtcdDiscoveryDomain,
 		Platform:            platform,
 		Proxy:               &proxy.Status,
-	}, nil
+	}
+
+	if proxy != nil {
+		ccSpec.Proxy = &proxy.Status
+	}
+
+	return ccSpec, nil
 }
 
 func clusterDNSIP(iprange string) (string, error) {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2/10

The job above failed a 4.1 -> 4.2 upgrade, logs in MCO shows:

```
E0702 05:58:10.557039       1 operator.go:311] proxy.config.openshift.io "cluster" not found
E0702 06:02:00.258227       1 operator.go:311] proxy.config.openshift.io "cluster" not found
E0702 06:05:49.965328       1 operator.go:311] proxy.config.openshift.io "cluster" not found
E0702 06:09:39.666065       1 operator.go:311] proxy.config.openshift.io "cluster" not found
E0702 06:13:29.368922       1 operator.go:311] proxy.config.openshift.io "cluster" not found
```

It means the proxy object isn't in the apiserver and we fail at getting it, disrupting the whole upgrade. Proxy comes in 4.2 but it's still valid to have no proxy during an upgrade (4.1 isn't creating a proxy object nor the upgrade is) and we shouldn't fail like that but just avoid configuring the proxy.

**- How to verify it**

4.1 -> 4.2 CI && manual 4.1 -> 4.2 upgrade

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
