### PR TITLE
Bug 1730562: templates: add proxy to pivot.service

### DIFF
--- a/templates/common/_base/files/etc-systemd-system-pivot.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-pivot.service.d-10-default-env.conf.yaml
@@ -1,0 +1,17 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/system/pivot.service.d/10-default-env.conf"
+contents:
+  inline: |
+    {{if .Proxy -}}
+    [Service]
+    {{if .Proxy.HTTPProxy -}}
+    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
+    {{end -}}
+    {{end -}}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

if pivot.service is there and we need to set a proxy, we need the template for that. Right now, we only do that for machine-config-daemon-host.service.
Fix the linked BZ

@cgwalters ptal

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
