### PR TITLE
[fcos] mcd-pull: fix command to extract mcd on the hosts

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -13,7 +13,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/bin/sh -c "/usr/bin/podman run --quiet --net=host --entrypoint=sh '{{ .Images.setupEtcdEnvKey }}' cat /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
+  ExecStart=/usr/bin/podman run --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/bin/restorecon /usr/local/bin/machine-config-daemon
 


### PR DESCRIPTION
This fixed mcd-pull service command, previous failed with `/usr/bin/cat: 
cannot execute binary file`

/cc @LorbusChris