### PR TITLE
Bug 1826896: [release-4.4] crio: set version-file{,-persist} correctly

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -9,8 +9,11 @@ contents:
     # the kubelet. The log directory specified must be an absolute directory.
     log_dir = "/var/log/crio/pods"
 
-    # Location for CRI-O to lay down the version file
-    version_file = "/var/lib/crio/version"
+    # Location for CRI-O to lay down the temporary version file
+    version_file = "/var/run/crio/version"
+
+    # Location for CRI-O to lay down the persistent version file
+    version_file_persist = "/var/lib/crio/version"
 
     # The crio.api table contains settings for the kubelet/gRPC interface.
     [crio.api]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -9,8 +9,11 @@ contents:
     # the kubelet. The log directory specified must be an absolute directory.
     log_dir = "/var/log/crio/pods"
 
-    # Location for CRI-O to lay down the version file
-    version_file = "/var/lib/crio/version"
+    # Location for CRI-O to lay down the temporary version file
+    version_file = "/var/run/crio/version"
+
+    # Location for CRI-O to lay down the persistent version file
+    version_file_persist = "/var/lib/crio/version"
 
     # The crio.api table contains settings for the kubelet/gRPC interface.
     [crio.api]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
with a new version of cri-o, we are going to cleanup containers when a node reboots (which we detect when a tmpfs file is removed), and cleanup images when a node upgraded (which we detect how we used to: persistent version file out of date)
This PR changes where cri-o looks for those files. These match the upstream defaults, so when we move to drop in files, we won't need to specify these

**- How to verify it**
containers are cleared on node reboot, images are cleared when we bump a cri-o minor version (1.17->1.18)
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
