### PR TITLE
Bug 1766918: Exit the verify_certs loop after 60 iterations

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -273,8 +273,14 @@ contents:
     }
 
     verify_certs() {
+      iterations=0
       while [ "$(ls $ETCD_STATIC_RESOURCES | wc -l)" -lt 9  ]; do
-        echo "Waiting for certs to generate.."
+        let iterations=$iterations+1
+        if [ $iterations -gt 60 ]; then
+          echo "Failed to verify cert generation after 60 iterations. Exiting!"
+          exit 1
+        fi
+        echo "Waiting for certs to generate... ($iterations/60)"
         sleep 10
       done
     }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: #1766918
**- What I did**
Added iteration counter to exit after 60 iterations.
**- How to verify it**
Verify that there is timeout for exit to prevent the script going forever in dead loop
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
timeout verify_certs() to prevent script going forever in dead loop.