### PR TITLE
pkg/controller: skip image config MCs sync for custom defined pools

### DIFF
--- a/manifests/master.machineconfigpool.yaml
+++ b/manifests/master.machineconfigpool.yaml
@@ -4,6 +4,7 @@ metadata:
   name: master
   labels:
     "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
+    "machineconfiguration.openshift.io/mco-built-in": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/manifests/worker.machineconfigpool.yaml
+++ b/manifests/worker.machineconfigpool.yaml
@@ -2,6 +2,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
   name: worker
+  labels:
+    "machineconfiguration.openshift.io/mco-built-in": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -50,6 +50,8 @@ const (
 	//
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
+
+	builtInLabelKey = "machineconfiguration.openshift.io/mco-built-in"
 )
 
 var (
@@ -625,8 +627,12 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 		return err
 	}
 
-	// Find all the MachineConfig pools
-	mcpPools, err := ctrl.mcpLister.List(labels.Everything())
+	sel, err := metav1.LabelSelectorAsSelector(metav1.AddLabelToSelector(&metav1.LabelSelector{}, builtInLabelKey, ""))
+	if err != nil {
+		return err
+	}
+	// Find all the MCO built in MachineConfigPools
+	mcpPools, err := ctrl.mcpLister.List(sel)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1287,6 +1287,7 @@ metadata:
   name: master
   labels:
     "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
+    "machineconfiguration.openshift.io/mco-built-in": ""
 spec:
   machineConfigSelector:
     matchLabels:
@@ -1314,6 +1315,8 @@ var _manifestsWorkerMachineconfigpoolYaml = []byte(`apiVersion: machineconfigura
 kind: MachineConfigPool
 metadata:
   name: worker
+  labels:
+    "machineconfiguration.openshift.io/mco-built-in": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -49,9 +49,11 @@ func NewMachineConfigPool(name string, mcSelector, nodeSelector *metav1.LabelSel
 			APIVersion: mcfgv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{},
-			UID:    types.UID(utilrand.String(5)),
+			Name: name,
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/mco-built-in": "",
+			},
+			UID: types.UID(utilrand.String(5)),
 		},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			NodeSelector:          nodeSelector,


### PR DESCRIPTION
**- What I did**

Fix https://github.com/openshift/machine-config-operator/issues/954

For custom defined pools (inheriting mainly from worker) do not sync the image config MCs. That's because we already sync for the default pools and that causes a resync for custom defined pool as well. Avoid also a spammy error log.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
