### PR TITLE
[release-4.1] Bug 1789982: cleanup sdn ips on reboot

### DIFF
--- a/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/none/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/master/00-master/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/aws/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/libvirt/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/none/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/openstack/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
+++ b/pkg/controller/template/test_data/templates/worker/00-worker/vsphere/files/-etc-tmpfiles.d-cleanup-cni.conf
@@ -1,5 +1,5 @@
 contents:
-  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0A
+  source: data:,r%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F80-openshift-network.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F10-ovn-kubernetes.conf%0Ar%20%2Fetc%2Fkubernetes%2Fcni%2Fnet.d%2F00-multus.conf%0AD%20%2Fvar%2Flib%2Fcni%2Fnetworks%2Fopenshift-sdn%2F%200755%20root%20root%20-%20-%0A
   verification: {}
 filesystem: root
 mode: 420

--- a/templates/master/00-master/_base/files/cleanup-cni-conf.yaml
+++ b/templates/master/00-master/_base/files/cleanup-cni-conf.yaml
@@ -6,3 +6,4 @@ contents:
     r /etc/kubernetes/cni/net.d/80-openshift-network.conf
     r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
     r /etc/kubernetes/cni/net.d/00-multus.conf
+    D /var/lib/cni/networks/openshift-sdn/ 0755 root root - -

--- a/templates/worker/00-worker/_base/files/cleanup-cni-conf.yaml
+++ b/templates/worker/00-worker/_base/files/cleanup-cni-conf.yaml
@@ -6,3 +6,4 @@ contents:
     r /etc/kubernetes/cni/net.d/80-openshift-network.conf
     r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
     r /etc/kubernetes/cni/net.d/00-multus.conf
+    D /var/lib/cni/networks/openshift-sdn/ 0755 root root - -


### PR DESCRIPTION
**- What I did**
Cherry pick of https://github.com/openshift/machine-config-operator/pull/1360

> SDN IPs are leaked on reboots because the files are not being cleaned. This PR removes /var/lib/cni/networks/openshift-sdn deleting the IP config files.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
