### PR TITLE
[release-4.4] Bug 1822748: [ctrcfg controller] Use a struct array instead of map when creating new ignitions

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -549,9 +549,9 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 				tempIgnCfg := ctrlcommon.NewIgnConfig()
 				mc = mtmpl.MachineConfigFromIgnConfig(role, managedKey, &tempIgnCfg)
 			}
-			mc.Spec.Config = createNewIgnition(map[string][]byte{
-				storageConfigPath: storageTOML,
-				crioConfigPath:    crioTOML,
+			mc.Spec.Config = createNewIgnition([]ignitionConfig{
+				{filePath: storageConfigPath, data: storageTOML},
+				{filePath: crioConfigPath, data: crioTOML},
 			})
 
 			mc.SetAnnotations(map[string]string{
@@ -751,9 +751,9 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 			return nil, fmt.Errorf("could not update policy json with new changes: %v", err)
 		}
 	}
-	registriesIgn := createNewIgnition(map[string][]byte{
-		registriesConfigPath: registriesTOML,
-		policyConfigPath:     policyJSON,
+	registriesIgn := createNewIgnition([]ignitionConfig{
+		{filePath: registriesConfigPath, data: registriesTOML},
+		{filePath: policyConfigPath, data: policyJSON},
 	})
 	return &registriesIgn, nil
 }

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -59,26 +59,34 @@ type tomlConfigCRIO struct {
 	} `toml:"crio"`
 }
 
+// ignitionConfig is a struct that holds the filepath and date of the various configs
+// Using a struct array ensures that the order of the ignition files always stay the same
+// ensuring that double MCs are not created due to a change in the order
+type ignitionConfig struct {
+	filePath string
+	data     []byte
+}
+
 type updateConfigFunc func(data []byte, internal *mcfgv1.ContainerRuntimeConfiguration) ([]byte, error)
 
 // createNewIgnition takes a map where the key is the path of the file, and the value is the
 // new data in the form of a byte array. The function returns the ignition config with the
 // updated data.
-func createNewIgnition(configs map[string][]byte) igntypes.Config {
+func createNewIgnition(configs []ignitionConfig) igntypes.Config {
 	tempIgnConfig := ctrlcommon.NewIgnConfig()
 	mode := 0644
 	// Create ignitions
-	for filePath, data := range configs {
+	for _, ignConf := range configs {
 		// If the file is not included, the data will be nil so skip over
-		if data == nil {
+		if ignConf.data == nil {
 			continue
 		}
-		configdu := dataurl.New(data, "text/plain")
+		configdu := dataurl.New(ignConf.data, "text/plain")
 		configdu.Encoding = dataurl.EncodingASCII
 		configTempFile := igntypes.File{
 			Node: igntypes.Node{
 				Filesystem: "root",
-				Path:       filePath,
+				Path:       ignConf.filePath,
 			},
 			FileEmbedded1: igntypes.FileEmbedded1{
 				Mode: &mode,


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

**- What I did**
This is backport of #1637

**- How to verify it**
Update the image.config.openshift.io CR with blocked registries and watch to ensure
that 2 MCs are not created after a few mins or hours.

**- Description for the changelog**
Use a struct array instead of map when creating new ignitions for the container
runtime config controller.