### PR TITLE
Bug 1806001: [baremetal] Set hostname when DHCP6_FQDN_FQDN is set

### DIFF
--- a/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -6,6 +6,8 @@ contents:
     #!/bin/bash
     IFACE=$1
     STATUS=$2
+    # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
+    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" ]] && hostname $DHCP6_FQDN_FQDN
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."

--- a/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -6,6 +6,8 @@ contents:
     #!/bin/bash
     IFACE=$1
     STATUS=$2
+    # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
+    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" ]] && hostname $DHCP6_FQDN_FQDN
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."


### PR DESCRIPTION
NetworkManager doesn't always set the hostname when DHCP6 is involved.
This sets the hostname when $DHCP6_FQDN_FQDN is populated and does not
equal localhost.localdomain. This is a workaround while we try to figure
out why NetworkManager is not setting the hostname as it should.
