### PR TITLE
Bug 1758687: remove_certs should not fail, if the certificates are not found

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -138,10 +138,12 @@ contents:
     }
 
     remove_certs() {
-      COUNT=$(ls $ETCD_STATIC_RESOURCES/system\:etcd-* 2>/dev/null | wc -l)
+      COUNT=$(ls $ETCD_STATIC_RESOURCES/system\:etcd-* 2>/dev/null | wc -l) || true
       if [ "$COUNT" -gt 1 ]; then
          echo "Removing etcd certs.."
          rm -f $ETCD_STATIC_RESOURCES/system\:etcd-*
+      else
+         echo "remove_certs: etcd TLS certificates are not found."
       fi
     }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
remove_certs() function should be considered successful, if it cannot find old certificates to be removed. Currently, remove_certs() fails on pipefail when calculating the certificate file count.
**- How to verify it**
4.3 recovery disruptive test should pass.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixes: 1758687