### PR TITLE
openstack: baremetal: Add static pod image flags to bootstrap.go

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -19,23 +19,28 @@ var (
 	}
 
 	bootstrapOpts struct {
-		cloudConfigFile      string
-		configFile           string
-		destinationDir       string
-		etcdCAFile           string
-		etcdImage            string
-		etcdMetricCAFile     string
-		imagesConfigMapFile  string
-		infraConfigFile      string
-		infraImage           string
-		kubeCAFile           string
-		kubeClientAgentImage string
-		mcoImage             string
-		networkConfigFile    string
-		oscontentImage       string
-		pullSecretFile       string
-		rootCAFile           string
-		proxyConfigFile      string
+		baremetalRuntimeCfgImage string
+		cloudConfigFile          string
+		configFile               string
+		corednsImage             string
+		destinationDir           string
+		etcdCAFile               string
+		etcdImage                string
+		etcdMetricCAFile         string
+		haproxyImage             string
+		imagesConfigMapFile      string
+		infraConfigFile          string
+		infraImage               string
+		keepalivedImage          string
+		kubeCAFile               string
+		kubeClientAgentImage     string
+		mcoImage                 string
+		mdnsPublisherImage       string
+		networkConfigFile        string
+		oscontentImage           string
+		pullSecretFile           string
+		rootCAFile               string
+		proxyConfigFile          string
 	}
 )
 
@@ -64,6 +69,11 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.networkConfigFile, "network-config-file", "/assets/manifests/cluster-network-02-config.yml", "File containing network.config.openshift.io manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.cloudConfigFile, "cloud-config-file", "", "File containing the config map that contains the cloud config for cloudprovider.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.proxyConfigFile, "proxy-config-file", "/assets/manifests/cluster-proxy-01-config.yaml", "File containing proxy.config.openshift.io manifest.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.keepalivedImage, "keepalived-image", "", "Image for Keepalived.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.corednsImage, "coredns-image", "", "Image for CoreDNS.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mdnsPublisherImage, "mdns-publisher-image", "", "Image for mdns-publisher.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
 }
 
 func runBootstrapCmd(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This is a prep patch to make these images available in MCO
templates. After this merges, we can merge a patch to the
installer which passes these flags.

These images are needed by the following PRs:
https://github.com/openshift/machine-config-operator/pull/795
https://github.com/openshift/machine-config-operator/pull/740
