### PR TITLE
Bug 1812649: split kernel arguments

### DIFF
--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -275,6 +275,16 @@ func TestKernelAguments(t *testing.T) {
 			additions: []string{"hello=world"},
 		},
 		{
+			args:      []string{"foo", "bar=1 hello=world"},
+			deletions: []string{"nosmt", "baz=test"},
+			additions: []string{"bar=1", "hello=world"},
+		},
+		{
+			args:      []string{"foo", " baz=test bar=\"hello world\""},
+			deletions: []string{"nosmt"},
+			additions: []string{"bar=\"hello world\""},
+		},
+		{
 			args:      append([]string{"baz=othertest"}, oldMcfg.Spec.KernelArguments...),
 			deletions: []string{},
 			additions: []string{"baz=othertest"},

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -201,7 +201,7 @@ func TestKernelArguments(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			KernelArguments: []string{"nosmt", "foo=bar"},
+			KernelArguments: []string{"nosmt", "foo=bar", " baz=test bar=\"hello world\""},
 		},
 	}
 
@@ -219,9 +219,10 @@ func TestKernelArguments(t *testing.T) {
 		assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 		assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 		kargs := execCmdOnNode(t, cs, node, "cat", "/rootfs/proc/cmdline")
-		for _, v := range kargsMC.Spec.KernelArguments {
+		expectedKernelArgs := []string{"nosmt", "foo=bar", "baz=test", "\"bar=hello world\""}
+		for _, v := range expectedKernelArgs {
 			if !strings.Contains(kargs, v) {
-				t.Fatalf("Missing '%s' in kargs", v)
+				t.Fatalf("Missing %q in kargs: %q", v, kargs)
 			}
 		}
 		t.Logf("Node %s has expected kargs", node.Name)


### PR DESCRIPTION
**- What I did**
Split multiple kernel parameters in a single string, best matching what the kernel does. This
allows users to provide kernelArguments space delineated as a single string. For
instance, the following will be treated the same:

```yaml
  kernelArguments:
  - a=1 b=2
```

and

```yaml
  kernelArguments:
  - a=1
  - b=2
```
**- How to verify it**

1.
```shell
oc create -f - <<EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 50-worker-custom
spec:
  kernelArguments:
  - a=1 b=2
EOF
```
2. Watch the node <node> reboot and become Ready.
3. Delete the custom MC
```shell
oc delete mc/50-worker-custom
```
4. Watch the node <node> reboot and become Ready

**- Description for the changelog**
Split multiple kernel parameters in a single string in best effort attempt. This
allows users to provide kernelArguments space delineated as a single string.

Fixes: [Bug-1812649](https://bugzilla.redhat.com/show_bug.cgi?id=1812649)