### PR TITLE
pkg/controller/kubelet-config: Fix wrapErrorWithCondition string formatting

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -146,18 +146,18 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.ContainerRunt
 			corev1.ConditionFalse,
 			fmt.Sprintf("Error: %v", err),
 		)
+		if len(args) > 0 {
+			format, ok := args[0].(string)
+			if ok {
+				condition.Message = fmt.Sprintf(format, args[1:]...)
+			}
+		}
 	} else {
 		condition = mcfgv1.NewContainerRuntimeConfigCondition(
 			mcfgv1.ContainerRuntimeConfigSuccess,
 			corev1.ConditionTrue,
 			"Success",
 		)
-	}
-	if len(args) > 0 {
-		format, ok := args[0].(string)
-		if ok {
-			condition.Message = fmt.Sprintf(format, args[:1]...)
-		}
 	}
 	return *condition
 }

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -110,18 +110,18 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.KubeletConfig
 			corev1.ConditionFalse,
 			fmt.Sprintf("Error: %v", err),
 		)
+		if len(args) > 0 {
+			format, ok := args[0].(string)
+			if ok {
+				condition.Message = fmt.Sprintf(format, args[1:]...)
+			}
+		}
 	} else {
 		condition = mcfgv1.NewKubeletConfigCondition(
 			mcfgv1.KubeletConfigSuccess,
 			corev1.ConditionTrue,
 			"Success",
 		)
-	}
-	if len(args) > 0 {
-		format, ok := args[0].(string)
-		if ok {
-			condition.Message = fmt.Sprintf(format, args[:1]...)
-		}
 	}
 	return *condition
 }

--- a/pkg/controller/kubelet-config/helpers_test.go
+++ b/pkg/controller/kubelet-config/helpers_test.go
@@ -59,7 +59,7 @@ func TestWrapErrorWithCondition(t *testing.T) {
 			expected: mcfgv1.KubeletConfigCondition{
 				Type:    mcfgv1.KubeletConfigSuccess,
 				Status:  corev1.ConditionTrue,
-				Message: "look at this: look at this: %v",
+				Message: "Success",
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestWrapErrorWithCondition(t *testing.T) {
 			expected: mcfgv1.KubeletConfigCondition{
 				Type:    mcfgv1.KubeletConfigFailure,
 				Status:  corev1.ConditionFalse,
-				Message: "look at this: look at this: %v",
+				Message: "look at this: stuff",
 			},
 		},
 	} {

--- a/pkg/controller/kubelet-config/helpers_test.go
+++ b/pkg/controller/kubelet-config/helpers_test.go
@@ -1,0 +1,82 @@
+package kubeletconfig
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+func TestWrapErrorWithCondition(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		error    error
+		args     []interface{}
+		expected mcfgv1.KubeletConfigCondition
+	}{
+		{
+			name:  "no error, no args",
+			expected: mcfgv1.KubeletConfigCondition{
+				Type:    mcfgv1.KubeletConfigSuccess,
+				Status:  corev1.ConditionTrue,
+				Message: "Success",
+			},
+		},
+		{
+			name:  "error, no args",
+			error: errors.New("some-error"),
+			expected: mcfgv1.KubeletConfigCondition{
+				Type:    mcfgv1.KubeletConfigFailure,
+				Status:  corev1.ConditionFalse,
+				Message: "Error: some-error",
+			},
+		},
+		{
+			name:  "no error, non-string args",
+			args:  []interface{}{1, 2},
+			expected: mcfgv1.KubeletConfigCondition{
+				Type:    mcfgv1.KubeletConfigSuccess,
+				Status:  corev1.ConditionTrue,
+				Message: "Success",
+			},
+		},
+		{
+			name:  "error, non-string args",
+			error: errors.New("some-error"),
+			args:  []interface{}{1, 2},
+			expected: mcfgv1.KubeletConfigCondition{
+				Type:    mcfgv1.KubeletConfigFailure,
+				Status:  corev1.ConditionFalse,
+				Message: "Error: some-error",
+			},
+		},
+		{
+			name:  "no error, string formatting",
+			args:  []interface{}{"look at this: %v", "stuff"},
+			expected: mcfgv1.KubeletConfigCondition{
+				Type:    mcfgv1.KubeletConfigSuccess,
+				Status:  corev1.ConditionTrue,
+				Message: "look at this: look at this: %v",
+			},
+		},
+		{
+			name:  "error, string formatting",
+			error: errors.New("some-error"),
+			args:  []interface{}{"look at this: %v", "stuff"},
+			expected: mcfgv1.KubeletConfigCondition{
+				Type:    mcfgv1.KubeletConfigFailure,
+				Status:  corev1.ConditionFalse,
+				Message: "look at this: look at this: %v",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			condition := wrapErrorWithCondition(testCase.error, testCase.args...)
+			testCase.expected.LastTransitionTime = condition.LastTransitionTime
+			assert.Equal(t, testCase.expected, condition)
+		})
+	}
+}


### PR DESCRIPTION
Two changes:

* Don't format the additional arguments on success.  Callers set this up with strings like:

        could not generate the original Kubelet config: %v

    that are only appropriate to the error condition.  Exposing additional details about non-error conditions would be nice, but seems awkward without a broader refactoring.

* Fix the `args[:1]` -> `args[1:]` when picking the arguments to pass in to get formatted.  The previous implementation would use `args[0]` as both the format string and the first argument to that format string.