### PR TITLE
Bug 1753293: kubelet: remove runtimeRequestTimeout

### DIFF
--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/aws/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/none/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/master/01-master-kubelet/vsphere/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/aws/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/libvirt/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/none/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/openstack/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/files/-etc-kubernetes-kubelet.conf
+++ b/pkg/controller/template/test_data/templates/worker/01-worker-kubelet/vsphere/files/-etc-kubernetes-kubelet.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AruntimeRequestTimeout%3A%2010m%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
+  source: data:,kind%3A%20KubeletConfiguration%0AapiVersion%3A%20kubelet.config.k8s.io%2Fv1beta1%0AcgroupDriver%3A%20systemd%0AclusterDNS%3A%0A%20%20-%2010.3.0.10%0AclusterDomain%3A%20cluster.local%0AmaxPods%3A%20250%0ArotateCertificates%3A%20true%0AserializeImagePulls%3A%20false%0AstaticPodPath%3A%20%2Fetc%2Fkubernetes%2Fmanifests%0AsystemReserved%3A%0A%20%20cpu%3A%20500m%0A%20%20memory%3A%20500Mi%0AfeatureGates%3A%0A%20%20RotateKubeletServerCertificate%3A%20true%0A%20%20ExperimentalCriticalPodAnnotation%3A%20true%0A%20%20SupportPodPidsLimit%3A%20true%0A%20%20LocalStorageCapacityIsolation%3A%20false%0AserverTLSBootstrap%3A%20true%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -10,7 +10,6 @@ contents:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
     maxPods: 250
-    runtimeRequestTimeout: 10m
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -11,7 +11,6 @@ contents:
     clusterDomain: cluster.local
     maxPods: 250
     rotateCertificates: true
-    runtimeRequestTimeout: 10m
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:


### PR DESCRIPTION
Backport: https://github.com/openshift/machine-config-operator/pull/1120

**- What I did**
This timeout delays when kubelet will send a sigkill to a process causing tests to timeout waiting for pods to be deleted. The delay for a SIGKILL is 10minutes+ when it should be much faster. The default will be around 2 minutes.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1752982

- How to verify it

**- How to verify it**

**- Description for the changelog**
```
Remove runtimeRequestTimeout from Kubelet config to improve pod deletion times. This option is also used for Pod terminations.
```