### PR TITLE
Bug 1749446: Creates alternative CNI configuration directory for the cluster network operator

### DIFF
--- a/templates/common/_base/files/cleanup-cni-conf.yaml
+++ b/templates/common/_base/files/cleanup-cni-conf.yaml
@@ -6,3 +6,4 @@ contents:
     r /etc/kubernetes/cni/net.d/80-openshift-network.conf
     r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
     r /etc/kubernetes/cni/net.d/00-multus.conf
+    d /run/multus/cni/net.d/ 0755 root root - -


### PR DESCRIPTION
This is a WIP to look at addressing release blocker bz @ https://bugzilla.redhat.com/show_bug.cgi?id=1749448

*NOTE*: Originally submitted as a test. I am actively looking for feedback as to where this code to create a directory should exist. Originally, I simply found a convenient part to sketch it in (otherwise, I am somewhat unfamiliar with the MCO)