### PR TITLE
pkg/operator: clarify MCO images and use better names

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -82,15 +82,19 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
 
 	imgs := operator.Images{
-		MachineConfigOperator:   bootstrapOpts.mcoImage,
-		MachineConfigController: bootstrapOpts.mccImage,
-		MachineConfigDaemon:     bootstrapOpts.mcdImage,
-		MachineConfigServer:     bootstrapOpts.mcsImage,
-		MachineOSContent:        bootstrapOpts.oscontentImage,
-		Etcd:                    bootstrapOpts.etcdImage,
-		SetupEtcdEnv:            bootstrapOpts.setupEtcdEnvImage,
-		InfraImage:              bootstrapOpts.infraImage,
-		KubeClientAgent:         bootstrapOpts.kubeClientAgentImage,
+		RenderConfigImages: operator.RenderConfigImages{
+			MachineConfigOperator:   bootstrapOpts.mcoImage,
+			MachineConfigController: bootstrapOpts.mccImage,
+			MachineConfigDaemon:     bootstrapOpts.mcdImage,
+			MachineConfigServer:     bootstrapOpts.mcsImage,
+			MachineOSContent:        bootstrapOpts.oscontentImage,
+		},
+		ControllerConfigImages: operator.ControllerConfigImages{
+			Etcd:            bootstrapOpts.etcdImage,
+			SetupEtcdEnv:    bootstrapOpts.setupEtcdEnvImage,
+			InfraImage:      bootstrapOpts.infraImage,
+			KubeClientAgent: bootstrapOpts.kubeClientAgentImage,
+		},
 	}
 
 	if err := operator.RenderBootstrap(

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -85,15 +85,14 @@ type ControllerConfigSpec struct {
 	// on all machines.
 	PullSecret *corev1.ObjectReference `json:"pullSecret,omitempty"`
 
-	// images is the map of images that are used by the controller,
-	// i.e. images for etcd Environment Setup, etcd, Kube Client Agent, and Infra containers.
+	// images is map of images that are used by the controller to render templates under ./templates/
 	Images map[string]string `json:"images"`
 
 	// osImageURL is the location of the container image that contains the OS update payload.
 	// Its value is taken from the data.osImageURL field on the machine-config-osimageurl ConfigMap.
 	OSImageURL string `json:"osImageURL"`
 
-	// Proxy holds the current proxy configuration for the nodes
+	// proxy holds the current proxy configuration for the nodes
 	Proxy *configv1.ProxyStatus `json:"proxy"`
 }
 

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -2,14 +2,14 @@ package template
 
 const (
 	// EtcdImageKey is the key that references the etcd image in the controller
-	EtcdImageKey string = "etcd"
+	EtcdImageKey string = "etcdKey"
 
 	// SetupEtcdEnvKey is the key that references the setup-etcd-environment image in the controller
-	SetupEtcdEnvKey string = "setupEtcdEnv"
+	SetupEtcdEnvKey string = "setupEtcdEnvKey"
 
 	// InfraImageKey is the key that references the infra image in the controller for crio.conf
-	InfraImageKey string = "infraImage"
+	InfraImageKey string = "infraImageKey"
 
 	// KubeClientAgentImageKey is the key that references the kube-client-agent image in the controller
-	KubeClientAgentImageKey string = "kubeClientAgentImage"
+	KubeClientAgentImageKey string = "kubeClientAgentImageKey"
 )

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -117,7 +117,7 @@ func RenderBootstrap(
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 	}
 
-	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, imgs, infra.Status.APIServerInternalURL)
+	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL)
 
 	manifests := []struct {
 		name     string

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -8,13 +8,23 @@ package operator
 // Change the installer to pass that arg with the image from the CVO
 // (some time later) Change the option to required and drop the default
 type Images struct {
+	RenderConfigImages
+	ControllerConfigImages
+}
+
+// RenderConfigImages are image names used to render templates under ./manifests/
+type RenderConfigImages struct {
 	MachineConfigOperator   string `json:"machineConfigOperator"`
 	MachineConfigController string `json:"machineConfigController"`
 	MachineConfigDaemon     string `json:"machineConfigDaemon"`
 	MachineConfigServer     string `json:"machineConfigServer"`
 	MachineOSContent        string `json:"machineOSContent"`
-	Etcd                    string `json:"etcd"`
-	SetupEtcdEnv            string `json:"setupEtcdEnv"`
-	InfraImage              string `json:"infraImage"`
-	KubeClientAgent         string `json:"kubeClientAgentImage"`
+}
+
+// ControllerConfigImages are image names used to render templates under ./templates/
+type ControllerConfigImages struct {
+	Etcd            string `json:"etcd"`
+	SetupEtcdEnv    string `json:"setupEtcdEnv"`
+	InfraImage      string `json:"infraImage"`
+	KubeClientAgent string `json:"kubeClientAgentImage"`
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -392,7 +392,7 @@ func (optr *Operator) getGlobalConfig() (*configv1.Infrastructure, *configv1.Net
 	return infra, network, proxy, nil
 }
 
-func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *Images, apiServerURL string) *renderConfig {
+func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *RenderConfigImages, apiServerURL string) *renderConfig {
 	return &renderConfig{
 		TargetNamespace:        tnamespace,
 		Version:                version.Raw,

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -21,7 +21,7 @@ type renderConfig struct {
 	Version                string
 	ControllerConfig       mcfgv1.ControllerConfigSpec
 	APIServerURL           string
-	Images                 *Images
+	Images                 *RenderConfigImages
 	KubeAPIServerServingCA string
 }
 

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -55,8 +55,9 @@ func TestRenderAsset(t *testing.T) {
 		Path: "manifests/machineconfigcontroller/deployment.yaml",
 		RenderConfig: &renderConfig{
 			TargetNamespace: "testing-namespace",
-			Images: &Images{
-				MachineConfigOperator: "{MCO: PLACEHOLDER}"},
+			Images: &RenderConfigImages{
+				MachineConfigOperator: "{MCO: PLACEHOLDER}",
+			},
 		},
 		FindExpected: "image: {MCO: PLACEHOLDER}",
 	}, {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -154,7 +154,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	}
 
 	// create renderConfig
-	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs, infra.Status.APIServerURL)
+	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra.Status.APIServerURL)
 	return nil
 }
 

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -13,7 +13,7 @@ contents:
     spec:
       initContainers:
       - name: discovery
-        image: "{{.Images.setupEtcdEnv}}"
+        image: "{{.Images.setupEtcdEnvKey}}"
         command: ["/usr/bin/setup-etcd-environment"]
         args:
         - "run"
@@ -24,7 +24,7 @@ contents:
         - name: discovery
           mountPath: /run/etcd/
       - name: certs
-        image: "{{.Images.kubeClientAgentImage}}"
+        image: "{{.Images.kubeClientAgentImageKey}}"
         command:
         - /bin/sh
         - -c
@@ -77,7 +77,7 @@ contents:
           mountPath: /etc/kubernetes/kubeconfig
       containers:
       - name: etcd-member
-        image: "{{.Images.etcd}}"
+        image: "{{.Images.etcdKey}}"
         command:
         - /bin/sh
         - -c
@@ -136,7 +136,7 @@ contents:
           containerPort: 2379
           protocol: TCP
       - name: etcd-metrics
-        image: "{{.Images.etcd}}"
+        image: "{{.Images.etcdKey}}"
         command:
         - /bin/sh
         - -c

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -203,7 +203,7 @@ contents:
     default_transport = "docker://"
 
     # pause_image is the image which we use to instantiate infra containers.
-    pause_image = "{{.Images.infraImage}}"
+    pause_image = "{{.Images.infraImageKey}}"
 
     # If not empty, the path to a docker/config.json-like file containing credentials
     # necessary for pulling the image specified by pause_image above.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -203,7 +203,7 @@ contents:
     default_transport = "docker://"
 
     # pause_image is the image which we use to instantiate infra containers.
-    pause_image = "{{.Images.infraImage}}"
+    pause_image = "{{.Images.infraImageKey}}"
 
     # If not empty, the path to a docker/config.json-like file containing credentials
     # necessary for pulling the image specified by pause_image above.


### PR DESCRIPTION
Honestly finding images in the struct confusing as it's really the
collection of two different sets of images (renderConfig and
ControllerConfig).
This also led to some hassles around changing images in #899 for
instance.
This patch adds some comments around the scope of the images, split the
set in two different ones (still tied to the original struct) and change
the template keys used to substite.