### PR TITLE
migrate rotate certificates to the config

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -16,6 +16,7 @@ contents:
     clusterDomain: cluster.local
     containerLogMaxSize: 50Mi
     maxPods: 250
+    rotateCertificates: true
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -18,7 +18,6 @@ contents: |
       kubelet \
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-        --rotate-certificates \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \

--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
@@ -18,7 +18,6 @@ contents: |
       kubelet \
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-        --rotate-certificates \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \


### PR DESCRIPTION
**- What I did**
Fixes a warning when the kubelet starts by migrating the rotateCertificates to the config file on masters. Workers already get set via config file.

**- How to verify it**
Kubelet will not warn with `Flag --rotate-certificates has been deprecated`.

**- Description for the changelog**
```
NONE
```