### PR TITLE
openstack: import HAproxy config fixes from BM

### DIFF
--- a/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
@@ -5,7 +5,7 @@ contents:
   inline: |
     defaults
       mode    tcp
-      log     global
+      log     /var/run/haproxy/haproxy-log.sock local0
       option  dontlognull
       retries 3
       timeout http-request 10s

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -58,10 +58,15 @@ contents:
           }
           set -ex
           declare -r haproxy_sock="/var/run/haproxy/haproxy-master.sock"
+          declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
           export -f msg_handler
           export -f reload_haproxy
           if [ -S "$haproxy_sock" ]; then
               rm "$haproxy_sock"
+          fi
+          socat UNIX-RECV:${haproxy_log_sock} STDOUT &
+          if [ -s "/etc/haproxy/haproxy.cfg" ]; then
+              /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
           fi
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
         volumeMounts:


### PR DESCRIPTION
The OpenStack HAproxy static pod configuration was copied from the
Baremetal implementation. This commit pulls the following 2 fixes from
BM haproxy config:

https://github.com/openshift/machine-config-operator/commit/8082db516b5d38c9d92a0f684c8a80a4816c93c0

https://github.com/openshift/machine-config-operator/commit/7b997f6c859240409f34539871190e433c1a872f

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
