### PR TITLE
controller/kubelet-config: Change validation of KubeletConfiguration to compare type-cast fields instead of reflections.

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -62,21 +62,6 @@ var updateBackoff = wait.Backoff{
 
 var errCouldNotFindMCPSet = errors.New("could not find any MachineConfigPool set for KubeletConfig")
 
-// A list of fields a user cannot set within the KubeletConfig CR. If a user
-// were to set these values, then the system may become unrecoverable (ie: not
-// recover after a reboot).
-//
-// If the KubeletConfig CR instance contains a non-zero or non-empty value for
-// the following fields, then the MCC will not apply the CR and log the message.
-var blacklistKubeletConfigurationFields = []string{
-	"CgroupDriver",
-	"ClusterDNS",
-	"ClusterDomain",
-	"FeatureGates",
-	"RuntimeRequestTimeout",
-	"StaticPodPath",
-}
-
 // Controller defines the kubelet config controller.
 type Controller struct {
 	templatesDir string


### PR DESCRIPTION
**- What I did**
Change validation of KubeletConfiguration to compare to type-cast fields instead of reflections.

**- How to verify it**
unit tests and CI

**- Description for the changelog**
Change validation of KubeletConfiguration to compare to type-cast fields instead of reflections.
