### PR TITLE
Bug 1817455: [release-4.4] pkg/daemon: fix deletion of stale files

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -792,20 +792,33 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) er
 
 	for _, f := range oldConfig.Spec.Config.Storage.Files {
 		if _, ok := newFileSet[f.Path]; !ok {
-			if _, err := os.Stat(noOrigFileName(f.Path)); err == nil {
-				if err := os.Remove(noOrigFileName(f.Path)); err != nil {
-					return errors.Wrapf(err, "deleting no orig file %q: %v", noOrigFileName(f.Path), err)
+			if _, err := os.Stat(noOrigFileStampName(f.Path)); err == nil {
+				if err := os.Remove(noOrigFileStampName(f.Path)); err != nil {
+					return errors.Wrapf(err, "deleting noorig file stamp %q: %v", noOrigFileStampName(f.Path), err)
 				}
 				glog.V(2).Infof("Removing file %q completely", f.Path)
 			} else if _, err := os.Stat(origFileName(f.Path)); err == nil {
-				if out, err := exec.Command("cp", "-a", "--reflink=auto", origFileName(f.Path), f.Path).CombinedOutput(); err != nil {
-					return errors.Wrapf(err, "restoring %q from orig file %q: %s", f.Path, origFileName(f.Path), string(out))
+				// Add a check for backwards compatibility: basically if the file doesn't exist in /usr/etc
+				// and no rpm is claming it, we assume that the orig file came from a wrongful backup of a
+				// MachineConfig file instead of a RHCOS file. See https://bugzilla.redhat.com/show_bug.cgi?id=1814397
+				if _, err := exec.Command("rpm", "-qf", f.Path).CombinedOutput(); err != nil {
+					if err := os.Remove(origFileName(f.Path)); err != nil {
+						return errors.Wrapf(err, "deleting orig file %q: %v", origFileName(f.Path), err)
+					}
+				} else if _, err := os.Stat("/usr" + f.Path); strings.HasPrefix(f.Path, "/etc") && os.IsNotExist(err) {
+					if err := os.Remove(origFileName(f.Path)); err != nil {
+						return errors.Wrapf(err, "deleting orig file %q: %v", origFileName(f.Path), err)
+					}
+				} else {
+					if out, err := exec.Command("cp", "-a", "--reflink=auto", origFileName(f.Path), f.Path).CombinedOutput(); err != nil {
+						return errors.Wrapf(err, "restoring %q from orig file %q: %s", f.Path, origFileName(f.Path), string(out))
+					}
+					if err := os.Remove(origFileName(f.Path)); err != nil {
+						return errors.Wrapf(err, "deleting orig file %q: %v", origFileName(f.Path), err)
+					}
+					glog.V(2).Infof("Restored file %q", f.Path)
+					continue
 				}
-				if err := os.Remove(origFileName(f.Path)); err != nil {
-					return errors.Wrapf(err, "deleting orig file %q: %v", origFileName(f.Path), err)
-				}
-				glog.V(2).Infof("Restored file %q", f.Path)
-				continue
 			}
 			glog.V(2).Infof("Deleting stale config file: %s", f.Path)
 			if err := os.Remove(f.Path); err != nil {
@@ -1023,23 +1036,30 @@ func origFileName(fpath string) string {
 	return filepath.Join(origParentDir(), fpath+".mcdorig")
 }
 
-func noOrigFileName(fpath string) string {
+// We use this to create a file that indicates that no original file existed on disk
+// when we write a file via a MachineConfig. Otherwise the MCD does not differentiate
+// between "a file existed due to a previous machineconfig" vs "a file existed on disk
+// before the MCD took over".Also see deleteStaleData() above.
+//
+// The "stamp" part of the name indicates it is not an actual backup file, just an
+// empty file to indicate lack of previous existence.
+func noOrigFileStampName(fpath string) string {
 	return filepath.Join(noOrigParentDir(), fpath+".mcdnoorig")
 }
 
 func createOrigFile(fpath string) error {
-	if _, err := os.Stat(noOrigFileName(fpath)); err == nil {
+	if _, err := os.Stat(noOrigFileStampName(fpath)); err == nil {
 		// we already created the no orig file for this default file
 		return nil
 	}
-	if _, err := os.Stat(fpath); err != nil {
+	if _, err := os.Stat(fpath); os.IsNotExist(err) {
 		// create a noorig file that tells the MCD that the file wasn't present on disk in RHCOS
 		// so it can just remove it when deleting stale data, as opposed as restoring a file
 		// that was shipped _with_ RHCOS (e.g. a default chrony config).
-		if err := os.MkdirAll(filepath.Dir(noOrigFileName(fpath)), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(noOrigFileStampName(fpath)), 0755); err != nil {
 			return errors.Wrapf(err, "creating no orig parent dir: %v", err)
 		}
-		return writeFileAtomicallyWithDefaults(noOrigFileName(fpath), nil)
+		return writeFileAtomicallyWithDefaults(noOrigFileStampName(fpath), nil)
 	}
 	if _, err := os.Stat(origFileName(fpath)); err == nil {
 		// the orig file is already there and we avoid creating a new one to preserve the real default

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -792,9 +792,17 @@ func (dn *Daemon) deleteStaleData(oldConfig, newConfig *mcfgv1.MachineConfig) er
 
 	for _, f := range oldConfig.Spec.Config.Storage.Files {
 		if _, ok := newFileSet[f.Path]; !ok {
-			if _, err := os.Stat(origFileName(f.Path)); err == nil {
-				if err := os.Rename(origFileName(f.Path), f.Path); err != nil {
-					return err
+			if _, err := os.Stat(noOrigFileName(f.Path)); err == nil {
+				if err := os.Remove(noOrigFileName(f.Path)); err != nil {
+					return errors.Wrapf(err, "deleting no orig file %q: %v", noOrigFileName(f.Path), err)
+				}
+				glog.V(2).Infof("Removing file %q completely", f.Path)
+			} else if _, err := os.Stat(origFileName(f.Path)); err == nil {
+				if out, err := exec.Command("cp", "-a", "--reflink=auto", origFileName(f.Path), f.Path).CombinedOutput(); err != nil {
+					return errors.Wrapf(err, "restoring %q from orig file %q: %s", f.Path, origFileName(f.Path), string(out))
+				}
+				if err := os.Remove(origFileName(f.Path)); err != nil {
+					return errors.Wrapf(err, "deleting orig file %q: %v", origFileName(f.Path), err)
 				}
 				glog.V(2).Infof("Restored file %q", f.Path)
 				continue
@@ -1007,15 +1015,31 @@ func origParentDir() string {
 	return filepath.Join("/etc", "machine-config-daemon", "orig")
 }
 
+func noOrigParentDir() string {
+	return filepath.Join("/etc", "machine-config-daemon", "noorig")
+}
+
 func origFileName(fpath string) string {
 	return filepath.Join(origParentDir(), fpath+".mcdorig")
 }
 
+func noOrigFileName(fpath string) string {
+	return filepath.Join(noOrigParentDir(), fpath+".mcdnoorig")
+}
+
 func createOrigFile(fpath string) error {
-	if _, err := os.Stat(fpath); err != nil {
-		// the file isn't there, no need to back it up
-		// we could check ENOENT only maybe?
+	if _, err := os.Stat(noOrigFileName(fpath)); err == nil {
+		// we already created the no orig file for this default file
 		return nil
+	}
+	if _, err := os.Stat(fpath); err != nil {
+		// create a noorig file that tells the MCD that the file wasn't present on disk in RHCOS
+		// so it can just remove it when deleting stale data, as opposed as restoring a file
+		// that was shipped _with_ RHCOS (e.g. a default chrony config).
+		if err := os.MkdirAll(filepath.Dir(noOrigFileName(fpath)), 0755); err != nil {
+			return errors.Wrapf(err, "creating no orig parent dir: %v", err)
+		}
+		return writeFileAtomicallyWithDefaults(noOrigFileName(fpath), nil)
 	}
 	if _, err := os.Stat(origFileName(fpath)); err == nil {
 		// the orig file is already there and we avoid creating a new one to preserve the real default


### PR DESCRIPTION
We have a serious bug in how we backup "original" files and restore them.
Here, "original" means files that ship with RHCOS. Think of a default Chrony
or another system daemon configuration file. When the MCD kicks in and writes
to those files, we want to backup the original one (the shipped-with-RHCOS) in order
to restore it if a user deletes the MC that modified it (this was the initial bug reported
in GitHub at https://github.com/openshift/machine-config-operator/issues/782).

However, that patch that fixed https://github.com/openshift/machine-config-operator/issues/782
was causing the following; if you shipped a file with just _one_ MC, removing it would wipe it out and that works.
However, if you modified that file later again with another MC, a backup
file will be created for the first MC, and when deleting the file by deleting the second MC, it will
restore the initial file shipped with the first MC instead of wiping it out completely which
it should have since that file was never meant to be backed up because it wasn't on RHCOS from the beginning.

This patch now differentiates between files that are already on RHCOS (on-disk so to speak)
and files that are shipped with an MC. For the former, the MCD will create a backup as it's doing today,
for the latter instead, the MCD creates a placeholder file that tells it to just get rid
of the file altogether (along with adding all the necessary checks and actions in order to create those backup files).

The issue popped up on upgrade paths where the new manifests rendered by the MCO don't contain a certain file.
The MCD notices that and go ahead trying to remove the file. It however notices that a backup file
(which was created for an MC shipped file and later other MC have modified it) is there and tries to restore it (also failing
with invalid cross-link device error, but that's another issue which I'm fixing here as well by using cp directly).

Really hoping all the above makes sense. Otherwise, an e2e can be consulted here https://github.com/openshift/machine-config-operator/pull/1590

Signed-off-by: Antonio Murdaca <runcom@linux.com>