### PR TITLE
etcd: remove etcd entries from mdns

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-mdns-config.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-mdns-config.yaml
@@ -7,15 +7,6 @@ contents:
     collision_avoidance = "hostname"
 
     service {
-        name = "{{`{{ .Cluster.Name }}`}} Etcd"
-        host_name = "{{`{{ .ShortHostname }}`}}.local."
-        type = "_etcd-server-ssl._tcp"
-        domain = "local."
-        port = 2380
-        ttl = 3200
-    }
-
-    service {
         name = "{{`{{ .Cluster.Name }}`}} Workstation"
         host_name = "{{`{{ .ShortHostname }}`}}.local."
         type = "_workstation._tcp"

--- a/templates/master/00-master/openstack/files/openstack-mdns-config.yaml
+++ b/templates/master/00-master/openstack/files/openstack-mdns-config.yaml
@@ -6,26 +6,10 @@ contents:
     bind_address = "{{`{{ .NonVirtualIP }}`}}"
     collision_avoidance = "hostname"
     service {
-        name = "{{`{{ .Cluster.Name }}`}} Etcd"
-        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
-        type = "_etcd-server-ssl._tcp"
-        domain = "local."
-        port = 2380
-        ttl = 3200
-    }
-    service {
         name = "{{`{{ .Cluster.Name }}`}} Workstation"
         host_name = "{{`{{ .ShortHostname }}`}}.local."
         type = "_workstation._tcp"
         domain = "local."
         port = 42424
         ttl = 3200
-    }
-    service {
-        name = "{{`{{ .Cluster.Name }}`}} EtcdWorkstation"
-        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
-        type = "_workstation._tcp"
-        domain = "local."
-        port = 42424
-        ttl = 300
     }

--- a/templates/master/00-master/ovirt/files/ovirt-mdns-config.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-mdns-config.yaml
@@ -7,28 +7,10 @@ contents:
     collision_avoidance = "hostname"
 
     service {
-        name = "{{`{{ .Cluster.Name }}`}} Etcd"
-        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
-        type = "_etcd-server-ssl._tcp"
-        domain = "local."
-        port = 2380
-        ttl = 3200
-    }
-
-    service {
         name = "{{`{{ .Cluster.Name }}`}} Workstation"
         host_name = "{{`{{ .ShortHostname }}`}}.local."
         type = "_workstation._tcp"
         domain = "local."
         port = 42424
         ttl = 3200
-    }
-
-    service {
-        name = "{{`{{ .Cluster.Name }}`}} EtcdWorkstation"
-        host_name = "{{`{{ .EtcdShortHostname }}`}}.local."
-        type = "_workstation._tcp"
-        domain = "local."
-        port = 42424
-        ttl = 300
     }

--- a/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
@@ -11,15 +11,6 @@ contents:
     collision_avoidance = "hostname"
 
     service {
-        name = "{{`{{ .Cluster.Name }}`}} Etcd"
-        host_name = "{{`{{ .ShortHostname }}`}}.local."
-        type = "_etcd-server-ssl._tcp"
-        domain = "local."
-        port = 2380
-        ttl = 3200
-    }
-
-    service {
         name = "{{`{{ .Cluster.Name }}`}} Workstation"
         host_name = "{{`{{ .ShortHostname }}`}}.local."
         type = "_workstation._tcp"


### PR DESCRIPTION
Similar to https://github.com/openshift/installer/pull/3265, this
removes the etcd entries from mdns config because etcd no longer uses
DNS.