### PR TITLE
Bug 1791008: OpenStack: Limit the number of nameservers to 3

### DIFF
--- a/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -21,6 +21,8 @@ contents:
             logger -s "NM resolv-prepender: Couldn't find a Virtual IP, just updating resolv.conf"
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
+        # Only leave the first 3 nameservers in /etc/resolv.conf
+        sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.conf
         ;;
         *)
         ;;

--- a/templates/worker/00-worker/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -24,6 +24,8 @@ contents:
             logger -s "Couldn't find a non-virtual IP, just updating resolv.conf"
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
+        # Only leave the first 3 nameservers in /etc/resolv.conf
+        sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.conf
         ;;
         *)
         ;;


### PR DESCRIPTION
This prevents the pods from complaining about the nameserver limits
exceeded:

    Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 10.0.128.6 10.0.128.12 10.0.128.11 (207 times)