### PR TITLE
setup-etcd-environment: support scaling from cluster-etcd-operator

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	EtcdScalingAnnotationKey = "etcd.operator.openshift.io/scale"
-	assetDir                 = "/etc/ssl/etcd"
+	etcdInitialExisting      = "existing"
 )
 
 var (
@@ -152,7 +152,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 			}
 			memberList = append(memberList, fmt.Sprintf("%s=https://%s:2380", etcdName, dns))
 			exportEnv["INITIAL_CLUSTER"] = strings.Join(memberList, ",")
-			exportEnv["INITIAL_CLUSTER_STATE"] = "existing"
+			exportEnv["INITIAL_CLUSTER_STATE"] = etcdInitialExisting
 			return true, nil
 		})
 
@@ -181,6 +181,12 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		exportEnv["ENDPOINTS"] = strings.Join(endpoints, ",")
+	} else {
+		// initialize envs used to bootstrap etcd
+		exportEnv, err = setBootstrapEnv(runOpts.outputFile, runOpts.discoverySRV, runOpts.bootstrapSRV)
+		if err != nil {
+			return err
+		}
 	}
 
 	out := os.Stdout
@@ -297,7 +303,7 @@ func reverseLookupSelf(service, proto, name, self string) (string, error) {
 }
 
 //
-func lookupTargetMatchSelf(target string, self string) (string, error) {
+func lookupTargetMatchSelf(target, self string) (string, error) {
 	addrs, err := net.LookupHost(target)
 	if err != nil {
 		return "", fmt.Errorf("could not resolve member %q", target)

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -7,12 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"net"
 	"os"
-	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -111,7 +108,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 				ip = cand
 				return true, nil
 			}
-			glog.V(4).Infof("no matching dns for %s", cand)
+			glog.V(4).Infof("no matching dns for %s in %s: %v", cand, runOpts.discoverySRV, err)
 		}
 		return false, nil
 	}); err != nil {
@@ -157,10 +154,6 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 			members := e.Members
 			if len(members) == 0 {
 				glog.Errorf("no members found in member-config")
-				return false, nil
-			}
-			err = waitForCerts(client, "openshift-etcd", etcdName, e.PodFQDN)
-			if err != nil {
 				return false, nil
 			}
 			var memberList []string
@@ -323,75 +316,4 @@ func inCluster() bool {
 		return false
 	}
 	return true
-}
-
-// TODO: Port this logic into Quay
-func waitForCerts(client *kubernetes.Clientset, secretNamespace, podName, podFQDN string) error {
-	peerSecretName := podName + "-peer"
-	serverSecretName := podName + "-server"
-	metricSecretName := podName + "-metric"
-	peerCN := "system:etcd-peer:" + podFQDN
-	secretCN := "system:etcd-server:" + podFQDN
-	metricCN := "system:etcd-metric:" + podFQDN
-
-	glog.Infof("getting peer secret %v/%v\n", secretNamespace, peerSecretName)
-	if err := writeSecret(client, peerSecretName, secretNamespace, peerCN); err != nil {
-		return err
-	}
-
-	// wait for server certs
-	glog.Infof("getting server secret %v/%v\n", secretNamespace, serverSecretName)
-	if err := writeSecret(client, serverSecretName, secretNamespace, secretCN); err != nil {
-		return err
-	}
-
-	// wait for server certs
-	glog.Infof("getting metric secret %v/%v\n", secretNamespace, metricSecretName)
-	if err := writeSecret(client, metricSecretName, secretNamespace, metricCN); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func writeSecret(client *kubernetes.Clientset, secretName, secretNamespace, cn string) error {
-	glog.Infof("getting secret %v/%v\n", secretNamespace, secretNamespace)
-	secret, err := client.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
-	if err != nil {
-		glog.Errorf("error in getting secret %s/%s: %v", secretNamespace, secretName, err)
-		return err
-	}
-	glog.Infof("ensure secret keys %v/%v\n", secretNamespace, secretName)
-	err = ensureCertKeys(secret.Data)
-	if err != nil {
-		return err
-	}
-
-	glog.Infof("writing secret to %v\n", cn)
-	err = writeToFile(secret, cn)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func ensureCertKeys(data map[string][]byte) error {
-	if len(data["tls.crt"]) == 0 || len(data["tls.key"]) == 0 {
-		return fmt.Errorf("invalid secret data")
-	}
-	return nil
-}
-
-func writeToFile(s *v1.Secret, commonName string) error {
-	// write out signed certificate to disk
-	certFile := path.Join(assetDir, commonName+".crt")
-	//fmt.Printf("%s", s.Data["tls.crt"])
-	if err := ioutil.WriteFile(certFile, s.Data["tls.crt"], 0644); err != nil {
-		return fmt.Errorf("unable to write to %s: %v", certFile, err)
-	}
-	keyFile := path.Join(assetDir, commonName+".key")
-	if err := ioutil.WriteFile(keyFile, s.Data["tls.key"], 0644); err != nil {
-		return fmt.Errorf("unable to write to %s: %v", keyFile, err)
-	}
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20191014195513-c9253efc14f4+incompatible
 	github.com/openshift/client-go v0.0.0-20191001081553-3b0e988f8cb0
 	github.com/openshift/cluster-api v0.0.0-20190923092624-4024de4fa64d
+	github.com/openshift/cluster-etcd-operator v0.0.0-alpha.0.0.20191025163650-5854b5c48ce4
 	github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901
 	github.com/openshift/runtime-utils v0.0.0-20191011150825-9169de69ebf6
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -685,6 +685,8 @@ github.com/openshift/client-go v0.0.0-20191001081553-3b0e988f8cb0 h1:U0rtkdPj1lT
 github.com/openshift/client-go v0.0.0-20191001081553-3b0e988f8cb0/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/cluster-api v0.0.0-20191004085540-83f32d3e7070 h1:Yw3cWSzWhZ9Kh8WqX6tOccVPs9BWUp4jDfb6I8AU/pg=
 github.com/openshift/cluster-api v0.0.0-20191004085540-83f32d3e7070/go.mod h1:mNsD1dsD4T57kV4/C6zTHke/Ro166xgnyyRZqkamiEU=
+github.com/openshift/cluster-etcd-operator v0.0.0-alpha.0.0.20191025163650-5854b5c48ce4 h1:EDZ2v8AqMnXgeT3bECcbamUg8Haz0V/iXqDMlu94Mrw=
+github.com/openshift/cluster-etcd-operator v0.0.0-alpha.0.0.20191025163650-5854b5c48ce4/go.mod h1:vcBAUefK8pQmTPQ3jlCemORXhnRnq3aTsfOSVeaWliY=
 github.com/openshift/imagebuilder v1.1.0 h1:oT704SkwMEzmIMU/+Uv1Wmvt+p10q3v2WuYMeFI18c4=
 github.com/openshift/imagebuilder v1.1.0/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/openshift/kubernetes v1.16.0-beta.0.0.20190913145653-2bd9643cee5b h1:b3r/3odnWNdjYRrwvXiqxLFbPYFQ+m2GblFK6RwTC9Y=

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -74,7 +74,7 @@ contents:
           mountPath: /etc/ssl/etcd/
         - name: kubeconfig
           mountPath: /etc/kubernetes/kubeconfig
-    {{if .Images.clusterEtcdOperatorImageKey}}
+   {{if .Images.clusterEtcdOperatorImageKey}}
         - name: sa
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
    {{end}}

--- a/vendor/github.com/openshift/cluster-etcd-operator/LICENSE
+++ b/vendor/github.com/openshift/cluster-etcd-operator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/cluster-etcd-operator/pkg/operator/api/scaling.go
+++ b/vendor/github.com/openshift/cluster-etcd-operator/pkg/operator/api/scaling.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	v1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type EtcdScaling struct {
+	Metadata *metav1.ObjectMeta `json:"metadata,omitempty"`
+	Members  []Member           `json:"members,omitempty"`
+	// deprecated pending removal
+	PodFQDN string `json:"podFQDN,omitempty"`
+}
+
+type Member struct {
+	ID         uint64            `json:"ID,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	PeerURLS   []string          `json:"peerURLs,omitempty"`
+	ClientURLS []string          `json:"clientURLs,omitempty"`
+	Conditions []MemberCondition `json:"conditions,omitempty"`
+}
+
+type MemberCondition struct {
+	// type describes the current condition
+	Type MemberConditionType `json:"type"`
+	// status is the status of the condition (True, False, Unknown)
+	Status v1.ConditionStatus `json:"status"`
+	// timestamp for the last update to this condition
+	// +optional
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+	// reason is the reason for the condition's last transition.
+	// +optional
+	Reason string `json:"reason,omitempty"`
+	// message is a human-readable explanation containing details about
+	// the transition
+	// +optional
+	Message string `json:"message,omitempty"`
+}
+
+type MemberConditionType string
+
+const (
+	// Ready indicated the member is part of the cluster and endpoint is Ready
+	MemberReady MemberConditionType = "Ready"
+	// Unknown indicated the member condition is unknown and requires further observations to verify
+	MemberUnknown MemberConditionType = "Unknown"
+	// Degraded indicates the member pod is in a degraded state and should be restarted
+	MemberDegraded MemberConditionType = "Degraded"
+	// Remove indicates the member should be removed from the cluster
+	MemberRemove MemberConditionType = "Remove"
+	// MemberAdd is a member who is ready to join cluster but currently has not
+	MemberAdd MemberConditionType = "Add"
+)
+
+func GetMemberCondition(status string) MemberConditionType {
+	switch {
+	case status == string(MemberReady):
+		return MemberReady
+	case status == string(MemberRemove):
+		return MemberRemove
+	case status == string(MemberUnknown):
+		return MemberUnknown
+	case status == string(MemberDegraded):
+		return MemberDegraded
+	}
+	return ""
+}


### PR DESCRIPTION
The discovery init container is a very important part of the bootstraping process. Currently, we use SRV queries to populate ENV variables consumed by other containers in the pod.

As we move to an operator managed etcd cluster additional data points and validations need to be performed. The scaling of etcd is managed by the clustermembercontroller (CMC). When a new candidate for membership is verified as `Ready` to join the cluster the CMC populates a ConfigMap with basic information for the scaling process. This information includes details on the current members of the cluster. From this information, we can then populate the ETCD_INITIAL_CLUSTER variable which directs etcd on who its peers are.

To manage new candidates from racing only 1 member can scale at a time. Until that member has been added and verified no other member can be added. We do this by doing a wait until we observe the data identifying the pod as scaling.
 
We also populate a new ENV variable  ETCD_ENDPOINTS this is used later on in the process by a new init container called membership.

Pending changes: The following items will change in the near future.
- the `member-config` ConfigMap will stop using annotations for scaling data instead a more traditional `data: ` key.

depends on https://github.com/openshift/machine-config-operator/pull/1224