### PR TITLE
Bug 1777204: [Baremetal] verify that 'old' HAProxy processes being deleted after HAProxy reload.

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -31,16 +31,37 @@ contents:
       containers:
       - name: haproxy
         image: {{.Images.haproxyImage}}
+        env:
+          - name: OLD_HAPROXY_PS_FORCE_DEL_TIMEOUT
+            value: "120"
         command:
         - "/bin/bash"
         - "-c"
         - |
           #/bin/bash
+          verify_old_haproxy_ps_being_deleted()
+          {
+            local prev_pids
+
+            prev_pids="$1"
+            sleep $OLD_HAPROXY_PS_FORCE_DEL_TIMEOUT
+            cur_pids=$(pidof haproxy)
+
+            for val in $prev_pids; do
+                if [[ $cur_pids =~ (^|[[:space:]])"$val"($|[[:space:]]) ]] ; then
+                   kill $val
+                fi
+            done
+          }
+
           reload_haproxy()
           {
             old_pids=$(pidof haproxy)
             if [ -n "$old_pids" ]; then
                 /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids &
+                #There seems to be some cases where HAProxy doesn't drain properly.
+                #To handle that case, SIGTERM signal being sent to old HAProxy processes which haven't terminated.
+                verify_old_haproxy_ps_being_deleted "$old_pids"  &
             else
                 /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
             fi
@@ -61,6 +82,7 @@ contents:
           declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
           export -f msg_handler
           export -f reload_haproxy
+          export -f verify_old_haproxy_ps_being_deleted
           rm -f "$haproxy_sock" "$haproxy_log_sock"
           socat UNIX-RECV:${haproxy_log_sock} STDOUT &
           if [ -s "/etc/haproxy/haproxy.cfg" ]; then


### PR DESCRIPTION
Since HAProxy timeout values could be sensitive to some applications (e.g: Kuryr) we use long (24 hours) timeout values for the API LB. 
Because of these timeout values, sometimes old HAProxy processes being terminated only after 24Hours when HAProxy reload operation activated.
So, if HAProxy reload operation triggered many times in a short period we may end-up with many HAProxy processes hanging around (as it's described in Bug 1777204)
 
This change force sending SIGTERM after timeout (default is 120 seconds) to old HAProxy processes which haven't terminated.
Fixes Bug 1777204: Many haproxy processes hanging around due to monitor not closing connections
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
