### PR TITLE
pkg/operator: bubble up errors during MCO initial sync

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -323,7 +323,7 @@ func (optr *Operator) sync(key string) error {
 	// any error marks sync as failure.
 	var syncFuncs = []syncFunc{
 		// "render-config" must always run first as it sets the renderConfig in the operator
-		// for the sync funcs below. This is the only function that prevents the others from even running also.
+		// for the sync funcs below
 		{"render-config", optr.syncRenderConfig},
 		{"pools", optr.syncMachineConfigPools},
 		{"mcd", optr.syncMachineConfigDaemon},
@@ -332,7 +332,7 @@ func (optr *Operator) sync(key string) error {
 		// this check must always run last since it makes sure the pools are in sync/upgrading correctly
 		{"required-pools", optr.syncRequiredMachineConfigPools},
 	}
-	return optr.syncAll(optr.renderConfig, syncFuncs)
+	return optr.syncAll(syncFuncs)
 }
 
 func (optr *Operator) getOsImageURL(namespace string) (string, error) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -320,8 +320,7 @@ func (optr *Operator) sync(key string) error {
 	}()
 
 	// syncFuncs is the list of sync functions that are executed in order.
-	// any error marks sync as failure but continues to next syncFunc unless it's the "render-config" one
-	// which is in charge of setting up the renderConfig for the subsequent syncfuncs.
+	// any error marks sync as failure.
 	var syncFuncs = []syncFunc{
 		// "render-config" must always run first as it sets the renderConfig in the operator
 		// for the sync funcs below. This is the only function that prevents the others from even running also.
@@ -330,6 +329,7 @@ func (optr *Operator) sync(key string) error {
 		{"mcd", optr.syncMachineConfigDaemon},
 		{"mcc", optr.syncMachineConfigController},
 		{"mcs", optr.syncMachineConfigServer},
+		// this check must always run last since it makes sure the pools are in sync/upgrading correctly
 		{"required-pools", optr.syncRequiredMachineConfigPools},
 	}
 	return optr.syncAll(optr.renderConfig, syncFuncs)

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -209,7 +209,7 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
 	// RelatedObjects are consumed by https://github.com/openshift/must-gather
 	co.Status.RelatedObjects = []configv1.ObjectReference{
-		{Resource: "namespaces", Name: "openshift-machine-config-operator"},
+		{Resource: "namespaces", Name: optr.namespace},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "master"},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "worker"},
 		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "cluster"},

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -479,7 +479,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 				optr.vStore.Set("operator", "test-version")
 			}
 			optr.configClient = fakeconfigclientset.NewSimpleClientset(co)
-			err := optr.syncAll(&renderConfig{}, sync.syncFuncs)
+			err := optr.syncAll(sync.syncFuncs)
 			if sync.expectOperatorFail {
 				assert.NotNil(t, err, "test case %d, sync call %d, expected an error", idx, j)
 			} else {
@@ -518,7 +518,7 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 	fn1 := func(config *renderConfig) error {
 		return errors.New("mocked fn1")
 	}
-	err := optr.syncAll(&renderConfig{}, []syncFunc{{name: "mock1", fn: fn1}})
+	err := optr.syncAll([]syncFunc{{name: "mock1", fn: fn1}})
 	assert.NotNil(t, err, "expected syncAll to fail")
 
 	assert.True(t, optr.inClusterBringup)
@@ -526,7 +526,7 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 	fn1 = func(config *renderConfig) error {
 		return nil
 	}
-	err = optr.syncAll(&renderConfig{}, []syncFunc{{name: "mock1", fn: fn1}})
+	err = optr.syncAll([]syncFunc{{name: "mock1", fn: fn1}})
 	assert.Nil(t, err, "expected syncAll to pass")
 
 	assert.False(t, optr.inClusterBringup)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -30,7 +30,7 @@ type syncFunc struct {
 	fn   func(config *renderConfig) error
 }
 
-func (optr *Operator) syncAll(rconfig *renderConfig, syncFuncs []syncFunc) error {
+func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 	if err := optr.syncProgressingStatus(); err != nil {
 		return fmt.Errorf("error syncing progressing status: %v", err)
 	}
@@ -38,7 +38,7 @@ func (optr *Operator) syncAll(rconfig *renderConfig, syncFuncs []syncFunc) error
 	var syncErr error
 	for _, sf := range syncFuncs {
 		startTime := time.Now()
-		syncErr = sf.fn(rconfig)
+		syncErr = sf.fn(optr.renderConfig)
 		if optr.inClusterBringup {
 			glog.Infof("[init mode] synced %s in %v", sf.name, time.Since(startTime))
 		}


### PR DESCRIPTION
Ref: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2/10

From the above jobs the MCO isn't reporting the internal error
preventing the upgrade (or sync) to go through. This patch moves the
renderConfig setup to its own sync function in order to be accounted in
the CO object as any other sync functions.