### PR TITLE
[baremetal] Change to unicast for keepalived

### DIFF
--- a/manifests/baremetal/keepalived.conf.tmpl
+++ b/manifests/baremetal/keepalived.conf.tmpl
@@ -12,6 +12,7 @@
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 50
     advert_int 1
+    {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {
         {{range .LBConfig.Backends}}
@@ -20,6 +21,7 @@
         {{.NonVirtualIP}}
         {{end}}
     }
+    {{end}}
     authentication {
         auth_type PASS
         auth_pass {{.Cluster.Name}}_api_vip
@@ -35,6 +37,7 @@
     virtual_router_id {{.Cluster.DNSVirtualRouterID }}
     priority 140
     advert_int 1
+    {{if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {
         {{range .LBConfig.Backends}}
@@ -43,6 +46,7 @@
         {{.NonVirtualIP}}
         {{end}}
     }
+    {{end}}
     authentication {
         auth_type PASS
         auth_pass {{.Cluster.Name}}_dns_vip

--- a/manifests/baremetal/keepalived.conf.tmpl
+++ b/manifests/baremetal/keepalived.conf.tmpl
@@ -4,32 +4,50 @@
 # For more information, see installer/data/data/bootstrap/baremetal/README.md
 # in the installer repo.
 
-vrrp_instance {{`{{.Cluster.Name}}`}}_API {
+{{`{{$nonVirtualIP := .NonVirtualIP}}`}}
+
+{{`vrrp_instance {{.Cluster.Name}}_API {
     state BACKUP
-    interface {{`{{.VRRPInterface}}`}}
-    virtual_router_id {{`{{.Cluster.APIVirtualRouterID }}`}}
+    interface {{.VRRPInterface}}
+    virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 50
     advert_int 1
+    unicast_src_ip {{.NonVirtualIP}}
+    unicast_peer {
+        {{range .LBConfig.Backends}}
+        {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
+        {{else}}
+        {{.NonVirtualIP}}
+        {{end}}
+    }
     authentication {
         auth_type PASS
-        auth_pass {{`{{.Cluster.Name}}`}}_api_vip
+        auth_pass {{.Cluster.Name}}_api_vip
     }
     virtual_ipaddress {
-        {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+        {{ .Cluster.APIVIP }}/{{ .Cluster.VIPNetmask }}
     }
-}
+}`}}
 
-vrrp_instance {{`{{.Cluster.Name}}`}}_DNS {
+{{`vrrp_instance {{.Cluster.Name}}_DNS {
     state MASTER
-    interface {{`{{.VRRPInterface}}`}}
-    virtual_router_id {{`{{.Cluster.DNSVirtualRouterID }}`}}
+    interface {{.VRRPInterface}}
+    virtual_router_id {{.Cluster.DNSVirtualRouterID }}
     priority 140
     advert_int 1
+    unicast_src_ip {{.NonVirtualIP}}
+    unicast_peer {
+        {{range .LBConfig.Backends}}
+        {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
+        {{else}}
+        {{.NonVirtualIP}}
+        {{end}}
+    }
     authentication {
         auth_type PASS
-        auth_pass {{`{{.Cluster.Name}}`}}_dns_vip
+        auth_pass {{.Cluster.Name}}_dns_vip
     }
     virtual_ipaddress {
-        {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+        {{ .Cluster.DNSVIP }}/{{ .Cluster.VIPNetmask }}
     }
-}
+}`}}

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -95,6 +95,9 @@ spec:
     imagePullPolicy: IfNotPresent
   - name: keepalived-monitor
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    env:
+      - name: ENABLE_UNICAST
+        value: "yes"
     command:
     - dynkeepalived
     - "/etc/kubernetes/kubeconfig"

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -21,52 +21,58 @@ spec:
   - name: manifests
     hostPath:
       path: "/opt/openshift/manifests"
-  initContainers:
-  - name: render-config
+  - name: run-dir
+    empty-dir: {}
+  containers:
+  - name: keepalived-unicast
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     command:
-    - runtimecfg
-    - render
-    - "/etc/kubernetes/kubeconfig"
+    - unicastipserver
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
     - "--dns-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
-    - "/config"
-    - "--out-dir"
-    - "/etc/keepalived"
-    - "--cluster-config"
-    - "/opt/openshift/manifests/cluster-config.yaml"
-    resources: {}
-    volumeMounts:
-    - name: resource-dir
-      mountPath: "/config"
-    - name: kubeconfig
-      mountPath: "/etc/kubernetes/kubeconfig"
-    - name: conf-dir
-      mountPath: "/etc/keepalived"
-    - name: manifests
-      mountPath: "/opt/openshift/manifests"
-    imagePullPolicy: IfNotPresent
-  containers:
   - name: keepalived
     securityContext:
       privileged: true
-    image: {{ .Images.KeepalivedBootstrap }}
+    image: {{.Images.KeepalivedBootstrap}}
     env:
       - name: NSS_SDB_USE_CACHE
         value: "no"
     command:
-    - /usr/sbin/keepalived
-    args:
-    - "-f"
-    - "/etc/keepalived/keepalived.conf"
-    - "--dont-fork"
-    - "--vrrp"
-    - "--log-detail"
-    - "--log-console"
+    - /bin/bash
+    - -c
+    - |
+      #/bin/bash
+      reload_keepalived()
+      {
+        if pid=$(pgrep -o keepalived); then
+            kill -s SIGHUP "$pid"
+        else
+            /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+        fi
+      }
+      msg_handler()
+      {
+        while read -r line; do
+          echo "The client sent: $line" >&2
+          # currently only 'reload' msg is supported
+          if [ "$line" = reload ]; then
+              reload_keepalived
+          fi
+        done
+      }
+      set -ex
+      declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
+      export -f msg_handler
+      export -f reload_keepalived
+      if [ -s "/etc/keepalived/keepalived.conf" ]; then
+          /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+      fi
+      rm -f "$keepalived_sock"
+      socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
     resources:
       requests:
         cpu: 100m
@@ -74,7 +80,49 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"
+    - name: run-dir
+      mountPath: "/var/run/keepalived"
+    livenessProbe:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - |
+          [[ -s /etc/keepalived/keepalived.conf ]] || \
+          kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+      initialDelaySeconds: 10
     terminationMessagePolicy: FallbackToLogsOnError
+    imagePullPolicy: IfNotPresent
+  - name: keepalived-monitor
+    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    command:
+    - dynkeepalived
+    - "/etc/kubernetes/kubeconfig"
+    - "/config/keepalived.conf.tmpl"
+    - "/etc/keepalived/keepalived.conf"
+    - "--api-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+    - "--dns-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
+    - "--ingress-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: resource-dir
+      mountPath: "/config"
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
+    - name: conf-dir
+      mountPath: "/etc/keepalived"
+    - name: run-dir
+      mountPath: "/var/run/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
     imagePullPolicy: IfNotPresent
   hostNetwork: true
   tolerations:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -250,6 +250,7 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 50
     advert_int 1
+    {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {
         {{range .LBConfig.Backends}}
@@ -258,6 +259,7 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
         {{.NonVirtualIP}}
         {{end}}
     }
+    {{end}}
     authentication {
         auth_type PASS
         auth_pass {{.Cluster.Name}}_api_vip
@@ -273,6 +275,7 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
     virtual_router_id {{.Cluster.DNSVirtualRouterID }}
     priority 140
     advert_int 1
+    {{if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {
         {{range .LBConfig.Backends}}
@@ -281,6 +284,7 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
         {{.NonVirtualIP}}
         {{end}}
     }
+    {{end}}
     authentication {
         auth_type PASS
         auth_pass {{.Cluster.Name}}_dns_vip
@@ -403,6 +407,9 @@ spec:
     imagePullPolicy: IfNotPresent
   - name: keepalived-monitor
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    env:
+      - name: ENABLE_UNICAST
+        value: "yes"
     command:
     - dynkeepalived
     - "/etc/kubernetes/kubeconfig"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -242,35 +242,53 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
 # For more information, see installer/data/data/bootstrap/baremetal/README.md
 # in the installer repo.
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_API {
+{{`+"`"+`{{$nonVirtualIP := .NonVirtualIP}}`+"`"+`}}
+
+{{`+"`"+`vrrp_instance {{.Cluster.Name}}_API {
     state BACKUP
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.APIVirtualRouterID }}`+"`"+`}}
+    interface {{.VRRPInterface}}
+    virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 50
     advert_int 1
+    unicast_src_ip {{.NonVirtualIP}}
+    unicast_peer {
+        {{range .LBConfig.Backends}}
+        {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
+        {{else}}
+        {{.NonVirtualIP}}
+        {{end}}
+    }
     authentication {
         auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_api_vip
+        auth_pass {{.Cluster.Name}}_api_vip
     }
     virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.APIVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
+        {{ .Cluster.APIVIP }}/{{ .Cluster.VIPNetmask }}
     }
-}
+}`+"`"+`}}
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
+{{`+"`"+`vrrp_instance {{.Cluster.Name}}_DNS {
     state MASTER
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.DNSVirtualRouterID }}`+"`"+`}}
+    interface {{.VRRPInterface}}
+    virtual_router_id {{.Cluster.DNSVirtualRouterID }}
     priority 140
     advert_int 1
+    unicast_src_ip {{.NonVirtualIP}}
+    unicast_peer {
+        {{range .LBConfig.Backends}}
+        {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
+        {{else}}
+        {{.NonVirtualIP}}
+        {{end}}
+    }
     authentication {
         auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_dns_vip
+        auth_pass {{.Cluster.Name}}_dns_vip
     }
     virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
+        {{ .Cluster.DNSVIP }}/{{ .Cluster.VIPNetmask }}
     }
-}
+}`+"`"+`}}
 `)
 
 func manifestsBaremetalKeepalivedConfTmplBytes() ([]byte, error) {
@@ -311,52 +329,58 @@ spec:
   - name: manifests
     hostPath:
       path: "/opt/openshift/manifests"
-  initContainers:
-  - name: render-config
+  - name: run-dir
+    empty-dir: {}
+  containers:
+  - name: keepalived-unicast
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     command:
-    - runtimecfg
-    - render
-    - "/etc/kubernetes/kubeconfig"
+    - unicastipserver
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
     - "--dns-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
-    - "/config"
-    - "--out-dir"
-    - "/etc/keepalived"
-    - "--cluster-config"
-    - "/opt/openshift/manifests/cluster-config.yaml"
-    resources: {}
-    volumeMounts:
-    - name: resource-dir
-      mountPath: "/config"
-    - name: kubeconfig
-      mountPath: "/etc/kubernetes/kubeconfig"
-    - name: conf-dir
-      mountPath: "/etc/keepalived"
-    - name: manifests
-      mountPath: "/opt/openshift/manifests"
-    imagePullPolicy: IfNotPresent
-  containers:
   - name: keepalived
     securityContext:
       privileged: true
-    image: {{ .Images.KeepalivedBootstrap }}
+    image: {{.Images.KeepalivedBootstrap}}
     env:
       - name: NSS_SDB_USE_CACHE
         value: "no"
     command:
-    - /usr/sbin/keepalived
-    args:
-    - "-f"
-    - "/etc/keepalived/keepalived.conf"
-    - "--dont-fork"
-    - "--vrrp"
-    - "--log-detail"
-    - "--log-console"
+    - /bin/bash
+    - -c
+    - |
+      #/bin/bash
+      reload_keepalived()
+      {
+        if pid=$(pgrep -o keepalived); then
+            kill -s SIGHUP "$pid"
+        else
+            /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+        fi
+      }
+      msg_handler()
+      {
+        while read -r line; do
+          echo "The client sent: $line" >&2
+          # currently only 'reload' msg is supported
+          if [ "$line" = reload ]; then
+              reload_keepalived
+          fi
+        done
+      }
+      set -ex
+      declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
+      export -f msg_handler
+      export -f reload_keepalived
+      if [ -s "/etc/keepalived/keepalived.conf" ]; then
+          /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+      fi
+      rm -f "$keepalived_sock"
+      socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
     resources:
       requests:
         cpu: 100m
@@ -364,7 +388,49 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"
+    - name: run-dir
+      mountPath: "/var/run/keepalived"
+    livenessProbe:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - |
+          [[ -s /etc/keepalived/keepalived.conf ]] || \
+          kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+      initialDelaySeconds: 10
     terminationMessagePolicy: FallbackToLogsOnError
+    imagePullPolicy: IfNotPresent
+  - name: keepalived-monitor
+    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    command:
+    - dynkeepalived
+    - "/etc/kubernetes/kubeconfig"
+    - "/config/keepalived.conf.tmpl"
+    - "/etc/keepalived/keepalived.conf"
+    - "--api-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+    - "--dns-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
+    - "--ingress-vip"
+    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: resource-dir
+      mountPath: "/config"
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
+    - name: conf-dir
+      mountPath: "/etc/keepalived"
+    - name: run-dir
+      mountPath: "/var/run/keepalived"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
     imagePullPolicy: IfNotPresent
   hostNetwork: true
   tolerations:

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -19,7 +19,10 @@ contents:
           path: "/etc/kubernetes/static-pod-resources/keepalived"
       - name: kubeconfig
         hostPath:
-          path: "/etc/kubernetes/kubeconfig"
+          path: "/etc/kubernetes"
+      - name: kubeconfigvarlib
+        hostPath:
+          path: "/var/lib/kubelet"
       - name: conf-dir
         hostPath:
           path: "/etc/keepalived"
@@ -89,10 +92,12 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: keepalived-monitor
+        securityContext:
+          privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - dynkeepalived
-        - "/etc/kubernetes/kubeconfig"
+        - "/var/lib/kubelet/kubeconfig"
         - "/config/keepalived.conf.tmpl"
         - "/etc/keepalived/keepalived.conf"
         - "--api-vip"
@@ -108,8 +113,8 @@ contents:
         volumeMounts:
         - name: resource-dir
           mountPath: "/config"
-        - name: kubeconfig
-          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         - name: conf-dir
           mountPath: "/etc/keepalived"
         - name: run-dir

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -95,6 +95,9 @@ contents:
         securityContext:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
+        env:
+          - name: ENABLE_UNICAST
+            value: "yes"
         command:
         - dynkeepalived
         - "/var/lib/kubelet/kubeconfig"

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -23,12 +23,21 @@ contents:
         weight 50
     }
 
+    {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
+
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.APIVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        unicast_src_ip {{`{{.NonVirtualIP}}`}}
+        unicast_peer {
+            {{`{{ .BootstrapIP }}`}}
+            {{`{{range .LBConfig.Backends}}
+            {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
+            {{end}}`}}
+        }
         authentication {
             auth_type PASS
             auth_pass {{`{{ .Cluster.Name }}`}}_api_vip
@@ -47,6 +56,13 @@ contents:
         virtual_router_id {{`{{ .Cluster.DNSVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        unicast_src_ip {{`{{.NonVirtualIP}}`}}
+        unicast_peer {
+            {{`{{ .BootstrapIP }}`}}
+            {{`{{range .LBConfig.Backends}}
+            {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
+            {{end}}`}}
+        }
         authentication {
             auth_type PASS
             auth_pass {{`{{ .Cluster.Name }}`}}_dns_vip
@@ -65,6 +81,12 @@ contents:
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        unicast_src_ip {{`{{.NonVirtualIP}}`}}
+        unicast_peer {
+            {{`{{range .IngressConfig.Peers}}
+            {{if ne $nonVirtualIP .}}{{.}}{{end}}
+            {{end}}`}}
+        }
         authentication {
             auth_type PASS
             auth_pass cluster_uuid_ingress_vip

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -31,6 +31,7 @@ contents:
         virtual_router_id {{`{{ .Cluster.APIVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
             {{`{{ .BootstrapIP }}`}}
@@ -38,6 +39,7 @@ contents:
             {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
             {{end}}`}}
         }
+        {{`{{end}}`}}
         authentication {
             auth_type PASS
             auth_pass {{`{{ .Cluster.Name }}`}}_api_vip
@@ -56,6 +58,7 @@ contents:
         virtual_router_id {{`{{ .Cluster.DNSVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
             {{`{{ .BootstrapIP }}`}}
@@ -63,6 +66,7 @@ contents:
             {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
             {{end}}`}}
         }
+        {{`{{end}}`}}
         authentication {
             auth_type PASS
             auth_pass {{`{{ .Cluster.Name }}`}}_dns_vip
@@ -81,12 +85,14 @@ contents:
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
             {{`{{range .IngressConfig.Peers}}
             {{if ne $nonVirtualIP .}}{{.}}{{end}}
             {{end}}`}}
         }
+        {{`{{end}}`}}
         authentication {
             auth_type PASS
             auth_pass cluster_uuid_ingress_vip

--- a/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -11,12 +11,20 @@ contents:
         weight 50
     }
 
+    {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
+
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        unicast_src_ip {{`{{.NonVirtualIP}}`}}
+        unicast_peer {
+            {{`{{range .IngressConfig.Peers}}
+            {{if ne $nonVirtualIP .}}{{.}}{{end}}
+            {{end}}`}}
+        }
         authentication {
             auth_type PASS
             auth_pass cluster_uuid_ingress_vip

--- a/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -19,12 +19,14 @@ contents:
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
         priority 40
         advert_int 1
+        {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
             {{`{{range .IngressConfig.Peers}}
             {{if ne $nonVirtualIP .}}{{.}}{{end}}
             {{end}}`}}
         }
+        {{`{{end}}`}}
         authentication {
             auth_type PASS
             auth_pass cluster_uuid_ingress_vip


### PR DESCRIPTION
This implements a unicast solution for keepalived. Multicast is often not available
so unicast is a more common method.

WIP

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
