### PR TITLE
 cmd: add gcp-routes-controllers to manage the routes service to prevent blackholes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN WHAT=machine-config-daemon ./hack/build-go.sh
 RUN WHAT=machine-config-controller ./hack/build-go.sh
 RUN WHAT=machine-config-server ./hack/build-go.sh
 RUN WHAT=setup-etcd-environment ./hack/build-go.sh
+RUN WHAT=gcp-routes-controller ./hack/build-go.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /usr/bin/
@@ -16,5 +17,6 @@ COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output
 COPY templates /etc/mcc/templates
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/setup-etcd-environment /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/gcp-routes-controller /usr/bin/
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -16,6 +16,9 @@ RUN WHAT=machine-config-server ./hack/build-go.sh; \
 RUN WHAT=setup-etcd-environment ./hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/setup-etcd-environment /tmp/build/setup-etcd-environment
+RUN WHAT=gcp-routes-controller ./hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/gcp-routes-controller /tmp/build/gcp-routes-controller
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /tmp/build/machine-config-operator /usr/bin/
@@ -26,5 +29,6 @@ COPY --from=builder /tmp/build/machine-config-controller /usr/bin/
 COPY templates /etc/mcc/templates
 COPY --from=builder /tmp/build/machine-config-server /usr/bin/
 COPY --from=builder /tmp/build/setup-etcd-environment /usr/bin/
+COPY --from=builder /tmp/build/gcp-routes-controller /usr/bin/
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,25 @@
   version = "v0.3.1"
 
 [[projects]]
+  digest = "1:dc9a4d45d78cfb93260316db90bd0647ad20c1af5ce7ccd1bbc4fa417cb40ea7"
+  name = "github.com/InVisionApp/go-health"
+  packages = [
+    ".",
+    "checkers",
+  ]
+  pruneopts = "NUT"
+  revision = "06e1878ab5a8acf6e841861c6cbfcc4d3036add0"
+  version = "v2.1.0"
+
+[[projects]]
+  digest = "1:38e80fb6f25ad94a601b2e7bc7718517ada1eded101fb0577bc9e214e5d7ea33"
+  name = "github.com/InVisionApp/go-logger"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "c377c6c3f6a48a6366517e86f77bafea18454ff1"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:25870183293a3fb61cc9afd060a61d63a486f091db72af01a8ea3449f5ca530d"
   name = "github.com/Masterminds/goutils"
   packages = ["."]
@@ -1184,6 +1203,8 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
+    "github.com/InVisionApp/go-health",
+    "github.com/InVisionApp/go-health/checkers",
     "github.com/Masterminds/sprig",
     "github.com/apparentlymart/go-cidr/cidr",
     "github.com/ashcrow/osrelease",
@@ -1247,6 +1268,7 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/runtime/serializer/json",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/diff",
     "k8s.io/apimachinery/pkg/util/errors",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -159,3 +159,7 @@ required = [
 [[constraint]]
   name = "github.com/containers/image"
   version = "v2.0.0"
+
+[[constraint]]
+  name = "github.com/InVisionApp/go-health"
+  version = "2.1.0"

--- a/cmd/gcp-routes-controller/main.go
+++ b/cmd/gcp-routes-controller/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+const (
+	componentName = "gcp-routes-controller"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:           componentName,
+		Short:         "Controls the gcp-routes.service on RHCOS hosts based on health checks",
+		Long:          "",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+)
+
+func init() {
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		glog.Exitf("Error executing %s: %v", componentName, err)
+	}
+}

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -73,6 +73,8 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	httpCheck, err := checkers.NewHTTP(&checkers.HTTPConfig{
 		URL: uri,
 		Client: &http.Client{Transport: &http.Transport{
+			// #nosec G402
+			// health checks to https endpoints can use InsecureSkipVerify.
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}},
 	})

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	health "github.com/InVisionApp/go-health"
+	"github.com/InVisionApp/go-health/checkers"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/machine-config-operator/pkg/version"
+)
+
+var (
+	runCmd = &cobra.Command{
+		Use:   "run",
+		Short: "Runs the gcp-routes-controller",
+		Long:  "",
+		RunE:  runRunCmd,
+	}
+
+	runOpts struct {
+		gcpRoutesService string
+		rootMount        string
+
+		healthCheckURL string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+	runCmd.PersistentFlags().StringVar(&runOpts.gcpRoutesService, "gcp-routes-service", "gcp-routes.service", "The name for the service controlling gcp routes on host")
+	runCmd.PersistentFlags().StringVar(&runOpts.rootMount, "root-mount", "/rootfs", "where the nodes root filesystem is mounted for chroot and file manipulation.")
+	runCmd.PersistentFlags().StringVar(&runOpts.healthCheckURL, "health-check-url", "", "HTTP(s) URL for the health check")
+}
+
+func runRunCmd(cmd *cobra.Command, args []string) error {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	// To help debugging, immediately log version
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+	if runOpts.rootMount != "" {
+		glog.Infof(`Calling chroot("%s")`, runOpts.rootMount)
+		if err := syscall.Chroot(runOpts.rootMount); err != nil {
+			return fmt.Errorf("Unable to chroot to %s: %s", runOpts.rootMount, err)
+		}
+
+		glog.V(2).Infof("Moving to / inside the chroot")
+		if err := os.Chdir("/"); err != nil {
+			return fmt.Errorf("Unable to change directory to /: %s", err)
+		}
+	}
+
+	uri, err := url.Parse(runOpts.healthCheckURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse health-check-url: %v", err)
+	}
+	if !uri.IsAbs() {
+		return fmt.Errorf("invalid URI %q (no scheme)", uri)
+	}
+
+	httpCheck, err := checkers.NewHTTP(&checkers.HTTPConfig{
+		URL: uri,
+		Client: &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create httpCheck: %v", err)
+	}
+
+	errCh := make(chan error)
+	tracker := &healthTracker{
+		ErrCh:            errCh,
+		SuccessThreshold: 2,
+		FailureThreshold: 10,
+		OnFailure:        func() error { return exec.Command("systemctl", "stop", runOpts.gcpRoutesService).Run() },
+		OnSuccess:        func() error { return exec.Command("systemctl", "start", runOpts.gcpRoutesService).Run() },
+	}
+
+	h := health.New()
+	h.AddChecks([]*health.Config{{
+		Name:       "dependency-check",
+		Checker:    httpCheck,
+		Interval:   time.Duration(5) * time.Second,
+		Fatal:      true,
+		OnComplete: tracker.OnComplete,
+	}})
+
+	if err := h.Start(); err != nil {
+		return fmt.Errorf("failed to start heath checker: %v", err)
+	}
+
+	for {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				return fmt.Errorf("error running health checker: %v", err)
+			}
+		}
+	}
+}
+
+type trackerState int
+
+const (
+	unknownTrackerState trackerState = iota
+	failedTrackerState
+	succeededTrackerState
+)
+
+type healthTracker struct {
+	sync.Mutex
+
+	state trackerState
+
+	succeeded int
+	failed    int
+
+	// ErrCh is used to collect errors
+	ErrCh chan<- error
+
+	// SuccessThreshold is the number of consecutive success
+	SuccessThreshold int
+
+	// FailureThreshold is the number of consecutive failure that trigger OnFailure func
+	FailureThreshold int
+
+	// OnFailure is the function that is triggered when the health check is in FAILED state
+	// Non nil error are sent over the ErrCh
+	// Only one OnFailure function will be active at a time.
+	OnFailure func() error
+
+	// OnSuccess is the function that is triggered when the health check is in SUCCEEDED state
+	// Non nil error are sent over the ErrCh
+	// Only one OnFailure function will be active at a time.
+	OnSuccess func() error
+}
+
+func (sl *healthTracker) OnComplete(state *health.State) {
+	sl.Lock()
+	defer sl.Unlock()
+
+	switch state.Status {
+	case "ok":
+		sl.failed = 0
+		sl.succeeded++
+		if sl.succeeded >= sl.SuccessThreshold {
+			if sl.state != succeededTrackerState {
+				glog.Info("Running OnSuccess trigger")
+				if err := sl.OnSuccess(); err != nil {
+					sl.ErrCh <- err
+				}
+			}
+			sl.state = succeededTrackerState
+		}
+	case "failed":
+		sl.succeeded = 0
+		sl.failed++
+		if sl.failed >= sl.FailureThreshold {
+			if sl.state != failedTrackerState {
+				glog.Info("Running OnFailure trigger")
+				if err := sl.OnFailure(); err != nil {
+					sl.ErrCh <- err
+				}
+			}
+			sl.state = failedTrackerState
+		}
+	}
+}

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -82,6 +82,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 
 	errCh := make(chan error)
 	tracker := &healthTracker{
+		state:            unknownTrackerState,
 		ErrCh:            errCh,
 		SuccessThreshold: 2,
 		FailureThreshold: 10,

--- a/cmd/gcp-routes-controller/version.go
+++ b/cmd/gcp-routes-controller/version.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of GCP Routes Controller",
+		Long:  `All software has versions. This is GCP Routes Controller's.`,
+		Run:   runVersionCmd,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func runVersionCmd(cmd *cobra.Command, args []string) {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	program := "GCP Routes Controller"
+	version := version.Raw + "-" + version.Hash
+
+	fmt.Println(program, version)
+}

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -7,6 +7,9 @@ const (
 	// SetupEtcdEnvKey is the key that references the setup-etcd-environment image in the controller
 	SetupEtcdEnvKey string = "setupEtcdEnvKey"
 
+	// GCPRoutesControllerKey is the key that references the gcp-routes-controller image in the controller
+	GCPRoutesControllerKey string = "gcpRoutesControllerKey"
+
 	// InfraImageKey is the key that references the infra image in the controller for crio.conf
 	InfraImageKey string = "infraImageKey"
 

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -132,6 +132,7 @@ func RenderBootstrap(
 	spec.Images = map[string]string{
 		templatectrl.EtcdImageKey:            imgs.Etcd,
 		templatectrl.SetupEtcdEnvKey:         imgs.MachineConfigOperator,
+		templatectrl.GCPRoutesControllerKey:  imgs.MachineConfigOperator,
 		templatectrl.InfraImageKey:           imgs.InfraImage,
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 		templatectrl.KeepalivedKey:           imgs.Keepalived,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -179,6 +179,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	spec.Images = map[string]string{
 		templatectrl.EtcdImageKey:            imgs.Etcd,
 		templatectrl.SetupEtcdEnvKey:         imgs.MachineConfigOperator,
+		templatectrl.GCPRoutesControllerKey:  imgs.MachineConfigOperator,
 		templatectrl.InfraImageKey:           imgs.InfraImage,
 		templatectrl.KubeClientAgentImageKey: imgs.KubeClientAgent,
 		templatectrl.KeepalivedKey:           imgs.Keepalived,

--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
@@ -1,0 +1,35 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/manifests/gcp-routes-controller.yaml"
+contents:
+  inline: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: gcp-routes-controller
+      namespace: kube-system
+    spec:
+      containers:
+      - name: gcp-routes-controller
+        image: "{{.Images.gcpRoutesControllerKey}}"
+        command: ["gcp-routes-controller"]
+        args:
+        - "run"
+        - "--health-check-url=https://127.0.0.1:6443/healthz"
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /rootfs
+          name: rootfs
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      restartPolicy: Always
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+

--- a/vendor/github.com/InVisionApp/go-health/LICENSE
+++ b/vendor/github.com/InVisionApp/go-health/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 InVision
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/InVisionApp/go-health/checkers/http.go
+++ b/vendor/github.com/InVisionApp/go-health/checkers/http.go
@@ -1,0 +1,160 @@
+package checkers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHTTPTimeout = time.Duration(3) * time.Second
+)
+
+// HTTPConfig is used for configuring an HTTP check. The only required field is `URL`.
+//
+// "Method" is optional and defaults to `GET` if undefined.
+//
+// "Payload" is optional and can accept `string`, `[]byte` or will attempt to
+// marshal the input to JSON for use w/ `bytes.NewReader()`.
+//
+// "StatusCode" is optional and defaults to `200`.
+//
+// "Expect" is optional; if defined, operates as a basic "body should contain <string>".
+//
+// "Client" is optional; if undefined, a new client will be created using "Timeout".
+//
+// "Timeout" is optional and defaults to "3s".
+type HTTPConfig struct {
+	URL        *url.URL      // Required
+	Method     string        // Optional (default GET)
+	Payload    interface{}   // Optional
+	StatusCode int           // Optional (default 200)
+	Expect     string        // Optional
+	Client     *http.Client  // Optional
+	Timeout    time.Duration // Optional (default 3s)
+}
+
+// HTTP implements the "ICheckable" interface.
+type HTTP struct {
+	Config *HTTPConfig
+}
+
+// NewHTTP creates a new HTTP checker that can be used for ".AddCheck(s)".
+func NewHTTP(cfg *HTTPConfig) (*HTTP, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("Passed in config cannot be nil")
+	}
+
+	if err := cfg.prepare(); err != nil {
+		return nil, fmt.Errorf("Unable to prepare given config: %v", err)
+	}
+
+	return &HTTP{
+		Config: cfg,
+	}, nil
+}
+
+// Status is used for performing an HTTP check against a dependency; it satisfies
+// the "ICheckable" interface.
+func (h *HTTP) Status() (interface{}, error) {
+	resp, err := h.do()
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Check if StatusCode matches
+	if resp.StatusCode != h.Config.StatusCode {
+		return nil, fmt.Errorf("Received status code '%v' does not match expected status code '%v'",
+			resp.StatusCode, h.Config.StatusCode)
+	}
+
+	// If Expect is set, verify if returned response contains expected data
+	if h.Config.Expect != "" {
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to read response body to perform content expectancy check: %v", err)
+		}
+
+		if !strings.Contains(string(data), h.Config.Expect) {
+			return nil, fmt.Errorf("Received response body '%v' does not contain expected content '%v'",
+				string(data), h.Config.Expect)
+		}
+	}
+
+	return nil, nil
+}
+
+func (h *HTTP) do() (*http.Response, error) {
+	payload, err := parsePayload(h.Config.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing payload: %v", err)
+	}
+
+	req, err := http.NewRequest(h.Config.Method, h.Config.URL.String(), payload)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create new HTTP request for HTTPMonitor check: %v", err)
+	}
+
+	resp, err := h.Config.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Ran into error while performing '%v' request: %v", h.Config.Method, err)
+	}
+
+	return resp, nil
+}
+
+func (h *HTTPConfig) prepare() error {
+	if h.URL == nil {
+		return errors.New("URL cannot be nil")
+	}
+
+	// Default StatusCode to 200
+	if h.StatusCode == 0 {
+		h.StatusCode = http.StatusOK
+	}
+
+	// Default to GET
+	if h.Method == "" {
+		h.Method = "GET"
+	}
+
+	if h.Timeout == 0 {
+		h.Timeout = defaultHTTPTimeout
+	}
+
+	if h.Client == nil {
+		h.Client = &http.Client{Timeout: h.Timeout}
+	} else {
+		h.Client.Timeout = h.Timeout
+	}
+
+	return nil
+}
+
+func parsePayload(b interface{}) (io.Reader, error) {
+	if b == nil {
+		return nil, nil
+	}
+
+	switch b.(type) {
+	case []byte:
+		return bytes.NewReader(b.([]byte)), nil
+	case string:
+		return bytes.NewReader([]byte(b.(string))), nil
+	default:
+		jb, err := json.Marshal(b)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal json body: %v", err)
+		}
+
+		return bytes.NewReader(jb), nil
+	}
+}

--- a/vendor/github.com/InVisionApp/go-health/checkers/reachable.go
+++ b/vendor/github.com/InVisionApp/go-health/checkers/reachable.go
@@ -1,0 +1,115 @@
+package checkers
+
+import (
+	"net"
+	"net/url"
+	"time"
+)
+
+const (
+	// ReachableDDHealthErrors is the datadog name used when there is a failure in the reachable checker
+	ReachableDDHealthErrors = "health.errors"
+	// ReachableDefaultPort is the default port used if no port is defined in a reachable checker
+	ReachableDefaultPort = "80"
+	// ReachableDefaultNetwork is the default network used in the reachable checker
+	ReachableDefaultNetwork = "tcp"
+)
+
+var (
+	// ReachableDefaultTimeout is the default timeout used when reachable is checking the URL
+	ReachableDefaultTimeout = time.Duration(3) * time.Second
+)
+
+// ReachableDialer is the signature for a function that checks if an address is reachable
+type ReachableDialer func(network, address string, timeout time.Duration) (net.Conn, error)
+
+// ReachableDatadogIncrementer is any datadog client that has the Incr method for tracking metrics
+type ReachableDatadogIncrementer interface {
+	Incr(name string, tags []string, rate float64) error
+}
+
+// ReachableConfig is used for configuring an HTTP check. The only required field is `URL`.
+//
+// "Dialer" is optional and defaults to using net.DialTimeout.
+//
+// "Timeout" is optional and defaults to "3s".
+//
+// "Network" is optional and defaults to "tcp"; it should be one of "tcp",
+// "tcp4", "tcp6", "unix", "unixpacket", "udp", "udp4", "udp6", "unixgram" or an
+// IP transport. The IP transports are "ip", "ip4", or "ip6" followed by a colon
+// and a literal protocol number or a protocol name, as in "ip:1" or "ip:icmp".
+//
+// "DatadogClient" is optional; if defined metrics will be sent via statsd.
+//
+// "DatadogTags" is optional; defines the tags that are passed to datadog when there is a failure
+type ReachableConfig struct {
+	URL           *url.URL                    // Required
+	Dialer        ReachableDialer             // Optional (default net.DialTimeout)
+	Timeout       time.Duration               // Optional (default 3s)
+	Network       string                      // Optional (default tcp)
+	DatadogClient ReachableDatadogIncrementer // Optional
+	DatadogTags   []string                    // Optional
+}
+
+// ReachableChecker checks that URL responds to a TCP request
+type ReachableChecker struct {
+	dialer  ReachableDialer
+	timeout time.Duration
+	network string
+	url     *url.URL
+	datadog ReachableDatadogIncrementer
+	tags    []string
+}
+
+// NewReachableChecker creates a new reachable health checker
+func NewReachableChecker(cfg *ReachableConfig) (*ReachableChecker, error) {
+	t := ReachableDefaultTimeout
+	if cfg.Timeout != 0 {
+		t = cfg.Timeout
+	}
+	d := net.DialTimeout
+	if cfg.Dialer != nil {
+		d = cfg.Dialer
+	}
+	n := ReachableDefaultNetwork
+	if cfg.Network != "" {
+		n = cfg.Network
+	}
+	r := &ReachableChecker{
+		dialer:  d,
+		timeout: t,
+		network: n,
+		url:     cfg.URL,
+		datadog: cfg.DatadogClient,
+		tags:    cfg.DatadogTags,
+	}
+	return r, nil
+}
+
+// Status checks if the endpoint is reachable
+func (r *ReachableChecker) Status() (interface{}, error) {
+	// We must provide a port so when a port is not set in the URL provided use
+	// the default port (80)
+	port := r.url.Port()
+	if len(port) == 0 {
+		port = ReachableDefaultPort
+	}
+
+	conn, err := r.dialer(r.network, r.url.Hostname()+":"+port, r.timeout)
+	if err != nil {
+		return r.fail(err)
+	}
+	if conn != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return r.fail(errClose)
+		}
+	}
+	return nil, nil
+}
+
+func (r *ReachableChecker) fail(err error) (interface{}, error) {
+	if r.datadog != nil {
+		r.datadog.Incr(ReachableDDHealthErrors, r.tags, 1.0)
+	}
+	return nil, err
+}

--- a/vendor/github.com/InVisionApp/go-health/checkers/sql.go
+++ b/vendor/github.com/InVisionApp/go-health/checkers/sql.go
@@ -1,0 +1,212 @@
+package checkers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+//go:generate counterfeiter -o ../fakes/isqlpinger.go . SQLPinger
+//go:generate counterfeiter -o ../fakes/isqlqueryer.go . SQLQueryer
+//go:generate counterfeiter -o ../fakes/isqlexecer.go . SQLExecer
+
+// SQLPinger is an interface that allows direct pinging of the database
+type SQLPinger interface {
+	PingContext(ctx context.Context) error
+}
+
+// SQLQueryer is an interface that allows querying of the database
+type SQLQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
+
+// SQLExecer is an interface that allows executing of queries in the database
+type SQLExecer interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
+// SQLQueryerResultHandler is the BYO function to
+// handle the result of an SQL SELECT query
+type SQLQueryerResultHandler func(rows *sql.Rows) (bool, error)
+
+// SQLExecerResultHandler is the BYO function
+// to handle a database exec result
+type SQLExecerResultHandler func(result sql.Result) (bool, error)
+
+// SQLConfig is used for configuring a database check.
+// One of the Pinger, Queryer, or Execer fields is required.
+//
+//
+// If Execer is set, it will take precedence over Queryer and Pinger,
+// Execer implements the SQLExecer interface in this package.
+// The sql.DB and sql.TX structs both implement this interface.
+//
+// Note that if the Execer is set, then the ExecerResultHandler
+// and Query values MUST also be set
+//
+//
+// If Queryer is set, it will take precedence over Pinger.
+// SQLQueryer implements the SQLQueryer interface in this package.
+// The sql.DB and sql.TX structs both implement this interface.
+//
+// Note that if the Queryer is set, then the QueryerResultHandler
+// and Query values MUST also be set
+//
+//
+// Pinger implements the SQLPinger interface in this package.
+// The sql.DB struct implements this interface.
+type SQLConfig struct {
+	// Pinger is the value implementing SQLPinger
+	Pinger SQLPinger
+
+	// Queryer is the value implementing SQLQueryer
+	Queryer SQLQueryer
+
+	// Execer is the value implementing SQLExecer
+	Execer SQLExecer
+
+	// Query is the parameterized SQL query required
+	// with both Queryer and Execer
+	Query string
+
+	// Params are the SQL query parameters, if any
+	Params []interface{}
+
+	// QueryerResultHandler handles the result of
+	// the QueryContext function
+	QueryerResultHandler SQLQueryerResultHandler
+
+	// ExecerResultHandler handles the result of
+	// the ExecContext function
+	ExecerResultHandler SQLExecerResultHandler
+}
+
+// SQL implements the "ICheckable" interface
+type SQL struct {
+	Config *SQLConfig
+}
+
+// NewSQL creates a new database checker that can be used for ".AddCheck(s)".
+func NewSQL(cfg *SQLConfig) (*SQL, error) {
+	if err := validateSQLConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return &SQL{
+		Config: cfg,
+	}, nil
+}
+
+// DefaultQueryHandler is the default SQLQueryer result handler
+// that assumes one row was returned from the passed query
+func DefaultQueryHandler(rows *sql.Rows) (bool, error) {
+	defer rows.Close()
+
+	numRows := 0
+	for rows.Next() {
+		numRows++
+	}
+
+	return numRows == 1, nil
+}
+
+// DefaultExecHandler is the default SQLExecer result handler
+// that assumes one row was affected in the passed query
+func DefaultExecHandler(result sql.Result) (bool, error) {
+	affectedRows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+
+	return affectedRows == int64(1), nil
+}
+
+// this makes sure the sql check is properly configured
+func validateSQLConfig(cfg *SQLConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	if cfg.Execer == nil && cfg.Queryer == nil && cfg.Pinger == nil {
+		return fmt.Errorf("one of Execer, Queryer, or Pinger is required in SQLConfig")
+	}
+
+	if (cfg.Execer != nil || cfg.Queryer != nil) && len(cfg.Query) == 0 {
+		return fmt.Errorf("SQLConfig.Query is required")
+	}
+
+	return nil
+}
+
+// Status is used for performing a database ping against a dependency; it satisfies
+// the "ICheckable" interface.
+func (s *SQL) Status() (interface{}, error) {
+	if err := validateSQLConfig(s.Config); err != nil {
+		return nil, err
+	}
+
+	switch {
+	// check for SQLExecer first
+	case s.Config.Execer != nil:
+		// if the result handler is nil, use the default
+		if s.Config.ExecerResultHandler == nil {
+			s.Config.ExecerResultHandler = DefaultExecHandler
+		}
+		// run the execer
+		return s.runExecer()
+	// check for SQLQueryer next
+	case s.Config.Queryer != nil:
+		// if the result handler is nil, use the default
+		if s.Config.QueryerResultHandler == nil {
+			s.Config.QueryerResultHandler = DefaultQueryHandler
+		}
+		// run the queryer
+		return s.runQueryer()
+	// finally, must be a pinger
+	default:
+		ctx := context.Background()
+		return nil, s.Config.Pinger.PingContext(ctx)
+	}
+}
+
+// This will run the execer from the Status func
+func (s *SQL) runExecer() (interface{}, error) {
+	ctx := context.Background()
+	result, err := s.Config.Execer.ExecContext(ctx, s.Config.Query, s.Config.Params...)
+	if err != nil {
+		return nil, err
+	}
+
+	ok, err := s.Config.ExecerResultHandler(result)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, fmt.Errorf("userland exec result handler returned false")
+	}
+
+	return nil, nil
+}
+
+// This will run the queryer from the Status func
+func (s *SQL) runQueryer() (interface{}, error) {
+	ctx := context.Background()
+	rows, err := s.Config.Queryer.QueryContext(ctx, s.Config.Query, s.Config.Params...)
+	if err != nil {
+		return nil, err
+	}
+
+	// the BYO result handler is responsible for closing the rows
+
+	ok, err := s.Config.QueryerResultHandler(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, fmt.Errorf("userland query result handler returned false")
+	}
+
+	return nil, nil
+}

--- a/vendor/github.com/InVisionApp/go-health/health.go
+++ b/vendor/github.com/InVisionApp/go-health/health.go
@@ -1,0 +1,364 @@
+// Package health is a library that enables *async* dependency health checking for services running on an orchestrated container platform such as kubernetes or mesos.
+//
+// For additional overview, documentation and contribution guidelines, refer to the project's "README.md".
+//
+// For example usage, refer to https://github.com/InVisionApp/go-health/tree/master/examples/simple-http-server.
+package health
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/InVisionApp/go-logger"
+)
+
+//go:generate counterfeiter -o ./fakes/icheckable.go . ICheckable
+
+var (
+	// ErrNoAddCfgWhenActive is returned when you attempt to add check(s) to an already active healthcheck instance
+	ErrNoAddCfgWhenActive = errors.New("Unable to add new check configuration(s) while healthcheck is active")
+
+	// ErrAlreadyRunning is returned when you attempt to "h.Start()" an already running healthcheck
+	ErrAlreadyRunning = errors.New("Healthcheck is already running - nothing to start")
+
+	// ErrAlreadyStopped is returned when you attempt to "h.Stop()" a non-running healthcheck instance
+	ErrAlreadyStopped = errors.New("Healthcheck is not running - nothing to stop")
+
+	// ErrEmptyConfigs is returned when you attempt to add an empty slice of configs via "h.AddChecks()"
+	ErrEmptyConfigs = errors.New("Configs appears to be empty - nothing to add")
+)
+
+// The IHealth interface can be useful if you plan on replacing the actual health
+// checker with a mock during testing. Otherwise, you can set "hc.Disable = true"
+// after instantiation.
+type IHealth interface {
+	AddChecks(cfgs []*Config) error
+	AddCheck(cfg *Config) error
+	Start() error
+	Stop() error
+	State() (map[string]State, bool, error)
+	Failed() bool
+}
+
+// ICheckable is an interface implemented by a number of bundled checkers such
+// as "MySQLChecker", "RedisChecker" and "HTTPChecker". By implementing the
+// interface, you can feed your own custom checkers into the health library.
+type ICheckable interface {
+	// Status allows you to return additional data as an "interface{}" and "error"
+	// to signify that the check has failed. If "interface{}" is non-nil, it will
+	// be exposed under "State.Details" for that particular check.
+	Status() (interface{}, error)
+}
+
+// IStatusListener is an interface that handles health check failures and
+// recoveries, primarily for stats recording purposes
+type IStatusListener interface {
+	// HealthCheckFailed is a function that handles the failure of a health
+	// check event. This function is called when a health check state
+	// transitions from passing to failing.
+	// 	* entry - The recorded state of the health check that triggered the failure
+	HealthCheckFailed(entry *State)
+
+	// HealthCheckRecovered is a function that handles the recovery of a failed
+	// health check.
+	// 	* entry - The recorded state of the health check that triggered the recovery
+	// 	* recordedFailures - the total failed health checks that lapsed
+	// 	  between the failure and recovery
+	//	* failureDurationSeconds - the lapsed time, in seconds, of the recovered failure
+	HealthCheckRecovered(entry *State, recordedFailures int64, failureDurationSeconds float64)
+}
+
+// Config is a struct used for defining and configuring checks.
+type Config struct {
+	// Name of the check
+	Name string
+
+	// Checker instance used to perform health check
+	Checker ICheckable
+
+	// Interval between health checks
+	Interval time.Duration
+
+	// Fatal marks a failing health check so that the
+	// entire health check request fails with a 500 error
+	Fatal bool
+
+	// Hook that gets called when this health check is complete
+	OnComplete func(state *State)
+}
+
+// State is a struct that contains the results of the latest
+// run of a particular check.
+type State struct {
+	// Name of the health check
+	Name string `json:"name"`
+
+	// Status of the health check state ("ok" or "failed")
+	Status string `json:"status"`
+
+	// Err is the error returned from a failed health check
+	Err string `json:"error,omitempty"`
+
+	// Fatal shows if the check will affect global result
+	Fatal bool `json:"fatal,omitempty"`
+
+	// Details contains more contextual detail about a
+	// failing health check.
+	Details interface{} `json:"details,omitempty"` // contains JSON message (that can be marshaled)
+
+	// CheckTime is the time of the last health check
+	CheckTime time.Time `json:"check_time"`
+
+	ContiguousFailures int64     `json:"num_failures"`     // the number of failures that occurred in a row
+	TimeOfFirstFailure time.Time `json:"first_failure_at"` // the time of the initial transitional failure for any given health check
+}
+
+// indicates state is failure
+func (s *State) isFailure() bool {
+	return s.Status == "failed"
+}
+
+// Health contains internal go-health internal structures.
+type Health struct {
+	Logger log.Logger
+
+	// StatusListener will report failures and recoveries
+	StatusListener IStatusListener
+
+	active     *sBool // indicates whether the healthcheck is actively running
+	configs    []*Config
+	states     map[string]State
+	statesLock sync.Mutex
+	runners    map[string]chan struct{} // contains map of active runners w/ a stop channel
+}
+
+// New returns a new instance of the Health struct.
+func New() *Health {
+	return &Health{
+		Logger:     log.NewSimple(),
+		configs:    make([]*Config, 0),
+		states:     make(map[string]State, 0),
+		runners:    make(map[string]chan struct{}, 0),
+		active:     newBool(),
+		statesLock: sync.Mutex{},
+	}
+}
+
+// DisableLogging will disable all logging by inserting the noop logger.
+func (h *Health) DisableLogging() {
+	h.Logger = log.NewNoop()
+}
+
+// AddChecks is used for adding multiple check definitions at once (as opposed
+// to adding them sequentially via "AddCheck()").
+func (h *Health) AddChecks(cfgs []*Config) error {
+	if h.active.val() {
+		return ErrNoAddCfgWhenActive
+	}
+
+	h.configs = append(h.configs, cfgs...)
+
+	return nil
+}
+
+// AddCheck is used for adding a single check definition to the current health
+// instance.
+func (h *Health) AddCheck(cfg *Config) error {
+	if h.active.val() {
+		return ErrNoAddCfgWhenActive
+	}
+
+	h.configs = append(h.configs, cfg)
+	return nil
+}
+
+// Start will start all of the defined health checks. Each of the checks run in
+// their own goroutines (as "time.Ticker").
+func (h *Health) Start() error {
+	if h.active.val() {
+		return ErrAlreadyRunning
+	}
+
+	// if there are no check configs, this is a noop
+	if len(h.configs) < 1 {
+		return nil
+	}
+
+	for _, c := range h.configs {
+		h.Logger.WithFields(log.Fields{"name": c.Name}).Debug("Starting checker")
+		ticker := time.NewTicker(c.Interval)
+		stop := make(chan struct{})
+
+		h.startRunner(c, ticker, stop)
+
+		h.runners[c.Name] = stop
+	}
+
+	// Checkers are now actively running
+	h.active.setTrue()
+
+	return nil
+}
+
+// Stop will cause all of the running health checks to be stopped. Additionally,
+// all existing check states will be reset.
+func (h *Health) Stop() error {
+	if !h.active.val() {
+		return ErrAlreadyStopped
+	}
+
+	for name, stop := range h.runners {
+		h.Logger.WithFields(log.Fields{"name": name}).Debug("Stopping checker")
+		close(stop)
+	}
+
+	// Reset runner map
+	h.runners = make(map[string]chan struct{}, 0)
+
+	// Reset states
+	h.safeResetStates()
+
+	return nil
+}
+
+// State will return a map of all current healthcheck states (thread-safe), a
+// bool indicating whether the healthcheck has fully failed and a potential error.
+//
+// The returned structs can be used for figuring out additional analytics or
+// used for building your own status handler (as opposed to using the built-in
+// "hc.HandlerBasic" or "hc.HandlerJSON").
+//
+// The map key is the name of the check.
+func (h *Health) State() (map[string]State, bool, error) {
+	return h.safeGetStates(), h.Failed(), nil
+}
+
+// Failed will return the basic state of overall health. This should be used when
+// details about the failure are not needed
+func (h *Health) Failed() bool {
+	for _, val := range h.safeGetStates() {
+		if val.Fatal && val.isFailure() {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Health) startRunner(cfg *Config, ticker *time.Ticker, stop <-chan struct{}) {
+
+	// function to execute and collect check data
+	checkFunc := func() {
+		data, err := cfg.Checker.Status()
+
+		stateEntry := &State{
+			Name:      cfg.Name,
+			Status:    "ok",
+			Details:   data,
+			CheckTime: time.Now(),
+			Fatal:     cfg.Fatal,
+		}
+
+		if err != nil {
+			h.Logger.WithFields(log.Fields{
+				"check": cfg.Name,
+				"fatal": cfg.Fatal,
+				"err":   err,
+			}).Error("healthcheck has failed")
+
+			stateEntry.Err = err.Error()
+			stateEntry.Status = "failed"
+		}
+
+		h.safeUpdateState(stateEntry)
+
+		if cfg.OnComplete != nil {
+			go cfg.OnComplete(stateEntry)
+		}
+	}
+
+	go func() {
+		defer ticker.Stop()
+
+		// execute once so that it is immediate
+		checkFunc()
+
+		// all following executions
+	RunLoop:
+		for {
+			select {
+			case <-ticker.C:
+				checkFunc()
+			case <-stop:
+				break RunLoop
+			}
+		}
+
+		h.Logger.WithFields(log.Fields{"name": cfg.Name}).Debug("Checker exiting")
+	}()
+}
+
+// resets the states in a concurrency-safe manner
+func (h *Health) safeResetStates() {
+	h.statesLock.Lock()
+	defer h.statesLock.Unlock()
+	h.states = make(map[string]State, 0)
+}
+
+// updates the check state in a concurrency-safe manner
+func (h *Health) safeUpdateState(stateEntry *State) {
+	// dispatch any status listeners
+	h.handleStatusListener(stateEntry)
+
+	// update states here
+	h.statesLock.Lock()
+	defer h.statesLock.Unlock()
+
+	h.states[stateEntry.Name] = *stateEntry
+}
+
+// get all states in a concurrency-safe manner
+func (h *Health) safeGetStates() map[string]State {
+	h.statesLock.Lock()
+	defer h.statesLock.Unlock()
+
+	// deep copy h.states to avoid race
+	statesCopy := make(map[string]State, 0)
+
+	for k, v := range h.states {
+		statesCopy[k] = v
+	}
+
+	return statesCopy
+}
+
+// if a status listener is attached
+func (h *Health) handleStatusListener(stateEntry *State) {
+	// get the previous state
+	h.statesLock.Lock()
+	prevState := h.states[stateEntry.Name]
+	h.statesLock.Unlock()
+
+	// state is failure
+	if stateEntry.isFailure() {
+		if !prevState.isFailure() {
+			// new failure: previous state was ok
+			if h.StatusListener != nil {
+				go h.StatusListener.HealthCheckFailed(stateEntry)
+			}
+
+			stateEntry.TimeOfFirstFailure = time.Now()
+		} else {
+			// carry the time of first failure from the previous state
+			stateEntry.TimeOfFirstFailure = prevState.TimeOfFirstFailure
+		}
+		stateEntry.ContiguousFailures = prevState.ContiguousFailures + 1
+	} else if prevState.isFailure() {
+		// recovery, previous state was failure
+		failureSeconds := time.Now().Sub(prevState.TimeOfFirstFailure).Seconds()
+
+		if h.StatusListener != nil {
+			go h.StatusListener.HealthCheckRecovered(stateEntry, prevState.ContiguousFailures, failureSeconds)
+		}
+	}
+}

--- a/vendor/github.com/InVisionApp/go-health/safe.go
+++ b/vendor/github.com/InVisionApp/go-health/safe.go
@@ -1,0 +1,48 @@
+package health
+
+import "sync"
+
+//#################
+//Thread Safe Types
+//#################
+
+type sBool struct {
+	v  bool
+	mu sync.Mutex
+}
+
+func newBool() *sBool {
+	return &sBool{v: false}
+}
+
+func (b *sBool) set(v bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.v = v
+}
+
+func (b *sBool) setFalse() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.v = false
+}
+
+func (b *sBool) setTrue() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.v = true
+}
+
+func (b *sBool) val() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.v
+}
+
+func (b *sBool) String() string {
+	if b.val() {
+		return "true"
+	}
+
+	return "false"
+}

--- a/vendor/github.com/InVisionApp/go-logger/LICENSE
+++ b/vendor/github.com/InVisionApp/go-logger/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 InVision
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/InVisionApp/go-logger/log.go
+++ b/vendor/github.com/InVisionApp/go-logger/log.go
@@ -1,0 +1,201 @@
+package log
+
+import (
+	"fmt"
+	stdlog "log"
+)
+
+//go:generate counterfeiter -o shims/fake/fake_logger.go . Logger
+
+// Logger interface allows you to maintain a unified interface while using a
+// custom logger. This allows you to write log statements without dictating
+// the specific underlying library used for logging. You can avoid vendoring
+// of logging libraries, which is especially useful when writing shared code
+// such as a library. This package contains a simple logger and a no-op logger
+// which both implement this interface. It is also supplemented with some
+// additional helpers/shims for other common logging libraries such as logrus
+type Logger interface {
+	Debug(msg ...interface{})
+	Info(msg ...interface{})
+	Warn(msg ...interface{})
+	Error(msg ...interface{})
+
+	Debugln(msg ...interface{})
+	Infoln(msg ...interface{})
+	Warnln(msg ...interface{})
+	Errorln(msg ...interface{})
+
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+
+	WithFields(Fields) Logger
+}
+
+// Fields is used to define structured fields which are appended to log messages
+type Fields map[string]interface{}
+
+/**************
+ Simple Logger
+**************/
+
+type simple struct {
+	fields map[string]interface{}
+}
+
+// NewSimple creates a basic logger that wraps the core log library.
+func NewSimple() Logger {
+	return &simple{}
+}
+
+// WithFields will return a new logger based on the original logger
+// with the additional supplied fields
+func (b *simple) WithFields(fields Fields) Logger {
+	cp := &simple{}
+
+	if b.fields == nil {
+		cp.fields = fields
+		return cp
+	}
+
+	cp.fields = make(map[string]interface{}, len(b.fields)+len(fields))
+	for k, v := range b.fields {
+		cp.fields[k] = v
+	}
+
+	for k, v := range fields {
+		cp.fields[k] = v
+	}
+
+	return cp
+}
+
+// Debug log message
+func (b *simple) Debug(msg ...interface{}) {
+	stdlog.Printf("[DEBUG] %s %s", fmt.Sprint(msg...), pretty(b.fields))
+}
+
+// Info log message
+func (b *simple) Info(msg ...interface{}) {
+	stdlog.Printf("[INFO] %s %s", fmt.Sprint(msg...), pretty(b.fields))
+}
+
+// Warn log message
+func (b *simple) Warn(msg ...interface{}) {
+	stdlog.Printf("[WARN] %s %s", fmt.Sprint(msg...), pretty(b.fields))
+}
+
+// Error log message
+func (b *simple) Error(msg ...interface{}) {
+	stdlog.Printf("[ERROR] %s %s", fmt.Sprint(msg...), pretty(b.fields))
+}
+
+// Debugln log line message
+func (b *simple) Debugln(msg ...interface{}) {
+	a := fmt.Sprintln(msg...)
+	stdlog.Println("[DEBUG]", a[:len(a)-1], pretty(b.fields))
+}
+
+// Infoln log line message
+func (b *simple) Infoln(msg ...interface{}) {
+	a := fmt.Sprintln(msg...)
+	stdlog.Println("[INFO]", a[:len(a)-1], pretty(b.fields))
+}
+
+// Warnln log line message
+func (b *simple) Warnln(msg ...interface{}) {
+	a := fmt.Sprintln(msg...)
+	stdlog.Println("[WARN]", a[:len(a)-1], pretty(b.fields))
+}
+
+// Errorln log line message
+func (b *simple) Errorln(msg ...interface{}) {
+	a := fmt.Sprintln(msg...)
+	stdlog.Println("[ERROR]", a[:len(a)-1], pretty(b.fields))
+}
+
+// Debugf log message with formatting
+func (b *simple) Debugf(format string, args ...interface{}) {
+	stdlog.Print(fmt.Sprintf("[DEBUG] "+format, args...), " ", pretty(b.fields))
+}
+
+// Infof log message with formatting
+func (b *simple) Infof(format string, args ...interface{}) {
+	stdlog.Print(fmt.Sprintf("[INFO] "+format, args...), " ", pretty(b.fields))
+}
+
+// Warnf log message with formatting
+func (b *simple) Warnf(format string, args ...interface{}) {
+	stdlog.Print(fmt.Sprintf("[WARN] "+format, args...), " ", pretty(b.fields))
+}
+
+// Errorf log message with formatting
+func (b *simple) Errorf(format string, args ...interface{}) {
+	stdlog.Print(fmt.Sprintf("[ERROR] "+format, args...), " ", pretty(b.fields))
+}
+
+// helper for pretty printing of fields
+func pretty(m map[string]interface{}) string {
+	if len(m) < 1 {
+		return ""
+	}
+
+	s := ""
+	for k, v := range m {
+		s += fmt.Sprintf("%s=%v ", k, v)
+	}
+
+	return s[:len(s)-1]
+}
+
+/*************
+ No-Op Logger
+*************/
+
+type noop struct{}
+
+// NewNoop creates a no-op logger that can be used to silence
+// all logging from this library. Also useful in tests.
+func NewNoop() Logger {
+	return &noop{}
+}
+
+// Debug log message no-op
+func (n *noop) Debug(msg ...interface{}) {}
+
+// Info log message no-op
+func (n *noop) Info(msg ...interface{}) {}
+
+// Warn log message no-op
+func (n *noop) Warn(msg ...interface{}) {}
+
+// Error log message no-op
+func (n *noop) Error(msg ...interface{}) {}
+
+// Debugln line log message no-op
+func (n *noop) Debugln(msg ...interface{}) {}
+
+// Infoln line log message no-op
+func (n *noop) Infoln(msg ...interface{}) {}
+
+// Warnln line log message no-op
+func (n *noop) Warnln(msg ...interface{}) {}
+
+// Errorln line log message no-op
+func (n *noop) Errorln(msg ...interface{}) {}
+
+// Debugf log message with formatting no-op
+func (n *noop) Debugf(format string, args ...interface{}) {}
+
+// Infof log message with formatting no-op
+func (n *noop) Infof(format string, args ...interface{}) {}
+
+// Warnf log message with formatting no-op
+func (n *noop) Warnf(format string, args ...interface{}) {}
+
+// Errorf log message with formatting no-op
+func (n *noop) Errorf(format string, args ...interface{}) {}
+
+// WithFields no-op
+func (n *noop) WithFields(fields Fields) Logger { return n }


### PR DESCRIPTION
turn a service on/off based on the status of the health check provided.

** Background

On GCP, network load balancing requires modification of the local machine's routes to include the forwarded_ips of the LB rules.
Therefore, for a VM in the backend pool, the traffic to the LB never leaves the box (regardless of the health checks...)
for more info: https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#test-from-backend-vms

This esp. affects the OpenShift control-plane as the clients like kubelet, openshift-networking (SDN) communicate with the apiserver using the LB.. and therefore can only communicate if the
local apiservers is running. This is very fragile during roll-out of the apiserver pods as any interminent faliure to start the local apiserver pod means that kubelet on the machine can no longer
reach any api to receive new pods for recovery to new version of the apiserver. A lot of the early users and CI is seeing these kinds of failures.

** What

With https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/481, the RHCOS's gcp-routes.service now cleans up any routes that were added for forwarded_ips when stopped, so to recover the blackhole, a user can logon to the machine
and stop the service long enough for progress to happen and then start the service again to get traffic again..

gcp-routes-controller performs health checks on the local apiserver so that,
- When the apiserver is known to be failing, the momentum to mark failure is large enough to not interfer with LB's halthchecks and trigger only in require's intervention cases, stop the gcp-routes.service to allow clients to communicate to other apiservers over the LB
- When the apiserver is running (succeeding), the momentum to mark sucess to small enough that the Lb's health checks will adde the instance to it's backend, it starts the service.

** What it solves

It solves 2 cases for GCP:

1) Improves the reliability of the apiserver roll-outs on GCP, making sure the kubelets have a chance to receive new versions that can unstick roll-outs

2) Improve the installation of GCP.
   Currently, the installer during bootstrapping only adds the bootstrap-host to the LB backend, as adding the control-plane makes the kubelets on those nodes incapaable to reaching out the bootstrap-control-plane on the bootstrap-host
   and switches the backends to control-plane during bootstrap destroy, making destroy bootstrap a required step to complete the bootstrapping and also creating a period of time where there are no active backends.
   On other platforms, installer keeps all nodes in the LB backend and after bootstrap-complete the bootstap-host is remove from the backends by the LB itself and technically the bootstrap destroy step is not required.

   This helps bring the GCP flow at par with others as the gcp-route-controller on the control-plane hosts will run the gcp-routes when the apiserver is running locally and the installer can keep all machines in the backend.

Other suggestions:

1) The same can be achieved by removing and adding nodes from the backend.
For this to work, all forwarding rules must be updated the remove the machine, which requires more nuanced agent that lists the forwarding rule to find out which backends have itself included and tracking membership... which can be api limits heavy.