### PR TITLE
DO NOT MERGE: Test with lower reservations for debugging the real failure

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -22,9 +22,8 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:
-      cpu: 768m
-      memory: 1Gi
-      ephemeral-storage: 1Gi
+      cpu: 500m
+      memory: 500Mi
     featureGates:
       IPv6DualStack: true
       LegacyNodeRoleBehavior: false

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -22,9 +22,8 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:
-      cpu: 768m
-      memory: 1Gi
-      ephemeral-storage: 1Gi
+      cpu: 500m
+      memory: 500Mi
     featureGates:
       IPv6DualStack: true
       LegacyNodeRoleBehavior: false


### PR DESCRIPTION
Reverts openshift/machine-config-operator#1450 so that we can easily test why the system failed.

Running out of memory should not cause nodes to die longer than the time for the kubelet to restart, nor silently corrupt the behavior of the kubelet.