### PR TITLE
Bug 1753067: Create a namespace for OpenStack infra static pods

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -7,3 +7,14 @@ metadata:
   labels:
     name: openshift-machine-config-operator
     openshift.io/run-level: "1"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-openstack-infra
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    name: openshift-openstack-infra
+    openshift.io/run-level: "1"
+

--- a/manifests/openstack/coredns.yaml
+++ b/manifests/openstack/coredns.yaml
@@ -3,11 +3,11 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: openshift-kni-infra
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-mdns
+    app: openstack-infra-mdns
 spec:
   volumes:
   - name: resource-dir

--- a/manifests/openstack/keepalived.yaml
+++ b/manifests/openstack/keepalived.yaml
@@ -3,11 +3,11 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: openshift-kni-infra
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-vrrp
+    app: openstack-infra-vrrp
 spec:
   volumes:
   - name: resource-dir

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1654,11 +1654,11 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: openshift-kni-infra
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-mdns
+    app: openstack-infra-mdns
 spec:
   volumes:
   - name: resource-dir
@@ -1815,11 +1815,11 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: openshift-kni-infra
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-vrrp
+    app: openstack-infra-vrrp
 spec:
   volumes:
   - name: resource-dir

--- a/templates/common/openstack/files/openstack-NetworkManager-conf.yaml
+++ b/templates/common/openstack/files/openstack-NetworkManager-conf.yaml
@@ -1,6 +1,6 @@
 filesystem: "root"
 mode: 0644
-path: "/etc/NetworkManager/conf.d/99-kni.conf"
+path: "/etc/NetworkManager/conf.d/99-openstack.conf"
 contents:
   inline: |
     [main]

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -7,11 +7,11 @@ contents:
     apiVersion: v1
     metadata:
       name: coredns
-      namespace: openshift-kni-infra
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-mdns
+        app: openstack-infra-mdns
     spec:
       volumes:
       - name: resource-dir

--- a/templates/common/openstack/files/openstack-keepalived.yaml
+++ b/templates/common/openstack/files/openstack-keepalived.yaml
@@ -7,11 +7,11 @@ contents:
     apiVersion: v1
     metadata:
       name: keepalived
-      namespace: openshift-kni-infra
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-vrrp
+        app: openstack-infra-vrrp
     spec:
       volumes:
       - name: resource-dir

--- a/templates/common/openstack/files/openstack-mdns-publisher.yaml
+++ b/templates/common/openstack/files/openstack-mdns-publisher.yaml
@@ -7,11 +7,11 @@ contents:
     apiVersion: v1
     metadata:
       name: mdns-publisher
-      namespace: openshift-kni-infra
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-mdns
+        app: openstack-infra-mdns
     spec:
       volumes:
       - name: resource-dir

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -7,11 +7,11 @@ contents:
     apiVersion: v1
     metadata:
       name: haproxy
-      namespace: openshift-kni-infra
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-api-lb
+        app: openstack-infra-api-lb
     spec:
       volumes:
       - name: resource-dir

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -7,11 +7,11 @@ contents:
     apiVersion: v1
     metadata:
       name: haproxy
-      namespace: openshift-kni-infra
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-api-lb
+        app: openstack-infra-api-lb
     spec:
       volumes:
       - name: resource-dir


### PR DESCRIPTION
Currently infra pods are created in "openshift-kni-infra" namespace, which doesn't exist. It leads to various OOM errors and CI issues.

This patch creates the missing namespace "openshift-openstack-infra" and puts all the pods there, since "openshift-kni-infra" belongs to KNI team.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1753067
