### PR TITLE
Revert "Bug 1750433: 1/3 etcd-member pods crashloopback"

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -20,8 +20,6 @@ contents:
         - "--discovery-srv={{.EtcdDiscoveryDomain}}"
         - "--output-file=/run/etcd/environment"
         - "--v=4"
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: discovery
           mountPath: /run/etcd/
@@ -69,8 +67,6 @@ contents:
                 --commonname=system:etcd-metric:${ETCD_DNS_NAME} \
                 --ipaddrs=${ETCD_IPV4_ADDRESS} \
 
-        securityContext:
-          privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: discovery
@@ -109,8 +105,6 @@ contents:
             --listen-client-urls=https://0.0.0.0:2379 \
             --listen-peer-urls=https://0.0.0.0:2380 \
             --listen-metrics-urls=https://0.0.0.0:9978 \
-        securityContext:
-          privileged: true
         resources:
           requests:
             memory: 600Mi


### PR DESCRIPTION
Reverts openshift/machine-config-operator#1112

I am seeing conflicting information on this between leads.

@mrunalp and @cgwalters differ. I am not comfortable with letting this just slide into 4.2 without a consensus. This was originally removed here #526.

/cc @smarterclayton @sjenning 

ref:
- https://github.com/openshift/machine-config-operator/pull/1112#issuecomment-531004708
- https://github.com/openshift/machine-config-operator/pull/1112#issuecomment-531081024

/hold