### PR TITLE
cmd/setup-etcd-environment: add support for exporting env

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -92,7 +92,6 @@ contents:
           set +a
 
           exec etcd \
-            --discovery-srv {{.EtcdDiscoveryDomain}} \
             --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \
@@ -122,6 +121,8 @@ contents:
           mountPath: /etc/etcd/
 
         env:
+        - name: ETCDCTL_API
+          value: "3"
         - name: ETCD_DATA_DIR
           value: "/var/lib/etcd"
         - name: ETCD_NAME
@@ -162,6 +163,9 @@ contents:
           mountPath: /run/etcd/
         - name: certs
           mountPath: /etc/ssl/etcd/
+        env:
+        - name: ETCDCTL_API
+          value: "3"
         ports:
         - name: metric
           containerPort: 9979


### PR DESCRIPTION
This PR adds support for exporting variables consumed as params by the etcd binary during the setup-etcd-environment init container. As we begin to move to cluster-etcd-operator managing bootstrap. We will need to gracefully transition the etcd-member.yaml spec to something more agnostic.

As an example use-case, I removed the runtime flag `--discovery-srv`  and replaced it with an environment variable. As some of these variables can be member-specific such as name they do not fit well with the MachineConfig model.

It would be easier in general to export all variables but as we prefix them with `ETCD_`  they will get picked up by the binary and print a bit of cruft during startup. For example.

```
2019-07-11 20:36:38.756064 W | pkg/flags: unrecognized environment variable ETCD_IPV4_ADDRESS=192.168.0.12
```
While this is mostly cosmetic I fear it could cause confusion which is the reason for adding the bool to export.

As a bonus all etcd containers now set ETCDCTL_API=3 as default.

/cc @abhinavdahiya @runcom 