### PR TITLE
Bug 1748798: Add backing up of client certs

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
@@ -53,6 +53,7 @@ contents:
       validate_environment
       source  /run/etcd/environment
       backup_etcd_conf
+      backup_etcd_client_certs
       stop_etcd
       backup_data_dir
       etcd_member_add


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: #1748798 
The current etcd-member-add.sh script wasn't backing up the client certificates, which are assumed to be available in the $ASSET_DIR/backup/ directory.
**- What I did**
Added `backup_etcd_client_certs` to the script

**- How to verify it**
 1.) Create a new cluster
2.) remove a member using the etcd-member-remove.sh script.
3.) rm -rf assets
4.) add back the member using this script
5.) verify with etcdctl member list

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added backing up of client certs needed for etcd-member-add.sh.