### PR TITLE
WIP: Move GCP routes service into gcp-routes-controller

### DIFF
--- a/cmd/gcp-routes-controller/deleteRoutes.go
+++ b/cmd/gcp-routes-controller/deleteRoutes.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/machine-config-operator/pkg/version"
+)
+
+var (
+	deleteRoutesCmd = &cobra.Command{
+		Use:   "delete-routes",
+		Short: "Deletes all GCP routes",
+		Long:  "",
+		RunE:  runDeleteRoutesCmd,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(deleteRoutesCmd)
+}
+
+func runDeleteRoutesCmd(cmd *cobra.Command, args []string) error {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	// To help debugging, immediately log version
+	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+	err := RunDelRoutes()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/gcp-routes-controller/main.go
+++ b/cmd/gcp-routes-controller/main.go
@@ -14,7 +14,7 @@ const (
 var (
 	rootCmd = &cobra.Command{
 		Use:           componentName,
-		Short:         "Controls the gcp-routes.service on RHCOS hosts based on health checks",
+		Short:         "Controls GCP routes on hosts based on health checks",
 		Long:          "",
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -283,6 +283,7 @@ func runSetRoutes() error {
 		for devName, fwips := range routes {
 			cmd := fmt.Sprintf("ip route show dev %s table local proto 66 | awk '{print$2}'", devName)
 			ipOutput, err := exec.Command("bash", "-c", cmd).Output()
+			glog.Info("RunSetRoutes CMD: " + cmd + "; Output: " + string(ipOutput))
 			if err != nil {
 				return fmt.Errorf("failed to show routes with command '%s': %v", cmd, err)
 			}
@@ -291,14 +292,16 @@ func runSetRoutes() error {
 
 				if !sliceContainsString(fwips, currentRoute) {
 					glog.Info("Removing stale forwarded IP " + currentRoute + "/32")
-					err := exec.Command("ip", "route", "del", currentRoute+"/32", "dev", devName, "table", "local", "proto", "66").Run()
+					op, err := exec.Command("ip", "route", "del", currentRoute+"/32", "dev", devName, "table", "local", "proto", "66").Output()
+					glog.Info("RunSetRoutes route del Output: " + string(op))
 					if err != nil {
 						return fmt.Errorf("failed to remove stale forwarded IP %s for device %s: %v", currentRoute, devName, err)
 					}
 				}
 			}
 			for _, fwip := range fwips {
-				err := exec.Command("ip", "route", "replace", "to", "local", fwip, "dev", devName, "proto", "66").Run()
+				op, err := exec.Command("ip", "route", "replace", "to", "local", fwip, "dev", devName, "proto", "66").Output()
+				glog.Info("RunSetRoutes route replace Output: " + string(op))
 				if err != nil {
 					return fmt.Errorf("failed to replace route to IP %s for device %s: %v", fwip, devName, err)
 				}
@@ -319,6 +322,7 @@ func RunDelRoutes() error {
 	for devName, fwips := range routes {
 		cmd := fmt.Sprintf("ip route show dev %s table local proto 66 | awk '{print$2}'", devName)
 		ipOutput, err := exec.Command("bash", "-c", cmd).Output()
+		glog.Info("RunDelRoutes CMD: " + cmd + "; Output: " + string(ipOutput))
 		if err != nil {
 			return fmt.Errorf("failed to show routes with command '%s': %v", cmd, err)
 		}
@@ -326,7 +330,8 @@ func RunDelRoutes() error {
 		for _, currentRoute := range ips {
 			if sliceContainsString(fwips, currentRoute) {
 				glog.Info("Removing forwarded IP " + currentRoute + "/32")
-				err := exec.Command("ip", "route", "del", currentRoute+"/32", "dev", devName, "table", "local", "proto", "66").Run()
+				op, err := exec.Command("ip", "route", "del", currentRoute+"/32", "dev", devName, "table", "local", "proto", "66").Output()
+				glog.Info("RunDelRoutes route del Output: " + string(op))
 				if err != nil {
 					return fmt.Errorf("failed to remove forwarded IP %s for device %s: %v", currentRoute, devName, err)
 				}

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -224,8 +224,8 @@ func getRoutes() (map[string][]string, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to get instances at %s: %v", fwipPath+level, err)
 			}
-			glog.Info("Processing route for NIC " + vif + hwAddr + " as " + devName + " for IPs " + strings.Join(fwips, ", "))
-			routes[devName] = fwips
+			glog.Info("Processing route for NIC " + vif + hwAddr + " as " + devName + " for " + strings.Join(fwips, ", "))
+			routes[devName] = append(routes[devName], fwips...)
 		}
 	}
 

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -89,7 +89,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		ErrCh:            errCh,
 		SuccessThreshold: 2,
 		FailureThreshold: 10,
-		OnFailure:        RunDelRoutes,
+		OnFailure:        func() error { _ = exec.Command("systemctl", "stop", "gcp-routes.service"); return RunDelRoutes() },
 		OnSuccess:        runSetRoutes,
 	}
 
@@ -111,6 +111,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	go func() {
 		for sig := range c {
 			glog.Infof("Signal %s received: shutting down gcp routes service", sig)
+			_ = exec.Command("systemctl", "stop", "gcp-routes.service").Run()
 			if err := RunDelRoutes(); err != nil {
 				glog.Infof("Failed to terminate gcp routes service on signal: %s", err)
 			} else {

--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -89,7 +89,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		ErrCh:            errCh,
 		SuccessThreshold: 2,
 		FailureThreshold: 10,
-		OnFailure:        runDelRoutes,
+		OnFailure:        RunDelRoutes,
 		OnSuccess:        runSetRoutes,
 	}
 
@@ -111,7 +111,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	go func() {
 		for sig := range c {
 			glog.Infof("Signal %s received: shutting down gcp routes service", sig)
-			if err := runDelRoutes(); err != nil {
+			if err := RunDelRoutes(); err != nil {
 				glog.Infof("Failed to terminate gcp routes service on signal: %s", err)
 			} else {
 				break
@@ -310,7 +310,8 @@ func runSetRoutes() error {
 	return nil
 }
 
-func runDelRoutes() error {
+// RunDelRoutes deletes all GCP routes. This function is also used by the delete-routes subcommand of gcp-routes-controller
+func RunDelRoutes() error {
 	routes, err := getRoutes()
 	if err != nil {
 		return fmt.Errorf("failed to get routes: %v", err)


### PR DESCRIPTION
[This script](https://github.com/LorbusChris/installer/blob/0fbddf1cd735a29282415aa0dae370bad9af5462/data/data/bootstrap/gcp/files/usr/local/bin/gcp-routes.sh) and its service are currently layered into RHCOS at build time. It controls the routes for the cluster on GCP.

This PR moves the functionality into the gcp-routes-controller container.
