### PR TITLE
[fcos] mcd-pull: sh is required for output redirection

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -13,7 +13,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/bin/podman run --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon
+  ExecStart=/usr/bin/sh -c "/usr/bin/podman run --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/bin/restorecon /usr/local/bin/machine-config-daemon
 


### PR DESCRIPTION
Follow-up for #1228 - command needs to be wrapped in "sh" to do output redirection.

Seems we're gonna need `/override ci/prow/e2e-aws` here too as installer PR is not yet merged

/cc @LorbusChris 
