### PR TITLE
[4.3] Update containers/image to v3.x

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,7 +108,7 @@
   revision = "d596c78861b15c27a9ac82975aca4413390b9b49"
 
 [[projects]]
-  digest = "1:613f0e16a97fc2dccc0d3c31b615eb3c8ecc57295b34949d47917ee1dde1476c"
+  digest = "1:b95fbd6527c5857d6292de810cd8756777c624b0e9b02903f8f8bedeac39132a"
   name = "github.com/containers/image"
   packages = [
     "docker/reference",
@@ -116,8 +116,8 @@
     "types",
   ]
   pruneopts = "NUT"
-  revision = "abf32c4ea589cb8e96bdca5a478dba68f11980e5"
-  version = "v2.0.0"
+  revision = "186df8702a61dd6ed16a88532ed9a10ddc679132"
+  version = "v3.0.2"
 
 [[projects]]
   digest = "1:490deff6409bd7c1e531e143c3adc5bf5e5ff39a7bad6a69f41d5efe95a7ec07"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -167,7 +167,7 @@ required = [
 
 [[constraint]]
   name = "github.com/containers/image"
-  version = "v2.0.0"
+  version = "v3.0.0"
 
 [[constraint]]
   name = "github.com/InVisionApp/go-health"

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -398,6 +398,7 @@ type ImageInspectInfo struct {
 	Architecture  string
 	Os            string
 	Layers        []string
+	Env           []string
 }
 
 // DockerAuthConfig contains authorization information for connecting to a registry.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

… to make it easier for consumers of `pkg/controller/container-runtime-config/registries`
to use the newer major API version.

**- How to verify it**

Existing tests; the bump changes nothing directly used from this repository.

**- Description for the changelog**
Updated containers/image to 3.0.2.