### PR TITLE
CRC: compare the correct object

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -672,7 +672,7 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 				return fmt.Errorf("could not find MachineConfig: %v", err)
 			}
 			isNotFound := errors.IsNotFound(err)
-			if !isNotFound && equality.Semantic.DeepEqual(registriesIgn, mc.Spec.Config) {
+			if !isNotFound && equality.Semantic.DeepEqual(*registriesIgn, mc.Spec.Config) {
 				// if the configuration for the registries is equal, we still need to compare
 				// the generated controller version because during an upgrade we need a new one
 				mcCtrlVersion := mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey]


### PR DESCRIPTION
Do not compare pointer and struct as that always yields false and forces
the controller to update the MC and spam the logs every ~20m.

Signed-off-by: Antonio Murdaca <runcom@linux.com>