### PR TITLE
docs: fix ssh machineconfigs to include ignition version

### DIFF
--- a/docs/Update-SSHKeys.md
+++ b/docs/Update-SSHKeys.md
@@ -86,6 +86,8 @@ metadata:
   name: 99-worker-ssh
 spec:
   config:
+    ignition:
+      version: 2.2.0
     passwd:
       users:
       - name: core
@@ -113,6 +115,8 @@ metadata:
   name: 99-worker-ssh
 spec:
   config:
+    ignition:
+      version: 2.2.0
     passwd:
       users:
       - name: core


### PR DESCRIPTION
Came to my attention these examples were missing ignition version..