### PR TITLE
Bug 1765609: templates: add chrony config on Azure for host time synchronization

### DIFF
--- a/templates/common/azure/files/chrony.yaml
+++ b/templates/common/azure/files/chrony.yaml
@@ -1,0 +1,51 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/chrony.conf"
+contents:
+  inline: |
+    # This file is shipped by the Machine Config Operator to synchronize host machine time on Azure.
+    # Make sure that chrony.conf content in machine-config-operator (/templates/common/azure/files) and
+    # installer (data/data/bootstrap/azure/files/etc) repo are in sync.
+    #
+    # see https://bugzilla.redhat.com/show_bug.cgi?id=1765609 and https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
+    refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+
+    # Use public servers from the pool.ntp.org project.
+    # Please consider joining the pool (http://www.pool.ntp.org/join.html).
+    pool 2.rhel.pool.ntp.org iburst
+
+    # Record the rate at which the system clock gains/losses time.
+    driftfile /var/lib/chrony/drift
+
+    # Allow the system clock to be stepped in the first three updates
+    # if its offset is larger than 1 second.
+    makestep 1.0 3
+
+    # Enable kernel synchronization of the real-time clock (RTC).
+    rtcsync
+
+    # Enable hardware timestamping on all interfaces that support it.
+    #hwtimestamp *
+
+    # Increase the minimum number of selectable sources required to adjust
+    # the system clock.
+    #minsources 2
+
+    # Allow NTP client access from local network.
+    #allow 192.168.0.0/16
+
+    # Serve time even if not synchronized to a time source.
+    #local stratum 10
+
+    # Specify file containing keys for NTP authentication.
+    keyfile /etc/chrony.keys
+
+    # Get TAI-UTC offset and leap seconds from the system tz database.
+    leapsectz right/UTC
+
+    # Specify directory for log files.
+    logdir /var/log/chrony
+
+    # Select which information is logged.
+    #log measurements statistics tracking
+


### PR DESCRIPTION
With default config, host time synchronization fails on RHCOS nodes
launched on Azure and results in time drift.
As per Azure best practices we are updating chrony.conf to use
PTP source clock https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1765609