### PR TITLE
pkg/server: Increase verbosity of server launching

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -48,7 +48,7 @@ func (a *APIServer) Serve() {
 		Handler: a.handler,
 	}
 
-	glog.Info("launching server")
+	glog.Infof("Launching server on %s", mcs.Addr)
 	if a.insecure {
 		// Serve a non TLS server.
 		if err := mcs.ListenAndServe(); err != http.ErrServerClosed {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This is a tiny improvement to the MCS init code logging. 
Right now, when you check the pods logs for the MCS, you see 2 lines that say `launching server`, one after another. This is confusing if you don't know that the MCS hosts both secure and insecure servers.  This PR changes the logging output so its more clear that the MCS is listening and serving on 2 different addresses, rather than accidentally starting 2 of the same server.
 
**- How to verify it**
Deploy image.
`oc logs machine-config-server-xxxx`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
pkg/server: Increase verbosity of server launching