### PR TITLE
gcp: add resource requests to gcp-routes-controller to make sure it is not in BestEffortQoS

### DIFF
--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
@@ -16,6 +16,10 @@ contents:
         args:
         - "run"
         - "--health-check-url=https://127.0.0.1:6443/healthz"
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true


### PR DESCRIPTION
**- What I did**

Added resource request to gcp-routes-controller. Added similar requests to machine-config-server

**- Why**
Test `[Feature:Platform][Smoke] Managed cluster should ensure control plane pods do not run in best-effort QoS [Suite:openshift/conformance/parallel]` is failing example
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/23569/pull-ci-openshift-origin-master-e2e-gcp/3217

because gcp-routes-controller pod is given BestEffortQoS as it doesn't define any resource requests.

more info: https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-burstable

/cc @csrwng 
