### PR TITLE
pkg/daemon: log during drain

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -83,6 +83,16 @@ func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
 	}
 }
 
+type drainLogger struct{}
+
+func (dl *drainLogger) Logf(format string, v ...interface{}) {
+	glog.Infof(format, v...)
+}
+
+func (dl *drainLogger) Log(v ...interface{}) {
+	glog.Info(v...)
+}
+
 // updateOSAndReboot is the last step in an update(), and it can also
 // be called as a special case for the "bootstrap pivot".
 func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr error) {
@@ -126,6 +136,7 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr err
 				Force:              true,
 				GracePeriodSeconds: 600,
 				IgnoreDaemonsets:   true,
+				Logger:             &drainLogger{},
 			})
 			if err == nil {
 				return true, nil


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Extracted from https://github.com/openshift/machine-config-operator/pull/962

I'm not sure how we used to live w/o this till now - it shows ignored/evicting pods and progress so far so it's clear who's staying longer at evicting for instance.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
