### PR TITLE
pkg/controller/template: avoid resyncing templates if the cc didn't change

### DIFF
--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -403,6 +403,9 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		if err := ctrl.syncRunningStatus(cfg); err != nil {
 			return err
 		}
+	} else {
+		glog.V(2).Info("ControllerConfig didn't change, skipping templates sync")
+		return nil
 	}
 
 	var pullSecretRaw []byte


### PR DESCRIPTION
There are two main reasons for this patch. The first one is obivious and
avoids spending time retemplating when there's no need since the
ControllerConfig's spec hasn't changed.
The second reason is king of tricky but what can happen is the
following:

0) between 4.1 and 4.2 MCO changed the etcd-member image name
placeholder from `setupEtcdEnv` to `setupEtcdEnvKey` (along with other
changes to image names)
1) when an upgrade from 4.1 starts the following happens:
   a) the new MCO is rolled out
   b) the new MCC is rolled out (note the template controller is also
rolled out here and can start before the new CC is rolled out with the
new image name placeholder!)
   c) RACE! the template controller starts running before the new
ControllerConfig with the new image name placeholder is created
   d) the MCC generates templates w/o the image name for the etcd member
   e) cluster dies

The patch does a simple thing but ensures that the above scenario isn't
hit since we're not going to retemplate anymore if the CC hasn't changed
(yet).

Signed-off-by: Antonio Murdaca <runcom@linux.com>
