### PR TITLE
Bug 1790823: [baremetal] Verify that MDNS doesn't advertise localhost 

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-mdns-hostname.yaml
+++ b/templates/common/baremetal/files/NetworkManager-mdns-hostname.yaml
@@ -1,0 +1,22 @@
+filesystem: "root"
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/40-mdns-hostname"
+contents:
+  inline: |
+    #!/bin/bash
+    STATUS=$2
+    case "$STATUS" in
+        up|down|dhcp4-change|dhcp6-change|hostname)
+        logger -s "NM mdns-hostname triggered by ${2}."
+        set +e
+        t_hostname=$(hostname)
+        if [ -z "${t_hostname}" ]; then
+           t_hostname="localhost"
+        fi
+        mkdir -p /etc/mdns
+        echo "${t_hostname}">/etc/mdns/hostname
+        logger -s "Hostname changed: ${t_hostname}"
+        ;;
+        *)
+        ;;
+    esac

--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -34,11 +34,23 @@ contents:
         - "-c"
         - |
           #/bin/bash
-          while [ "$(hostname)" == "$DEFAULT_LOCAL_HOSTNAME" ]
+          function get_hostname()
+          {
+            if [[ -s /etc/mdns/hostname ]]; then
+              cat /etc/mdns/hostname
+            else
+              # if hostname wasn't updated by NM script, read hostname
+              hostname
+            fi
+          }
+          while [ "$(get_hostname)" == "$DEFAULT_LOCAL_HOSTNAME" ]
           do
             echo "hostname is still ${DEFAULT_LOCAL_HOSTNAME}"
-            sleep 10
+            sleep 1
           done
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/mdns"
       - name: render-config
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:


### PR DESCRIPTION
MDNS publisher static pod should start advertising the node
only after node's hostname was set by DHCP.

The idea is to add an init container that will monitor host's hostname
until hostname != localhost.

The issue was how host's hostname should be retrieved by the init container.

Since the MDNS static pod doesn't use host's uts namespace, reading 'hostname'
is not an option.
Reading hostname using dbus didn't work due to security constraints(SElinux).

The suggested solution composed of:
 1. NM dispatcher script will monitor & store hostname in a file
 2. Init container will mount this file, and read the value

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
