### PR TITLE
Bug 1728873: pkg/daemon: reconcile killed just prior drain+reboot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -771,24 +771,20 @@ func (dn *Daemon) writePendingConfig(desiredConfig *mcfgv1.MachineConfig) error 
 
 // XXX: drop this
 // we need this compatibility layer for now
-func (dn *Daemon) getPendingConfig() (string, error) {
+func (dn *Daemon) getPendingConfig() (*pendingConfigState, error) {
 	s, err := ioutil.ReadFile("/etc/machine-config-daemon/state.json")
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return "", errors.Wrapf(err, "loading transient state")
+			return nil, errors.Wrapf(err, "loading transient state")
 		}
 		dn.logSystem("error loading pending config %v", err)
-		return "", nil
+		return nil, nil
 	}
 	var p pendingConfigState
 	if err := json.Unmarshal([]byte(s), &p); err != nil {
-		return "", errors.Wrapf(err, "parsing transient state")
+		return nil, errors.Wrapf(err, "parsing transient state")
 	}
-
-	if p.BootID == dn.bootID {
-		return "", fmt.Errorf("pending config %s bootID %s matches current! Failed to reboot?", p.PendingConfig, dn.bootID)
-	}
-	return p.PendingConfig, nil
+	return &p, nil
 }
 
 func (dn *Daemon) getCurrentConfigOnDisk() (*mcfgv1.MachineConfig, error) {
@@ -820,22 +816,41 @@ func (dn *Daemon) storeCurrentConfigOnDisk(current *mcfgv1.MachineConfig) error 
 //
 // Some more background in this PR: https://github.com/openshift/machine-config-operator/pull/245
 func (dn *Daemon) CheckStateOnBoot() error {
-	pendingConfigName, err := dn.getPendingState()
+	pendingState, err := dn.getPendingState()
 	if err != nil {
 		return err
 	}
+	var pendingConfigName, bootID string
+	if pendingState != nil {
+		pendingConfigName = pendingState.Message
+		bootID = pendingState.BootID
+	}
 	// XXX: drop this
 	// we need this compatibility layer for now
-	if pendingConfigName == "" {
-		pendingConfigName, err = dn.getPendingConfig()
+	if pendingState == nil {
+		legacyPendingState, err := dn.getPendingConfig()
 		if err != nil {
 			return err
 		}
+		if legacyPendingState != nil {
+			pendingConfigName = legacyPendingState.PendingConfig
+			bootID = legacyPendingState.BootID
+		}
 	}
+
 	state, err := dn.getStateAndConfigs(pendingConfigName)
 	if err != nil {
 		return err
 	}
+
+	// if we have a pendingConfig but we're into the same bootid, the MCD has been likely killed
+	// with force (OOM for instance). If the kill happened after we applied the update but we
+	// were there draining for instance, instead of perma-failing the next sync, re-try the drain+reboot phase
+	if state.pendingConfig != nil && bootID == dn.bootID {
+		dn.logSystem("killed by kube, retrying...")
+		return dn.drainAndReboot(state.pendingConfig)
+	}
+
 	if err := dn.detectEarlySSHAccessesFromBoot(); err != nil {
 		return fmt.Errorf("error detecting previous SSH accesses: %v", err)
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -89,7 +89,10 @@ func (dn *Daemon) updateOSAndReboot(newConfig *mcfgv1.MachineConfig) (retErr err
 	if err := dn.updateOS(newConfig); err != nil {
 		return err
 	}
+	return dn.drainAndReboot(newConfig)
+}
 
+func (dn *Daemon) drainAndReboot(newConfig *mcfgv1.MachineConfig) (retErr error) {
 	if out, err := dn.storePendingState(newConfig, 1); err != nil {
 		return errors.Wrapf(err, "failed to log pending config: %s", string(out))
 	}
@@ -719,7 +722,7 @@ func (dn *Daemon) isLoggingToJournalSupported() bool {
 	return strings.Contains(string(loggerOutput), "--journald")
 }
 
-func (dn *Daemon) getPendingStateLegacyLogger() (string, error) {
+func (dn *Daemon) getPendingStateLegacyLogger() (*journalMsg, error) {
 	glog.Info("logger doesn't support --jounald, grepping the journal")
 
 	cmdLiteral := "journalctl -o cat | grep OPENSHIFT_MACHINE_CONFIG_DAEMON_LEGACY_LOG_HACK"
@@ -728,7 +731,7 @@ func (dn *Daemon) getPendingStateLegacyLogger() (string, error) {
 	cmd.Stdout = &combinedOutput
 	cmd.Stderr = &combinedOutput
 	if err := cmd.Start(); err != nil {
-		return "", errors.Wrap(err, "failed shelling out to journalctl -o cat")
+		return nil, errors.Wrap(err, "failed shelling out to journalctl -o cat")
 	}
 	if err := cmd.Wait(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
@@ -738,44 +741,42 @@ func (dn *Daemon) getPendingStateLegacyLogger() (string, error) {
 				// grep exit with 1 if it doesn't find anything
 				// from man: Normally, the exit status is 0 if selected lines are found and 1 otherwise. But the exit status is 2 if an error occurred
 				if status.ExitStatus() == 1 {
-					return "", nil
+					return nil, nil
 				}
 				if status.ExitStatus() > 1 {
-					return "", errors.Wrapf(fmt.Errorf("grep exited with %s", combinedOutput.Bytes()), "failed to grep on journal output: %v", exiterr)
+					return nil, errors.Wrapf(fmt.Errorf("grep exited with %s", combinedOutput.Bytes()), "failed to grep on journal output: %v", exiterr)
 				}
 			}
 		} else {
-			return "", errors.Wrap(err, "command wait error")
+			return nil, errors.Wrap(err, "command wait error")
 		}
 	}
 	journalOutput := combinedOutput.Bytes()
 	// just an extra safety check?
 	if len(journalOutput) == 0 {
-		return "", nil
+		return nil, nil
 	}
 	return dn.processJournalOutput(journalOutput)
 }
 
-func (dn *Daemon) processJournalOutput(journalOutput []byte) (string, error) {
+type journalMsg struct {
+	Message   string `json:"MESSAGE,omitempty"`
+	BootID    string `json:"BOOT_ID,omitempty"`
+	Pending   string `json:"PENDING,omitempty"`
+	OldLogger string `json:"OPENSHIFT_MACHINE_CONFIG_DAEMON_LEGACY_LOG_HACK,omitempty"` // unused today
+}
+
+func (dn *Daemon) processJournalOutput(journalOutput []byte) (*journalMsg, error) {
 	lines := strings.Split(strings.TrimSpace(string(journalOutput)), "\n")
 	last := lines[len(lines)-1]
-	type journalMsg struct {
-		Message   string `json:"MESSAGE,omitempty"`
-		BootID    string `json:"BOOT_ID,omitempty"`
-		Pending   string `json:"PENDING,omitempty"`
-		OldLogger string `json:"OPENSHIFT_MACHINE_CONFIG_DAEMON_LEGACY_LOG_HACK,omitempty"` // unused today
-	}
 	entry := &journalMsg{}
 	if err := json.Unmarshal([]byte(last), entry); err != nil {
-		return "", errors.Wrap(err, "getting pending state from journal")
+		return nil, errors.Wrap(err, "getting pending state from journal")
 	}
 	if entry.Pending == "0" {
-		return "", nil
+		return nil, nil
 	}
-	if entry.BootID == dn.bootID {
-		return "", fmt.Errorf("pending config %s bootID %s matches current! Failed to reboot?", entry.Message, dn.bootID)
-	}
-	return entry.Message, nil
+	return entry, nil
 }
 
 // getPendingState loads the JSON state we cache across attempting to apply
@@ -783,16 +784,16 @@ func (dn *Daemon) processJournalOutput(journalOutput []byte) (string, error) {
 // The bootID is stored in the pending state; if it is unchanged, we assume
 // that we failed to reboot; that for now should be a fatal error, in order to avoid
 // reboot loops.
-func (dn *Daemon) getPendingState() (string, error) {
+func (dn *Daemon) getPendingState() (*journalMsg, error) {
 	if !dn.loggerSupportsJournal {
 		return dn.getPendingStateLegacyLogger()
 	}
 	journalOutput, err := exec.Command("journalctl", "-o", "json", fmt.Sprintf("MESSAGE_ID=%s", pendingStateMessageID)).CombinedOutput()
 	if err != nil {
-		return "", errors.Wrap(err, "error running journalctl -o json")
+		return nil, errors.Wrap(err, "error running journalctl -o json")
 	}
 	if len(journalOutput) == 0 {
-		return "", nil
+		return nil, nil
 	}
 	return dn.processJournalOutput(journalOutput)
 }


### PR DESCRIPTION
If the MCD has applied the update during a sync but it's still in
drain+reboot phase and it gets killed (OOM for instance), it can end up
in a permanent failure leaving node unschedulable as well. Since we know
at which point of the sync the MCD was (we have state on disk and bootid), if it
happens to be killed, instead of permanently failing, we can attempt the
drain+reboot phase again. 
This is definitely better than just bailing and leaving nodes
unschedulable which might also disrupt upgrades.

Signed-off-by: Antonio Murdaca <runcom@linux.com>