### PR TITLE
cmd/setup-etcd-environment: refactor and add tests

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -25,8 +25,15 @@ import (
 )
 
 const (
-	EtcdScalingAnnotationKey = "etcd.operator.openshift.io/scale"
+	etcdBootstrapName        = "etcd-bootstrap"
 	etcdInitialExisting      = "existing"
+	EtcdScalingAnnotationKey = "etcd.operator.openshift.io/scale"
+	retryDuration            = 10 * time.Second
+	saTokenPath              = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	// testing only
+	testHost      = "etcd-test.testcluster.openshift.com"
+	testIPAddress = "127.0.0.256"
 )
 
 var (
@@ -36,20 +43,61 @@ var (
 		Long:  "",
 		RunE:  runRunCmd,
 	}
-
-	runOpts struct {
-		discoverySRV string
-		ifName       string
-		outputFile   string
-		bootstrapSRV bool
-	}
+	runOpts opts
 )
+
+type opts struct {
+	discoverySRV string
+	ifName       string
+	outputFile   string
+	bootstrapSRV bool
+}
+
+type SetupEnv struct {
+	opts            *opts
+	etcdDNS         string
+	etcdName        string
+	etcdDataDir     string
+	etcdIP          string
+	Client          *kubernetes.Clientset
+	unsupportedArch string
+}
 
 func init() {
 	rootCmd.AddCommand(runCmd)
 	rootCmd.PersistentFlags().StringVar(&runOpts.discoverySRV, "discovery-srv", "", "DNS domain used to populate envs from SRV query.")
 	rootCmd.PersistentFlags().StringVar(&runOpts.outputFile, "output-file", "", "file where the envs are written. If empty, prints to Stdout.")
 	rootCmd.PersistentFlags().BoolVar(&runOpts.bootstrapSRV, "bootstrap-srv", true, "use SRV discovery for bootstraping etcd cluster.")
+}
+
+func newSetupEnv(runOpts *opts, etcdName, etcdDataDir string, ips []string) (*SetupEnv, error) {
+	dns, ip, err := validateMember(runOpts.discoverySRV, etcdName, ips)
+	if err != nil {
+		return nil, err
+	}
+
+	// enable etcd to run using s390 and s390x. Because these are not officially supported upstream
+	// etcd requires population of environment variable ETCD_UNSUPPORTED_ARCH at runtime.
+	// https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/supported-platform.md
+	var unsupportedArch string
+	arch := runtime.GOARCH
+	if strings.HasPrefix(arch, "s390") {
+		unsupportedArch = arch
+	}
+
+	s := &SetupEnv{
+		opts:            runOpts,
+		etcdName:        etcdName,
+		etcdDataDir:     etcdDataDir,
+		etcdDNS:         dns,
+		etcdIP:          ip,
+		unsupportedArch: unsupportedArch,
+	}
+	if err := s.setClient(); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 func runRunCmd(cmd *cobra.Command, args []string) error {
@@ -67,56 +115,31 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	if etcdName == "" {
 		return fmt.Errorf("environment variable ETCD_NAME has no value")
 	}
-
 	etcdDataDir := os.Getenv("ETCD_DATA_DIR")
 	if etcdDataDir == "" {
 		return fmt.Errorf("environment variable ETCD_DATA_DIR has no value")
 	}
-
 	if !inCluster() {
 		glog.V(4).Infof("KUBERNETES_SERVICE_HOST or KUBERNETES_SERVICE_PORT contain no value, running in standalone mode.")
 	}
 
-	ips, err := ipAddrs()
+	// preferredIP allows for a specific IP to be used as long as it is found on the interface. If found
+	// use it to populate `ETCD_IPV4_ADDRESS` on disk otherwise we fallback to default lookup list.
+	preferredIP := os.Getenv("ETCD_IPV4_ADDRESS")
+
+	ips, err := ipAddrs(preferredIP)
 	if err != nil {
 		return err
 	}
 
-	var dns string
-	var ip string
-	if err := wait.PollImmediate(30*time.Second, 5*time.Minute, func() (bool, error) {
-		for _, cand := range ips {
-			found, err := reverseLookup("etcd-server-ssl", "tcp", runOpts.discoverySRV, cand, runOpts.bootstrapSRV)
-			if err != nil {
-				glog.Errorf("error looking up self for candidate IP %s: %v", cand, err)
-				continue
-			}
-			if found != "" {
-				dns = found
-				ip = cand
-				return true, nil
-			}
-			glog.V(4).Infof("no matching dns for %s in %s: %v", cand, runOpts.discoverySRV, err)
-		}
-		return false, nil
-	}); err != nil {
-		return fmt.Errorf("could not find self: %v", err)
+	setupEnv, err := newSetupEnv(&runOpts, etcdName, etcdDataDir, ips)
+	if err != nil {
+		return err
 	}
-	glog.Infof("dns name is %s", dns)
 
-	var exportEnv map[string]string
-
-	if _, err := os.Stat(fmt.Sprintf("%s/member", etcdDataDir)); os.IsNotExist(err) && !runOpts.bootstrapSRV && inCluster() {
-		exportEnv, err = setExportEnv(etcdName, dns)
-		if err != nil {
-			return err
-		}
-	} else {
-		// initialize envs used to bootstrap etcd
-		exportEnv, err = setBootstrapEnv(runOpts.outputFile, runOpts.discoverySRV, runOpts.bootstrapSRV)
-		if err != nil {
-			return err
-		}
+	exportEnv, err := setupEnv.getExportEnv()
+	if err != nil {
+		return err
 	}
 
 	out := os.Stdout
@@ -129,85 +152,52 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		out = f
 	}
 
-	if runOpts.bootstrapSRV {
-		exportEnv["DISCOVERY_SRV"] = runOpts.discoverySRV
-	} else {
-		exportEnv["NAME"] = etcdName
-	}
-
-	// enable etcd to run using s390 and s390x. Because these are not officially supported upstream
-	// etcd requires population of environment variable ETCD_UNSUPPORTED_ARCH at runtime.
-	// https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/supported-platform.md
-	arch := runtime.GOARCH
-	if strings.HasPrefix(arch, "s390") {
-		exportEnv["UNSUPPORTED_ARCH"] = arch
-	}
 	if err := writeEnvironmentFile(exportEnv, out, true); err != nil {
 		return err
 	}
 
-	return writeEnvironmentFile(map[string]string{
-		"IPV4_ADDRESS":      ip,
-		"DNS_NAME":          dns,
-		"WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", runOpts.discoverySRV),
-	}, out, false)
+	unexportedEnv := map[string]string{
+		"IPV4_ADDRESS":      setupEnv.etcdIP,
+		"WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", setupEnv.opts.discoverySRV),
+	}
+	if setupEnv.etcdDNS != "" {
+		unexportedEnv["DNS_NAME"] = setupEnv.etcdDNS
+	}
+	return writeEnvironmentFile(unexportedEnv, out, false)
 }
 
-func setExportEnv(etcdName, dns string) (map[string]string, error) {
-	exportEnv := make(map[string]string)
-	duration := 10 * time.Second
-	wait.PollInfinite(duration, func() (bool, error) {
-		if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token"); os.IsNotExist(err) {
-			glog.Errorf("serviceaccount failed: %v", err)
-			return false, nil
-		}
-		return true, nil
-	})
-
-	clientConfig, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
+func (s *SetupEnv) getExportEnv() (map[string]string, error) {
+	// if etcd is managed by the operator populate ENV from configmap
+	if s.isEtcdScaling() {
+		return s.getOperatorEnv()
 	}
-	client, err := kubernetes.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating client: %v", err)
-	}
-	var e ceoapi.EtcdScaling
-	// wait forever for success and retry every duration interval
-	wait.PollInfinite(duration, func() (bool, error) {
-		result, err := client.CoreV1().ConfigMaps("openshift-etcd").Get("member-config", metav1.GetOptions{})
-		if err != nil {
-			glog.Errorf("error creating client %v", err)
-			return false, nil
-		}
-		if err := json.Unmarshal([]byte(result.Annotations[EtcdScalingAnnotationKey]), &e); err != nil {
-			glog.Errorf("error decoding result %v", err)
-			return false, nil
-		}
-		if e.Metadata.Name != etcdName {
-			glog.Errorf("could not find self in member-config")
-			return false, nil
-		}
-		members := e.Members
-		if len(members) == 0 {
-			glog.Errorf("no members found in member-config")
-			return false, nil
-		}
-		var memberList []string
-		for _, m := range members {
-			memberList = append(memberList, fmt.Sprintf("%s=%s", m.Name, m.PeerURLS[0]))
-		}
-		memberList = append(memberList, fmt.Sprintf("%s=https://%s:2380", etcdName, dns))
-		exportEnv["INITIAL_CLUSTER"] = strings.Join(memberList, ",")
-		exportEnv["INITIAL_CLUSTER_STATE"] = etcdInitialExisting
-		return true, nil
-	})
+	// initialize envs used to bootstrap etcd using SRV discovery or disaster recovery.
+	return s.getBootstrapEnv()
+}
 
-	ep, err := client.CoreV1().Endpoints("openshift-etcd").Get("etcd", metav1.GetOptions{})
+// getOperatorEnv returns a maping of ENV variables required to scale etcd via operator
+func (s *SetupEnv) getOperatorEnv() (map[string]string, error) {
+	env := make(map[string]string)
+	env["NAME"] = s.etcdName
+
+	memberList := s.getEtcdMemberList()
+	env["INITIAL_CLUSTER"] = strings.Join(memberList, ",")
+	env["INITIAL_CLUSTER_STATE"] = etcdInitialExisting
+
+	endpoints, err := s.getEtcdEndpoints()
 	if err != nil {
 		return nil, err
 	}
-	hostEtcdEndpoint, err := client.CoreV1().Endpoints("openshift-etcd").Get("host-etcd", metav1.GetOptions{})
+	env["ENDPOINTS"] = strings.Join(endpoints, ",")
+	return env, nil
+}
+
+func (s *SetupEnv) getEtcdEndpoints() ([]string, error) {
+	ep, err := s.Client.CoreV1().Endpoints("openshift-etcd").Get("etcd", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	hostEtcdEndpoint, err := s.Client.CoreV1().Endpoints("openshift-etcd").Get("host-etcd", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -217,9 +207,13 @@ func setExportEnv(etcdName, dns string) (map[string]string, error) {
 
 	endpoints := make([]string, 0)
 	for _, member := range hostEtcdEndpoint.Subsets[0].Addresses {
-		if member.Hostname == "etcd-bootstrap" {
-			endpoints = append(endpoints, "https://etcd-bootstrap."+runOpts.discoverySRV+":2379")
-			break
+		// TODO validate IP?
+		if member.Hostname == etcdBootstrapName {
+			if member.IP != "" {
+				endpoints = append(endpoints, fmt.Sprintf("https://%s:2379", member.IP))
+				break
+			}
+			return nil, fmt.Errorf("openshift-etcd/host-etcd hostname %s has no IP", etcdBootstrapName)
 		}
 	}
 	if len(ep.Subsets) != 1 {
@@ -228,35 +222,106 @@ func setExportEnv(etcdName, dns string) (map[string]string, error) {
 	for _, s := range ep.Subsets[0].Addresses {
 		endpoints = append(endpoints, "https://"+s.IP+":2379")
 	}
-
-	exportEnv["ENDPOINTS"] = strings.Join(endpoints, ",")
-	return exportEnv, nil
+	return endpoints, nil
 }
 
-// setBootstrapEnv populates and returns a map based on envs from file.
-func setBootstrapEnv(envFile, discoverySRV string, bootstrapSRV bool) (map[string]string, error) {
+func (s *SetupEnv) getEtcdMemberList() []string {
+	var memberList []string
+
+	// wait forever for success and retry every duration interval
+	wait.PollInfinite(retryDuration, func() (bool, error) {
+		var e ceoapi.EtcdScaling
+		result, err := s.Client.CoreV1().ConfigMaps("openshift-etcd").Get("member-config", metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("error creating client %v", err)
+			return false, nil
+		}
+		if err := json.Unmarshal([]byte(result.Annotations[EtcdScalingAnnotationKey]), &e); err != nil {
+			glog.Errorf("error decoding result %v", err)
+			return false, nil
+		}
+		if e.Metadata.Name != s.etcdName {
+			glog.Errorf("could not find self in member-config")
+			return false, nil
+		}
+		members := e.Members
+		if len(members) == 0 {
+			glog.Errorf("no members found in member-config")
+			return false, nil
+		}
+		for _, m := range members {
+			memberList = append(memberList, fmt.Sprintf("%s=%s", m.Name, m.PeerURLS[0]))
+		}
+		memberList = append(memberList, fmt.Sprintf("%s=https://%s:2380", s.etcdName, s.etcdDNS))
+		return true, nil
+	})
+	return memberList
+}
+
+// getBootstrapEnv populates ENV variables used for bootstrapping etcd with SRV and recovery. We take care
+// to persist important ENV during reboot. We also make sure to not mix ENV that might cause etcd to fail to start.
+func (s *SetupEnv) getBootstrapEnv() (map[string]string, error) {
 	bootstrapEnv := make(map[string]string)
-	if _, err := os.Stat(envFile); !os.IsNotExist(err) {
-		recoveryEnv, err := godotenv.Read(envFile)
+	if _, err := os.Stat(s.opts.outputFile); !os.IsNotExist(err) {
+		// read existing ENV file
+		existingEnv, err := godotenv.Read(s.opts.outputFile)
 		if err != nil {
 			return nil, err
 		}
-		// persist any observed envs used for recovery
+		// persist any observed envs used for recovery. We want to make sure that ETCD_INITIAL_CLUSTER and
+		// ETCD_INITIAL_CLUSTER_STATE survive reboot.
 		for _, val := range []string{"INITIAL_CLUSTER", "INITIAL_CLUSTER_STATE"} {
 			rkey := fmt.Sprintf("ETCD_%s", val)
-			if recoveryEnv[rkey] != "" {
-				bootstrapEnv[val] = recoveryEnv[rkey]
+			if existingEnv[rkey] != "" {
+				bootstrapEnv[val] = existingEnv[rkey]
 			}
 		}
 	}
-	// define srv discovery if enabeled and not in recovery mode
-	if len(bootstrapEnv) == 0 && bootstrapSRV {
-		bootstrapEnv["DISCOVERY_SRV"] = discoverySRV
+
+	// Define SRV discovery variables if enabeled and not in recovery mode. This is important because we can
+	// not mix `ETCD_DISCOVERY_SRV` with ETCD_INITIAL_CLUSTER` or etcd will fail to start.
+	if len(bootstrapEnv) == 0 && s.opts.bootstrapSRV {
+		bootstrapEnv["DISCOVERY_SRV"] = s.opts.discoverySRV
 	}
 	return bootstrapEnv, nil
 }
 
-func ipAddrs() ([]string, error) {
+// isEtcdScaling performs a series of checks to see if etcd is currently attempting to scale from the
+// `cluster-etcd-operator` and returns true if yes. If false we can conclude that the member is already
+// part of the cluster or we have/are bootstrapping etcd using SRV discovery.
+func (s *SetupEnv) isEtcdScaling() bool {
+	if _, err := os.Stat(fmt.Sprintf("%s/member", s.etcdDataDir)); os.IsNotExist(err) && !s.opts.bootstrapSRV && inCluster() {
+		return true
+	}
+	return false
+}
+
+func (s *SetupEnv) setClient() error {
+	if inCluster() && !s.opts.bootstrapSRV {
+		wait.PollInfinite(retryDuration, func() (bool, error) {
+			if _, err := os.Stat(saTokenPath); os.IsNotExist(err) {
+				glog.Errorf("serviceaccount failed: %v", err)
+				return false, nil
+			}
+			return true, nil
+		})
+		clientConfig, err := rest.InClusterConfig()
+		if err != nil {
+			panic(err.Error())
+		}
+		client, err := kubernetes.NewForConfig(clientConfig)
+		if err != nil {
+			return fmt.Errorf("error creating client: %v", err)
+		}
+		s.Client = client
+	}
+	glog.Infof("no client set")
+	return nil
+}
+
+// ipAddrs checks the local interfaces and returns a populated list of addresses as a slice of string.
+// This function also accepts an optional preferredIP address which if found will be explicitly used.
+func ipAddrs(preferredIP string) ([]string, error) {
 	var ips []string
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
@@ -283,17 +348,20 @@ func ipAddrs() ([]string, error) {
 		ips = append(ips, ip.String())
 	}
 
+	// validate preferredIP is valid for this system or fall back to default list.
+	if preferredIP != "" {
+		for _, ip := range ips {
+			if ip == preferredIP {
+				glog.Infof("ipAddrs: preferredIP %s found", preferredIP)
+				return []string{preferredIP}, nil
+			}
+		}
+		glog.Infof("ipAddrs: preferredIP %s not found on system interfaces", preferredIP)
+	}
 	return ips, nil
 }
 
-func reverseLookup(service, proto, name, self string, bootstrapSRV bool) (string, error) {
-	if bootstrapSRV || inCluster() {
-		return reverseLookupSelf(service, proto, name, self)
-	}
-	return lookupTargetMatchSelf(fmt.Sprintf("etcd-bootstrap.%s", name), self)
-}
-
-// returns the target from the SRV record that resolves to self.
+// reverseLookupSelf returns the target from the SRV record that resolves to self.
 func reverseLookupSelf(service, proto, name, self string) (string, error) {
 	_, srvs, err := net.LookupSRV(service, proto, name)
 	if err != nil {
@@ -312,13 +380,14 @@ func reverseLookupSelf(service, proto, name, self string) (string, error) {
 	return "", fmt.Errorf("could not find self")
 }
 
-//
+// lookupTargetMatchSelf takes a target FQDN and performs a DNS lookup. If the result of the
+// lookup addresses matches self we return that address.
 func lookupTargetMatchSelf(target, self string) (string, error) {
+	var selfTarget string
 	addrs, err := net.LookupHost(target)
 	if err != nil {
-		return "", fmt.Errorf("could not resolve member %q", target)
+		return selfTarget, fmt.Errorf("could not resolve member %q", target)
 	}
-	selfTarget := ""
 	for _, addr := range addrs {
 		if addr == self {
 			selfTarget = strings.Trim(target, ".")
@@ -348,4 +417,41 @@ func inCluster() bool {
 		return false
 	}
 	return true
+}
+
+// validateMember performs an SRV lookup for a service based on the cluster domain. If an IP address
+// found in the list of IPs for the system we return that IP address and the matching FQDN.
+func validateMember(discoverySRV, etcdName string, ips []string) (string, string, error) {
+	var dns string
+	var ip string
+	// for testing only
+	if len(ips) > 0 && ips[0] == testIPAddress {
+		return testHost, testIPAddress, nil
+	}
+
+	// bootstrap is a special case we do not use FQDN
+	if etcdName == etcdBootstrapName {
+		return dns, ips[0], nil
+	}
+
+	if err := wait.PollImmediate(30*time.Second, 5*time.Minute, func() (bool, error) {
+		for _, cand := range ips {
+			found, err := reverseLookupSelf("etcd-server-ssl", "tcp", discoverySRV, cand)
+			if err != nil {
+				glog.Errorf("error looking up self for candidate IP %s: %v", cand, err)
+				continue
+			}
+			if found != "" {
+				dns = found
+				ip = cand
+				return true, nil
+			}
+			glog.V(4).Infof("no matching dns for %s in %s: %v", cand, discoverySRV, err)
+		}
+		return false, nil
+	}); err != nil {
+		return dns, ip, fmt.Errorf("could not find self: %v", err)
+	}
+	glog.Infof("dns name is %s", dns)
+	return dns, ip, nil
 }

--- a/cmd/setup-etcd-environment/run_test.go
+++ b/cmd/setup-etcd-environment/run_test.go
@@ -4,8 +4,180 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
+
+	"github.com/joho/godotenv"
 )
+
+type testConfig struct {
+	t            *testing.T
+	etcdName     string
+	discoverySRV string
+	dr           bool
+	inCluster    bool
+	bootstrapSRV bool
+
+	Want map[string]string
+}
+
+func TestSetupEnvSRVWithDR(t *testing.T) {
+	config := &testConfig{
+		t:            t,
+		etcdName:     "etcd-test",
+		discoverySRV: "testcluster.openshift.com",
+		dr:           true,
+		inCluster:    false,
+		bootstrapSRV: true,
+	}
+	config.Want = map[string]string{
+		"ETCD_IPV4_ADDRESS":      testIPAddress,
+		"ETCD_DNS_NAME":          fmt.Sprintf("%s.%s", config.etcdName, config.discoverySRV),
+		"ETCD_INITIAL_CLUSTER":   fmt.Sprintf("%s=%s.%s", config.etcdName, config.etcdName, config.discoverySRV),
+		"ETCD_WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", config.discoverySRV),
+	}
+	testSetupEnv(config)
+}
+
+func TestSetupEnvSRV(t *testing.T) {
+	config := &testConfig{
+		t:            t,
+		etcdName:     "etcd-test",
+		discoverySRV: "testcluster.openshift.com",
+		dr:           false,
+		inCluster:    false,
+		bootstrapSRV: true,
+	}
+	config.Want = map[string]string{
+		"ETCD_DISCOVERY_SRV":     config.discoverySRV,
+		"ETCD_IPV4_ADDRESS":      testIPAddress,
+		"ETCD_DNS_NAME":          fmt.Sprintf("%s.%s", config.etcdName, config.discoverySRV),
+		"ETCD_WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", config.discoverySRV),
+	}
+	testSetupEnv(config)
+}
+
+func TestSetupEnvSRVInCluster(t *testing.T) {
+	config := &testConfig{
+		t:            t,
+		etcdName:     "etcd-test",
+		discoverySRV: "testcluster.openshift.com",
+		dr:           false,
+		inCluster:    true,
+		bootstrapSRV: true,
+	}
+	config.Want = map[string]string{
+		"ETCD_DISCOVERY_SRV":     config.discoverySRV,
+		"ETCD_IPV4_ADDRESS":      testIPAddress,
+		"ETCD_DNS_NAME":          fmt.Sprintf("%s.%s", config.etcdName, config.discoverySRV),
+		"ETCD_WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", config.discoverySRV),
+	}
+	testSetupEnv(config)
+}
+
+func testSetupEnv(tc *testConfig) {
+	previousFile, err := ioutil.TempFile("/tmp", "run-etcd-environment.*")
+	if err != nil {
+		tc.t.Fatal(err)
+	}
+
+	// set ENV which emulates inCuster
+	if tc.inCluster {
+		os.Setenv("KUBERNETES_SERVICE_HOST", "kubernetes.default")
+		os.Setenv("KUBERNETES_SERVICE_PORT", "2379")
+		defer os.Unsetenv("KUBERNETES_SERVICE_HOST")
+		defer os.Unsetenv("KUBERNETES_SERVICE_PORT")
+	}
+
+	runOpts := &opts{
+		discoverySRV: tc.discoverySRV,
+		ifName:       "",
+		outputFile:   previousFile.Name(),
+		bootstrapSRV: tc.bootstrapSRV,
+	}
+
+	setupEnv, err := newSetupEnv(runOpts, tc.etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		tc.t.Fatalf("testSetupEnv() failed: %s", err)
+	}
+
+	if tc.dr {
+		// set up a populated Env emulating an DR senario
+		existingExportEnv := map[string]string{
+			"INITIAL_CLUSTER": fmt.Sprintf("%s=%s", tc.etcdName, setupEnv.etcdDNS),
+			"DISCOVERY_SRV":   setupEnv.opts.discoverySRV,
+		}
+		if err := writeEnvironmentFile(existingExportEnv, previousFile, true); err != nil {
+			tc.t.Fatal(err)
+		}
+
+		existingUnexportedEnv := map[string]string{
+			"IPV4_ADDRESS":      setupEnv.etcdIP,
+			"DNS_NAME":          setupEnv.etcdDNS,
+			"WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", setupEnv.opts.discoverySRV),
+		}
+		if err := writeEnvironmentFile(existingUnexportedEnv, previousFile, true); err != nil {
+			tc.t.Fatalf("testSetupEnv() failed: %s", err)
+		}
+	}
+
+	// Close existingFile now that it is populated/parsed
+	if err := previousFile.Close(); err != nil {
+		tc.t.Fatal(err)
+	}
+
+	// runs against previousFile
+	exportEnv, err := setupEnv.getExportEnv()
+	if err != nil {
+		tc.t.Fatalf("testSetupEnv() failed: %s", err)
+	}
+
+	currentFile, err := os.Create(setupEnv.opts.outputFile)
+	if err != nil {
+		tc.t.Fatalf("testSetupEnv() failed: %s", err)
+	}
+
+	// cleanup
+	defer currentFile.Close()
+	defer os.Remove(setupEnv.opts.outputFile)
+
+	if err := writeEnvironmentFile(exportEnv, currentFile, true); err != nil {
+		tc.t.Fatalf("testSetupEnv() failed: %s", err)
+	}
+
+	nonExportEnv := map[string]string{
+		"IPV4_ADDRESS":      setupEnv.etcdIP,
+		"DNS_NAME":          setupEnv.etcdDNS,
+		"WILDCARD_DNS_NAME": fmt.Sprintf("*.%s", setupEnv.opts.discoverySRV),
+	}
+
+	if err := writeEnvironmentFile(nonExportEnv, currentFile, false); err != nil {
+		tc.t.Fatalf("testSetupEnv() failed: %s", err)
+	}
+
+	if _, err := os.Stat(setupEnv.opts.outputFile); !os.IsNotExist(err) {
+		if got, _ := godotenv.Read(setupEnv.opts.outputFile); !reflect.DeepEqual(got, tc.Want) {
+			tc.t.Errorf("testSetupEnv() got %q, want %q", got, tc.Want)
+		}
+	}
+}
+
+func TestPreferredIP(t *testing.T) {
+	var preferredIP string
+	testIPs, err := ipAddrs(preferredIP)
+	if err != nil {
+		t.Errorf("TestOverrideIP() failed: %v", err)
+	}
+
+	preferredIP = testIPs[0]
+	ip, err := ipAddrs(preferredIP)
+	if err != nil {
+		t.Errorf("TestOverrideIP() failed: %v", err)
+	}
+	if testIPs[0] != ip[0] {
+		t.Errorf("TestOverrideIP() failed: got %q, want %q", ip[0], testIPs[0])
+	}
+}
 
 // These test cases test setBootstrapEnv() function for 4 scenarios. If INITIAL_CLUSTER and INITIAL_CLUSTER_STATE are defined,
 // then, setBookstrapEnv() should not include the conflicting DISCOVERY_SRV environment variable and instead copy those variables
@@ -16,164 +188,231 @@ import (
 // 4. Test with none of the variables defined.
 
 func TestNonExtantFile(t *testing.T) {
-
+	etcdName := "etcdname.devcluster.openshift.com"
 	fileName := fmt.Sprintf("/tmp/etcdDoesNotExist_%d", os.Getpid())
 
-	bootEnv, err := setBootstrapEnv(fileName, "etcdname.devcluster.openshift.com", true)
+	runOpts := &opts{
+		discoverySRV: "devcluster.openshift.com",
+		ifName:       "",
+		outputFile:   fileName,
+		bootstrapSRV: true,
+	}
 
+	setupEnv, err := newSetupEnv(runOpts, etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		t.Fatalf("setupEnv() failed: %s", err)
+	}
+
+	bootEnv, err := setupEnv.getBootstrapEnv()
 	if err != nil {
 		t.Fatalf("setBootstrapEnv() failed: %s", err)
 	}
 
-	if bootEnv["DISCOVERY_SRV"] != "etcdname.devcluster.openshift.com" {
-		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = \"%s\"; want \"etcdname.devcluster.openshift.com\" ", bootEnv["DISCOVERY_SRV"])
+	if bootEnv["DISCOVERY_SRV"] != setupEnv.opts.discoverySRV {
+		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = %q; want %q", bootEnv["DISCOVERY_SRV"], setupEnv.opts.discoverySRV)
 	}
-
 	if bootEnv["INITIAL_CLUSTER"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = %q; want %q", bootEnv["INITIAL_CLUSTER"], "")
 	}
 	if bootEnv["INITIAL_CLUSTER_STATE"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER_STATE"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = %q; want %q", bootEnv["INITIAL_CLUSTER_STATE"], "")
 	}
 }
 
 func TestFileWithInitialCluster(t *testing.T) {
-
-	file, err := ioutil.TempFile("/tmp/", "etcd_")
+	etcdName := "etcdname.devcluster.openshift.com"
+	etcdIntialClusterState := "existing"
+	file, err := ioutil.TempFile("/tmp", "run-etcd-environment.*")
 	if err != nil {
 		t.Fatalf("Creating a tempfile failed: %s", err)
 	}
 	defer os.Remove(file.Name())
 
-	initialClusterStr := "etcd-member-ip-10-0-147-172.us-east-2.compute.internal=https://etcd-1.etcdname.devcluster.openshift.com:2380,etcd-member-ip-10-0-171-108.us-east-2.compute.internal=https://etcd-2.etcdname.devcluster.openshift.com:2380,etcd-member-ip-10-0-128-73.us-east-2.compute.internal=https://etcd-0.etcdname.devcluster.openshift.com:2380"
+	runOpts := &opts{
+		discoverySRV: "devcluster.openshift.com",
+		ifName:       "",
+		outputFile:   file.Name(),
+		bootstrapSRV: true,
+	}
+
+	initialClusterStr := "etcd-member-ip-10-0-147-172.us-east-2.compute.internal=https://etcd-1.etcdname.devcluster.openshift.com:2380"
 	m := make(map[string]string)
 	m["INITIAL_CLUSTER"] = initialClusterStr
-	m["INITIAL_CLUSTER_STATE"] = "existing"
+	m["INITIAL_CLUSTER_STATE"] = etcdIntialClusterState
 
 	writeEnvironmentFile(m, file, false)
 
-	bootEnv, err := setBootstrapEnv(file.Name(), "etcdname.devcluster.openshift.com", true)
+	setupEnv, err := newSetupEnv(runOpts, etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		t.Fatalf("setupEnv() failed: %s", err)
+	}
 
+	bootEnv, err := setupEnv.getBootstrapEnv()
 	if err != nil {
 		t.Fatalf("setBootstrapEnv() failed: %s", err)
 	}
 
 	if bootEnv["DISCOVERY_SRV"] != "" {
-		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = \"%s\"; want \"\" ", bootEnv["DISCOVERY_SRV"])
+		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = %q; want %q", bootEnv["DISCOVERY_SRV"], "")
 	}
-
 	if bootEnv["INITIAL_CLUSTER"] != initialClusterStr {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = \"%s\"; want \"%s\" ", bootEnv["INITIAL_CLUSTER"], initialClusterStr)
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = %q; want %q", bootEnv["INITIAL_CLUSTER"], initialClusterStr)
 	}
-	if bootEnv["INITIAL_CLUSTER_STATE"] != "existing" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = \"%s\"; want \"existing\" ", bootEnv["INITIAL_CLUSTER_STATE"])
+	if bootEnv["INITIAL_CLUSTER_STATE"] != etcdIntialClusterState {
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = %q; want %q", bootEnv["INITIAL_CLUSTER_STATE"], etcdIntialClusterState)
 	}
 }
 
 func TestFileWithDiscoverySrv(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp/", "etcd_")
+	etcdName := "etcdname.devcluster.openshift.com"
+	file, err := ioutil.TempFile("/tmp", "run-etcd-environment.*")
 	if err != nil {
 		t.Fatalf("Creating a tempfile failed: %s", err)
 	}
 	defer os.Remove(file.Name())
+
+	runOpts := &opts{
+		discoverySRV: "devcluster.openshift.com",
+		ifName:       "",
+		outputFile:   file.Name(),
+		bootstrapSRV: true,
+	}
 
 	m := make(map[string]string)
 	m["DISCOVERY_SRV"] = "OLDNAME.devcluster.openshift.com"
 
 	writeEnvironmentFile(m, file, false)
 
-	bootEnv, err := setBootstrapEnv(file.Name(), "etcdname.devcluster.openshift.com", true)
+	setupEnv, err := newSetupEnv(runOpts, etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		t.Fatalf("setupEnv() failed: %s", err)
+	}
 
+	bootEnv, err := setupEnv.getBootstrapEnv()
 	if err != nil {
 		t.Fatalf("setBootstrapEnv() failed: %s", err)
 	}
 
-	if bootEnv["DISCOVERY_SRV"] != "etcdname.devcluster.openshift.com" {
-		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = \"%s\"; want \"etcdname.devcluster.openshift.com\" ", bootEnv["DISCOVERY_SRV"])
+	if bootEnv["DISCOVERY_SRV"] != setupEnv.opts.discoverySRV {
+		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = %q; want %q", bootEnv["DISCOVERY_SRV"], setupEnv.opts.discoverySRV)
 	}
-
 	if bootEnv["INITIAL_CLUSTER"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = %q; want %q", bootEnv["INITIAL_CLUSTER"], "")
 	}
 	if bootEnv["INITIAL_CLUSTER_STATE"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER_STATE"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = %q; want %q", bootEnv["INITIAL_CLUSTER_STATE"], "")
 	}
 }
 
 func TestFileWithDiscoverySrvWithFalseFlag(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp/", "etcd_")
+	etcdName := "etcdname.devcluster.openshift.com"
+	file, err := ioutil.TempFile("/tmp", "run-etcd-environment.*")
 	if err != nil {
 		t.Fatalf("Creating a tempfile failed: %s", err)
 	}
 	defer os.Remove(file.Name())
+
+	runOpts := &opts{
+		discoverySRV: "devcluster.openshift.com",
+		ifName:       "",
+		outputFile:   file.Name(),
+		bootstrapSRV: false,
+	}
 
 	m := make(map[string]string)
 	m["DISCOVERY_SRV"] = "OLDNAME.devcluster.openshift.com"
 
 	writeEnvironmentFile(m, file, false)
 
-	bootEnv, err := setBootstrapEnv(file.Name(), "etcdname.devcluster.openshift.com", false)
+	setupEnv, err := newSetupEnv(runOpts, etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		t.Fatalf("setupEnv() failed: %s", err)
+	}
 
+	bootEnv, err := setupEnv.getBootstrapEnv()
 	if err != nil {
 		t.Fatalf("setBootstrapEnv() failed: %s", err)
 	}
 
 	if bootEnv["DISCOVERY_SRV"] != "" {
-		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = \"%s\"; want \"\" ", bootEnv["DISCOVERY_SRV"])
+		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = %q; want %q", bootEnv["DISCOVERY_SRV"], "")
 	}
-
 	if bootEnv["INITIAL_CLUSTER"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = %q; want %q", bootEnv["INITIAL_CLUSTER"], "")
 	}
 	if bootEnv["INITIAL_CLUSTER_STATE"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER_STATE"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = %q; want %q", bootEnv["INITIAL_CLUSTER_STATE"], "")
 	}
 }
 
 func TestFileWithNoVariables(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp/", "etcd_")
+	etcdName := "etcdname.devcluster.openshift.com"
+	file, err := ioutil.TempFile("/tmp", "run-etcd-environment.*")
 	if err != nil {
 		t.Fatalf("Creating a tempfile failed: %s", err)
 	}
 	defer os.Remove(file.Name())
 
-	bootEnv, err := setBootstrapEnv(file.Name(), "etcdname.devcluster.openshift.com", true)
+	runOpts := &opts{
+		discoverySRV: "devcluster.openshift.com",
+		ifName:       "",
+		outputFile:   file.Name(),
+		bootstrapSRV: true,
+	}
 
+	setupEnv, err := newSetupEnv(runOpts, etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		t.Fatalf("setupEnv() failed: %s", err)
+	}
+
+	bootEnv, err := setupEnv.getBootstrapEnv()
 	if err != nil {
 		t.Fatalf("setBootstrapEnv() failed: %s", err)
 	}
 
-	if bootEnv["DISCOVERY_SRV"] != "etcdname.devcluster.openshift.com" {
-		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = \"%s\"; want \"etcdname.devcluster.openshift.com\" ", bootEnv["DISCOVERY_SRV"])
+	if bootEnv["DISCOVERY_SRV"] != setupEnv.opts.discoverySRV {
+		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = %q; want %q", bootEnv["DISCOVERY_SRV"], setupEnv.opts.discoverySRV)
 	}
 	if bootEnv["INITIAL_CLUSTER"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = %q; want %q", bootEnv["INITIAL_CLUSTER"], "")
 	}
 	if bootEnv["INITIAL_CLUSTER_STATE"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER_STATE"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = %q; want %q", bootEnv["INITIAL_CLUSTER_STATE"], "")
 	}
 }
 
 func TestFileWithNoVariablesFalseFlag(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp/", "etcd_")
+	etcdName := "etcdname.devcluster.openshift.com"
+	file, err := ioutil.TempFile("/tmp", "run-etcd-environment.*")
 	if err != nil {
 		t.Fatalf("Creating a tempfile failed: %s", err)
 	}
 	defer os.Remove(file.Name())
 
-	bootEnv, err := setBootstrapEnv(file.Name(), "etcdname.devcluster.openshift.com", false)
+	runOpts := &opts{
+		discoverySRV: "devcluster.openshift.com",
+		ifName:       "",
+		outputFile:   file.Name(),
+		bootstrapSRV: false,
+	}
 
+	setupEnv, err := newSetupEnv(runOpts, etcdName, "./tmp", []string{testIPAddress})
+	if err != nil {
+		t.Fatalf("setupEnv() failed: %s", err)
+	}
+
+	bootEnv, err := setupEnv.getBootstrapEnv()
 	if err != nil {
 		t.Fatalf("setBootstrapEnv() failed: %s", err)
 	}
 
 	if bootEnv["DISCOVERY_SRV"] != "" {
-		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = \"%s\"; want \"\" ", bootEnv["DISCOVERY_SRV"])
+		t.Errorf("bootEnv[\"DISCOVERY_SRV\"] = %q; want %q", bootEnv["DISCOVERY_SRV"], "")
 	}
 	if bootEnv["INITIAL_CLUSTER"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER\"] = %q; want %q ", bootEnv["INITIAL_CLUSTER"], "")
 	}
 	if bootEnv["INITIAL_CLUSTER_STATE"] != "" {
-		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = \"%s\"; want \"\" ", bootEnv["INITIAL_CLUSTER_STATE"])
+		t.Errorf("bootEnv[\"INITIAL_CLUSTER_STATE\"] = %q; want %q", bootEnv["INITIAL_CLUSTER_STATE"], "")
 	}
 }


### PR DESCRIPTION
During the work before feature freeze, we introduced a regression in DR. The codebase had become a bit convoluted and hard to test. This PR introduces new unit tests that cover DR to prevent this from happening again. As we continue efforts with `cluster-etcd-operator` these e2e tests will be extended include that functionality.

The regression was reverted in 4.3 FTR [1]

[1] https://github.com/openshift/machine-config-operator/pull/1304