### PR TITLE
Make the infra object available for template rendering

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -94,6 +94,10 @@ type ControllerConfigSpec struct {
 
 	// proxy holds the current proxy configuration for the nodes
 	Proxy *configv1.ProxyStatus `json:"proxy"`
+
+	// infra holds the infrastructure details
+	// TODO this makes platform redundant as everything is contained inside Infra.Status
+	Infra *configv1.Infrastructure `json:"infra"`
 }
 
 // ControllerConfigStatus is the status for ControllerConfig

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -253,6 +253,11 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		*out = new(configv1.ProxyStatus)
 		**out = **in
 	}
+	if in.Infra != nil {
+		in, out := &in.Infra, &out.Infra
+		*out = new(configv1.Infrastructure)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -88,6 +88,7 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		CloudProviderConfig: "",
 		EtcdDiscoveryDomain: infra.Status.EtcdDiscoveryDomain,
 		Platform:            platform,
+		Infra:               infra,
 	}
 
 	if proxy != nil {


### PR DESCRIPTION
oVirt and possibly other platforms needs access the InfrastructureStatus
to render properly config files with stuff like API VIP, DNS VIP etc.

By embedding the infra object its available for rendering in
tremplates - for example a coredns config file like this:

```
{{ ControllerConfig.Infra.Status.PlatformStatus.Ovirt.DnsVIP }} api-int.{{.EtcdDiscoveryDomain}} api.{{.EtcdDiscoveryDomain}} ns1.{{.EtcdDiscoveryDomain}}

```

**How to verify it**
TODO will create a test

Fixes: #812 
Required-by: #795 