### PR TITLE
[release-4.4] Bug 1829651: MC CRD: preserve unknown fields

### DIFF
--- a/manifests/machineconfig.crd.yaml
+++ b/manifests/machineconfig.crd.yaml
@@ -74,6 +74,7 @@ spec:
                   description: Ignition section contains metadata about the configuration
                     itself. We only permit a subsection of ignition fields for MachineConfigs.
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     config:
                       type: object
@@ -147,6 +148,7 @@ spec:
                 storage:
                   description: Storage describes the desired state of the system's storage devices.
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     directories:
                       description: Directories is the list of directories to be created

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1334,6 +1334,7 @@ spec:
                   description: Ignition section contains metadata about the configuration
                     itself. We only permit a subsection of ignition fields for MachineConfigs.
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     config:
                       type: object
@@ -1407,6 +1408,7 @@ spec:
                 storage:
                   description: Storage describes the desired state of the system's storage devices.
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     directories:
                       description: Directories is the list of directories to be created


### PR DESCRIPTION
TL;DR; if somebody provides fields like disks and other we don't specify in the crd
those get dropped and can cause whatever issue you can think of.
I think adding that will preserve the unknown field.

Signed-off-by: Antonio Murdaca <runcom@linux.com>

holding pending tests