### PR TITLE
Bug 1743361: fix updating version output

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -513,7 +513,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	if err != nil {
 		return err
 	}
-	glog.V(2).Infof("Pool %s: now targeting: %s", pool.Name, generated.Name)
+	glog.V(2).Infof("Pool %s: now targeting: %s", pool.Name, pool.Spec.Configuration.Name)
 
 	if err := ctrl.garbageCollectRenderedConfigs(pool); err != nil {
 		return err

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -335,7 +335,7 @@ func machineConfigPoolStatus(pool *mcfgv1.MachineConfigPool) string {
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdated):
 		return fmt.Sprintf("all %d nodes are at latest configuration %s", pool.Status.MachineCount, pool.Status.Configuration.Name)
 	case mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating):
-		return fmt.Sprintf("%d (ready %d) out of %d nodes are updating to latest configuration %s", pool.Status.UpdatedMachineCount, pool.Status.ReadyMachineCount, pool.Status.MachineCount, pool.Status.Configuration.Name)
+		return fmt.Sprintf("%d (ready %d) out of %d nodes are updating to latest configuration %s", pool.Status.UpdatedMachineCount, pool.Status.ReadyMachineCount, pool.Status.MachineCount, pool.Spec.Configuration.Name)
 	default:
 		return "<unknown>"
 	}


### PR DESCRIPTION
Problem: output of  `oc get co machine-config -o yaml` is pointing to current config name: 
```worker: 0 (ready 0) out of 2 nodes are updating to latest configuration rendered-worker-2fe2c50ca1b300646e59b6fad007d537``` 
instead of the name of the desired/target config that is being applied.

Through some testing/adding additional logs I verified the target config in Spec was set properly at the correct time.  The issue was status.go was improperly referencing `pool.Status.Configuration.Name`  (current config) instead of `pool.Spec.Configuration.Name` in its output.

Closes: BZ 1743361