### PR TITLE
Bug 1841066: OpenStack: Remove DNS VIP

### DIFF
--- a/manifests/openstack/coredns.yaml
+++ b/manifests/openstack/coredns.yaml
@@ -30,8 +30,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
     - "/config"

--- a/manifests/openstack/keepalived.conf.tmpl
+++ b/manifests/openstack/keepalived.conf.tmpl
@@ -18,18 +18,3 @@ vrrp_instance {{`{{.Cluster.Name}}`}}_API {
         {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
     }
 }
-
-vrrp_instance {{`{{.Cluster.Name}}`}}_DNS {
-    state MASTER
-    interface {{`{{.VRRPInterface}}`}}
-    virtual_router_id {{`{{.Cluster.DNSVirtualRouterID }}`}}
-    priority 140
-    advert_int 1
-    authentication {
-        auth_type PASS
-        auth_pass {{`{{.Cluster.Name}}`}}_dns_vip
-    }
-    virtual_ipaddress {
-        {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
-    }
-}

--- a/manifests/openstack/keepalived.yaml
+++ b/manifests/openstack/keepalived.yaml
@@ -30,8 +30,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
     - "/config"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1805,8 +1805,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
     - "/config"
@@ -1902,21 +1900,6 @@ vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_API {
         {{`+"`"+`{{ .Cluster.APIVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
     }
 }
-
-vrrp_instance {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_DNS {
-    state MASTER
-    interface {{`+"`"+`{{.VRRPInterface}}`+"`"+`}}
-    virtual_router_id {{`+"`"+`{{.Cluster.DNSVirtualRouterID }}`+"`"+`}}
-    priority 140
-    advert_int 1
-    authentication {
-        auth_type PASS
-        auth_pass {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}_dns_vip
-    }
-    virtual_ipaddress {
-        {{`+"`"+`{{ .Cluster.DNSVIP }}`+"`"+`}}/{{`+"`"+`{{ .Cluster.VIPNetmask }}`+"`"+`}}
-    }
-}
 `)
 
 func manifestsOpenstackKeepalivedConfTmplBytes() ([]byte, error) {
@@ -1966,8 +1949,6 @@ spec:
     - "/etc/kubernetes/kubeconfig"
     - "--api-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-    - "--dns-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
     - "--ingress-vip"
     - "{{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
     - "/config"

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -32,8 +32,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
         - "/config"

--- a/templates/common/openstack/files/openstack-keepalived.yaml
+++ b/templates/common/openstack/files/openstack-keepalived.yaml
@@ -32,8 +32,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
         - "/config"

--- a/templates/common/openstack/files/openstack-mdns-publisher.yaml
+++ b/templates/common/openstack/files/openstack-mdns-publisher.yaml
@@ -64,8 +64,6 @@ contents:
         - "/etc/kubernetes/kubeconfig"
         - "--api-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
-        - "--dns-vip"
-        - "{{ .Infra.Status.PlatformStatus.OpenStack.NodeDNSIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.OpenStack.IngressIP }}"
         - "/config"

--- a/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -14,7 +14,14 @@ contents:
         # Ensure resolv.conf exists before we try to run podman
         cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
 
-        NAMESERVER_IP="{{.Infra.Status.PlatformStatus.OpenStack.NodeDNSIP}}"
+        NAMESERVER_IP=$(/usr/bin/podman run --rm \
+            --authfile /var/lib/kubelet/config.json \
+            --net=host \
+            {{ .Images.baremetalRuntimeCfgImage }} \
+            node-ip \
+            show \
+            "{{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP}}" \
+            "{{.Infra.Status.PlatformStatus.OpenStack.IngressIP}}")
         DOMAIN="{{.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -8,11 +8,7 @@ contents:
         interval 1
         weight 50
     }
-    vrrp_script chk_dns {
-        script "/usr/bin/host -t SRV _etcd-server-ssl._tcp.{{ .EtcdDiscoveryDomain }} localhost"
-        interval 1
-        weight 50
-    }
+
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
@@ -20,6 +16,7 @@ contents:
         interval 1
         weight 50
     }
+
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -37,23 +34,7 @@ contents:
             chk_ocp
         }
     }
-    vrrp_instance {{`{{ .Cluster.Name }}`}}_DNS {
-        state BACKUP
-        interface {{`{{ .VRRPInterface }}`}}
-        virtual_router_id {{`{{ .Cluster.DNSVirtualRouterID }}`}}
-        priority 40
-        advert_int 1
-        authentication {
-            auth_type PASS
-            auth_pass {{`{{ .Cluster.Name }}`}}_dns_vip
-        }
-        virtual_ipaddress {
-            {{`{{ .Cluster.DNSVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
-        }
-        track_script {
-            chk_dns
-        }
-    }
+
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}

--- a/templates/worker/00-worker/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -16,7 +16,6 @@ contents:
             node-ip \
             show \
             "{{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP}}" \
-            "{{.Infra.Status.PlatformStatus.OpenStack.NodeDNSIP}}" \
             "{{.Infra.Status.PlatformStatus.OpenStack.IngressIP}}")
         DOMAIN="{{.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then


### PR DESCRIPTION
Now that etcd does not need DNS for clustering, we no longer need to
have a VIP to allow the masters to use the bootstrap coredns until
their own coredns instances start. Instead, we can just point them
at the local coredns directly and skip the extra complexity. We
already do this on the workers because they never had a dependency
on the bootstrap coredns so the same method is now used for masters.

This brings the BM change #1569 to OpenStack platform.
