### PR TITLE
Bug 1790823: [IPI][BAREMETAL] Verify that mdns-publisher starts after hostname is set

### DIFF
--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -24,6 +24,21 @@ contents:
         hostPath:
           path: "/etc/mdns"
       initContainers:
+      - name: verify-hostname
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        env:
+          - name: DEFAULT_LOCAL_HOSTNAME
+            value: "localhost"
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          while [ "$(hostname)" == "$DEFAULT_LOCAL_HOSTNAME" ]
+          do
+            echo "hostname is still ${DEFAULT_LOCAL_HOSTNAME}"
+            sleep 10
+          done
       - name: render-config
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:


### PR DESCRIPTION
This change verifies that mdns-publisher pod advertises node's
name only after hostname being set.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
