### PR TITLE
Bug 1820785: [baremetal] Correctly handle requests for ipv4/ipv6 records

### DIFF
--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -5,14 +5,31 @@
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
-    hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
-    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+    template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
         match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
-        answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -101,14 +101,31 @@ var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
-    hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.IngressVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
-    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+    template IN {{`+"`"+`{{ .Cluster.IngressVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
         match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
-        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        fallthrough
+    }
+    template IN {{`+"`"+`{{ .Cluster.APIVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+        fallthrough
+    }
+    template IN {{`+"`"+`{{ .Cluster.APIVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        fallthrough
+    }
+    template IN {{`+"`"+`{{ .Cluster.APIVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+        fallthrough
+    }
+    template IN {{`+"`"+`{{ .Cluster.APIVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
+        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
         fallthrough
     }
 }

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -9,14 +9,31 @@ contents:
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
-        hosts {
-            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
-            {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }} api.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
             fallthrough
         }
-        template IN A {{ .Infra.Status.EtcdDiscoveryDomain }} {
+        template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
             match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
-            answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match api.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match api.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
+            match api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
             fallthrough
         }
     }


### PR DESCRIPTION
Previously the ingress record was hard-coded to be an A record, which
does not work when deploying with an ipv6 ingress VIP. While fixing
that, an issue with the api and api-int records was also exposed.

According to RFC 4074, when a query for a record comes in that asks
for the wrong type of record (i.e. asking for an A record when only
a AAAA record exists), the server should return NOERROR with an
empty list of records. This indicates to the client resolver that
a record of that name exists, but not with that type.

For our purposes, it was necessary to convert all of the records to
use the template plugin in order to get this behavior. The hosts
plugin previously used for the api records does not correctly handle
requests for the wrong record type, at least with the fallthrough
option that we also need. The file plugin, which does correctly
handle requests for the wrong record type, has a different issue.
We want to allow external records in the same subdomain (and this is
necessary for development purposes), but there is no way to make
the file plugin forward requests it can't handle.

To make the template plugin behave correctly, two entries are needed
for each record: one with the correct type and the appropriate answer,
and one with the incorrect type and an empty answer. This gets us
RFC-compliant behavior while still allowing fallthrough for requests
that are not present in the local server.

This change requires new fields from baremetal-runtimecfg that are
added in https://github.com/openshift/baremetal-runtimecfg/pull/60.

**- How to verify it**
Requests for the matching record type should return the appropriate record, requests for the wrong record type for the VIP IP version should return NOERROR with an empty record list.

**- Description for the changelog**
Fixes misbehavior in the internal coredns server when dealing with ipv4 and ipv6 records.
