### PR TITLE
WIP Bug 1797244: etcd-member.yaml: use etcd db file existence as a condition

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -111,7 +111,9 @@ contents:
             export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key) \
               ETCDCTL_ENDPOINTS="$ETCD_ENDPOINTS"
 
-            until $(etcdctl member list | grep $ETCD_DNS_NAME>/dev/null)
+            DEBUG=$(etcdctl member list)
+            echo "etcdctl result: $DEBUG"
+            until $(echo "$DEBUG" | grep $ETCD_DNS_NAME>/dev/null)
             do
               echo "waiting for $ETCD_DNS_NAME to be added to etcd membership"
               sleep 2

--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -23,6 +23,8 @@ contents:
         volumeMounts:
         - name: sa
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
+        - name: data-dir
+          mountPath: /var/lib/etcd/
     {{end}}
       - name: discovery
         image: "{{.Images.setupEtcdEnvKey}}"
@@ -100,8 +102,12 @@ contents:
             #!/bin/sh
             set -euxo pipefail
 
-            source /run/etcd/environment
+            if [ -e  "/var/lib/etcd/member/snap/db" ]; then
+              echo "etcd has previously been initialized as a member"
+              exit 0
+            fi
 
+            source /run/etcd/environment
             export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key) \
               ETCDCTL_ENDPOINTS="$ETCD_ENDPOINTS"
 
@@ -118,6 +124,8 @@ contents:
             mountPath: /run/etcd/
           - name: certs
             mountPath: /etc/ssl/etcd/
+          - name: data-dir
+            mountPath: /var/lib/etcd/
    {{end}}
       containers:
       - name: etcd-member


### PR DESCRIPTION
`cluster-etcd-operator` introduced a few additional init containers some of these containers utilize k8s clients to communicate with the apiserver. This becomes a chicken and egg situation during situations where kube may never exist during the life of the container. An example of this is disaster recovery.

By checking for the existence of the etcd db we can conclude if that member has been previously initialized. If it has then we do not require the k8s clients we can utilize the ENV variables populated in the discovery container based on system-level queries (ip address) and SRV lookups.

depends on https://github.com/openshift/cluster-etcd-operator/pull/73