### PR TITLE
Bug 1772440: OpenStack: decrease haproxy container resource consumption

### DIFF
--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -69,8 +69,8 @@ contents:
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"


### PR DESCRIPTION
HAProxy container have "requests" section with 1Gb of RAM and 150m of CPU, but it does not consume more than 200mb and 100m respectively.
This leads to irrational use of resources.

All other infra containers by https://github.com/openshift/machine-config-operator/pull/1268