### PR TITLE
[release 4.1] Bug 1741065: Report degraded reason in cluster operator status

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -411,11 +411,11 @@ func (optr *Operator) sync(key string) error {
 	// syncFuncs is the list of sync functions that are executed in order.
 	// any error marks sync as failure but continues to next syncFunc
 	var syncFuncs = []syncFunc{
-		{"pools", optr.syncMachineConfigPools},
-		{"mcd", optr.syncMachineConfigDaemon},
-		{"mcc", optr.syncMachineConfigController},
-		{"mcs", optr.syncMachineConfigServer},
-		{"required-pools", optr.syncRequiredMachineConfigPools},
+		{"MachineConfigPools", optr.syncMachineConfigPools},
+		{"MachineConfigDaemon", optr.syncMachineConfigDaemon},
+		{"MachineConfigController", optr.syncMachineConfigController},
+		{"MachineConfigServer", optr.syncMachineConfigServer},
+		{"RequiredPools", optr.syncRequiredMachineConfigPools},
 	}
 	return optr.syncAll(rc, syncFuncs)
 }

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -158,6 +158,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 						{
 							Type:   configv1.OperatorAvailable,
@@ -319,6 +320,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 					},
 					expectOperatorFail: true,
@@ -348,6 +350,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 					},
 					expectOperatorFail: true,
@@ -373,6 +376,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 					},
 					expectOperatorFail: true,
@@ -424,6 +428,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 						{
 							Type:   configv1.OperatorDegraded,
 							Status: configv1.ConditionTrue,
+							Reason: "fn1Failed",
 						},
 					},
 					expectOperatorFail: true,
@@ -496,6 +501,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 					}
 				}
 				assert.Equal(t, cond.Status, condition.Status, "test case %d, sync call %d, expected condition %v to be %v, but got %v", idx, j, condition.Type, cond.Status, condition.Status)
+				assert.Equal(t, cond.Reason, condition.Reason, "test case %d, sync call %d, expected reason to be %v, but got %v", idx, j, cond.Reason, condition.Reason)
 			}
 		}
 	}


### PR DESCRIPTION
Closes: BZ 1741065

**- What I did**
4.1.z backport of BZ 1741064 (GH https://github.com/openshift/machine-config-operator/pull/1064)
Makes syncAll fail fast like upstream
Add reason for degradation to ClusterOperatorStatusCondition
Updated unit tests

**- How to verify it**
CI

**- Description for the changelog**
pkg/operator: Report degraded reason in cluster operator status
