### PR TITLE
Bug 1774369: skip setting the kubeletconfig finalizer if it is set

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -547,6 +547,13 @@ func (ctrl *Controller) addFinalizerToKubeletConfig(kc *mcfgv1.KubeletConfig, mc
 			return err
 		}
 
+		// if the finalizer is already set then skip
+		for _, finalizerName := range newcfg.Finalizers {
+			if finalizerName == mc.Name {
+				return nil
+			}
+		}
+
 		kcTmp := newcfg.DeepCopy()
 		kcTmp.Finalizers = append(kcTmp.Finalizers, mc.Name)
 


### PR DESCRIPTION
**- What I did**
If the finalizer is already set, then we skip setting another finalizer.

Fixes an issue where Finalizers may be duplicated:

```
  finalizers:
  - 99-worker-935d0eac-d152-4f2a-a754-7f8086c591a1-kubelet
  - 99-worker-935d0eac-d152-4f2a-a754-7f8086c591a1-kubelet
```

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1774369
**- How to verify it**

**- Description for the changelog**
```
NONE
```