### PR TITLE
Bug 1810333: daemon: Always create tempfiles in target dir

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -57,10 +57,11 @@ func writeFileAtomicallyWithDefaults(fpath string, b []byte) error {
 // writeFileAtomically uses the renameio package to provide atomic file writing, we can't use renameio.WriteFile
 // directly since we need to 1) Chown 2) go through a buffer since files provided can be big
 func writeFileAtomically(fpath string, b []byte, dirMode, fileMode os.FileMode, uid, gid int) error {
-	if err := os.MkdirAll(filepath.Dir(fpath), dirMode); err != nil {
+	dir := filepath.Dir(fpath)
+	if err := os.MkdirAll(dir, dirMode); err != nil {
 		return fmt.Errorf("failed to create directory %q: %v", filepath.Dir(fpath), err)
 	}
-	t, err := renameio.TempFile("", fpath)
+	t, err := renameio.TempFile(dir, fpath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

When we go to write a file, we need to create the temporary
file in the exact target directory, not (potentially) `/tmp`. This will
ensure that the right SELinux label is used by default.

Currently the `renameio` library's logic tries to optimize things
by using `/tmp` if possible, otherwise the target directory.
And without SELinux that's a sane optimization.  But we
can't do it.

Force using the target directory by passing it explicitly.

Should fix a bug seen with the baremetal config which
ended up with a `tmp_t` labeled file in `/etc`.