### PR TITLE
pkg/controller: bring back old keys for image names

### DIFF
--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -18,7 +18,7 @@ spec:
     keepalivedImage: ""
     kubeClientAgentImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     mdnsPublisherImage: ""
-    setupEtcdEnvKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+    setupEtcdEnv: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
   infra:
     apiVersion: config.openshift.io/v1
     kind: Infrastructure

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -2,19 +2,19 @@ package template
 
 const (
 	// EtcdImageKey is the key that references the etcd image in the controller
-	EtcdImageKey string = "etcdKey"
+	EtcdImageKey string = "etcd"
 
 	// SetupEtcdEnvKey is the key that references the setup-etcd-environment image in the controller
-	SetupEtcdEnvKey string = "setupEtcdEnvKey"
+	SetupEtcdEnvKey string = "setupEtcdEnv"
 
 	// GCPRoutesControllerKey is the key that references the gcp-routes-controller image in the controller
-	GCPRoutesControllerKey string = "gcpRoutesControllerKey"
+	GCPRoutesControllerKey string = "gcpRoutesController"
 
 	// InfraImageKey is the key that references the infra image in the controller for crio.conf
-	InfraImageKey string = "infraImageKey"
+	InfraImageKey string = "infraImage"
 
 	// KubeClientAgentImageKey is the key that references the kube-client-agent image in the controller
-	KubeClientAgentImageKey string = "kubeClientAgentImageKey"
+	KubeClientAgentImageKey string = "kubeClientAgentImage"
 
 	// KeepalivedKey is the key that references the keepalived-ipfailover image in the controller
 	KeepalivedKey string = "keepalivedImage"

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -13,7 +13,7 @@ contents:
     spec:
       initContainers:
       - name: discovery
-        image: "{{.Images.setupEtcdEnvKey}}"
+        image: "{{.Images.setupEtcdEnv}}"
         command: ["/usr/bin/setup-etcd-environment"]
         args:
         - "run"
@@ -26,7 +26,7 @@ contents:
         - name: discovery
           mountPath: /run/etcd/
       - name: certs
-        image: "{{.Images.kubeClientAgentImageKey}}"
+        image: "{{.Images.kubeClientAgentImage}}"
         command:
         - /bin/sh
         - -c
@@ -81,7 +81,7 @@ contents:
           mountPath: /etc/kubernetes/kubeconfig
       containers:
       - name: etcd-member
-        image: "{{.Images.etcdKey}}"
+        image: "{{.Images.etcd}}"
         command:
         - /bin/sh
         - -c
@@ -143,7 +143,7 @@ contents:
           containerPort: 2379
           protocol: TCP
       - name: etcd-metrics
-        image: "{{.Images.etcdKey}}"
+        image: "{{.Images.etcd}}"
         command:
         - /bin/sh
         - -c

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -207,7 +207,7 @@ contents:
     global_auth_file = "/var/lib/kubelet/config.json"
 
     # pause_image is the image which we use to instantiate infra containers.
-    pause_image = "{{.Images.infraImageKey}}"
+    pause_image = "{{.Images.infraImage}}"
 
     # If not empty, the path to a docker/config.json-like file containing credentials
     # necessary for pulling the image specified by pause_image above.


### PR DESCRIPTION
To try and avoid failures in upgrades from 4.1 (???)

Signed-off-by: Antonio Murdaca <runcom@linux.com>