### PR TITLE
Bug 1828106: cloudConfig: remove bare metal from platforms that require a cloud conifg

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -504,7 +504,7 @@ func cloudConfigFlag(cfg RenderConfig) interface{} {
 	}
 	flag := "--cloud-config=/etc/kubernetes/cloud.conf"
 	switch cfg.Platform {
-	case platformAWS, platformAzure, platformBaremetal, platformGCP, platformOpenStack, platformOvirt, platformVSphere:
+	case platformAWS, platformAzure, platformGCP, platformOpenStack, platformOvirt, platformVSphere:
 		return flag
 	default:
 		return ""

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -102,7 +102,7 @@ func isCloudConfigRequired(infra *configv1.Infrastructure) bool {
 	if infra.Spec.CloudConfig.Name != "" {
 		return true
 	}
-	for _, platform := range []configv1.PlatformType{configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType,
+	for _, platform := range []configv1.PlatformType{configv1.AzurePlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType,
 		configv1.OvirtPlatformType, configv1.VSpherePlatformType} {
 		if platform == infra.Status.PlatformStatus.Type {
 			return true


### PR DESCRIPTION
Baremetal IPI doesn't use a cloud config, and [this change](https://github.com/openshift/machine-config-operator/pull/1658) is now
breaking CI:

```
level=error msg="Cluster operator machine-config Degraded is True with
RenderConfigFailed: Unable to apply 0.0.1-2020-04-26-200215:
openshift-config-managed/kube-cloud-config configmap is required on
platform BareMetal but not found: configmap \"kube-cloud-config\" not
found"
```
