### PR TITLE
Update vSphere IPI removing DNS VIP

### DIFF
--- a/manifests/vsphere/coredns.yaml
+++ b/manifests/vsphere/coredns.yaml
@@ -30,8 +30,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
     - "/config"

--- a/manifests/vsphere/keepalived.conf.tmpl
+++ b/manifests/vsphere/keepalived.conf.tmpl
@@ -19,17 +19,3 @@ vrrp_instance {{`{{.Cluster.Name}}`}}_API {
     }
 }
 
-vrrp_instance {{`{{.Cluster.Name}}`}}_DNS {
-    state MASTER
-    interface {{`{{.VRRPInterface}}`}}
-    virtual_router_id {{`{{.Cluster.DNSVirtualRouterID }}`}}
-    priority 140
-    advert_int 1
-    authentication {
-        auth_type PASS
-        auth_pass {{`{{.Cluster.Name}}`}}_dns_vip
-    }
-    virtual_ipaddress {
-        {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
-    }
-}

--- a/manifests/vsphere/keepalived.yaml
+++ b/manifests/vsphere/keepalived.yaml
@@ -30,8 +30,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
     - "/config"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3509,8 +3509,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
     - "/config"
@@ -3607,20 +3605,6 @@ vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_API {
     }
 }
 
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
-    state MASTER
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.DNSVirtualRouterID }}`+"`"+`}}
-    priority 140
-    advert_int 1
-    authentication {
-        auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_dns_vip
-    }
-    virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
-    }
-}
 `)
 
 func manifestsVsphereKeepalivedConfTmplBytes() ([]byte, error) {
@@ -3670,8 +3654,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
     - "/config"

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -37,8 +37,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         - "/config"
@@ -100,8 +98,6 @@ contents:
         - "/etc/coredns/Corefile"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         resources:

--- a/templates/common/vsphere/files/vsphere-keepalived.yaml
+++ b/templates/common/vsphere/files/vsphere-keepalived.yaml
@@ -99,8 +99,6 @@ contents:
         - "/etc/keepalived/keepalived.conf"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         resources:

--- a/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
+++ b/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
@@ -64,8 +64,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         - "/config"

--- a/templates/master/00-master/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -13,7 +13,9 @@ contents:
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
-        NAMESERVER_IP="{{.Infra.Status.PlatformStatus.VSphere.NodeDNSIP}}"
+        NAMESERVER_IP=$(/usr/local/bin/non_virtual_ip \
+            "{{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP}}" \
+            "{{.Infra.Status.PlatformStatus.VSphere.IngressIP}}")
         DOMAIN="{{.EtcdDiscoveryDomain}}"
         set +e
         if [[ -n "$NAMESERVER_IP" ]]; then

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -11,12 +11,6 @@ contents:
         weight 50
     }
 
-    vrrp_script chk_dns {
-        script "/usr/bin/host -t SRV _etcd-server-ssl._tcp.{{ .EtcdDiscoveryDomain }} localhost"
-        interval 1
-        weight 50
-    }
-
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
@@ -40,24 +34,6 @@ contents:
         }
         track_script {
             chk_ocp
-        }
-    }
-
-    vrrp_instance {{`{{ .Cluster.Name }}`}}_DNS {
-        state BACKUP
-        interface {{`{{ .VRRPInterface }}`}}
-        virtual_router_id {{`{{ .Cluster.DNSVirtualRouterID }}`}}
-        priority 40
-        advert_int 1
-        authentication {
-            auth_type PASS
-            auth_pass {{`{{ .Cluster.Name }}`}}_dns_vip
-        }
-        virtual_ipaddress {
-            {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
-        }
-        track_script {
-            chk_dns
         }
     }
 

--- a/templates/worker/00-worker/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -15,7 +15,6 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
         NAMESERVER_IP=$(/usr/local/bin/non_virtual_ip \
             "{{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP}}" \
-            "{{.Infra.Status.PlatformStatus.VSphere.NodeDNSIP}}" \
             "{{.Infra.Status.PlatformStatus.VSphere.IngressIP}}")
         DOMAIN="{{.EtcdDiscoveryDomain}}"
         set +e


### PR DESCRIPTION
Align with current updates to baremetal
See PR #1569

"Now that etcd does not need DNS for clustering, we no longer need to
have a VIP to allow the masters to use the bootstrap coredns until
their own coredns instances start. Instead, we can just point them
at the local coredns directly and skip the extra complexity. We
already do this on the workers because they never had a dependency
on the bootstrap coredns so the same method is now used for masters."


