### PR TITLE
pkg/controller: allow custom pool rollback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ images.rhel7: $(imc7)
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	go test -timeout 75m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -timeout 90m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -438,12 +438,20 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 		glog.Infof("Pool %s: node %s has completed update to %s", pool.Name, curNode.Name, curNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
 		changed = true
 	} else {
-		annos := []string{daemonconsts.CurrentMachineConfigAnnotationKey, daemonconsts.DesiredMachineConfigAnnotationKey, daemonconsts.MachineConfigDaemonStateAnnotationKey}
+		annos := []string{
+			daemonconsts.CurrentMachineConfigAnnotationKey,
+			daemonconsts.DesiredMachineConfigAnnotationKey,
+			daemonconsts.MachineConfigDaemonStateAnnotationKey,
+		}
 		for _, anno := range annos {
 			if oldNode.Annotations[anno] != curNode.Annotations[anno] {
 				glog.Infof("Pool %s: node %s changed %s = %s", pool.Name, curNode.Name, anno, curNode.Annotations[anno])
 				changed = true
 			}
+		}
+		if !reflect.DeepEqual(oldNode.Labels, curNode.Labels) {
+			glog.Infof("Pool %s: node %s changed labels", pool.Name, curNode.Name)
+			changed = true
 		}
 	}
 


### PR DESCRIPTION
In case a user needs to rollback the custom pool he can do so by
removing the custom pool label from the node. However, w/o this patch
the MCC wasn't reacting to label changes. It should be safe to only
react to label changes also since we only care about the role label and
the labels aren't updated that often.

`oc label node ip-10-0-143-53.ec2.internal node-role.kubernetes.io/infra-`

The command above is going to drop the infra label from a worker,infra node causing it to rollback to a worker rendered MC.

This also expands the e2e added in #1007 

Signed-off-by: Antonio Murdaca <runcom@linux.com>