### PR TITLE
local dev/hacking improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ _build-%:
 
 # Use podman to build the image.
 image:
-	hack/build-image.sh
+	hack/build-image
 
 # Build + push + deploy image for a component. Intended to be called via another target.
 # Example:

--- a/hack/build-image
+++ b/hack/build-image
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+import os, sys, json, subprocess
+# Wrapper for building the MCO image which is oriented
+# around the git hash, to only build if it changes.
+
+imgname = "localhost/machine-config-operator:latest"
+vskey = 'vcs-ref'
+# Strip these out to avoid confusion.
+openshift_keys = ['io.openshift.build.commit' + k for k in ['author', 'date', 'id', 'message', 'ref']]
+vcs_keys = ['vcs-ref', 'vcs-type', 'vcs-url']
+
+gitrev = subprocess.check_output(['git', 'rev-parse', "HEAD"], encoding='UTF-8').strip()
+gitdesc = subprocess.check_output(['git', 'describe', '--tags', '--always', gitrev], encoding='UTF-8').strip()
+
+# Support overriding podman via environment variable;
+# From @cgwalters :
+# I do development inside https://github.com/cgwalters/coretoolbox
+# and `podman` there tries to run recursively which doesn't work
+# at all today, so I have an alias `podman-host-sudo` that calls
+# out to the host (and also uses `sudo`)
+# to ensure we're using overlayfs and we don't hit rootless bugs.
+podman = os.environ.get('podman', 'podman')
+
+inspect_data = None
+try:
+    inspect_data = subprocess.check_output([podman, 'inspect', '--type=image', imgname], stderr=subprocess.DEVNULL)
+except subprocess.CalledProcessError as e:
+    pass
+
+if inspect_data is None:
+    print("No previous build")
+else:
+    inspect = json.loads(inspect_data)[0]
+    labels = inspect.get('Config', {}).get('Labels')
+    prev_ref = labels.get('vcs-ref')
+    if prev_ref == gitrev:
+        print(f"Previous build {imgname} matches HEAD commit: {gitrev}")
+        sys.exit(0)
+    print(f"Previous commit: {prev_ref}")
+    print(f"HEAD commit: {gitrev}")
+    args = [podman, 'build', '-t', imgname, '-f', 'Dockerfile', '--no-cache']
+    for k in openshift_keys:
+        args.append(f'--label={k}=')
+    args.extend([f'--label=vcs-ref={gitrev}', '--label=vcs-type=git', '--label=vcs-url='])
+    print(subprocess.list2cmdline(args))
+    os.execlp(podman, *args)

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -eu
-podman=${podman:-podman}
-exec $podman build -t "localhost/machine-config-operator:latest" -f Dockerfile --no-cache

--- a/hack/cluster-push.sh
+++ b/hack/cluster-push.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
-# Build an image and push it to the cluster registry.
-# You must have first run `cluster-push-prep.sh` once.
-# Assumptions: You have set KUBECONFIG to point to your local cluster,
-# and you have exposed the registry via e.g.
-# https://github.com/openshift/installer/issues/411#issuecomment-445165262
+# Build the MCO image and push it to the cluster registry,
+# then directly patch the deployments/daemonsets to use that image.
+# This is generally faster than building a new release image and
+# upgrading to it, but also consequently doesn't work the same way as production
+# upgrades work.
+#
+# To use this, you must first run `cluster-push-prep.sh` (once) for your cluster.
+#
+# Assumptions: You have set KUBECONFIG to point to your cluster.
 
 set -xeuo pipefail
 
@@ -22,7 +26,7 @@ imgname=machine-config-operator
 LOCAL_IMGNAME=localhost/${imgname}:latest
 REMOTE_IMGNAME=openshift-machine-config-operator/${imgname}
 if [ "${do_build}" = 1 ]; then
-    ./hack/build-image.sh
+    ./hack/build-image
 fi
 $podman push --tls-verify=false "${LOCAL_IMGNAME}" ${registry}/${REMOTE_IMGNAME}
 


### PR DESCRIPTION
This fixes the `./hack/cluster.push` script to replace all MCO components rather than accepting a `WHAT` since...a lot of nontrivial changes require doing all of them, and since we have a uni-image we might as well now!

The `build-image` script changes apply to both the "cluster push fast-path" as well as the "new release image" path.

The `HACKING.md` doc is updated for the above and more.