### PR TITLE
OpenStack: enable cloud provider

### DIFF
--- a/templates/master/00-master/openstack/units/afterburn-hostname.yaml
+++ b/templates/master/00-master/openstack/units/afterburn-hostname.yaml
@@ -1,0 +1,12 @@
+name: "afterburn-hostname.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Afterburn Hostname
+
+  [Service]
+  ExecStart=/usr/bin/afterburn --provider openstack-metadata --hostname=/etc/hostname
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/master/01-master-kubelet/openstack/files/generate-kubeconfig.yaml
+++ b/templates/master/01-master-kubelet/openstack/files/generate-kubeconfig.yaml
@@ -1,0 +1,24 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/generate-kubeconfig.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    /usr/bin/timeout 900 /bin/bash -c -- \
+    'while true; do \
+      /usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --rotate-certificates \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --minimum-container-ttl-duration=6m0s \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --v=3; done'
+    
+    echo "Finishing kubeconfig generation"

--- a/templates/master/01-master-kubelet/openstack/units/generate-kubeconfig.yaml
+++ b/templates/master/01-master-kubelet/openstack/units/generate-kubeconfig.yaml
@@ -1,0 +1,20 @@
+name: "generate-kubeconfig.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Generate Kubeconfig using Kubelet
+  Wants=rpc-statd.service crio.service
+  After=crio.service afterburn-sethostname.service
+
+  [Service]
+  Type=oneshot
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+
+  ExecStart=/usr/local/bin/generate-kubeconfig.sh
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/master/01-master-kubelet/openstack/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/openstack/units/kubelet.yaml
@@ -1,0 +1,35 @@
+name: "kubelet.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service crio.service
+  After=generate-kubeconfig.service
+
+  [Service]
+  Type=notify
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+
+  ExecStart=/usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --rotate-certificates \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --minimum-container-ttl-duration=6m0s \
+        --cloud-provider=openstack \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --cloud-config=/etc/kubernetes/cloud.conf \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --v=3 \
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/00-worker/openstack/units/afterburn-hostname.yaml
+++ b/templates/worker/00-worker/openstack/units/afterburn-hostname.yaml
@@ -1,0 +1,12 @@
+name: "afterburn-hostname.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Afterburn Hostname
+
+  [Service]
+  ExecStart=/usr/bin/afterburn --provider openstack-metadata --hostname=/etc/hostname
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/openstack/files/generate-kubeconfig.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/files/generate-kubeconfig.yaml
@@ -1,0 +1,22 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/generate-kubeconfig.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    /usr/bin/timeout 900 /bin/bash -c -- \
+    'while true; do \
+      /usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+        --minimum-container-ttl-duration=6m0s \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --v=3; done'
+    
+    echo "Finishing kubeconfig generation"

--- a/templates/worker/01-worker-kubelet/openstack/units/generate-kubeconfig.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/units/generate-kubeconfig.yaml
@@ -1,0 +1,21 @@
+name: "generate-kubeconfig.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Generate Kubeconfig using Kubelet
+  Wants=rpc-statd.service crio.service
+  After=crio.service afterburn-sethostname.service
+
+  [Service]
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+
+  ExecStart=/usr/local/bin/generate-kubeconfig.sh
+  
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml
@@ -1,0 +1,35 @@
+name: "kubelet.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service crio.service
+  After=generate-kubeconfig.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+
+  ExecStart=/usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+        --minimum-container-ttl-duration=6m0s \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --cloud-provider=openstack \
+        --cloud-config=/etc/kubernetes/cloud.conf \
+        --v=3 \
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
One of the requirements for starting the cloud provider is the ability to read data from the secret.
Despite the fact that the cloud provider supports this feature, there are a number of limitations that do not allow to run it at the initial stage.
The peculiarity of the cloud provider is that it requires a list of nodes from Nova at the earliest stage of kubelet loading, when the certificates required for reading the secret have not been received yet and the kubeconfig file has not been generated yet.
The absence of this file leads to a complete failure of kubelet and the impossibility to continue the installation.

As a solution, changes were proposed to the kubelet itself, both in the upstream and downstream versions. But since these are very serious changes, and the cloud provider was deprecated, we will
probably not be able to merge them.
https://github.com/kubernetes/kubernetes/pull/79221
https://github.com/openshift/origin/pull/23290

The following commit was offered as an alternative, more convenient solution. The idea is to run kubelet without cloud provider support for a certain period of time so that it can generate the necessary kubeconfig file (generate-kubeconfig.service) and then run the real kubelet with cloud provider support (kubelet.service).