### PR TITLE
baremetal: keepalived to pass cluster-config.yml to runtimecfg

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -18,6 +18,9 @@ spec:
       path: "/etc/kubernetes/kubeconfig"
   - name: conf-dir
     empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
   initContainers:
   - name: render-config
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
@@ -34,6 +37,8 @@ spec:
     - "/config"
     - "--out-dir"
     - "/etc/keepalived"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
     resources: {}
     volumeMounts:
     - name: resource-dir
@@ -42,6 +47,8 @@ spec:
       mountPath: "/etc/kubernetes/kubeconfig"
     - name: conf-dir
       mountPath: "/etc/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
     imagePullPolicy: IfNotPresent
   containers:
   - name: keepalived

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -299,6 +299,9 @@ spec:
       path: "/etc/kubernetes/kubeconfig"
   - name: conf-dir
     empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
   initContainers:
   - name: render-config
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
@@ -315,6 +318,8 @@ spec:
     - "/config"
     - "--out-dir"
     - "/etc/keepalived"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
     resources: {}
     volumeMounts:
     - name: resource-dir
@@ -323,6 +328,8 @@ spec:
       mountPath: "/etc/kubernetes/kubeconfig"
     - name: conf-dir
       mountPath: "/etc/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
     imagePullPolicy: IfNotPresent
   containers:
   - name: keepalived


### PR DESCRIPTION
A recent installer change started using a loopback address in kubeconfig
as the default on the bootstrap node. baremetal-runtimecfg will begin
using cluster-config.yml if it exists first, in order to get the domain
and name of the cluster.

This patch adds a flag for this to the keepalived bootstrap pod in order
to utilize it. This should only affect the bootstrap pods.

Fixes: #1037
Depends on openshift/baremetal-runtimecfg#16

