### PR TITLE
Bug 1781575: Remove rejects from icmp ratemask

### DIFF
--- a/templates/common/_base/files/sysctl-icmp-conf.yaml
+++ b/templates/common/_base/files/sysctl-icmp-conf.yaml
@@ -1,0 +1,6 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/sysctl.d/00-icmp.conf"
+contents:
+  inline: |
+    net.ipv4.icmp_ratemask = 6160


### PR DESCRIPTION
Fixes 1781575

**- What I did**:
Clears the 4th bit of the icmp_ratemask

**- How to verify it**:
cat /proc/sys/net/ipv4/icmp_ratemask must return a number which has the 4th bit set to 0.
Do a curl request to a service without endpoints. It should consistently fail with a connection rejected rather than a timeout.

**- Description for the changelog**
Remove icmp rejects rate limit. This is necessary so that kubernetes services without endpoints are timely rejected.