### PR TITLE
[FCOS] machine-config-daemon service improvements

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -18,6 +18,9 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
+  # Image is being pulled explicitly so that an empty /usr/local/bin/machine-config-daemon won't be
+  # created in case there was a network problem
+  ExecStart=/usr/bin/podman pull '{{ .Images.setupEtcdEnvKey }}'
   ExecStart=/usr/bin/sh -c "/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/sbin/restorecon /usr/local/bin/machine-config-daemon

--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -21,6 +21,8 @@ contents: |
   ExecStart=/usr/bin/sh -c "/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/sbin/restorecon /usr/local/bin/machine-config-daemon
+  Restart=on-failure
+  RestartSec=10s
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -9,6 +9,10 @@ contents: |
   ConditionPathExists=/etc/pivot/image-pullspec
   ConditionPathExists=/var/lib/kubelet/config.json
   ConditionPathExists=!/usr/local/bin/machine-config-daemon
+  # Run after network is available
+  After=network-online.target
+  Wants=network-online.target
+  # Pivot should run after MCD image is pulled
   Before=machine-config-daemon-host.service
 
   [Service]


### PR DESCRIPTION
Updated machine-config-daemon-pull.service so that it would be more resilent.

* Run the service only once network is up
* Restart service on errors
* Pull MCD image explicitly so that an empty binary would not be created when image cannot be fetched

/cc @LorbusChris 