### PR TITLE
[wip][release-4.3] etcd-member: add terminationGracePeriodSeconds

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -178,6 +178,7 @@ contents:
           protocol: TCP
         securityContext:
           privileged: true
+      terminationGracePeriodSeconds: 60
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
During upgrades, we see cases where etcd is restarted in what appears to be close proximity to other etcd instances that are being upgraded in rolling fashion. I would like to test adding a termination grace period to help make the timing between etcd upgrades more predictable and stable.

Of we look at these etcd logs[1] the container was only up for a few seconds during an upgrade. My hope is this would help those scenarios.

[1] https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/14324/artifacts/e2e-aws-upgrade/pods/openshift-etcd_etcd-member-ip-10-0-144-85.ec2.internal_etcd-member_previous.log

ref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/411