### PR TITLE
install: add kube-rbac-proxy daemonset to protect crio /metrics endpoint

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -39,6 +39,7 @@ var (
 		mcoImage                  string
 		mdnsPublisherImage        string
 		oauthProxyImage           string
+		kubeRBACProxyImage        string
 		networkConfigFile         string
 		oscontentImage            string
 		pullSecretFile            string
@@ -81,6 +82,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oauthProxyImage, "oauth-proxy-image", "", "Image for origin oauth proxy.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeRBACProxyImage, "kube-rbac-proxy-image", "", "Image for origin kube-rbac-proxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.cloudProviderCAFile, "cloud-provider-ca-file", "", "path to cloud provider CA certificate")
 
 }
@@ -111,6 +113,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 			MdnsPublisher:       bootstrapOpts.mdnsPublisherImage,
 			Haproxy:             bootstrapOpts.haproxyImage,
 			BaremetalRuntimeCfg: bootstrapOpts.baremetalRuntimeCfgImage,
+			KubeRBACProxy:       bootstrapOpts.kubeRBACProxyImage,
 		},
 	}
 

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -17,5 +17,6 @@ data:
       "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",
       "haproxyImage": "registry.svc.ci.openshift.org/openshift:haproxy-router",
       "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg",
-      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy"
+      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy",
+      "kubeRbacProxy": "registry.svc.ci.openshift.org/openshift:kube-rbac-proxy"
     }

--- a/install/0000_90_machine-config-operator_01-service.yaml
+++ b/install/0000_90_machine-config-operator_01-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: crio-tls
+  labels:
+    app.kubernetes.io/name: kube-rbac-proxy
+    app.kubernetes.io/version: v0.4.1
+  name: crio
+  namespace: openshift-node
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9999
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: kube-rbac-proxy
+    app.kubernetes.io/version: v0.4.1

--- a/install/0000_90_machine-config-operator_02-role.yaml
+++ b/install/0000_90_machine-config-operator_02-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crio
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - crio
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/install/0000_90_machine-config-operator_03-role-binding.yaml
+++ b/install/0000_90_machine-config-operator_03-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crio
+subjects:
+- kind: ServiceAccount
+  name: crio
+  namespace: openshift-node

--- a/install/0000_90_machine-config-operator_04-scc.yaml
+++ b/install/0000_90_machine-config-operator_04-scc.yaml
@@ -1,0 +1,13 @@
+allowHostNetwork: true
+allowHostPorts: true
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: crio scc is used for securing cri-o metrics endpoint
+  name: crio
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users: []

--- a/install/0000_90_machine-config-operator_05-service-account.yaml
+++ b/install/0000_90_machine-config-operator_05-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crio
+  namespace: openshift-node

--- a/install/0000_90_machine-config-operator_06-daemonset.yaml
+++ b/install/0000_90_machine-config-operator_06-daemonset.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-rbac-proxy
+    app.kubernetes.io/version: v0.4.1
+  name: crio
+  namespace: openshift-node
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-rbac-proxy
+      app.kubernetes.io/version: v0.4.1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-rbac-proxy
+        app.kubernetes.io/version: v0.4.1
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9999
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:9537/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.0.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+          name: https
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: crio-tls
+          readOnly: false
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext: {}
+      serviceAccountName: crio
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: crio-tls
+        secret:
+          secretName: crio-tls

--- a/install/0000_90_machine-config-operator_07-service-monitor.yaml
+++ b/install/0000_90_machine-config-operator_07-service-monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-rbac-proxy
+    app.kubernetes.io/version: v0.4.1
+  name: crio
+  namespace: openshift-node
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/ca-bundle.crt
+      insecureSkipVerify: false
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - openshift-node
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-rbac-proxy
+      app.kubernetes.io/version: v0.4.1

--- a/install/image-references
+++ b/install/image-references
@@ -59,3 +59,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -37,4 +37,5 @@ type ControllerConfigImages struct {
 	MdnsPublisher       string `json:"mdnsPublisherImage"`
 	Haproxy             string `json:"haproxyImage"`
 	BaremetalRuntimeCfg string `json:"baremetalRuntimeCfgImage"`
+	KubeRBACProxy       string `json:"kubeRBACProxy"`
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added kube-rbac-proxy DaemonSet for exposing and securing crio /metrics endpoint

https://issues.redhat.com/browse/OCPNODE-321

**- How to verify it**
1. Start a cluster
2. Go to prometheus UI targets page
3. Check if crio job is scraping targets over HTTPS

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
add kube-rbac-proxy daemonset to protect crio /metrics endpoint

/cc @rphillips 