### PR TITLE
Deprecate Platform field on ControllerConfig CRD

### DIFF
--- a/examples/cluster.controllerconfig.yaml
+++ b/examples/cluster.controllerconfig.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   clusterDNSIP: "10.3.0.10"
   clusterName: "adahiya-0"
-  platform: "libvirt"
+  infra:
+    status:
+      platformStatus: 
+        type: "Libvirt"
   baseDomain: "tt.testing"
   etcdInitialCount: 1

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -75,6 +75,11 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
 	setBytesIfSet(modified, &existing.CloudProviderCAData, required.CloudProviderCAData)
 
+	if !equality.Semantic.DeepEqual(existing.Infra.Status.PlatformStatus.Type, required.Infra.Status.PlatformStatus.Type) {
+		*modified = true
+		existing.Infra.Status.PlatformStatus.Type = required.Infra.Status.PlatformStatus.Type
+	}
+
 	if !equality.Semantic.DeepEqual(existing.Proxy, required.Proxy) {
 		*modified = true
 		existing.Proxy = required.Proxy

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -86,8 +86,7 @@ spec:
               additionalProperties:
                 type: string
             infra:
-              description: infra holds the infrastructure details TODO this makes
-                platform redundant as everything is contained inside Infra.Status
+              description: infra holds the infrastructure details
               type: object
               required:
               - spec
@@ -352,8 +351,7 @@ spec:
                 field on the machine-config-osimageurl ConfigMap.
               type: string
             platform:
-              description: The openshift platform, e.g. "libvirt", "openstack", "gcp",
-                "baremetal", "aws", or "none"
+              description: platform is deprecated. Use infra.status.platformStatus.type instead
               type: string
             proxy:
               description: proxy holds the current proxy configuration for the nodes

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -37,10 +37,8 @@ type ControllerConfigSpec struct {
 	// cloudProviderConfig is the configuration for the given cloud provider
 	CloudProviderConfig string `json:"cloudProviderConfig"`
 
-	// TODO: Use PlatformType instead of string
-
-	// The openshift platform, e.g. "libvirt", "openstack", "gcp", "baremetal", "aws", or "none"
-	Platform string `json:"platform"`
+	// platform is deprecated, use Infra.Status.PlatformStatus.Type instead
+	Platform string `json:"platform,omitempty"`
 
 	// etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain instead
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain,omitempty"`
@@ -86,7 +84,6 @@ type ControllerConfigSpec struct {
 	Proxy *configv1.ProxyStatus `json:"proxy"`
 
 	// infra holds the infrastructure details
-	// TODO this makes platform redundant as everything is contained inside Infra.Status
 	// +nullable
 	Infra *configv1.Infrastructure `json:"infra"`
 

--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -32,12 +32,10 @@ spec:
       apiServerURL: https://api.domain.example.com:6443
       etcdDiscoveryDomain: domain.example.com
       infrastructureName: lab-0aaaa
-      platform: None
       platformStatus:
         type: None
   kubeAPIServerServingCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCktVQkUgQVBJIFNFUlZFUiBTRVJWSU5HIENBIERBVEEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   osImageURL: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-  platform: none
   proxy: null
   rootCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClJPT1QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
   

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -101,7 +101,7 @@ func (f *fixture) validateActions() {
 	}
 }
 
-func newControllerConfig(name, platform string) *mcfgv1.ControllerConfig {
+func newControllerConfig(name string, platform apicfgv1.PlatformType) *mcfgv1.ControllerConfig {
 	cc := &mcfgv1.ControllerConfig{
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
@@ -109,9 +109,11 @@ func newControllerConfig(name, platform string) *mcfgv1.ControllerConfig {
 			Infra: &apicfgv1.Infrastructure{
 				Status: apicfgv1.InfrastructureStatus{
 					EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
+					PlatformStatus: &apicfgv1.PlatformStatus{
+						Type: platform,
+					},
 				},
 			},
-			Platform: platform,
 		},
 	}
 	return cc
@@ -397,8 +399,8 @@ var ctrcfgPatchBytes = []uint8{0x7b, 0x22, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0
 // TestContainerRuntimeConfigCreate ensures that a create happens when an existing containerruntime config is created.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestContainerRuntimeConfigCreate(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -434,8 +436,8 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 // TestContainerRuntimeConfigUpdate ensures that an update happens when an existing containerruntime config is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestContainerRuntimeConfigUpdate(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -515,8 +517,8 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 // TestImageConfigCreate ensures that a create happens when an image config is created.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestImageConfigCreate(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -557,8 +559,8 @@ func TestImageConfigCreate(t *testing.T) {
 // TestImageConfigUpdate ensures that an update happens when an existing image config is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestImageConfigUpdate(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -653,8 +655,8 @@ func TestImageConfigUpdate(t *testing.T) {
 // TestICSPUpdate ensures that an update happens when an existing ICSP is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestICSPUpdate(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -758,8 +760,8 @@ func TestICSPUpdate(t *testing.T) {
 func TestRunImageBootstrap(t *testing.T) {
 	emptyImgCfg := &apicfgv1.Image{}
 
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			pools := []*mcfgv1.MachineConfigPool{
 				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -96,7 +96,7 @@ func newFeatures(name string, enabled, disabled []string, labels map[string]stri
 	}
 }
 
-func newControllerConfig(name, platform string) *mcfgv1.ControllerConfig {
+func newControllerConfig(name string, platform osev1.PlatformType) *mcfgv1.ControllerConfig {
 	cc := &mcfgv1.ControllerConfig{
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
@@ -104,9 +104,11 @@ func newControllerConfig(name, platform string) *mcfgv1.ControllerConfig {
 			Infra: &osev1.Infrastructure{
 				Status: osev1.InfrastructureStatus{
 					EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
+					PlatformStatus: &osev1.PlatformStatus{
+						Type: platform,
+					},
 				},
 			},
-			Platform: platform,
 		},
 	}
 	return cc
@@ -316,8 +318,8 @@ func (f *fixture) expectUpdateKubeletConfig(config *mcfgv1.KubeletConfig) {
 }
 
 func TestKubeletConfigCreate(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -349,8 +351,8 @@ func TestKubeletConfigCreate(t *testing.T) {
 }
 
 func TestKubeletConfigUpdates(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -510,8 +512,8 @@ func TestKubeletConfigBlacklistedOptions(t *testing.T) {
 }
 
 func TestKubeletFeatureExists(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "Unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/vincent-petithory/dataurl"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -12,8 +13,8 @@ import (
 )
 
 func TestFeatureGateDrift(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
@@ -37,8 +38,8 @@ func TestFeatureGateDrift(t *testing.T) {
 }
 
 func TestFeaturesDefault(t *testing.T) {
-	for _, platform := range []string{"aws", "none", "unrecognized"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/golang/glog"
+	configv1 "github.com/openshift/api/config/v1"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -26,20 +27,9 @@ type RenderConfig struct {
 }
 
 const (
-	filesDir = "files"
-	unitsDir = "units"
-
-	// TODO: these constants are wrong, they should match what is reported by the infrastructure provider
-	platformAWS       = "aws"
-	platformAzure     = "azure"
-	platformBaremetal = "baremetal"
-	platformGCP       = "gcp"
-	platformOpenStack = "openstack"
-	platformLibvirt   = "libvirt"
-	platformNone      = "none"
-	platformVSphere   = "vsphere"
-	platformBase      = "_base"
-	platformOvirt     = "ovirt"
+	filesDir     = "files"
+	unitsDir     = "units"
+	platformBase = "_base"
 )
 
 // generateTemplateMachineConfigs returns MachineConfig objects from the templateDir and a config object
@@ -130,21 +120,34 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 	return cfgs, nil
 }
 
-func platformFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, error) {
-	switch ic.Platform {
+func platformStringFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, error) {
+	if ic.Infra == nil {
+		ic.Infra = &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{},
+		}
+	}
+
+	if ic.Infra.Status.PlatformStatus == nil {
+		ic.Infra.Status.PlatformStatus = &configv1.PlatformStatus{
+			Type: "",
+		}
+	}
+
+	switch ic.Infra.Status.PlatformStatus.Type {
 	case "":
 		// if Platform is nil, return nil platform and an error message
-		return "", fmt.Errorf("cannot generate MachineConfigs when no platform is set")
+		return "", fmt.Errorf("cannot generate MachineConfigs when no platformStatus.type is set")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case platformAWS, platformAzure, platformBaremetal, platformGCP, platformOpenStack, platformLibvirt, platformOvirt, platformVSphere, platformNone:
-		return ic.Platform, nil
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.NonePlatformType:
+		return strings.ToLower(string(ic.Infra.Status.PlatformStatus.Type)), nil
 	default:
 		// platformNone is used for a non-empty, but currently unsupported platform.
 		// This allows us to incrementally roll out new platforms across the project
 		// by provisioning platforms before all support is added.
-		glog.Warningf("Warning: the controller config referenced an unsupported platform: %s", ic.Platform)
-		return platformNone, nil
+		glog.Warningf("Warning: the controller config referenced an unsupported platform: %v", ic.Infra.Status.PlatformStatus.Type)
+
+		return strings.ToLower(string(configv1.NonePlatformType)), nil
 	}
 }
 
@@ -181,7 +184,7 @@ func filterTemplates(toFilter map[string]string, path string, config *RenderConf
 }
 
 func generateMachineConfigForName(config *RenderConfig, role, name, templateDir, path string, commonAdded *bool) (*mcfgv1.MachineConfig, error) {
-	platform, err := platformFromControllerConfigSpec(config.ControllerConfigSpec)
+	platformString, err := platformStringFromControllerConfigSpec(config.ControllerConfigSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +192,7 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 	platformDirs := []string{}
 	if !*commonAdded {
 		// Loop over templates/common which applies everywhere
-		for _, dir := range []string{platformBase, platform} {
+		for _, dir := range []string{platformBase, platformString} {
 			basePath := filepath.Join(templateDir, "common", dir)
 			exists, err := existsDir(basePath)
 			if err != nil {
@@ -203,7 +206,7 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 		*commonAdded = true
 	}
 	// And now over the target e.g. templates/master/00-master,01-master-container-runtime,01-master-kubelet
-	for _, dir := range []string{platformBase, platform} {
+	for _, dir := range []string{platformBase, platformString} {
 		platformPath := filepath.Join(path, dir)
 		exists, err := existsDir(platformPath)
 		if err != nil {
@@ -419,10 +422,10 @@ func etcdMetricCertCommand(cfg RenderConfig) (interface{}, error) {
 }
 
 func cloudProvider(cfg RenderConfig) (interface{}, error) {
-	switch cfg.Platform {
-	case platformAWS, platformAzure, platformOpenStack, platformVSphere:
-		return cfg.Platform, nil
-	case platformGCP:
+	switch cfg.Infra.Status.PlatformStatus.Type {
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
+		return strings.ToLower(string(cfg.Infra.Status.PlatformStatus.Type)), nil
+	case configv1.GCPPlatformType:
 		return "gce", nil
 	default:
 		return "", nil
@@ -441,9 +444,22 @@ func cloudConfigFlag(cfg RenderConfig) interface{} {
 	if cfg.CloudProviderConfig == "" {
 		return ""
 	}
+
+	if cfg.Infra == nil {
+		cfg.Infra = &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{},
+		}
+	}
+
+	if cfg.Infra.Status.PlatformStatus == nil {
+		cfg.Infra.Status.PlatformStatus = &configv1.PlatformStatus{
+			Type: "",
+		}
+	}
+
 	flag := "--cloud-config=/etc/kubernetes/cloud.conf"
-	switch cfg.Platform {
-	case platformAWS, platformAzure, platformGCP, platformOpenStack, platformVSphere:
+	switch cfg.Infra.Status.PlatformStatus.Type {
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
 		return flag
 	default:
 		return ""

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -64,9 +64,11 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 			Infra: &configv1.Infrastructure{
 				Status: configv1.InfrastructureStatus{
 					EtcdDiscoveryDomain: fmt.Sprintf("%s.openshift.testing", name),
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.LibvirtPlatformType,
+					},
 				},
 			},
-			Platform: "libvirt",
 			PullSecret: &corev1.ObjectReference{
 				Namespace: "default",
 				Name:      "coreos-pull-secret",

--- a/pkg/controller/template/test_data/controller_config_aws.yaml
+++ b/pkg/controller/template/test_data/controller_config_aws.yaml
@@ -4,7 +4,6 @@ spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
   etcdInitialCount: 3
-  platform: "aws"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -22,3 +21,5 @@ spec:
       apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
+      platformStatus:
+        type: "AWS"

--- a/pkg/controller/template/test_data/controller_config_baremetal.yaml
+++ b/pkg/controller/template/test_data/controller_config_baremetal.yaml
@@ -4,7 +4,6 @@ spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
   etcdInitialCount: 3
-  platform: "baremetal"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -27,6 +26,7 @@ spec:
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
       platformStatus:
+        type: "BareMetal"
         baremetal:
           apiServerInternalIP: 10.0.0.1
           ingressIP: 10.0.0.2

--- a/pkg/controller/template/test_data/controller_config_gcp.yaml
+++ b/pkg/controller/template/test_data/controller_config_gcp.yaml
@@ -4,7 +4,6 @@ spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
   etcdInitialCount: 3
-  platform: "gcp"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -22,3 +21,5 @@ spec:
       apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
+      platformStatus:
+        type: "GCP"

--- a/pkg/controller/template/test_data/controller_config_libvirt.yaml
+++ b/pkg/controller/template/test_data/controller_config_libvirt.yaml
@@ -4,7 +4,6 @@ spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
   etcdInitialCount: 3
-  platform: "libvirt"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -22,3 +21,5 @@ spec:
       apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
+      platformStatus:
+        type: "Libvirt"

--- a/pkg/controller/template/test_data/controller_config_none.yaml
+++ b/pkg/controller/template/test_data/controller_config_none.yaml
@@ -4,7 +4,6 @@ spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
   etcdInitialCount: 3
-  platform: "none"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -22,3 +21,5 @@ spec:
       apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
+      platformStatus:
+        type: "None"

--- a/pkg/controller/template/test_data/controller_config_openstack.yaml
+++ b/pkg/controller/template/test_data/controller_config_openstack.yaml
@@ -8,7 +8,6 @@ spec:
     [test]
       option = dummy
   etcdInitialCount: 3
-  platform: "openstack"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -27,6 +26,7 @@ spec:
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
       platformStatus:
+        type: "OpenStack"
         openstack:
           apiServerInternalIP: 10.0.0.1
           ingressIP: 10.0.0.2

--- a/pkg/controller/template/test_data/controller_config_ovirt.yaml
+++ b/pkg/controller/template/test_data/controller_config_ovirt.yaml
@@ -8,7 +8,6 @@ spec:
     [test]
       option = dummy
   etcdInitialCount: 3
-  platform: "ovirt"
   etcdCAData: OHVtbXkgZXRjZC1jYQo=
   rootCAData: OHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -26,3 +25,5 @@ spec:
       apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
+      platformStatus:
+        type: "oVirt"

--- a/pkg/controller/template/test_data/controller_config_vsphere.yaml
+++ b/pkg/controller/template/test_data/controller_config_vsphere.yaml
@@ -8,7 +8,6 @@ spec:
     [test]
       option = dummy
   etcdInitialCount: 3
-  platform: "vsphere"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=
   rootCAData: ZHVtbXkgcm9vdC1jYQo=
   pullSecret:
@@ -27,6 +26,7 @@ spec:
       etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
       infrastructureName: my-test-cluster
       platformStatus:
+        type: "VSphere"
         vsphere:
           apiServerInternalIP: 10.0.0.1
           ingressIP: 10.0.0.2

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -540,8 +540,7 @@ spec:
               additionalProperties:
                 type: string
             infra:
-              description: infra holds the infrastructure details TODO this makes
-                platform redundant as everything is contained inside Infra.Status
+              description: infra holds the infrastructure details
               type: object
               required:
               - spec
@@ -806,8 +805,7 @@ spec:
                 field on the machine-config-osimageurl ConfigMap.
               type: string
             platform:
-              description: The openshift platform, e.g. "libvirt", "openstack", "gcp",
-                "baremetal", "aws", or "none"
+              description: platform is deprecated. Use infra.status.platformStatus.type instead
               type: string
             proxy:
               description: proxy holds the current proxy configuration for the nodes

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -2,9 +2,10 @@ package operator
 
 import (
 	"fmt"
-	configv1 "github.com/openshift/api/config/v1"
 	"strings"
 	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func TestClusterDNSIP(t *testing.T) {
@@ -192,7 +193,7 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 			Spec: configv1.NetworkSpec{ServiceNetwork: []string{}}},
 		Error: true,
 	}, {
-		// Test old Platform field instead of PlatformStatus
+		// Test old Infra.Status.Platform field instead of Infra.Status.PlatformStatus
 		Infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
 				Platform:            configv1.AWSPlatformType,
@@ -217,7 +218,7 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 			}
 			if controllerConfigSpec == nil {
 				t.Fatalf("Controller config spec did not get initialized")
-			} else if controllerConfigSpec.Platform == "" {
+			} else if controllerConfigSpec.Infra.Status.PlatformStatus.Type == "" {
 				t.Fatalf("Error setting controller config platform")
 			}
 			etcdDomain := controllerConfigSpec.Infra.Status.EtcdDiscoveryDomain


### PR DESCRIPTION
Currently ControllerConfig.Platform and
ControllerConfig.Infra.Status.PlatformStatus.Type contain redundant
information. However, the former is encoded as untyped string and the
latter as configv1.PlatformType.

This deprecates the ControllerConfig.Platform field and leaves
ControllerConfig.Infra.Status.PlatformStatus.Type as the
canonical platform identifier, making all internals consume that field
instead.