### PR TITLE
baremetal: templates/manifests: Remove parameters from hosts plugin c…

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -5,7 +5,7 @@
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+    hosts {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
         fallthrough
     }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -97,7 +97,7 @@ var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+    hosts {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
         fallthrough
     }

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -10,7 +10,7 @@ contents:
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
-        hosts /etc/coredns/api-int.hosts {{ .EtcdDiscoveryDomain }} {
+        hosts {
             {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .EtcdDiscoveryDomain }}
             fallthrough
         }


### PR DESCRIPTION
…onfiguration

Currently we have the hosts plugin configured to look at a dummy
file since we serve all of our addresses from the inline content.
However, this causes a warning when coredns starts up because the
file doesn't exist.

Since all of the parameters to the hosts plugin are optional, we can
just drop the file entirely. This also requires dropping the zone,
but since we use fallthrough it doesn't really matter if we specify
a zone. Any requests the hosts plugin can't handle will just be
passed along to the next plugin.

Not specifying a file causes it to default to /etc/hosts, which is
fine because the coredns container /etc/hosts file only contains
the entries for localhost.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
