### PR TITLE
[DO NOT MERGE] test e2e-aws-op on 4.2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # machine-config-operator
 
+
 OpenShift 4 is an [operator-focused platform](https://blog.openshift.com/openshift-4-a-noops-platform/),
 and the Machine Config operator extends that to the operating system itself,
 managing updates and configuration changes to essentially everything between the kernel and kubelet.


### PR DESCRIPTION
`master` seems broken because we can't evict the router pod - a 4.2 PR passed the tests tho so this is making sure 4.2 is unaffected.
