### PR TITLE
Provide RoleLabelKey as const to be re-used by other operators

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// MachineConfigRoleLabelKey is metadata key in the MachineConfig. Specifies the node role that config should be applied to.
+// For example: `master` or `worker`
+const MachineConfigRoleLabelKey = "machineconfiguration.openshift.io/role"
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -275,14 +275,10 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 	return mcfg, nil
 }
 
-const (
-	machineConfigRoleLabelKey = "machineconfiguration.openshift.io/role"
-)
-
 // MachineConfigFromIgnConfig creates a MachineConfig with the provided Ignition config
 func MachineConfigFromIgnConfig(role, name string, ignCfg *igntypes.Config) *mcfgv1.MachineConfig {
 	labels := map[string]string{
-		machineConfigRoleLabelKey: role,
+		mcfgv1.MachineConfigRoleLabelKey: role,
 	}
 	return &mcfgv1.MachineConfig{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -296,7 +296,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 				t.Fatal("non-nil labels expected")
 			}
 
-			role, ok := cfg.Labels[machineConfigRoleLabelKey]
+			role, ok := cfg.Labels[mcfgv1.MachineConfigRoleLabelKey]
 			if !ok || role == "" {
 				t.Fatal("role label missing")
 			}

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -47,7 +47,7 @@ func TestMCDToken(t *testing.T) {
 
 func mcLabelForRole(role string) map[string]string {
 	mcLabels := make(map[string]string)
-	mcLabels["machineconfiguration.openshift.io/role"] = role
+	mcLabels[mcfgv1.MachineConfigRoleLabelKey] = role
 	return mcLabels
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -131,7 +131,7 @@ func createMCP(t *testing.T, cs *framework.ClientSet, mcpName string) func() {
 	infraMCP.Spec.MachineConfigSelector = &mcSelector
 	infraMCP.Spec.MachineConfigSelector.MatchExpressions = []metav1.LabelSelectorRequirement{
 		{
-			Key:      "machineconfiguration.openshift.io/role",
+			Key:      mcfgv1.MachineConfigRoleLabelKey,
 			Operator: metav1.LabelSelectorOpIn,
 			Values:   []string{"worker", mcpName},
 		},


### PR DESCRIPTION
Other operators may need to use the MCO and hence they need to know this constant. Keeping this constant on a single place may turn out to be advantageous to the whole OpenShift ecosystem.

https://bugzilla.redhat.com/show_bug.cgi?id=1797559

Closes #1797559

