### PR TITLE
Bug 1747608: APIServerInternalURL fix for kubelet

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -221,7 +221,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	}
 
 	// create renderConfig
-	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra.Status.APIServerURL)
+	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL)
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**
The kubelet should always use the internal API server FQDN, so it does not rely on the LB certificates.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
