### PR TITLE
Bug 1752982: kubelet: remove runtimeRequestTimeout

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -16,7 +16,6 @@ contents:
     clusterDomain: cluster.local
     containerLogMaxSize: 50Mi
     maxPods: 250
-    runtimeRequestTimeout: 10m
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -17,7 +17,6 @@ contents:
     containerLogMaxSize: 50Mi
     maxPods: 250
     rotateCertificates: true
-    runtimeRequestTimeout: 10m
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:


### PR DESCRIPTION
**- What I did**
This timeout delays when kubelet will send a sigkill to a process causing tests to timeout waiting for pods to be deleted. The delay for a SIGKILL is 10minutes+ when it should be much faster. The default will be around 2 minutes.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1752982

**- How to verify it**

**- Description for the changelog**
```
Remove runtimeRequestTimeout from Kubelet config to improve pod deletion times. This option is also used for Pod terminations.
```