### PR TITLE
Bug 1809345: templates: add etc-networkmanager-dispatcher.d-90-long-hostname.yaml

### DIFF
--- a/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
+++ b/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
@@ -1,0 +1,40 @@
+filesystem: "root"
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/90-long-hostname"
+contents:
+  inline: |
+    #!/bin/bash
+    #
+    # On Google Compute Platform (GCP) the hostname may be too long (>63 chars).
+    # During firstboot the hostname is set in the initramfs before NetworkManager
+    # runs; on reboot affect nodes use 'localhost'. This hook is a simple work
+    # around: if the host name is longer than 63 characters, then the hostname
+    # is truncated at the _first_ dot.
+    #
+    # Additionally, this hook does not break DNS or cluster DNS resolution,
+    # since NetworkManager sets the appropriate /etc/resolv.conf settings.
+
+    IF=$1
+    STATUS=$2
+
+    log() { logger --tag "network-manager/$(basename $0)" "${@}"; }
+
+    # capture all eligible hostnames
+    if [[ ! "$(/bin/hostname)" =~ (localhost|localhost.local) ]]; then
+        log "hostname is already set"
+        exit 0
+    fi
+
+    if [[ ! "$STATUS" =~ (up|hostname|dhcp4-change|dhcp6-change) ]]; then
+        exit 0
+    fi
+
+    default_host="${DHCP4_HOST_NAME:-$DHCP6_HOST_NAME}"
+    # truncate the hostname to the first dot and than 64 characters.
+    host=$(echo ${default_host} | cut -f1 -d'.' | cut -c -63)
+
+    if [ "${#default_host}" -gt 63 ]; then
+        log "discovered hostname is longer than than 63 characters"
+        log "truncating ${default_host} => ${host}"
+        /bin/hostnamectl --transient set-hostname "${host}"
+    fi


### PR DESCRIPTION
On GCP it is not uncommon to have DNS names that are too long.
Linux restricts the kernel hostname to being less than 63 characters.
The new template simply ensures that a hostname is set in the event that
NetworkManager is unable to do so.

Bug: 1809345
