### PR TITLE
Bug 1743768: avoid excessive dentries due to keepalived static pod health check

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -55,6 +55,9 @@ spec:
     securityContext:
       privileged: true
     image: {{ .Images.KeepalivedBootstrap }}
+    env:
+      - name: NSS_SDB_USE_CACHE
+        value: "no"
     command:
     - /usr/sbin/keepalived
     args:

--- a/templates/common/openstack/files/openstack-keepalived.yaml
+++ b/templates/common/openstack/files/openstack-keepalived.yaml
@@ -53,6 +53,9 @@ contents:
         securityContext:
           privileged: true
         image: {{.Images.keepalivedImage}}
+        env:
+          - name: NSS_SDB_USE_CACHE
+            value: "no"
         command:
         - /usr/sbin/keepalived
         args:


### PR DESCRIPTION
The 'curl' commands on the keepalived static pod cause a huge amount of memory dentries.
The underlying bug is https://bugzilla.redhat.com/show_bug.cgi?id=1571183.
This commit work-around this problem. 
For more details see:
https://github.com/openshift/machine-config-operator/pull/705
https://github.com/openshift/openshift-ansible/pull/11829

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
