### PR TITLE
Make sure corev1 schema is registered

### DIFF
--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -25,9 +25,11 @@ const (
 
 // CreateResourceLock returns an interface for the resource lock.
 func CreateResourceLock(cb *clients.Builder, componentNamespace, componentName string) resourcelock.Interface {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
 	recorder := record.
 		NewBroadcaster().
-		NewRecorder(runtime.NewScheme(), corev1.EventSource{Component: componentName})
+		NewRecorder(scheme, corev1.EventSource{Component: componentName})
 
 	id, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
When upgrading 4.2.16 to 4.2.18 I noticed that the `machine-config`
cluster operator remained at 4.2.16. Looking at the logs of the
`machine-config-operator` I noticed the following:

```
I0227 20:34:38.428822       1 start.go:42] Version: v4.2.15-202001171551-dirty (31fed93186c9f84708f5cdfd0227ffe4f79b31cd)
E0227 20:34:38.458532       1 event.go:247] Could not construct reference to: '&v1.ConfigMap{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"machine-config", GenerateName:"", Namespace:"openshift-machine-config-operator", SelfLink:"/api/v1/namespaces/openshift-machine-config-operator/configmaps/machine-config", UID:"9305be83-59a0-11ea-a084-064dd2f0c578", ResourceVersion:"42279333", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63718432478, loc:(*time.Location)(0x23664a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"machine-config-operator-596785879d-qsb4k_9302eaa1-59a0-11ea-923a-0a580a810191\",\"leaseDurationSeconds\":90,\"acquireTime\":\"2020-02-27T20:34:38Z\",\"renewTime\":\"2020-02-27T20:34:38Z\",\"leaderTransitions\":0}"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Data:map[string]string(nil), BinaryData:map[string][]uint8(nil)}' due to: 'no kind is registered for the type v1.ConfigMap in scheme "github.com/openshift/machine-config-operator/cmd/common/helpers.go:30"'. Will not report event: 'Normal' 'LeaderElection' 'machine-config-operator-596785879d-qsb4k_9302eaa1-59a0-11ea-923a-0a580a810191 became leader'
I0227 20:34:38.786752       1 operator.go:246] Starting MachineConfigOperator
```

It seemed to me that the corev1 schema was not registered so I added
`corev1.AddToScheme(scheme)` for the schema used by the `recorder`.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Run the upgrade from 4.2.16 to 4.2.18, looked at the logs of the `machine-config-operator`, so added `corev1.AddToScheme(scheme)` for the schema used by the `recorder` in `cmd/common/helpers.go`.

**- How to verify it**

Not sure if this has anything to do with the upgrade. Perhaps just running the operator and seeing that the message `Could not construct reference to...` is not logged.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed recording of LeaderElection event