### PR TITLE
Bug 1772440: OpenStack: decrease infra pods resource consumption

### DIFF
--- a/manifests/openstack/coredns.yaml
+++ b/manifests/openstack/coredns.yaml
@@ -60,8 +60,8 @@ spec:
     - "/etc/coredns/Corefile"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"

--- a/manifests/openstack/keepalived.yaml
+++ b/manifests/openstack/keepalived.yaml
@@ -69,8 +69,8 @@ spec:
     - "--log-console"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1832,8 +1832,8 @@ spec:
     - "/etc/coredns/Corefile"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
@@ -2002,8 +2002,8 @@ spec:
     - "--log-console"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -58,8 +58,8 @@ contents:
         - "/etc/coredns/Corefile"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"

--- a/templates/common/openstack/files/openstack-keepalived.yaml
+++ b/templates/common/openstack/files/openstack-keepalived.yaml
@@ -67,8 +67,8 @@ contents:
         - "--log-console"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/keepalived"

--- a/templates/common/openstack/files/openstack-mdns-publisher.yaml
+++ b/templates/common/openstack/files/openstack-mdns-publisher.yaml
@@ -55,8 +55,8 @@ contents:
         - "--debug"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -96,8 +96,8 @@ contents:
         - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"


### PR DESCRIPTION
All infra pods have "requests" section with 1Gb of RAM and 150m of CPU, but they do not consume more than 200mb and 100m respectively.
This leads to irrational use of resources and prevents the launch of workloads on workers.

Fixes: bz1772440