### PR TITLE
Bug 1806027: Specify cgroups in kubelet.conf so cAdvisor stats will be tracked

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -11,6 +11,7 @@ contents:
       anonymous:
         enabled: false
     cgroupDriver: systemd
+    cgroupRoot: /
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
@@ -19,8 +20,10 @@ contents:
     kubeAPIQPS: 50
     kubeAPIBurst: 100
     rotateCertificates: true
+    runtimeCgroups: /system.slice/crio.service
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
+    systemCgroups: /system.slice
     systemReserved:
       cpu: 500m
       memory: 1Gi

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -11,6 +11,7 @@ contents:
       anonymous:
         enabled: false
     cgroupDriver: systemd
+    cgroupRoot: /
     clusterDNS:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
@@ -19,8 +20,10 @@ contents:
     kubeAPIQPS: 50
     kubeAPIBurst: 100
     rotateCertificates: true
+    runtimeCgroups: /system.slice/crio.service
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
+    systemCgroups: /system.slice
     systemReserved:
       cpu: 500m
       memory: 1Gi


### PR DESCRIPTION
Specifying `runtimeCgroups` will cause the Kubelet to monitor statistics for the specified cgroup so that we have statistics for crio.

Specifying `systemCgroups` will cause the Kubelet to monitor
statistics for system processes and make that data available
in our metrics pipeline.

Specifying `cgroupRoot` explicitly is required when specifying
`systemCgroups`


**- What I did**

Added cgroup parameters so that the eventual
`/etc/kubernetes/kubelet.conf` will be configured for the kubelet
to monitor cgroup statistics for the crio runtime and other system
processes.

**- How to verify it**
```
oc get --raw /api/v1/nodes/node-name-of-one-of-your-nodes/proxy/metrics/cadvisor | grep crio\\.service
```

Before this change, no metrics will be returned, and after, you should see several metrics returned.
Additionally, try with services like `sshd` instead of `crio` and you should also see those.

**- Description for the changelog**
Kubelet will monitor statistics for system processes and crio