### PR TITLE
Bug 1734554: DR: add etcd-member-remove.sh

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-remove-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-remove-sh.yaml
@@ -1,0 +1,42 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/etcd-member-remove.sh"
+contents:
+  inline: |
+    #!/usr/bin/env bash
+
+    # example
+    # sudo ./etcd-member-remove.sh $etcd_name
+
+    if [[ $EUID -ne 0 ]]; then
+      echo "This script must be run as root"
+      exit 1
+    fi
+
+    usage () {
+        echo 'The name of the etcd member to remove is required: ./etcd-member-remove.sh $etcd_name'
+        exit 1
+    }
+
+    if [ "$1" == "" ]; then
+        usage
+    fi
+
+    ETCD_NAME=$1
+    ASSET_DIR=./assets
+    ASSET_DIR_TMP="$ASSET_DIR/tmp"
+    ETCDCTL=$ASSET_DIR/bin/etcdctl
+    ETCD_VERSION=v3.3.10
+    ETCD_DATA_DIR=/var/lib/etcd
+    CONFIG_FILE_DIR=/etc/kubernetes
+
+    source "/usr/local/bin/openshift-recovery-tools"
+
+    function run {
+      init
+      dl_etcdctl
+      backup_etcd_client_certs
+      etcd_member_remove $ETCD_NAME
+    }
+
+    run

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -4,6 +4,9 @@ path: "/usr/local/bin/openshift-recovery-tools"
 contents:
   inline: |
     #!/usr/bin/env bash
+    export ETCDCTL_API=3
+
+    ETCDCTL_WITH_TLS="$ETCDCTL --cert $ASSET_DIR/backup/etcd-client.crt --key $ASSET_DIR/backup/etcd-client.key --cacert $ASSET_DIR/backup/etcd-ca-bundle.crt"
 
     init() {
       ASSET_BIN=${ASSET_DIR}/bin
@@ -25,7 +28,7 @@ contents:
         && tar -xzf $ASSET_DIR/tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -C $ASSET_DIR/shared --strip-components=1 \
         && mv $ASSET_DIR/shared/etcdctl $ASSET_DIR/bin \
         && rm $ASSET_DIR/shared/etcd \
-        && ETCDCTL_API=3 $ASSET_DIR/bin/etcdctl version
+        && $ASSET_DIR/bin/etcdctl version
     }
 
     #backup etcd client certs
@@ -89,11 +92,7 @@ contents:
     }
 
     snapshot_data_dir() {
-      ETCDCTL_API=3 ${ETCDCTL} \
-        --cert $ASSET_DIR/backup/etcd-client.crt \
-        --key $ASSET_DIR/backup/etcd-client.key \
-        --cacert $ASSET_DIR/backup/etcd-ca-bundle.crt \
-        snapshot save ${SNAPSHOT_FILE}
+      ${ETCDCTL_WITH_TLS} snapshot save ${SNAPSHOT_FILE}
     }
 
     # backup etcd peer, server and metric certs
@@ -153,7 +152,7 @@ contents:
       fi
 
       echo "Restoring etcd member $ETCD_NAME from snapshot.."
-      env ETCDCTL_API=3 ${ETCDCTL} snapshot restore $SNAPSHOT_FILE \
+      ${ETCDCTL} snapshot restore $SNAPSHOT_FILE \
         --name $ETCD_NAME \
         --initial-cluster ${ETCD_INITIAL_CLUSTER} \
         --initial-cluster-token etcd-cluster-1 \
@@ -196,7 +195,7 @@ contents:
     EOF
     }
 
-    # add member cluster
+    # add member to cluster
     etcd_member_add() {
       echo "Updating etcd membership.."
       if [ -d "$ETCD_DATA_DIR" ]; then
@@ -204,22 +203,43 @@ contents:
         rm -rf $ETCD_DATA_DIR
       fi
 
-      RESPONSE=$(env ETCDCTL_API=3 $ETCDCTL --cert $ASSET_DIR/backup/etcd-client.crt --key $ASSET_DIR/backup/etcd-client.key --cacert $ASSET_DIR/backup/etcd-ca-bundle.crt \
-        --endpoints ${RECOVERY_SERVER_IP}:2379 member add $ETCD_NAME --peer-urls=https://${ETCD_DNS_NAME}:2380)
-
-       if [ $? -eq 0 ]; then
-         echo "$RESPONSE"
-         APPEND_CONF=$(echo "$RESPONSE" | sed -e '1,2d')
-         echo -e "\n\n#[recover]\n$APPEND_CONF" >> $ETCD_CONFIG
-       else
-         echo "$RESPONSE"
-         exit 1
-       fi
+      RESPONSE=$($ETCDCTL_WITH_TLS --endpoints ${RECOVERY_SERVER_IP}:2379 member add $ETCD_NAME --peer-urls=https://${ETCD_DNS_NAME}:2380)
+      if [ $? -eq 0 ]; then
+        echo "$RESPONSE"
+        APPEND_CONF=$(echo "$RESPONSE" | sed -e '1,2d')
+        echo -e "\n\n#[recover]\n$APPEND_CONF" >> $ETCD_CONFIG
+      else
+        echo "$RESPONSE"
+        exit 1
+      fi
     }
 
     start_etcd() {
       echo "Starting etcd.."
       mv ${MANIFEST_STOPPED_DIR}/etcd-member.yaml $MANIFEST_DIR
+    }
+
+    # remove member from cluster by name
+    etcd_member_remove() {
+      NAME="$1"
+
+      if [ -z "$NAME" ]; then
+        echo "etcd_member_remove requires 1 argument NAME"
+        exit 1
+      fi
+
+      ID=$($ETCDCTL_WITH_TLS member list | awk -F "," "/\s${NAME}\,/"'{print $1}')
+      if [ "$?" -ne 0 ] || [ -z "$ID" ]; then
+        echo "could not find etcd member $NAME to remove."
+        exit 1
+      fi
+
+      $ETCDCTL_WITH_TLS member remove $ID
+      if [ "$?" -ne 0 ]; then
+        echo "removing etcd member $NAME with ID: $ID failed"
+        exit 1
+      fi
+      echo "etcd member $NAME with $ID successfully removed.."
     }
 
     populate_template() {


### PR DESCRIPTION
The current etcd DR scripts are intended to be used when quorum is lost. In the case of for example, on-disk corruption etcd may fail to restart. The solution is to remove the member from the cluster, destroy data-dir, and re-add using etcd-member-recover.sh. This script allows for the removal of an etcd member to take place easily.

**- What I did**

Created a new DR script etcd-member-remove.sh this allows users to easily remove a failed etcd member.

**- How to verify it**

1.) Create a new cluster
2.) remove a member using the script.
3.) verify with etcdctl member list

**- Description for the changelog**

- Added: new DR script etcd-member-remove.sh to easily facilitate removal and replacement of failed etcd member.

openshift-recovery-tools
- Added: export ETCDCTL_API=3 

- Added: etcd_member_remove function

Fiex https://bugzilla.redhat.com/show_bug.cgi?id=1734554

/cc @alaypatel07 @retroflexer 