### PR TITLE
Bug 1811211: remove validation of kubeletcfg which is breaking our kubeletcfg

### DIFF
--- a/manifests/kubeletconfig.crd.yaml
+++ b/manifests/kubeletconfig.crd.yaml
@@ -42,7 +42,6 @@ spec:
           properties:
             kubeletConfig:
               type: object
-              x-kubernetes-embedded-resource: true
               x-kubernetes-preserve-unknown-fields: true
             machineConfigPoolSelector:
               description: A label selector is a label query over a set of resources.

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1161,7 +1161,6 @@ spec:
           properties:
             kubeletConfig:
               type: object
-              x-kubernetes-embedded-resource: true
               x-kubernetes-preserve-unknown-fields: true
             machineConfigPoolSelector:
               description: A label selector is a label query over a set of resources.


### PR DESCRIPTION
Recent changes to kubeletcfg manifests seem to have broken our kubeletcfgs.  This is on a cluster using master.

When I create a new kubelet config from https://github.com/openshift/machine-config-operator/blob/master/docs/KubeletConfigDesign.md#spec 
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: set-max-pods
spec:
  machineConfigPoolSelector:
    matchLabels:
      custom-kubelet: small-pods
  kubeletConfig:
    maxPods: 100
```

I see errors:
```$ oc apply -f maxpods.yaml
The KubeletConfig "set-max-pods" is invalid: 
* spec.kubeletConfig.apiVersion: Required value: must not be empty
* spec.kubeletConfig.kind: Required value: must not be empty
```

It seems to be validating against something different than our kubeletconfig type (upstream maybe?)

Thoughts?