### PR TITLE
Set correct labels to ovirt and kni infra pods

### DIFF
--- a/manifests/ovirt/coredns.yaml
+++ b/manifests/ovirt/coredns.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-mdns
+    app: ovirt-infra-mdns
 spec:
   volumes:
   - name: resource-dir

--- a/manifests/ovirt/keepalived.yaml
+++ b/manifests/ovirt/keepalived.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-vrrp
+    app: ovirt-infra-vrrp
 spec:
   volumes:
   - name: resource-dir

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2053,7 +2053,7 @@ metadata:
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-mdns
+    app: ovirt-infra-mdns
 spec:
   volumes:
   - name: resource-dir
@@ -2214,7 +2214,7 @@ metadata:
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: kni-infra-vrrp
+    app: ovirt-infra-vrrp
 spec:
   volumes:
   - name: resource-dir

--- a/templates/common/ovirt/files/ovirt-coredns.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns.yaml
@@ -11,7 +11,7 @@ contents:
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-mdns
+        app: ovirt-infra-mdns
     spec:
       volumes:
       - name: resource-dir

--- a/templates/common/ovirt/files/ovirt-keepalived.yaml
+++ b/templates/common/ovirt/files/ovirt-keepalived.yaml
@@ -11,7 +11,7 @@ contents:
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-vrrp
+        app: ovirt-infra-vrrp
     spec:
       volumes:
       - name: resource-dir

--- a/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
+++ b/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
@@ -11,7 +11,7 @@ contents:
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: kni-infra-mdns
+        app: ovirt-infra-mdns
     spec:
       volumes:
       - name: resource-dir

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -11,7 +11,7 @@ contents:
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: openstack-infra-api-lb
+        app: kni-infra-api-lb
     spec:
       volumes:
       - name: resource-dir

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -11,7 +11,7 @@ contents:
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: openstack-infra-api-lb
+        app: ovirt-infra-api-lb
     spec:
       volumes:
       - name: resource-dir


### PR DESCRIPTION
Baremetal and ovirt should use there own app labels