### PR TITLE
hack/build-go: Print `go env` if it doesn't give us what we want

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -8,6 +8,11 @@ GOFLAGS=${GOFLAGS:-}
 GLDFLAGS=${GLDFLAGS:-}
 
 eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+if [ -z "${GOHOSTOS:-}" ] || [ -z "${GOHOSTARCH:-}" ]; then
+  go env
+  echo 'Failed to find expected variables in `go env` output above' 1>&2
+  exit 1
+fi
 
 : "${GOOS:=${GOHOSTOS}}"
 : "${GOARCH:=${GOHOSTARCH}}"


### PR DESCRIPTION
This is failing in Brew (rpm build) and reproducing that is annoying,
so let's have this print the env if it fails.
