### PR TITLE
Bug 1810333: Detect default hostname in its variants

### DIFF
--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -27,15 +27,14 @@ contents:
       - name: verify-hostname
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
-          - name: DEFAULT_LOCAL_HOSTNAME
-            value: "localhost"
           - name: RUNTIMECFG_HOSTNAME_PATH
             value: "/etc/mdns/hostname"
         command:
         - "/bin/bash"
         - "-c"
         - |
-          #/bin/bash
+          #!/bin/bash
+          set -xv
           function get_hostname()
           {
             if [[ -s $RUNTIMECFG_HOSTNAME_PATH ]]; then
@@ -45,9 +44,8 @@ contents:
               hostname
             fi
           }
-          while [ "$(get_hostname)" == "$DEFAULT_LOCAL_HOSTNAME" ]
-          do
-            echo "hostname is still ${DEFAULT_LOCAL_HOSTNAME}"
+          while [[ "$(get_hostname)" =~ ^localhost(.localdomain)?$ ]]; do
+            echo "hostname is still set to a default value"
             sleep 1
           done
         volumeMounts:
@@ -71,6 +69,7 @@ contents:
         - "/config"
         - "--out-dir"
         - "/etc/mdns"
+        - "--verbose"
         resources: {}
         volumeMounts:
         - name: kubeconfig


### PR DESCRIPTION
On some environments, `hostname` returns localhost whereas on others it
returns `localhost.localdomain`. This commit ensures that we'll catch
both.

It also increases verbosity of initcontainers to ease debugging of
similar issues in the future.
