### PR TITLE
templates: Let m-c-d binary on host process encapsulated MC on firstboot

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service
@@ -5,11 +5,8 @@ contents: |
   Description=Machine Config Daemon Firstboot
   # Make sure it runs only on OSTree booted system
   ConditionPathExists=/run/ostree-booted
-  # This effectively disables this unit unitl we get latest
-  # machine-config-daemon package into bootimage
-  ConditionPathExists=!/etc/pivot/image-pullspec
-  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
   BindsTo=ignition-firstboot-complete.service
+  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
   After=ignition-firstboot-complete.service
   Before=kubelet.service
 


### PR DESCRIPTION
During firstboot machine-config-daemon running on host will read
/etc/ignition-machine-config-encapsulated.json file available on
node, process it and applies MachineConfig provided like
kernelArguments