### PR TITLE
Bug 1784201: lib/resourcemerge: set AdditionalTrustBundle

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -68,6 +68,7 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setStringIfSet(modified, &existing.EtcdDiscoveryDomain, required.EtcdDiscoveryDomain)
 	setStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
 
+	setBytesIfSet(modified, &existing.AdditionalTrustBundle, required.AdditionalTrustBundle)
 	setBytesIfSet(modified, &existing.EtcdCAData, required.EtcdCAData)
 	setBytesIfSet(modified, &existing.EtcdMetricCAData, required.EtcdMetricCAData)
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)


### PR DESCRIPTION
Proxy day2 wasn't working because the MCO wasn't rolling the additionalTrustBundle to nodes. Now it does and day2 proxy is deployed.

Signed-off-by: Antonio Murdaca <runcom@linux.com>