### PR TITLE
Bug 1748081: DR: send error to stderr before exit for validate_etcd_name

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -375,7 +375,7 @@ contents:
     validate_etcd_name() {
       ETCD_NAME=$(echo ${ETCD_INITIAL_CLUSTER} | grep -oP "(?<=)[^,,\s]*(?==[^=]*${ETCD_DNS_NAME}\b)") || true
       if [ -z "$ETCD_NAME" ]; then
-        echo "Validating INITIAL_CLUSTER failed: ${ETCD_DNS_NAME} is not found in ${ETCD_INITIAL_CLUSTER}"
+        echo "Validating INITIAL_CLUSTER failed: ${ETCD_DNS_NAME} is not found in ${ETCD_INITIAL_CLUSTER}" >&2
         exit 1
       fi
       echo "$ETCD_NAME"


### PR DESCRIPTION
We are still losing the err message in  `validate_etcd_name`..... this PR allows the script to prints the error message before exit.

```
[core@ip-10-0-141-100 ~]$ export INITIAL_CLUSTER="foo=bar"
[core@ip-10-0-141-100 ~]$ sudo /usr/local/bin/etcd-snapshot-restore.sh ./snapshot.db $INITIAL_CLUSTER
Downloading etcdctl binary..
etcdctl version: 3.3.10
API version: 3.3
etcd-member.yaml found in ./assets/backup/
checking against etcd-0.qe-geliu-0911.qe.devcluster.openshift.com
dns name is etcd-0.qe-geliu-0911.qe.devcluster.openshift.com
Validating INITIAL_CLUSTER failed: etcd-0.qe-geliu-0911.qe.devcluster.openshift.com is not found in foo=ba
```