### PR TITLE
openstack: keepalived to pass cluster-config.yml to runtimecfg

### DIFF
--- a/manifests/openstack/keepalived.yaml
+++ b/manifests/openstack/keepalived.yaml
@@ -18,6 +18,9 @@ spec:
       path: "/etc/kubernetes/kubeconfig"
   - name: conf-dir
     empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
   initContainers:
   - name: render-config
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
@@ -34,6 +37,8 @@ spec:
     - "/config"
     - "--out-dir"
     - "/etc/keepalived"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
     resources: {}
     volumeMounts:
     - name: resource-dir
@@ -42,6 +47,8 @@ spec:
       mountPath: "/etc/kubernetes/kubeconfig"
     - name: conf-dir
       mountPath: "/etc/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
     imagePullPolicy: IfNotPresent
   containers:
   - name: keepalived

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1822,6 +1822,9 @@ spec:
       path: "/etc/kubernetes/kubeconfig"
   - name: conf-dir
     empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
   initContainers:
   - name: render-config
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
@@ -1838,6 +1841,8 @@ spec:
     - "/config"
     - "--out-dir"
     - "/etc/keepalived"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
     resources: {}
     volumeMounts:
     - name: resource-dir
@@ -1846,6 +1851,8 @@ spec:
       mountPath: "/etc/kubernetes/kubeconfig"
     - name: conf-dir
       mountPath: "/etc/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
     imagePullPolicy: IfNotPresent
   containers:
   - name: keepalived


### PR DESCRIPTION
This pulls in fix
https://github.com/openshift/machine-config-operator/pull/1043 for
openstack.

A recent installer change started using a loopback address in
kubeconfig as the default on the bootstrap node. baremetal-runtimecfg
will begin using cluster-config.yml if it exists first, in order to get
the domain and name of the cluster.

This patch adds a flag for this to the keepalived bootstrap pod in
order to utilize it. This should only affect the bootstrap pods.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
