### PR TITLE
daemon: leave backup copy of encapsulated machineconfig

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -43,6 +43,11 @@ const (
 	// non-Ignition fields such as the osImageURL and kernelArguments.
 	MachineConfigEncapsulatedPath = "/etc/ignition-machine-config-encapsulated.json"
 
+	// MachineConfigEncapsulatedBakPath defines the path where the machineconfigdaemom-firstboot.service
+	// will leave a copy of the encapsulated MachineConfig in MachineConfigEncapsulatedPath after
+	// processing for debugging and auditing purposes.
+	MachineConfigEncapsulatedBakPath = "/etc/ignition-machine-config-encapsulated.json.bak"
+
 	// MachineConfigDaemonForceFile if present causes the MCD to skip checking the validity of the
 	// "currentConfig" state.  Create this file (empty contents is fine) if you wish the MCD
 	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -483,8 +483,8 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	}
 
 	// Removing this file signals completion of the initial MC processing.
-	if err := os.Remove(constants.MachineConfigEncapsulatedPath); err != nil {
-		return errors.Wrapf(err, "failed to remove %s", constants.MachineConfigEncapsulatedPath)
+	if err := os.Rename(constants.MachineConfigEncapsulatedPath, constants.MachineConfigEncapsulatedBakPath); err != nil {
+		return errors.Wrap(err, "failed to rename encapsulated MachineConfig after processing on firstboot")
 	}
 
 	dn.skipReboot = false


### PR DESCRIPTION
Rename rather than remove the encapsulated MachineConfig file after processing
on firstboot. This allows users to check what data was processed on the node
after the machineconfigdaemon-firstboot.service has run successfully.