### PR TITLE
Telemetry: add prometheus service monitor and MCD metrics listener

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -46,7 +46,7 @@ func init() {
 	startCmd.PersistentFlags().BoolVar(&startOpts.skipReboot, "skip-reboot", false, "Skips reboot after a sync, applies only in once-from")
 	startCmd.PersistentFlags().BoolVar(&startOpts.kubeletHealthzEnabled, "kubelet-healthz-enabled", true, "kubelet healthz endpoint monitoring")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeletHealthzEndpoint, "kubelet-healthz-endpoint", "http://localhost:10248/healthz", "healthz endpoint to check health")
-	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8080", "URL for prometheus metrics listener")
+	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8797", "URL for prometheus metrics listener")
 }
 
 // bindPodMounts ensures that the daemon can still see e.g. /run/secrets/kubernetes.io

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -33,6 +33,7 @@ var (
 		fromIgnition           bool
 		kubeletHealthzEnabled  bool
 		kubeletHealthzEndpoint string
+		promMetricsURL         string
 	}
 )
 
@@ -45,6 +46,7 @@ func init() {
 	startCmd.PersistentFlags().BoolVar(&startOpts.skipReboot, "skip-reboot", false, "Skips reboot after a sync, applies only in once-from")
 	startCmd.PersistentFlags().BoolVar(&startOpts.kubeletHealthzEnabled, "kubelet-healthz-enabled", true, "kubelet healthz endpoint monitoring")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeletHealthzEndpoint, "kubelet-healthz-endpoint", "http://localhost:10248/healthz", "healthz endpoint to check health")
+	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8080", "URL for prometheus metrics listener")
 }
 
 // bindPodMounts ensures that the daemon can still see e.g. /run/secrets/kubernetes.io
@@ -134,6 +136,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	// This channel is used to ensure all spawned goroutines exit when we exit.
 	stopCh := make(chan struct{})
 	defer close(stopCh)
+
+	// Start local metrics listener
+	go daemon.StartMetricsListener(startOpts.promMetricsURL, stopCh)
 
 	ctx := controllercommon.CreateControllerContext(cb, stopCh, componentName)
 	// create the daemon instance. this also initializes kube client items

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -36,6 +36,7 @@ var (
 		kubeClientAgentImage      string
 		mcoImage                  string
 		mdnsPublisherImage        string
+		oauthProxyImage           string
 		networkConfigFile         string
 		oscontentImage            string
 		pullSecretFile            string
@@ -76,6 +77,8 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mdnsPublisherImage, "mdns-publisher-image", "", "Image for mdns-publisher.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oauthProxyImage, "oauth-proxy-image", "", "Image for origin oauth proxy.")
+
 }
 
 func runBootstrapCmd(cmd *cobra.Command, args []string) {
@@ -92,6 +95,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 			KeepalivedBootstrap:          bootstrapOpts.keepalivedImage,
 			CorednsBootstrap:             bootstrapOpts.corednsImage,
 			BaremetalRuntimeCfgBootstrap: bootstrapOpts.baremetalRuntimeCfgImage,
+			OauthProxy:                   bootstrapOpts.oauthProxyImage,
 		},
 		ControllerConfigImages: operator.ControllerConfigImages{
 			Etcd:                bootstrapOpts.etcdImage,

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/openshift/cluster-api v0.0.0-20190923092624-4024de4fa64d
 	github.com/openshift/library-go v0.0.0-20191002112944-09fe7ddc84d4
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.1.0
 	github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     name: openshift-machine-config-operator
     openshift.io/run-level: "1"
+    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -27,4 +28,3 @@ metadata:
   labels:
     name: openshift-kni-infra
     openshift.io/run-level: "1"
-

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -14,5 +14,6 @@ data:
       "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",
       "haproxyImage": "registry.svc.ci.openshift.org/openshift:haproxy-router",
-      "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg"
+      "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg",
+      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy"
     }

--- a/install/0000_80_machine-config-operator_03_rbac.yaml
+++ b/install/0000_80_machine-config-operator_03_rbac.yaml
@@ -11,3 +11,36 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+---
+# Role for accessing metrics exposed by MCD in MCO namepsace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-machine-config-operator
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    - endpoints
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+---
+# Grant cluster-monitoring access to MCD metrics in MCO namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-machine-config-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/install/0000_90_machine-config-operator_00_servicemonitor.yaml
+++ b/install/0000_90_machine-config-operator_00_servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: machine-config-daemon
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: machine-config-daemon
+spec:
+  endpoints:
+  - interval: 30s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    port: metrics
+    scheme: https
+    path: /metrics
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: machine-config-daemon.openshift-machine-config-operator.svc
+  namespaceSelector:
+    matchNames:
+    - openshift-machine-config-operator
+  selector:
+    matchLabels:
+      k8s-app: machine-config-daemon

--- a/install/0001_00_machine-config-operator_00_service.yaml
+++ b/install/0001_00_machine-config-operator_00_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: machine-config-daemon
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: machine-config-daemon
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: proxy-tls
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: machine-config-daemon
+  ports:
+  - name: metrics
+    port: 9001
+    protocol: TCP

--- a/install/image-references
+++ b/install/image-references
@@ -16,6 +16,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:pod
+  - name: oauth-proxy
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:oauth-proxy
   # This one is special, it's the OS payload
   # https://github.com/openshift/machine-config-operator/issues/183
   # See the machine-config-osimageurl configmap.

--- a/manifests/machineconfigdaemon/clusterrole.yaml
+++ b/manifests/machineconfigdaemon/clusterrole.yaml
@@ -22,3 +22,16 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs"]
   verbs: ["*"]
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/manifests/machineconfigdaemon/clusterrolebinding.yaml
+++ b/manifests/machineconfigdaemon/clusterrolebinding.yaml
@@ -10,3 +10,18 @@ subjects:
 - kind: ServiceAccount
   namespace: {{.TargetNamespace}}
   name: machine-config-daemon
+---
+# Bind auth-delegator role to the MCD service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: machine-config-daemon
+  namespace: {{.TargetNamespace}}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-daemon

--- a/manifests/machineconfigdaemon/cookie-secret.yaml
+++ b/manifests/machineconfigdaemon/cookie-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cookie-secret
+  namespace: {{.TargetNamespace}}
+type: Opaque
+data:
+  cookie-secret: {{.GenerateProxyCookieSecret}}

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
         - --https-address=:9001
         - --provider=openshift
         - --openshift-service-account=machine-config-daemon
-        - --upstream=http://127.0.0.1:8080
+        - --upstream=http://127.0.0.1:8797
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret-file=/etc/tls/cookie-secret/cookie-secret

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -34,6 +34,31 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+      - name: oauth-proxy
+        image: {{.Images.OauthProxy}}
+        ports:
+        - containerPort: 9001
+          name: metrics
+          protocol: TCP
+        args:
+        - --https-address=:9001
+        - --provider=openshift
+        - --openshift-service-account=machine-config-daemon
+        - --upstream=http://127.0.0.1:8080
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --cookie-secret-file=/etc/tls/cookie-secret/cookie-secret
+        - '--openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '--openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: proxy-tls
+        - mountPath: /etc/tls/cookie-secret
+          name: cookie-secret
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
@@ -52,3 +77,9 @@ spec:
         - name: rootfs
           hostPath:
             path: /
+        - name: proxy-tls
+          secret:
+            secretName: proxy-tls
+        - name: cookie-secret
+          secret:
+            secretName: cookie-secret

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -8,8 +8,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// DefaultBindAddress is the port for the metrics listener
 var DefaultBindAddress = ":8797"
 
+// StartMetricsListener is metrics listener via http on localhost
 func StartMetricsListener(addr string, stopCh chan struct{}) {
 	if addr == "" {
 		addr = DefaultBindAddress
@@ -20,12 +22,12 @@ func StartMetricsListener(addr string, stopCh chan struct{}) {
 	mux.Handle("/metrics", promhttp.Handler())
 	s := http.Server{Addr: addr, Handler: mux}
 	go func() {
-		if err := s.ListenAndServe(); err != nil {
-			glog.Exitf("Unable to start metrics listener: %v", err)
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			glog.Errorf("metrics listener exited with error: %v", err)
 		}
 	}()
 	<-stopCh
 	if err := s.Shutdown(context.Background()); err != http.ErrServerClosed {
-		glog.Infof("Error stopping metrics listener: %v", err)
+		glog.Errorf("error stopping metrics listener: %v", err)
 	}
 }

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var DefaultBindAddress = ":8080"
+var DefaultBindAddress = ":8797"
 
 func StartMetricsListener(addr string, stopCh chan struct{}) {
 	if addr == "" {

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var DefaultBindAddress = ":8080"
+
+func StartMetricsListener(addr string, stopCh chan struct{}) {
+	if addr == "" {
+		addr = DefaultBindAddress
+	}
+
+	glog.Infof("Starting metrics listener on %s", addr)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	s := http.Server{Addr: addr, Handler: mux}
+	go func() {
+		if err := s.ListenAndServe(); err != nil {
+			glog.Exitf("Unable to start metrics listener: %v", err)
+		}
+	}()
+	<-stopCh
+	if err := s.Shutdown(context.Background()); err != http.ErrServerClosed {
+		glog.Infof("Error stopping metrics listener: %v", err)
+	}
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1168,7 +1168,7 @@ spec:
         - --https-address=:9001
         - --provider=openshift
         - --openshift-service-account=machine-config-daemon
-        - --upstream=http://127.0.0.1:8080
+        - --upstream=http://127.0.0.1:8797
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
         - --cookie-secret-file=/etc/tls/cookie-secret/cookie-secret

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -22,6 +22,7 @@ type RenderConfigImages struct {
 	KeepalivedBootstrap          string `json:"keepalived"`
 	CorednsBootstrap             string `json:"coredns"`
 	BaremetalRuntimeCfgBootstrap string `json:"baremetalRuntimeCfg"`
+	OauthProxy                   string `json:"oauthProxy"`
 }
 
 // ControllerConfigImages are image names used to render templates under ./templates/

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"strings"
@@ -16,6 +17,7 @@ import (
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/operator/assets"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 type renderConfig struct {
@@ -114,4 +116,10 @@ func clusterDNSIP(iprange string) (string, error) {
 		return "", err
 	}
 	return ip.String(), nil
+}
+
+// GenerateProxyCookieSecret creates a random b64 encoded secret
+// for the proxy cookie secret object
+func (rc renderConfig) GenerateProxyCookieSecret() string {
+	return base64.StdEncoding.EncodeToString([]byte(utilrand.String(32)))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -725,8 +725,8 @@ github.com/pquerna/ffjson/inception
 github.com/pquerna/ffjson/shared
 github.com/pquerna/ffjson/fflib/v1/internal
 # github.com/prometheus/client_golang v1.1.0
-github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 # github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 github.com/prometheus/client_model/go


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add required components for the Prometheus operator to scrape MCD metrics via TLS. 

We can't serve Prometheus metrics via open `http` since the metrics we will be implementing will consist of data that should be restricted to cluster admins. To serve metrics via authenticated `https`, this PR adds an `oauth-proxy` container to the MCD daemonset. The MCD container then serves a metrics listener via `http` on `localhost`. The `oauth-proxy` forwards incoming secure (and authenticated) connections on port `9001` of the pod to the local metrics listener. This is how the [elastic search operator](https://github.com/openshift/elasticsearch-operator) handles secure metrics.

**- How to verify it**

- Build MCO image and deploy.
- Verify that the MCD is visible in the cluster prometheus UI under the "targets" listing:
 From the OCP page see Monitoring -> Metrics -> Prometheus UI -> Status (Top menu) -> Targets (dropdown)

ex:
![proof](https://user-images.githubusercontent.com/17414243/62330468-a0940180-b46d-11e9-9bdd-df66a125ab18.png)

To see the Prometheus data manually, run the following on an MCD pod.

`kubectl port-forward -n openshift-machine-config-operator machine-config-daemon-xxxx 9001:9001`

then in a new terminal with `KUBECONFIG` set, 

`curl -H "Authorization: Bearer $(oc serviceaccounts -n openshift-monitoring get-token prometheus-k8s)" -k https://127.0.0.1:9001/metrics`

This should list the contents being scraped by the Prometheus operator.

To try out a sample metric through the golang client, follow this basic example in the [cluster auth operator](https://github.com/openshift/cluster-authentication-operator/blob/226f263d77b90ece9f36d229ed0f6ecff3405cce/pkg/version/version.go#L37-L46)

(The Go prom client dependency is already included in this PR)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[4.3] Add prometheus service monitor and MCD metrics listener