### PR TITLE
[release-4.3] Bug 1807279: templates/master/00-master/azure: bump raft tunables

### DIFF
--- a/templates/master/00-master/azure/files/etc-etcd-etcd-conf.yaml
+++ b/templates/master/00-master/azure/files/etc-etcd-etcd-conf.yaml
@@ -1,0 +1,18 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/etcd/etcd.conf"
+contents:
+  inline: |
+    #[member]
+    ETCD_SNAPSHOT_COUNT=100000
+    ETCD_HEARTBEAT_INTERVAL=500
+    ETCD_ELECTION_TIMEOUT=2500
+
+    #[storage]
+    ETCD_QUOTA_BACKEND_BYTES=7516192768
+
+    #[logging]
+    ETCD_DEBUG=false
+
+    #[profiling]
+    ETCD_ENABLE_PPROF=false


### PR DESCRIPTION
The reason for this change is that currently, Azure disk performance does not allow for the throughput provided by default raft settings. Under heavier, disk I/O Azure will throttle disks causing massive spikes in I/O 600ms+. By reducing the throughput ETCD_HEARTBEAT_INTERVAL and also extending the timeout for etcd elections ETCD_ELECTION_TIMEOUT we can improve stability in slower disks by reducing leader elections.