### PR TITLE
vsphere ipi: set hostname using vmtoolsd and VM extra config

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -1,0 +1,14 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/bin/vsphere-hostname.sh"
+contents:
+  inline: |
+    #!/usr/bin/env bash
+    set -e
+
+    if [ $(hostname -s) = "localhost" ]; then
+      if hostname=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
+          /usr/bin/hostnamectl --transient --static set-hostname ${hostname}
+      fi
+    fi
+

--- a/templates/common/vsphere/units/vsphere-hostname.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.yaml
@@ -1,0 +1,16 @@
+name: "vsphere-hostname.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=vSphere hostname
+  After=vmtoolsd.service
+  Before=kubelet.service
+
+  [Service]
+  ExecStart=/usr/local/bin/vsphere-hostname.sh
+  Restart=on-failure
+  RestartSec=15
+
+  [Install]
+  WantedBy=multi-user.target
+


### PR DESCRIPTION
This commit adds two new files:
- A systemd unit that runs a shell script
- A shell script that runs vmtoolsd to retrieve `guestinfo.hostname`
from vm guest. Then uses hostnamectl to set hostname.

