### PR TITLE
Bug 1794824: If PlatformStatus.VSphere is nil do not template the file

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -276,7 +276,7 @@ func appendManifestsByPlatform(manifests []manifest, infra configv1.Infrastructu
 			},
 		)
 	}
-	if infra.Status.PlatformStatus.VSphere != nil {
+	if infra.Status.PlatformStatus.VSphere != nil && infra.Status.PlatformStatus.VSphere.APIServerInternalIP != "" {
 		manifests = append(manifests,
 			manifest{
 				name:     "manifests/vsphere/coredns.yaml",

--- a/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
+++ b/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
@@ -3,5 +3,9 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/99-kni.conf"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     [main]
     dhcp=dhclient
+    {{ end -}}
+    {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/coredns/Corefile.tmpl"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     . {
         errors
         health :18080
@@ -12,3 +14,5 @@ contents:
         reload
         file /etc/coredns/node-dns-db {{ .EtcdDiscoveryDomain }}
     }
+    {{ end -}}
+    {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns-db.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-db.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/coredns/node-dns-db"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     $ORIGIN {{ .EtcdDiscoveryDomain }}.
     @    3600 IN SOA host.{{ .EtcdDiscoveryDomain }}. hostmaster (
                                     2017042752 ; serial
@@ -15,3 +17,5 @@ contents:
     api IN A {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
 
     *.apps  IN  A {{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}
+    {{ end -}}
+    {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/manifests/coredns.yaml"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -89,3 +91,5 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
+    {{ end -}}

--- a/templates/common/vsphere/files/vsphere-keepalived.yaml
+++ b/templates/common/vsphere/files/vsphere-keepalived.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/manifests/keepalived.yaml"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -116,3 +118,5 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
+    {{ end -}}

--- a/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
+++ b/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/manifests/mdns-publisher.yaml"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -73,3 +75,5 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
+    {{ end -}}

--- a/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
@@ -3,5 +3,9 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
+    {{ end -}}
+    {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/haproxy/haproxy.cfg.tmpl"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     defaults
       maxconn 20000
       mode    tcp
@@ -38,3 +40,5 @@ contents:
     {{`{{- range .LBConfig.Backends }}
        server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
     {{- end }}`}}
+    {{ end -}}
+    {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/manifests/haproxy.yaml"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -116,3 +118,5 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
+    {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
         script "/usr/bin/curl -o /dev/null -kLs https://0:6443/readyz"
         interval 1
@@ -76,3 +78,5 @@ contents:
             chk_ingress
         }
     }
+    {{ end -}}
+    {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     bind_address = "{{`{{ .NonVirtualIP }}`}}"
     collision_avoidance = "hostname"
 
@@ -32,3 +34,5 @@ contents:
         port = 42424
         ttl = 300
     }
+    {{ end -}}
+    {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
@@ -3,5 +3,9 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
+    {{ end -}}
+    {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
@@ -28,3 +30,5 @@ contents:
             chk_ingress
         }
     }
+    {{ end -}}
+    {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
@@ -3,6 +3,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     bind_address = "{{`{{ .NonVirtualIP }}`}}"
     collision_avoidance = "hostname"
 
@@ -14,3 +16,5 @@ contents:
         port = 42424
         ttl = 3200
     }
+    {{ end -}}
+    {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-non-virtual-ip.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-non-virtual-ip.yaml
@@ -3,6 +3,8 @@ mode: 0755
 path: "/usr/local/bin/non_virtual_ip"
 contents:
   inline: |
+    {{ if .Infra.Status.PlatformStatus.VSphere -}}
+    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     #!/usr/libexec/platform-python
     import collections
     import socket
@@ -136,3 +138,5 @@ contents:
 
     if __name__ == '__main__':
         main()
+    {{ end -}}
+    {{ end -}}


### PR DESCRIPTION
When installing onto vSphere UPI MCC fails templating the in-service networking
components because there is no vSphere platformstatus.
Add check to each template.

If vSphere platform status does not exist create empty files

Tested with both vSphere IPI and UPI.