### PR TITLE
Bug 1796440: [release-4.3] DR: Cherry-pick  keep keys and data separate for snapshot backup

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-backup-sh.yaml
@@ -34,8 +34,8 @@ contents:
 
     BACKUP_DIR="$1"
     DATESTRING=$(date "+%F_%H%M%S")
-    BACKUP_TAR_FILE=${BACKUP_DIR}/snapshot_db_kuberesources_$DATESTRING.tar
-    SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
+    BACKUP_TAR_FILE=${BACKUP_DIR}/static_kuberesources_${DATESTRING}.tar.gz
+    SNAPSHOT_FILE="${BACKUP_DIR}/snapshot_${DATESTRING}.db"
 
     trap "rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}" ERR
 
@@ -57,10 +57,7 @@ contents:
       backup_manifest
       backup_latest_kube_static_resources
       snapshot_data_dir
-      tar rf ${BACKUP_TAR_FILE} -C ${ASSET_DIR}/tmp snapshot.db
-      gzip ${BACKUP_TAR_FILE}
-      rm -f ${SNAPSHOT_FILE}
-      echo "snapshot db and kube resources are successfully saved to ${BACKUP_TAR_FILE}.gz!"
+      echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}!"
     }
 
     run

--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-snapshot-restore-sh.yaml
@@ -17,7 +17,8 @@ contents:
     fi
 
     usage () {
-        echo 'Path to backup file and initial cluster are required: ./etcd-snapshot-restore.sh $path-to-backup $initial_cluster'
+        echo 'Path to backup file and initial cluster are required: ./etcd-snapshot-restore.sh <path-to-backup> $INITIAL_CLUSTER'
+        echo 'path-to-backup can be a directory containing kube static resources and snapshot db, or a single file containing snapshot db'
         exit 1
     }
 
@@ -25,9 +26,32 @@ contents:
         usage
     fi
 
-    BACKUP_FILE="$1"
     INITIAL_CLUSTER="$2"
     ASSET_DIR=./assets
+
+    RESTORE_STATIC_RESOURCES="true"
+    if [ -f "$1" ]; then
+      # For backward-compatibility, we support restoring from single snapshot.db file or single tar.gz file
+      if [[ "$1" =~ \.db$ ]]; then
+        RESTORE_STATIC_RESOURCES="false"
+        SNAPSHOT_FILE="$1"
+      elif [[ "$1" =~ \.tar\.gz$ ]]; then
+        BACKUP_FILE="$1"
+        tar xzf ${BACKUP_FILE} -C ${ASSET_DIR}/tmp/ snapshot.db
+        SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
+      else
+        usage
+      fi
+    elif [ -d "$1" ]; then
+      BACKUP_FILE=$(ls -vd "$1"/static_kuberesources*.tar.gz | tail -1) || true
+      SNAPSHOT_FILE=$(ls -vd "$1"/snapshot*.db | tail -1) || true
+      if [ ! -f ${BACKUP_FILE}  -o ! -f ${SNAPSHOT_FILE} ]; then
+        usage
+      fi
+    else
+      usage
+    fi
+
     CONFIG_FILE_DIR=/etc/kubernetes
     MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
     MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
@@ -39,26 +63,11 @@ contents:
     ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
     STOPPED_STATIC_PODS="${ASSET_DIR}/tmp/stopped-static-pods"
 
-    if [ ! -f "${BACKUP_FILE}" ]; then
-      echo "etcd snapshot ${BACKUP_FILE} does not exist."
-      exit 1
-    fi
-
     source "/usr/local/bin/openshift-recovery-tools"
 
     function run {
       ETCD_INITIAL_CLUSTER="${INITIAL_CLUSTER}"
       init
-      if [ ${BACKUP_FILE#*.} = "tar.gz" ]; then
-        RESTORE_STATIC_RESOURCES="true"
-        tar xzf ${BACKUP_FILE} -C ${ASSET_DIR}/tmp/ snapshot.db
-        SNAPSHOT_FILE="${ASSET_DIR}/tmp/snapshot.db"
-      else
-        # For backward-compatibility, we support restoring from single snapshot.db file
-        RESTORE_STATIC_RESOURCES="false" 
-        SNAPSHOT_FILE="${BACKUP_FILE}"
-      fi
-
       if [ ! -f "${SNAPSHOT_FILE}" ]; then
         echo "etcd snapshot ${SNAPSHOT_FILE} does not exist."
         exit 1

--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -38,8 +38,8 @@ contents:
       if [ -f "$ASSET_DIR/backup/etcd-ca-bundle.crt" ] && [ -f "$ASSET_DIR/backup/etcd-client.crt" ] && [ -f "$ASSET_DIR/backup/etcd-client.key" ]; then
          echo "etcd client certs already backed up and available $ASSET_DIR/backup/"
       else
-        STATIC_DIRS=($(ls -td "${CONFIG_FILE_DIR}"/static-pod-resources/kube-apiserver-pod-[0-9]*))
-        if [ "$?" -ne 0 ]; then
+        STATIC_DIRS=($(ls -td "${CONFIG_FILE_DIR}"/static-pod-resources/kube-apiserver-pod-[0-9]*)) || true
+        if [ -z "${STATIC_DIRS}" ]; then
           echo "error finding static-pod-resources"
           exit 1
         fi
@@ -69,7 +69,15 @@ contents:
           echo "error finding static-pod-resources"
           exit 1
       fi
-      tar -cpf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} ${LATEST_STATIC_POD_DIR#$CONFIG_FILE_DIR/}
+
+      # tar up the static kube resources, with the path relative to CONFIG_FILE_DIR
+      tar -cpzf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} ${LATEST_STATIC_POD_DIR#$CONFIG_FILE_DIR/}
+    }
+
+    append_snapshot_to_tar_and_gzip() {
+      # "r" flag is used to append snapshot.db to the existing tar archive
+      tar rf ${BACKUP_TAR_FILE} -C ${ASSET_DIR}/tmp snapshot.db
+      gzip ${BACKUP_TAR_FILE}
     }
 
     # backup current etcd-member pod manifest


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: #1796440
**- What I did**
Manually cherry picked changes to keep data and keys separate for snapshot backup and restore scripts.
**- How to verify it**
1. Take snapshot backup using the DR script.
2. Verify that it produces two files: one containing static pod resources and another snapshot db.
3. Restore the snapshot following the documentation, and verify that etcd comes up and healthy.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Keep etcd keys and data separate for enhanced security.