### PR TITLE
[FCOS] templates: remove /usr/share/containers/oci/hooks.d from crio config

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -159,9 +159,9 @@ contents:
     # Path to OCI hooks directories for automatically executed hooks.
     # Note: the default is just /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
     # so we add /etc/containers/oci/hooks.d as well
+    # /usr/share/containers/oci/hooks.d is not available in recent CRI-O
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
-        "/usr/share/containers/oci/hooks.d",
     ]
 
     # List of default mounts for each container. **Deprecated:** this option will

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -159,9 +159,9 @@ contents:
     # Path to OCI hooks directories for automatically executed hooks.
     # Note: the default is just /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
     # so we add /etc/containers/oci/hooks.d as well
+    # /usr/share/containers/oci/hooks.d is not available in recent CRI-O
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
-        "/usr/share/containers/oci/hooks.d",
     ]
 
     # List of default mounts for each container. **Deprecated:** this option will


### PR DESCRIPTION
For some reason its not available on masters/workers.


Not sure why this dir is not there, probably an older crio is being mixed in machine-os-content? 

UPD. this dir is provided by `oci-systemd-hook`, which no longer gets pulled in

Ref: https://github.com/openshift/machine-config-operator/pull/1305, https://github.com/openshift/openshift-ansible/pull/12047

/cc @LorbusChris @smarterclayton 