### PR TITLE
Bug 1753067: Revert: "Temporarily put OpenStack infra pods into non-existing namespace"

### DIFF
--- a/manifests/openstack/coredns.yaml
+++ b/manifests/openstack/coredns.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: non-existent
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/manifests/openstack/keepalived.yaml
+++ b/manifests/openstack/keepalived.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: non-existent
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1654,7 +1654,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: non-existent
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
@@ -1815,7 +1815,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: non-existent
+  namespace: openshift-openstack-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: coredns
-      namespace: non-existent
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/common/openstack/files/openstack-keepalived.yaml
+++ b/templates/common/openstack/files/openstack-keepalived.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: keepalived
-      namespace: non-existent
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/common/openstack/files/openstack-mdns-publisher.yaml
+++ b/templates/common/openstack/files/openstack-mdns-publisher.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: mdns-publisher
-      namespace: non-existent
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: haproxy
-      namespace: non-existent
+      namespace: openshift-kni-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: haproxy
-      namespace: non-existent
+      namespace: openshift-openstack-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1753067

This reverts commit ae890b7a4d363655d8c49ee375247079be9d5869.