### PR TITLE
Baremetal: enable Haproxy events logging after Haproxy container  being restarted

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -61,9 +61,7 @@ contents:
           declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
           export -f msg_handler
           export -f reload_haproxy
-          if [ -S "$haproxy_sock" ]; then
-              rm "$haproxy_sock"
-          fi
+          rm -f "$haproxy_sock" "$haproxy_log_sock"
           socat UNIX-RECV:${haproxy_log_sock} STDOUT &
           if [ -s "/etc/haproxy/haproxy.cfg" ]; then
               /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &


### PR DESCRIPTION
This commit enables the logging of Haproxy events into haproxy container after
Haproxy container being restarted once.
In current code, after Haproxy container being restarted(e.g: due to Liveness probe); we'll
hit [1] error.

[1]- + socat UNIX-RECV:/var/run/haproxy/haproxy-log.sock STDOUT
2019/08/14 07:21:03 socat[8] E "/var/run/haproxy/haproxy-log.sock" exists

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
