### PR TITLE
[FCOS] machine-config-daemon service improvements

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -9,7 +9,9 @@ contents: |
   ConditionPathExists=/etc/pivot/image-pullspec
   ConditionPathExists=/var/lib/kubelet/config.json
   ConditionPathExists=!/usr/local/bin/machine-config-daemon
+  # Pivot should run after MCD image is pulled
   Before=machine-config-daemon-host.service
+  After=network-online.service
 
   [Service]
   # Need oneshot to delay kubelet

--- a/templates/common/_base/units/machine-config-daemon-pull.service
+++ b/templates/common/_base/units/machine-config-daemon-pull.service
@@ -16,6 +16,9 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
+  # Image is being pulled explicitly so that an empty /usr/local/bin/machine-config-daemon won't be
+  # created in case there was a network problem
+  ExecStart=/usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.setupEtcdEnvKey }}'
   ExecStart=/usr/bin/sh -c "/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/sbin/restorecon /usr/local/bin/machine-config-daemon


### PR DESCRIPTION
Updated machine-config-daemon-pull.service so that it would be more resilent.

* Run the service only once network is up
* ~~Restart service on errors~~
systemd v243 doesn't support restarting oneshot services. This would need to be implemented once F31 is updated to v244+
* Pull MCD image explicitly so that an empty binary would not be created when image cannot be fetched

Fixes https://github.com/openshift/okd/issues/22
Fixes https://github.com/openshift/okd/issues/31

/cc @LorbusChris