### PR TITLE
OpenStack: set correct hostnames for masters and workers

### DIFF
--- a/templates/common/openstack/units/afterburn-hostname.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.yaml
@@ -1,0 +1,13 @@
+name: "afterburn-hostname.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Afterburn Hostname
+  Before=kubelet.service
+
+  [Service]
+  ExecStart=/usr/bin/afterburn --provider openstack-metadata --hostname=/etc/hostname
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
This commit sets hostnames equal to OpenStack node names.