### PR TITLE
Bug 1741817: mcd: Add /run/machine-config-daemon-force stamp file

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -40,4 +40,9 @@ const (
 	// object so that Ignition can process it on first boot, and then the MCD can act on
 	// non-Ignition fields such as the osImageURL and kernelArguments.
 	MachineConfigEncapsulatedPath = "/etc/ignition-machine-config-encapsulated.json"
+
+	// MachineConfigDaemonForceFile if present causes the MCD to skip checking the validity of the
+	// "currentConfig" state.  Create this file (empty contents is fine) if you wish the MCD
+	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.
+	MachineConfigDaemonForceFile = "/run/machine-config-daemon-force"
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -892,8 +892,12 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		glog.Infof("Validating against current config %s", state.currentConfig.GetName())
 		expectedConfig = state.currentConfig
 	}
-	if !dn.validateOnDiskState(expectedConfig) {
-		return fmt.Errorf("unexpected on-disk state validating against %s", expectedConfig.GetName())
+	if _, err := os.Stat(constants.MachineConfigDaemonForceFile); err != nil {
+		if !dn.validateOnDiskState(expectedConfig) {
+			return fmt.Errorf("unexpected on-disk state validating against %s", expectedConfig.GetName())
+		}
+	} else {
+		glog.Infof("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 	}
 	glog.Info("Validated on-disk state")
 


### PR DESCRIPTION
This causes the MCD to skip validating against `currentConfig` (or `pendingConfig`).

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1741817

A long time ago, this PR introduced the current model:
https://github.com/openshift/machine-config-operator/pull/245
One aspect of this is we need to avoid reboot loops; that was
a real-world problem early in OpenShift development, although
it is probably unlikely to re-occur today.

Another problem is that we can't simply reconcile by default because
we don't have a mechanism to coordinate reboots:
 https://github.com/openshift/machine-config-operator/issues/662#issuecomment-506472687

However, this PR should aid disaster recovery scenarios and others
where administrators want the MCD to "just do it".
