### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-machine-config-operator
   labels:
     k8s-app: machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   selector:

--- a/install/0000_80_machine-config-operator_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config-operator_06_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: machine-config
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:

--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: etcd-quorum-guard
   namespace: openshift-machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 3
   selector:

--- a/install/0000_80_machine-config-operator_08_etcdquorumguard_pdb.yaml
+++ b/install/0000_80_machine-config-operator_08_etcdquorumguard_pdb.yaml
@@ -3,6 +3,8 @@ kind: PodDisruptionBudget
 metadata:
   namespace: openshift-machine-config-operator
   name: etcd-quorum-guard
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   maxUnavailable: 1
   selector:


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252