### PR TITLE
Bug 1777837: BAREMETAL- decrease infra pods resources

### DIFF
--- a/manifests/baremetal/coredns.yaml
+++ b/manifests/baremetal/coredns.yaml
@@ -60,8 +60,8 @@ spec:
     - "/etc/coredns/Corefile"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -69,8 +69,8 @@ spec:
     - "--log-console"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -185,8 +185,8 @@ spec:
     - "/etc/coredns/Corefile"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
@@ -355,8 +355,8 @@ spec:
     - "--log-console"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"

--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -58,8 +58,8 @@ contents:
         - "/etc/coredns/Corefile"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -70,8 +70,8 @@ contents:
           socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/keepalived"

--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -55,8 +55,8 @@ contents:
         - "--debug"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"


### PR DESCRIPTION
All infra pods have "requests" section with 1Gb of RAM and 150m of CPU,
but they do not consume more than 200mb and 100m respectively.
This leads to irrational use of resources and prevents the launch of
workloads on workers.
Fixes Bug 1777837 : [IPI][Baremetal] Infra pods consume too much resources

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
