### PR TITLE
make etcd quorum guard privileged to read files from etcd operator

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -88,6 +88,8 @@ spec:
           requests:
             cpu: 10m
             memory: 5Mi
+        securityContext:
+          privileged: true
       volumes:
       - name: kubecerts
         hostPath:


### PR DESCRIPTION
paired with https://github.com/openshift/cluster-etcd-operator/pull/162 to make sure the quorum guard can read the correct files off disk.  We would pick this back to 4.3

/cherrypick release-4.3