### PR TITLE
reconcile relatedObjects and place them in the clusteroperator for CVO

### DIFF
--- a/install/0000_80_machine-config-operator_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config-operator_06_clusteroperator.yaml
@@ -9,3 +9,16 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ""
+      name: openshift-machine-config-operator
+      resource: namespaces
+    - group: machineconfiguration.openshift.io
+      name: master
+      resource: machineconfigpools
+    - group: machineconfiguration.openshift.io
+      name: worker
+      resource: machineconfigpools
+    - group: machineconfiguration.openshift.io
+      name: machine-config-controller
+      resource: controllerconfigs

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -8,6 +8,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +49,33 @@ func (optr *Operator) syncVersion() error {
 	optr.setOperatorStatusExtension(&co.Status, nil)
 	_, err = optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
 	return err
+}
+
+// syncRelatedObjects handles reporting the relatedObjects to the clusteroperator
+func (optr *Operator) syncRelatedObjects() error {
+	co, err := optr.fetchClusterOperator()
+	if err != nil {
+		return err
+	}
+	if co == nil {
+		return nil
+	}
+
+	coCopy := co.DeepCopy()
+	// RelatedObjects are consumed by https://github.com/openshift/must-gather
+	co.Status.RelatedObjects = []configv1.ObjectReference{
+		{Resource: "namespaces", Name: optr.namespace},
+		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "master"},
+		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "worker"},
+		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "machine-config-controller"},
+	}
+
+	if !equality.Semantic.DeepEqual(coCopy.Status.RelatedObjects, co.Status.RelatedObjects) {
+		_, err := optr.configClient.ConfigV1().ClusterOperators().UpdateStatus(co)
+		return err
+	}
+
+	return nil
 }
 
 // syncAvailableStatus applies the new condition to the mco's ClusterOperator object.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -81,6 +81,10 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		return fmt.Errorf("error syncing version: %v", err)
 	}
 
+	if err := optr.syncRelatedObjects(); err != nil {
+		return fmt.Errorf("error syncing relatedObjects: %v", err)
+	}
+
 	if optr.inClusterBringup && syncErr.err == nil {
 		glog.Infof("Initialization complete")
 		optr.inClusterBringup = false


### PR DESCRIPTION
fixes relatedObject reconciliation found in https://github.com/openshift/cluster-version-operator/pull/318 .  This is in service to https://github.com/openshift/enhancements/pull/149 .  The addition of relatedObjects in the CO itself means that when the operator doesn't start during bootstrapping, we can still get good PD data.