### PR TITLE
install: add exclusion annotations to all resources

### DIFF
--- a/install/0000_80_machine-config-operator_00_clusterreader_clusterrole.yaml
+++ b/install/0000_80_machine-config-operator_00_clusterreader_clusterrole.yaml
@@ -4,6 +4,8 @@ metadata:
   name: system:openshift:machine-config-operator:cluster-reader
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - machineconfiguration.openshift.io

--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-machine-config-operator
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     name: openshift-machine-config-operator
     openshift.io/run-level: "1"
@@ -15,6 +16,7 @@ metadata:
   name: openshift-openstack-infra
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     name: openshift-openstack-infra
     openshift.io/run-level: "1"
@@ -25,6 +27,7 @@ metadata:
   name: openshift-kni-infra
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     name: openshift-kni-infra
     openshift.io/run-level: "1"
@@ -35,6 +38,7 @@ metadata:
   name: openshift-ovirt-infra
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     name: openshift-ovirt-infra
     openshift.io/run-level: "1"

--- a/install/0000_80_machine-config-operator_01_mcoconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_mcoconfig.crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: mcoconfigs.machineconfiguration.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: machine-config-operator-images
   namespace: openshift-machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   images.json: >
     {

--- a/install/0000_80_machine-config-operator_03_rbac.yaml
+++ b/install/0000_80_machine-config-operator_03_rbac.yaml
@@ -3,6 +3,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: default-account-openshift-machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
 - kind: ServiceAccount
   name: default
@@ -18,6 +20,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
     - ""
@@ -36,6 +40,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: machine-config-osimageurl
   namespace: openshift-machine-config-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   # The OS payload, managed by the daemon + pivot + rpm-ostree
   # https://github.com/openshift/machine-config-operator/issues/183

--- a/install/0000_90_machine-config-operator_00_servicemonitor.yaml
+++ b/install/0000_90_machine-config-operator_00_servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-machine-config-operator
   labels:
     k8s-app: machine-config-daemon
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - interval: 30s

--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-machine-config-operator
   labels:
     k8s-app: machine-config-daemon
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: mcd-reboot-error

--- a/install/0001_00_machine-config-operator_00_service.yaml
+++ b/install/0001_00_machine-config-operator_00_service.yaml
@@ -7,6 +7,7 @@ metadata:
     k8s-app: machine-config-daemon
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: proxy-tls
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.