### PR TITLE
build-sys: Remove dead code in Makefile, fix HACKING.md typo

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -181,7 +181,7 @@ generated in `make image` to the container registry of your choice. For example,
 in via the command-line:
 
 ```
-REPO={docker.io/username} /hack/push-image.sh
+REPO={docker.io/username} ./hack/push-image.sh
 ```
 
 Quay.io or any other public registry isn't strictly required - you can use a local


### PR DESCRIPTION
There's only one image now, so remove the `Makefile` bits
around multiple images.  Doing this since I typed `make images`
which failed, when I meant `make image`.
