### PR TITLE
pkg/operator: clear Degraded on task's success

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -63,6 +63,9 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		if syncErr.err != nil {
 			break
 		}
+		if err := optr.clearDegradedStatus(sf.name); err != nil {
+			return fmt.Errorf("error clearing degraded status: %v", err)
+		}
 	}
 
 	if err := optr.syncDegradedStatus(syncErr); err != nil {


### PR DESCRIPTION
The MCO runs a bunch of sync functions during its sync. Each of these functions has
a name (a task name). When we loop through the sync functions and fail on any of them,
the MCO breaks and reports the Degraded status for that task as Reason: TaskNameFailed.
It then goes and retries all the sync functions (no change in behavior till here).
During some debugging and testing I've noticed that the RenderConfig task failed with the
version mismatch error for osImageURL. That is good, and also right. The MCO went ahead
and set the Degraded condition to RenderConfigFailed (correctly!). The MCO then went again
and re-tried all the sync functions. Now the RenderConfig task succeeded (the version mismatch error
can indeed be temporary). What happened from now on is that the MCO kept rolling and eventually finishes
the upgrade I was running but the RenderConfigFailed Degraded status was never cleared back to False
even if the task _did_ succeed (I had to wait for all the sync functions to finish as expected, and it takes a while still reporting degraded).
This patch introduces a new function which we call after every sync function in order to clear
any previous degraded status when it instead succeeded in later syncs.

Signed-off-by: Antonio Murdaca <runcom@linux.com>