### PR TITLE
[FCOS] Pull MCD image and extract binary if it doesn't exists

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -8,7 +8,7 @@ contents: |
   ConditionPathExists=/run/ostree-booted
   ConditionPathExists=/etc/pivot/image-pullspec
   ConditionPathExists=/var/lib/kubelet/config.json
-  After=ignition-firstboot-complete.service
+  ConditionPathExists=!/usr/local/bin/machine-config-daemon
   Before=machine-config-daemon-host.service
 
   [Service]


### PR DESCRIPTION
This removes condition to run this after first boot, cause some UPI 
installs may want to have other modification right after the 
first boot.

Required to make vSphere UPI tests pass, as these reboot machine to set static IP thus `ignition-firstboot-complete.service` is not active and MCD image cannot be pulled.

/cc @LorbusChris
