### PR TITLE
pkg/daemon: remove force validation file if it exists

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -898,6 +898,9 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		}
 	} else {
 		glog.Infof("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
+		if err := os.Remove(constants.MachineConfigDaemonForceFile); err != nil {
+			return errors.Wrap(err, "failed to remove force validation file")
+		}
 	}
 	glog.Info("Validated on-disk state")
 


### PR DESCRIPTION
Even if we document that the file needs to be removed it sounds like the
MCD should do it itself if the force validation file exists. The case
would be someone forgetting to remove the file causing validation to
always be skipped, even on upgrades.

Signed-off-by: Antonio Murdaca <runcom@linux.com>

cc @cgwalters @rphillips 