### PR TITLE
[release-4.3] Bug 1801824: kubelet: add more system reservation to protect node

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -25,7 +25,8 @@ contents:
     systemCgroups: /system.slice
     systemReserved:
       cpu: 500m
-      memory: 500Mi
+      memory: 1Gi
+      ephemeral-storage: 1Gi
     featureGates:
       RotateKubeletServerCertificate: true
       NodeDisruptionExclusion: true

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -25,7 +25,8 @@ contents:
     systemCgroups: /system.slice
     systemReserved:
       cpu: 500m
-      memory: 500Mi
+      memory: 1Gi
+      ephemeral-storage: 1Gi
     featureGates:
       RotateKubeletServerCertificate: true
       NodeDisruptionExclusion: true


### PR DESCRIPTION
Cherry pick of: https://github.com/openshift/machine-config-operator/pull/1450

Kubelet and Crio are running at around 250-500 MB each (on default installs). This PR bumps the limit to 1 GB to allow for a bit of headroom to preserve some of the Kernel cache as well. If we don't bump the limit then memory pressure on the node could flush some of the kernel cache resulting in the kernel trying to re-read the cache. This flood of IOPS can be throttled  by the cloud providers which results in a kernel pause.

**- What I did**

**- How to verify it**

**- Description for the changelog**
