### PR TITLE
fold mco images/ ratchet: add new master Dockerfiles with finalized names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN WHAT=machine-config-operator ./hack/build-go.sh
+RUN WHAT=machine-config-daemon ./hack/build-go.sh
+RUN WHAT=machine-config-controller ./hack/build-go.sh
+RUN WHAT=machine-config-server ./hack/build-go.sh
+RUN WHAT=setup-etcd-environment ./hack/build-go.sh
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /usr/bin/
+COPY install /manifests
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
+RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-controller /usr/bin/
+COPY templates /etc/mcc/templates
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/setup-etcd-environment /usr/bin/
+ENTRYPOINT ["/usr/bin/machine-config-operator"]
+LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,0 +1,30 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN WHAT=machine-config-operator ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-operator /tmp/build/machine-config-operator
+RUN WHAT=machine-config-daemon ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-daemon /tmp/build/machine-config-daemon
+RUN WHAT=machine-config-controller ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-controller /tmp/build/machine-config-controller
+RUN WHAT=machine-config-server ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-server /tmp/build/machine-config-server
+RUN WHAT=setup-etcd-environment ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/setup-etcd-environment /tmp/build/setup-etcd-environment
+
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
+COPY --from=builder /tmp/build/machine-config-operator /usr/bin/
+COPY install /manifests
+COPY --from=builder /tmp/build/machine-config-daemon /usr/bin/
+RUN yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*
+COPY --from=builder /tmp/build/machine-config-controller /usr/bin/
+COPY templates /etc/mcc/templates
+COPY --from=builder /tmp/build/machine-config-server /usr/bin/
+COPY --from=builder /tmp/build/setup-etcd-environment /usr/bin/
+ENTRYPOINT ["/usr/bin/machine-config-operator"]
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
The final mco master dockerfiles will be named:
Dockerfile and Dockerfile.rhel7 We need to ratchet in the name
change by first adding these files and copying contents of the
current master dockerfiles Dockerfile.machine-config-operator/.rhel7

Once this is is merged will be able to update the names in release
and ART in followup prs and remove all other Dockerfiles.

Related-to: #739
Related-to: #894
Required-by: openshift/release#4314
