### PR TITLE
Bug 1769578: Specfile: Make `%global commit ...` overridable

### DIFF
--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -1,5 +1,7 @@
 %define debug_package %{nil}
+%{!?commit:
 %global commit          1bb46853cd115d5545aa6fd9f03fde92acce16f6
+}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           machine-config-daemon


### PR DESCRIPTION
Backport of https://github.com/openshift/machine-config-operator/pull/1225
Blocks: https://github.com/openshift/release/pull/5572

**- What I did**
Make `%global commit foo` overridable with `rpmbuild --define "commit bar"`

**- How to verify it**
CI does not break

**- Description for the changelog**
Specfile: Make `%global commit ...` overridable