### PR TITLE
Bug 1743487: Do not requeue a failed kubeletconfig decode

### DIFF
--- a/pkg/controller/kubelet-config/errors.go
+++ b/pkg/controller/kubelet-config/errors.go
@@ -1,0 +1,13 @@
+package kubeletconfig
+
+type forgetError struct {
+	Err error
+}
+
+func newForgetError(err error) *forgetError {
+	return &forgetError{Err: err}
+}
+
+func (e *forgetError) Error() string {
+	return e.Err.Error()
+}


### PR DESCRIPTION
**- What I did**
Add a forgettable error type that is caught by the error handler to not requeue the key.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1743487

**- How to verify it**

**- Description for the changelog**
```NONE```