### PR TITLE
Bug 1821798: OpenStack: disable tx checksum offload for workers

### DIFF
--- a/templates/worker/00-worker/openstack/files/openstack-disable-tx-checksum-offload.yaml
+++ b/templates/worker/00-worker/openstack/files/openstack-disable-tx-checksum-offload.yaml
@@ -1,0 +1,10 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-tx-checksum-offload.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    # This is a workaround for BZ#1794714
+    if [[ ! -e /var/lib/cni/bin/ovn-k8s-cni-overlay ]]; then
+      nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-checksum-ip-generic off;
+    fi


### PR DESCRIPTION
This patch adds the workaround suggested on [1]
to make nodeport work, instead of ethtool we use
NM to apply the fix for each connction before it is up.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1794714

Brings the following ovirt fixes to openstack platform:
- #1606
- #1621