### PR TITLE
Bug 1809611: OpenStack: Set coredns forward policy to sequencial

### DIFF
--- a/manifests/openstack/coredns-corefile.tmpl
+++ b/manifests/openstack/coredns-corefile.tmpl
@@ -2,7 +2,9 @@
     errors
     health :18080
     mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
-    forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+    forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+        policy sequential
+    }
     cache 30
     reload
     hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2856,7 +2856,9 @@ var _manifestsOpenstackCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
     mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
-    forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
+    forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}} {
+        policy sequential
+    }
     cache 30
     reload
     hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {

--- a/templates/common/openstack/files/openstack-coredns-corefile.yaml
+++ b/templates/common/openstack/files/openstack-coredns-corefile.yaml
@@ -7,7 +7,9 @@ contents:
         errors
         health :18080
         mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
-        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+            policy sequential
+        }
         cache 30
         reload
         file /etc/coredns/node-dns-db {{ .EtcdDiscoveryDomain }}


### PR DESCRIPTION
The default policy for CoreDNS forward plugin being random [1], the
cluster may not be able to resolve the OpenStack API hostname when the
user sets multiple external DNS resolvers such as
['172.31.8.1','8.8.8.8'], where 172.31.8.1 knows to resolve internal
hostnames and 8.8.8.8 is a public resolver that doesn't know how to
resolve internal hostnames.

Switch to the sequencial policy to simulate the libc behavior and not
surprise users who expect the DNS servers specified via `externalDNS`
option to have a hierarchy.

[1] https://coredns.io/plugins/forward/