### PR TITLE
hack: Don't error out on cluster-push.sh by default

### DIFF
--- a/hack/cluster-push.sh
+++ b/hack/cluster-push.sh
@@ -29,7 +29,7 @@ fi
 builder_secretid=$(oc get -n openshift-machine-config-operator secret | egrep '^builder-token-'| head -1 | cut -f 1 -d ' ')
 secret="$(oc get -n openshift-machine-config-operator -o json secret/${builder_secretid} | jq -r '.data.token' | base64 -d)"
 
-if [[ "${podman}" =~ "docker" ]]; then
+if [[ "${podman:-}" =~ "docker" ]]; then
   imgstorage="docker-daemon:"
 else
   imgstorage="containers-storage:"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Right now the `cluster-push` script errors out if you don't export `podman=podman` or `podman=docker`.
Since the `build-image` script assumes you are using `podman` as a default, we can ignore the `podman` variable in _this_ script if it is not set in the env (and thus default to `podman` when building).
**- How to verify it**
`unset podman`
`./hack/cluster-push.sh`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
hack: Don't error out on cluster-push.sh by default