### PR TITLE
Bug 1738857: use internal URI for recovery kubeconfig

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-kubeconfig-gen.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-kubeconfig-gen.yaml
@@ -8,7 +8,7 @@ contents:
     set -eou pipefail
     
     # context
-    intapi=$(oc get infrastructures.config.openshift.io cluster -o "jsonpath={.status.apiServerURL}")
+    intapi=$(oc get infrastructures.config.openshift.io cluster -o "jsonpath={.status.apiServerInternalURI}")
     context="$(oc config current-context)"
     # cluster
     cluster="$(oc config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.cluster}")"


### PR DESCRIPTION
**- What I did**
Changes the kubelet recovery script to use the internal URI. The initial kubeconfig uses the internal URI as well. Additionally, this removes a dependency on the load balancer cert being valid during recovery.

**- How to verify it**
`recovery-kubeconfig` will contain the api-int.* domain name in the server field.

**- Description for the changelog**
`NONE`