### PR TITLE
test/e2e: add e2e to test files proper deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,4 +107,4 @@ Dockerfile.rhel7: Dockerfile Makefile
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operato
 test-e2e:
-	go test -mod=vendor -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -mod=vendor -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -165,6 +165,12 @@ func createMC(name, role string) *mcfgv1.MachineConfig {
 // execCmdOnNode finds a node's mcd, and oc rsh's into it to execute a command on the node
 // all commands should use /rootfs as root
 func execCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, args ...string) string {
+	out, err := execCmdOnNodeWithErr(t, cs, node, args...)
+	require.Nil(t, err, "failed to exec cmd %v on node %s", args, node.Name)
+	return string(out)
+}
+
+func execCmdOnNodeWithErr(t *testing.T, cs *framework.ClientSet, node corev1.Node, args ...string) (string, error) {
 	mcd, err := mcdForNode(cs, &node)
 	require.Nil(t, err)
 	mcdName := mcd.ObjectMeta.Name
@@ -177,6 +183,6 @@ func execCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, args
 	cmd = append(cmd, args...)
 
 	b, err := exec.Command(entryPoint, cmd...).CombinedOutput()
-	require.Nil(t, err, "failed to exec cmd %v on node %s", args, node.Name)
-	return string(b)
+	return string(b), err
 }
+


### PR DESCRIPTION
This e2e verifies what's being fixed in https://github.com/openshift/machine-config-operator/pull/1586 and it'll fail w/o that patch (which is why I'm carrying it here right now)

Signed-off-by: Antonio Murdaca <runcom@linux.com>