### PR TITLE
build: do not export GOFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export GOPATH=$(shell echo $${GOPATH:-$$HOME/go})
 export GO111MODULE
 export GOPROXY=https://proxy.golang.org
 
-GOFLAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
+GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 
 # grab the version from a dummy pkg in k8s.io/code-generator from vendor/modules.txt (read by go list)
 versionPath=$(shell GO111MODULE=on go list -f {{.Dir}} k8s.io/code-generator/cmd/client-gen)
@@ -47,7 +47,7 @@ test: test-unit test-e2e
 
 # Unit tests only (no active cluster required)
 test-unit:
-	go test -tags=$(GOFLAGS) -count=1 -v ./cmd/... ./pkg/... ./lib/...
+	go test -tags=$(GOTAGS) -count=1 -v ./cmd/... ./pkg/... ./lib/...
 
 # Run the code generation tasks.
 # Example:
@@ -73,7 +73,7 @@ install-tools:
 # Example:
 #    make verify
 verify: install-tools
-	golangci-lint run --build-tags=$(GOFLAGS)
+	golangci-lint run --build-tags=$(GOTAGS)
 	# Remove once https://github.com/golangci/golangci-lint/issues/597 is
 	# addressed
 	gosec -severity high --confidence medium -exclude G204 -quiet ./...

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -4,7 +4,7 @@ set -eu
 
 REPO=github.com/openshift/machine-config-operator
 WHAT=${WHAT:-machine-config-operator}
-GOFLAGS=${GOFLAGS:-}
+GOTAGS=${GOTAGS:-}
 GLDFLAGS=${GLDFLAGS:-}
 
 eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
@@ -40,8 +40,8 @@ mkdir -p ${BIN_PATH}
 CGO_ENABLED=0
 
 if [[ $WHAT == "machine-config-controller" ]]; then
-    GOFLAGS="containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
+    GOTAGS="containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 fi
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE}, ${HASH})"
-CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOFLAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}
+CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}


### PR DESCRIPTION
GOFLAGS env shouldn't be exported as it's meant for something else but we're using
it for "tags" - that's why the build fails on rhel (not sure why it started recently).

Tested in the golang-1.12 container and works fine, should further fix the ocp builds.

Reference to GOFLAGS env: https://tip.golang.org/cmd/go/#hdr-Environment_variables

```
GOFLAGS
	A space-separated list of -flag=value settings to apply
	to go commands by default, when the given flag is known by
	the current command. Each entry must be a standalone flag.
	Because the entries are space-separated, flag values must
	not contain spaces. Flags listed on the command line
	are applied after this list and therefore override it.
```

ref #1364 

Signed-off-by: Antonio Murdaca <runcom@linux.com>