### PR TITLE
ovirt: ensure NetworkManager restart after changes

### DIFF
--- a/templates/common/ovirt/units/afterburn-hostname.yaml
+++ b/templates/common/ovirt/units/afterburn-hostname.yaml
@@ -1,0 +1,13 @@
+name: "post-network-changes.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Refresh Network Manager after ignition changed settings
+  Before=kubelet.service
+
+  [Service]
+  ExecStart=systemctl restart NetworkManager
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
Workers get a dhclient.conf to prepend the nameserver first
but it doesn't take effect on the /etc/resolv.conf because
NetworkManager is already running.
This makes sure changes take effect.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->