### PR TITLE
Bug 1770273: Verify all containers are dead in stop_all_containers() function

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -330,8 +330,20 @@ contents:
     }
 
     stop_all_containers() {
-      echo "Stopping all containers.."
-      crictl ps -q | xargs -r crictl stop
+      conids=$(crictl ps -q)
+      iterations=0
+      while [ ! -z "$conids" ]; do
+          let iterations=$iterations+1
+          if [ $iterations -ge 60 ]; then
+              echo "Failed to stop all containers after 60 iterations. Exiting!"
+              exit 1
+          fi
+          crictl stop $conids || true
+          echo "Waiting for all containers to stop... ($iterations/60)"
+          sleep 5
+          conids=$(crictl ps -q)
+      done
+      echo "All containers are stopped."
     }
 
     # validate_environment performs the same actions as the discovery container in etcd-member init


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Verify all containers are dead in stop_all_containers() function.
Fixes: #1770273 
**- What I did**
Added a while loop to validate that all containers have stopped.

**- How to verify it**
While running the DR function of restore.sh, verify that stop_all_containers function does indeed stop all containers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Verify all containers are stopped in stop_all_containers() function.