### PR TITLE
Bug 1777082: set vsphere as provider

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -467,12 +467,10 @@ func etcdMetricCertCommand(cfg RenderConfig) (interface{}, error) {
 
 func cloudProvider(cfg RenderConfig) (interface{}, error) {
 	switch cfg.Platform {
-	case platformAWS, platformAzure, platformOpenStack:
+	case platformAWS, platformAzure, platformOpenStack, platformVSphere:
 		return cfg.Platform, nil
 	case platformGCP:
 		return "gce", nil
-	case platformVSphere:
-		return "", nil // kubelet crash errors when provider set to VSphere right now
 	default:
 		return "", nil
 	}

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -43,6 +43,9 @@ func TestCloudProvider(t *testing.T) {
 	}, {
 		platform: "none",
 		res:      "",
+	}, {
+		platform: "vsphere",
+		res:      "vsphere",
 	}}
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)


### PR DESCRIPTION
fix(pkg/controller/template/render): set vsphere as provider

Set cloudProvider to VSphere in the kubelet configs.
Fixes Bug 1777082: volume cannot mount to node after upgrade
