### PR TITLE
baremetal: Remove DNS VIP

### DIFF
--- a/manifests/baremetal/coredns.yaml
+++ b/manifests/baremetal/coredns.yaml
@@ -30,8 +30,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
     - "/config"

--- a/manifests/baremetal/keepalived.conf.tmpl
+++ b/manifests/baremetal/keepalived.conf.tmpl
@@ -18,18 +18,3 @@ vrrp_instance {{`{{.Cluster.Name}}`}}_API {
         {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
     }
 }
-
-vrrp_instance {{`{{.Cluster.Name}}`}}_DNS {
-    state MASTER
-    interface {{`{{.VRRPInterface}}`}}
-    virtual_router_id {{`{{.Cluster.DNSVirtualRouterID }}`}}
-    priority 140
-    advert_int 1
-    authentication {
-        auth_type PASS
-        auth_pass {{`{{.Cluster.Name}}`}}_dns_vip
-    }
-    virtual_ipaddress {
-        {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
-    }
-}

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -30,8 +30,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
     - "/config"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -165,8 +165,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
     - "/config"
@@ -262,21 +260,6 @@ vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_API {
         {{`+"`"+`{{ .Cluster.APIVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
     }
 }
-
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
-    state MASTER
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.DNSVirtualRouterID }}`+"`"+`}}
-    priority 140
-    advert_int 1
-    authentication {
-        auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_dns_vip
-    }
-    virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
-    }
-}
 `)
 
 func manifestsBaremetalKeepalivedConfTmplBytes() ([]byte, error) {
@@ -326,8 +309,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
     - "/config"

--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -35,8 +35,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         - "/config"
@@ -98,8 +96,6 @@ contents:
         - "/etc/coredns/Corefile"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         resources:

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -96,8 +96,6 @@ contents:
         - "/etc/keepalived/keepalived.conf"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         resources:

--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -62,8 +62,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.BareMetal.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         - "/config"

--- a/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -11,7 +11,9 @@ contents:
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
-        NAMESERVER_IP="{{.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP}}"
+        NAMESERVER_IP=$(/usr/local/bin/non_virtual_ip \
+            "{{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP}}" \
+            "{{.Infra.Status.PlatformStatus.BareMetal.IngressIP}}")
         DOMAIN="{{.EtcdDiscoveryDomain}}"
         set +e
         if [[ -n "$NAMESERVER_IP" ]]; then

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -9,12 +9,6 @@ contents:
         weight 50
     }
 
-    vrrp_script chk_dns {
-        script "/usr/bin/host -t SRV _etcd-server-ssl._tcp.{{ .EtcdDiscoveryDomain }} localhost"
-        interval 1
-        weight 50
-    }
-
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
@@ -38,24 +32,6 @@ contents:
         }
         track_script {
             chk_ocp
-        }
-    }
-
-    vrrp_instance {{`{{ .Cluster.Name }}`}}_DNS {
-        state BACKUP
-        interface {{`{{ .VRRPInterface }}`}}
-        virtual_router_id {{`{{ .Cluster.DNSVirtualRouterID }}`}}
-        priority 40
-        advert_int 1
-        authentication {
-            auth_type PASS
-            auth_pass {{`{{ .Cluster.Name }}`}}_dns_vip
-        }
-        virtual_ipaddress {
-            {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
-        }
-        track_script {
-            chk_dns
         }
     }
 

--- a/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -13,7 +13,6 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
         NAMESERVER_IP=$(/usr/local/bin/non_virtual_ip \
             "{{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP}}" \
-            "{{.Infra.Status.PlatformStatus.BareMetal.NodeDNSIP}}" \
             "{{.Infra.Status.PlatformStatus.BareMetal.IngressIP}}")
         DOMAIN="{{.EtcdDiscoveryDomain}}"
         set +e


### PR DESCRIPTION
Now that etcd does not need DNS for clustering, we no longer need to
have a VIP to allow the masters to use the bootstrap coredns until
their own coredns instances start. Instead, we can just point them
at the local coredns directly and skip the extra complexity. We
already do this on the workers because they never had a dependency
on the bootstrap coredns so the same method is now used for masters.
