### PR TITLE
Bug 1804944: Point etcd SRV record at master hostnames

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-mdns-config.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-mdns-config.yaml
@@ -8,7 +8,7 @@ contents:
 
     service {
         name = "{{`{{ .Cluster.Name }}`}} Etcd"
-        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
+        host_name = "{{`{{ .ShortHostname }}`}}.local."
         type = "_etcd-server-ssl._tcp"
         domain = "local."
         port = 2380
@@ -22,13 +22,4 @@ contents:
         domain = "local."
         port = 42424
         ttl = 3200
-    }
-
-    service {
-        name = "{{`{{ .Cluster.Name }}`}} EtcdWorkstation"
-        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
-        type = "_workstation._tcp"
-        domain = "local."
-        port = 42424
-        ttl = 300
     }


### PR DESCRIPTION
Our current method of mapping master hostnames to etcd-[0,1,2] records introduces undesirable restrictions on the names of master nodes. Now that cluster-etcd-operator allows us to bootstrap the etcd cluster using the SRV record, we can just point it at the masters directly and drop the extra etcd-specific record. This should eliminate the hostname requirements entirely.

This will need to wait for https://github.com/openshift/coredns-mdns/pull/52 to merge since that is forcing use of the etcd record.