### PR TITLE
1790819: [baremetal] Add watcher sidecar container for Coredns static pod

### DIFF
--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -23,6 +23,9 @@ contents:
       - name: conf-dir
         hostPath:
           path: "/etc/coredns"
+      - name: nm-resolv
+        hostPath:
+          path: "/var/run/NetworkManager"
       initContainers:
       - name: render-config
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -84,6 +87,35 @@ contents:
           failureThreshold: 5
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
+      - name: coredns-monitor
+        securityContext:
+          privileged: true
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - corednsmonitor
+        - "/etc/kubernetes/kubeconfig"
+        - "/config/Corefile.tmpl"
+        - "/etc/coredns/Corefile"
+        - "--api-vip"
+        - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+        - "--dns-vip"
+        - "{{ .Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
+        - "--ingress-vip"
+        - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi          
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: resource-dir
+          mountPath: "/config"
+        - name: conf-dir
+          mountPath: "/etc/coredns"
+        - name: nm-resolv
+          mountPath: "/var/run/NetworkManager"
+        imagePullPolicy: IfNotPresent        
       hostNetwork: true
       tolerations:
       - operator: Exists


### PR DESCRIPTION
When /etc/resolv.conf file is modified, the forward section of
Coredns Corefile should be updated.
This patch adds sidecar container (similar to HAProxy and Keepalived) that
checks resolv.conf file and updates Coredns Corefile.

This PR should be merged only after https://github.com/openshift/baremetal-runtimecfg/pull/49 is merged.
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
