### PR TITLE
*: conditionally populate the images configmap with cluster-etcd-operator image 

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -74,6 +74,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.ClientBuilder.APIExtClientOrDie(componentName),
 			ctrlctx.ClientBuilder.ConfigClientOrDie(componentName),
 			ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
+			ctrlctx.EtcdInformer,
 		)
 
 		ctrlctx.NamespacedInformerFactory.Start(ctrlctx.Stop)
@@ -82,6 +83,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		ctrlctx.APIExtInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
 		close(ctrlctx.InformersStarted)
 
 		go controller.Run(2, ctrlctx.Stop)

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -11,7 +11,7 @@ data:
       "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
       "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
       "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift:kube-client-agent",
-      "clusterEtcdOperatorImage": "",
+      "clusterEtcdOperatorImage": "registry.svc.ci.openshift.org/openshift:cluster-etcd-operator",
       "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
       "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",

--- a/install/image-references
+++ b/install/image-references
@@ -31,6 +31,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:kube-client-agent
+  - name: cluster-etcd-operator
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:cluster-etcd-operator
   - name: cli
     from:
       kind: DockerImage

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -22,3 +22,6 @@ rules:
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["etcds"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -867,6 +867,9 @@ rules:
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["etcds"]
+  verbs: ["get", "list", "watch"]
 `)
 
 func manifestsMachineconfigcontrollerClusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
[This](https://github.com/openshift/machine-config-operator/pull/1224) adds a flag to MCO for cluster-etcd-operator image and hardcodes
 the value to `""`. 

This PR conditionally populates the cluster-etcd-operator image only
if the etcd custom resource exists and if it has a spec field set as
`managementState: Managed`. It is the same mechanism used 
in the [installer](https://github.com/openshift/installer/pull/2730). This will make sure that the MC rendered during the initial.
boot with the value coming in from the installer flag is always same
 as one generate in the sync loop.

With this, we can use a single [knob](https://github.com/openshift/cluster-etcd-operator/blob/master/manifests/0000_12_etcd-operator_01_operator.cr.yaml#L8) in cluster-etcd-operator 
project to test the bootstrap process in CI with cluster-etcd-operator 
enabled.

The existence of cluster-etcd-operator image is used to render static 
etcd pod yaml. This PR will be followed by another PR which introduces
a boolean flag to be used for conditional rendering of the static pod image. 
It will be a more readable way of achieving the same means.
 
