### PR TITLE
vendor: run make go-deps

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -712,8 +712,6 @@ github.com/openshift/imagebuilder v1.1.0 h1:oT704SkwMEzmIMU/+Uv1Wmvt+p10q3v2WuYM
 github.com/openshift/imagebuilder v1.1.0/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/openshift/kubernetes v0.0.0-20191212072028-a49679c4e335 h1:UPRpcHXSBcT7q4cOUOQD+Fh3wNcOrCd/I99gA6GqR1U=
 github.com/openshift/kubernetes v0.0.0-20191212072028-a49679c4e335/go.mod h1:Ytydf4f0F5OdfEVFET3R4UYX5JAQRVI/s/VrOfR6uDY=
-github.com/openshift/kubernetes v1.16.0-beta.0.0.20190913145653-2bd9643cee5b h1:b3r/3odnWNdjYRrwvXiqxLFbPYFQ+m2GblFK6RwTC9Y=
-github.com/openshift/kubernetes v1.16.0-beta.0.0.20190913145653-2bd9643cee5b/go.mod h1:nlP2zevWKRGKuaaVbKIwozU0Rjg9leVDXkL4YTtjmVs=
 github.com/openshift/kubernetes-apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783 h1:Mek6OZC4QulQv6YQdwlHinEcsBGfynqh3dMXlBAv0h0=
 github.com/openshift/kubernetes-apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783/go.mod h1:xvae1SZB3E17UpV59AWc271W/Ph25N+bjPyR63X6tPY=
 github.com/openshift/kubernetes-apiserver v0.0.0-20190918160949-bfa5e2e684ad h1:W8VdXiC+oDn+l5R37SBlvILBdnBiRiGOL/lWyt5wHfI=
@@ -1224,8 +1222,6 @@ k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKf
 k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d h1:Xpe6sK+RY4ZgCTyZ3y273UmFmURhjtoJiwOMbQsXitY=
 k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kubectl v0.0.0-20190831152136-eb175a4e3db6/go.mod h1:L66D9uMGB/b+dDqI6Oz6VDls9Am0U6tV1T8qM76RgY0=
-k8s.io/kubelet v0.0.0-20190831152136-ba9cf7ec6904 h1:+OnZB035t7XqQMn7cjmhW9XVAkLJGSSmn5hUJ0Zd77w=
-k8s.io/kubelet v0.0.0-20190831152136-ba9cf7ec6904/go.mod h1:3nVkot3Entuhkhr3SEcGL9qVrAULbAg3vyl0X1mqlbQ=
 k8s.io/repo-infra v0.0.0-20181204233714-00fe14e3d1a3/go.mod h1:+G1xBfZDfVFsm1Tj/HNCvg4QqWx8rJ2Fxpqr1rqp/gQ=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=


### PR DESCRIPTION
Re-run `make go-deps` with go 1.12 (that's what we're using in openshift 4.3)

Signed-off-by: Antonio Murdaca <runcom@linux.com>