### PR TITLE
add setupEtcdEnvKey to images.json

### DIFF
--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -15,5 +15,6 @@ data:
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",
       "haproxyImage": "registry.svc.ci.openshift.org/openshift:haproxy-router",
       "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg",
-      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy"
+      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy",
+      "setupEtcdEnvKey": "registry.svc.ci.openshift.org/openshift:setup-etcd-environment"
     }


### PR DESCRIPTION
**- What I did**
setupEtcdEnvKey is referenced in the images.json file and is missing from the ConfigMap. `images.json` is generated from the ConfigMap.

I checked `release-4.2` and this will need backported as well. We also need @runcom's fix https://github.com/openshift/machine-config-operator/pull/1177

**- How to verify it**

**- Description for the changelog**
