### PR TITLE
Bug 1820785: [baremetal] Correctly handle both ipv4 and ipv6 for ingress records

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -10,9 +10,9 @@
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+    template IN ANY {{ .ControllerConfig.EtcdDiscoveryDomain }} {
         match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
-        answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -110,9 +110,9 @@ var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
         {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
+    template IN ANY {{ .ControllerConfig.EtcdDiscoveryDomain }} {
         match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
-        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
 }

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -15,9 +15,9 @@ contents:
             {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .EtcdDiscoveryDomain }}
             fallthrough
         }
-        template IN A {{ .EtcdDiscoveryDomain }} {
+        template IN ANY {{ .EtcdDiscoveryDomain }} {
             match .*.apps.{{ .EtcdDiscoveryDomain }}
-            answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
             fallthrough
         }
     }


### PR DESCRIPTION
The template plugin entries for the ingress *.apps addresses were
hard-coded for ipv4 A records, but we need to also be able to handle
ipv6 AAAA records. Otherwise queries for those addresses in ipv6
environments will fail because the values returned are not valid
ipv4.

This change makes the plugin handle any type of query for those and
templates the type of the query into the response so A queries will
return A records and AAAA queries will return AAAA records.

Closes: #1820785