### PR TITLE
Fix update codegen script to be compatible with go mod vendor

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
-${SCRIPT_ROOT}/vendor/k8s.io/code-generator/generate-groups.sh all \
+bash ${SCRIPT_ROOT}/vendor/k8s.io/code-generator/generate-groups.sh all \
   github.com/openshift/machine-config-operator/pkg/generated github.com/openshift/machine-config-operator/pkg/apis \
   "machineconfiguration.openshift.io:v1" \
   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt


### PR DESCRIPTION
Manual cherry-pick from the fix @sgreene570 added on the `fcos` branch.