### PR TITLE
baremetal: static hostname to prevent DNS lookup

### DIFF
--- a/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -7,7 +7,7 @@ contents:
     IFACE=$1
     STATUS=$2
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
-    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" ]] && hostname $DHCP6_FQDN_FQDN
+    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."

--- a/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -7,7 +7,7 @@ contents:
     IFACE=$1
     STATUS=$2
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
-    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" ]] && hostname $DHCP6_FQDN_FQDN
+    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."


### PR DESCRIPTION
When keepalived sets the VIP, it triggers a connection event in
NetworkManager that, since the name we set from DHCP was transient it
would do a reverse lookup on the connection address. Unfortunately, NM
does not filter out the deprecated VIP for the reverse lookup and ends
up overriding the hostname with DNS names that map to VIPs configured in
the system.

This fix is a workaround that on environments that have DHCP provide the
hostname, will prevent the erroneous behavior of NM by setting DHCP
provided FQDN addresses as static, which prevents NM from doing further
address lookups.

On hostname-less DHCP environments we'd want to hook to the hostname
event in NM and make sure that the first one that does not map to a VIP
is the one that gets set as static.