### PR TITLE
cri-o: set log level to info

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -155,7 +155,7 @@ contents:
     # Changes the verbosity of the logs based on the level it is set to. Options
     # are fatal, panic, error, warn, info, and debug. This option supports live
     # configuration reload.
-    log_level = "error"
+    log_level = "info"
 
     # The UID mappings for the user namespace of each container. A range is
     # specified in the form containerUID:HostUID:Size. Multiple ranges must be

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -155,7 +155,7 @@ contents:
     # Changes the verbosity of the logs based on the level it is set to. Options
     # are fatal, panic, error, warn, info, and debug. This option supports live
     # configuration reload.
-    log_level = "error"
+    log_level = "info"
 
     # The UID mappings for the user namespace of each container. A range is
     # specified in the form containerUID:HostUID:Size. Multiple ranges must be


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
set log level to info as it's difficult to debug with cri-o only set to log level error
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
set default log level to info for CRI-O