### PR TITLE
Bug 1762536: pkg/daemon: drain before applying changes

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -874,7 +874,10 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	// take a stab at that and re-run the drain+reboot routine
 	if state.pendingConfig != nil && bootID == dn.bootID {
 		dn.logSystem("drain interrupted, retrying")
-		return dn.drainAndReboot(state.pendingConfig)
+		if err := dn.drain(); err != nil {
+			return err
+		}
+		return dn.finalizeAndReboot(state.pendingConfig)
 	}
 
 	if err := dn.detectEarlySSHAccessesFromBoot(); err != nil {


### PR DESCRIPTION
Drain before applying manifests and writing files to avoid, mainly, new pods being scheduled before we reboot into the new configuration which might also lead to etcd-quorum-guard being fooled and cluster disruption.

Signed-off-by: Antonio Murdaca <runcom@linux.com>