### PR TITLE
Bug 1763700: kubelet: add dependency on network-online.target

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -3,8 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service crio.service
-  After=crio.service
+  Wants=rpc-statd.service network-online.target crio.service
+  After=network-online.target crio.service
 
   [Service]
   Type=notify

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -3,8 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service crio.service
-  After=crio.service
+  Wants=rpc-statd.service network-online.target crio.service
+  After=network-online.target crio.service
 
   [Service]
   Type=notify


### PR DESCRIPTION
**- What I did**
This fixes a race when the kubelet enumerates the hostname at startup. Wait for the network-online.target to be ready before starting the Kubelet.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1763700

**- How to verify it**

**- Description for the changelog**
