### PR TITLE
HAProxy infra pod: Make v4/v6 compatible

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -16,10 +16,10 @@ contents:
       timeout server       86400s
       timeout tunnel       86400s
     frontend  main
-      bind {{`{{ .LBConfig.FrontendAddr }}`}}:{{`{{ .LBConfig.LbPort }}`}}
+      bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters
     listen health_check_http_url
-      bind :50936
+      bind :::50936 v4v6
       mode http
       monitor-uri /healthz
       option dontlognull

--- a/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
@@ -17,10 +17,10 @@ contents:
       timeout server          86400s
       timeout tunnel          86400s
     frontend  main
-      bind :{{`{{ .LBConfig.LbPort }}`}}
+      bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters
     listen health_check_http_url
-      bind :50936
+      bind :::50936 v4v6
       mode http
       monitor-uri /healthz
       option dontlognull

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy-haproxy.yaml
@@ -16,10 +16,10 @@ contents:
       timeout server       86400s
       timeout tunnel       86400s
     frontend  main
-      bind :{{`{{ .LBConfig.LbPort }}`}}
+      bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters
     listen health_check_http_url
-      bind :50936
+      bind :::50936 v4v6
       mode http
       monitor-uri /healthz
       option dontlognull


### PR DESCRIPTION
Have the bind to all interfaces statements listen to both IPv4 and IPv6 so it
works both on single and dual stack deployments.

Fixes: #1389 
