### PR TITLE
Bug 1825948: cloudConfig: read cloud Config from openshift-config-managed/kube-cloud-config ConfigMap

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -504,7 +504,7 @@ func cloudConfigFlag(cfg RenderConfig) interface{} {
 	}
 	flag := "--cloud-config=/etc/kubernetes/cloud.conf"
 	switch cfg.Platform {
-	case platformAzure, platformOpenStack:
+	case platformAWS, platformAzure, platformBaremetal, platformGCP, platformOpenStack, platformOvirt, platformVSphere:
 		return flag
 	default:
 		return ""

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -84,7 +84,18 @@ func TestCloudConfigFlag(t *testing.T) {
 		content:  "",
 		res:      "",
 	}, {
+		platform: "libvirt",
+		content:  "",
+		res:      "",
+	}, {
 		platform: "aws",
+		content: `
+[dummy-config]
+    option = a
+`,
+		res: "--cloud-config=/etc/kubernetes/cloud.conf",
+	}, {
+		platform: "libvirt",
 		content: `
 [dummy-config]
     option = a


### PR DESCRIPTION
cloudConfig is now generated by kube_cloud_config controller for all supported
platforms. Controller generates kube-cloud-config ConfigMap in openshift-config-managed
namespace where cloud.conf key is stored.

Links:
- https://github.com/openshift/enhancements/blob/master/enhancements/installer/aws-custom-region-and-endpoints.md
- https://github.com/openshift/api/pull/599
- https://github.com/openshift/api/pull/621
