### PR TITLE
Bug 1800319: kubelet: bump CPU reservation back to 500m

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -22,7 +22,7 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:
-      cpu: 768m
+      cpu: 500m
       memory: 1Gi
       ephemeral-storage: 1Gi
     featureGates:

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -22,7 +22,7 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemReserved:
-      cpu: 768m
+      cpu: 500m
       memory: 1Gi
       ephemeral-storage: 1Gi
     featureGates:


### PR DESCRIPTION
**- What I did**
We are seeing some instances where openshift components do not fit on the nodes anymore. Retune the CPU limit to the original.

**- How to verify it**

**- Description for the changelog**

