### PR TITLE
WIP: [baremetal] Add a VIP for provisioning network

### DIFF
--- a/manifests/baremetal/keepalived.conf.tmpl
+++ b/manifests/baremetal/keepalived.conf.tmpl
@@ -33,3 +33,20 @@ vrrp_instance {{`{{.Cluster.Name}}`}}_DNS {
         {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
     }
 }
+
+{{`{{if .Cluster.APIProvisioningVIP}}`}}
+vrrp_instance {{`{{.Cluster.Name}}`}}_PROVISION {
+    state BACKUP
+    interface {{`{{ .VRRPProvInterface }}`}}
+    virtual_router_id {{`{{ .Cluster.APIProvisioningVirtualRouterID }}`}}
+    priority 140
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{`{{ .Cluster.Name }}`}}_api_provisioning_vip
+    }
+    virtual_ipaddress {
+        {{`{{ .Cluster.APIProvisioningVIP }}`}}/{{`{{ .Cluster.ProvVIPNetmask }}`}}
+    }
+}
+{{`{{end}}`}}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -267,6 +267,23 @@ vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
         {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
     }
 }
+
+{{`+"`"+`{{if .Cluster.APIProvisioningVIP}}`+"`"+`}}
+vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_PROVISION {
+    state BACKUP
+    interface {{`+"`"+`{{ .VRRPProvInterface }}`+"`"+`}}
+    virtual_router_id {{`+"`"+`{{ .Cluster.APIProvisioningVirtualRouterID }}`+"`"+`}}
+    priority 140
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{`+"`"+`{{ .Cluster.Name }}`+"`"+`}}_api_provisioning_vip
+    }
+    virtual_ipaddress {
+        {{`+"`"+`{{ .Cluster.APIProvisioningVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.ProvVIPNetmask }}`+"`"+`}}
+    }
+}
+{{`+"`"+`{{end}}`+"`"+`}}
 `)
 
 func manifestsBaremetalKeepalivedConfTmplBytes() ([]byte, error) {

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -23,6 +23,14 @@ contents:
         weight 50
     }
 
+    {{`{{if .Cluster.APIProvisioningVIP}}`}}
+    vrrp_script chk_api_prov {
+        script "/usr/bin/curl -o /dev/null -kLs https://0:22623"
+        interval 1
+        weight 50
+    }
+    {{`{{end}}`}}
+
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -76,3 +84,23 @@ contents:
             chk_ingress
         }
     }
+
+    {{`{{if .Cluster.APIProvisioningVIP}}`}}
+    vrrp_instance {{`{{.Cluster.Name}}`}}_PROVISION {
+        state BACKUP
+        interface {{`{{ .VRRPProvInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.APIProvisioningVirtualRouterID }}`}}
+        priority 40
+        advert_int 1
+        authentication {
+            auth_type PASS
+            auth_pass {{`{{ .Cluster.Name }}`}}_api_provisioning_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.APIProvisioningVIP }}`}}/{{`{{ .Cluster.ProvVIPNetmask }}`}}
+        }
+        track_script {
+            chk_api_prov
+        }
+    }
+    {{`{{end}}`}}


### PR DESCRIPTION
A provisioning VIP to reach Ignition may be necessary in some networks. If
the provisioning-api hostname is present, set up keepalived to use it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
