### PR TITLE
Bug 1712826: DR: Add pre-run checks for backup and restore scripts

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -16,11 +16,17 @@ contents:
       exit 1
     fi
 
+    usage () {
+        echo 'Path to backup file required: ./etcd-snapshot-backup.sh ./backup.db'
+        exit 1
+    }
+
     ASSET_DIR=./assets
-    SNAPSHOT_FILE="${ASSET_DIR}/backup/etcd/member/snap/db"
 
     if [ "$1" != "" ]; then
       SNAPSHOT_FILE="$1"
+    else
+      usage
     fi
 
     CONFIG_FILE_DIR=/etc/kubernetes

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -40,6 +40,11 @@ contents:
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
     STOPPED_STATIC_PODS="${ASSET_DIR}/tmp/stopped-static-pods"
 
+    if [ ! -f "$SNAPSHOT_FILE" ]; then
+      echo "etcd snapshot $SNAPSHOT_FILE does not exist."
+      exit 1
+    fi
+
     source "/usr/local/bin/openshift-recovery-tools"
 
     function run {


### PR DESCRIPTION
Currently, the DR scripts do not check if parameters are valid. 

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added checks for valid params to backup and restore scripts.

**- Description for the changelog**
Fixes: [BZ 1712826](https://bugzilla.redhat.com/show_bug.cgi?id=1712826)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

/cc @hexfusion  @retroflexer 