### PR TITLE
Bug 1744580: pkg/daemon: create orig file outside of pwd for the file

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -747,8 +747,12 @@ func (dn *Daemon) writeFiles(files []igntypes.File) error {
 	return nil
 }
 
+func origParentDir() string {
+	return filepath.Join("/etc", "machine-config-daemon", "orig")
+}
+
 func origFileName(fpath string) string {
-	return fpath + ".mcdorig"
+	return filepath.Join(origParentDir(), fpath+".mcdorig")
 }
 
 func createOrigFile(fpath string) error {
@@ -760,6 +764,9 @@ func createOrigFile(fpath string) error {
 	if _, err := os.Stat(origFileName(fpath)); err == nil {
 		// the orig file is already there and we avoid creating a new one to preserve the real default
 		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(origFileName(fpath)), 0755); err != nil {
+		return errors.Wrapf(err, "creating orig parent dir: %v", err)
 	}
 	if out, err := exec.Command("cp", "-a", "--reflink=auto", fpath, origFileName(fpath)).CombinedOutput(); err != nil {
 		return errors.Wrapf(err, "creating orig file for %q: %s", fpath, string(out))


### PR DESCRIPTION
Backing up the original file to its $PWD has a side effect on certain
directories like the Kube static pod dir. If a file is backed up there,
it will be still processed by kube which is completely wrong and
unwanted.
This patch is instead backing up the file inside
/etc/machine-config-daemon/$FPATH avoiding the pitfall above.

Fix https://github.com/openshift/machine-config-operator/issues/1074

Let's debate on the `/etc/machine-config-daemon` location, I don't really like it but I'm accepting other suggestions.

cc @hexfusion 

Signed-off-by: Antonio Murdaca <runcom@linux.com>
