### PR TITLE
pkg/daemon: add check for logger in CentOS

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -216,10 +216,10 @@ func New(
 		}
 	}
 
-	// RHEL 7.6 logger (util-linux) doesn't have the --journald flag
+	// RHEL 7.6/Centos 7 logger (util-linux) doesn't have the --journald flag
 	loggerSupportsJournal := true
 	if !mock {
-		if operatingSystem == machineConfigDaemonOSRHEL {
+		if operatingSystem == machineConfigDaemonOSRHEL || operatingSystem == machineConfigDaemonOSCENTOS {
 			loggerOutput, err := exec.Command("logger", "--help").CombinedOutput()
 			if err != nil {
 				return nil, errors.Wrapf(err, "running logger --help")


### PR DESCRIPTION
Currently this check for journal is just executed in the case of RHEL (for 7.6) . But with CentOS we are in the same situation.
So the fix is as simple as to add the CentOS check to the conditional.
In order to verify it, i just added a CentOS worker. Before that, it was failing in MCP with that logger failure. With the patch, node reports fine.

**- Description for the changelog**
Add check for logger in CentOS
