### PR TITLE
Bug 1783448: [release-4.3] DR: save and restore kube apiserver's static pod resources

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -7,6 +7,7 @@ contents:
 
     set -o errexit
     set -o pipefail
+    set -o errtrace
 
     # example
     # etcd-snapshot-backup.sh $path-to-snapshot
@@ -17,17 +18,26 @@ contents:
     fi
 
     usage () {
-        echo 'Path to backup file required: ./etcd-snapshot-backup.sh ./backup.db'
+        echo 'Path to backup dir required: ./etcd-snapshot-backup.sh <path-to-backup-dir>'
         exit 1
     }
 
     ASSET_DIR=./assets
 
-    if [ "$1" != "" ]; then
-      SNAPSHOT_FILE="$1"
-    else
+    if [ -z "$1" ] || [ -f "$1" ]; then
       usage
     fi
+
+    if [ ! -d "$1" ]; then
+      mkdir -p $1
+    fi
+
+    BACKUP_DIR="$1"
+    DATESTRING=$(date "+%F_%H%M%S")
+    BACKUP_TAR_FILE=${BACKUP_DIR}/snapshot_db_kuberesources_$DATESTRING.tar
+    SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
+
+    trap "rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}" ERR
 
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
@@ -45,7 +55,12 @@ contents:
       dl_etcdctl
       backup_etcd_client_certs
       backup_manifest
+      backup_latest_kube_static_resources
       snapshot_data_dir
+      tar rf ${BACKUP_TAR_FILE} -C ${ASSET_DIR}/tmp snapshot.db
+      gzip ${BACKUP_TAR_FILE}
+      rm -f ${SNAPSHOT_FILE}
+      echo "snapshot db and kube resources are successfully saved to ${BACKUP_TAR_FILE}.gz!"
     }
 
     run

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -9,7 +9,7 @@ contents:
     set -o pipefail
 
     # example
-    # ./etcd-snapshot-restore.sh $path-to-snapshot $inital_cluster
+    # ./etcd-snapshot-restore.sh $path-to-backup $inital_cluster
 
     if [[ $EUID -ne 0 ]]; then
       echo "This script must be run as root"
@@ -17,7 +17,7 @@ contents:
     fi
 
     usage () {
-        echo 'Path to snapshot and initial cluster are required: ./etcd-snapshot-restore.sh $path-to-snapshot $initial_cluster'
+        echo 'Path to backup file and initial cluster are required: ./etcd-snapshot-restore.sh $path-to-backup $initial_cluster'
         exit 1
     }
 
@@ -25,7 +25,7 @@ contents:
         usage
     fi
 
-    SNAPSHOT_FILE="$1"
+    BACKUP_FILE="$1"
     INITIAL_CLUSTER="$2"
     ASSET_DIR=./assets
     CONFIG_FILE_DIR=/etc/kubernetes
@@ -39,8 +39,8 @@ contents:
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
     STOPPED_STATIC_PODS="${ASSET_DIR}/tmp/stopped-static-pods"
 
-    if [ ! -f "$SNAPSHOT_FILE" ]; then
-      echo "etcd snapshot $SNAPSHOT_FILE does not exist."
+    if [ ! -f "${BACKUP_FILE}" ]; then
+      echo "etcd snapshot ${BACKUP_FILE} does not exist."
       exit 1
     fi
 
@@ -49,6 +49,21 @@ contents:
     function run {
       ETCD_INITIAL_CLUSTER="${INITIAL_CLUSTER}"
       init
+      if [ ${BACKUP_FILE#*.} = "tar.gz" ]; then
+        RESTORE_STATIC_RESOURCES="true"
+        tar xzf ${BACKUP_FILE} -C ${ASSET_DIR}/tmp/ snapshot.db
+        SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
+      else
+        # For backward-compatibility, we support restoring from single snapshot.db file
+        RESTORE_STATIC_RESOURCES="false" 
+        SNAPSHOT_FILE="${BACKUP_FILE}"
+      fi
+
+      if [ ! -f "${SNAPSHOT_FILE}" ]; then
+        echo "etcd snapshot ${SNAPSHOT_FILE} does not exist."
+        exit 1
+      fi
+
       dl_etcdctl
       backup_manifest
       DISCOVERY_DOMAIN=$(grep -oP '(?<=discovery-srv=).*[^"]' $ASSET_DIR/backup/etcd-member.yaml )
@@ -66,7 +81,9 @@ contents:
       stop_all_containers
       backup_data_dir
       remove_data_dir
+      [ "${RESTORE_STATIC_RESOURCES}" = "true" ] && remove_kube_static_resources
       restore_snapshot
+      [ "${RESTORE_STATIC_RESOURCES}" = "true" ] && restore_kube_static_resources
       start_static_pods
       start_kubelet
     }

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -38,7 +38,7 @@ contents:
       if [ -f "$ASSET_DIR/backup/etcd-ca-bundle.crt" ] && [ -f "$ASSET_DIR/backup/etcd-client.crt" ] && [ -f "$ASSET_DIR/backup/etcd-client.key" ]; then
          echo "etcd client certs already backed up and available $ASSET_DIR/backup/"
       else
-        STATIC_DIRS=($(ls -d "${CONFIG_FILE_DIR}"/static-pod-resources/kube-apiserver-pod-[0-9]*))
+        STATIC_DIRS=($(ls -td "${CONFIG_FILE_DIR}"/static-pod-resources/kube-apiserver-pod-[0-9]*))
         if [ "$?" -ne 0 ]; then
           echo "error finding static-pod-resources"
           exit 1
@@ -59,6 +59,17 @@ contents:
         echo "backup failed: client certs not found"
         exit 1
       fi
+    }
+
+    #backup latest static pod resources for kube-apiserver
+    backup_latest_kube_static_resources() {
+      echo "Trying to backup latest static pod resources.."
+      LATEST_STATIC_POD_DIR=$(ls -vd "${CONFIG_FILE_DIR}"/static-pod-resources/kube-apiserver-pod-[0-9]* | tail -1) || true
+      if [ -z "$LATEST_STATIC_POD_DIR" ]; then
+          echo "error finding static-pod-resources"
+          exit 1
+      fi
+      tar -cpf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} ${LATEST_STATIC_POD_DIR#$CONFIG_FILE_DIR/}
     }
 
     # backup current etcd-member pod manifest
@@ -148,6 +159,18 @@ contents:
       fi
     }
 
+    remove_kube_static_resources() {
+      # Only remove those directories that are greater or equal to the backed up revision.
+      REVISION=$(tar tf $BACKUP_FILE | grep -oP "(?<=static-pod-resources/kube-apiserver-)pod-[0-9]*" | head -1) || true
+      KUBE_DIRS=$(ls -vd ${CONFIG_FILE_DIR}/static-pod-resources/kube-apiserver-pod-[0-9]* | awk -v REV="${REVISION}$" '$0 ~ REV {seen=1} seen { print}') || true
+      if [ ! -z "${KUBE_DIRS}" ]; then
+         echo "Removing newer static pod resources..."
+         rm -rf ${KUBE_DIRS}
+      else
+         echo "remove_kube_static_resources: newer revisions of kube-apiserver-pod static resources are not found."
+      fi
+    }
+
     restore_snapshot() {
       if [ ! -f "$SNAPSHOT_FILE" ]; then
         echo "Snapshot file not found, restore failed: $SNAPSHOT_FILE."
@@ -162,6 +185,10 @@ contents:
         --skip-hash-check=true \
         --initial-advertise-peer-urls https://${ETCD_IPV4_ADDRESS}:2380 \
         --data-dir $ETCD_DATA_DIR
+    }
+
+    restore_kube_static_resources() {
+      tar -C ${CONFIG_FILE_DIR} -xzf $BACKUP_FILE static-pod-resources
     }
 
     patch_manifest() {
@@ -401,3 +428,4 @@ contents:
       fi
       echo "$ETCD_NAME"
     }
+


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: 1783448
**- What I did**
Backup should save static pod resources of kube-apiserver along with the snapshot of etcd database. Similarly, when a restore is invoked, it should restore the static pod resources along with the etcd database.
**- How to verify it**
Follow DR documentation to back up and restore. The cluster should functional after the same backup is restored on all masters.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Save and restore kube apiserver's static pod resources along with etcd database.