### PR TITLE
Makefile: increase test-e2e timeout to 120m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ images.rhel7: $(imc7)
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	go test -timeout 90m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -121,7 +121,7 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 // waitForPoolComplete polls a pool until it has completed an update to target
 func waitForPoolComplete(t *testing.T, cs *framework.ClientSet, pool, target string) error {
 	startTime := time.Now()
-	if err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
+	if err := wait.Poll(2*time.Second, 20*time.Minute, func() (bool, error) {
 		mcp, err := cs.MachineConfigPools().Get(pool, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -145,7 +145,7 @@ func TestMCDeployed(t *testing.T) {
 	bumpPoolMaxUnavailableTo(t, cs, 3)
 
 	// TODO: bring this back to 10
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		startTime := time.Now()
 		mcadd := createMCToAddFile("add-a-file", fmt.Sprintf("/etc/mytestconf%d", i), "test", "root")
 


### PR DESCRIPTION
Since the router pod started using a PDB, we're noticing a 3m+ delay in
drain on the node that hosts the router, which makes e2e timeouts.
This patch increases the timeout to 120m to be sure we're in time.

Fix #1039 

Signed-off-by: Antonio Murdaca <runcom@linux.com>