### PR TITLE
pkg/operator: use corev1 codecs to decode configmaps

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -88,7 +88,7 @@ func RenderBootstrap(
 		return err
 	}
 	if additionalTrustBundleData != nil {
-		obji, err = runtime.Decode(configscheme.Codecs.UniversalDecoder(configv1.SchemeGroupVersion), additionalTrustBundleData)
+		obji, err := runtime.Decode(scheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion), additionalTrustBundleData)
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ func RenderBootstrap(
 		if !ok {
 			return fmt.Errorf("expected *corev1.ConfigMap found %T", obji)
 		}
-		spec.AdditionalTrustBundle = additionalTrustBundle.BinaryData["ca-bundle.crt"]
+		spec.AdditionalTrustBundle = []byte(additionalTrustBundle.Data["ca-bundle.crt"])
 	}
 
 	// if the cloudConfig is set in infra read the cloudConfigFile


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Fix https://github.com/openshift/machine-config-operator/issues/1017

We were wrongly using the config scheme codec. This fixes that by using the corev1 and fixes the issue linked.

@jcpowermac ptal

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
