### PR TITLE
 Don't enable machine-config-daemon-host.service by default

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-host.service
+++ b/templates/common/_base/units/machine-config-daemon-host.service
@@ -1,5 +1,5 @@
 name: "machine-config-daemon-host.service"
-enabled: true
+enabled: false
 contents: |
   [Unit]
   Description=Machine Config Daemon Initial


### PR DESCRIPTION

Today the MCS serves both `/etc/pivot/image-pullspec` *and*
`/etc/ignition-machine-config-encapsulated.json` - and we have
to serve both so that using 4.1 bootimages works.

However, we absolutely shouldn't start *both* services on a modern
4.3+ system on firstboot - they will race, both trying to update,
and one doing a reboot.

Only enable the `-firstboot.service` which will itself currently
invoke `-host.service`, though in the future we should clean this
up by having the firstboot code run rpm-ostree *directly*, since
we're already on the host.

Motivated by discussions around RT kernel handling.