### PR TITLE
Bug 1754924: Makefile: pin tools to specific versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPONENTS = daemon controller server operator
 # vim: noexpandtab ts=8
 export GOPATH=$(shell echo $${GOPATH:-$$HOME/go})
 
-.PHONY: clean test test-unit test-e2e verify update
+.PHONY: clean test test-unit test-e2e verify update install-tools
 # Remove build artifaces
 # Example:
 #    make clean
@@ -40,16 +40,19 @@ test-unit:
 # Run the code generation tasks.
 # Example:
 #    make update
-update:
-	@which go-bindata 2> /dev/null >&1 || { echo "go-bindata must be installed to update generated code";  exit 1; }
+update: install-go-bindata
 	hack/update-codegen.sh
 	hack/update-generated-bindata.sh
+
+install-go-bindata:
+	hack/install-go-bindata.sh
+
+install-tools: install-go-bindata
 
 # Run verification steps
 # Example:
 #    make verify
-verify:
-	@which go-bindata 2> /dev/null >&1 || { echo "go-bindata must be installed to verify generated code";  exit 1; }
+verify: install-tools
 	hack/verify-codegen.sh
 	hack/verify-generated-bindata.sh
 

--- a/hack/install-go-bindata.sh
+++ b/hack/install-go-bindata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+version=6025e8de665b31fa74ab1a66f2cddd8c0abf887e
+
+OLD_GOPATH=$GOPATH
+GOPATH="$(mktemp -d)"
+
+mkdir $GOPATH/bin &&\
+git clone https://github.com/jteeuwen/go-bindata.git "$GOPATH/src/github.com/jteeuwen/go-bindata" &&\
+cd "$GOPATH/src/github.com/jteeuwen/go-bindata" &&\
+git checkout -q "$version" &&\
+go build -o build-go-bindata ./go-bindata
+
+GOPATH=$OLD_GOPATH
+cp build-go-bindata $GOPATH/bin/go-bindata


### PR DESCRIPTION
Get rid of the build failures cause of go1.10 with golangci-lint seen in https://github.com/openshift/machine-config-operator/pull/1121 and https://github.com/openshift/machine-config-operator/pull/1119

requires https://github.com/openshift/release/pull/5162