### PR TITLE
Bug 1737575: DR: use observed directories vs assumptions for backup_etcd_client_certs

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -34,19 +34,27 @@ contents:
       if [ -f "$ASSET_DIR/backup/etcd-ca-bundle.crt" ] && [ -f "$ASSET_DIR/backup/etcd-client.crt" ] && [ -f "$ASSET_DIR/backup/etcd-client.key" ]; then
          echo "etcd client certs already backed up and available $ASSET_DIR/backup/"
       else
-        for i in {1..10}; do
-            SECRET_DIR="${CONFIG_FILE_DIR}/static-pod-resources/kube-apiserver-pod-${i}/secrets/etcd-client"
-            CONFIGMAP_DIR="${CONFIG_FILE_DIR}/static-pod-resources/kube-apiserver-pod-${i}/configmaps/etcd-serving-ca"
-            if [ -f "$CONFIGMAP_DIR/ca-bundle.crt" ] && [ -f "$SECRET_DIR/tls.crt" ] && [ -f "$SECRET_DIR/tls.key" ]; then
-              cp $CONFIGMAP_DIR/ca-bundle.crt $ASSET_DIR/backup/etcd-ca-bundle.crt
-              cp $SECRET_DIR/tls.crt $ASSET_DIR/backup/etcd-client.crt
-              cp $SECRET_DIR/tls.key $ASSET_DIR/backup/etcd-client.key
-              break
-            else
-              echo "$SECRET_DIR does not contain etcd client certs, trying next source .."
-            fi
+        STATIC_DIRS=($(ls -d "${CONFIG_FILE_DIR}"/static-pod-resources/kube-apiserver-pod-[0-9]*))
+        if [ "$?" -ne 0 ]; then
+          echo "error finding static-pod-resources"
+          exit 1
+        fi
+        for APISERVER_POD_DIR in "${STATIC_DIRS[@]}"; do
+          SECRET_DIR="${APISERVER_POD_DIR}/secrets/etcd-client"
+          CONFIGMAP_DIR="${APISERVER_POD_DIR}/configmaps/etcd-serving-ca"
+          if [ -f "$CONFIGMAP_DIR/ca-bundle.crt" ] && [ -f "$SECRET_DIR/tls.crt" ] && [ -f "$SECRET_DIR/tls.key" ]; then
+            echo "etcd client certs found in $APISERVER_POD_DIR backing up to $ASSET_DIR/backup/"
+            cp $CONFIGMAP_DIR/ca-bundle.crt $ASSET_DIR/backup/etcd-ca-bundle.crt
+            cp $SECRET_DIR/tls.crt $ASSET_DIR/backup/etcd-client.crt
+            cp $SECRET_DIR/tls.key $ASSET_DIR/backup/etcd-client.key
+            return 0
+          else
+            echo "${APISERVER_POD_DIR} does not contain etcd client certs, trying next .."
+          fi
         done
-       fi
+        echo "backup failed: client certs not found"
+        exit 1
+      fi
     }
 
     # backup current etcd-member pod manifest


### PR DESCRIPTION
Currently, we use a poor assumption that the static pod revision will never go higher than 10[1]. As reported in BZ and confirmed with masters team this is not the case. While the controller would set a MaxEligibleRevision[2] this does mean a linear 0 -> N meaning although `0 - 9` is valid so is `20 - 29`. So we no longer assume instead we populate an array with observed directories output from ls.


[1]https://github.com/openshift/machine-config-operator/compare/master...hexfusion:fx_etcd_backup?expand=1#diff-df2f7b2c367c15c3aa83f8b8e002b3d8L37
[2] https://github.com/openshift/library-go/blob/a5507e7eb29c0ec68b73bd355cf5d248586fd776/pkg/operator/staticpod/prune/cmd.go#L56

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1737575
