### PR TITLE
baremetal: Add external DNS entries to coredns

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -7,6 +7,12 @@
     reload
     hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        fallthrough
+    }
+    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -98,6 +98,12 @@ var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     reload
     hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        fallthrough
+    }
+    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
 }

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -12,6 +12,12 @@ contents:
         reload
         hosts /etc/coredns/api-int.hosts {{ .EtcdDiscoveryDomain }} {
             {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .EtcdDiscoveryDomain }}
+            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .EtcdDiscoveryDomain }}
+            fallthrough
+        }
+        template IN A {{ .EtcdDiscoveryDomain }} {
+            match .*.apps.{{ .EtcdDiscoveryDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
             fallthrough
         }
     }


### PR DESCRIPTION
In order to facilitate deployments where the external DNS records do
not exist yet, add them to our coredns configuration so that the
deployment can be done in a completely self-contained manner.

Note that the external DNS entries will still need to be added for
production use of the cluster, but this lowers the barrier to entry
for PoC and initial deployments.

Because the hosts plugin does not support wildcard entries, the
template plugin is used for the ingress record instead.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
