### PR TITLE
[fcos] templates: place /etc/pivot/kernel-args on masters/workers

### DIFF
--- a/templates/common/_base/files/etc-pivot-kernel-args.yaml
+++ b/templates/common/_base/files/etc-pivot-kernel-args.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/pivot/kernel-args"
+contents:
+  inline: |
+    DELETE mitigations=auto,nosmt
+    ADD systemd.unified_cgroup_hierarchy=0


### PR DESCRIPTION
This would disable cgroupsv2 and Spectre mitigations. These files are served by MCD to ensure correct initial hash on masters is being calculated
