### PR TITLE
hack/build-go.sh: removed not needed eval go env

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -29,8 +29,6 @@ HASH=${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}
 
 GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE} -X ${REPO}/pkg/version.Hash=${HASH}"
 
-eval $(go env)
-
 if [ -z ${BIN_PATH+a} ]; then
 	export BIN_PATH=_output/${GOOS}/${GOARCH}
 fi


### PR DESCRIPTION
Should fix what we've seen in the ose builds:

...
hack/build-go.sh: line 32: exclude_graphdriver_devicemapper: command not found
...

Still not super sure about what's happening, might be GOFLAGS cluttering
go env and causing an unquoted string which is then eval'ed and errors
out.

Also, there's no reason about having that eval in there in the first
place. No git history shows why it's there as well so get rid of it.

Signed-off-by: Antonio Murdaca <runcom@linux.com>