### PR TITLE
Bug 1745875: Change config templates for BYOH Proxy 

### DIFF
--- a/templates/common/_base/files/etc-systemd-system-crio.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-crio.service.d-10-default-env.conf.yaml
@@ -6,12 +6,12 @@ contents:
     {{if .Proxy -}}
     [Service]
     {{if .Proxy.HTTPProxy -}}
-    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}

--- a/templates/common/_base/files/etc-systemd-system-kubelet.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-kubelet.service.d-10-default-env.conf.yaml
@@ -6,12 +6,12 @@ contents:
     {{if .Proxy -}}
     [Service]
     {{if .Proxy.HTTPProxy -}}
-    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}

--- a/templates/common/_base/files/etc-systemd-system-machine-config-daemon-host.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-machine-config-daemon-host.service.d-10-default-env.conf.yaml
@@ -6,12 +6,12 @@ contents:
     {{if .Proxy -}}
     [Service]
     {{if .Proxy.HTTPProxy -}}
-    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}

--- a/templates/common/_base/files/etc-systemd-system-pivot.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-pivot.service.d-10-default-env.conf.yaml
@@ -6,12 +6,12 @@ contents:
     {{if .Proxy -}}
     [Service]
     {{if .Proxy.HTTPProxy -}}
-    Environment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    Environment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    Environment=NO_PROXY="{{.Proxy.NoProxy}}"
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}


### PR DESCRIPTION
Fixes [bz-1745875](https://bugzilla.redhat.com/show_bug.cgi?id=1745875)

**- What I did**
Remove double quotes surrounding proxy envvar values in config templates. The quotes seem to be causing issues on RHEL worker nodes.

**- How to verify it**
Run cluster install and then RHEL scaleup using HEAD: worker nodes do not become ready. 
Run cluster install and then RHEL scaleup using this change: worker nodes join cluster.

**- Description for the changelog**
Remove double quotes in proxy config templates for compatibility with RHEL scaleup.
