### PR TITLE
[baremetal] Update keepalived Liveness check

### DIFF
--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -80,12 +80,11 @@ contents:
         livenessProbe:
           exec:
             command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
-              [[ -s /etc/keepalived/keepalived.conf ]] || \
               kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
-          initialDelaySeconds: 10
+          initialDelaySeconds: 20
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: keepalived-monitor


### PR DESCRIPTION
Update Liveness probe for keepalived container to check also keepalived process existence, 
with this fix if for some reason keepalived process exits - kubelet will automatically restart the container. 
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
