### PR TITLE
Bug 1829642: templates: Add a special machine-config-daemon-firstboot-v42.service

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot-v42.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot-v42.service
@@ -1,22 +1,21 @@
-name: "machine-config-daemon-firstboot.service"
+name: "machine-config-daemon-firstboot-v42.service"
 enabled: true
 contents: |
   [Unit]
-  Description=Machine Config Daemon Firstboot
+  Description=Machine Config Daemon Firstboot (4.2 bootimage)
   # Make sure it runs only on OSTree booted system
   ConditionPathExists=/run/ostree-booted
   BindsTo=ignition-firstboot-complete.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
-  # We only want to run on 4.3 clusters and above; this came from
-  # https://github.com/coreos/coreos-assembler/pull/768
-  ConditionPathExists=/sysroot/.coreos-aleph-version.json
+  # Note the opposite of this in machine-config-daemon-firstboot
+  ConditionPathExists=!/sysroot/.coreos-aleph-version.json
   After=ignition-firstboot-complete.service
   Before=kubelet.service
 
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/libexec/machine-config-daemon firstboot-complete-machineconfig
+  ExecStart=/usr/libexec/machine-config-daemon pivot
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
This is aiming to fix:
https://bugzilla.redhat.com/show_bug.cgi?id=1829642
AKA
https://github.com/openshift/machine-config-operator/pull/1215#issuecomment-622081019

Basically we have our systemd units dynamically differentiate between
"4.2" and "4.3 or above" by looking at the aleph version.

---

# https://bugzilla.redhat.com/show_bug.cgi?id=1829642

## Background

In the beginning, we had this concept of `pivot.service` whose whole job was to pull a new `machine-os-content` and reboot, running `Before=kubelet.service`.
More: [OSUpgrades](https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md).

That was simple, and worked well!  Life was good.  Everyone was relaxing on the beach.

Then, we needed to [handle kernel arguments](https://github.com/openshift/installer/pull/1392) (specifically adding `nosmt`).

But a core problem here is that we have [no mechanism to update bootimages](https://github.com/openshift/enhancements/pull/201) by default - so every change we make that needs to happen on this "firstboot" becomes an upgrade hazard.

Further, we had a strong split between the `pivot` code (day 0) and what happened in the MCO.  So we started baking in the MCD to the host; https://github.com/openshift/machine-config-operator/pull/868 is a notable commit here.

But still today, the MCO needs to handle having even very old bootimages (from 4.1) scale up and join the cluster.

https://github.com/openshift/machine-config-operator/pull/891 is a notable commit here; basically the MCS serves Ignition which contains a pair of systemd units:

[machine-config-daemon-firstboot.service](https://github.com/openshift/machine-config-operator/blob/5396c45464fc1658c65bad980de0a386958fbf9a/templates/common/_base/units/machine-config-daemon-firstboot.service):  Replaces `pivot.service` - this handles everything the MCO knows how to handle day 1/2, such as kernel arguments too.

[machine-config-daemon-host.service](https://github.com/openshift/machine-config-operator/blob/5396c45464fc1658c65bad980de0a386958fbf9a/templates/common/_base/units/machine-config-daemon-host.service): Run by rpm-ostree to perform upgrades.  This is not enabled by default, but is started by the MCD (both via the `-firstboot.service` as well as "day 2" when the MCD runs as a daemonset).

Now wait...trying to re-understand the difference between them, I found https://github.com/openshift/machine-config-operator/pull/1215 (landed for 4.4).

Before that commit...we basically didn't run the new code AFAICS because the MCS still today writes `/etc/pivot/image-pullspec` (for compatibility with 4.1 bootimages).  See [this commit](https://github.com/openshift/machine-config-operator/commit/40d8225dae9f25b392e39fa2ce30c48d18638fa5) which added the code.
