### PR TITLE
etcd: Add initial support for an IPv6 control plane

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -338,10 +338,6 @@ func ipAddrs(preferredIP string) ([]string, error) {
 		if ip == nil {
 			continue
 		}
-		ip = ip.To4()
-		if ip == nil {
-			continue // not an ipv4 address
-		}
 		if !ip.IsGlobalUnicast() {
 			continue // we only want global unicast address
 		}

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -179,7 +179,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	unexportedEnv := map[string]string{
 		// TODO This can actually be IPv6, so we should rename this ...
 		"IPV4_ADDRESS":         setupEnv.etcdIP,
-		"ESCAPED_IP_ADDR":      escapedIP,
+		"ESCAPED_IP_ADDRESS":   escapedIP,
 		"ESCAPED_ALL_IPS":      escapedAllIPs,
 		"LOCALHOST_IP":         localhostIP,
 		"ESCAPED_LOCALHOST_IP": escapedLocalhostIP,

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -156,9 +156,34 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	parsedIP := net.ParseIP(setupEnv.etcdIP)
+	if parsedIP == nil {
+		return fmt.Errorf("Failed to parse IP '%s'", setupEnv.etcdIP)
+	}
+
+	escapedIP := setupEnv.etcdIP
+	escapedAllIPs := "0.0.0.0"
+	localhostIP := "127.0.0.1"
+	escapedLocalhostIP := "127.0.0.1"
+	if parsedIP.To4() == nil {
+		// This is an IPv6 address, not IPv4.
+
+		// When using an IPv6 address in a URL, we must wrap the address portion in
+		// [::] so that a ":port" suffix can still be added and parsed correctly.
+		escapedIP = fmt.Sprintf("[%s]", setupEnv.etcdIP)
+		escapedAllIPs = "[::]"
+		localhostIP = "::1"
+		escapedLocalhostIP = "[::1]"
+	}
+
 	unexportedEnv := map[string]string{
-		"IPV4_ADDRESS":      setupEnv.etcdIP,
-		"WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", setupEnv.opts.discoverySRV),
+		// TODO This can actually be IPv6, so we should rename this ...
+		"IPV4_ADDRESS":         setupEnv.etcdIP,
+		"ESCAPED_IP_ADDR":      escapedIP,
+		"ESCAPED_ALL_IPS":      escapedAllIPs,
+		"LOCALHOST_IP":         localhostIP,
+		"ESCAPED_LOCALHOST_IP": escapedLocalhostIP,
+		"WILDCARD_DNS_NAME":    fmt.Sprintf("*.%s", setupEnv.opts.discoverySRV),
 	}
 	if setupEnv.etcdDNS != "" {
 		unexportedEnv["DNS_NAME"] = setupEnv.etcdDNS

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -404,7 +404,7 @@ func etcdServerCertCommand(cfg RenderConfig) (interface{}, error) {
 			"  --assetsdir=/etc/ssl/etcd \\",
 			fmt.Sprintf("  --dnsnames=%s \\", serverCertDNS),
 			"  --commonname=system:etcd-server:${ETCD_DNS_NAME} \\",
-			"  --ipaddrs=${ETCD_IPV4_ADDRESS},127.0.0.1 \\",
+			"  --ipaddrs=${ETCD_IPV4_ADDRESS},${ETCD_LOCALHOST_IP} \\",
 		}...)
 	} else {
 		commands = append(commands, []string{

--- a/templates/common/_base/files/sysctl-forward-conf.yaml
+++ b/templates/common/_base/files/sysctl-forward-conf.yaml
@@ -4,4 +4,5 @@ path: "/etc/sysctl.d/forward.conf"
 contents:
   inline: |
     net.ipv4.ip_forward = 1
+    net.ipv6.conf.all.forwarding = 1
 

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -135,7 +135,7 @@ contents:
           set +a
 
           exec etcd \
-            --initial-advertise-peer-urls=https://${ETCD_ESCAPED_IP_ADDR}:2380 \
+            --initial-advertise-peer-urls=https://${ETCD_ESCAPED_IP_ADDRESS}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \
             --trusted-ca-file=/etc/ssl/etcd/ca.crt \
@@ -144,7 +144,7 @@ contents:
             --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key \
             --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
             --peer-client-cert-auth=true \
-            --advertise-client-urls=https://${ETCD_ESCAPED_IP_ADDR}:2379 \
+            --advertise-client-urls=https://${ETCD_ESCAPED_IP_ADDRESS}:2379 \
             --listen-client-urls=https://${ETCD_ESCAPED_ALL_IPS}:2379 \
             --listen-peer-urls=https://${ETCD_ESCAPED_ALL_IPS}:2380 \
             --listen-metrics-urls=https://${ETCD_ESCAPED_ALL_IPS}:9978 \

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -135,7 +135,7 @@ contents:
           set +a
 
           exec etcd \
-            --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
+            --initial-advertise-peer-urls=https://${ETCD_ESCAPED_IP_ADDR}:2380 \
             --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
             --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \
             --trusted-ca-file=/etc/ssl/etcd/ca.crt \
@@ -144,10 +144,10 @@ contents:
             --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key \
             --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
             --peer-client-cert-auth=true \
-            --advertise-client-urls=https://${ETCD_IPV4_ADDRESS}:2379 \
-            --listen-client-urls=https://0.0.0.0:2379 \
-            --listen-peer-urls=https://0.0.0.0:2380 \
-            --listen-metrics-urls=https://0.0.0.0:9978 \
+            --advertise-client-urls=https://${ETCD_ESCAPED_IP_ADDR}:2379 \
+            --listen-client-urls=https://${ETCD_ESCAPED_ALL_IPS}:2379 \
+            --listen-peer-urls=https://${ETCD_ESCAPED_ALL_IPS}:2380 \
+            --listen-metrics-urls=https://${ETCD_ESCAPED_ALL_IPS}:9978 \
         securityContext:
           privileged: true
         resources:
@@ -194,8 +194,8 @@ contents:
 
           exec etcd grpc-proxy start \
             --endpoints https://${ETCD_DNS_NAME}:9978 \
-            --metrics-addr https://0.0.0.0:9979 \
-            --listen-addr 127.0.0.1:9977 \
+            --metrics-addr https://${ETCD_ESCAPED_ALL_IPS}:9979 \
+            --listen-addr ${ETCD_ESCAPED_LOCALHOST_IP}:9977 \
             --key /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key \
             --key-file /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.key \
             --cert /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.crt \


### PR DESCRIPTION
I'm working on bringing OpenShift up with an IPv6 control plane.  With these changes, the etcd cluster forms and the bootstrap process continues.  There are still some suspicious messages in the etcd-member log, but this seems like a good start.

The changes should have no impact to other installs unless the etcd DNS records are created with IPv6 addresses instead of IPv4.  Otherwise, there should be no changes in the resulting behavior.

This is not intended to be complete IPv6 support, just a start.  There's an `IPV4_ADDRESS` variable I left unchanged to cut down on the size of the patch.  I also noticed similar issues still need to be fixed in the recovery tools.