### PR TITLE
OpenStack: create a symlink for cloud provider config

### DIFF
--- a/templates/common/openstack/units/openstack-cloud-config-symlink.yaml
+++ b/templates/common/openstack/units/openstack-cloud-config-symlink.yaml
@@ -1,0 +1,14 @@
+name: "openstack-cloud-config-symlink.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Create a symlink '/etc/kubernetes/cloud.conf' -> '/etc/kubernetes/cloud-config'
+  Before=kubelet.service
+  ConditionPathExists=!/etc/kubernetes/cloud-config
+
+  [Service]
+  ExecStart=/usr/bin/ln -s /etc/kubernetes/cloud.conf /etc/kubernetes/cloud-config
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
To attach a cinder volume Kubernetes requires that cloud provider config be placed in /etc/kubernetes/cloud-config file, but OCP puts it in /etc/kubernetes/cloud.conf, and Kubelet refuses to work.
https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/cinder/cinder.go#L44

To fix that this patch creates a symlink '/etc/kubernetes/cloud.conf' -> '/etc/kubernetes/cloud-config'

Closes: https://github.com/openshift/installer/issues/2102
