### PR TITLE
ovirt: reduce static pods mem/cpu requirements

### DIFF
--- a/manifests/ovirt/coredns.yaml
+++ b/manifests/ovirt/coredns.yaml
@@ -60,8 +60,8 @@ spec:
     - "/etc/coredns/Corefile"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"

--- a/manifests/ovirt/keepalived.yaml
+++ b/manifests/ovirt/keepalived.yaml
@@ -69,8 +69,8 @@ spec:
     - "--log-console"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2125,8 +2125,8 @@ spec:
     - "/etc/coredns/Corefile"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
@@ -2295,8 +2295,8 @@ spec:
     - "--log-console"
     resources:
       requests:
-        cpu: 150m
-        memory: 1Gi
+        cpu: 100m
+        memory: 200Mi
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"

--- a/templates/common/ovirt/files/ovirt-coredns.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns.yaml
@@ -58,8 +58,8 @@ contents:
         - "/etc/coredns/Corefile"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"

--- a/templates/common/ovirt/files/ovirt-keepalived.yaml
+++ b/templates/common/ovirt/files/ovirt-keepalived.yaml
@@ -70,8 +70,8 @@ contents:
           socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/keepalived"

--- a/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
+++ b/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
@@ -55,8 +55,8 @@ contents:
         - "--debug"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -67,6 +67,10 @@ contents:
               /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
           fi
           socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"
@@ -90,6 +94,10 @@ contents:
         - "/etc/haproxy/haproxy.cfg"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"


### PR DESCRIPTION
**- What I did**

Set much lower resources request by the static coredns, mdns publisher, and keepalived.

**- How to verify it**

Run IPI installation of oVirt, 3 master (all of them use those static pods)  and 2 workers (uses coredns, mdns publisher) see the install complete, cluster is fully operational, the static pods works with no hiccups.

**- Description for the changelog**
Set much lower resources request by the static coredns, mdns publisher, and keepalived.
Those static pods requested way too much resources, adding pressure on the nodes and sometimes causing pods to be killed by the OOM manager.