### PR TITLE
ovirt: ipv6, switch to NM dispatcher for DNS VIP prepending

### DIFF
--- a/templates/common/ovirt/files/ovirt-NetworkManager-kni-conf.yaml
+++ b/templates/common/ovirt/files/ovirt-NetworkManager-kni-conf.yaml
@@ -5,3 +5,4 @@ contents:
   inline: |
     [main]
     dhcp=dhclient
+    rc-manager=unmanaged

--- a/templates/master/00-master/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -1,0 +1,24 @@
+filesystem: "root"
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
+contents:
+  inline: |
+    #!/bin/bash
+    IFACE=$1
+    STATUS=$2
+    case "$STATUS" in
+        up|down|dhcp4-change|dhcp6-change)
+        logger -s "NM resolv-prepender triggered by ${1} ${2}."
+        NAMESERVER_IP="{{.Infra.Status.PlatformStatus.Ovirt.NodeDNSIP}}"
+        set +e
+        if [[ -n "$NAMESERVER_IP" ]]; then
+            logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to other nameservers in /etc/resolv.conf"
+            sed "/^search .*$/a nameserver $NAMESERVER_IP" /var/run/NetworkManager/resolv.conf > /etc/resolv.conf
+        else
+            logger -s "NM resolv-prepender: Couldn't find a Virtual IP, just updating resolv.conf"
+            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        fi
+        ;;
+        *)
+        ;;
+    esac

--- a/templates/master/00-master/ovirt/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/ovirt/files/dhcp-dhclient-conf.yaml
@@ -4,4 +4,3 @@ path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
-    prepend domain-name-servers {{ .Infra.Status.PlatformStatus.Ovirt.NodeDNSIP }};

--- a/templates/worker/00-worker/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -1,0 +1,27 @@
+filesystem: "root"
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
+contents:
+  inline: |
+    #!/bin/bash
+    IFACE=$1
+    STATUS=$2
+    case "$STATUS" in
+        up|down|dhcp4-change|dhcp6-change)
+        logger -s "NM resolv-prepender triggered by ${1} ${2}."
+        NAMESERVER_IP=$(/usr/local/bin/non_virtual_ip \
+            "{{.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP}}" \
+            "{{.Infra.Status.PlatformStatus.Ovirt.NodeDNSIP}}" \
+            "{{.Infra.Status.PlatformStatus.Ovirt.IngressIP}}")
+        set +e
+        if [[ -n "$NAMESERVER_IP" ]]; then
+            logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to other nameservers in /var/run/NetworkManager/resolv.conf"
+            sed "/^search .*$/a nameserver $NAMESERVER_IP" /var/run/NetworkManager/resolv.conf > /etc/resolv.conf
+        else
+            logger -s "Couldn't find a non-virtual IP, just updating resolv.conf"
+            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        fi
+        ;;
+        *)
+        ;;
+    esac

--- a/templates/worker/00-worker/ovirt/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/ovirt/files/dhcp-dhclient-conf.yaml
@@ -4,4 +4,3 @@ path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
-    prepend domain-name-servers {{ .Infra.Status.PlatformStatus.Ovirt.NodeDNSIP }};


### PR DESCRIPTION
The prepend via dhclient doesn't work via ipv6, so switch to a
NetworkManager dispatcher that runs after dhclient instead as a
workaround.

Motivation
- add ipV6 support
- point worker dns queries to their local coredns instance instead of
DNS_VIP effectivly removing pressure from the control plane dns.

Co-Authored-By: Antoni Segura Puimedon <apuimedo@redhat.com>
Co-Authored-By: Author: Steven Hardy <shardy@redhat.com>

This work is a port of baremetal's #1396

**Description for the changelog**
For the ovirt platform, management of the resolv.conf is now handled via a NetworkManager dispatcher script, so that the necessary DNS server can be prepended for both ipv4 and ipv6 environments.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->