### PR TITLE
[baremetal] Add support for reading API LB backends from KUBE-API

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -17,9 +17,9 @@ contents:
       - name: resource-dir
         hostPath:
           path: "/etc/kubernetes/static-pod-resources/haproxy"
-      - name: kubeconfig
+      - name: kubeconfigvarlib
         hostPath:
-          path: "/etc/kubernetes/kubeconfig"
+          path: "/var/lib/kubelet"
       - name: run-dir
         empty-dir: {}
       - name: conf-dir
@@ -111,7 +111,7 @@ contents:
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - monitor
-        - "/etc/kubernetes/kubeconfig"
+        - "/var/lib/kubelet/kubeconfig"
         - "/config/haproxy.cfg.tmpl"
         - "/etc/haproxy/haproxy.cfg"
         - "--api-vip"
@@ -129,8 +129,8 @@ contents:
           mountPath: "/config"
         - name: chroot-host
           mountPath: "/host"
-        - name: kubeconfig
-          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true


### PR DESCRIPTION
This PR updates HAProxy static pod manifest to enable reading API LB backend details
from Kubernetes instead of _etcd-server-ssl._tcp SRV.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
