### PR TITLE
Bug 1777838: [release-4.3] CRI-O: add old default hook directories

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -157,8 +157,12 @@ contents:
     # ]
 
     # Path to OCI hooks directories for automatically executed hooks.
-    # hooks_dir = [
-    # ]
+    # Note: the default is just /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
+    # so we add /etc/containers/oci/hooks.d as well
+    hooks_dir = [
+        "/etc/containers/oci/hooks.d",
+        "/usr/share/containers/oci/hooks.d",
+    ]
 
     # List of default mounts for each container. **Deprecated:** this option will
     # be removed in future versions in favor of default_mounts_file.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -157,8 +157,12 @@ contents:
     # ]
 
     # Path to OCI hooks directories for automatically executed hooks.
-    # hooks_dir = [
-    # ]
+    # Note: the default is just /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
+    # so we add /etc/containers/oci/hooks.d as well
+    hooks_dir = [
+        "/etc/containers/oci/hooks.d",
+        "/usr/share/containers/oci/hooks.d",
+    ]
 
     # List of default mounts for each container. **Deprecated:** this option will
     # be removed in future versions in favor of default_mounts_file.


### PR DESCRIPTION
In CRI-O we moved to not using implicit hooks dirs (https://github.com/cri-o/cri-o/pull/1943, https://github.com/cri-o/cri-o/pull/2731).
Unfortunately, we never set a default, until: https://github.com/cri-o/cri-o/pull/3011. The default isn't enough, though.
We also need /etc/containers/oci/hook.d because /usr is immutable, so a user can't add hooks.

Signed-off-by: Peter Hunt <pehunt@redhat.com>