### PR TITLE
pkg/controller: clarify platform none constant in template/render.go

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -124,12 +124,16 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 func platformFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, error) {
 	switch ic.Platform {
 	case "":
-		return "", fmt.Errorf("cannot generate MachineConfigs with an empty platform field")
+		// if Platform is nil, return nil platform and an error message
+		return "", fmt.Errorf("cannot generate MachineConfigs when no platform is set")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
 	case platformAWS, platformAzure, platformBaremetal, platformGCP, platformOpenstack, platformLibvirt, platformNone:
 		return ic.Platform, nil
 	default:
+		// platformNone is used for a non-empty, but currently unsupported platform.
+		// This allows us to incrementally roll out new platforms across the project
+		// by provisioning platforms before all support is added.
 		glog.Warningf("Warning: the controller config referenced an unsupported platform: %s", ic.Platform)
 		return platformNone, nil
 	}


### PR DESCRIPTION
Closes #857

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Clarify platform none vs "" in template platform code.
https://github.com/openshift/installer/blob/master/pkg/types/installconfig.go#L122
The installer explicitly sets the `Platform` field to be `""` when a platform type is not specified.
Also, unsupported Platform fields should not be considered as `platformNone` since technically
`platformNone` is a [hidden-but-supported](https://github.com/openshift/installer/blob/master/pkg/types/installconfig.go#L36) platform.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
pkg/controller: clarify platform none constant in template/render.go