### PR TITLE
Bug 1811140: Add containernetworking-plugin RPM's bin location to CRI-O config

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -253,6 +253,7 @@ contents:
     # Paths to directories where CNI plugin binaries are located.
     plugin_dirs = [
         "/var/lib/cni/bin",
+        "/usr/libexec/cni",
     ]
 
     # A necessary configuration for Prometheus based metrics retrieval

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -253,6 +253,7 @@ contents:
     # Paths to directories where CNI plugin binaries are located.
     plugin_dirs = [
         "/var/lib/cni/bin",
+        "/usr/libexec/cni",
     ]
 
     # A necessary configuration for Prometheus based metrics retrieval


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This is a back-port PR for https://github.com/openshift/machine-config-operator/pull/1630, goes hand-in-hand with https://github.com/openshift/cluster-network-operator/pull/602

Let me know in case someone requires more information.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

/cc @danwinship 