### PR TITLE
Bug 1816254: pkg/controller/template: Support architecture specific files and units

### DIFF
--- a/templates/common/_base/ppc64le/files/disable-nic-tso.yaml
+++ b/templates/common/_base/ppc64le/files/disable-nic-tso.yaml
@@ -1,0 +1,10 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-nic-tso.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    # This is a workaround for BZ#1816254.If the ibmveth driver is used, disable TSO
+    if lsmod|grep -q 'ibmveth'; then
+      UUID=$(nmcli -t c show --active | cut -d ":" -f 2) ; nmcli conn modify $UUID ethtool.feature-tso off;
+    fi


### PR DESCRIPTION
For a managed baremetal install on ppc64le, there was a need to disable TSO (https://bugzilla.redhat.com/show_bug.cgi?id=1816254). To do this in an architecture specific manner, this PR introduces the ability to specify architecture directories (specified by the architecture uname) which can contain files and systemd units. These can be specified across the different platforms similar to how files and systemd units can be specified today.

Closes: #1638
