### PR TITLE
Bug 1800319: kubelet: add kube reservation for kubernetes components

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -22,8 +22,9 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 768m
+      memory: 1Gi
+      ephemeral-storage: 1Gi
     featureGates:
       IPv6DualStack: true
       LegacyNodeRoleBehavior: false

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -22,8 +22,9 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 768m
+      memory: 1Gi
+      ephemeral-storage: 1Gi
     featureGates:
       IPv6DualStack: true
       LegacyNodeRoleBehavior: false


### PR DESCRIPTION
**- What I did**
bumps `systemReserved`. Fixes an issue where the kubelet and node could become starved causing the node to hang.

[upstream doc](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved)
[BZ1800319](https://bugzilla.redhat.com/show_bug.cgi?id=1800319)

**- How to verify it**
The BZ has an attached test case.

**- Description for the changelog**
```NONE```

/cc @smarterclayton @sjenning @mrunalp 