### PR TITLE
give etcd-metrics container privilege

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -176,6 +176,8 @@ contents:
         - name: metric
           containerPort: 9979
           protocol: TCP
+        securityContext:
+          privileged: true
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
**- What I did**
Explicitally give etcd-metrics container privilege, as it is trying to run /run/etc/environment on the host, but wasn't given permissions to do so

