### PR TITLE
[release-4.4] Bug 1830102: templates: Add a special machine-config-daemon-firstboot-v42.service

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot-v42.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot-v42.service
@@ -1,22 +1,21 @@
-name: "machine-config-daemon-firstboot.service"
+name: "machine-config-daemon-firstboot-v42.service"
 enabled: true
 contents: |
   [Unit]
-  Description=Machine Config Daemon Firstboot
+  Description=Machine Config Daemon Firstboot (4.2 bootimage)
   # Make sure it runs only on OSTree booted system
   ConditionPathExists=/run/ostree-booted
   BindsTo=ignition-firstboot-complete.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
-  # We only want to run on 4.3 clusters and above; this came from
-  # https://github.com/coreos/coreos-assembler/pull/768
-  ConditionPathExists=/sysroot/.coreos-aleph-version.json
+  # Note the opposite of this in machine-config-daemon-firstboot
+  ConditionPathExists=!/sysroot/.coreos-aleph-version.json
   After=ignition-firstboot-complete.service
   Before=kubelet.service
 
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/libexec/machine-config-daemon firstboot-complete-machineconfig
+  ExecStart=/usr/libexec/machine-config-daemon pivot
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
Backport of #1706
```
This is aiming to fix:
https://bugzilla.redhat.com/show_bug.cgi?id=1829642
AKA
#1215 (comment)

Basically we have our systemd units dynamically differentiate between
"4.2" and "4.3 or above" by looking at the aleph version.
```