### PR TITLE
Bug 1744764: Report degraded reason in cluster operator status

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -325,15 +325,15 @@ func (optr *Operator) sync(key string) error {
 	// syncFuncs is the list of sync functions that are executed in order.
 	// any error marks sync as failure.
 	var syncFuncs = []syncFunc{
-		// "render-config" must always run first as it sets the renderConfig in the operator
+		// "RenderConfig" must always run first as it sets the renderConfig in the operator
 		// for the sync funcs below
-		{"render-config", optr.syncRenderConfig},
-		{"pools", optr.syncMachineConfigPools},
-		{"mcd", optr.syncMachineConfigDaemon},
-		{"mcc", optr.syncMachineConfigController},
-		{"mcs", optr.syncMachineConfigServer},
+		{"RenderConfig", optr.syncRenderConfig},
+		{"MachineConfigPools", optr.syncMachineConfigPools},
+		{"MachineConfigDaemon", optr.syncMachineConfigDaemon},
+		{"MachineConfigController", optr.syncMachineConfigController},
+		{"MachineConfigServer", optr.syncMachineConfigServer},
 		// this check must always run last since it makes sure the pools are in sync/upgrading correctly
-		{"required-pools", optr.syncRequiredMachineConfigPools},
+		{"RequiredPools", optr.syncRequiredMachineConfigPools},
 	}
 	return optr.syncAll(syncFuncs)
 }

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -158,6 +158,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 						{
 							Type:   configv1.OperatorAvailable,
@@ -170,6 +171,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -198,6 +200,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -230,6 +233,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -256,6 +260,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -288,6 +293,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -320,6 +326,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -343,10 +350,12 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					expectOperatorFail: true,
@@ -376,10 +385,12 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					expectOperatorFail: true,
@@ -405,10 +416,12 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					expectOperatorFail: true,
@@ -442,6 +455,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -464,10 +478,12 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					expectOperatorFail: true,
@@ -495,6 +511,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorUpgradeable,
 							Status: configv1.ConditionTrue,
+							Reason: asExpectedReason,
 						},
 					},
 					syncFuncs: []syncFunc{
@@ -545,6 +562,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 					}
 				}
 				assert.Equal(t, cond.Status, condition.Status, "test case %d, sync call %d, expected condition %v to be %v, but got %v", idx, j, condition.Type, cond.Status, condition.Status)
+				assert.Equal(t, cond.Reason, condition.Reason, "test case %d, sync call %d, expected reason to be %v, but got %v", idx, j, cond.Reason, condition.Reason)
 			}
 		}
 	}


### PR DESCRIPTION
Needs cherrypicking for 4.1.z, in order to fix BZ 1741065: 

**- What I did**
Add reason for degradation to ClusterOperatorStatusCondition

**- How to verify it**
CI

**- Description for the changelog**
pkg/operator: Report degraded reason in cluster operator status


