### PR TITLE
pkg/operator: support additional CA bundle

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -423,7 +423,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c94bba30993ebfe6eb036983b04ad6ac6b89377d2f6dfeb729f39109ddbda053"
+  digest = "1:c73e66fb08463eb969add0a45509c5233679396bfa1fe9422afc54838167e576"
   name = "github.com/openshift/api"
   packages = [
     "config/v1",
@@ -431,7 +431,7 @@
     "operator/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "9525304a0adb725ab4a4a54539a1a6bf6cc343d3"
+  revision = "b7d4eb0fa1e0c1e03f97c97c08d0ef1f025c0838"
 
 [[projects]]
   branch = "master"
@@ -1280,7 +1280,6 @@
     "k8s.io/client-go/tools/leaderelection",
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
-    "k8s.io/client-go/util/cert",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -19,28 +19,29 @@ var (
 	}
 
 	bootstrapOpts struct {
-		baremetalRuntimeCfgImage string
-		cloudConfigFile          string
-		configFile               string
-		corednsImage             string
-		destinationDir           string
-		etcdCAFile               string
-		etcdImage                string
-		etcdMetricCAFile         string
-		haproxyImage             string
-		imagesConfigMapFile      string
-		infraConfigFile          string
-		infraImage               string
-		keepalivedImage          string
-		kubeCAFile               string
-		kubeClientAgentImage     string
-		mcoImage                 string
-		mdnsPublisherImage       string
-		networkConfigFile        string
-		oscontentImage           string
-		pullSecretFile           string
-		rootCAFile               string
-		proxyConfigFile          string
+		baremetalRuntimeCfgImage  string
+		cloudConfigFile           string
+		configFile                string
+		corednsImage              string
+		destinationDir            string
+		etcdCAFile                string
+		etcdImage                 string
+		etcdMetricCAFile          string
+		haproxyImage              string
+		imagesConfigMapFile       string
+		infraConfigFile           string
+		infraImage                string
+		keepalivedImage           string
+		kubeCAFile                string
+		kubeClientAgentImage      string
+		mcoImage                  string
+		mdnsPublisherImage        string
+		networkConfigFile         string
+		oscontentImage            string
+		pullSecretFile            string
+		rootCAFile                string
+		proxyConfigFile           string
+		additionalTrustBundleFile string
 	}
 )
 
@@ -69,6 +70,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.networkConfigFile, "network-config-file", "/assets/manifests/cluster-network-02-config.yml", "File containing network.config.openshift.io manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.cloudConfigFile, "cloud-config-file", "", "File containing the config map that contains the cloud config for cloudprovider.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.proxyConfigFile, "proxy-config-file", "/assets/manifests/cluster-proxy-01-config.yaml", "File containing proxy.config.openshift.io manifest.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.additionalTrustBundleFile, "additional-trust-bundle-config-file", "/assets/manifests/user-ca-bundle-config.yaml", "File containing the additional user provided CA bundle manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.keepalivedImage, "keepalived-image", "", "Image for Keepalived.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.corednsImage, "coredns-image", "", "Image for CoreDNS.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mdnsPublisherImage, "mdns-publisher-image", "", "Image for mdns-publisher.")
@@ -96,6 +98,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	}
 
 	if err := operator.RenderBootstrap(
+		bootstrapOpts.additionalTrustBundleFile,
 		bootstrapOpts.proxyConfigFile,
 		bootstrapOpts.configFile,
 		bootstrapOpts.infraConfigFile, bootstrapOpts.networkConfigFile,

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -82,6 +82,10 @@ type ControllerConfigSpec struct {
 	// rootCAData specifies the root CA data
 	RootCAData []byte `json:"rootCAData"`
 
+	// additionalTrustBundle is a certificate bundle that will be added to the nodes
+	// trusted certificate store.
+	AdditionalTrustBundle []byte `json:"additionalTrustBundle"`
+
 	// TODO: Investigate using a ConfigMapNameReference for the PullSecret and OSImageURL
 
 	// pullSecret is the default pull secret that needs to be installed

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -241,6 +241,11 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalTrustBundle != nil {
+		in, out := &in.AdditionalTrustBundle, &out.AdditionalTrustBundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.PullSecret != nil {
 		in, out := &in.PullSecret, &out.PullSecret
 		*out = new(corev1.ObjectReference)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -151,6 +151,12 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		return err
 	}
 
+	additionalTrustBundle, err := optr.getCAsFromConfigMap("openshift-config-managed", "user-ca-bundle", "ca-bundle.crt")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	spec.AdditionalTrustBundle = additionalTrustBundle
+
 	// if the cloudConfig is set in infra read the cloud config reference
 	if infra.Spec.CloudConfig.Name != "" {
 		cc, err := optr.getCloudConfigFromConfigMap("openshift-config", infra.Spec.CloudConfig.Name, infra.Spec.CloudConfig.Key)

--- a/templates/common/_base/files/additional-trust-bundle.yaml
+++ b/templates/common/_base/files/additional-trust-bundle.yaml
@@ -1,0 +1,8 @@
+filesystem: "root"
+mode: 0600
+path: "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
+contents:
+  inline: |
+{{if .AdditionalTrustBundle -}}
+{{.AdditionalTrustBundle | toString | indent 4}}
+{{end -}}

--- a/vendor/github.com/openshift/api/config/v1/types_apiserver.go
+++ b/vendor/github.com/openshift/api/config/v1/types_apiserver.go
@@ -8,7 +8,9 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// APIServer holds cluster-wide information about api-servers.  The canonical name is `cluster`
+// APIServer holds configuration (like serving certificates, client CA and CORS domains)
+// shared by all API servers in the system, among them especially kube-apiserver
+// and openshift-apiserver. The canonical name of an instance is 'cluster'.
 type APIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/github.com/openshift/api/config/v1/types_authentication.go
+++ b/vendor/github.com/openshift/api/config/v1/types_authentication.go
@@ -6,7 +6,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Authentication holds cluster-wide information about Authentication.  The canonical name is `cluster`
+// Authentication specifies cluster-wide settings for authentication (like OAuth and
+// webhook token authenticators). The canonical name of an instance is `cluster`.
 type Authentication struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -25,6 +26,7 @@ type AuthenticationSpec struct {
 	// type identifies the cluster managed, user facing authentication mode in use.
 	// Specifically, it manages the component that responds to login attempts.
 	// The default is IntegratedOAuth.
+	// +optional
 	Type AuthenticationType `json:"type"`
 
 	// oauthMetadata contains the discovery endpoint data for OAuth 2.0

--- a/vendor/github.com/openshift/api/config/v1/types_console.go
+++ b/vendor/github.com/openshift/api/config/v1/types_console.go
@@ -6,7 +6,9 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Console holds cluster-wide information about Console.  The canonical name is `cluster`.
+// Console holds cluster-wide configuration for the web console, including the
+// logout URL, and reports the public URL of the console. The canonical name is
+// `cluster`.
 type Console struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/vendor/github.com/openshift/api/config/v1/types_dns.go
+++ b/vendor/github.com/openshift/api/config/v1/types_dns.go
@@ -31,12 +31,20 @@ type DNSSpec struct {
 	BaseDomain string `json:"baseDomain"`
 	// publicZone is the location where all the DNS records that are publicly accessible to
 	// the internet exist.
+	//
 	// If this field is nil, no public records should be created.
+	//
+	// Once set, this field cannot be changed.
+	//
 	// +optional
 	PublicZone *DNSZone `json:"publicZone,omitempty"`
 	// privateZone is the location where all the DNS records that are only available internally
 	// to the cluster exist.
+	//
 	// If this field is nil, no private records should be created.
+	//
+	// Once set, this field cannot be changed.
+	//
 	// +optional
 	PrivateZone *DNSZone `json:"privateZone,omitempty"`
 }

--- a/vendor/github.com/openshift/api/config/v1/types_proxy.go
+++ b/vendor/github.com/openshift/api/config/v1/types_proxy.go
@@ -39,6 +39,29 @@ type ProxySpec struct {
 	// readinessEndpoints is a list of endpoints used to verify readiness of the proxy.
 	// +optional
 	ReadinessEndpoints []string `json:"readinessEndpoints,omitempty"`
+
+	// trustedCA is a reference to a ConfigMap containing a CA certificate bundle used
+	// for client egress HTTPS connections. The certificate bundle must be from the CA
+	// that signed the proxy's certificate and be signed for everything. trustedCA should
+	// only be consumed by a proxy validator. The validator is responsible for reading
+	// ConfigMapNameReference, validating the certificate and copying "ca-bundle.crt"
+	// from data to a ConfigMap in the namespace of an operator configured for proxy.
+	// The namespace for this ConfigMap is "openshift-config-managed". Here is an example
+	// ConfigMap (in yaml):
+	//
+	// apiVersion: v1
+	// kind: ConfigMap
+	// metadata:
+	//  name: proxy-ca
+	//  namespace: openshift-config-managed
+	//  data:
+	//    ca-bundle.crt: |
+	//      -----BEGIN CERTIFICATE-----
+	//      Custom CA certificate bundle.
+	//      -----END CERTIFICATE-----
+	//
+	// +optional
+	TrustedCA ConfigMapNameReference `json:"trustedCA,omitempty"`
 }
 
 // ProxyStatus shows current known state of the cluster proxy.

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.deepcopy.go
@@ -2669,6 +2669,7 @@ func (in *ProxySpec) DeepCopyInto(out *ProxySpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	out.TrustedCA = in.TrustedCA
 	return
 }
 

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -244,7 +244,7 @@ func (StringSourceSpec) SwaggerDoc() map[string]string {
 }
 
 var map_APIServer = map[string]string{
-	"": "APIServer holds cluster-wide information about api-servers.  The canonical name is `cluster`",
+	"": "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'.",
 }
 
 func (APIServer) SwaggerDoc() map[string]string {
@@ -280,7 +280,7 @@ func (APIServerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_Authentication = map[string]string{
-	"":         "Authentication holds cluster-wide information about Authentication.  The canonical name is `cluster`",
+	"":         "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`.",
 	"metadata": "Standard object's metadata.",
 	"spec":     "spec holds user settable values for configuration",
 	"status":   "status holds observed values from the cluster. They may not be overridden.",
@@ -539,7 +539,7 @@ func (UpdateHistory) SwaggerDoc() map[string]string {
 }
 
 var map_Console = map[string]string{
-	"":         "Console holds cluster-wide information about Console.  The canonical name is `cluster`.",
+	"":         "Console holds cluster-wide configuration for the web console, including the logout URL, and reports the public URL of the console. The canonical name is `cluster`.",
 	"metadata": "Standard object's metadata.",
 	"spec":     "spec holds user settable values for configuration",
 	"status":   "status holds observed values from the cluster. They may not be overridden.",
@@ -604,8 +604,8 @@ func (DNSList) SwaggerDoc() map[string]string {
 
 var map_DNSSpec = map[string]string{
 	"baseDomain":  "baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base.\n\nFor example, given the base domain `openshift.example.com`, an API server DNS record may be created for `cluster-api.openshift.example.com`.",
-	"publicZone":  "publicZone is the location where all the DNS records that are publicly accessible to the internet exist. If this field is nil, no public records should be created.",
-	"privateZone": "privateZone is the location where all the DNS records that are only available internally to the cluster exist. If this field is nil, no private records should be created.",
+	"publicZone":  "publicZone is the location where all the DNS records that are publicly accessible to the internet exist.\n\nIf this field is nil, no public records should be created.\n\nOnce set, this field cannot be changed.",
+	"privateZone": "privateZone is the location where all the DNS records that are only available internally to the cluster exist.\n\nIf this field is nil, no private records should be created.\n\nOnce set, this field cannot be changed.",
 }
 
 func (DNSSpec) SwaggerDoc() map[string]string {
@@ -1208,6 +1208,7 @@ var map_ProxySpec = map[string]string{
 	"httpsProxy":         "httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.",
 	"noProxy":            "noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in an env var.",
 	"readinessEndpoints": "readinessEndpoints is a list of endpoints used to verify readiness of the proxy.",
+	"trustedCA":          "trustedCA is a reference to a ConfigMap containing a CA certificate bundle used for client egress HTTPS connections. The certificate bundle must be from the CA that signed the proxy's certificate and be signed for everything. trustedCA should only be consumed by a proxy validator. The validator is responsible for reading ConfigMapNameReference, validating the certificate and copying \"ca-bundle.crt\" from data to a ConfigMap in the namespace of an operator configured for proxy. The namespace for this ConfigMap is \"openshift-config-managed\". Here is an example ConfigMap (in yaml):\n\napiVersion: v1 kind: ConfigMap metadata:\n name: proxy-ca\n namespace: openshift-config-managed\n data:\n   ca-bundle.crt: |",
 }
 
 func (ProxySpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This patch implements the last mile to the Proxy support specifically
(and later, CAs for mirrors).
This just reads from the installer objects and set up the bundle on disk
to be later updated via the new update-ca service shipped in RHCOS.
The service should always run early enough to always have the correct CA
on system to services to be consumed.

Signed-off-by: Antonio Murdaca <runcom@linux.com>