### PR TITLE
baremetal: IPv6 add dhcp-duid to NetworkManager config

### DIFF
--- a/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
+++ b/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
@@ -6,3 +6,5 @@ contents:
     [main]
     dhcp=dhclient
     rc-manager=unmanaged
+    [connection]
+    ipv6.dhcp-duid=ll


### PR DESCRIPTION
Adding ipv6.dhcp-duid=ll means we get a predictable
client ID so that reservations can be made on the
DHCP server - this is useful if you want to provide
the hostname via DHCP (although a reverse DNS lookup
should also work)

Reservations are also required to ensure the controlplane
IP of the masters won't ever change post-deployment
which will be necessary if the DNS lookup approach
is taken to set the hostnames.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Updated the NetworkManager configuration, only for the baremetal (IPI) platform, so we specify the ipv6.dhcp-duid=ll option.  This enables a predictable (mac derived) client ID/DUID when deploying in an IPv6 environment.

**- How to verify it**

If testing with dev-scripts you can check via `virsh net-dhcp-leases baremetal` - on baremetal you can check the client ID in the lease for the nic connected to the controlplane network (`/var/lib/NetworkManager/dhclient6*.lease`)

In both cases the controlplane network must be configured for single-stack ipv6, and there are some other PRs open to enable that e2e with the default OpenShift builds. https://github.com/openshift-metal3/dev-scripts/pull/871 has some more details.

**- Description for the changelog**

Updated the NetworkManager configuration, for the baremetal (IPI) platform to specify the ipv6.dhcp-duid=ll option.  This enables a predictable (mac derived) client ID/DUID.
