### PR TITLE
[Don't merge] Test CI test failure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -157,3 +157,5 @@ See [FAQ.md](/docs/FAQ.md).
 If you've found a security issue that you'd like to disclose confidentially
 please contact Red Hat's Product Security team. Details at
 https://access.redhat.com/security/team/contact
+
+Test


### PR DESCRIPTION
This PR is to debug why TestKernelType test is failing in e2e gcp-op run while it seems to work fine on a local cluster.

[Log](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/1541/pull-ci-openshift-machine-config-operator-master-e2e-gcp-op/1472) from one of the [MCD worker pod](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/1541/pull-ci-openshift-machine-config-operator-master-e2e-gcp-op/1472/artifacts/e2e-gcp-op/pods/openshift-machine-config-operator_machine-config-daemon-88wfj_machine-config-daemon.log) says:
```
 writer.go:135] Marking Degraded due to: No kernel-rt package available in the OSContainer with URL registry.svc.ci.openshift.org/ci-op-3iigfkst/stable@sha256:84e3cbc499264b663ed9dea874d294920bc27ae92a4519f31307bee4a39fd251 
```