### PR TITLE
Bug 1743621: pkg/daemon: error early if updating FIPS on non-RHCOS

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -284,6 +284,9 @@ func (dn *Daemon) updateFIPS(current, desired *mcfgv1.MachineConfig) error {
 	if current.Spec.Fips == desired.Spec.Fips {
 		return nil
 	}
+	if dn.OperatingSystem != machineConfigDaemonOSRHCOS {
+		return errors.New("Updating FIPS on non-RHCOS nodes is not supported")
+	}
 	arg := "enable"
 	if !desired.Spec.Fips {
 		arg = "disable"


### PR DESCRIPTION
Do not even run the script  for enabling/disabling FIPS on non-RHCOS. Fix the linked BZ.