### PR TITLE
[release-4.4] crio: Add explicit paths for configuration settings

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -80,7 +80,7 @@ contents:
     # Path to the seccomp.json profile which is used as the default seccomp profile
     # for the runtime. If not specified, then the internal default seccomp profile
     # will be used.
-    seccomp_profile = ""
+    seccomp_profile = "/etc/crio/seccomp.json"
 
     # Used to change the name of the default AppArmor profile of CRI-O. The default
     # profile name is "crio-default-" followed by the version string of CRI-O.
@@ -196,7 +196,7 @@ contents:
     # - runtime_root (optional, string): root directory for storage of containers
     #   state.
     [crio.runtime.runtimes.runc]
-    runtime_path = ""
+    runtime_path = "/usr/bin/runc"
     runtime_type = "oci"
     runtime_root = "/run/runc"
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -80,7 +80,7 @@ contents:
     # Path to the seccomp.json profile which is used as the default seccomp profile
     # for the runtime. If not specified, then the internal default seccomp profile
     # will be used.
-    seccomp_profile = ""
+    seccomp_profile = "/etc/crio/seccomp.json"
 
     # Used to change the name of the default AppArmor profile of CRI-O. The default
     # profile name is "crio-default-" followed by the version string of CRI-O.
@@ -196,7 +196,7 @@ contents:
     # - runtime_root (optional, string): root directory for storage of containers
     #   state.
     [crio.runtime.runtimes.runc]
-    runtime_path = ""
+    runtime_path = "/usr/bin/runc"
     runtime_type = "oci"
     runtime_root = "/run/runc"
 


### PR DESCRIPTION
There is a window during machine set scale up where a 1.14 crio
uses this configuration and it doesn't understand these empty
settings. Restoring the settings back to full paths till
we also update the boot image for machine sets as part of updates.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1829642


**- What I did**
Restore some crio settings to older values to make them forward compatible with older crio versions.

**- How to verify it**
Test that cri-o 4.2 can still understand the default rendered 4.4 crio.conf.

**- Description for the changelog**
Add back explicit path for settings to be forwards compatible with older crio versions.
