### PR TITLE
Bug 1741955: bump containerLogMaxSize to 50MB

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -14,6 +14,7 @@ contents:
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
+    containerLogMaxSize: 50Mi
     maxPods: 250
     runtimeRequestTimeout: 10m
     serializeImagePulls: false

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -14,6 +14,7 @@ contents:
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
+    containerLogMaxSize: 50Mi
     maxPods: 250
     rotateCertificates: true
     runtimeRequestTimeout: 10m


### PR DESCRIPTION
On high message rates, the default 10MB buffer rotates quickly enough to miss messages. OSE 3.11 
bumped this limit to 50MB within this [commit](https://github.com/openshift/openshift-ansible/commit/5e57addcb1bc88d36015e6f06c209985d1e0dbc7) to capture more messages before the buffer rotates.

**- What I did**
Bump the limit in the kubelet master and worker configuration files to 50 MB.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1741955

**- How to verify it**

**- Description for the changelog**
```
Bump Kubelet container log buffers to 50 MB. Disk space on a node will increase due to more logs being retained.
```
