### PR TITLE
[fcos] machine-config-daemon-firstboot: retry podman pull

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service
@@ -14,7 +14,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.setupEtcdEnvKey }}'
+  ExecStart=/usr/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.setupEtcdEnvKey }}'; do sleep 5; done"
   ExecStart=/usr/bin/sh -c "/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --quiet --net=host --entrypoint=cat '{{ .Images.setupEtcdEnvKey }}' /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon"
   ExecStart=/usr/bin/chmod +x /usr/local/bin/machine-config-daemon
   ExecStart=/usr/sbin/restorecon /usr/local/bin/machine-config-daemon


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Wrapped "podman pull <machine-config-daemon container>" in a retry loop

**- How to verify it**
Run OKD install when registry.svc.ci.openshift.org is unstable. Less flakes are expected on CI / user installs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixes https://github.com/openshift/okd/issues/124
