### PR TITLE
hack: allow using Docker for development

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -38,7 +38,7 @@ The `manifests` folder also contains global manifests at its root.
 Every time you modify any of the manifests in `manifests` please run the following command to update the `bindata` for Machine Config Operator.
 
 ```sh
-./hack/update-generated-bindata.sh
+make update
 ```
 
 # Unit Tests
@@ -89,21 +89,6 @@ dep ensure
 This [guide](https://golang.github.io/dep/docs/daily-dep.html) a great source to learn more about using `dep` is .
 
 For the sake of your fellow reviewers, commit vendored code separately from any other changes.
-
-# Turn on verbose mode for development
-
-Given you already have a cluster up and running, you can turn verbose on (level 4)
-for any given component with:
-
-```sh
-oc patch daemonset/machine-config-daemon --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--v=4"}]'
-```
-
-You can replace `daemonset/machine-config-daemon` with any other MCO component.
-If the component already has a `--v=` flag set, the command above still adds
-verbose and ignores the previous one already set.
-If you watch the pods, you'll notice your component restarting as well.
-Note this still requires [disabling the CVO](https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusterversion.md#disabling-the-cluster-version-operator).
 
 # Developing the MCD without building images
 

--- a/hack/build-image
+++ b/hack/build-image
@@ -40,7 +40,7 @@ else:
     print(f"Previous commit: {prev_ref}")
 
 print(f"HEAD commit: {gitrev}")
-args = [podman, 'build', '-t', imgname, '-f', 'Dockerfile', '--no-cache']
+args = [podman, 'build', '-t', imgname, '--no-cache', '.']
 for k in openshift_keys:
     args.append(f'--label={k}=')
 args.extend([f'--label=vcs-ref={gitrev}', '--label=vcs-type=git', '--label=vcs-url='])

--- a/hack/cluster-push.sh
+++ b/hack/cluster-push.sh
@@ -12,8 +12,6 @@
 
 set -xeuo pipefail
 
-podman=${podman:-podman}
-
 do_build=1
 if [ "${1:-}" = "-n" ]; then
     do_build=0
@@ -28,9 +26,17 @@ REMOTE_IMGNAME=openshift-machine-config-operator/${imgname}
 if [ "${do_build}" = 1 ]; then
     ./hack/build-image
 fi
-$podman push --tls-verify=false "${LOCAL_IMGNAME}" ${registry}/${REMOTE_IMGNAME}
+builder_secretid=$(oc get -n openshift-machine-config-operator secret | egrep '^builder-token-'| head -1 | cut -f 1 -d ' ')
+secret="$(oc get -n openshift-machine-config-operator -o json secret/${builder_secretid} | jq -r '.data.token' | base64 -d)"
 
-digest=$(skopeo inspect --tls-verify=false docker://${registry}/${REMOTE_IMGNAME} | jq -r .Digest)
+if [[ "${podman}" =~ "docker" ]]; then
+  imgstorage="docker-daemon:"
+else
+  imgstorage="containers-storage:"
+fi
+skopeo copy --dest-tls-verify=false --dest-creds unused:${secret} "${imgstorage}${LOCAL_IMGNAME}" "docker://${registry}/${REMOTE_IMGNAME}"
+
+digest=$(skopeo inspect --creds unused:${secret} --tls-verify=false docker://${registry}/${REMOTE_IMGNAME} | jq -r .Digest)
 imageid=${REMOTE_IMGNAME}@${digest}
 
 oc project openshift-machine-config-operator


### PR DESCRIPTION
This patch mainly modifies scripts under ./hack to allow people (me) to
develop using docker instead of podman (various reasons behind that, osx
mainly but still, many people are using docker). What this allows is:

podman=docker ./hack/cluster-push.sh

The normal flow with podman shouldn't have changed (please test it out!).

Also dropped a wrong section from HACKING.md and a minor change there as well.

Signed-off-by: Antonio Murdaca <runcom@linux.com>