### PR TITLE
Bug 1763636: [release-4.2] pkg/operator: fix race between images CM and MCO

### DIFF
--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   images.json: >
     {
+      "releaseVersion": "0.0.1-snapshot",
       "machineConfigOperator": "registry.svc.ci.openshift.org/openshift:machine-config-operator",
       "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
       "infraImage": "registry.svc.ci.openshift.org/openshift:pod",

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -8,6 +8,7 @@ package operator
 // Change the installer to pass that arg with the image from the CVO
 // (some time later) Change the option to required and drop the default
 type Images struct {
+	ReleaseVersion string `json:"releaseVersion,omitempty"`
 	RenderConfigImages
 	ControllerConfigImages
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -112,6 +112,11 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		return err
 	}
 
+	optrVersion, _ := optr.vStore.Get("operator")
+	if imgs.ReleaseVersion != optrVersion {
+		return fmt.Errorf("refusing to read images.json version %q, operator version %q", imgs.ReleaseVersion, optrVersion)
+	}
+
 	// sync up CAs
 	etcdCA, err := optr.getCAsFromConfigMap("openshift-config", "etcd-serving-ca", "ca-bundle.crt")
 	if err != nil {


### PR DESCRIPTION
Full context here https://docs.google.com/document/d/1mBDXujKsQjf0SSP9abLE_Mczvc8KE9D8qmeyoGdrD5Y/edit# (will make it public asap)

holding as it needs a proper bugzilla and whole process as well if this is accepted.

Signed-off-by: Antonio Murdaca <runcom@linux.com>