### PR TITLE
daemon: Support unpivoted images

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1154,6 +1154,11 @@ func compareOSImageURL(current, desired string) (bool, error) {
 		return true, nil
 	}
 
+	// If we're not in pivot:// right now, then it must not match.
+	if current == "" {
+		return false, nil
+	}
+
 	if current == desired {
 		return true, nil
 	}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
@@ -128,6 +129,9 @@ func TestCompareOSImageURL(t *testing.T) {
 	if m || err == nil {
 		t.Fatalf("Expected err")
 	}
+	m, err = compareOSImageURL("", refA)
+	assert.False(t, m)
+	assert.Nil(t, err)
 }
 
 type fixture struct {


### PR DESCRIPTION
Today the RHCOS bootimages come "prepivoted"; they have a custom
origin set to the `machine-os-content` that matches.  The idea
here is to avoid an extra reboot.

In practice we're always going to be updating and rebooting today,
because we don't have a mechanism to update bootimages:
https://github.com/openshift/os/issues/381

I plan to change the RHCOS build system to stop "prepivoting"; the
oscontainer will be pushed *after* the bootimages.  This breaks
a complicated dependency and ensures that the RHCOS "source of truth"
is the cosa storage.

Also, this allows one to use the MCD when e.g. booting Fedora CoreOS.

Closes: https://github.com/openshift/machine-config-operator/issues/981
