### PR TITLE
DR: Backup should keep data and keys separate

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -34,8 +34,8 @@ contents:
 
     BACKUP_DIR="$1"
     DATESTRING=$(date "+%F_%H%M%S")
-    BACKUP_TAR_FILE=${BACKUP_DIR}/snapshot_db_kuberesources_$DATESTRING.tar
-    SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
+    BACKUP_TAR_FILE=${BACKUP_DIR}/static_kuberesources_${DATESTRING}.tar.gz
+    SNAPSHOT_FILE="${BACKUP_DIR}/snapshot_${DATESTRING}.db"
 
     trap "rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}" ERR
 
@@ -57,9 +57,7 @@ contents:
       backup_manifest
       backup_latest_kube_static_resources
       snapshot_data_dir
-      append_snapshot_to_tar_and_gzip
-      rm -f ${SNAPSHOT_FILE}
-      echo "snapshot db and kube resources are successfully saved to ${BACKUP_TAR_FILE}.gz!"
+      echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}!"
     }
 
     run

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -17,7 +17,8 @@ contents:
     fi
 
     usage () {
-        echo 'Path to backup file and initial cluster are required: ./etcd-snapshot-restore.sh $path-to-backup $initial_cluster'
+        echo 'Path to backup file and initial cluster are required: ./etcd-snapshot-restore.sh <path-to-backup> $INITIAL_CLUSTER'
+        echo 'path-to-backup can be a directory containing kube static resources and snapshot db, or a single file containing snapshot db'
         exit 1
     }
 
@@ -25,9 +26,32 @@ contents:
         usage
     fi
 
-    BACKUP_FILE="$1"
     INITIAL_CLUSTER="$2"
     ASSET_DIR=./assets
+
+    RESTORE_STATIC_RESOURCES="true"
+    if [ -f "$1" ]; then
+      # For backward-compatibility, we support restoring from single snapshot.db file or single tar.gz file
+      if [[ "$1" =~ \.db$ ]]; then
+        RESTORE_STATIC_RESOURCES="false"
+        SNAPSHOT_FILE="$1"
+      elif [[ "$1" =~ \.tar\.gz$ ]]; then
+        BACKUP_FILE="$1"
+        tar xzf ${BACKUP_FILE} -C ${ASSET_DIR}/tmp/ snapshot.db
+        SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
+      else
+        usage
+      fi
+    elif [ -d "$1" ]; then
+      BACKUP_FILE=$(ls -vd "$1"/static_kuberesources*.tar.gz | tail -1) || true
+      SNAPSHOT_FILE=$(ls -vd "$1"/snapshot*.db | tail -1) || true
+      if [ ! -f ${BACKUP_FILE}  -o ! -f ${SNAPSHOT_FILE} ]; then
+        usage
+      fi
+    else
+      usage
+    fi
+
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
     MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
@@ -39,26 +63,11 @@ contents:
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
     STOPPED_STATIC_PODS="${ASSET_DIR}/tmp/stopped-static-pods"
 
-    if [ ! -f "${BACKUP_FILE}" ]; then
-      echo "etcd snapshot ${BACKUP_FILE} does not exist."
-      exit 1
-    fi
-
     source "/usr/local/bin/openshift-recovery-tools"
 
     function run {
       ETCD_INITIAL_CLUSTER="${INITIAL_CLUSTER}"
       init
-      if [[ ${BACKUP_FILE} =~ \.tar\.gz$ ]]; then
-        RESTORE_STATIC_RESOURCES="true"
-        tar xzf ${BACKUP_FILE} -C ${ASSET_DIR}/tmp/ snapshot.db
-        SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
-      else
-        # For backward-compatibility, we support restoring from single snapshot.db file
-        RESTORE_STATIC_RESOURCES="false" 
-        SNAPSHOT_FILE="${BACKUP_FILE}"
-      fi
-
       if [ ! -f "${SNAPSHOT_FILE}" ]; then
         echo "etcd snapshot ${SNAPSHOT_FILE} does not exist."
         exit 1

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -71,7 +71,7 @@ contents:
       fi
 
       # tar up the static kube resources, with the path relative to CONFIG_FILE_DIR
-      tar -cpf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} ${LATEST_STATIC_POD_DIR#$CONFIG_FILE_DIR/}
+      tar -cpzf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} ${LATEST_STATIC_POD_DIR#$CONFIG_FILE_DIR/}
     }
 
     append_snapshot_to_tar_and_gzip() {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Backup should save static pod resources of kube-apiserver separate from the snapshot of etcd database. When etcd is encrypted, it is important to keep the data and keys separatedly for security. 

Similarly, restore can be invoked on a backup directory containing files for the static pod resources along with the etcd database.
**- How to verify it**
Follow DR documentation to back up and restore. The cluster should functional after the same backup is restored on all masters.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Save and restore kube apiserver's static pod resources separatedly from the etcd database.