### PR TITLE
Makefile: Drop -mod=vendor flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,6 @@ export GOPROXY=https://proxy.golang.org
 
 GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 
-# grab the version from a dummy pkg in k8s.io/code-generator from vendor/modules.txt (read by go list)
-versionPath=$(shell GO111MODULE=on go list -f {{.Dir}} k8s.io/code-generator/cmd/client-gen)
-codegeneratorRoot=$(versionPath:/cmd/client-gen=)
-codegeneratorTarget:=./vendor/k8s.io/code-generator
-
 .PHONY: clean test test-unit test-e2e verify update install-tools
 # Remove build artifaces
 # Example:
@@ -47,7 +42,7 @@ test: test-unit test-e2e
 
 # Unit tests only (no active cluster required)
 test-unit:
-	CGO_ENABLED=0 go test -mod=vendor -tags=$(GOTAGS) -count=1 -v ./cmd/... ./pkg/... ./lib/...
+	CGO_ENABLED=0 go test -tags=$(GOTAGS) -count=1 -v ./cmd/... ./pkg/... ./lib/...
 
 # Run the code generation tasks.
 # Example:
@@ -60,14 +55,13 @@ go-deps:
 	go mod tidy
 	go mod vendor
 	go mod verify
-	# go mod does not vendor in scripts so we need to get them manually...
-	@mkdir -p $(codegeneratorRoot)
-	@cp $(codegeneratorRoot)/generate-groups.sh $(codegeneratorTarget) && chmod +x $(codegeneratorTarget)/generate-groups.sh
-	@cp $(codegeneratorRoot)/generate-internal-groups.sh $(codegeneratorTarget) && chmod +x $(codegeneratorTarget)/generate-internal-groups.sh
+	# make scripts executable
+	chmod +x ./vendor/k8s.io/code-generator/generate-groups.sh
+	chmod +x ./vendor/k8s.io/code-generator/generate-internal-groups.sh
 
 install-tools:
-	GO111MODULE=on go build -o $(GOPATH)/bin/golangci-lint -mod=vendor ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
-	GO111MODULE=on go build -o $(GOPATH)/bin/gosec -mod=vendor ./vendor/github.com/securego/gosec/cmd/gosec
+	GO111MODULE=on go build -o $(GOPATH)/bin/golangci-lint ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
+	GO111MODULE=on go build -o $(GOPATH)/bin/gosec ./vendor/github.com/securego/gosec/cmd/gosec
 
 # Run verification steps
 # Example:
@@ -77,6 +71,10 @@ verify: install-tools
 	# Remove once https://github.com/golangci/golangci-lint/issues/597 is
 	# addressed
 	gosec -severity high --confidence medium -exclude G204 -quiet ./...
+	# Remove once code-generator plays nice with go modules, see
+	# https://github.com/kubernetes/kubernetes/issues/82531 and
+	# https://github.com/kubernetes/kubernetes/pull/85559
+	pushd vendor/k8s.io/code-generator && go mod vendor && popd
 	hack/verify-codegen.sh
 	hack/verify-generated-bindata.sh
 
@@ -105,6 +103,6 @@ Dockerfile.rhel7: Dockerfile Makefile
 	(echo '# THIS FILE IS GENERATED FROM '$<' DO NOT EDIT' && \
 	 sed -e s,org/openshift/release,org/ocp/builder, -e s,/openshift/origin-v4.0:base,/ocp/4.0:base, < $<) > $@.tmp && mv $@.tmp $@
 
-# This was copied from https://github.com/openshift/cluster-image-registry-operato
+# This was copied from https://github.com/openshift/cluster-image-registry-operator
 test-e2e:
-	go test -mod=vendor -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/


### PR DESCRIPTION
This is inferred by the golang-1.13 container now and currently block CI testing

**- What I did**
Makefile: Drop -mod=vendor flag

**- How to verify it**
CI

**- Description for the changelog**
Makefile: Drop -mod=vendor flag
