### PR TITLE
Bug 1797897: etcd-member: do not wait-for-kube or validate membership for existing members

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -23,6 +23,8 @@ contents:
         volumeMounts:
         - name: sa
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount/
+        - name: data-dir
+          mountPath: /var/lib/etcd/
     {{end}}
       - name: discovery
         image: "{{.Images.setupEtcdEnvKey}}"
@@ -102,6 +104,12 @@ contents:
 
             source /run/etcd/environment
 
+            # no validation required if member is existing
+            [ ! -e "/var/lib/etcd/member/snap/db" ] || {
+              echo "etcd has previously been initialized as a member"
+              exit 0
+            }
+
             export ETCDCTL_API=3 ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key) \
               ETCDCTL_ENDPOINTS="$ETCD_ENDPOINTS"
 
@@ -118,6 +126,8 @@ contents:
             mountPath: /run/etcd/
           - name: certs
             mountPath: /etc/ssl/etcd/
+          - name: data-dir
+            mountPath: /var/lib/etcd/
    {{end}}
       containers:
       - name: etcd-member


### PR DESCRIPTION
In some circumstances such as lights out where all nodes are shutdown `wait-for-kube` init would fail as kube would never be available before etcd. Also the membership init container will attempt to validate etcd membership but that is not possible when etcd is not running...

This PR adds the ability to fall through these checks by validating the existence of an etcd data file.

the full solution requires [1]s but does not block this PR.

[1] https://github.com/openshift/cluster-etcd-operator/pull/73