### PR TITLE
daemon: Move "Validated on-disk state" log to only when we have

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -962,13 +962,13 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		if !dn.validateOnDiskState(expectedConfig) {
 			return fmt.Errorf("unexpected on-disk state validating against %s", expectedConfig.GetName())
 		}
+		glog.Info("Validated on-disk state")
 	} else {
 		glog.Infof("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 		if err := os.Remove(constants.MachineConfigDaemonForceFile); err != nil {
 			return errors.Wrap(err, "failed to remove force validation file")
 		}
 	}
-	glog.Info("Validated on-disk state")
 
 	// We've validated our state.  In the case where we had a pendingConfig,
 	// make that now currentConfig.  We update the node annotation, delete the


### PR DESCRIPTION
When the force file is present, we didn't actually validate.
Obviously, this just changes logging; I was just reading the code
as part of looking at
https://bugzilla.redhat.com/show_bug.cgi?id=1766515
