### PR TITLE
Bug 1770269: DR: etcdctl version should match with what is shipped with product

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
@@ -35,7 +35,6 @@ contents:
     ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
     ETCD_CONFIG=$RUN_ENV
     ETCDCTL=$ASSET_DIR/bin/etcdctl
-    ETCD_VERSION=v3.3.10
     ETCD_DATA_DIR=/var/lib/etcd
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
     

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-recover-sh.yaml
@@ -43,7 +43,6 @@ contents:
     ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
     ETCD_CONFIG=$RUN_ENV
     ETCDCTL=$ASSET_DIR/bin/etcdctl
-    ETCD_VERSION=v3.3.10
     ETCD_DATA_DIR=/var/lib/etcd
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
 

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-remove-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-remove-sh.yaml
@@ -26,7 +26,6 @@ contents:
     ASSET_DIR=./assets
     ASSET_DIR_TMP="$ASSET_DIR/tmp"
     ETCDCTL=$ASSET_DIR/bin/etcdctl
-    ETCD_VERSION=v3.3.10
     ETCD_DATA_DIR=/var/lib/etcd
     CONFIG_FILE_DIR=/etc/kubernetes
 

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -32,7 +32,6 @@ contents:
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
     MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
-    ETCD_VERSION=v3.3.10
     ETCDCTL="${ASSET_DIR}/bin/etcdctl"
     ETCD_DATA_DIR=/var/lib/etcd
     ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -33,7 +33,6 @@ contents:
     MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
     RUN_ENV=/run/etcd/environment
 
-    ETCD_VERSION=v3.3.10
     ETCDCTL="${ASSET_DIR}/bin/etcdctl"
     ETCD_DATA_DIR=/var/lib/etcd
     ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -5,6 +5,7 @@ contents:
   inline: |
     #!/usr/bin/env bash
     export ETCDCTL_API=3
+    export ETCD_VERSION=v3.3.17
 
     ETCDCTL_WITH_TLS="$ETCDCTL --cert $ASSET_DIR/backup/etcd-client.crt --key $ASSET_DIR/backup/etcd-client.key --cacert $ASSET_DIR/backup/etcd-ca-bundle.crt"
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: #1770269
**- What I did**
Added etcdctl version in usr-local-bin-openshift-recovery-tools-sh.yaml
**- How to verify it**
Verify that the DR scripts of release 4.3 use etcdctl of version v3.3.17
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The DR scripts download the etcdctl on-demand, but the version was set in various scripts to an older version. This change sets the ETCD_VERSION in one place, and removes all the older versions from the other places.