### PR TITLE
[4.3] manifests: Show machine counts in `oc get machineconfigpools` output

### DIFF
--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -22,6 +22,22 @@ spec:
     description: When progress is blocked on updating one or more nodes, or the pool configuration is failing.
     name: Degraded
     type: string
+  - JSONPath: .status.machineCount
+    description: Total number of machines in the machine config pool
+    name: MachineCount
+    type: number
+  - JSONPath: .status.readyMachineCount
+    description: Total number of ready machines targeted by the pool
+    name: ReadyMachineCount
+    type: number
+  - JSONPath: .status.updatedMachineCount
+    description: Total number of machines targeted by the pool that have the CurrentMachineConfig as their config
+    name: UpdatedMachineCount
+    type: number
+  - JSONPath: .status.degradedMachineCount
+    description: Total number of machines marked degraded (or unreconcilable)
+    name: DegradedMachineCount
+    type: number
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -964,6 +964,22 @@ spec:
     description: When progress is blocked on updating one or more nodes, or the pool configuration is failing.
     name: Degraded
     type: string
+  - JSONPath: .status.machineCount
+    description: Total number of machines in the machine config pool
+    name: MachineCount
+    type: number
+  - JSONPath: .status.readyMachineCount
+    description: Total number of ready machines targeted by the pool
+    name: ReadyMachineCount
+    type: number
+  - JSONPath: .status.updatedMachineCount
+    description: Total number of machines targeted by the pool that have the CurrentMachineConfig as their config
+    name: UpdatedMachineCount
+    type: number
+  - JSONPath: .status.degradedMachineCount
+    description: Total number of machines marked degraded (or unreconcilable)
+    name: DegradedMachineCount
+    type: number
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition


### PR DESCRIPTION
by adding new printer columns

Closes: #903

**- What I did**
Add columns to the MachineConfigPool CRD manifest
to show machine counts for each pool in output of `oc get mcp`

**- How to verify it**
`oc get mcp` shows MACHINECOUNT columns containing the number of machines in each pool

**- Description for the changelog**
Add machine counts info on `oc get mcp` output 
