### PR TITLE
OpenStack: CI failure: ensure infra pods have tolerations

### DIFF
--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -86,6 +86,13 @@ contents:
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:
-      - operator: Exists
+      - key: node.kubernetes.io/not-ready
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
+      - key: node.kubernetes.io/unreachable
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
       priorityClassName: system-node-critical
     status: {}

--- a/templates/common/openstack/files/openstack-keepalived.yaml
+++ b/templates/common/openstack/files/openstack-keepalived.yaml
@@ -82,6 +82,13 @@ contents:
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:
-      - operator: Exists
+      - key: node.kubernetes.io/not-ready
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
+      - key: node.kubernetes.io/unreachable
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
       priorityClassName: system-node-critical
     status: {}

--- a/templates/common/openstack/files/openstack-mdns-publisher.yaml
+++ b/templates/common/openstack/files/openstack-mdns-publisher.yaml
@@ -70,6 +70,13 @@ contents:
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:
-      - operator: Exists
+      - key: node.kubernetes.io/not-ready
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
+      - key: node.kubernetes.io/unreachable
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
       priorityClassName: system-node-critical
     status: {}

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -113,6 +113,16 @@ contents:
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:
-      - operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
+      - key: node.kubernetes.io/unreachable
+        effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 120
       priorityClassName: system-node-critical
     status: {}

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -67,6 +67,10 @@ contents:
               /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
           fi
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"
@@ -90,6 +94,10 @@ contents:
         - "/etc/haproxy/haproxy.cfg"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"


### PR DESCRIPTION
One of the OpenShift requirements is that all pods must have "not-ready" and "unreachable" tolerations. This commit adds them to the infra pods.