### PR TITLE
Bug 1817236: baremetal: Handle unused route fields in non_virtual_ip

### DIFF
--- a/templates/common/baremetal/files/baremetal-non-virtual-ip.yaml
+++ b/templates/common/baremetal/files/baremetal-non-virtual-ip.yaml
@@ -67,7 +67,7 @@ contents:
 
 
     class V6Route:
-        def __init__(self, destination: str, dev: Optional[str] = None, proto: Optional[str] = None, metric: Optional[int] = None, pref: Optional[str] = None, via: Optional[str] = None) -> None:
+        def __init__(self, destination: str, dev: Optional[str] = None, proto: Optional[str] = None, metric: Optional[int] = None, pref: Optional[str] = None, via: Optional[str] = None, **kwargs) -> None:
              self.destination: str = destination
              self.via: Optional[str] = via
              self.dev: Optional[str] = dev
@@ -77,7 +77,7 @@ contents:
 
         @classmethod
         def from_line(cls: Type[TR], line: str) -> TR:
-            items = line.split()
+            items = [i for i in line.split() if i != '\\']
             dest = items[0]
             if dest == 'default':
                 dest = '::/0'


### PR DESCRIPTION
In my deployments I am seeing routes that include fields the
non_virtual_ip script can't handle. This causes it to fail and anything
relying on it to function incorrectly.

This change adds a **kwargs parameter to the class constructor so
it will take arbitrary params that we will then ignore. It also
filters out \ characters from the routes because I'm seeing that
as well and we don't want to try to parse it. The \ appears in
multi-line routes that can't be handled correctly by the existing
structure of the class because they have multiple 'via' values and
the class can only handle one per route. However, this is happening
only on the default route in my case, which we ignore anyway, and
this script is being replaced by a Go implementation in the near
future so I don't think it's worth rewriting it to handle multi-line
routes.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
