### PR TITLE
Bug 1753932: OpenStack: Ensure haproxy pod has the needed resources

### DIFF
--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -67,6 +67,10 @@ contents:
               /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
           fi
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"
@@ -90,6 +94,10 @@ contents:
         - "/etc/haproxy/haproxy.cfg"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"


### PR DESCRIPTION
One of the consequences of making the static pods known to k8s in https://github.com/openshift/machine-config-operator/pull/1122 is that now the smoke test complain that some of the pods do not comply with the requirements.

By adding resources claim to the `haproxy` pod, we ensure it is not running with best-effort QoS.

This fixes the "[Feature:Platform][Smoke] Managed cluster should ensure control plane pods do not run in best-effort QoS [Suite:openshift/conformance/parallel]" failure in e2e-openstack job.