### PR TITLE
ctrcfg: setup OWNERS for code and templates

### DIFF
--- a/pkg/controller/container-runtime-config/OWNERS
+++ b/pkg/controller/container-runtime-config/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+reviewers:
+  - umohnani8
+  - mtrmac

--- a/templates/master/01-master-container-runtime/OWNERS
+++ b/templates/master/01-master-container-runtime/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+reviewers:
+  - umohnani8
+  - mtrmac

--- a/templates/worker/01-worker-container-runtime/OWNERS
+++ b/templates/worker/01-worker-container-runtime/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+reviewers:
+  - umohnani8
+  - mtrmac


### PR DESCRIPTION
Code and templates is owned by the Node team (was Container Runtime team). Setup some OWNERS file
to make sure they're correctly assigned when something changes there.

Signed-off-by: Antonio Murdaca <runcom@linux.com>