### PR TITLE
templates: fix proxy envvars set in drop-in files

### DIFF
--- a/templates/common/_base/files/etc-systemd-system-crio.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-crio.service.d-10-default-env.conf.yaml
@@ -4,14 +4,14 @@ path: "/etc/systemd/system/crio.service.d/10-default-env.conf"
 contents:
   inline: |
     {{if .Proxy -}}
-    [Manager]
+    [Service]
     {{if .Proxy.HTTPProxy -}}
-    DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
     {{end -}}
-    {{end -}} 
+    {{end -}}

--- a/templates/common/_base/files/etc-systemd-system-kubelet.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-kubelet.service.d-10-default-env.conf.yaml
@@ -4,14 +4,14 @@ path: "/etc/systemd/system/kubelet.service.d/10-default-env.conf"
 contents:
   inline: |
     {{if .Proxy -}}
-    [Manager]
+    [Service]
     {{if .Proxy.HTTPProxy -}}
-    DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
     {{end -}}
-    {{end -}} 
+    {{end -}}

--- a/templates/common/_base/files/etc-systemd-system-machine-config-daemon-host.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-machine-config-daemon-host.service.d-10-default-env.conf.yaml
@@ -4,14 +4,14 @@ path: "/etc/systemd/system/machine-config-daemon-host.service.d/10-default-env.c
 contents:
   inline: |
     {{if .Proxy -}}
-    [Manager]
+    [Service]
     {{if .Proxy.HTTPProxy -}}
-    DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
     {{end -}}
-    {{end -}} 
+    {{end -}}


### PR DESCRIPTION
https://github.com/openshift/machine-config-operator/pull/912/files moved files from system|user.conf.d without changing the format.
```
# systemctl status crio
● crio.service - Open Container Initiative Daemon
   Loaded: loaded (/usr/lib/systemd/system/crio.service; disabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/crio.service.d
           └─10-default-env.conf
   Active: active (running) since Mon 2019-07-15 19:27:16 UTC; 18min ago
     Docs: https://github.com/kubernetes-sigs/cri-o
 Main PID: 1257 (crio)
    Tasks: 21
   Memory: 90.3M
      CPU: 831ms
   CGroup: /system.slice/crio.service
           └─1257 /usr/bin/crio --enable-metrics=true --metrics-port=9537

Jul 15 19:27:15 master-0 systemd[1]: Starting Open Container Initiative Daemon...
Jul 15 19:27:16 master-0 systemd[1]: Started Open Container Initiative Daemon.

# cat /etc/systemd/system/crio.service.d/10-default-env.conf 
[Manager]
DefaultEnvironment=HTTP_PROXY="http://10.42.15.3:3128"
DefaultEnvironment=HTTPS_PROXY="http://10.42.15.3:3128"
DefaultEnvironment=NO_PROXY=",10.128.0.0/14,127.0.0.1,172.30.0.0/16,api-int.lab.variantweb.net,api.lab.variantweb.net,etcd-0.lab.variantweb.net,localhost"

# cat /proc/1257/environ 
LANG=en_US.UTF-8PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/binNOTIFY_SOCKET=/run/systemd/notifyINVOCATION_ID=cab2122f397240c9ad1be938d5324037JOURNAL_STREAM=9:24453GOTRACEBACK=crashCRIO_METRICS_OPTIONS=--enable-metrics=true --metrics-port=9537CRIO_NETWORK_OPTIONS=CRIO_STORAGE_OPTIONS=
```

after this PR

```
# systemctl status crio
● crio.service - Open Container Initiative Daemon
   Loaded: loaded (/usr/lib/systemd/system/crio.service; disabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/crio.service.d
           └─10-default-env.conf
   Active: active (running) since Mon 2019-07-15 19:53:32 UTC; 1s ago
     Docs: https://github.com/kubernetes-sigs/cri-o
 Main PID: 2437 (crio)
    Tasks: 13
   Memory: 37.1M
      CPU: 138ms
   CGroup: /system.slice/crio.service
           └─2437 /usr/bin/crio --enable-metrics=true --metrics-port=9537

Jul 15 19:53:32 master-0 systemd[1]: Starting Open Container Initiative Daemon...
Jul 15 19:53:32 master-0 systemd[1]: Started Open Container Initiative Daemon.

# cat /etc/systemd/system/crio.service.d/10-default-env.conf
[Service]
Environment=HTTP_PROXY="http://10.42.15.3:3128"
Environment=HTTPS_PROXY="http://10.42.15.3:3128"
Environment=NO_PROXY=",10.128.0.0/14,127.0.0.1,172.30.0.0/16,api-int.lab.variantweb.net,api.lab.variantweb.net,etcd-0.lab.variantweb.net,localhost"

# cat /proc/2437/environ 
LANG=en_US.UTF-8PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/binNOTIFY_SOCKET=/run/systemd/notifyINVOCATION_ID=7cde9f109c0a4c6f9a5b7b017b4b6545JOURNAL_STREAM=9:31980GOTRACEBACK=crashHTTP_PROXY=http://10.42.15.3:3128HTTPS_PROXY=http://10.42.15.3:3128NO_PROXY=,10.128.0.0/14,127.0.0.1,172.30.0.0/16,api-int.lab.variantweb.net,api.lab.variantweb.net,etcd-0.lab.variantweb.net,localhostCRIO_METRICS_OPTIONS=--enable-metrics=true --metrics-port=9537CRIO_NETWORK_OPTIONS=CRIO_STORAGE_OPTIONS=
```
@mrunalp @umohnani8 @runcom 