### PR TITLE
pkg/controller/kubelet-config: fix owener reference

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -51,7 +51,7 @@ const (
 
 var (
 	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = mcfgv1.SchemeGroupVersion.WithKind("ContainerRuntimeConfig")
+	controllerKind = mcfgv1.SchemeGroupVersion.WithKind("KubeletConfig")
 )
 
 var updateBackoff = wait.Backoff{


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This fixes a regression introduced in https://github.com/openshift/machine-config-operator/commit/680f79c9c7002bdc56b7d5f7481a2c7712fda164#diff-bc0cd3d2a7a92d7ffb804b2d7b2a5636R54 - I think this can cause the resulting kubeletConfig MC to be deleted when the kube GC kicks in but I haven't successfully verified that. Besides, the controller for kubeConfig is `KubeletConfig` so fix that.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
