### PR TITLE
CI: Add gosec to make verify

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - gofmt
     - goimports
     - golint
-    - gosec
+    #- gosec
     - govet
     - ineffassign
     #- interfacer

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ verify:
 	@which golangci-lint 2> /dev/null >&1 || { echo "golangci-lint must be installed to lint code";  exit 1; }
 	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
 	golangci-lint run
+	# Remove once https://github.com/golangci/golangci-lint/issues/597 is
+	# addressed
 	gosec -severity high --confidence medium -exclude G204 -quiet ./...
 	hack/verify-codegen.sh
 	hack/verify-generated-bindata.sh

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ update:
 verify:
 	@which go-bindata 2> /dev/null >&1 || { echo "go-bindata must be installed to verify generated code";  exit 1; }
 	@which golangci-lint 2> /dev/null >&1 || { echo "golangci-lint must be installed to lint code";  exit 1; }
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
 	golangci-lint run
+	gosec -severity high --confidence medium -exclude G204 -quiet ./...
 	hack/verify-codegen.sh
 	hack/verify-generated-bindata.sh
 


### PR DESCRIPTION
While golangci-lint runs gosec as well; the way they did it was by
forking the gosec code and importing it. The issue is that they
haven't updated the fork in almost a year.

So to get the latest gosec, lets call it explicitly.

This depends on  openshift/release#4273

If golangci/golangci-lint#597 gets fixed, we could get rid of this.