### PR TITLE
pkg/operator: fix DS unavailable count reporting

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -631,7 +631,7 @@ func (optr *Operator) waitForDaemonsetRollout(resource *appsv1.DaemonSet) error 
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedNumberScheduled == d.Status.DesiredNumberScheduled && d.Status.NumberUnavailable == 0 {
 			return true, nil
 		}
-		lastErr = fmt.Errorf("Daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberReady, d.Status.NumberAvailable)
+		lastErr = fmt.Errorf("Daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberReady, d.Status.NumberUnavailable)
 		return false, nil
 	}); err != nil {
 		if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
Spotted in a BZ while looking around for something else. The mistake is
pretty obvious, we need to report the unavailable count but we
were reporting the available ones...

Signed-off-by: Antonio Murdaca <runcom@linux.com>