### PR TITLE
DO NOT MERGE: Delete pods after drain with shutdown annotation

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -33,6 +33,12 @@ const (
 	// InitialNodeAnnotationsBakPath defines the path of InitialNodeAnnotationsFilePath when the initial bootstrap is done. We leave it around for debugging and reconciling.
 	InitialNodeAnnotationsBakPath = "/etc/machine-config-daemon/node-annotation.json.bak"
 
+	// OpenShiftDeleteOnNodeShutdownAnnotationKey is currently specific to OpenShift and will
+	// cause a pod (should be a daemonset) to be explicitly deleted before shutdown.  This
+	// helps ensure that availability is correctly tracked.  See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1884053 for example.
+	OpenShiftDeleteOnNodeShutdownAnnotationKey = "upgrade.openshift.io/delete-on-node-shutdown"
+
 	// EtcPivotFile is used by the `pivot` command
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44
 	EtcPivotFile = "/etc/pivot/image-pullspec"


### PR DESCRIPTION
Allow pods to request deletion when MCD drains before a reboot to
ensure the pod is up to date after drain. This is testing a different
daemonset update pattern for pods that cannot be safely restarted
while workloads are on the machine (like OVS).