### PR TITLE
Add vSphere IPI

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -38,3 +38,13 @@ metadata:
   labels:
     name: openshift-ovirt-infra
     openshift.io/run-level: "1"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-vsphere-infra
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    name: openshift-vsphere-infra
+    openshift.io/run-level: "1"

--- a/manifests/vsphere/coredns-corefile.tmpl
+++ b/manifests/vsphere/coredns-corefile.tmpl
@@ -1,0 +1,12 @@
+. {
+    errors
+    health :18080
+    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+    cache 30
+    reload
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        fallthrough
+    }
+}

--- a/manifests/vsphere/coredns.yaml
+++ b/manifests/vsphere/coredns.yaml
@@ -1,0 +1,92 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: coredns
+  namespace: openshift-vsphere-infra
+  creationTimestamp:
+  deletionGracePeriodSeconds: 65
+  labels:
+    app: vsphere-infra-mdns
+spec:
+  volumes:
+  - name: resource-dir
+    hostPath:
+      path: "/etc/kubernetes/static-pod-resources/coredns"
+  - name: kubeconfig
+    hostPath:
+      path: "/etc/kubernetes/kubeconfig"
+  - name: conf-dir
+    empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
+  initContainers:
+  - name: render-config
+    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    command:
+    - runtimecfg
+    - render
+    - "/etc/kubernetes/kubeconfig"
+    - "--api-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+    - "--dns-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
+    - "--ingress-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
+    - "/config"
+    - "--out-dir"
+    - "/etc/coredns"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
+    resources: {}
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
+    - name: resource-dir
+      mountPath: "/config"
+    - name: conf-dir
+      mountPath: "/etc/coredns"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
+    imagePullPolicy: IfNotPresent
+  containers:
+  - name: coredns
+    securityContext:
+      privileged: true
+    image: {{ .Images.CorednsBootstrap }}
+    args:
+    - "--conf"
+    - "/etc/coredns/Corefile"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: conf-dir
+      mountPath: "/etc/coredns"
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 18080
+        scheme: HTTP
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+      timeoutSeconds: 10
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 18080
+        scheme: HTTP
+      initialDelaySeconds: 60
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
+    terminationMessagePolicy: FallbackToLogsOnError
+  hostNetwork: true
+  tolerations:
+  - operator: Exists
+  priorityClassName: system-node-critical
+status: {}

--- a/manifests/vsphere/keepalived.conf.tmpl
+++ b/manifests/vsphere/keepalived.conf.tmpl
@@ -1,0 +1,35 @@
+# Configuration template for Keepalived, which is used to manage the DNS and
+# API VIPs.
+#
+# For more information, see installer/data/data/bootstrap/baremetal/README.md
+# in the installer repo.
+
+vrrp_instance {{`{{.Cluster.Name}}`}}_API {
+    state BACKUP
+    interface {{`{{.VRRPInterface}}`}}
+    virtual_router_id {{`{{.Cluster.APIVirtualRouterID }}`}}
+    priority 50
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{`{{.Cluster.Name}}`}}_api_vip
+    }
+    virtual_ipaddress {
+        {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+    }
+}
+
+vrrp_instance {{`{{.Cluster.Name}}`}}_DNS {
+    state MASTER
+    interface {{`{{.VRRPInterface}}`}}
+    virtual_router_id {{`{{.Cluster.DNSVirtualRouterID }}`}}
+    priority 140
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{`{{.Cluster.Name}}`}}_dns_vip
+    }
+    virtual_ipaddress {
+        {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+    }
+}

--- a/manifests/vsphere/keepalived.yaml
+++ b/manifests/vsphere/keepalived.yaml
@@ -1,0 +1,83 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: keepalived
+  namespace: openshift-vsphere-infra
+  creationTimestamp:
+  deletionGracePeriodSeconds: 65
+  labels:
+    app: vsphere-infra-vrrp
+spec:
+  volumes:
+  - name: resource-dir
+    hostPath:
+      path: "/etc/kubernetes/static-pod-resources/keepalived"
+  - name: kubeconfig
+    hostPath:
+      path: "/etc/kubernetes/kubeconfig"
+  - name: conf-dir
+    empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
+  initContainers:
+  - name: render-config
+    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    command:
+    - runtimecfg
+    - render
+    - "/etc/kubernetes/kubeconfig"
+    - "--api-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+    - "--dns-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
+    - "--ingress-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
+    - "/config"
+    - "--out-dir"
+    - "/etc/keepalived"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
+    resources: {}
+    volumeMounts:
+    - name: resource-dir
+      mountPath: "/config"
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
+    - name: conf-dir
+      mountPath: "/etc/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
+    imagePullPolicy: IfNotPresent
+  containers:
+  - name: keepalived
+    securityContext:
+      privileged: true
+    image: {{ .Images.KeepalivedBootstrap }}
+    env:
+      - name: NSS_SDB_USE_CACHE
+        value: "no"
+    command:
+    - /usr/sbin/keepalived
+    args:
+    - "-f"
+    - "/etc/keepalived/keepalived.conf"
+    - "--dont-fork"
+    - "--vrrp"
+    - "--log-detail"
+    - "--log-console"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: conf-dir
+      mountPath: "/etc/keepalived"
+    terminationMessagePolicy: FallbackToLogsOnError
+    imagePullPolicy: IfNotPresent
+  hostNetwork: true
+  tolerations:
+  - operator: Exists
+  priorityClassName: system-node-critical
+status: {}

--- a/pkg/controller/template/test_data/controller_config_vsphere.yaml
+++ b/pkg/controller/template/test_data/controller_config_vsphere.yaml
@@ -19,3 +19,10 @@ spec:
     setupEtcdEnv: image/setupEtcdEnv:1
     infraImage: image/infraImage:1
     kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    status:
+      platformStatus:
+        vsphere:
+          apiServerInternalIP: 10.0.0.1
+          ingressIP: 10.0.0.2
+          nodeDNSIP: 10.0.0.3

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -269,6 +269,26 @@ func appendManifestsByPlatform(manifests []manifest, infra configv1.Infrastructu
 			},
 		)
 	}
+	if infra.Status.PlatformStatus.VSphere != nil {
+		manifests = append(manifests,
+			manifest{
+				name:     "manifests/vsphere/coredns.yaml",
+				filename: "vsphere/manifests/coredns.yaml",
+			},
+			manifest{
+				name:     "manifests/vsphere/coredns-corefile.tmpl",
+				filename: "vsphere/static-pod-resources/coredns/Corefile.tmpl",
+			},
+			manifest{
+				name:     "manifests/vsphere/keepalived.yaml",
+				filename: "vsphere/manifests/keepalived.yaml",
+			},
+			manifest{
+				name:     "manifests/vsphere/keepalived.conf.tmpl",
+				filename: "vsphere/static-pod-resources/keepalived/keepalived.conf.tmpl",
+			},
+		)
+	}
 
 	return manifests
 }

--- a/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
+++ b/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/NetworkManager/conf.d/99-kni.conf"
+contents:
+  inline: |
+    [main]
+    dhcp=dhclient

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -1,0 +1,14 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/coredns/Corefile.tmpl"
+contents:
+  inline: |
+    . {
+        errors
+        health :18080
+        mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+        cache 30
+        reload
+        file /etc/coredns/node-dns-db {{ .EtcdDiscoveryDomain }}
+    }

--- a/templates/common/vsphere/files/vsphere-coredns-db.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-db.yaml
@@ -1,0 +1,17 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/coredns/node-dns-db"
+contents:
+  inline: |
+    $ORIGIN {{ .EtcdDiscoveryDomain }}.
+    @    3600 IN SOA host.{{ .EtcdDiscoveryDomain }}. hostmaster (
+                                    2017042752 ; serial
+                                    7200       ; refresh (2 hours)
+                                    3600       ; retry (1 hour)
+                                    1209600    ; expire (2 weeks)
+                                    3600       ; minimum (1 hour)
+                                    )
+    api-int IN A {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
+    api IN A {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
+
+    *.apps  IN  A {{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -1,0 +1,91 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/manifests/coredns.yaml"
+contents:
+  inline: |
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: coredns
+      namespace: openshift-vsphere-infra
+      creationTimestamp:
+      deletionGracePeriodSeconds: 65
+      labels:
+        app: vsphere-infra-mdns
+    spec:
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/coredns"
+      - name: kubeconfig
+        hostPath:
+          path: "/etc/kubernetes/kubeconfig"
+      - name: conf-dir
+        hostPath:
+          path: "/etc/coredns"
+      initContainers:
+      - name: render-config
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - runtimecfg
+        - render
+        - "/etc/kubernetes/kubeconfig"
+        - "--api-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+        - "--dns-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
+        - "--ingress-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
+        - "/config"
+        - "--out-dir"
+        - "/etc/coredns"
+        resources: {}
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: resource-dir
+          mountPath: "/config"
+        - name: conf-dir
+          mountPath: "/etc/coredns"
+        imagePullPolicy: IfNotPresent
+      containers:
+      - name: coredns
+        securityContext:
+          privileged: true
+        image: {{.Images.corednsImage}}
+        args:
+        - "--conf"
+        - "/etc/coredns/Corefile"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/coredns"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 18080
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 18080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+    status: {}

--- a/templates/common/vsphere/files/vsphere-keepalived.yaml
+++ b/templates/common/vsphere/files/vsphere-keepalived.yaml
@@ -1,0 +1,118 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/manifests/keepalived.yaml"
+contents:
+  inline: |
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: keepalived
+      namespace: openshift-vsphere-infra
+      creationTimestamp:
+      deletionGracePeriodSeconds: 65
+      labels:
+        app: vsphere-infra-vrrp
+    spec:
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/keepalived"
+      - name: kubeconfig
+        hostPath:
+          path: "/etc/kubernetes/kubeconfig"
+      - name: conf-dir
+        hostPath:
+          path: "/etc/keepalived"
+      - name: run-dir
+        empty-dir: {}
+      containers:
+      - name: keepalived
+        securityContext:
+          privileged: true
+        image: {{.Images.keepalivedImage}}
+        env:
+          - name: NSS_SDB_USE_CACHE
+            value: "no"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #/bin/bash
+          reload_keepalived()
+          {
+            if pid=$(pgrep -o keepalived); then
+                kill -s SIGHUP "$pid"
+            else
+                /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+            fi
+          }
+
+          msg_handler()
+          {
+            while read -r line; do
+              echo "The client sent: $line" >&2
+              # currently only 'reload' msg is supported
+              if [ "$line" = reload ]; then
+                  reload_keepalived
+              fi
+            done
+          }
+
+          set -ex
+          declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
+          export -f msg_handler
+          export -f reload_keepalived
+          if [ -s "/etc/keepalived/keepalived.conf" ]; then
+              /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+          fi
+
+          rm -f "$keepalived_sock"
+          socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/keepalived"
+        - name: run-dir
+          mountPath: "/var/run/keepalived"
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              [[ -s /etc/keepalived/keepalived.conf ]] || \
+              kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+          initialDelaySeconds: 10
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      - name: keepalived-monitor
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - dynkeepalived
+        - "/etc/kubernetes/kubeconfig"
+        - "/config/keepalived.conf.tmpl"
+        - "/etc/keepalived/keepalived.conf"
+        - "--api-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+        - "--dns-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
+        - "--ingress-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
+        volumeMounts:
+        - name: resource-dir
+          mountPath: "/config"
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: conf-dir
+          mountPath: "/etc/keepalived"
+        - name: run-dir
+          mountPath: "/var/run/keepalived"
+        imagePullPolicy: IfNotPresent
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+    status: {}

--- a/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
+++ b/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
@@ -1,0 +1,75 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/manifests/mdns-publisher.yaml"
+contents:
+  inline: |
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: mdns-publisher
+      namespace: openshift-vsphere-infra
+      creationTimestamp:
+      deletionGracePeriodSeconds: 65
+      labels:
+        app: vsphere-infra-mdns
+    spec:
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/mdns"
+      - name: kubeconfig
+        hostPath:
+          path: "/etc/kubernetes/kubeconfig"
+      - name: conf-dir
+        hostPath:
+          path: "/etc/mdns"
+      initContainers:
+      - name: render-config
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - runtimecfg
+        - render
+        - "/etc/kubernetes/kubeconfig"
+        - "--api-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+        - "--dns-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
+        - "--ingress-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
+        - "/config"
+        - "--out-dir"
+        - "/etc/mdns"
+        resources: {}
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: resource-dir
+          mountPath: "/config"
+        - name: conf-dir
+          mountPath: "/etc/mdns"
+        imagePullPolicy: IfNotPresent
+      containers:
+      - name: mdns-publisher
+        image: {{.Images.mdnsPublisherImage}}
+        args:
+        - "--debug"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/mdns"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - mdns-publisher
+          initialDelaySeconds: 10
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+    status: {}

--- a/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/dhcp/dhclient.conf"
+contents:
+  inline: |
+    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
@@ -1,0 +1,40 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/haproxy/haproxy.cfg.tmpl"
+contents:
+  inline: |
+    defaults
+      maxconn 20000
+      mode    tcp
+      log     /var/run/haproxy/haproxy-log.sock local0
+      option  dontlognull
+      retries 3
+      timeout http-request 10s
+      timeout queue        1m
+      timeout connect      10s
+      timeout client       86400s
+      timeout server       86400s
+      timeout tunnel       86400s
+    frontend  main
+      bind :{{`{{ .LBConfig.LbPort }}`}}
+      default_backend masters
+    listen health_check_http_url
+      bind :50936
+      mode http
+      monitor-uri /healthz
+      option dontlognull
+    listen stats
+      bind 127.0.0.1:{{`{{ .LBConfig.StatPort }}`}}
+      mode http
+      stats enable
+      stats hide-version
+      stats uri /haproxy_stats
+      stats refresh 30s
+      stats auth Username:Password
+    backend masters
+       option  httpchk GET /healthz HTTP/1.0
+       option  log-health-checks
+       balance roundrobin
+    {{`{{- range .LBConfig.Backends }}
+       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
+    {{- end }}`}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -1,0 +1,118 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/manifests/haproxy.yaml"
+contents:
+  inline: |
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: haproxy
+      namespace: openshift-vsphere-infra
+      creationTimestamp:
+      deletionGracePeriodSeconds: 65
+      labels:
+        app: vsphere-infra-api-lb
+    spec:
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/haproxy"
+      - name: kubeconfig
+        hostPath:
+          path: "/etc/kubernetes/kubeconfig"
+      - name: run-dir
+        empty-dir: {}
+      - name: conf-dir
+        hostPath:
+          path: "/etc/haproxy"
+      - name: chroot-host
+        hostPath:
+          path: "/"
+      containers:
+      - name: haproxy
+        image: {{.Images.haproxyImage}}
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          reload_haproxy()
+          {
+            old_pids=$(pidof haproxy)
+            if [ -n "$old_pids" ]; then
+                /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids &
+            else
+                /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
+            fi
+          }
+
+          msg_handler()
+          {
+            while read -r line; do
+              echo "The client send: $line"  >&2
+              # currently only 'reload' msg is supported
+              if [ "$line" = reload ]; then
+                  reload_haproxy
+              fi
+            done
+          }
+          set -ex
+          declare -r haproxy_sock="/var/run/haproxy/haproxy-master.sock"
+          declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
+          export -f msg_handler
+          export -f reload_haproxy
+          rm -f "$haproxy_sock" "$haproxy_log_sock"
+          socat UNIX-RECV:${haproxy_log_sock} STDOUT &
+          if [ -s "/etc/haproxy/haproxy.cfg" ]; then
+              /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
+          fi
+          socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/haproxy"
+        - name: run-dir
+          mountPath: "/var/run/haproxy"
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: /healthz
+            port: 50936
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      - name: haproxy-monitor
+        securityContext:
+          privileged: true
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - monitor
+        - "/etc/kubernetes/kubeconfig"
+        - "/config/haproxy.cfg.tmpl"
+        - "/etc/haproxy/haproxy.cfg"
+        - "--api-vip"
+        - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/haproxy"
+        - name: run-dir
+          mountPath: "/var/run/haproxy"
+        - name: resource-dir
+          mountPath: "/config"
+        - name: chroot-host
+          mountPath: "/host"
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes/kubeconfig"
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+    status: {}

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -1,0 +1,78 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
+contents:
+  inline: |
+    vrrp_script chk_ocp {
+        script "/usr/bin/curl -o /dev/null -kLs https://0:6443/readyz"
+        interval 1
+        weight 50
+    }
+
+    vrrp_script chk_dns {
+        script "/usr/bin/host -t SRV _etcd-server-ssl._tcp.{{ .EtcdDiscoveryDomain }} localhost"
+        interval 1
+        weight 50
+    }
+
+    # TODO: Improve this check. The port is assumed to be alive.
+    # Need to assess what is the ramification if the port is not there.
+    vrrp_script chk_ingress {
+        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        interval 1
+        weight 50
+    }
+
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_API {
+        state BACKUP
+        interface {{`{{ .VRRPInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.APIVirtualRouterID }}`}}
+        priority 40
+        advert_int 1
+        authentication {
+            auth_type PASS
+            auth_pass {{`{{ .Cluster.Name }}`}}_api_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+        }
+        track_script {
+            chk_ocp
+        }
+    }
+
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_DNS {
+        state BACKUP
+        interface {{`{{ .VRRPInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.DNSVirtualRouterID }}`}}
+        priority 40
+        advert_int 1
+        authentication {
+            auth_type PASS
+            auth_pass {{`{{ .Cluster.Name }}`}}_dns_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+        }
+        track_script {
+            chk_dns
+        }
+    }
+
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
+        state BACKUP
+        interface {{`{{ .VRRPInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
+        priority 40
+        advert_int 1
+        authentication {
+            auth_type PASS
+            auth_pass cluster_uuid_ingress_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+        }
+        track_script {
+            chk_ingress
+        }
+    }

--- a/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
@@ -1,0 +1,34 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
+contents:
+  inline: |
+    bind_address = "{{`{{ .NonVirtualIP }}`}}"
+    collision_avoidance = "hostname"
+
+    service {
+        name = "{{`{{ .Cluster.Name }}`}} Etcd"
+        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
+        type = "_etcd-server-ssl._tcp"
+        domain = "local."
+        port = 2380
+        ttl = 3200
+    }
+
+    service {
+        name = "{{`{{ .Cluster.Name }}`}} Workstation"
+        host_name = "{{`{{ .ShortHostname }}`}}.local."
+        type = "_workstation._tcp"
+        domain = "local."
+        port = 42424
+        ttl = 3200
+    }
+
+    service {
+        name = "{{`{{ .Cluster.Name }}`}} EtcdWorkstation"
+        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
+        type = "_workstation._tcp"
+        domain = "local."
+        port = 42424
+        ttl = 300
+    }

--- a/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/dhcp/dhclient.conf"
+contents:
+  inline: |
+    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -1,0 +1,30 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
+contents:
+  inline: |
+    # TODO: Improve this check. The port is assumed to be alive.
+    # Need to assess what is the ramification if the port is not there.
+    vrrp_script chk_ingress {
+        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        interval 1
+        weight 50
+    }
+
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
+        state BACKUP
+        interface {{`{{ .VRRPInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
+        priority 40
+        advert_int 1
+        authentication {
+            auth_type PASS
+            auth_pass cluster_uuid_ingress_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+        }
+        track_script {
+            chk_ingress
+        }
+    }

--- a/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
@@ -1,0 +1,16 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
+contents:
+  inline: |
+    bind_address = "{{`{{ .NonVirtualIP }}`}}"
+    collision_avoidance = "hostname"
+
+    service {
+        name = "{{`{{ .Cluster.Name }}`}} Workstation"
+        host_name = "{{`{{ .ShortHostname }}`}}.local."
+        type = "_workstation._tcp"
+        domain = "local."
+        port = 42424
+        ttl = 3200
+    }

--- a/templates/worker/00-worker/vsphere/files/vsphere-non-virtual-ip.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-non-virtual-ip.yaml
@@ -1,0 +1,138 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/non_virtual_ip"
+contents:
+  inline: |
+    #!/usr/libexec/platform-python
+    import collections
+    import socket
+    import struct
+    import subprocess
+    import sys
+
+
+    class SubnetNotFoundException(Exception):
+        """
+        Exception raised when no subnet in the systems ifaces is on the VIP subnet
+        """
+        pass
+
+
+    Address = collections.namedtuple('Address', 'index name family cidr scope')
+
+    SUBNET_MASK_LEN = {
+        'inet': 32,
+        'inet6': 128
+    }
+
+
+    def ntoa(family, num):
+        if family == 'inet':
+            result = socket.inet_ntoa(struct.pack("!I", num))
+        else:
+            lo_half = num & 0xFFFFFFFFFFFFFFFF
+            hi_half = num >> 64
+            result = socket.inet_ntop(socket.AF_INET6,
+                                      struct.pack(">QQ", hi_half, lo_half))
+        return result
+
+
+    def aton(family, rep):
+        if family == 'inet':
+            result = struct.unpack("!I", socket.inet_aton(rep))[0]
+        else:
+            hi_half, lo_half = struct.unpack(">QQ", socket.inet_pton(socket.AF_INET6, rep))
+            result = (hi_half << 64) | lo_half
+        return result
+
+
+    def addr_subnet_int_min_max(addr):
+        ip, prefix = addr.cidr.split('/')
+        ip_int = aton(addr.family, ip)
+
+        prefix_int = int(prefix)
+        mask = int('1' * prefix_int +
+                   '0' * (SUBNET_MASK_LEN[addr.family] - prefix_int), 2)
+
+        subnet_ip_int_min = ip_int & mask
+
+        remainder = '1' * (SUBNET_MASK_LEN[addr.family] - prefix_int)
+        subnet_ip_int_max = subnet_ip_int_min | (
+            0 if remainder == '' else int(remainder, 2))
+        return subnet_ip_int_min, subnet_ip_int_max
+
+
+    def vip_subnet_cidr(vip, addrs):
+        try:
+            vip_int = aton('inet', vip)
+        except Exception:
+            vip_int = aton('inet6', vip)
+        for addr in addrs:
+            subnet_ip_int_min, subnet_ip_int_max = addr_subnet_int_min_max(addr)
+            subnet_ip = ntoa(addr.family, subnet_ip_int_min)
+            subnet_ip_max = ntoa(addr.family, subnet_ip_int_max)
+
+            sys.stderr.write('Is %s between %s and %s\n' %
+                             (vip, subnet_ip, subnet_ip_max))
+            if subnet_ip_int_min < vip_int < subnet_ip_int_max:
+                subnet_ip = socket.inet_ntoa(struct.pack("!I", subnet_ip_int_min))
+                return Address(index="-1",
+                               name="subnet",
+                               cidr='%s/%s' % (subnet_ip, addr.cidr.split('/')[1]),
+                               family=addr.family,
+                               scope='')
+        raise SubnetNotFoundException()
+
+
+    def line_to_address(line):
+        spl = line.split()
+        return Address(index=spl[0][:-1],
+                       name=spl[1],
+                       family=spl[2],
+                       cidr=spl[3],
+                       scope=spl[5])
+
+
+    def interface_cidrs(filter_func=None):
+        try:
+            out = subprocess.check_output(["ip", "-o", "addr", "show"], encoding=sys.stdout.encoding)
+        except TypeError:  # python2
+            out = subprocess.check_output(["ip", "-o", "addr", "show"])
+        for addr in (line_to_address(line) for line in out.splitlines()):
+            if filter_func(addr):
+                yield addr
+
+
+    def non_host_scope(addr):
+        return addr.scope != 'host'
+
+
+    def in_subnet(subnet):
+        subnet_ip_int_min, subnet_ip_int_max = addr_subnet_int_min_max(subnet)
+
+        def filt(addr):
+            ip, _ = addr.cidr.split('/')
+            ip_int = aton(addr.family, ip)
+            return subnet_ip_int_min < ip_int < subnet_ip_int_max
+        return filt
+
+
+    def main():
+        api_vip, dns_vip, ingress_vip = sys.argv[1:4]
+        vips = set(sys.argv[1:4])
+        iface_cidrs = list(interface_cidrs(non_host_scope))
+        try:
+            subnet = vip_subnet_cidr(api_vip, iface_cidrs)
+
+            sys.stderr.write('VIP Subnet %s\n' % subnet.cidr)
+
+            for addr in interface_cidrs(in_subnet(subnet)):
+                ip, prefix = addr.cidr.split('/')
+                if ip not in vips:
+                    print(addr.cidr.split('/')[0])
+                    sys.exit(0)
+        except SubnetNotFoundException:
+            sys.exit(1)
+
+    if __name__ == '__main__':
+        main()


### PR DESCRIPTION
Uses existing baremetal networking like openstack and ovirt.

- Added manifests and template for vSphere which identical
beyond names as ovirt (cp and sed).
- Updated bindata as required
- Update pkg/operator/bootstrap for vsphere

Requires: https://github.com/openshift/api/pull/541