### PR TITLE
OWNERS: add BZ component name

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,5 @@ approvers:
   - runcom
   - sinnykumari
   - yuqi-zhang
+
+component: "Machine Config Operator"


### PR DESCRIPTION
We need to add this now to efficiently route BZs.

Signed-off-by: Antonio Murdaca <runcom@linux.com>