### PR TITLE
Bug 1825221: templates/master:openshift-recovery-tools pass --authfile to podman create

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -5,7 +5,6 @@ contents:
   inline: |
     #!/usr/bin/env bash
     export ETCDCTL_API=3
-    export ETCD_VERSION=v3.3.17
 
     ETCDCTL_WITH_TLS="$ETCDCTL --cert $ASSET_DIR/backup/etcd-client.crt --key $ASSET_DIR/backup/etcd-client.key --cacert $ASSET_DIR/backup/etcd-ca-bundle.crt"
 
@@ -19,12 +18,12 @@ contents:
       fi
     }
 
-    # download and test etcdctl from upstream release assets
+    # extract etcdctl binary from container image
     dl_etcdctl() {
       local etcdimg="{{.Images.etcdKey}}"
-      local etcdctr=$(podman create "${etcdimg}")
+      local etcdctr=$(podman create "${etcdimg}" --authfile=/var/lib/kubelet/config.json)
       local etcdmnt=$(podman mount "${etcdctr}")
-      cp ${etcdmnt}/bin/etcdctl $ASSET_DIR/bin
+      cp ${etcdmnt}/bin/etcdctl $ASSET_DIR/bin/
       umount "${etcdmnt}"
       podman rm "${etcdctr}"
       $ASSET_DIR/bin/etcdctl version


### PR DESCRIPTION
In the case that a master node is new it is possible that the etcd container has not yet been downloaded. In this case, DR script will fail because we need auth to create the container by first pulling the image.
