### PR TITLE
*: enable cluster-etcd-operator

### DIFF
--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -11,7 +11,7 @@ data:
       "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
       "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
       "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift:kube-client-agent",
-      "clusterEtcdOperatorImage": "",
+      "clusterEtcdOperatorImage": "registry.svc.ci.openshift.org/openshift:cluster-etcd-operator",
       "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
       "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",

--- a/install/image-references
+++ b/install/image-references
@@ -31,6 +31,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:kube-client-agent
+  - name: cluster-etcd-operator
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:cluster-etcd-operator
   - name: cli
     from:
       kind: DockerImage


### PR DESCRIPTION
Currently, we use the presence/existence of the clusterEtcdOperatorImageKey flag value and the value of the clusterEtcdOperatorImage [1] [2] as a condition for using the old style SRV bootstrap or enable cluster-etcd-operator to scale etcd. This PR would enable 4.3 scaling for MCO.

- https://github.com/openshift/machine-config-operator/blob/release-4.3/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml#L22

- https://github.com/openshift/machine-config-operator/compare/master...hexfusion:enable_ceo?expand=1#diff-cbbafda65814e4ab5960f98e6b8c109fR14