### PR TITLE
Bug 1823677:etcdquorumguard_deployment: pass NSS_SDB_USE_CACHE=no to curl

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -83,9 +83,8 @@ spec:
           declare -r cert="${croot}/system:etcd-peer-${NODE_NAME}.crt"
           declare -r key="${croot}/system:etcd-peer-${NODE_NAME}.key"
           declare -r cacert="$croot/ca.crt"
-          export NSS_SDB_USE_CACHE=no
           [[ -z $cert || -z $key ]] && exit 1
-          echo "curl --silent --max-time 2 --cert \"${cert//:/\:}\" --key \"$key\" --cacert \"$cacert\" \"$health_endpoint\"" > /usr/local/bin/etcd-quorum-guard.sh
+          echo "env NSS_SDB_USE_CACHE=no curl --silent --max-time 2 --cert \"${cert//:/\:}\" --key \"$key\" --cacert \"$cacert\" \"$health_endpoint\"" > /usr/local/bin/etcd-quorum-guard.sh
 
           chmod +x /usr/local/bin/etcd-quorum-guard.sh
           sleep infinity & wait


### PR DESCRIPTION
**- What I did**
Updated the script created by etcd quroum guard deployment to run curl with `NSS_SDB_USE_CACHE=no`

**- How to verify it**
Observe etcd-quorum-guard memory consumption

**- Description for the changelog**
Fixed an issue in 4.5/4.4 which caused memory consumption of readyness probes in etcd-quorum-guard

Initial fix: #705, regression occurred in #1552 
Ref: https://github.com/openshift/okd/issues/146