### PR TITLE
Bug 1766356: templates: tell NetworkManager to ignore interfaces

### DIFF
--- a/templates/common/_base/files/nm-ignore-sdn.yaml
+++ b/templates/common/_base/files/nm-ignore-sdn.yaml
@@ -1,0 +1,9 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/NetworkManager/conf.d/sdn.conf"
+contents:
+  inline: |
+    # ignore known SDN-managed devices
+    [device]
+    match-device=interface-name:br-int;interface-name:br-local;interface-name:br-nexthop,interface-name:k8s-*;interface-name:tun0;interface-name:br0;driver:veth
+    managed=0


### PR DESCRIPTION
The recent os bump includes the OVS plugin for NetworkManager, causing it to manage interfaces that were previously left unmanaged.

This functionality will be used, so we can't tell it to ignore all interfaces of type openvswitch. So, add the interfaces created by openshift-sdn and ovn-kubernetes to the Unmanaged list.
