### PR TITLE
build-sys: Generate Dockerfile.rhel7 from Dockerfile

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,34 +1,17 @@
+# THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN WHAT=machine-config-operator ./hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-operator /tmp/build/machine-config-operator
-RUN WHAT=machine-config-daemon ./hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-daemon /tmp/build/machine-config-daemon
-RUN WHAT=machine-config-controller ./hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-controller /tmp/build/machine-config-controller
-RUN WHAT=machine-config-server ./hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/machine-config-server /tmp/build/machine-config-server
-RUN WHAT=setup-etcd-environment ./hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/setup-etcd-environment /tmp/build/setup-etcd-environment
-RUN WHAT=gcp-routes-controller ./hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/machine-config-operator/_output/linux/$(go env GOARCH)/gcp-routes-controller /tmp/build/gcp-routes-controller
+RUN make binaries
+# FIXME once we can depend on a new enough host that supports globs for COPY,
+# just use that.  For now we work around this by copying a tarball.
+RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /tmp/build/machine-config-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
+RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
-COPY --from=builder /tmp/build/machine-config-daemon /usr/bin/
-RUN yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*
-COPY --from=builder /tmp/build/machine-config-controller /usr/bin/
+RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
 COPY templates /etc/mcc/templates
-COPY --from=builder /tmp/build/machine-config-server /usr/bin/
-COPY --from=builder /tmp/build/setup-etcd-environment /usr/bin/
-COPY --from=builder /tmp/build/gcp-routes-controller /usr/bin/
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ images: $(imc)
 #    make images.rhel7
 images.rhel7: $(imc7)
 
+Dockerfile.rhel7: Dockerfile Makefile
+	(echo '# THIS FILE IS GENERATED FROM '$<' DO NOT EDIT' && \
+	 sed -e s,org/openshift/release,org/ocp/builder, -e s,/openshift/origin-v4.0:base,/ocp/4.0:base, < $<) > $@.tmp && mv $@.tmp $@
+
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
 	go test -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/


### PR DESCRIPTION
This finally merges all of the cleanups that went into our
main `Dockerfile` into the ART build, and should ensure the
two stay in sync from now on.
