### PR TITLE
Add kernelType to MachineConfig

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -45,6 +45,8 @@ func EnsureMachineConfigPool(modified *bool, existing *mcfgv1.MachineConfigPool,
 
 func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec, required mcfgv1.MachineConfigSpec) {
 	setStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
+	setStringIfSet(modified, &existing.KernelType, required.KernelType)
+
 	if !equality.Semantic.DeepEqual(existing.KernelArguments, required.KernelArguments) {
 		*modified = true
 		(*existing).KernelArguments = required.KernelArguments

--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -233,6 +233,9 @@ spec:
           fips:
             description: "fips controls FIPS mode"
             type: boolean
+          kernelType:
+            description: "contains which kernel we want to be running like default (traditional), realtime"
+            type: string
           osImageURL:
             description: "osImageURL specifies the remote location that will be used to fetch the OS"
             type: string

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -21,6 +21,7 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 	sort.Slice(configs, func(i, j int) bool { return configs[i].Name < configs[j].Name })
 
 	var fips bool
+	var kernelType string
 	outIgn := configs[0].Spec.Config
 	for idx := 1; idx < len(configs); idx++ {
 		// if any of the config has FIPS enabled, it'll be set
@@ -29,6 +30,23 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 		}
 		outIgn = ign.Append(outIgn, configs[idx].Spec.Config)
 	}
+
+	// sets the KernelType if specified in any of the MachineConfig
+	for _, cfg := range configs {
+		if cfg.Spec.KernelType == "realtime" {
+			kernelType = cfg.Spec.KernelType
+			break
+		}
+		if kernelType == "default" && cfg.Spec.KernelType != "realtime" {
+			kernelType = cfg.Spec.KernelType
+		}
+	}
+
+	// If no MC sets kerneType, then set it to 'default' since that's what it is using
+	if kernelType == "" {
+		kernelType = "default"
+	}
+
 	kargs := []string{}
 	for _, cfg := range configs {
 		kargs = append(kargs, cfg.Spec.KernelArguments...)
@@ -40,6 +58,7 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 			KernelArguments: kargs,
 			Config:          outIgn,
 			FIPS:            fips,
+			KernelType:      kernelType,
 		},
 	}
 }

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -32,12 +32,12 @@ func MergeMachineConfigs(configs []*MachineConfig, osImageURL string) *MachineCo
 	}
 
 	// sets the KernelType if specified in any of the MachineConfig
+	// Setting kerneType to realtime in any of MachineConfig takes priority
 	for _, cfg := range configs {
 		if cfg.Spec.KernelType == "realtime" {
 			kernelType = cfg.Spec.KernelType
 			break
-		}
-		if kernelType == "default" && cfg.Spec.KernelType != "realtime" {
+		} else if kernelType == "default" {
 			kernelType = cfg.Spec.KernelType
 		}
 	}

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -188,7 +188,8 @@ type MachineConfigSpec struct {
 
 	KernelArguments []string `json:"kernelArguments"`
 
-	FIPS bool `json:"fips"`
+	FIPS       bool   `json:"fips"`
+	KernelType string `json:"kernelType"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -45,7 +45,6 @@ func ValidateIgnition(cfg igntypes.Config) error {
 
 // ValidateMachineConfig validates that given MachineConfig Spec is valid.
 func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
-
 	if !(cfg.KernelType == "" || cfg.KernelType == "default" || cfg.KernelType == "realtime") {
 		return errors.Errorf("kernelType=%s is invalid", cfg.KernelType)
 	}

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -7,6 +7,7 @@ import (
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	validate "github.com/coreos/ignition/config/validate"
 	"github.com/golang/glog"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	errors "github.com/pkg/errors"
 )
 
@@ -38,6 +39,18 @@ func ValidateIgnition(cfg igntypes.Config) error {
 	}
 	if report := validate.ValidateWithoutSource(reflect.ValueOf(cfg)); report.IsFatal() {
 		return errors.Errorf("invalid Ignition config found: %v", report)
+	}
+	return nil
+}
+
+// ValidateMachineConfig validates that given MachineConfig Spec is valid.
+func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
+
+	if !(cfg.KernelType == "" || cfg.KernelType == "default" || cfg.KernelType == "realtime") {
+		return errors.Errorf("kernelType=%s is invalid", cfg.KernelType)
+	}
+	if err := ValidateIgnition(cfg.Config); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -524,9 +524,9 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 
 // generateRenderedMachineConfig takes all MCs for a given pool and returns a single rendered MC. For ex master-XXXX or worker-XXXX
 func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig) (*mcfgv1.MachineConfig, error) {
-	// Before merging all MCs for a specific pool, let's make sure each contains a valid Ignition Config
+	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid
 	for _, config := range configs {
-		if err := ctrlcommon.ValidateIgnition(config.Spec.Config); err != nil {
+		if err := ctrlcommon.ValidateMachineConfig(config.Spec); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -821,6 +821,9 @@ spec:
           fips:
             description: "fips controls FIPS mode"
             type: boolean
+          kernelType:
+            description: "contains which kernel we want to be running like default (traditional), realtime"
+            type: string
           osImageURL:
             description: "osImageURL specifies the remote location that will be used to fetch the OS"
             type: string


### PR DESCRIPTION
By default we use traditional kernel on RHCOS system. With this,
one can create a MachineConfig specifying `kernelType: realtime` .
Once this MachineConfig is applied to OpenShift cluster,
targetted RHCOS node should switch to using realtime kernel.

Currently, realtime kernel packages are shipped as rpm files in
RHCOS OSContainer. MCO fetches those rpms from OSContainer and
uses rpm-ostree to layer realtime kernel on host.