### PR TITLE
Bug 1820975: oVirt, fix disable tx checksum offload for workers

### DIFF
--- a/templates/worker/00-worker/ovirt/files/ovirt-disable-tx-checksum-offload.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-disable-tx-checksum-offload.yaml
@@ -1,0 +1,10 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-tx-checksum-offload.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    # This is a workaround for BZ#1794714
+    if [[ ! -e /var/lib/cni/bin/ovn-k8s-cni-overlay ]]; then
+      nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-checksum-ip-generic off;
+    fi


### PR DESCRIPTION
We need to disable tx checksum offload on worker nodes due to BZ#1794714.
This is currenly a workaround and is tracked for removal on BZ#18.

Signed-off-by: Gal Zaidman <gzaidman@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
