### PR TITLE
[Baremetal] - update haproxy statistics url

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -24,7 +24,7 @@ contents:
       monitor-uri /healthz
       option dontlognull
     listen stats
-      bind 127.0.0.1:{{`{{ .LBConfig.StatPort }}`}}
+      bind localhost:{{`{{ .LBConfig.StatPort }}`}}
       mode http
       stats enable
       stats hide-version


### PR DESCRIPTION
Update statistics url in Haproxy config to support both
IPv4 and IPv6 (single stack).

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
