### PR TITLE
Update kubelet.config for single-stack IPv6

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -105,6 +105,9 @@ type ControllerConfigSpec struct {
 	// infra holds the infrastructure details
 	// TODO this makes platform redundant as everything is contained inside Infra.Status
 	Infra *configv1.Infrastructure `json:"infra"`
+
+	// kubeletIPv6 is true to force a single-stack IPv6 kubelet config
+	KubeletIPv6 bool `json:"kubeletIPv6,omitempty"`
 }
 
 // ControllerConfigStatus is the status for ControllerConfig

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -38,6 +38,43 @@ func TestClusterDNSIP(t *testing.T) {
 	}
 }
 
+func TestIsSingleStackIPv6(t *testing.T) {
+	tests := []struct {
+		Ranges []string
+		Output bool
+		Error  bool
+	}{{
+		Ranges: []string{"192.168.2.0/20"},
+		Output: false,
+	}, {
+		Ranges: []string{"2001:db8::/32"},
+		Output: true,
+	}, {
+		Ranges: []string{"192.168.2.0/20", "2001:db8::/32"},
+		Output: false,
+	}, {
+		Ranges: []string{"2001:db8::/32", "192.168.2.0/20"},
+		Output: false,
+	}, {
+		Ranges: []string{"192.168.1.254/32"},
+		Error:  true,
+	}}
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			desc := fmt.Sprintf("isSingleStackIPv6(%#v)", test.Ranges)
+			ipv6, err := isSingleStackIPv6(test.Ranges)
+			if err != nil {
+				if !test.Error {
+					t.Fatalf("%s failed: %s", desc, err.Error())
+				}
+			}
+			if ipv6 != test.Output {
+				t.Fatalf("%s failed: got = %t want = %t", desc, ipv6, test.Output)
+			}
+		})
+	}
+}
+
 func TestRenderAsset(t *testing.T) {
 	tests := []struct {
 		Path         string

--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -22,6 +22,9 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+{{- if .KubeletIPv6}}
+        --node-ip :: \
+{{- end}}
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -22,6 +22,9 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+{{- if .KubeletIPv6}}
+        --node-ip :: \
+{{- end}}
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \


### PR DESCRIPTION
**- What I did**
In a single-stack IPv6 environment, update the `kubelet.config` to pass `--node-ip ::` to tell it to pick an IPv6 address rather than an IPv4 address for the node address. (Depends on https://github.com/openshift/origin/pull/24401 which is why this was not merged with the other IPv6 changes before (#1211).)

Specifically, this fixes the problem of trying to bring up a single-stack IPv6 cluster on a node that happens to have IPv4 addresses that you aren't using. (eg, this is necessary for testing single-stack IPv6 on AWS or Azure, since there is no way to bring up a node there there doesn't have an IPv4 address.) By default, if you don't specify an explicit `--node-ip`, and there are IPv4 node IPs addresses present, then kubelet will pick the node's default IPv4 address to be its primary IP, even if the cluster and service CIDRs are IPv6-only (which will then result in a cluster that doesn't work). The newly added `--node-ip ::` option tells it to pick the node's default IPv6 address instead.

**- How to verify it**
... You can't easily. But this has been part of the IPv6 testing environment. And it has unit tests!

**- Description for the changelog**
In a single-stack IPv6 environment, kubelet will be configured to pick an IPv6 address rather than an IPv4 one for the default node IP (even if there are IPv4 addresses on the node).