### PR TITLE
Bug 1753411: manifests: Create namespace for static pods IPI-BM

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -17,4 +17,14 @@ metadata:
   labels:
     name: openshift-openstack-infra
     openshift.io/run-level: "1"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kni-infra
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    name: openshift-kni-infra
+    openshift.io/run-level: "1"
 


### PR DESCRIPTION
Currently infra pods are created in "openshift-kni-infra" namespace, which doesn't exist. It leads to various OOM errors.

This patch creates the missing namespace "openshift-kni-infra".

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
