### PR TITLE
Bug 1795696: templates: etcd-member: setup environment variables needed for easy etcdctl execution

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -176,12 +176,21 @@ contents:
           mountPath: /var/lib/etcd/
         - name: conf
           mountPath: /etc/etcd/
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - echo 'export ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)' >> /root/.profile
 
         env:
         - name: ETCDCTL_API
           value: "3"
         - name: ETCD_DATA_DIR
           value: "/var/lib/etcd"
+        - name: ENV
+          value: "/root/.profile"
         - name: ETCD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: #1795696

One can easily update .bashrc or .bash_profile using postStart hooks. However, `oc rsh` apparently doesn't use bash, so these are not getting automatically invoked.

https://github.com/openshift/origin/issues/7514
https://github.com/openshift/origin/issues/7496 

https://github.com/openshift/origin/pull/7519

However, standard shell (Bourne shell) uses .profile. But in RHCOS, /bin/sh is symbolically linked to /usr/bin/bash. 

> If bash is invoked with the name sh, it tries to mimic the startup behavior of historical versions of sh as closely as possible, while conforming to the POSIX standard as well. [...] When invoked as an interactive shell with the name sh, bash looks for the variable ENV, expands its value if it is defined, and uses the expanded value as the name of a file to read and execute. Since a shell invoked as sh does not attempt to read and execute commands from any other startup files, the --rcfile option has no effect.

**- What I did**
Added the environment variables needed for straightforward execution of etcdctl into /root/.profile, so that `oc rsh` has the ready-made environment.
**- How to verify it**
1. Install cluster
2. oc rsh -n openshift-etcd _etcd-member-pod_
3. Run etcdctl commands such as `etcdctl member list`

Should work right off the bat.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Provide environment variables for straightfoward execution of etcdctl commands on pods.