### PR TITLE
[fcos] Specfile: Make `%global commit ...` overridable

### DIFF
--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -1,5 +1,5 @@
 %define debug_package %{nil}
-%global commit          1bb46853cd115d5545aa6fd9f03fde92acce16f6
+%{!?commit:%global commit 1bb46853cd115d5545aa6fd9f03fde92acce16f6}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           machine-config-daemon


### PR DESCRIPTION
Blocks: https://github.com/openshift/release/pull/5659

**- What I did**
Make `%global commit foo` overridable with `rpmbuild --define "commit bar"`

**- How to verify it**
This should unblock the `build-rpms-from-tar` job over in https://github.com/openshift/release/pull/5659

**- Description for the changelog**
Specfile: Make `%global commit ...` overridable