### PR TITLE
controller/template: update the cloud provider value for GCP to gce

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -370,8 +370,10 @@ func cloudProvider(cfg RenderConfig) (interface{}, error) {
 	// FIXME Explicitly disable (remove) the cloud provider on OpenStack for now
 	// Don't forget to turn the test case back on as well
 	switch cfg.Platform {
-	case platformAWS, platformAzure, platformGCP, platformVSphere:
+	case platformAWS, platformAzure, platformVSphere:
 		return cfg.Platform, nil
+	case platformGCP:
+		return "gce", nil
 	default:
 		return "", nil
 	}

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -37,7 +37,7 @@ func TestCloudProvider(t *testing.T) {
 		res:      "",
 	}, {
 		platform: "gcp",
-		res:      "gcp",
+		res:      "gce",
 	}, {
 		platform: "libvirt",
 		res:      "",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

currently the kubelet on GCP are failing with error:
```
Jul 13 01:06:03 ad-1-cmxng-master-0.c.openshift-dev-installer.internal hyperkube[1147]: F0713 01:06:03.195790    1147 server.go:267] failed to run Kubelet: unknown cloud provider "gcp"
```
the cloud provide name for GCP platform is `gce` [1]

[1]: https://github.com/kubernetes/kubernetes/blob/844a0c9a10cd52367ec7c05f5a8c176535dcef38/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L59

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
the cloud provide name for GCP platform is `gce`
