### PR TITLE
templates: Don't run machine-config-daemon-host on BYO RHEL

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-host.service
+++ b/templates/common/_base/units/machine-config-daemon-host.service
@@ -3,6 +3,9 @@ enabled: true
 contents: |
   [Unit]
   Description=Machine Config Daemon Initial
+  # This only applies to ostree (MCD) systems;
+  # see also https://github.com/openshift/machine-config-operator/issues/1046
+  ConditionPathExists=/run/ostree-booted
   ConditionPathExists=/etc/pivot/image-pullspec
   # If pivot exists, defer to it.  Note similar code in update.go
   ConditionPathExists=!/usr/lib/systemd/system/pivot.service


### PR DESCRIPTION
Implicitly this was happening before because the `pivot` package
contained the systemd unit, and so there was nothing to react
to the MCS injecting `/etc/pivot/image-pullspec`.  Now that the MCD
injects this systemd unit, we need to ensure it's only run
on ostree-managed systems, not BYO RHEL.

Closes: https://github.com/openshift/machine-config-operator/issues/1046
