### PR TITLE
add new node role labels

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -21,7 +21,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --node-labels=node.kubernetes.io/master,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
@@ -21,7 +21,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --node-labels=node.kubernetes.io/master,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -21,7 +21,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+        --node-labels=node.kubernetes.io/worker,node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \


### PR DESCRIPTION
**- What I did**
1.15 [removed](https://github.com/kubernetes/kubernetes/pull/68267) support for node-role.kubernetes.io/{master,worker} labels. We include a carry patch in origin to get around the issue.

To remove the carry patch we will need to upgrade the system in the following manner:

1. Add new labels to Openshift.... node.kubernetes.io/master and node.kubernetes.io/worker
2. Patch MCO to list nodes, and add the new labels to the current nodes
  note: There is not a component in the system that updates a nodes' labels.
3. Over the course of the 4.3.z stream
  a. Update the operators to support the new label role
4. In the 4.4 release use the new label and remove the node-role label from node's registration (systemd config file for the kubelet).

**- How to verify it**

**- Description for the changelog**

self imposed hold for discussion
/hold