### PR TITLE
[release-4.1] Bug 1749271: Backport mcd: Add /run/machine-config-daemon-force stampfile #1086

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -34,4 +34,9 @@ const (
 	// EtcPivotFile is used by the `pivot` command
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44
 	EtcPivotFile = "/etc/pivot/image-pullspec"
+
+	// MachineConfigDaemonForceFile if present causes the MCD to skip checking the validity of the
+	// "currentConfig" state.  Create this file (empty contents is fine) if you wish the MCD
+	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.
+	MachineConfigDaemonForceFile = "/run/machine-config-daemon-force"
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -913,8 +913,12 @@ func (dn *Daemon) CheckStateOnBoot() error {
 		glog.Infof("Validating against current config %s", state.currentConfig.GetName())
 		expectedConfig = state.currentConfig
 	}
-	if !dn.validateOnDiskState(expectedConfig) {
-		return fmt.Errorf("unexpected on-disk state validating against %s", expectedConfig.GetName())
+	if _, err := os.Stat(constants.MachineConfigDaemonForceFile); err != nil {
+		if !dn.validateOnDiskState(expectedConfig) {
+			return fmt.Errorf("unexpected on-disk state validating against %s", expectedConfig.GetName())
+		}
+	} else {
+		glog.Infof("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 	}
 	glog.Info("Validated on-disk state")
 


### PR DESCRIPTION
**- What I did**
Backports https://github.com/openshift/machine-config-operator/pull/1086 to 4.1, since Kubelet CA rotation was backported to 4.1 (https://github.com/openshift/machine-config-operator/pull/1000).

**- How to verify it**

**- Description for the changelog**
```
NONE
```

/cc @runcom 