### PR TITLE
Bug 1821005: oVirt, fix disable tx checksum offload for workers

### DIFF
--- a/templates/worker/00-worker/ovirt/files/ovirt-disable-tx-checksum-offload.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-disable-tx-checksum-offload.yaml
@@ -5,6 +5,6 @@ contents:
   inline: |
     #!/bin/bash
     # This is a workaround for BZ#1794714
-    if [[ -e /var/lib/cni/bin/openshift-sdn ]]; then
+    if [[ ! -e /var/lib/cni/bin/ovn-k8s-cni-overlay ]]; then
       nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-checksum-ip-generic off;
     fi


### PR DESCRIPTION
On PR [1] we added a workaround for Bug [2], this
fails when the worker starts for the first time since openshift-sdn
is created only when the sdn pod is starting.
Instead we will disable by default and enable tx-checksum offload\
only when running with OVNkubernetes

[1] On PR https://github.com/openshift/machine-config-operator/pull/1606,
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1794714

Signed-off-by: Gal Zaidman <gzaidman@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
