### PR TITLE
Makefile: pin tools to specific versions

### DIFF
--- a/hack/install-go-bindata.sh
+++ b/hack/install-go-bindata.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+tmp=$(mktemp -d)
+version=ee3c2418e3682cc4a4e6c5dd1b32d0b98f7e2c55
+
+cd $tmp &&\
+git clone https://github.com/go-bindata/go-bindata.git &&\
+cd $tmp/go-bindata &&\
+git checkout -q $version &&\
+go build -o build-go-bindata ./go-bindata &&\
+cp build-go-bindata $GOPATH/bin/go-bindata


### PR DESCRIPTION
This also inverts the dependency we have with openshift/release.

This has a downside tho..if someone adds something that brings down the whole infra it can be our fault to have allowed arbitrary binaries executions. On the other hand.. we're running in pods

Close https://github.com/openshift/machine-config-operator/issues/951