### PR TITLE
Increase KubeAPIQPS and KubeAPIBurst to 50/100 respectively

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -16,6 +16,8 @@ contents:
     clusterDomain: cluster.local
     containerLogMaxSize: 50Mi
     maxPods: 250
+    kubeAPIQPS: 50
+    kubeAPIBurst: 100
     rotateCertificates: true
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -16,6 +16,8 @@ contents:
     clusterDomain: cluster.local
     containerLogMaxSize: 50Mi
     maxPods: 250
+    kubeAPIQPS: 50
+    kubeAPIBurst: 100
     rotateCertificates: true
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Increase the kubelet API QPS parameters to allow for more API transactions by the kubelet.

**- How to verify it**

Inspect the kubelet.conf on workers and masters, and the kubelet logs to ensure that the parameters are set accordingly

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Increase the kubelet API QPS parameters to allow for heavier load on nodes.