### PR TITLE
[4.3] bump pid limit for large workloads

### DIFF
--- a/templates/common/_base/files/sysctl-pid-limit.yaml
+++ b/templates/common/_base/files/sysctl-pid-limit.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/pid_max.conf"
+contents:
+  inline: |
+    kernel.pid_max = 4194304
+


### PR DESCRIPTION
**- What I did**
@RobertKrawitz was testing some large workloads, and we found pid limits pretty small (131072). This PR bumps the pid limits to 4194304.

**- How to verify it**

**- Description for the changelog**
```
Bumps PID limits to 4194304.
```
