### PR TITLE
Bug 1734554: provide etcd-member-add.sh for adding back a member with valid certs

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
@@ -1,0 +1,62 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/etcd-member-add.sh"
+contents:
+  inline: |
+    #!/usr/bin/env bash
+    
+    # This script should be invoked only if the member already has valid certs.
+    # example
+    # sudo -E ./etcd-member-add.sh 192.168.1.100 $etcd_name
+    
+    if [[ $EUID -ne 0 ]]; then
+      echo "This script must be run as root"
+      exit 1
+    fi
+    
+    usage () {
+        echo 'Active server IP address and etcd name required: ./etcd-member-add.sh 192.168.1.100 $etcd_name'
+        exit 1
+    }
+    
+    if [ "$1" == "" ] || [ "$2" == "" ]; then
+        usage
+    fi
+    
+    RECOVERY_SERVER_IP=$1
+    ETCD_NAME=$2
+    
+    ASSET_DIR=./assets
+    CONFIG_FILE_DIR=/etc/kubernetes
+    MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
+    RUN_ENV=/run/etcd/environment
+    
+    MANIFEST_STOPPED_DIR="$ASSET_DIR/manifests-stopped"
+    ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
+    ETCD_CONFIG=/etc/etcd/etcd.conf
+    ETCDCTL=$ASSET_DIR/bin/etcdctl
+    ETCD_VERSION=v3.3.10
+    ETCD_DATA_DIR=/var/lib/etcd
+    ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
+    
+    source "/usr/local/bin/openshift-recovery-tools"
+    
+    function run {
+      init
+      dl_etcdctl
+      backup_manifest
+      DISCOVERY_DOMAIN=$(grep -oP '(?<=discovery-srv=).*[^"]' $ASSET_DIR/backup/etcd-member.yaml )
+      if [ -z "$DISCOVERY_DOMAIN" ]; then
+        echo "Discovery domain can not be extracted from $ASSET_DIR/backup/etcd-member.yaml"
+        exit 1
+      fi
+      validate_environment
+      source  /run/etcd/environment
+      backup_etcd_conf
+      stop_etcd
+      backup_data_dir
+      etcd_member_add
+      start_etcd
+    }
+    
+    run


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: #1734554
The current etcd DR scripts are intended to be used when quorum is lost. However, in simpler cases, an etcd member may fail to restart, but the certificates are valid. In that case, The solution is to remove the member from the cluster, and re-add using etcd-member-add.sh. This script can be used in conjunction with etcd-member-remove.sh.

**- What I did**
Created a new DR script etcd-member-add.sh which allows users to easily add back an etcd member when the certs are valid.


**- How to verify it**
1.) Create a new cluster
2.) remove a member using the etcd-member-remove.sh script.
3.) add back the member using this script
3.) verify with etcdctl member list


**- Description for the changelog**
<!--
Created a new DR script etcd-member-add.sh which allows users to easily add back an etcd member when the certs are valid.
-->
