### PR TITLE
OpenStack: change coredns healthcheck port 8080->18080

### DIFF
--- a/manifests/openstack/coredns-corefile.tmpl
+++ b/manifests/openstack/coredns-corefile.tmpl
@@ -1,6 +1,6 @@
 . {
     errors
-    health
+    health :18080
     mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30

--- a/manifests/openstack/coredns.yaml
+++ b/manifests/openstack/coredns.yaml
@@ -68,7 +68,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /health
-        port: 8080
+        port: 18080
         scheme: HTTP
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -78,7 +78,7 @@ spec:
     livenessProbe:
       httpGet:
         path: /health
-        port: 8080
+        port: 18080
         scheme: HTTP
       initialDelaySeconds: 60
       timeoutSeconds: 5

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1622,7 +1622,7 @@ func manifestsMasterMachineconfigpoolYaml() (*asset, error) {
 
 var _manifestsOpenstackCorednsCorefileTmpl = []byte(`. {
     errors
-    health
+    health :18080
     mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
@@ -1719,7 +1719,7 @@ spec:
     readinessProbe:
       httpGet:
         path: /health
-        port: 8080
+        port: 18080
         scheme: HTTP
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -1729,7 +1729,7 @@ spec:
     livenessProbe:
       httpGet:
         path: /health
-        port: 8080
+        port: 18080
         scheme: HTTP
       initialDelaySeconds: 60
       timeoutSeconds: 5

--- a/templates/common/openstack/files/openstack-coredns-corefile.yaml
+++ b/templates/common/openstack/files/openstack-coredns-corefile.yaml
@@ -5,7 +5,7 @@ contents:
   inline: |
     . {
         errors
-        health
+        health :18080
         mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -66,7 +66,7 @@ contents:
         readinessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: 18080
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -76,7 +76,7 @@ contents:
         livenessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: 18080
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5


### PR DESCRIPTION
Port 8080 is used by cluster-network-operator in 4.3, so we can't deploy a cluster because of the conflict with coredns:

error listening on :8080: listen tcp :8080: bind: address already in use

This patch changes the coredns healthcheck port from 8080 to 18080 to resolve the conflict.