### PR TITLE
baremetal: fix haproxy logging

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -5,7 +5,7 @@ contents:
   inline: |
     defaults
       mode    tcp
-      log     global
+      log     /var/run/haproxy/haproxy-log.sock local0
       option  dontlognull
       retries 3
       timeout http-request 10s

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -58,11 +58,13 @@ contents:
           }
           set -ex
           declare -r haproxy_sock="/var/run/haproxy/haproxy-master.sock"
+          declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
           export -f msg_handler
           export -f reload_haproxy
           if [ -S "$haproxy_sock" ]; then
               rm "$haproxy_sock"
           fi
+          socat UNIX-RECV:${haproxy_log_sock} STDOUT &
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
         volumeMounts:
         - name: conf-dir


### PR DESCRIPTION
**- What I did**

Modify the haproxy container so that before starting HAProxy it creates a unix datagram socket that haproxy can connect to as if it were syslog's socket.

**- How to verify it**
```crictl logs id_of_haproxy_container```

should give an output containing entries like this:

```
<133>Jul 29 11:23:20 haproxy[14]: Proxy main started.
<141>Jul 29 11:23:20 haproxy[14]: Proxy main started.
<133>Jul 29 11:23:20 haproxy[14]: Proxy health_check_http_url started.
<141>Jul 29 11:23:20 haproxy[14]: Proxy health_check_http_url started.
<133>Jul 29 11:23:20 haproxy[14]: Proxy stats started.
<141>Jul 29 11:23:20 haproxy[14]: Proxy stats started.
<133>Jul 29 11:23:20 haproxy[14]: Proxy masters started.
<141>Jul 29 11:23:20 haproxy[14]: Proxy masters started.
<134>Jul 29 11:23:20 haproxy[15]: Connect from 192.168.111.22:50858 to 192.168.111.22:50936 (health_check_http_url/HTTP)
<134>Jul 29 11:23:30 haproxy[15]: Connect from 192.168.111.22:51032 to 192.168.111.22:50936 (health_check_http_url/HTTP)
<134>Jul 29 11:23:40 haproxy[15]: Connect from 192.168.111.22:51190 to 192.168.111.22:50936 (health_check_http_url/HTTP)
<134>Jul 29 11:23:45 haproxy[15]: Connect from 127.0.0.1:52758 to 127.0.0.1:7443 (main/TCP)
<134>Jul 29 11:23:50 haproxy[15]: Connect from 192.168.111.22:51360 to 192.168.111.22:50936 (health_check_http_url/HTTP)```



**- Description for the changelog**

Fix missing baremetal haproxy container logging
