### PR TITLE
setup-etcd-environment/run.go: fix upgrade path

### DIFF
--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -193,7 +193,9 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 
 func (s *SetupEnv) getExportEnv() (map[string]string, error) {
 	// if etcd is managed by the operator populate ENV from configmap
-	if s.isEtcdScaling() {
+	// TODO: alaypatel07/hexfusion figure out a better way of implementing isScaling
+	// if s.isEtcdScaling() {
+	if inCluster() && !s.opts.bootstrapSRV {
 		return s.getOperatorEnv()
 	}
 	// initialize envs used to bootstrap etcd using SRV discovery or disaster recovery.
@@ -315,6 +317,7 @@ func (s *SetupEnv) getBootstrapEnv() (map[string]string, error) {
 // `cluster-etcd-operator` and returns true if yes. If false we can conclude that the member is already
 // part of the cluster or we have/are bootstrapping etcd using SRV discovery.
 func (s *SetupEnv) isEtcdScaling() bool {
+	// TODO: reimplement me!
 	if _, err := os.Stat(fmt.Sprintf("%s/member", s.etcdDataDir)); os.IsNotExist(err) && !s.opts.bootstrapSRV && inCluster() {
 		return true
 	}
@@ -339,6 +342,7 @@ func (s *SetupEnv) setClient() error {
 			return fmt.Errorf("error creating client: %v", err)
 		}
 		s.Client = client
+		return nil
 	}
 	glog.Infof("no client set")
 	return nil


### PR DESCRIPTION
Upgrades from a 4.3 cluster to a cluster-etcd-operator enabled
cluster discovery fails because the expected operator environment
is not being populated. The `isScaling` function was passing in normal
scale-up but not in an upgrade, where etcd pods already exist with the
directory and we cannot afford to delete the etcd data directory.
 
This is a temporary solution until we find a better way of differentiating 
between scale-up and upgrade.

More context [here](https://github.com/openshift/cluster-etcd-operator/pull/51#issuecomment-566886783)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- How to verify it**
- Install a 4.4 cluster from CI for example, registry.svc.ci.openshift.org/ocp/release:4.4-ci
- Upgrade to a cluster-etcd-operator enabled cluster

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fixes upgrades to cluster-etcd-operator enabled cluster
