### PR TITLE
[release-4.2] pkg/controller: bring back old keys for image names

### DIFF
--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -18,7 +18,7 @@ spec:
     keepalivedImage: ""
     kubeClientAgentImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     mdnsPublisherImage: ""
-    setupEtcdEnvKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+    setupEtcdEnv: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
   infra:
     apiVersion: config.openshift.io/v1
     kind: Infrastructure

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -2,19 +2,19 @@ package template
 
 const (
 	// EtcdImageKey is the key that references the etcd image in the controller
-	EtcdImageKey string = "etcdKey"
+	EtcdImageKey string = "etcd"
 
 	// SetupEtcdEnvKey is the key that references the setup-etcd-environment image in the controller
-	SetupEtcdEnvKey string = "setupEtcdEnvKey"
+	SetupEtcdEnvKey string = "setupEtcdEnv"
 
 	// GCPRoutesControllerKey is the key that references the gcp-routes-controller image in the controller
-	GCPRoutesControllerKey string = "gcpRoutesControllerKey"
+	GCPRoutesControllerKey string = "gcpRoutesController"
 
 	// InfraImageKey is the key that references the infra image in the controller for crio.conf
-	InfraImageKey string = "infraImageKey"
+	InfraImageKey string = "infraImage"
 
 	// KubeClientAgentImageKey is the key that references the kube-client-agent image in the controller
-	KubeClientAgentImageKey string = "kubeClientAgentImageKey"
+	KubeClientAgentImageKey string = "kubeClientAgentImage"
 
 	// KeepalivedKey is the key that references the keepalived-ipfailover image in the controller
 	KeepalivedKey string = "keepalivedImage"

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -403,9 +403,6 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		if err := ctrl.syncRunningStatus(cfg); err != nil {
 			return err
 		}
-	} else {
-		glog.V(2).Info("ControllerConfig didn't change, skipping templates sync")
-		return nil
 	}
 
 	var pullSecretRaw []byte

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -220,6 +220,12 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		templatectrl.BaremetalRuntimeCfgKey:  imgs.BaremetalRuntimeCfg,
 	}
 
+	glog.Infof("runcom: ControllerConfig.Images: %+v", spec.Images)
+
+	if spec.Images[templatectrl.SetupEtcdEnvKey] == "" {
+		return fmt.Errorf("setupEtcdEnvImage is freaking empty")
+	}
+
 	// create renderConfig
 	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL)
 	return nil

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -13,7 +13,7 @@ contents:
     spec:
       initContainers:
       - name: discovery
-        image: "{{.Images.setupEtcdEnvKey}}"
+        image: "{{.Images.setupEtcdEnv}}"
         command: ["/usr/bin/setup-etcd-environment"]
         args:
         - "run"
@@ -26,7 +26,7 @@ contents:
         - name: discovery
           mountPath: /run/etcd/
       - name: certs
-        image: "{{.Images.kubeClientAgentImageKey}}"
+        image: "{{.Images.kubeClientAgentImage}}"
         command:
         - /bin/sh
         - -c
@@ -81,7 +81,7 @@ contents:
           mountPath: /etc/kubernetes/kubeconfig
       containers:
       - name: etcd-member
-        image: "{{.Images.etcdKey}}"
+        image: "{{.Images.etcd}}"
         command:
         - /bin/sh
         - -c
@@ -143,7 +143,7 @@ contents:
           containerPort: 2379
           protocol: TCP
       - name: etcd-metrics
-        image: "{{.Images.etcdKey}}"
+        image: "{{.Images.etcd}}"
         command:
         - /bin/sh
         - -c

--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
@@ -11,7 +11,7 @@ contents:
     spec:
       containers:
       - name: gcp-routes-controller
-        image: "{{.Images.gcpRoutesControllerKey}}"
+        image: "{{.Images.gcpRoutesController}}"
         command: ["gcp-routes-controller"]
         args:
         - "run"

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -207,7 +207,7 @@ contents:
     global_auth_file = "/var/lib/kubelet/config.json"
 
     # pause_image is the image which we use to instantiate infra containers.
-    pause_image = "{{.Images.infraImageKey}}"
+    pause_image = "{{.Images.infraImage}}"
 
     # If not empty, the path to a docker/config.json-like file containing credentials
     # necessary for pulling the image specified by pause_image above.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -207,7 +207,7 @@ contents:
     global_auth_file = "/var/lib/kubelet/config.json"
 
     # pause_image is the image which we use to instantiate infra containers.
-    pause_image = "{{.Images.infraImageKey}}"
+    pause_image = "{{.Images.infraImage}}"
 
     # If not empty, the path to a docker/config.json-like file containing credentials
     # necessary for pulling the image specified by pause_image above.


### PR DESCRIPTION
To try and avoid failures in upgrades from 4.1 (???)

backport of #1192 

Signed-off-by: Antonio Murdaca <runcom@linux.com>