### PR TITLE
WIP set bfq scheduler as default

### DIFF
--- a/templates/master/00-master/_base/files/etc-udev-rules.d-60-block.rules.yaml
+++ b/templates/master/00-master/_base/files/etc-udev-rules.d-60-block.rules.yaml
@@ -1,0 +1,6 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/udev/rules.d/60-block.rules"
+contents:
+  inline: |
+    ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="bfq"


### PR DESCRIPTION
testing setting `bfq` as default vs `mq-deadline`

I was digging around and pretty surprised to see this.

[core@ip-10-0-167-161 test]$ cat /sys/block/xvda/queue/scheduler
[mq-deadline] kyber bfq none

ref: https://www.phoronix.com/scan.php?page=article&item=linux-50hdd-io&num=3