### PR TITLE
Bug 1825823: Add support for reading API LB backends from KUBE-API for OpenStack and Ovirt

### DIFF
--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -17,9 +17,9 @@ contents:
       - name: resource-dir
         hostPath:
           path: "/etc/kubernetes/static-pod-resources/haproxy"
-      - name: kubeconfig
+      - name: kubeconfigvarlib
         hostPath:
-          path: "/etc/kubernetes/kubeconfig"
+          path: "/var/lib/kubelet"
       - name: run-dir
         empty-dir: {}
       - name: conf-dir
@@ -109,7 +109,7 @@ contents:
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - monitor
-        - "/etc/kubernetes/kubeconfig"
+        - "/var/lib/kubelet/kubeconfig"
         - "/config/haproxy.cfg.tmpl"
         - "/etc/haproxy/haproxy.cfg"
         - "--api-vip"
@@ -127,8 +127,8 @@ contents:
           mountPath: "/config"
         - name: chroot-host
           mountPath: "/host"
-        - name: kubeconfig
-          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -17,9 +17,9 @@ contents:
       - name: resource-dir
         hostPath:
           path: "/etc/kubernetes/static-pod-resources/haproxy"
-      - name: kubeconfig
+      - name: kubeconfigvarlib
         hostPath:
-          path: "/etc/kubernetes/kubeconfig"
+          path: "/var/lib/kubelet"
       - name: run-dir
         empty-dir: {}
       - name: conf-dir
@@ -89,7 +89,7 @@ contents:
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - monitor
-        - "/etc/kubernetes/kubeconfig"
+        - "/var/lib/kubelet/kubeconfig"
         - "/config/haproxy.cfg.tmpl"
         - "/etc/haproxy/haproxy.cfg"
         - "--api-vip"
@@ -107,8 +107,8 @@ contents:
           mountPath: "/config"
         - name: chroot-host
           mountPath: "/host"
-        - name: kubeconfig
-          mountPath: "/etc/kubernetes/kubeconfig"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true


### PR DESCRIPTION
This PR updates OpenStack and Ovirt HAProxy static pod manifest to enable reading API LB backend details from Kubernetes instead of _etcd-server-ssl._tcp SRV.

Original baremetal PR: https://github.com/openshift/machine-config-operator/pull/1574