### PR TITLE
Bug 1797790: [release-4.2] prevent hitting annotation max size limit on nodes (cherry-pick)

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -60,7 +60,7 @@ func getNodeAnnotationExt(node *corev1.Node, k string, allowNoent bool) (string,
 	v, ok := node.Annotations[k]
 	if !ok {
 		if !allowNoent {
-			return "", fmt.Errorf("%s annotation not found in %s", k, node)
+			return "", fmt.Errorf("%s annotation not found on node '%s'", k, node.Name)
 		}
 		return "", nil
 	}

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -102,9 +104,12 @@ func (nw *clusterNodeWriter) SetWorking(client corev1client.NodeInterface, liste
 // SetUnreconcilable sets the state to Unreconcilable.
 func (nw *clusterNodeWriter) SetUnreconcilable(err error, client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error {
 	glog.Errorf("Marking Unreconcilable due to: %v", err)
+	// truncatedErr caps error message at a reasonable length to limit the risk of hitting the total
+	// annotation size limit (256 kb) at any point
+	truncatedErr := fmt.Sprintf("%.2000s", err.Error())
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateUnreconcilable,
-		constants.MachineConfigDaemonReasonAnnotationKey: err.Error(),
+		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
 	respChan := make(chan error, 1)
 	nw.writer <- message{
@@ -125,9 +130,12 @@ func (nw *clusterNodeWriter) SetUnreconcilable(err error, client corev1client.No
 // Returns an error if it couldn't set the annotation.
 func (nw *clusterNodeWriter) SetDegraded(err error, client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error {
 	glog.Errorf("Marking Degraded due to: %v", err)
+	// truncatedErr caps error message at a reasonable length to limit the risk of hitting the total
+	// annotation size limit (256 kb) at any point
+	truncatedErr := fmt.Sprintf("%.2000s", err.Error())
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateDegraded,
-		constants.MachineConfigDaemonReasonAnnotationKey: err.Error(),
+		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
 	respChan := make(chan error, 1)
 	nw.writer <- message{


### PR DESCRIPTION
Cherry-pick of #1404 

---

- What I did
Fixes issue where an "annotation not found" error compounds via wrapping the node in the error message, growing the machineconfiguration.openshift.io/reason annotation until it hits the annotation max size limit, thereby preventing updates to that node's annotations by controllers.

    Remove node object from "annotation not found" error and replace with just node name
    Truncate errors used in machineconfiguration.openshift.io/reason node annotation to prevent any that may contain large amounts of data from maxing out annotation size.

- How to verify it

    Stop MCO and MCC controllers
    Delete the machineconfiguration.openshift.io/desiredConfig annotation on a node and wait for the MCD to sync the update
    Check the node object for the annotation"machineconfiguration.openshift.io/reason": "machineconfiguration.openshift.io/desiredConfig annotation not found in node '<name here>'"

- Description for the changelog

    Truncate errors used in machineconfiguration.openshift.io/reason node annotation to prevent hitting the max annotation size

Fixes: Bug 1797790
