### PR TITLE
Bug 1796444: gcp: use readyz endpoint

### DIFF
--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-gcp-routes-controller.yaml
@@ -15,7 +15,7 @@ contents:
         command: ["gcp-routes-controller"]
         args:
         - "run"
-        - "--health-check-url=https://127.0.0.1:6443/healthz"
+        - "--health-check-url=https://127.0.0.1:6443/readyz"
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
This PR is related to this conversation https://github.com/openshift/machine-config-operator/pull/1031#discussion_r371965677

@sttts suggested to use `readyz` instead of the `healthz` endpoint.

I've just edited the template instead of changing the whole command line flag for the binary itself (cc @abhinavdahiya)

I suspect this needs a BZ and backports, holding for the moment till we figure it out (I can also go ahead and create BZs as needed)

Signed-off-by: Antonio Murdaca <runcom@linux.com>