### PR TITLE
Bug 1803232: Fixed hardcoded ingress VIP password

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -67,7 +67,7 @@ contents:
         advert_int 1
         authentication {
             auth_type PASS
-            auth_pass cluster_uuid_ingress_vip
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
             {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -62,7 +62,7 @@ contents:
         advert_int 1
         authentication {
             auth_type PASS
-            auth_pass cluster_uuid_ingress_vip
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
             {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -67,7 +67,7 @@ contents:
         advert_int 1
         authentication {
             auth_type PASS
-            auth_pass cluster_uuid_ingress_vip
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
             {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}

--- a/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -19,7 +19,7 @@ contents:
         advert_int 1
         authentication {
             auth_type PASS
-            auth_pass cluster_uuid_ingress_vip
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
             {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}

--- a/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
@@ -18,7 +18,7 @@ contents:
         advert_int 1
         authentication {
             auth_type PASS
-            auth_pass cluster_uuid_ingress_vip
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
             {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}

--- a/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -19,7 +19,7 @@ contents:
         advert_int 1
         authentication {
             auth_type PASS
-            auth_pass cluster_uuid_ingress_vip
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
             {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}


### PR DESCRIPTION
Fixes #1379

**- What I did**
The current keepalived ingress VIP password is hardcoded so I've changed to follow the other VIP passwords.

**- How to verify it**
Deploy a cluster and observe the `/etc/keepalived/keepalived.conf` file

**- Description for the changelog**
Fixed hardcoded ingress VIP password
