### PR TITLE
Allow tuning mitigation=auto kernel argument

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -36,7 +36,8 @@ const (
 // TODO: fill out the whitelist
 // tuneableArgsWhitelist contains allowed keys for tunable arguments
 var tuneableArgsWhitelist = map[string]bool{
-	"nosmt": true,
+	"nosmt":            true,
+	"mitigations=auto": true,
 }
 
 var pivotCmd = &cobra.Command{


### PR DESCRIPTION
This is required for Fedora CoreOS 31 (and greater) hosts