### PR TITLE
Bug 1764116: templates: rename our dropins to include the mco string

### DIFF
--- a/templates/common/_base/files/etc-systemd-system-crio.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-crio.service.d-10-default-env.conf.yaml
@@ -1,6 +1,6 @@
 filesystem: "root"
 mode: 0644
-path: "/etc/systemd/system/crio.service.d/10-default-env.conf"
+path: "/etc/systemd/system/crio.service.d/10-mco-default-env.conf"
 contents:
   inline: |
     {{if .Proxy -}}

--- a/templates/common/_base/files/etc-systemd-system-kubelet.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-kubelet.service.d-10-default-env.conf.yaml
@@ -1,6 +1,6 @@
 filesystem: "root"
 mode: 0644
-path: "/etc/systemd/system/kubelet.service.d/10-default-env.conf"
+path: "/etc/systemd/system/kubelet.service.d/10-mco-default-env.conf"
 contents:
   inline: |
     {{if .Proxy -}}

--- a/templates/common/_base/files/etc-systemd-system-machine-config-daemon-host.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-machine-config-daemon-host.service.d-10-default-env.conf.yaml
@@ -1,6 +1,6 @@
 filesystem: "root"
 mode: 0644
-path: "/etc/systemd/system/machine-config-daemon-host.service.d/10-default-env.conf"
+path: "/etc/systemd/system/machine-config-daemon-host.service.d/10-mco-default-env.conf"
 contents:
   inline: |
     {{if .Proxy -}}

--- a/templates/common/_base/files/etc-systemd-system-pivot.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-pivot.service.d-10-default-env.conf.yaml
@@ -1,6 +1,6 @@
 filesystem: "root"
 mode: 0644
-path: "/etc/systemd/system/pivot.service.d/10-default-env.conf"
+path: "/etc/systemd/system/pivot.service.d/10-mco-default-env.conf"
 contents:
   inline: |
     {{if .Proxy -}}


### PR DESCRIPTION
Mainly to avoid ppl to ship something which could override the MCO files.

The situation can still happen, in which case, the bad MC must be deleted and in order to rollback the maxUnavailable for the pool must be increased by at least 1

Signed-off-by: Antonio Murdaca <runcom@linux.com>