### PR TITLE
Bug 1763638: [release-4.1] pkg/operator: fix race between images CM and MCO

### DIFF
--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   images.json: >
     {
+      "releaseVersion": "0.0.1-snapshot",
       "machineConfigController": "docker.io/openshift/origin-machine-config-controller:v4.0.0",
       "machineConfigDaemon": "docker.io/openshift/origin-machine-config-daemon:v4.0.0",
       "machineConfigServer": "docker.io/openshift/origin-machine-config-server:v4.0.0",

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -8,6 +8,7 @@ package operator
 // Change the installer to pass that arg with the image from the CVO
 // (some time later) Change the option to required and drop the default
 type Images struct {
+	ReleaseVersion          string `json:"releaseVersion,omitempty"`
 	MachineConfigController string `json:"machineConfigController"`
 	MachineConfigDaemon     string `json:"machineConfigDaemon"`
 	MachineConfigServer     string `json:"machineConfigServer"`

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -334,6 +334,11 @@ func (optr *Operator) sync(key string) error {
 		return err
 	}
 
+	optrVersion, _ := optr.vStore.Get("operator")
+	if imgs.ReleaseVersion != optrVersion {
+		return fmt.Errorf("refusing to read images.json version %q, operator version %q", imgs.ReleaseVersion, optrVersion)
+	}
+
 	// sync up CAs
 	etcdCA, err := optr.getCAsFromConfigMap("openshift-config", "etcd-serving-ca", "ca-bundle.crt")
 	if err != nil {


### PR DESCRIPTION
Full context here https://docs.google.com/document/d/1mBDXujKsQjf0SSP9abLE_Mczvc8KE9D8qmeyoGdrD5Y/edit# (will make it public asap)

holding as it needs a proper bugzilla and whole process as well if this is accepted.

Signed-off-by: Antonio Murdaca runcom@linux.com