### PR TITLE
Include candidate IP in log message.

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -64,7 +64,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		for _, cand := range ips {
 			found, err := reverseLookupSelf("etcd-server-ssl", "tcp", runOpts.discoverySRV, cand)
 			if err != nil {
-				glog.Errorf("error looking up self: %v", err)
+				glog.Errorf("error looking up self for candidate IP %s: %v", cand, err)
 				continue
 			}
 			if found != "" {


### PR DESCRIPTION
I hit this log message when doing some IPv6 testing.  I found that it
would have been helpful to know the IP address it was checking.
There's a verbose message a few lines later that would print it, but
it won't be hit in this error scenario.