### PR TITLE
Bug 1755557: Ensure ETCD_INITIAL_CLUSTER is preserved during restore

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -26,7 +26,7 @@ contents:
     fi
 
     SNAPSHOT_FILE="$1"
-    ETCD_INITIAL_CLUSTER="$2"
+    INITIAL_CLUSTER="$2"
     ASSET_DIR=./assets
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
@@ -48,6 +48,7 @@ contents:
     source "/usr/local/bin/openshift-recovery-tools"
 
     function run {
+      ETCD_INITIAL_CLUSTER="${INITIAL_CLUSTER}"
       init
       dl_etcdctl
       backup_manifest
@@ -58,6 +59,7 @@ contents:
       fi
       validate_environment
       source /run/etcd/environment
+      ETCD_INITIAL_CLUSTER="${INITIAL_CLUSTER}"
       ETCD_NAME=$(validate_etcd_name)
       stop_static_pods
       stop_etcd


### PR DESCRIPTION
`/run/etcd/environment` can contain ETCD_INITIAL_CLUSTER which would override the value the user provided as an argument. This flow is used during disaster recovery when only a single master remains and the INITIAL_CLUSTER value needs to come from the user (the other members are dead / gone).  In the specific case, the recovery flow failed because we couldn't reestablish the master.

Backport #1133