### PR TITLE
[release-4.1] Bug 1749070: vendor: use cluster-api's drain lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -475,12 +475,12 @@
   revision = "0255926f53935175fe90b8e7672c4c06c17d79e6"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cdf4d8665620f7588f2edcc6cd88dcf5f9497f1dc4758eb49ace646e4d7c8f3d"
-  name = "github.com/openshift/kubernetes-drain"
-  packages = ["."]
+  branch = "openshift-4.1-cluster-api-0.0.0-alpha.4"
+  digest = "1:9a7d52b9df3f2c44692d76a3408b186f9e343a283dbb72c83a9dfb0f5ea786db"
+  name = "github.com/openshift/cluster-api"
+  packages = ["pkg/drain"]
   pruneopts = "NUT"
-  revision = "d20a33f09dbf11716de3110d7759f384ba9ef7c3"
+  revision = "53b696be18ad63f7a21f603a4311044a9697807c"
 
 [[projects]]
   branch = "master"
@@ -1183,13 +1183,14 @@
     "github.com/openshift/client-go/config/informers/externalversions",
     "github.com/openshift/client-go/config/informers/externalversions/config/v1",
     "github.com/openshift/client-go/config/listers/config/v1",
-    "github.com/openshift/kubernetes-drain",
+    "github.com/openshift/cluster-api/pkg/drain",
     "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers",
     "github.com/pkg/errors",
     "github.com/spf13/cobra",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/vincent-petithory/dataurl",
+    "golang.org/x/time/rate",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/policy/v1beta1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -84,8 +84,8 @@ required = [
   branch = "master"
 
 [[constraint]]
-  name = "github.com/openshift/kubernetes-drain"
-  branch = "master"
+  name = "github.com/openshift/cluster-api"
+  branch = "openshift-4.1-cluster-api-0.0.0-alpha.4"
 
 [[constraint]]
   name = "github.com/openshift/library-go"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -22,7 +22,7 @@ import (
 	ignv2 "github.com/coreos/ignition/config/v2_2"
 	ignv2_2types "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
-	drain "github.com/openshift/kubernetes-drain"
+	drain "github.com/openshift/cluster-api/pkg/drain"
 	"github.com/openshift/machine-config-operator/lib/resourceread"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -20,7 +20,7 @@ import (
 	"github.com/coreos/ignition/config/validate"
 	"github.com/golang/glog"
 	"github.com/google/renameio"
-	drain "github.com/openshift/kubernetes-drain"
+	drain "github.com/openshift/cluster-api/pkg/drain"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	errors "github.com/pkg/errors"

--- a/vendor/github.com/openshift/cluster-api/LICENSE
+++ b/vendor/github.com/openshift/cluster-api/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
Backport for #1098 

Signed-off-by: Antonio Murdaca <runcom@linux.com>