### PR TITLE
Bug 1797908: kubelet: Remove quotes from log level argument

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.yaml
@@ -31,7 +31,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-        --v="${KUBELET_LOG_LEVEL}"
+        --v=${KUBELET_LOG_LEVEL}
 
   Restart=always
   RestartSec=10

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.yaml
@@ -30,7 +30,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
-        --v="${KUBELET_LOG_LEVEL}"
+        --v=${KUBELET_LOG_LEVEL}
 
   Restart=always
   RestartSec=10


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed quotes around the KUBELET_LOG_LEVEL variable in the kubelet unit file.
Resolves the following error message produced in kubelet log on RHEL host:
```
hyperkube[66517]: F0204 19:10:58.178624   66517 server.go:156] invalid argument "\"3\"" for "-v, --v" flag: strconv.ParseInt: parsing "\"3\"": invalid syntax
```
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
