### PR TITLE
Bug 1809274: crd/kubelet: do not prune kubelet rawExtension fields

### DIFF
--- a/manifests/kubeletconfig.crd.yaml
+++ b/manifests/kubeletconfig.crd.yaml
@@ -42,6 +42,8 @@ spec:
           properties:
             kubeletConfig:
               type: object
+              x-kubernetes-embedded-resource: true
+              x-kubernetes-preserve-unknown-fields: true
             machineConfigPoolSelector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1155,6 +1155,8 @@ spec:
           properties:
             kubeletConfig:
               type: object
+              x-kubernetes-embedded-resource: true
+              x-kubernetes-preserve-unknown-fields: true
             machineConfigPoolSelector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty


### PR DESCRIPTION
The kubelet config is now validated, but fields are being silently
dropped since its an "unknown field" (rawExtension), which by
default is pruned by the validator.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>