### PR TITLE
bug 1804693: Revert "pkg/daemon: skip /etc/kubernetes/manifests/etcd-member.yaml"

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1332,10 +1332,6 @@ func checkFiles(files []igntypes.File) bool {
 // error in case of an error or mismatch and returns the status of the
 // evaluation.
 func checkFileContentsAndMode(filePath string, expectedContent []byte, mode os.FileMode) bool {
-	if filePath == "/etc/kubernetes/manifests/etcd-member.yaml" {
-		glog.Warningf("skipping etcd-member.yaml")
-		return true
-	}
 	fi, err := os.Lstat(filePath)
 	if err != nil {
 		glog.Errorf("could not stat file: %q, error: %v", filePath, err)


### PR DESCRIPTION
Restores the file consistency check.

@runcom interesting side-node.  I'm not completely sure which operator reports the failure sometimes during upgrade.  If the MCO doesn't upgrade when degraded, you may not be able to pick this into 4.4 without breaking 4.3 to 4.4 upgrades.