### PR TITLE
etcd quorum guard: don't set hostNetwork

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -21,7 +21,6 @@ spec:
         name: etcd-quorum-guard
         k8s-app: etcd-quorum-guard
     spec:
-      hostNetwork: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -86,8 +85,7 @@ spec:
           declare -r cacert="$croot/ca.crt"
           export NSS_SDB_USE_CACHE=no
           [[ -z $cert || -z $key ]] && exit 1
-          echo "curl --silent --max-time 2 --cert \"${cert//:/\:}\" --key \"$key\" --cacert \"$cacert\" \"$health_endpoint\"" >
-              /usr/local/bin/etcd-quorum-guard.sh
+          echo "curl --silent --max-time 2 --cert \"${cert//:/\:}\" --key \"$key\" --cacert \"$cacert\" \"$health_endpoint\"" > /usr/local/bin/etcd-quorum-guard.sh
 
           chmod +x /usr/local/bin/etcd-quorum-guard.sh
           sleep infinity & wait

--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -61,27 +61,41 @@ spec:
           name: kubecerts
         command:
         - /bin/bash
+        env:
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
         args:
         - -c
         - |
           # properly handle TERM and exit as soon as it is signaled
           set -euo pipefail
           trap 'jobs -p | xargs -r kill; exit 0' TERM
+          # prepare readiness script
+          declare -r croot=/mnt/kube
+          declare -r health_endpoint="https://${NODE_IP}:2379/health"
+          declare -r cert="${croot}/system:etcd-peer-${NODE_NAME}.crt"
+          declare -r key="${croot}/system:etcd-peer-${NODE_NAME}.key"
+          declare -r cacert="$croot/ca.crt"
+          export NSS_SDB_USE_CACHE=no
+          [[ -z $cert || -z $key ]] && exit 1
+          echo "curl --silent --max-time 2 --cert \"${cert//:/\:}\" --key \"$key\" --cacert \"$cacert\" \"$health_endpoint\"" >
+              /usr/local/bin/etcd-quorum-guard.sh
+
+          chmod +x /usr/local/bin/etcd-quorum-guard.sh
           sleep infinity & wait
         readinessProbe:
           exec:
             command:
             - /bin/sh
-            - -c
-            - |
-                declare -r croot=/mnt/kube
-                declare -r health_endpoint="https://127.0.0.1:2379/health"
-                declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print -quit)"
-                declare -r key="${cert%.crt}.key"
-                declare -r cacert="$croot/ca.crt"
-                export NSS_SDB_USE_CACHE=no
-                [[ -z $cert || -z $key ]] && exit 1
-                curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+            - /usr/local/bin/etcd-quorum-guard.sh
             initialDelaySecond: 5
             periodSecond: 5
         resources:


### PR DESCRIPTION
**- What I did**

* updated `etcd-quorum-guard` deployment to generate readiness script once and use host IP and name to find certificates in defined locations.

* removed `hostNetwork: true` from this deployment.
  This caused all network traffic to be counted as a container traffic, so some pods had > 4MBps network in/out in console

**- How to verify it**

Run setup / upgrade. 
Check network in/out data for etcd-quorum pods

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
