### PR TITLE
[WIP]: *: adds a flag to mco for reading etcd CR yaml

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -26,6 +26,7 @@ var (
 		destinationDir            string
 		etcdCAFile                string
 		etcdImage                 string
+		etcdConfigFile            string
 		etcdMetricCAFile          string
 		haproxyImage              string
 		imagesConfigMapFile       string
@@ -64,6 +65,7 @@ func init() {
 	bootstrapCmd.MarkFlagRequired("etcd-image")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeClientAgentImage, "kube-client-agent-image", "", "Image for Kube Client Agent.")
 	bootstrapCmd.MarkFlagRequired("kube-client-agent-image")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.etcdConfigFile, "etcd-config-file", "", "Etcd Config file.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.clusterEtcdOperatorImage, "cluster-etcd-operator-image", "", "Image for Cluster Etcd Operator. An empty string here means the cluster boots without CEO.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "", "Image for Infra Containers.")
 	bootstrapCmd.MarkFlagRequired("infra-image")
@@ -118,7 +120,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.configFile,
 		bootstrapOpts.infraConfigFile, bootstrapOpts.networkConfigFile,
 		bootstrapOpts.cloudConfigFile,
-		bootstrapOpts.etcdCAFile, bootstrapOpts.etcdMetricCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
+		bootstrapOpts.etcdCAFile, bootstrapOpts.etcdMetricCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.etcdConfigFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
 		&imgs,
 		bootstrapOpts.destinationDir,
 	); err != nil {

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -74,6 +74,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.ClientBuilder.APIExtClientOrDie(componentName),
 			ctrlctx.ClientBuilder.ConfigClientOrDie(componentName),
 			ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
+			ctrlctx.EtcdInformer,
 		)
 
 		ctrlctx.NamespacedInformerFactory.Start(ctrlctx.Stop)

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -83,6 +83,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		ctrlctx.APIExtInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
 		close(ctrlctx.InformersStarted)
 
 		go controller.Run(2, ctrlctx.Stop)

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -11,7 +11,7 @@ data:
       "etcd": "registry.svc.ci.openshift.org/openshift:etcd",
       "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
       "kubeClientAgentImage": "registry.svc.ci.openshift.org/openshift:kube-client-agent",
-      "clusterEtcdOperatorImage": "",
+      "clusterEtcdOperatorImage": "registry.svc.ci.openshift.org/openshift:cluster-etcd-operator",
       "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
       "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",

--- a/install/image-references
+++ b/install/image-references
@@ -31,6 +31,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:kube-client-agent
+  - name: cluster-etcd-operator
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:cluster-etcd-operator
   - name: cli
     from:
       kind: DockerImage

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -68,6 +68,7 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 
 	setBytesIfSet(modified, &existing.EtcdCAData, required.EtcdCAData)
 	setBytesIfSet(modified, &existing.EtcdMetricCAData, required.EtcdMetricCAData)
+	setBool(modified, &existing.ClusterEtcdOperatorEnabled, required.ClusterEtcdOperatorEnabled)
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
 

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -22,3 +22,6 @@ rules:
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["etcds"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -95,6 +95,9 @@ type ControllerConfigSpec struct {
 	// images is map of images that are used by the controller to render templates under ./templates/
 	Images map[string]string `json:"images"`
 
+	// ClusterEtcdOperatorEnabled is used to determine if etcd is managed by the operator or not
+	ClusterEtcdOperatorEnabled bool `json:"clusterEtcdOperatorEnabled"`
+
 	// osImageURL is the location of the container image that contains the OS update payload.
 	// Its value is taken from the data.osImageURL field on the machine-config-osimageurl ConfigMap.
 	OSImageURL string `json:"osImageURL"`

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	operatorv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	"github.com/openshift/machine-config-operator/internal/clients"
@@ -88,7 +89,7 @@ func CreateControllerContext(cb *clients.Builder, stop <-chan struct{}, targetNa
 	configSharedInformer := configinformers.NewSharedInformerFactory(configClient, resyncPeriod()())
 	operatorSharedInformer := operatorinformers.NewSharedInformerFactory(operatorClient, resyncPeriod()())
 
-	etcdInformer := operatorSharedInformer.Operator().V1().Etcds()
+	etcdInformer := getEtcdInformer(operatorClient, operatorSharedInformer)
 
 	return &ControllerContext{
 		ClientBuilder:                                       cb,
@@ -106,4 +107,19 @@ func CreateControllerContext(cb *clients.Builder, stop <-chan struct{}, targetNa
 		InformersStarted:                                    make(chan struct{}),
 		ResyncPeriod:                                        resyncPeriod(),
 	}
+}
+
+func getEtcdInformer(operatorClient operatorclientset.Interface, operatorSharedInformer operatorinformers.SharedInformerFactory) operatorv1.EtcdInformer {
+	operatorGroups, err := operatorClient.Discovery().ServerResourcesForGroupVersion("operator.openshift.io/v1")
+	if err != nil {
+		glog.Errorf("unable to get operatorGroups: %#v", err)
+		return nil
+	}
+
+	for _, o := range operatorGroups.APIResources {
+		if o.Kind == "Etcd" {
+			return operatorSharedInformer.Operator().V1().Etcds()
+		}
+	}
+	return nil
 }

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -383,7 +383,7 @@ func etcdPeerCertDNSNames(cfg RenderConfig) (interface{}, error) {
 
 func etcdServerCertCommand(cfg RenderConfig) (interface{}, error) {
 	commands := []string{}
-	if cfg.Images[ClusterEtcdOperatorImageKey] == "" {
+	if !cfg.ClusterEtcdOperatorEnabled {
 		serverCertDNS, err := etcdServerCertDNSNames(cfg)
 		if err != nil {
 			return nil, err
@@ -411,7 +411,7 @@ func etcdServerCertCommand(cfg RenderConfig) (interface{}, error) {
 
 func etcdPeerCertCommand(cfg RenderConfig) (interface{}, error) {
 	commands := []string{}
-	if cfg.Images[ClusterEtcdOperatorImageKey] == "" {
+	if !cfg.ClusterEtcdOperatorEnabled {
 		peerCertDNS, err := etcdPeerCertDNSNames(cfg)
 		if err != nil {
 			return nil, err
@@ -439,7 +439,7 @@ func etcdPeerCertCommand(cfg RenderConfig) (interface{}, error) {
 
 func etcdMetricCertCommand(cfg RenderConfig) (interface{}, error) {
 	commands := []string{}
-	if cfg.Images[ClusterEtcdOperatorImageKey] == "" {
+	if !cfg.ClusterEtcdOperatorEnabled {
 		metricCertDNS, err := etcdServerCertDNSNames(cfg)
 		if err != nil {
 			return nil, err

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -867,6 +867,9 @@ rules:
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["etcds"]
+  verbs: ["get", "list", "watch"]
 `)
 
 func manifestsMachineconfigcontrollerClusterroleYamlBytes() ([]byte, error) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -8,6 +8,8 @@ import (
 	"github.com/golang/glog"
 
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	opeartorv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	operatorlisterv1 "github.com/openshift/client-go/operator/listers/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextinformersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
@@ -16,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	rbacinformersv1 "k8s.io/client-go/informers/rbac/v1"
@@ -24,6 +25,7 @@ import (
 	coreclientsetv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslisterv1 "k8s.io/client-go/listers/apps/v1"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
+
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
@@ -80,7 +82,7 @@ type Operator struct {
 	clusterCmLister  corelisterv1.ConfigMapLister
 	proxyLister      configlistersv1.ProxyLister
 	oseKubeAPILister corelisterv1.ConfigMapLister
-	etcdInformer     informers.GenericInformer
+	etcdLister       operatorlisterv1.EtcdLister
 
 	crdListerSynced                  cache.InformerSynced
 	deployListerSynced               cache.InformerSynced
@@ -97,7 +99,7 @@ type Operator struct {
 	clusterRoleBindingInformerSynced cache.InformerSynced
 	proxyListerSynced                cache.InformerSynced
 	oseKubeAPIListerSynced           cache.InformerSynced
-	clusterEtcdSynced                cache.InformerSynced
+	etcdSynced                       cache.InformerSynced
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
@@ -129,7 +131,7 @@ func New(
 	apiExtClient apiextclientset.Interface,
 	configClient configclientset.Interface,
 	oseKubeAPIInformer coreinformersv1.ConfigMapInformer,
-	etcdInformer informers.GenericInformer,
+	etcdInformer opeartorv1.EtcdInformer,
 ) *Operator {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
@@ -145,7 +147,6 @@ func New(
 		apiExtClient:  apiExtClient,
 		configClient:  configClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigoperator"}),
-		etcdInformer:  etcdInformer,
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
 	}
 
@@ -198,7 +199,8 @@ func New(
 	optr.infraListerSynced = infraInformer.Informer().HasSynced
 	optr.networkLister = networkInformer.Lister()
 	optr.networkListerSynced = networkInformer.Informer().HasSynced
-	optr.clusterEtcdSynced = etcdInformer.Informer().HasSynced
+	optr.etcdLister = etcdInformer.Lister()
+	optr.etcdSynced = etcdInformer.Informer().HasSynced
 
 	optr.vStore.Set("operator", os.Getenv("RELEASE_VERSION"))
 
@@ -244,7 +246,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 			optr.mcpListerSynced,
 			optr.ccListerSynced,
 			optr.mcListerSynced,
-			optr.clusterEtcdSynced,
+			optr.etcdSynced,
 		) {
 			glog.Error("failed to sync caches")
 			return

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -19,7 +19,7 @@ contents:
         - "run"
         - "--discovery-srv={{.EtcdDiscoveryDomain}}"
         - "--output-file=/run/etcd/environment"
-        - "--bootstrap-srv={{if .Images.clusterEtcdOperatorImageKey}}{{false}}{{else}}{{true}}{{end}}"
+        - "--bootstrap-srv={{if .ClusterEtcdOperatorEnabled}}{{false}}{{else}}{{true}}{{end}}"
         - "--v=4"
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ contents:
           mountPath: /var/lib/etcd/
         - name: certs
           mountPath: /etc/ssl/etcd/
-    {{if .Images.clusterEtcdOperatorImageKey}}
+    {{if .ClusterEtcdOperatorEnabled}}
         - name: sa
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
     {{end}}
@@ -42,7 +42,7 @@ contents:
             fieldRef:
               fieldPath: metadata.name
       - name: certs
-        image: {{if .Images.clusterEtcdOperatorImageKey }}"{{.Images.clusterEtcdOperatorImageKey}}"{{else}}"{{.Images.kubeClientAgentImageKey}}"{{end}}
+        image: {{if .ClusterEtcdOperatorEnabled}}"{{.Images.clusterEtcdOperatorImageKey}}"{{else}}"{{.Images.kubeClientAgentImageKey}}"{{end}}
         command:
         - /bin/sh
         - -c
@@ -74,11 +74,11 @@ contents:
           mountPath: /etc/ssl/etcd/
         - name: kubeconfig
           mountPath: /etc/kubernetes/kubeconfig
-   {{if .Images.clusterEtcdOperatorImageKey}}
+   {{if .ClusterEtcdOperatorEnabled}}
         - name: sa
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
    {{end}}
-   {{if .Images.clusterEtcdOperatorImageKey}}
+   {{if .ClusterEtcdOperatorEnabled}}
       - name: membership
         image: "{{.Images.etcdKey}}"
         command:
@@ -238,7 +238,7 @@ contents:
       - name: conf
         hostPath:
           path: /etc/etcd
-   {{if .Images.clusterEtcdOperatorImageKey}}
+   {{if .ClusterEtcdOperatorEnabled}}
       - name: sa
         hostPath:
           path: /etc/kubernetes/static-pod-resources/etcd-member/secrets/kubernetes.io/sa-token


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- added a flag to MCO for reading the etcd CR yaml.
- add a field in ControllerConfigSpec to save if cluster-etcd-operator is enabled
- modify the logic to use this added field in ControllerConfigSpec to render etcd static pod yaml

**-  Depends on** 
-  #1288

**- How to verify it**
The current value for Spec is defaulting to False. It will change once we enable cluster-etcd-operator
so should be able to see ControllerConfig as
```
spec:
  ...
  clusterEtcdOperatorEnabled: false
  ...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
add a flag to mco to read etcd config file
