### PR TITLE
Makefile: add -failfast to e2e-op

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,4 +109,4 @@ Dockerfile.rhel7: Dockerfile Makefile
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operator
 test-e2e:
-	go test -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/


### PR DESCRIPTION
When an MCO e2e test fails, we keep running all the others till the end.
That has the shortcoming of not providing the journal for any test that
failed. This has been found in https://bugzilla.redhat.com/show_bug.cgi?id=1827712
The bug itself needs journal to debug.
Adding -failfast will halt test execution at the first failure which I think it's
generally better for e2e-op as we get a fast feedback from tests.
To further debug that BZ tho we'd need to capture the last boot as well which I'll
fix in a follow up PR to openshift/release (https://github.com/openshift/release/pull/8558)

Signed-off-by: Antonio Murdaca <runcom@linux.com>