### PR TITLE
baremetal - haproxy static pod, run haproxy process if cfg file exist

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -65,6 +65,9 @@ contents:
               rm "$haproxy_sock"
           fi
           socat UNIX-RECV:${haproxy_log_sock} STDOUT &
+          if [ -s "/etc/haproxy/haproxy.cfg" ]; then
+              /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
+          fi
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
         volumeMounts:
         - name: conf-dir


### PR DESCRIPTION
In current code, the haproxy process in haproxy container being started/restarted
only upon request (configuration change) from the monitor container.
So in case haproxy container fail due to liveness probe, it won't run the haproxy
process until configuration will be changed.
To fix that,  the haproxy process will be started if the haproxy cfg file exists.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
