### PR TITLE
Bug 1747432: manifests: Add missing terminationMessagePolicy FallbackToLogsOnError

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -28,6 +28,7 @@ spec:
         env:
           - name: RELEASE_VERSION
             value: "0.0.1-snapshot"
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: root-ca
           mountPath: /etc/ssl/kubernetes/ca.crt

--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -21,6 +21,7 @@ spec:
         memory: 50Mi
     securityContext:
       privileged: true
+    terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - name: bootstrap-manifests
       mountPath: /etc/mcc/bootstrap
@@ -32,6 +33,7 @@ spec:
     command: ["/usr/bin/machine-config-server"]
     args:
       - "bootstrap"
+    terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - name: server-certs
       mountPath: /etc/ssl/mcs

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -24,6 +24,7 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: machine-config-controller
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
             memory: 50Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - mountPath: /rootfs
             name: rootfs

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: certs
           mountPath: /etc/ssl/mcs

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -402,6 +402,7 @@ spec:
         memory: 50Mi
     securityContext:
       privileged: true
+    terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - name: bootstrap-manifests
       mountPath: /etc/mcc/bootstrap
@@ -413,6 +414,7 @@ spec:
     command: ["/usr/bin/machine-config-server"]
     args:
       - "bootstrap"
+    terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - name: server-certs
       mountPath: /etc/ssl/mcs
@@ -939,6 +941,7 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: machine-config-controller
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -1092,6 +1095,7 @@ spec:
             memory: 50Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - mountPath: /rootfs
             name: rootfs
@@ -1450,6 +1454,7 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: certs
           mountPath: /etc/ssl/mcs

--- a/templates/master/00-master/_base/files/usr-local-share-openshift-recovery-template-etcd-generate-certs-yaml-template.yaml
+++ b/templates/master/00-master/_base/files/usr-local-share-openshift-recovery-template-etcd-generate-certs-yaml-template.yaml
@@ -20,6 +20,7 @@ contents:
         - "--discovery-srv=__ETCD_DISCOVERY_DOMAIN__"
         - "--output-file=/run/etcd/environment"
         - "--v=4"
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: discovery
           mountPath: /run/etcd/


### PR DESCRIPTION
All containers should generally set terminationMessagePolicy to fallback
so that system agents can observe the last chunk of error output when a
pod crashes or dies.

In 4.2 insights-operator will automatically gather these if containers
have crashed.