### PR TITLE
Bug 1809007: [ctrcfg controller] Use a struct array instead of map when creating new ignitions

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -552,9 +552,9 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 				}
 			}
 
-			ctrRuntimeConfigIgn := createNewIgnition(map[string][]byte{
-				storageConfigPath: storageTOML,
-				crioConfigPath:    crioTOML,
+			ctrRuntimeConfigIgn := createNewIgnition([]ignitionConfig{
+				{filePath: storageConfigPath, data: storageTOML},
+				{filePath: crioConfigPath, data: crioTOML},
 			})
 			rawCtrRuntimeConfigIgn, err := json.Marshal(ctrRuntimeConfigIgn)
 			if err != nil {
@@ -766,9 +766,9 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 			return nil, fmt.Errorf("could not update policy json with new changes: %v", err)
 		}
 	}
-	registriesIgn := createNewIgnition(map[string][]byte{
-		registriesConfigPath: registriesTOML,
-		policyConfigPath:     policyJSON,
+	registriesIgn := createNewIgnition([]ignitionConfig{
+		{filePath: registriesConfigPath, data: registriesTOML},
+		{filePath: policyConfigPath, data: policyJSON},
 	})
 	return &registriesIgn, nil
 }

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -60,26 +60,34 @@ type tomlConfigCRIO struct {
 	} `toml:"crio"`
 }
 
+// ignitionConfig is a struct that holds the filepath and date of the various configs
+// Using a struct array ensures that the order of the ignition files always stay the same
+// ensuring that double MCs are not created due to a change in the order
+type ignitionConfig struct {
+	filePath string
+	data     []byte
+}
+
 type updateConfigFunc func(data []byte, internal *mcfgv1.ContainerRuntimeConfiguration) ([]byte, error)
 
 // createNewIgnition takes a map where the key is the path of the file, and the value is the
 // new data in the form of a byte array. The function returns the ignition config with the
 // updated data.
-func createNewIgnition(configs map[string][]byte) igntypes.Config {
+func createNewIgnition(configs []ignitionConfig) igntypes.Config {
 	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	mode := 0644
 	// Create ignitions
-	for filePath, data := range configs {
+	for _, ignConf := range configs {
 		// If the file is not included, the data will be nil so skip over
-		if data == nil {
+		if ignConf.data == nil {
 			continue
 		}
-		configdu := dataurl.New(data, "text/plain")
+		configdu := dataurl.New(ignConf.data, "text/plain")
 		configdu.Encoding = dataurl.EncodingASCII
 		configTempFile := igntypes.File{
 			Node: igntypes.Node{
 				Filesystem: "root",
-				Path:       filePath,
+				Path:       ignConf.filePath,
 			},
 			FileEmbedded1: igntypes.FileEmbedded1{
 				Mode: &mode,


### PR DESCRIPTION
Fixes #1809007 (https://bugzilla.redhat.com/show_bug.cgi?id=1809007)

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
A map doesn't guarantee order when we are creating new ignitions.
When we update the image CR with blocked registries, the ctrcfg
controller needs to update two files registries.conf and policy.json.
Since we get an update from the image CR about every 20 mins, we compare
the semantics to see if anything has changed. But since the order is not
guaranteed, the controller might think that the semantics is not equal
even if nothing in the data changed. Hence another MC is created, and
everytime we get an update the MC applied to the nodes keeps flipping
back and forth for the 2 possible orders causing the nodes to reboot a
bunch of times. So move to using a struct array to ensure the order is
always the same and we don't have two similar MCs being created.

**- How to verify it**
Update the image.config.openshift.io CR with blocked registries and watch to ensure
that 2 MCs are not created after a few mins or hours.

**- Description for the changelog**
Use a struct array instead of map when creating new ignitions for the container
runtime config controller.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
