### PR TITLE
[baremetal] Decrease resources of keepalived monitor container

### DIFF
--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -103,8 +103,8 @@ contents:
         - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         resources:
           requests:
-            cpu: 150m
-            memory: 1Gi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: resource-dir
           mountPath: "/config"


### PR DESCRIPTION
All static pods containers resources should be set to (cpu: 100m and memory: 200Mi), this change updates keepalived-monitor resources to these values.
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
