### PR TITLE
Bug 1769581: 4.2: Specfile: Make `%global commit ...` overridable

### DIFF
--- a/machine-config-daemon.spec
+++ b/machine-config-daemon.spec
@@ -1,5 +1,7 @@
 %define debug_package %{nil}
+%{!?commit:
 %global commit          4e75a8f20e5cf44374fd1bf3b3df997b8689d3ff
+}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           machine-config-daemon


### PR DESCRIPTION
Backport of https://github.com/openshift/machine-config-operator/pull/1225
Blocks: https://github.com/openshift/release/pull/5572

**- What I did**
Make `%global commit foo` overridable with `rpmbuild --define "commit bar"`

**- How to verify it**
CI does not break

**- Description for the changelog**
Specfile: Make `%global commit ...` overridable