### PR TITLE
[4.3] baremetal: run coredns healthcheck on 8083

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -1,6 +1,6 @@
 . {
     errors
-    health
+    health :8083
     mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30

--- a/manifests/baremetal/coredns.yaml
+++ b/manifests/baremetal/coredns.yaml
@@ -68,7 +68,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /health
-        port: 8080
+        port: 8083
         scheme: HTTP
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -78,7 +78,7 @@ spec:
     livenessProbe:
       httpGet:
         path: /health
-        port: 8080
+        port: 8083
         scheme: HTTP
       initialDelaySeconds: 60
       timeoutSeconds: 5


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
change the port used for coredns health plugin in baremetal platform

**- How to verify it**
deploy with baremetal and check port 8083

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
switch to port 8083 for coredns healthcheck on baremetal
