### PR TITLE
Bug 1812179: manifests/controllerconfig: make infra nullable

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -336,6 +336,7 @@ spec:
                                 as a static pod to serve those hostnames to the nodes
                                 in the cluster.
                               type: string
+              nullable: true
             kubeAPIServerServingCAData:
               description: kubeAPIServerServingCAData managed Kubelet to API Server
                 Cert... Rotated automatically

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -88,6 +88,7 @@ type ControllerConfigSpec struct {
 
 	// infra holds the infrastructure details
 	// TODO this makes platform redundant as everything is contained inside Infra.Status
+	// +nullable
 	Infra *configv1.Infrastructure `json:"infra"`
 
 	// kubeletIPv6 is true to force a single-stack IPv6 kubelet config

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -987,6 +987,7 @@ spec:
                                 as a static pod to serve those hostnames to the nodes
                                 in the cluster.
                               type: string
+              nullable: true
             kubeAPIServerServingCAData:
               description: kubeAPIServerServingCAData managed Kubelet to API Server
                 Cert... Rotated automatically


### PR DESCRIPTION
Infra does not seem mandatory for every platform, and can be null
for some existing clusters. Thus, make it able to be a null object,
otherwise it will fail validation.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1812179

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>
