### PR TITLE
Bug 1820823: [4.4] sdn: ignore new ovn-kubernetes OVS internal port names ovn-k8s-gw0 and ovn-k8s-mp0

### DIFF
--- a/templates/common/_base/files/nm-ignore-sdn.yaml
+++ b/templates/common/_base/files/nm-ignore-sdn.yaml
@@ -5,5 +5,5 @@ contents:
   inline: |
     # ignore known SDN-managed devices
     [device]
-    match-device=interface-name:br-int;interface-name:br-local;interface-name:br-nexthop,interface-name:k8s-*;interface-name:tun0;interface-name:br0;driver:veth
+    match-device=interface-name:br-int;interface-name:br-local;interface-name:br-nexthop,interface-name:ovn-k8s-*,interface-name:k8s-*;interface-name:tun0;interface-name:br0;driver:veth
     managed=0


### PR DESCRIPTION
To prevent racing with NetworkManager's OVS plugin resulting in IP addresses sometimes being cleared from the OVS internal ports that openshift-sdn and ovn-kubernetes set up, we must tell NM to ignore those ports.

@trozet @danwinship @squeed @openshift/networking

backport of https://github.com/openshift/machine-config-operator/pull/1614