### PR TITLE
Bug 1762868: revert #1177 and fix common templates in MCs

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -104,6 +104,10 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 	}
 
 	cfgs := []*mcfgv1.MachineConfig{}
+	// This func doesn't process "common"
+	// common templates are only added to 00-<role>
+	// templates/<role>/{00-<role>,01-<role>-container-runtime,01-<role>-kubelet}
+	var commonAdded bool
 	for _, info := range infos {
 		if !info.IsDir() {
 			glog.Infof("ignoring non-directory path %q", info.Name())
@@ -111,7 +115,7 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 		}
 		name := info.Name()
 		namePath := filepath.Join(path, name)
-		nameConfig, err := generateMachineConfigForName(config, role, name, templateDir, namePath)
+		nameConfig, err := generateMachineConfigForName(config, role, name, templateDir, namePath, &commonAdded)
 		if err != nil {
 			return nil, err
 		}
@@ -171,26 +175,29 @@ func filterTemplates(toFilter map[string]string, path string, config *RenderConf
 	return filepath.Walk(path, walkFn)
 }
 
-func generateMachineConfigForName(config *RenderConfig, role, name, templateDir, path string) (*mcfgv1.MachineConfig, error) {
+func generateMachineConfigForName(config *RenderConfig, role, name, templateDir, path string, commonAdded *bool) (*mcfgv1.MachineConfig, error) {
 	platform, err := platformFromControllerConfigSpec(config.ControllerConfigSpec)
 	if err != nil {
 		return nil, err
 	}
 
 	platformDirs := []string{}
-	// Loop over templates/common which applies everywhere
-	for _, dir := range []string{platformBase, platform} {
-		basePath := filepath.Join(templateDir, "common", dir)
-		exists, err := existsDir(basePath)
-		if err != nil {
-			return nil, err
+	if !*commonAdded {
+		// Loop over templates/common which applies everywhere
+		for _, dir := range []string{platformBase, platform} {
+			basePath := filepath.Join(templateDir, "common", dir)
+			exists, err := existsDir(basePath)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				continue
+			}
+			platformDirs = append(platformDirs, basePath)
 		}
-		if !exists {
-			continue
-		}
-		platformDirs = append(platformDirs, basePath)
+		*commonAdded = true
 	}
-	// And now over the target e.g. templates/master
+	// And now over the target e.g. templates/master/00-master,01-master-container-runtime,01-master-kubelet
 	for _, dir := range []string{platformBase, platform} {
 		platformPath := filepath.Join(path, dir)
 		exists, err := existsDir(platformPath)

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -403,9 +403,6 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		if err := ctrl.syncRunningStatus(cfg); err != nil {
 			return err
 		}
-	} else {
-		glog.V(2).Info("ControllerConfig didn't change, skipping templates sync")
-		return nil
 	}
 
 	var pullSecretRaw []byte


### PR DESCRIPTION
What #1177 had inadvertently regressed is that our MCs aren't rolled back anymore. This was sort of fine till the BZ came in, which exposed another bug we had. Basically, the code was adding duplicate and triplicates of common files all over. If you pair that with #1177, you'll get the bug in the title. 