### PR TITLE
Bug 1759363: lib/resourcemerge: account for proxy changes

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -71,6 +71,11 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
 
+	if !equality.Semantic.DeepEqual(existing.Proxy, required.Proxy) {
+		*modified = true
+		existing.Proxy = required.Proxy
+	}
+
 	if required.PullSecret != nil && !equality.Semantic.DeepEqual(existing.PullSecret, required.PullSecret) {
 		existing.PullSecret = required.PullSecret
 		*modified = true


### PR DESCRIPTION
`ensureControllerConfigSpec` wasn't accounting for any change for the
Proxy field which lead to the `modified` bool not flipping to true when
the Proxy did change. That causes any edits in the Proxy object to not
trigger a resync because the new controllerconfig isn't updated with the
new proxy field. Fix all that by teaching `ensureControllerConfigSpec`
about Proxy field changes so the MCO _is_ resyncing once it changes.

Signed-off-by: Antonio Murdaca <runcom@linux.com>