### PR TITLE
Bug 1821888: controller: do not error on empty Ignition configs

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -138,7 +138,7 @@ func findRegistriesConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 func findPolicyJSON(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	ignCfg, report, err := ign.Parse(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Ignition config failed with error: %v\nReport: %v", err, report)
+		return nil, fmt.Errorf("parsing Policy JSON Ignition config failed with error: %v\nReport: %v", err, report)
 	}
 	for _, c := range ignCfg.Storage.Files {
 		if c.Path == policyConfigPath {

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -52,7 +52,7 @@ func createNewDefaultFeatureGate() *osev1.FeatureGate {
 func findKubeletConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	ignCfg, report, err := ign.Parse(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Ignition config failed with error: %v\nReport: %v", err, report)
+		return nil, fmt.Errorf("parsing Kubelet Ignition config failed with error: %v\nReport: %v", err, report)
 	}
 	for _, c := range ignCfg.Storage.Files {
 		if c.Path == "/etc/kubernetes/kubelet.conf" {


### PR DESCRIPTION
With the introduction of rawExtension for Ignition config objects
via https://github.com/openshift/machine-config-operator/pull/996,
we also now use ignition.Parse directly to process the validity of
ignition configs. This will cause machineconfigs without a Ignition
section to fail, which we don't want.

Also modify some error messages for clarity.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>

