### PR TITLE
spec: Remove GOPATH hacks

### DIFF
--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -18,12 +18,8 @@ BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1
 
 %prep
 %autosetup -Sgit -n machine-config-operator-%{commit}
-mkdir -p src/github.com/openshift/
-ln -sr . src/github.com/openshift/machine-config-operator
 
 %build
-export GOPATH=`pwd`
-cd src/github.com/openshift/machine-config-operator
 env VERSION_OVERRIDE=%{version} SOURCE_GIT_COMMIT=%{commit} make daemon
 
 %install


### PR DESCRIPTION
Now that I look at the build log more closely, the error is obvious:
`$GOPATH/go.mod exists but should not`

Now that in 4.3 we use go modules, we don't need to mess around with
`GOPATH`. 🎊

Closes: https://github.com/openshift/machine-config-operator/issues/1185
