### PR TITLE
[release-4.1] Bug 1726866: mcc: fix ignition validation to validate entire ign config

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -526,7 +526,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig) (*mcfgv1.MachineConfig, error) {
 	// Before merging all MCs for a specific pool, let's make sure each contains a valid Ignition Config
 	for _, config := range configs {
-		rpt := validate.ValidateWithoutSource(reflect.ValueOf(config.Spec.Config.Ignition))
+		rpt := validate.ValidateWithoutSource(reflect.ValueOf(config.Spec.Config))
 		if rpt.IsFatal() {
 			return nil, fmt.Errorf("machine config: %v contains invalid ignition config: %v", config.ObjectMeta.Name, rpt)
 		}

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -59,7 +59,7 @@ func newMachineConfigPool(name string, selector *metav1.LabelSelector, currentMa
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.MachineConfigPoolSpec{
 			MachineConfigSelector: selector,
-			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
+			Configuration:         mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
 		},
 		Status: mcfgv1.MachineConfigPoolStatus{
 			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: currentMachineConfig}},
@@ -296,11 +296,13 @@ func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
 	files := []ignv2_2types.File{{
 		Node: ignv2_2types.Node{
-			Path: "/dummy/0",
+			Filesystem: "root",
+			Path:       "/dummy/0",
 		},
 	}, {
 		Node: ignv2_2types.Node{
-			Path: "/dummy/1",
+			Filesystem: "root",
+			Path:       "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
@@ -326,11 +328,13 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
 	files := []ignv2_2types.File{{
 		Node: ignv2_2types.Node{
-			Path: "/dummy/0",
+			Filesystem: "root",
+			Path:       "/dummy/0",
 		},
 	}, {
 		Node: ignv2_2types.Node{
-			Path: "/dummy/1",
+			Filesystem: "root",
+			Path:       "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
@@ -390,11 +394,13 @@ func TestDoNothing(t *testing.T) {
 	mcp := newMachineConfigPool("test-cluster-master", metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role", "master"), "")
 	files := []ignv2_2types.File{{
 		Node: ignv2_2types.Node{
-			Path: "/dummy/0",
+			Filesystem: "root",
+			Path:       "/dummy/0",
 		},
 	}, {
 		Node: ignv2_2types.Node{
-			Path: "/dummy/1",
+			Filesystem: "root",
+			Path:       "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{


### PR DESCRIPTION
also update existing unit tests to pass new validation

closes: BZ 1726866

Note: this is already fixed in master in PR  #894 This PR is a backport for 4.1.z

cc: @runcom 