### PR TITLE
OpenStack: Add ca cert to disk on all nodes so kubelet can start up

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -22,6 +22,7 @@ var (
 		baremetalRuntimeCfgImage  string
 		cloudConfigFile           string
 		configFile                string
+		cloudProviderCAFile       string
 		corednsImage              string
 		destinationDir            string
 		etcdCAFile                string
@@ -80,6 +81,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oauthProxyImage, "oauth-proxy-image", "", "Image for origin oauth proxy.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.cloudProviderCAFile, "cloud-provider-ca-file", "", "path to cloud provider CA certificate")
 
 }
 
@@ -118,6 +120,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.configFile,
 		bootstrapOpts.infraConfigFile, bootstrapOpts.networkConfigFile,
 		bootstrapOpts.cloudConfigFile,
+		bootstrapOpts.cloudProviderCAFile,
 		bootstrapOpts.etcdCAFile, bootstrapOpts.etcdMetricCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
 		&imgs,
 		bootstrapOpts.destinationDir,

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -72,6 +72,7 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setBytesIfSet(modified, &existing.EtcdMetricCAData, required.EtcdMetricCAData)
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
+	setBytesIfSet(modified, &existing.CloudProviderCAData, required.CloudProviderCAData)
 
 	if !equality.Semantic.DeepEqual(existing.Proxy, required.Proxy) {
 		*modified = true

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -82,6 +82,9 @@ type ControllerConfigSpec struct {
 	// rootCAData specifies the root CA data
 	RootCAData []byte `json:"rootCAData"`
 
+	// cloudProvider specifies the cloud provider CA data
+	CloudProviderCAData []byte `json:"cloudProviderCAData"`
+
 	// additionalTrustBundle is a certificate bundle that will be added to the nodes
 	// trusted certificate store.
 	AdditionalTrustBundle []byte `json:"additionalTrustBundle"`

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -241,6 +241,11 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.CloudProviderCAData != nil {
+		in, out := &in.CloudProviderCAData, &out.CloudProviderCAData
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.AdditionalTrustBundle != nil {
 		in, out := &in.AdditionalTrustBundle, &out.AdditionalTrustBundle
 		*out = make([]byte, len(*in))

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -29,7 +29,7 @@ func RenderBootstrap(
 	proxyFile,
 	clusterConfigConfigMapFile,
 	infraFile, networkFile,
-	cloudConfigFile,
+	cloudConfigFile, cloudProviderCAFile,
 	etcdCAFile, etcdMetricCAFile, rootCAFile, kubeAPIServerServingCA, pullSecretFile string,
 	imgs *Images,
 	destinationDir string,
@@ -47,6 +47,9 @@ func RenderBootstrap(
 	}
 	if kubeAPIServerServingCA != "" {
 		files = append(files, kubeAPIServerServingCA)
+	}
+	if cloudProviderCAFile != "" {
+		files = append(files, cloudProviderCAFile)
 	}
 	for _, file := range files {
 		data, err := ioutil.ReadFile(file)
@@ -128,6 +131,10 @@ func RenderBootstrap(
 	if _, ok := filesData[kubeAPIServerServingCA]; ok {
 		bundle = append(bundle, filesData[kubeAPIServerServingCA]...)
 		spec.KubeAPIServerServingCAData = filesData[kubeAPIServerServingCA]
+	}
+	// Set the cloud-provider CA if given.
+	if data, ok := filesData[cloudProviderCAFile]; ok {
+		spec.CloudProviderCAData = data
 	}
 
 	spec.EtcdCAData = filesData[etcdCAFile]

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -205,6 +205,11 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 			return err
 		}
 		spec.CloudProviderConfig = cc
+
+		caCert, err := optr.getCAsFromConfigMap("openshift-config", infra.Spec.CloudConfig.Name, "ca-bundle.pem")
+		if err == nil {
+			spec.CloudProviderCAData = caCert
+		}
 	}
 
 	//TODO: alaypatel07 remove after cluster-etcd-operator deployed via CVO as Managed

--- a/templates/common/_base/files/cloud-provider-ca.yaml
+++ b/templates/common/_base/files/cloud-provider-ca.yaml
@@ -1,0 +1,8 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
+contents:
+  inline: |
+{{if .CloudProviderCAData -}}
+{{.CloudProviderCAData | toString | indent 4}}
+{{end -}}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did** Add support for Ca certs being added to the cloud-provider-config configmap, and writing those certs to where kubelet will know to look for them. This is associated with https://github.com/openshift/installer/pull/2932/files, and is part of a greater scheme to add support for self signed platform (openstack) CA certificates outlined here: https://docs.google.com/document/d/1bKXArO_dtIOQMVqV35GTmUdzoRQAgUqIVMbO9kpfknI/edit?folder=0AFMASrm3oxfNUk9PVA#heading=h.9jxn8ewfjnas

**- How to verify it** For all platforms excluding openstack, this should have no affect on the way the MCO runs. This should be verifiable by the MCO being able to pass its normal unit and e2e test suite. For openstack, this is being tested in a specialized cluster in combination with a number of other pending code changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog: a certificate (.pem) file is added to the filesystem of the masters and workers if we are using the openstack platform. 
-->
