### PR TITLE
Standardize printer column "Age" on mco CRDs.

### DIFF
--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -16,7 +16,7 @@ spec:
     name: IgnitionVersion
     type: string
   - JSONPath: .metadata.creationTimestamp
-    name: Created
+    name: Age
     type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io

--- a/manifests/machineconfigpool.crd.yaml
+++ b/manifests/machineconfigpool.crd.yaml
@@ -38,6 +38,9 @@ spec:
     description: Total number of machines marked degraded (or unreconcilable)
     name: DegradedMachineCount
     type: number
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -599,7 +599,7 @@ spec:
     name: IgnitionVersion
     type: string
   - JSONPath: .metadata.creationTimestamp
-    name: Created
+    name: Age
     type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1285,6 +1285,9 @@ spec:
     description: Total number of machines marked degraded (or unreconcilable)
     name: DegradedMachineCount
     type: number
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
   # list of versions supported by this CustomResourceDefinition


### PR DESCRIPTION
#### Description
Display the age of MCO custom resources as a custom printer column. The "Age" column is standard across most kube api-resources and is useful for quick debugging purposes. Update MCO CRDs to be consistent with this.

#### Changes
- Rename "Created" printer column to "Age" in `MachineConfig` crd for consistency
- Add "Age" printer column to `MachineConfigPool` crd 

#### Example
##### Before:
```sh
$ oc get machineconfigpools
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED
master   rendered-master-85f8a8bd448e5e02aa8464072ae232fb   True      False      False
worker   rendered-worker-d3f5e04eb265eeafa0b5091a06a368ed   True      False      False

$ oc get machineconfigs
NAME        GENERATEDBYCONTROLLER                      IGNITIONVERSION   CREATED
00-master   8e55d6bdecfc26b31758eb3142b7da2330a24bef   2.2.0             2d
00-worker   8e55d6bdecfc26b31758eb3142b7da2330a24bef   2.2.0             2d
```
 
##### After:
```sh
$ oc get machineconfigpools
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   AGE
master   rendered-master-85f8a8bd448e5e02aa8464072ae232fb   True      False      False      2d
worker   rendered-worker-d3f5e04eb265eeafa0b5091a06a368ed   True      False      False      2d

$ oc get machineconfigs
NAME        GENERATEDBYCONTROLLER                      IGNITIONVERSION   AGE
00-master   8e55d6bdecfc26b31758eb3142b7da2330a24bef   2.2.0             2d
00-worker   8e55d6bdecfc26b31758eb3142b7da2330a24bef   2.2.0             2d
```
 