### PR TITLE
pkg/daemon: reuse rpm-ostree code to get currently booted CoreOS host info

### DIFF
--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -49,3 +49,7 @@ func (r RpmOstreeClientMock) PullAndRebase(string, bool) (string, bool, error) {
 func (r RpmOstreeClientMock) GetStatus() (string, error) {
 	return "rpm-ostree mock: blah blah some status here", nil
 }
+
+func (r RpmOstreeClientMock) GetBootedDeployment() (*RpmOstreeDeployment, error) {
+	return &RpmOstreeDeployment{}, nil
+}

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -28,7 +28,7 @@ func TestUpdateOS(t *testing.T) {
 		RunPivotReturns: []error{
 			// First run will return no error
 			nil,
-			// Second rrun will return our expected error
+			// Second run will return our expected error
 			expectedError},
 	}
 


### PR DESCRIPTION
Make GetBootedDeployment() function from rpm-ostree.go public
so that it can be reused.

Follow-up from PR https://github.com/openshift/machine-config-operator/pull/1612