### PR TITLE
Bug 1777150: pkg/controller: allow kubelet config and runtime changes for custom pools

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -97,7 +97,15 @@ func generateTemplateMachineConfigs(config *RenderConfig, templateDir string) ([
 
 // GenerateMachineConfigsForRole creates MachineConfigs for the role provided
 func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir string) ([]*mcfgv1.MachineConfig, error) {
-	path := filepath.Join(templateDir, role)
+	rolePath := role
+	//nolint:goconst
+	if role != "worker" && role != "master" {
+		// custom pools are only allowed to be worker's children
+		// and can reuse the worker templates
+		rolePath = "worker"
+	}
+
+	path := filepath.Join(templateDir, rolePath)
 	infos, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dir %q: %v", path, err)


### PR DESCRIPTION
Having kubelet config or runtime MCs for custom pools isn't possible today.
The reason for that was to avoid risking drift between workers when it comes
to kubelet and runtime configs.
This patches changes that behavior by allowing custom pools to use the worker
base templates in order to generate MCs for kubelet and runtime configs.

Fixes https://github.com/openshift/machine-config-operator/issues/1156

@rphillips @umohnani8 ptal

Signed-off-by: Antonio Murdaca <runcom@linux.com>