### PR TITLE
Bug 1792914: prevent hitting annotation max size limit on nodes

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -60,7 +60,7 @@ func getNodeAnnotationExt(node *corev1.Node, k string, allowNoent bool) (string,
 	v, ok := node.Annotations[k]
 	if !ok {
 		if !allowNoent {
-			return "", fmt.Errorf("%s annotation not found in %s", k, node)
+			return "", fmt.Errorf("%s annotation not found on node '%s'", k, node.Name)
 		}
 		return "", nil
 	}


### PR DESCRIPTION
**- What I did**
Fixes issue where an "annotation not found" error compounds via wrapping the node in the error message, growing the `machineconfiguration.openshift.io/reason` annotation until it hits the annotation max size limit, thereby preventing updates to that node's annotations by controllers.

- Remove node object from  "annotation not found" error and replace with just node name
- Truncate errors used in `machineconfiguration.openshift.io/reason` node annotation to prevent any that may contain large amounts of data from maxing out annotation size.

**- How to verify it**
- Stop MCO and MCC controllers
- Delete the `machineconfiguration.openshift.io/desiredConfig` annotation on a node and wait for the MCD to sync the update
- Check the node object for the annotation`"machineconfiguration.openshift.io/reason": "machineconfiguration.openshift.io/desiredConfig annotation not found in node '<name here>'"`

**- Description for the changelog**
- Truncate errors used in `machineconfiguration.openshift.io/reason` node annotation to prevent hitting the max annotation size

Fixes: [Bug 1792914](https://bugzilla.redhat.com/show_bug.cgi?id=1792914)