### PR TITLE
Bug 1804693: Revert the changes to skip file checks on etcd-member

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1332,10 +1332,6 @@ func checkFiles(files []igntypes.File) bool {
 // error in case of an error or mismatch and returns the status of the
 // evaluation.
 func checkFileContentsAndMode(filePath string, expectedContent []byte, mode os.FileMode) bool {
-	if filePath == "/etc/kubernetes/manifests/etcd-member.yaml" {
-		glog.Warningf("skipping etcd-member.yaml")
-		return true
-	}
 	fi, err := os.Lstat(filePath)
 	if err != nil {
 		glog.Errorf("could not stat file: %q, error: %v", filePath, err)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: 1804693
**- What I did**
We had skipped a file check on etcd-member so as to enable landing of cluster-etcd-operator, but we can remove that check now that we have been able to remove the file overall.

**- How to verify it**
Install or upgrade to OCP 4.5, it should come up.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
