### PR TITLE
Add containernetworking-plugin RPM's bin location to CRI-O config

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -249,6 +249,7 @@ contents:
     # Paths to directories where CNI plugin binaries are located.
     plugin_dirs = [
         "/var/lib/cni/bin",
+        "/usr/libexec/cni",
     ]
 
     # A necessary configuration for Prometheus based metrics retrieval

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -249,6 +249,7 @@ contents:
     # Paths to directories where CNI plugin binaries are located.
     plugin_dirs = [
         "/var/lib/cni/bin",
+        "/usr/libexec/cni",
     ]
 
     # A necessary configuration for Prometheus based metrics retrieval


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #"
-->

**- What I did**

RHCOS is shipped with `containernetworking-plugins` (which is a dependency for CRI-O and podman), ex:

```
$ rpm -qa | grep containernetwo
containernetworking-plugins-0.8.3-4.module+el8.1.1+5259+bcdd613a.x86_64
```
These binaries are needed for rudimentary networking actions and the CNO has a much more intricate way of copying the binaries on the host by checking `/etc/os-release` and selecting the right binary depending on the underlying OS. 

Since the rpm exist, let's just add the unpacked RPM's bin location to CRI-O's config so that it can look there. The final goal of this is to stop copying binaries (at least `loopback`) in the CNO.  

**- How to verify it**


**- Description for the changelog**

Add containernetworking-plugin RPM's bin location to CRI-O config

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
