### PR TITLE
baremetal: templates/manifests: configure coredns hosts plugin to point at /dev/null

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -5,7 +5,7 @@
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+    hosts /dev/null {{ .ControllerConfig.EtcdDiscoveryDomain }} {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
         fallthrough
     }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -96,7 +96,7 @@ var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+    hosts /dev/null {{ .ControllerConfig.EtcdDiscoveryDomain }} {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
         fallthrough
     }

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -10,7 +10,7 @@ contents:
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
-        hosts /etc/coredns/api-int.hosts {{ .EtcdDiscoveryDomain }} {
+        hosts /dev/null {{ .EtcdDiscoveryDomain }} {
             {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .EtcdDiscoveryDomain }}
             fallthrough
         }


### PR DESCRIPTION
We aren't actually reading any records from the configured file, but
we need to have it anyway. Currently it points at a non-existent
file, which causes unnecessary warnings at startup. Setting it to
/dev/null instead silences these warnings and better indicates the
intent to have the file be a noop.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Configure baremetal coredns hosts plugin to point at /dev/null to silence missing file warnings.
