### PR TITLE
Bug 1728216: manifests: explicitely set command in deployments and daemonsets

### DIFF
--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
       - name: machine-config-controller
         image: {{.Images.MachineConfigController}}
+        command: ["/usr/bin/machine-config-controller"]
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: machine-config-daemon
         image: {{.Images.MachineConfigDaemon}}
+        command: ["/usr/bin/machine-config-daemon"]
         args:
           - "start"
         resources:

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: machine-config-server
         image: {{.Images.MachineConfigServer}}
+        command: ["/usr/bin/machine-config-server"]
         args:
           - "start"
           - "--apiserver-url={{.APIServerURL}}"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -421,6 +421,7 @@ spec:
       containers:
       - name: machine-config-controller
         image: {{.Images.MachineConfigController}}
+        command: ["/usr/bin/machine-config-controller"]
         args:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"
@@ -570,6 +571,7 @@ spec:
       containers:
       - name: machine-config-daemon
         image: {{.Images.MachineConfigDaemon}}
+        command: ["/usr/bin/machine-config-daemon"]
         args:
           - "start"
         resources:
@@ -923,6 +925,7 @@ spec:
       containers:
       - name: machine-config-server
         image: {{.Images.MachineConfigServer}}
+        command: ["/usr/bin/machine-config-server"]
         args:
           - "start"
           - "--apiserver-url={{.APIServerURL}}"


### PR DESCRIPTION
**- What I did**
Added "command" to container spec in deployments/daemonset operator syncs.

This ensures DS and deployment would be correctly synced by operator if command was modified there.

This has been fixed in 4.2 by https://github.com/openshift/machine-config-operator/pull/850, but still affects 4.1

**- How to verify it**
`oc edit ds machine-config-server`, change "args" and "command" - operator should rollback these changes

**- Description for the changelog**
Operator ensures "command" spec is synced in MCC / MCD

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1728216
Fixes #93