### PR TITLE
Bug 1775647: pkg/daemon: randomize pivot container name

### DIFF
--- a/pkg/daemon/pivot/types/imageinspection.go
+++ b/pkg/daemon/pivot/types/imageinspection.go
@@ -1,6 +1,6 @@
 package types
 
 const (
-	// PivotName is literally the name of the new pivot
-	PivotName = "ostree-container-pivot"
+	// PivotNamePrefix is literally the name prefix of the new pivot
+	PivotNamePrefix = "ostree-container-pivot-"
 )


### PR DESCRIPTION
If podman has a bug and cannot cleanup container names, we'll be stuck
in the update process as seen in
https://bugzilla.redhat.com/show_bug.cgi?id=1775647.
Randomize container names with UUID to avoid that and I think it's
generally better to do this w/o cleaning up at the beginning every time.

The linked bug won't be closed by this, just using it to attach to it so we can merge as part of that. The podman fix, if any, will close it.

Signed-off-by: Antonio Murdaca <runcom@linux.com>