### PR TITLE
Switch to managing network ns lifecycle

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -229,7 +229,7 @@ contents:
 
     # ManageNetworkNSLifecycle determines whether we pin and remove network namespace
     # and manage its lifecycle.
-    # manage_network_ns_lifecycle = false
+    manage_network_ns_lifecycle = true
 
     # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
     # The runtime to use is picked based on the runtime_handler provided by the CRI.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -229,7 +229,7 @@ contents:
 
     # ManageNetworkNSLifecycle determines whether we pin and remove network namespace
     # and manage its lifecycle.
-    # manage_network_ns_lifecycle = false
+    manage_network_ns_lifecycle = true
 
     # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
     # The runtime to use is picked based on the runtime_handler provided by the CRI.


### PR DESCRIPTION
as it is an objectively better way to manage namespaces, is much safer, and will help protect against races now that CRI-O is erroring on network stop

Signed-off-by: Peter Hunt <pehunt@redhat.com>