### PR TITLE
pkg/operator: actually do not set proxy if empty...

### DIFF
--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -91,7 +91,6 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		CloudProviderConfig: "",
 		EtcdDiscoveryDomain: infra.Status.EtcdDiscoveryDomain,
 		Platform:            platform,
-		Proxy:               &proxy.Status,
 	}
 
 	if proxy != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

I've been silly here https://github.com/openshift/machine-config-operator/pull/910/files#r299605265, shame on me, the previous PR works but makes the MCO panic and fail the upgrade anyway

Fix that

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
