### PR TITLE
Bug 1748844: vendor: use cluster-api's drain lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -486,12 +486,12 @@
   revision = "c44a8b61b9f46cd9e802384dfeda0bc9942db68a"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cdf4d8665620f7588f2edcc6cd88dcf5f9497f1dc4758eb49ace646e4d7c8f3d"
-  name = "github.com/openshift/kubernetes-drain"
-  packages = ["."]
+  branch = "openshift-4.2-cluster-api-0.1.0"
+  digest = "1:9a7d52b9df3f2c44692d76a3408b186f9e343a283dbb72c83a9dfb0f5ea786db"
+  name = "github.com/openshift/cluster-api"
+  packages = ["pkg/drain"]
   pruneopts = "NUT"
-  revision = "d20a33f09dbf11716de3110d7759f384ba9ef7c3"
+  revision = "072f7d777dc81aac0dd222686e1516dd9e7db38b"
 
 [[projects]]
   branch = "master"
@@ -1247,7 +1247,7 @@
     "github.com/openshift/client-go/operator/informers/externalversions",
     "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1",
     "github.com/openshift/client-go/operator/listers/operator/v1alpha1",
-    "github.com/openshift/kubernetes-drain",
+    "github.com/openshift/cluster-api/pkg/drain",
     "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers",
     "github.com/openshift/library-go/pkg/operator/v1helpers",
     "github.com/pkg/errors",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -84,8 +84,8 @@ required = [
   branch = "master"
 
 [[constraint]]
-  name = "github.com/openshift/kubernetes-drain"
-  branch = "master"
+  name = "github.com/openshift/cluster-api"
+  branch = "openshift-4.2-cluster-api-0.1.0"
 
 [[constraint]]
   name = "github.com/openshift/library-go"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -22,7 +22,7 @@ import (
 	ign "github.com/coreos/ignition/config/v2_2"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
-	drain "github.com/openshift/kubernetes-drain"
+	drain "github.com/openshift/cluster-api/pkg/drain"
 	"github.com/openshift/machine-config-operator/lib/resourceread"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -18,7 +18,7 @@ import (
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	"github.com/google/renameio"
-	drain "github.com/openshift/kubernetes-drain"
+	drain "github.com/openshift/cluster-api/pkg/drain"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"

--- a/vendor/github.com/openshift/cluster-api/LICENSE
+++ b/vendor/github.com/openshift/cluster-api/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
openshift/kubernetes-drain is about to be officially deprecated and
already discontinued. We need to use the cluster-api's one (which is
basically a fork +
https://github.com/openshift/kubernetes-drain/pull/4).
We also need https://github.com/openshift/kubernetes-drain/pull/4 to
avoid flooding the apiserver as the MAO did (https://bugzilla.redhat.com/show_bug.cgi?id=1733708).
Also, MCO already updated in 4.1 and 4.2 with https://github.com/openshift/kubernetes-drain/pull/3 which is the actual fix to limit the rate of requests for eviction - this bump is to make sure to bring the deadlock fix.

Signed-off-by: Antonio Murdaca <runcom@linux.com>