### PR TITLE
Bug 1727022: set upgradeable operator condition

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -177,6 +177,27 @@ func (optr *Operator) syncDegradedStatus(ierr error) (err error) {
 	return optr.updateStatus(co, coStatus)
 }
 
+// syncUpgradeableStatus applies the new condition to the mco's ClusterOperator object.
+func (optr *Operator) syncUpgradeableStatus() error {
+	co, err := optr.fetchClusterOperator()
+	if err != nil {
+		return err
+	}
+	if co == nil {
+		return nil
+	}
+	// Report default "Upgradeable=True" status. When known hazardous states for upgrades are
+	// determined, specific "Upgradeable=False" status can be added with messages for how admins
+	// can resolve it.
+	// [ref] https://github.com/openshift/cluster-version-operator/blob/8402d219f36fc79e03edf45918785376113f2cc1/docs/dev/clusteroperator.md#what-should-an-operator-report-with-clusteroperator-custom-resource
+	coStatus := configv1.ClusterOperatorStatusCondition{
+		Type:   configv1.OperatorUpgradeable,
+		Status: configv1.ConditionTrue,
+		Reason: "AsExpected",
+	}
+	return optr.updateStatus(co, coStatus)
+}
+
 func (optr *Operator) fetchClusterOperator() (*configv1.ClusterOperator, error) {
 	co, err := optr.configClient.ConfigV1().ClusterOperators().Get(optr.name, metav1.GetOptions{})
 	if meta.IsNoMatchError(err) {

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -200,9 +200,15 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 	if err != nil {
 		return nil, err
 	}
-	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
-	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
-	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorUpgradeable, Status: configv1.ConditionUnknown, Reason: "NoData"})
+
 	// RelatedObjects are consumed by https://github.com/openshift/must-gather
 	co.Status.RelatedObjects = []configv1.ObjectReference{
 		{Resource: "namespaces", Name: optr.namespace},

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -125,10 +125,6 @@ func (optr *Operator) syncProgressingStatus() error {
 }
 
 func (optr *Operator) updateStatus(co *configv1.ClusterOperator, status configv1.ClusterOperatorStatusCondition) error {
-	existingCondition := cov1helpers.FindStatusCondition(co.Status.Conditions, status.Type)
-	if existingCondition.Status != status.Status {
-		status.LastTransitionTime = metav1.Now()
-	}
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, status)
 	optr.setOperatorStatusExtension(&co.Status, nil)
 	_, err := optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -167,6 +167,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorProgressing,
 							Status: configv1.ConditionFalse,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					syncFuncs: []syncFunc{
 						{
@@ -190,6 +194,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorProgressing,
 							Status: configv1.ConditionFalse,
+						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -219,6 +227,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionFalse,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					syncFuncs: []syncFunc{
 						{
@@ -240,6 +252,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionFalse,
+						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -269,6 +285,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionFalse,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					syncFuncs: []syncFunc{
 						{
@@ -297,6 +317,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionFalse,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					syncFuncs: []syncFunc{
 						{
@@ -318,6 +342,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 						},
 						{
 							Type:   configv1.OperatorDegraded,
+							Status: configv1.ConditionTrue,
+						},
+						{
+							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
 						},
 					},
@@ -349,6 +377,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					expectOperatorFail: true,
 					syncFuncs: []syncFunc{
@@ -372,6 +404,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 						},
 						{
 							Type:   configv1.OperatorDegraded,
+							Status: configv1.ConditionTrue,
+						},
+						{
+							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
 						},
 					},
@@ -403,6 +439,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionFalse,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					syncFuncs: []syncFunc{
 						{
@@ -423,6 +463,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 						},
 						{
 							Type:   configv1.OperatorDegraded,
+							Status: configv1.ConditionTrue,
+						},
+						{
+							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
 						},
 					},
@@ -448,6 +492,10 @@ func TestOperatorSyncStatus(t *testing.T) {
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionFalse,
 						},
+						{
+							Type:   configv1.OperatorUpgradeable,
+							Status: configv1.ConditionTrue,
+						},
 					},
 					syncFuncs: []syncFunc{
 						{
@@ -469,6 +517,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 		cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
 		cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
 		cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
+		cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorUpgradeable, Status: configv1.ConditionUnknown})
 		co.Status.Versions = append(co.Status.Versions, configv1.OperandVersion{Name: "operator", Version: "test-version"})
 
 		for j, sync := range testCase.syncs {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -64,6 +64,10 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		return fmt.Errorf("error syncing available status: %v", err)
 	}
 
+	if err := optr.syncUpgradeableStatus(); err != nil {
+		return fmt.Errorf("error syncing upgradeble status: %v", err)
+	}
+
 	if err := optr.syncVersion(); err != nil {
 		return fmt.Errorf("error syncing version: %v", err)
 	}


### PR DESCRIPTION
Set the condition "upgradeable" on the "machine-config"  cluster operator.
https://github.com/openshift/api/blob/9525304a0adb725ab4a4a54539a1a6bf6cc343d3/config/v1/types_cluster_operator.go#L140

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1727022
