### PR TITLE
Bug 1811758 :  baremetal: Add missing network-online dependency to kubelet unit

### DIFF
--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
@@ -3,8 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service crio.service
-  After=crio.service
+  Wants=rpc-statd.service network-online.target crio.service
+  After=network-online.target crio.service
 
   [Service]
   Type=notify


### PR DESCRIPTION
This was added in #1206 to the base unit, but not the baremetal
copy of this file

**- What I did**
Added a dependency on the network-online target for the baremetal copy of the kubelet unit file.

**- How to verify it**
Verify the unit file on a IPI baremetal deployment or via `systemctl list-dependencies`

**- Description for the changelog**
Added missing dependency for kubelet on the network-online target, for the baremetal platform.