### PR TITLE
Stop parsing our own version as semver

### DIFF
--- a/cmd/machine-config-controller/bootstrap.go
+++ b/cmd/machine-config-controller/bootstrap.go
@@ -37,7 +37,7 @@ func runbootstrapCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	if bootstrapOpts.manifestsDir == "" || bootstrapOpts.destinationDir == "" {
 		glog.Fatalf("--dest-dir or --manifest-dir not set")

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -47,7 +47,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	cb, err := clients.NewBuilder(startOpts.kubeconfig)
 	if err != nil {

--- a/cmd/machine-config-controller/version.go
+++ b/cmd/machine-config-controller/version.go
@@ -26,7 +26,7 @@ func runVersionCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	program := "MachineConfigController"
-	version := "v" + version.Version.String() + "-" + version.Hash
+	version := version.Raw + "-" + version.Hash
 
 	fmt.Println(program, version)
 }

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -65,7 +65,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	glog.V(2).Infof("Options parsed: %+v", startOpts)
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	onceFromMode := startOpts.onceFrom != ""
 	if !onceFromMode {

--- a/cmd/machine-config-daemon/version.go
+++ b/cmd/machine-config-daemon/version.go
@@ -26,7 +26,7 @@ func runVersionCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	program := "MachineConfigDaemon"
-	version := "v" + version.Version.String() + "-" + version.Hash
+	version := version.Raw + "-" + version.Hash
 
 	fmt.Println(program, version)
 }

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -71,7 +71,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -39,7 +39,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	if startOpts.imagesFile == "" {
 		glog.Fatal("--images-json cannot be empty")

--- a/cmd/machine-config-operator/version.go
+++ b/cmd/machine-config-operator/version.go
@@ -26,7 +26,7 @@ func runVersionCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	program := "MachineConfigOperator"
-	version := "v" + version.Version.String() + "-" + version.Hash
+	version := version.Raw + "-" + version.Hash
 
 	fmt.Println(program, version)
 }

--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -34,7 +34,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	bs, err := server.NewBootstrapServer(bootstrapOpts.serverBaseDir, bootstrapOpts.serverKubeConfig)
 

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -35,7 +35,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	if startOpts.apiserverURL == "" {
 		glog.Exitf("--apiserver-url cannot be empty")

--- a/cmd/machine-config-server/version.go
+++ b/cmd/machine-config-server/version.go
@@ -26,7 +26,7 @@ func runVersionCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	program := "MachineConfigServer"
-	version := "v" + version.Version.String() + "-" + version.Hash
+	version := version.Raw + "-" + version.Hash
 
 	fmt.Println(program, version)
 }

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -43,7 +43,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Version, version.Hash)
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	if runOpts.discoverySRV == "" {
 		return errors.New("--discovery-srv cannot be empty")

--- a/cmd/setup-etcd-environment/version.go
+++ b/cmd/setup-etcd-environment/version.go
@@ -26,7 +26,7 @@ func runVersionCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	program := "Setup Etcd Environment"
-	version := "v" + version.Version.String() + "-" + version.Hash
+	version := version.Raw + "-" + version.Hash
 
 	fmt.Println(program, version)
 }

--- a/pkg/controller/template/status.go
+++ b/pkg/controller/template/status.go
@@ -17,7 +17,7 @@ import (
 // - does not modify `failing` condition.
 func (ctrl *Controller) syncRunningStatus(ctrlconfig *mcfgv1.ControllerConfig) error {
 	updateFunc := func(cfg *mcfgv1.ControllerConfig) error {
-		reason := fmt.Sprintf("syncing towards (%d) generation using controller version %s", cfg.GetGeneration(), version.Version)
+		reason := fmt.Sprintf("syncing towards (%d) generation using controller version %s", cfg.GetGeneration(), version.Raw)
 		rcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateControllerRunning, corev1.ConditionTrue, "", reason)
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *rcond)
 		if cfg.GetGeneration() != cfg.Status.ObservedGeneration && mcfgv1.IsControllerConfigStatusConditionPresentAndEqual(cfg.Status.Conditions, mcfgv1.TemplateControllerCompleted, corev1.ConditionTrue) {
@@ -38,7 +38,7 @@ func (ctrl *Controller) syncFailingStatus(ctrlconfig *mcfgv1.ControllerConfig, o
 		return nil
 	}
 	updateFunc := func(cfg *mcfgv1.ControllerConfig) error {
-		message := fmt.Sprintf("failed to syncing towards (%d) generation using controller version %s: %v", cfg.GetGeneration(), version.Version, oerr)
+		message := fmt.Sprintf("failed to syncing towards (%d) generation using controller version %s: %v", cfg.GetGeneration(), version.Raw, oerr)
 		fcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateControllerFailing, corev1.ConditionTrue, "", message)
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *fcond)
 		acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateControllerCompleted, corev1.ConditionFalse, "", "")
@@ -59,7 +59,7 @@ func (ctrl *Controller) syncFailingStatus(ctrlconfig *mcfgv1.ControllerConfig, o
 // - sets the `completed` condition to `true`
 func (ctrl *Controller) syncCompletedStatus(ctrlconfig *mcfgv1.ControllerConfig) error {
 	updateFunc := func(cfg *mcfgv1.ControllerConfig) error {
-		reason := fmt.Sprintf("sync completed towards (%d) generation using controller version %s", cfg.GetGeneration(), version.Version)
+		reason := fmt.Sprintf("sync completed towards (%d) generation using controller version %s", cfg.GetGeneration(), version.Raw)
 		acond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateControllerCompleted, corev1.ConditionTrue, "", reason)
 		mcfgv1.SetControllerConfigStatusCondition(&cfg.Status, *acond)
 		rcond := mcfgv1.NewControllerConfigStatusCondition(mcfgv1.TemplateControllerRunning, corev1.ConditionFalse, "", "")

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -267,7 +267,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 	}
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version v0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 
@@ -278,7 +278,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version v0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateControllerFailing, Status: corev1.ConditionFalse},
 	}
@@ -306,7 +306,7 @@ func TestDoNothing(t *testing.T) {
 
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version v0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 	for idx := range mcs {
@@ -315,7 +315,7 @@ func TestDoNothing(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version v0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateControllerFailing, Status: corev1.ConditionFalse},
 	}
@@ -343,7 +343,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version v0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 
@@ -354,7 +354,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version v0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateControllerFailing, Status: corev1.ConditionFalse},
 	}
@@ -387,7 +387,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	}
 	rcc := cc.DeepCopy()
 	rcc.Status.ObservedGeneration = 1
-	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version 0.0.0-was-not-built-properly"}}
+	rcc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionTrue, Message: "syncing towards (1) generation using controller version v0.0.0-was-not-built-properly"}}
 	f.expectUpdateControllerConfigStatus(rcc)
 	f.expectGetSecretAction(ps)
 	for idx := range expmcs {
@@ -397,7 +397,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	ccc := cc.DeepCopy()
 	ccc.Status.ObservedGeneration = 1
 	ccc.Status.Conditions = []mcfgv1.ControllerConfigStatusCondition{
-		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version 0.0.0-was-not-built-properly"},
+		{Type: mcfgv1.TemplateControllerCompleted, Status: corev1.ConditionTrue, Message: "sync completed towards (1) generation using controller version v0.0.0-was-not-built-properly"},
 		{Type: mcfgv1.TemplateControllerRunning, Status: corev1.ConditionFalse},
 		{Type: mcfgv1.TemplateControllerFailing, Status: corev1.ConditionFalse},
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,9 +2,6 @@ package version
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/blang/semver"
 )
 
 var (
@@ -14,9 +11,6 @@ var (
 
 	// Hash is the git hash we've built the MCO with
 	Hash = "was-not-built-properly"
-
-	// Version is semver representation of the version.
-	Version = semver.MustParse(strings.TrimLeft(Raw, "v"))
 
 	// String is the human-friendly representation of the version.
 	String = fmt.Sprintf("MachineConfigOperator %s", Raw)


### PR DESCRIPTION
Since we now have a single image, we don't need to worry about
drift between them.

Previously we were trying to parse the output
of `git describe` (trimmed) as a semantic version, which blew
up when ART pushed a git tag that didn't conform to the previous pattern.

Just refer to the literal raw tag name instead of trying to parse it.

Closes: https://github.com/openshift/machine-config-operator/issues/976
