### PR TITLE
cri-o: remove hooks dir /usr/share/containers/oci/hooks.d

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -157,11 +157,10 @@ contents:
     # ]
 
     # Path to OCI hooks directories for automatically executed hooks.
-    # Note: the default is just /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
-    # so we add /etc/containers/oci/hooks.d as well
+    # Note: the default is /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
+    # so we use /etc/containers/oci/hooks.d instead
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
-        "/usr/share/containers/oci/hooks.d",
     ]
 
     # List of default mounts for each container. **Deprecated:** this option will

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -157,11 +157,10 @@ contents:
     # ]
 
     # Path to OCI hooks directories for automatically executed hooks.
-    # Note: the default is just /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
-    # so we add /etc/containers/oci/hooks.d as well
+    # Note: the default is /usr/share/containers/oci/hooks.d, but /usr is immutable in RHCOS
+    # so we use /etc/containers/oci/hooks.d instead
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
-        "/usr/share/containers/oci/hooks.d",
     ]
 
     # List of default mounts for each container. **Deprecated:** this option will


### PR DESCRIPTION
By default in IPI, the only hooks that we add are oci-systemd-hook, which is deprecated and should be removed.
Since /etc... is actually mutable, and the only shipped hook in /usr... is deprecated, we should remove /usr...

This also will fix https://bugzilla.redhat.com/show_bug.cgi?id=1781019 (once backported to 4.3)

Signed-off-by: Peter Hunt <pehunt@redhat.com>