### PR TITLE
templates: remove /usr/share/containers/oci/hooks.d from crio config

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -161,7 +161,6 @@ contents:
     # so we add /etc/containers/oci/hooks.d as well
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
-        "/usr/share/containers/oci/hooks.d",
     ]
 
     # List of default mounts for each container. **Deprecated:** this option will

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -161,7 +161,6 @@ contents:
     # so we add /etc/containers/oci/hooks.d as well
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
-        "/usr/share/containers/oci/hooks.d",
     ]
 
     # List of default mounts for each container. **Deprecated:** this option will


### PR DESCRIPTION
**- What I did**
Removed /usr/share/containers/oci/hooks.d from CRI-O config. This folder is not available on RHEL7 hosts when CRI-O is being installed.

This dir is provided by `oci-systemd-hook` (if I understood correctly), however it is planned to be dropped during 4.3 lifecycle. This PR would ensure CRI-O is configured correctly in preparation to that

**- How to verify it**

Run RHEL7 scaleup - it should pass

**- Description for the changelog**
/usr/share/containers/oci/hooks.d is no longer being used as a source of CRI-O hooks.

/cc @mtnbikenc 
