### PR TITLE
Bug 1825909: baremetal - Limit the number of nameservers to 3

### DIFF
--- a/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -30,6 +30,8 @@ contents:
             logger -s "NM resolv-prepender: Couldn't find a Virtual IP, just updating resolv.conf"
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
+        # Only leave the first 3 nameservers in /etc/resolv.conf
+        sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.conf
         ;;
         *)
         ;;

--- a/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -30,6 +30,8 @@ contents:
             logger -s "Couldn't find a non-virtual IP, just updating resolv.conf"
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
+        # Only leave the first 3 nameservers in /etc/resolv.conf
+        sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.conf
         ;;
         *)
         ;;


### PR DESCRIPTION
This PR prevents the pods from complaining about the nameserver limits
exceeded:

    Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 10.0.128.6 10.0.128.12 10.0.128.11 (207 times)

Original openstack PR: #1573 

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
