### PR TITLE
Bug 1735661: add template with default inotify.max_users settings

### DIFF
--- a/templates/common/_base/files/sysctl-inotify.conf.yaml
+++ b/templates/common/_base/files/sysctl-inotify.conf.yaml
@@ -1,0 +1,8 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/inotify.conf"
+contents:
+  inline: |
+ 
+    fs.inotify.max_user_watches = 65536
+    fs.inotify.max_user_instances = 8192


### PR DESCRIPTION
add template to create /etc/sysctl.d/inotify.conf with inotify.max_users defaults taken from: 
https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/tuned/templates/openshift-node/tuned.conf

Closes: BZ 1735661

