### PR TITLE
pkg/daemon: return from signal handler once signaled

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -464,6 +464,7 @@ func (dn *Daemon) InstallSignalHandler(signaled chan struct{}) {
 					glog.Info("Got SIGTERM, but actively updating")
 				} else {
 					close(signaled)
+					return
 				}
 			}
 		}


### PR DESCRIPTION
Saw this panic in a job:

```
I0911 12:04:57.511213   19608 update.go:984] initiating reboot: Node will reboot into config rendered-worker-01b1c0acbda55b81b7aa8bb9fb9a80d5
panic: close of closed channel

goroutine 85 [running]:
github.com/openshift/machine-config-operator/pkg/daemon.(*Daemon).InstallSignalHandler.func1(0xc00007bda0, 0xc00028d180, 0xc000098660)
	/go/src/github.com/openshift/machine-config-operator/pkg/daemon/daemon.go:466 +0x13f
created by github.com/openshift/machine-config-operator/pkg/daemon.(*Daemon).InstallSignalHandler
	/go/src/github.com/openshift/machine-config-operator/pkg/daemon/daemon.go:455 +0xbf
```

This patch fixes the above by returning as soon as we're signaled cause
the MCD is going to shut down anyway, and the node reboot anyway.

Signed-off-by: Antonio Murdaca <runcom@linux.com>