### PR TITLE
pkg/operator: log when proxy isn't going to be set

### DIFF
--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -91,7 +92,11 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 	}
 
 	if proxy != nil {
-		ccSpec.Proxy = &proxy.Status
+		if proxy.Status == (configv1.ProxyStatus{}) {
+			glog.Info("Not setting proxy config because Proxy status is empty")
+		} else {
+			ccSpec.Proxy = &proxy.Status
+		}
 	}
 
 	return ccSpec, nil


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Set the proxy iff its status isn't empty + add a log to signal we're not setting proxy otherwise. Been debugging an issue with @sjenning and it turns out we weren't setting the proxy because the proxy object hasn't the Status populated but that's it's expected to be populated so something else is going on.

From the design doc:

> A simple proxy operator will watch for this resource and upon seeing it (or changes to it), will validate the proxies defined in the spec are reachable.  If they are, the proxy configuration will be copied to the status field, indicating a proxy configuration which is valid to be consumed by other components.  The purpose of this operator is to ensure that if an admin provides an invalid proxy configuration, the consuming components are not immediately broken.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
