### PR TITLE
Bug 1745772: pkg/daemon: default drain grace period to -1

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -137,7 +137,7 @@ func (dn *Daemon) drainAndReboot(newConfig *mcfgv1.MachineConfig) (retErr error)
 			err := drain.Drain(dn.kubeClient, []*corev1.Node{dn.node}, &drain.DrainOptions{
 				DeleteLocalData:    true,
 				Force:              true,
-				GracePeriodSeconds: 600,
+				GracePeriodSeconds: -1,
 				IgnoreDaemonsets:   true,
 				Logger:             &drainLogger{},
 			})


### PR DESCRIPTION
Changing the timeout to -1 ensures the library always honor the pod's
grace period and fixes a subtle issue with the "downloads" pod taking
600s to be evicted.

Signed-off-by: Antonio Murdaca <runcom@linux.com>
