### PR TITLE
Create openshift-ovirt-infra namespace

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -28,3 +28,13 @@ metadata:
   labels:
     name: openshift-kni-infra
     openshift.io/run-level: "1"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-ovirt-infra
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    name: openshift-ovirt-infra
+    openshift.io/run-level: "1"

--- a/manifests/ovirt/coredns.yaml
+++ b/manifests/ovirt/coredns.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: openshift-kni-infra
+  namespace: openshift-ovirt-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/manifests/ovirt/keepalived.yaml
+++ b/manifests/ovirt/keepalived.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: openshift-kni-infra
+  namespace: openshift-ovirt-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2049,7 +2049,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: openshift-kni-infra
+  namespace: openshift-ovirt-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
@@ -2210,7 +2210,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: openshift-kni-infra
+  namespace: openshift-ovirt-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/templates/common/ovirt/files/ovirt-coredns.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: coredns
-      namespace: openshift-kni-infra
+      namespace: openshift-ovirt-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/common/ovirt/files/ovirt-keepalived.yaml
+++ b/templates/common/ovirt/files/ovirt-keepalived.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: keepalived
-      namespace: openshift-kni-infra
+      namespace: openshift-ovirt-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
+++ b/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: mdns-publisher
-      namespace: openshift-kni-infra
+      namespace: openshift-ovirt-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -7,7 +7,7 @@ contents:
     apiVersion: v1
     metadata:
       name: haproxy
-      namespace: openshift-kni-infra
+      namespace: openshift-ovirt-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:


### PR DESCRIPTION
This commit creates new openshift-ovirt-infra namespace and moves there all ovirt infra pods from openshift-kni-infra