### PR TITLE
Bug 1765759: templates/*etcd-member.yaml: give etcd-metrics container privilege

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -176,6 +176,8 @@ contents:
         - name: metric
           containerPort: 9979
           protocol: TCP
+        securityContext:
+          privileged: true
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
Please provide the following information:
-->
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1765759


**- What I did**
Cherry-pick #1222 for 4.2
