### PR TITLE
Deprecate EtcdDiscoveryDomain field on ControllerConfig CRD

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -1,17 +1,17 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
     hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -73,7 +73,7 @@ spec:
               type: string
               format: byte
             etcdDiscoveryDomain:
-              description: etcdDiscoveryDomain specifies the etcd discovery domain
+              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
               type: string
             etcdMetricCAData:
               description: etcdMetricData specifies the etcd metric CA data

--- a/manifests/openstack/coredns-corefile.tmpl
+++ b/manifests/openstack/coredns-corefile.tmpl
@@ -1,14 +1,14 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
         policy sequential
     }
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
 }

--- a/manifests/ovirt/coredns-corefile.tmpl
+++ b/manifests/ovirt/coredns-corefile.tmpl
@@ -1,12 +1,12 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
 }

--- a/manifests/vsphere/coredns-corefile.tmpl
+++ b/manifests/vsphere/coredns-corefile.tmpl
@@ -1,17 +1,17 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
     hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         fallthrough
     }

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -42,8 +42,8 @@ type ControllerConfigSpec struct {
 	// The openshift platform, e.g. "libvirt", "openstack", "gcp", "baremetal", "aws", or "none"
 	Platform string `json:"platform"`
 
-	// etcdDiscoveryDomain specifies the etcd discovery domain
-	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
+	// etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain instead
+	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain,omitempty"`
 
 	// TODO: Use string for CA data
 

--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -7,7 +7,6 @@ spec:
   cloudProviderConfig: ""
   clusterDNSIP: 172.30.0.10
   etcdCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkVUQ0QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
-  etcdDiscoveryDomain: domain.example.com
   etcdMetricCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkVUQ0QgTUVUUklDIENBIERBVEEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   images:
     baremetalRuntimeCfgImage: ""

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -106,8 +106,12 @@ func newControllerConfig(name, platform string) *mcfgv1.ControllerConfig {
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.ControllerConfigSpec{
-			EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
-			Platform:            platform,
+			Infra: &apicfgv1.Infrastructure{
+				Status: apicfgv1.InfrastructureStatus{
+					EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
+				},
+			},
+			Platform: platform,
 		},
 	}
 	return cc

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -101,8 +101,12 @@ func newControllerConfig(name, platform string) *mcfgv1.ControllerConfig {
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.ControllerConfigSpec{
-			EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
-			Platform:            platform,
+			Infra: &osev1.Infrastructure{
+				Status: osev1.InfrastructureStatus{
+					EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
+				},
+			},
+			Platform: platform,
 		},
 	}
 	return cc

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/clarketm/json"
 	ign "github.com/coreos/ignition/config/v2_2"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -220,8 +221,12 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.ControllerConfigSpec{
-			EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
-			OSImageURL:          "dummy",
+			Infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					EtcdDiscoveryDomain: fmt.Sprintf("%s.tt.testing", name),
+				},
+			},
+			OSImageURL: "dummy",
 		},
 		Status: mcfgv1.ControllerConfigStatus{
 			Conditions: []mcfgv1.ControllerConfigStatusCondition{

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -349,13 +349,13 @@ func etcdServerCertDNSNames(cfg RenderConfig) (interface{}, error) {
 }
 
 func etcdPeerCertDNSNames(cfg RenderConfig) (interface{}, error) {
-	if cfg.EtcdDiscoveryDomain == "" {
+	if cfg.Infra.Status.EtcdDiscoveryDomain == "" {
 		return nil, fmt.Errorf("invalid configuration")
 	}
 
 	var dnsNames = []string{
 		"${ETCD_DNS_NAME}",
-		cfg.EtcdDiscoveryDomain, // https://github.com/etcd-io/etcd/blob/583763261f1c843e07c1bf7fea5fb4cfb684fe87/Documentation/op-guide/clustering.md#dns-discovery
+		cfg.Infra.Status.EtcdDiscoveryDomain, // https://github.com/etcd-io/etcd/blob/583763261f1c843e07c1bf7fea5fb4cfb684fe87/Documentation/op-guide/clustering.md#dns-discovery
 	}
 	return strings.Join(dnsNames, ","), nil
 }

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -11,6 +11,7 @@ import (
 
 	ign "github.com/coreos/ignition/config/v2_2"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -152,7 +153,11 @@ func TestEtcdPeerCertDNSNames(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			config := &mcfgv1.ControllerConfig{
 				Spec: mcfgv1.ControllerConfigSpec{
-					EtcdDiscoveryDomain: c.etcdDiscoveryDomain,
+					Infra: &configv1.Infrastructure{
+						Status: configv1.InfrastructureStatus{
+							EtcdDiscoveryDomain: c.etcdDiscoveryDomain,
+						},
+					},
 				},
 			}
 			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,9 +60,13 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Generation: 1},
 		Spec: mcfgv1.ControllerConfigSpec{
-			ClusterDNSIP:        "10.3.0.1/16",
-			EtcdDiscoveryDomain: fmt.Sprintf("%s.openshift.testing", name),
-			Platform:            "libvirt",
+			ClusterDNSIP: "10.3.0.1/16",
+			Infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					EtcdDiscoveryDomain: fmt.Sprintf("%s.openshift.testing", name),
+				},
+			},
+			Platform: "libvirt",
 			PullSecret: &corev1.ObjectReference{
 				Namespace: "default",
 				Name:      "coreos-pull-secret",

--- a/pkg/controller/template/test_data/controller_config_aws.yaml
+++ b/pkg/controller/template/test_data/controller_config_aws.yaml
@@ -3,7 +3,6 @@ kind: "ControllerConfig"
 spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "aws"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_baremetal.yaml
+++ b/pkg/controller/template/test_data/controller_config_baremetal.yaml
@@ -3,7 +3,6 @@ kind: "ControllerConfig"
 spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "baremetal"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_gcp.yaml
+++ b/pkg/controller/template/test_data/controller_config_gcp.yaml
@@ -3,7 +3,6 @@ kind: "ControllerConfig"
 spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "gcp"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_libvirt.yaml
+++ b/pkg/controller/template/test_data/controller_config_libvirt.yaml
@@ -3,7 +3,6 @@ kind: "ControllerConfig"
 spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "libvirt"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_none.yaml
+++ b/pkg/controller/template/test_data/controller_config_none.yaml
@@ -3,7 +3,6 @@ kind: "ControllerConfig"
 spec:
   clusterDNSIP: "10.3.0.10"
   cloudProviderConfig: ""
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "none"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_openstack.yaml
+++ b/pkg/controller/template/test_data/controller_config_openstack.yaml
@@ -7,7 +7,6 @@ spec:
     multi-line cloud config
     [test]
       option = dummy
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "openstack"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_ovirt.yaml
+++ b/pkg/controller/template/test_data/controller_config_ovirt.yaml
@@ -7,7 +7,6 @@ spec:
     multi-line cloud config
     [test]
       option = dummy
-  etcdDiscoveryDomain: "my-test-cluster.example.org"
   etcdInitialCount: 3
   platform: "ovirt"
   etcdCAData: OHVtbXkgZXRjZC1jYQo=

--- a/pkg/controller/template/test_data/controller_config_vsphere.yaml
+++ b/pkg/controller/template/test_data/controller_config_vsphere.yaml
@@ -7,7 +7,6 @@ spec:
     multi-line cloud config
     [test]
       option = dummy
-  etcdDiscoveryDomain: "my-test-cluster.installer.team.coreos.systems"
   etcdInitialCount: 3
   platform: "vsphere"
   etcdCAData: ZHVtbXkgZXRjZC1jYQo=

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -97,17 +97,17 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
     hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
@@ -527,7 +527,7 @@ spec:
               type: string
               format: byte
             etcdDiscoveryDomain:
-              description: etcdDiscoveryDomain specifies the etcd discovery domain
+              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
               type: string
             etcdMetricCAData:
               description: etcdMetricData specifies the etcd metric CA data
@@ -1745,14 +1745,14 @@ func manifestsMasterMachineconfigpoolYaml() (*asset, error) {
 var _manifestsOpenstackCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}} {
         policy sequential
     }
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
 }
@@ -2018,12 +2018,12 @@ func manifestsOpenstackKeepalivedYaml() (*asset, error) {
 var _manifestsOvirtCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
 }
@@ -2289,17 +2289,17 @@ func manifestsOvirtKeepalivedYaml() (*asset, error) {
 var _manifestsVsphereCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
     hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.EtcdDiscoveryDomain }}
+    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         fallthrough
     }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -95,6 +95,8 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		ClusterDNSIP:        dnsIP,
 		KubeletIPv6:         ipv6,
 		CloudProviderConfig: "",
+		// EtcdDiscoveryDomain is unused and deprecated in favour of using Infra.Status.EtcdDiscoveryDomain directly
+		// Still populating it here for now until it will be removed eventually
 		EtcdDiscoveryDomain: infra.Status.EtcdDiscoveryDomain,
 		Platform:            platform,
 		Infra:               infra,

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -220,7 +220,7 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 			} else if controllerConfigSpec.Platform == "" {
 				t.Fatalf("Error setting controller config platform")
 			}
-			etcdDomain := controllerConfigSpec.EtcdDiscoveryDomain
+			etcdDomain := controllerConfigSpec.Infra.Status.EtcdDiscoveryDomain
 			testDomain := test.Infra.Status.EtcdDiscoveryDomain
 			if etcdDomain != testDomain {
 				t.Fatalf("%s failed: got = %s want = %s", desc, etcdDomain, testDomain)

--- a/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -23,7 +23,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.BareMetal.IngressIP}}")
-        DOMAIN="{{.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -5,17 +5,17 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
         hosts {
-            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .EtcdDiscoveryDomain }}
-            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .EtcdDiscoveryDomain }}
+            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .Infra.Status.EtcdDiscoveryDomain }}
             fallthrough
         }
-        template IN A {{ .EtcdDiscoveryDomain }} {
-            match .*.apps.{{ .EtcdDiscoveryDomain }}
+        template IN A {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
             fallthrough
         }

--- a/templates/common/openstack/files/openstack-coredns-corefile.yaml
+++ b/templates/common/openstack/files/openstack-coredns-corefile.yaml
@@ -5,11 +5,11 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
             policy sequential
         }
         cache 30
         reload
-        file /etc/coredns/node-dns-db {{ .EtcdDiscoveryDomain }}
+        file /etc/coredns/node-dns-db {{ .Infra.Status.EtcdDiscoveryDomain }}
     }

--- a/templates/common/openstack/files/openstack-coredns-db.yaml
+++ b/templates/common/openstack/files/openstack-coredns-db.yaml
@@ -2,8 +2,8 @@ mode: 0644
 path: "/etc/coredns/node-dns-db"
 contents:
   inline: |
-    $ORIGIN {{ .EtcdDiscoveryDomain }}.
-    @    3600 IN SOA host.{{ .EtcdDiscoveryDomain }}. hostmaster (
+    $ORIGIN {{ .Infra.Status.EtcdDiscoveryDomain }}.
+    @    3600 IN SOA host.{{ .Infra.Status.EtcdDiscoveryDomain }}. hostmaster (
                                     2017042752 ; serial
                                     7200       ; refresh (2 hours)
                                     3600       ; retry (1 hour)

--- a/templates/common/ovirt/files/ovirt-coredns-corefile.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns-corefile.yaml
@@ -5,9 +5,9 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
-        file /etc/coredns/node-dns-db {{ .EtcdDiscoveryDomain }}
+        file /etc/coredns/node-dns-db {{ .Infra.Status.EtcdDiscoveryDomain }}
     }

--- a/templates/common/ovirt/files/ovirt-coredns-db.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns-db.yaml
@@ -2,8 +2,8 @@ mode: 0644
 path: "/etc/coredns/node-dns-db"
 contents:
   inline: |
-    $ORIGIN {{ .EtcdDiscoveryDomain }}.
-    @    3600 IN SOA host.{{ .EtcdDiscoveryDomain }}. hostmaster (
+    $ORIGIN {{ .Infra.Status.EtcdDiscoveryDomain }}.
+    @    3600 IN SOA host.{{ .Infra.Status.EtcdDiscoveryDomain }}. hostmaster (
                                     2017042752 ; serial
                                     7200       ; refresh (2 hours)
                                     3600       ; retry (1 hour)

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -9,17 +9,17 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
         hosts {
-            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .EtcdDiscoveryDomain }}
-            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .EtcdDiscoveryDomain }}
+            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .Infra.Status.EtcdDiscoveryDomain }}
             fallthrough
         }
-        template IN A {{ .EtcdDiscoveryDomain }} {
-            match .*.apps.{{ .EtcdDiscoveryDomain }}
+        template IN A {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
             fallthrough
         }

--- a/templates/master/00-master/baremetal/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/baremetal/files/dhcp-dhclient-conf.yaml
@@ -2,4 +2,4 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";

--- a/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -21,7 +21,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.OpenStack.IngressIP}}")
-        DOMAIN="{{.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/master/00-master/openstack/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/openstack/files/dhcp-dhclient-conf.yaml
@@ -2,4 +2,4 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";

--- a/templates/master/00-master/ovirt/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/ovirt/files/dhcp-dhclient-conf.yaml
@@ -2,4 +2,4 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";

--- a/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
@@ -6,7 +6,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/baremetal/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/baremetal/files/dhcp-dhclient-conf.yaml
@@ -2,4 +2,4 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";

--- a/templates/worker/00-worker/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -16,7 +16,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.OpenStack.IngressIP}}")
-        DOMAIN="{{.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/worker/00-worker/openstack/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/openstack/files/dhcp-dhclient-conf.yaml
@@ -2,4 +2,4 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";

--- a/templates/worker/00-worker/ovirt/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/ovirt/files/dhcp-dhclient-conf.yaml
@@ -2,4 +2,4 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";

--- a/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
@@ -6,7 +6,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
-    supersede domain-search "{{ .EtcdDiscoveryDomain }}";
+    supersede domain-search "{{ .Infra.Status.EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
     {{ end -}}
     {{ end -}}


### PR DESCRIPTION
Currently ControllerConfig.EtcdDiscoveryDomain and
ControllerConfig.Infra.Status.EtcdDiscoveryDomain are redundant..

**- What I did**
This deprecates the ControllerConfig.EtcdDiscoveryDomain field and
leaves ControllerConfig.Infra.Status.EtcdDiscoveryDomain as the
canonical location.

**- How to verify it**
CI

**- Description for the changelog**
Deprecate EtcdDiscvoeryDomain field on ControllerConfig CRD
