### PR TITLE
Bug 1831866: cri-o: manage ns lifecycle, again!

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,7 @@ contents:
         "SYS_CHROOT",
         "KILL",
     ]
+    manage_ns_lifecycle = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,7 @@ contents:
         "SYS_CHROOT",
         "KILL",
     ]
+    manage_ns_lifecycle = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
change the entry in crio.conf template to manage ns lifecycle
As it is more secure and gives cri-o more control of namespace lifecycle

This is attempting to do what https://github.com/openshift/machine-config-operator/pull/1568 did, but now we've hopefully ironed out the issues that caused the need for https://github.com/openshift/machine-config-operator/pull/1600

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
CRI-O now manages namespace lifecycle