### PR TITLE
pkg/controller: add a node hold API

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -432,7 +432,7 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 		glog.Infof("Pool %s: node %s has completed update to %s", pool.Name, curNode.Name, curNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
 		changed = true
 	} else {
-		annos := []string{daemonconsts.CurrentMachineConfigAnnotationKey, daemonconsts.DesiredMachineConfigAnnotationKey, daemonconsts.MachineConfigDaemonStateAnnotationKey}
+		annos := []string{daemonconsts.CurrentMachineConfigAnnotationKey, daemonconsts.DesiredMachineConfigAnnotationKey, daemonconsts.MachineConfigDaemonStateAnnotationKey, daemonconsts.NodeOnHoldAnnotationKey}
 		for _, anno := range annos {
 			if oldNode.Annotations[anno] != curNode.Annotations[anno] {
 				glog.Infof("Pool %s: node %s changed %s = %s", pool.Name, curNode.Name, anno, curNode.Annotations[anno])

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -14,6 +14,8 @@ const (
 	DesiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
 	// MachineConfigDaemonStateAnnotationKey is used to fetch the state of the daemon on the machine.
 	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
+	// NodeOnHoldAnnotationKey is used by external components to put a node on hold from being accounted for in the node controller
+	NodeOnHoldAnnotationKey = "machineconfiguration.openshift.io/hold"
 	// MachineConfigDaemonStateWorking is set by daemon when it is applying an update.
 	MachineConfigDaemonStateWorking = "Working"
 	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

The storage team has an additional requirement when calculating if a node is ready. The node is ready and the node controller can proceed to target the next node in the pool iif the Ceph cluster is ready. Before this patch, we calculate availability to proceed only based on node readiness. To account for their additional requirement (and given the short notice/period before the freeze), this patch adds a simple mechanism to _hold_ a node from being targeted for an upgrade/config change. The mechanism is driven by an annotation containing a counter. The reason for the counter is the possibility for more than one component to interact with the functionality. The API is pretty simple, a component set the annotation and set the counter (either initializing the annotation to 1 or just by increasing the counter). External components are also responsible to decrease the counter when ready to proceed.

This is far from being ideal and also, we can't use the Paused field on an MCP cause we can't differentiate more than user interacting with the field.

I'll put this on hold but I've tested it out and works fine as is - leaving hold for code review (especially naming and further checks).

The whole discussion started here https://github.com/openshift/machine-config-operator/issues/662#issuecomment-510057616

/cc @rohantmp

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
