### PR TITLE
machineconfig: Capitalize FIPS fully

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -53,9 +53,9 @@ func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec,
 		*modified = true
 		(*existing).Config = required.Config
 	}
-	if existing.Fips != required.Fips {
+	if existing.FIPS != required.FIPS {
 		*modified = true
-		(*existing).Fips = required.Fips
+		(*existing).FIPS = required.FIPS
 	}
 }
 

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -24,7 +24,7 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 	outIgn := configs[0].Spec.Config
 	for idx := 1; idx < len(configs); idx++ {
 		// if any of the config has FIPS enabled, it'll be set
-		if configs[idx].Spec.Fips {
+		if configs[idx].Spec.FIPS {
 			fips = true
 		}
 		outIgn = ign.Append(outIgn, configs[idx].Spec.Config)
@@ -39,7 +39,7 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 			OSImageURL:      osImageURL,
 			KernelArguments: kargs,
 			Config:          outIgn,
-			Fips:            fips,
+			FIPS:            fips,
 		},
 	}
 }

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -185,7 +185,7 @@ type MachineConfigSpec struct {
 
 	KernelArguments []string `json:"kernelArguments"`
 
-	Fips bool `json:"fips"`
+	FIPS bool `json:"fips"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -281,14 +281,14 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 }
 
 func (dn *Daemon) updateFIPS(current, desired *mcfgv1.MachineConfig) error {
-	if current.Spec.Fips == desired.Spec.Fips {
+	if current.Spec.FIPS == desired.Spec.FIPS {
 		return nil
 	}
 	if dn.OperatingSystem != machineConfigDaemonOSRHCOS {
 		return errors.New("Updating FIPS on non-RHCOS nodes is not supported")
 	}
 	arg := "enable"
-	if !desired.Spec.Fips {
+	if !desired.Spec.FIPS {
 		arg = "disable"
 	}
 	cmd := exec.Command(fipsCommand, arg)
@@ -420,7 +420,7 @@ func Reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) (*MachineConfigDif
 	return &MachineConfigDiff{
 		osUpdate: oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL,
 		kargs:    !reflect.DeepEqual(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments),
-		fips:     oldConfig.Spec.Fips != newConfig.Spec.Fips,
+		fips:     oldConfig.Spec.FIPS != newConfig.Spec.FIPS,
 		passwd:   passwdChanged,
 		files:    !reflect.DeepEqual(oldIgn.Storage.Files, newIgn.Storage.Files),
 		units:    !reflect.DeepEqual(oldIgn.Systemd.Units, newIgn.Systemd.Units),

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -530,7 +530,7 @@ func TestFIPS(t *testing.T) {
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Config: ctrlcommon.NewIgnConfig(),
-			Fips:   true,
+			FIPS:   true,
 		},
 	}
 


### PR DESCRIPTION
It's an acronym, so make it follow golang style:
https://github.com/golang/go/wiki/CodeReviewComments#initialisms
