### PR TITLE
cri-o: set manage_ns_lifecycle to true

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -171,9 +171,9 @@ contents:
     # regarding the proper termination of the container.
     ctr_stop_timeout = 0
 
-    # ManageNetworkNSLifecycle determines whether we pin and remove network namespace
-    # and manage its lifecycle.
-    manage_network_ns_lifecycle = false
+    # ManageNSLifecycle determines whether we pin and remove namespaces
+    # and manage their lifecycle.
+    manage_ns_lifecycle = true
 
     # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
     # The runtime to use is picked based on the runtime_handler provided by the CRI.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -171,9 +171,9 @@ contents:
     # regarding the proper termination of the container.
     ctr_stop_timeout = 0
 
-    # ManageNetworkNSLifecycle determines whether we pin and remove network namespace
-    # and manage its lifecycle.
-    manage_network_ns_lifecycle = false
+    # ManageNSLifecycle determines whether we pin and remove namespaces
+    # and manage their lifecycle.
+    manage_ns_lifecycle = true
 
     # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
     # The runtime to use is picked based on the runtime_handler provided by the CRI.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
change the entry in crio.conf template to manage ns lifecycle
As it is more secure and gives cri-o more control of namespace lifecycle. Also change the outdated config name value

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
CRI-O now manages namespace lifecycle