### PR TITLE
[4.3] pkg/daemon: MCD constants fixup

### DIFF
--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -8,6 +8,7 @@ import (
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/machine-config-operator/internal/clients"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	mcfginformers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
 	apiextinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +79,7 @@ func CreateControllerContext(cb *clients.Builder, stop <-chan struct{}, targetNa
 			glog.Warningf("unable to convert selector %q to map: %v", opts.LabelSelector, err)
 			return
 		}
-		opts.LabelSelector = labels.Merge(labelsMap, map[string]string{"openshift.io/operator-managed": ""}).String()
+		opts.LabelSelector = labels.Merge(labelsMap, map[string]string{daemonconsts.OpenShiftOperatorManagedLabel: ""}).String()
 	}
 	apiExtSharedInformer := apiextinformers.NewSharedInformerFactoryWithOptions(apiExtClient, resyncPeriod()(),
 		apiextinformers.WithNamespace(targetNamespace), apiextinformers.WithTweakListOptions(assignFilterLabels))

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -3,7 +3,7 @@ package constants
 const (
 	// XXX
 	//
-	// Add a constant here, if and only if: it's exported (of course) and it's reused across all the project.
+	// Add a constant here, if and only if: it's exported (of course) and it's reused across the entire project.
 	// Otherwise, prefer an unexported const in a specific package.
 	//
 	// XXX
@@ -21,7 +21,7 @@ const (
 	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.
 	MachineConfigDaemonStateDone = "Done"
 	// MachineConfigDaemonStateDegraded is set by daemon when an error not caused by a bad MachineConfig
-	// is thrown during an udpate.
+	// is thrown during an update.
 	MachineConfigDaemonStateDegraded = "Degraded"
 	// MachineConfigDaemonStateUnreconcilable is set by the daemon when a MachineConfig cannot be applied.
 	MachineConfigDaemonStateUnreconcilable = "Unreconcilable"

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -14,6 +14,8 @@ const (
 	DesiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
 	// MachineConfigDaemonStateAnnotationKey is used to fetch the state of the daemon on the machine.
 	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
+	// OpenShiftOperatorManagedLabel is used to filter out kube objects that don't need to be synced by the MCO
+	OpenShiftOperatorManagedLabel = "openshift.io/operator-managed"
 	// MachineConfigDaemonStateWorking is set by daemon when it is applying an update.
 	MachineConfigDaemonStateWorking = "Working"
 	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add the `"openshift.io/operator-managed"` label from #832 to the MCD global constants file.
This way the operator managed label can be easily swapped out if the need arises (once #817 is merged the label will be used more than once, and it is an important label). 

I also cleaned up some small typos in the constants file.

**- How to verify it**
CI
