### PR TITLE
Bug 1750433: 1/3 etcd-member pods crashloopback

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -20,6 +20,8 @@ contents:
         - "--discovery-srv={{.EtcdDiscoveryDomain}}"
         - "--output-file=/run/etcd/environment"
         - "--v=4"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: discovery
           mountPath: /run/etcd/
@@ -67,6 +69,8 @@ contents:
                 --commonname=system:etcd-metric:${ETCD_DNS_NAME} \
                 --ipaddrs=${ETCD_IPV4_ADDRESS} \
 
+        securityContext:
+          privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: discovery
@@ -105,6 +109,8 @@ contents:
             --listen-client-urls=https://0.0.0.0:2379 \
             --listen-peer-urls=https://0.0.0.0:2380 \
             --listen-metrics-urls=https://0.0.0.0:9978 \
+        securityContext:
+          privileged: true
         resources:
           requests:
             memory: 600Mi


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Make the `etcd` pod privileged to work around issue of `etcd-member` sporadically not starting due to avc denial (not long term fix).

**- How to verify it**
Inspect running `etcd` processes, ensure they are running privileged.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix etcd sporadically going into crash loop backoff on startup on one or more masters.