### PR TITLE
Bug 1821833: The Multus CNI configuration file "00-multus.conf" should not be removed

### DIFF
--- a/templates/common/_base/files/cleanup-cni-conf.yaml
+++ b/templates/common/_base/files/cleanup-cni-conf.yaml
@@ -5,6 +5,5 @@ contents:
   inline: |
     r /etc/kubernetes/cni/net.d/80-openshift-network.conf
     r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
-    r /etc/kubernetes/cni/net.d/00-multus.conf
     d /run/multus/cni/net.d/ 0755 root root - -
     D /var/lib/cni/networks/openshift-sdn/ 0755 root root - -


### PR DESCRIPTION
This is due to the fact that we'd like the nodes to come into a "Ready" state
sooner during an upgrade. Multus CNI has the ability to wait for an indication
of the readiness of the default CNI network (typically, openshift-sdn)
