### PR TITLE
CRI-O: Set conmon_cgroup to "pod"

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -104,7 +104,7 @@ contents:
     conmon = "/usr/libexec/crio/conmon"
 
     # Cgroup setting for conmon
-    # conmon_cgroup = "system.slice"
+    conmon_cgroup = "pod"
 
     # Environment variable list for the conmon process, used for passing necessary
     # environment variables to conmon or the runtime.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -104,7 +104,7 @@ contents:
     conmon = "/usr/libexec/crio/conmon"
 
     # Cgroup setting for conmon
-    # conmon_cgroup = "system.slice"
+    conmon_cgroup = "pod"
 
     # Environment variable list for the conmon process, used for passing necessary
     # environment variables to conmon or the runtime.


### PR DESCRIPTION
Upstream cri-o has moved to set the conmon-cgroup to system.slice
by default. But we want the conmon cgroup to be under the pod by
default in OpenShift. So explicitly setting it here in the MCO
templates for crio.conf

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
