### PR TITLE
pkg/operator: Change proxy logging verbosity

### DIFF
--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -94,7 +94,7 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 
 	if proxy != nil {
 		if proxy.Status == (configv1.ProxyStatus{}) {
-			glog.Info("Not setting proxy config because Proxy status is empty")
+			glog.V(2).Info("Not setting proxy config because Proxy status is empty")
 		} else {
 			ccSpec.Proxy = &proxy.Status
 		}


### PR DESCRIPTION
Closes #1001

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Drop the verbosity of the "proxy not set" warning.
**- How to verify it**
`oc project openshift-machine-config-operator`
`oc get pods`
`oc logs machine-config-operator-xxxx`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
pkg/operator: Fix proxy logging verbosity