### PR TITLE
Revert "cri-o: set manage_ns_lifecycle to true"

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -171,9 +171,9 @@ contents:
     # regarding the proper termination of the container.
     ctr_stop_timeout = 0
 
-    # ManageNSLifecycle determines whether we pin and remove namespaces
-    # and manage their lifecycle.
-    manage_ns_lifecycle = true
+    # ManageNetworkNSLifecycle determines whether we pin and remove network namespace
+    # and manage its lifecycle.
+    manage_network_ns_lifecycle = false
 
     # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
     # The runtime to use is picked based on the runtime_handler provided by the CRI.

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -171,9 +171,9 @@ contents:
     # regarding the proper termination of the container.
     ctr_stop_timeout = 0
 
-    # ManageNSLifecycle determines whether we pin and remove namespaces
-    # and manage their lifecycle.
-    manage_ns_lifecycle = true
+    # ManageNetworkNSLifecycle determines whether we pin and remove network namespace
+    # and manage its lifecycle.
+    manage_network_ns_lifecycle = false
 
     # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
     # The runtime to use is picked based on the runtime_handler provided by the CRI.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This reverts commit 9b3e28d2f6bf884c3903581ac96ee2e690df5c86.
there were some breakages with third party networking plugins as the network ns path changed unexpectedly. revert the switch to cri-o managing namespace lifecycle until this problem is fixed

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
CRI-O is no longer managing namespace lifecycle