### PR TITLE
Bug 1820507: Add new crio.conf field to the template

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -74,6 +74,10 @@ contents:
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     ]
 
+    default_env = [
+        "NSS_SDB_USE_CACHE=no",
+    ]
+
     # If true, SELinux will be used for pod separation on the host.
     selinux = true
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -74,6 +74,10 @@ contents:
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     ]
 
+    default_env = [
+        "NSS_SDB_USE_CACHE=no",
+    ]
+
     # If true, SELinux will be used for pod separation on the host.
     selinux = true
 


### PR DESCRIPTION
Fixes #1820507 (https://bugzilla.redhat.com/show_bug.cgi?id=1820507)

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add the default_env field to the crio.conf template
that is laid down by the MCO

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add default_env filed to the crio.conf template
