### PR TITLE
daemon: Tweak wording for SSH metric

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -24,7 +24,7 @@ var (
 	MCDSSHAccessed = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "ssh_accessed",
-			Help: "indicates whether ssh access attempt",
+			Help: "indicates a successful SSH login",
 		})
 
 	// MCDDrainErr logs errors received during failed drain


### PR DESCRIPTION
We only see successful logins, let's make that clear.
Also capitalize SSH since it's an acronym.
