### PR TITLE
Bug 1823852: pkg/server: disable weak TLS versions

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -47,6 +47,7 @@ func (a *APIServer) Serve() {
 	mcs := &http.Server{
 		Addr:    fmt.Sprintf(":%v", a.port),
 		Handler: a.handler,
+		// We don't want to allow 1.1 as that's old.  This was flagged in a security audit.
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -46,6 +47,9 @@ func (a *APIServer) Serve() {
 	mcs := &http.Server{
 		Addr:    fmt.Sprintf(":%v", a.port),
 		Handler: a.handler,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
 	}
 
 	glog.Infof("Launching server on %s", mcs.Addr)


### PR DESCRIPTION
Coming from an user request but it makes sense as we (OpenShift) use and control
that port.

It's not fully clear to me if we _can_ drop tls < 1.2 but I'm leaning toward so for security reasons

Signed-off-by: Antonio Murdaca <runcom@linux.com>

@cgwalters also ptal