### PR TITLE
templates: etcd-member: add waitforkube init container

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -12,6 +12,18 @@ contents:
         k8s-app: etcd
     spec:
       initContainers:
+    {{if .Images.clusterEtcdOperatorImageKey}}
+      - name: wait-for-kube
+        image: "{{.Images.clusterEtcdOperatorImageKey}}"
+        command: ["/usr/bin/cluster-etcd-operator"]
+        args:
+        - "wait-for-kube"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: sa
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
+    {{end}}
       - name: discovery
         image: "{{.Images.setupEtcdEnvKey}}"
         command: ["/usr/bin/setup-etcd-environment"]


### PR DESCRIPTION
This PR adds an init container `waitforkube` if CEO is enabled.

Depends on https://github.com/openshift/cluster-etcd-operator/pull/46