### PR TITLE
Bug 1745240: pkg/operator: fix related objects for must-gather

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -235,7 +235,7 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 		{Resource: "namespaces", Name: optr.namespace},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "master"},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "worker"},
-		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "cluster"},
+		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "machine-config-controller"},
 	}
 	// During an installation we report the RELEASE_VERSION as soon as the component is created.
 	// For both normal runs and upgrades, this code isn't hit and we get the right version every


### PR DESCRIPTION
The ControllerConfig name is "machine-config-controller", not "cluster".
That was causing the cc to not being collected with must-gather.

Signed-off-by: Antonio Murdaca <runcom@linux.com>