### PR TITLE
BZ 1770273: Fix a possible crictl error in stop all containers

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -331,7 +331,13 @@ contents:
 
     stop_all_containers() {
       echo "Stopping all containers.."
-      crictl ps -q | xargs -r crictl stop
+      conids=$(crictl ps -q)
+      while [ ! -z "$conids" ]; do
+          crictl stop $conids
+          echo "Waiting for all containers to stop"
+          sleep 5
+          conids=$(crictl ps -q)
+      done
     }
 
     # validate_environment performs the same actions as the discovery container in etcd-member init


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Verify all containers are dead in stop_all_containers() function.
Fixes: #1770273

**- What I did**
Added a while loop to validate that all containers have stopped.

**- How to verify it**
While running the DR function of restore.sh, verify that stop_all_containers function does indeed stop all containers.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
