### PR TITLE
spec: Add -mod=vendor in GOFLAGS

### DIFF
--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -1,17 +1,17 @@
 %define debug_package %{nil}
-%global commit          4e75a8f20e5cf44374fd1bf3b3df997b8689d3ff
+%global commit          1bb46853cd115d5545aa6fd9f03fde92acce16f6
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           machine-config-daemon
 Version:        4.0.0
-Release:        1.rhaos4.2.git%{shortcommit}%{?dist}
+Release:        1.rhaos4.3.git%{shortcommit}%{?dist}
 Summary:        https://github.com/openshift/machine-config-operator
 License:        ASL 2.0
 URL:            https://github.com/openshift/machine-config-operator
 Source0:        https://github.com/openshift/machine-config-operator/archive/%{commit}/machine-config-operator-%{shortcommit}.tar.gz
 
 BuildRequires:  git
-BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.6.2}
+BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.12}
 
 %description
 %{summary}
@@ -20,7 +20,9 @@ BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1
 %autosetup -Sgit -n machine-config-operator-%{commit}
 
 %build
-env VERSION_OVERRIDE=%{version} SOURCE_GIT_COMMIT=%{commit} make daemon
+# By default go build doesn't uses vendored packags with Go modules
+# Should be fixed with Go 1.14 - https://github.com/golang/go/issues/33848
+env VERSION_OVERRIDE=%{version} SOURCE_GIT_COMMIT=%{commit} GOFLAGS='-mod=vendor' WHAT='machine-config-daemon' ./hack/build-go.sh
 
 %install
 install -D -m 0755 _output/linux/*/%{name} $RPM_BUILD_ROOT/usr/libexec/%{name}


### PR DESCRIPTION
With Go module switch, by default go build doesn't use vendor/
directory during. We need to explicitly set GOFLAGS with
-mod=vendor. This is required to build packages in build system
like brew/koji where external network download doesn't work

Support of using default vendored packages has landed recently
in Go https://github.com/golang/go/issues/33848, we might not
need this hack once Go 1.14 is out

Also update spec to recent MCO commit needed by MCD in 4.3
