### PR TITLE
Bug 1780396: Get etcdctl binary from the etcd image and not from the upstream releases

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -30,15 +30,13 @@ contents:
            exit 1
         fi
       else
-        GOOGLE_URL=https://storage.googleapis.com/etcd
-        DOWNLOAD_URL=${GOOGLE_URL}
-
-        echo "Downloading etcdctl binary.."
-        curl -s -L ${DOWNLOAD_URL}/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -o $ASSET_DIR/tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
-          && tar -xzf $ASSET_DIR/tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -C $ASSET_DIR/shared --strip-components=1 \
-          && mv $ASSET_DIR/shared/etcdctl $ASSET_DIR/bin \
-          && rm $ASSET_DIR/shared/etcd \
-          && $ETCDCTL_BIN version
+        local etcdimg="{{.Images.etcdKey}}"
+        local etcdctr=$(podman create ${etcdimg})
+        local etcdmnt=$(podman mount "${etcdctr}")
+        cp ${etcdmnt}/bin/etcdctl $ASSET_DIR/bin
+        umount "${etcdmnt}"
+        podman rm "${etcdctr}"
+        $ETCDCTL_BIN version
       fi
     }
 


### PR DESCRIPTION
For non-x86 architectures there is no etcdctl binary available for the upstream releases of etcd. The suggestion from @cgwalters was to get the binary from the image(https://bugzilla.redhat.com/show_bug.cgi?id=1780396#c4)
which makes sense.

Verified by making the changes on an s390x system and executing the snapshot backup script.