### PR TITLE
[fcos] retry pulling mcd image

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -12,11 +12,12 @@ contents: |
   Before=machine-config-daemon-host.service
 
   [Service]
-  # Need oneshot to delay kubelet
-  Type=oneshot
+  Type=simple
   ExecStart=/usr/bin/sh -c "/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/sbin/restorecon /usr/local/bin/machine-config-daemon
+  Restart=on-failure
+  RestartSec=30
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
**- What I did**

* Changed type of `machine-config-daemon-pull.service` to `simple` (there is no kubelet on base FCOS and it hasn't pivoted yet)
* Added systemd options to restart failed pulls

**- How to verify it**

This would cut amount of flakes due to registry pulls

**- Description for the changelog**
Retry pulling MCD image on FCOS systems

TODO:

```
Nov 19 12:53:57 ip-10-0-2-229 bootkube.sh[1094]: error: /var/lib/containers/storage/overlay/ad28b6934666a530eb061fdedf6d552006cadac9c318559eb90eca0f4cbe4fdd/merged/srv/repo: opendir(/var/lib/containers/storage/overlay/ad28b6934666a530eb061fdedf6d552006cadac9c318559eb90eca0f4cbe4fdd/merged/srv/repo): No such file or directory
Nov 19 12:53:57 ip-10-0-2-229 bootkube.sh[1094]: error: error running ostree refs --repo /var/lib/containers/storage/overlay/ad28b6934666a530eb061fdedf6d552006cadac9c318559eb90eca0f4cbe4fdd/merged/srv/repo: : exit status 1
```

/cc @LorbusChris 