### PR TITLE
build-sys: Add `make install`, use it in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,13 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN make binaries
+# FIXME once we can depend on a new enough host that supports globs for COPY,
+# just use that.  For now we work around this by copying a tarball.
+RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-# FIXME once we can depend on build hosts having new enough container runtime
-# to support globs, let's use that.
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-daemon /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-controller /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/machine-config-server /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/setup-etcd-environment /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/machine-config-operator/_output/linux/amd64/gcp-routes-controller /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
+RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
 RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
 COPY templates /etc/mcc/templates

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 MCO_COMPONENTS = daemon controller server operator
 EXTRA_COMPONENTS = setup-etcd-environment gcp-routes-controller
 ALL_COMPONENTS = $(patsubst %,machine-config-%,$(MCO_COMPONENTS)) $(EXTRA_COMPONENTS)
+PREFIX ?= /usr
 GO111MODULE?=on
+
+# Copied from coreos-assembler
+GOARCH := $(shell uname -m)
+ifeq ($(GOARCH),x86_64)
+	GOARCH = amd64
+else ifeq ($(GOARCH),aarch64)
+	GOARCH = arm64
+endif
 
 # vim: noexpandtab ts=8
 export GOPATH=$(shell echo $${GOPATH:-$$HOME/go})
@@ -100,12 +109,17 @@ endef
 # Generate 'image_template' for each component
 $(foreach C, $(MCO_COMPONENTS), $(eval $(call image_template,$(C))))
 
-.PHONY: binaries images images.rhel7
+.PHONY: binaries install images images.rhel7
 
 # Build all binaries:
 # Example:
 #    make binaries
 binaries: $(patsubst %,_build-%,$(ALL_COMPONENTS))
+
+install: binaries
+	for component in $(ALL_COMPONENTS); do \
+	  install -D -m 0755 _output/linux/$(GOARCH)/$${component} $(DESTDIR)$(PREFIX)/bin/$${component}; \
+	done
 
 # Build all images:
 # Example:


### PR DESCRIPTION
This way we avoid hardcoding the architecture, which helps
multi-arch porting.  We also avoid enumerating the components
in `Dockerfile`.

For now, use a hack with `tar` - in the future we'll switch
to using globs once the api.ci cluster updates to 4.x.
