### PR TITLE
Bug 1785281: Discard audit messages from journald

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -937,7 +937,7 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig) error {
 func (dn *Daemon) getPendingStateLegacyLogger() (*journalMsg, error) {
 	glog.Info("logger doesn't support --jounald, grepping the journal")
 
-	cmdLiteral := "journalctl -o cat _UID=0 | grep OPENSHIFT_MACHINE_CONFIG_DAEMON_LEGACY_LOG_HACK"
+	cmdLiteral := "journalctl -o cat _UID=0 | grep -v audit | grep OPENSHIFT_MACHINE_CONFIG_DAEMON_LEGACY_LOG_HACK"
 	cmd := exec.Command("bash", "-c", cmdLiteral)
 	var combinedOutput bytes.Buffer
 	cmd.Stdout = &combinedOutput


### PR DESCRIPTION
Fixes bz#1785219 with the simplest approach.

Since this is a corner case [1] which probably few people will hit, this is the simplest approach to fix the issue, also it will be short-lived as RHEL7.7 comes with logger supporting --journald flag.

[1] RHEL7.6 + audit enabled + logger not supporting --journald flag