### PR TITLE
[WIP] controller: error if node with custom role is missing worker label

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -556,10 +556,13 @@ func (ctrl *Controller) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.MachineCon
 		}
 		// One custom role, let's use its pool
 		pls := []*mcfgv1.MachineConfigPool{custom[0]}
+
 		if worker != nil {
 			pls = append(pls, worker)
+			return pls, nil
 		}
-		return pls, nil
+		// All nodes with custom pools must have 2 labels: the custom pool label and the worker label.
+		return nil, fmt.Errorf("node %s has custom role %s but is missing required worker role", node.Name, custom[0].Name)
 	} else if master != nil {
 		// In the case where a node is both master/worker, have it live under
 		// the master pool. This occurs in CodeReadyContainers and general


### PR DESCRIPTION
WIP: first pass, need to test


TO-DO: I think the unit test helper is creating the custom pool incorrectly (in MCSelector field)... will fix...


-------

When a user does not setup their custom pools correctly and do not label nodes as both worker and custompool, the errors are confusing, for ex:
`kubelet_config_controller.go:303] Error syncing kubeletconfig cluster: GenerateMachineConfigsforRole failed with error failed to read dir "/etc/mcc/templates/infra": open /etc/mcc/templates/infra: no such file or directory`

All nodes using custom roles must belong to both the custom & worker pools as per: https://github.com/openshift/machine-config-operator/blob/master/docs/custom-pools.md  so add an explicit error so user can fix...

