### PR TITLE
Bug 1787581: cleanup sdn ips on reboot

### DIFF
--- a/templates/common/_base/files/cleanup-cni-conf.yaml
+++ b/templates/common/_base/files/cleanup-cni-conf.yaml
@@ -7,3 +7,4 @@ contents:
     r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
     r /etc/kubernetes/cni/net.d/00-multus.conf
     d /run/multus/cni/net.d/ 0755 root root - -
+    D /var/lib/cni/networks/openshift-sdn/ 0755 root root - -


### PR DESCRIPTION
**- What I did**
SDN IPs are leaked on reboots because the files are not being cleaned. This PR removes `/var/lib/cni/networks/openshift-sdn` deleting the IP config files.

**- How to verify it**

**- Description for the changelog**
