### PR TITLE
Bug 1811898: cmd/machine-config-operator: log RELEASE_VERSION when starting up

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"os"
 
 	"github.com/golang/glog"
 	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
@@ -42,7 +43,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	glog.Infof("Version: %s (Raw: %s, Hash: %s)", os.Getenv("RELEASE_VERSION"), version.Raw, version.Hash)
 
 	if startOpts.imagesFile == "" {
 		glog.Fatal("--images-json cannot be empty")


### PR DESCRIPTION
Other subcomponents are still following the old version logging when Raw and Hash
are sufficient for us to debug. This patch just changes the MCO itself to print
RELEASE_VERSION at startup. We might want to revisit this for all components and
bootstrap commands later but not critical either.

Signed-off-by: Antonio Murdaca <runcom@linux.com>