### PR TITLE
Bug 1810680: make file diffs more user friendly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/mock v1.3.1 // indirect
 	github.com/golangci/golangci-lint v1.18.0
+	github.com/google/go-cmp v0.3.1
 	github.com/google/renameio v0.1.0
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gostaticanalysis/analysisutil v0.0.3 // indirect

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	ign "github.com/coreos/ignition/config/v2_2"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/machine-config-operator/lib/resourceread"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -32,7 +33,6 @@ import (
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/diff"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
@@ -1419,7 +1419,7 @@ func checkFileContentsAndMode(filePath string, expectedContent []byte, mode os.F
 		return false
 	}
 	if !bytes.Equal(contents, expectedContent) {
-		glog.Errorf("content mismatch for file %s: %s", filePath, diff.StringDiff(string(contents), string(expectedContent)))
+		glog.Errorf("content mismatch for file %s (-want +got):\n%s", filePath, cmp.Diff(expectedContent, contents))
 		return false
 	}
 	return true


### PR DESCRIPTION
This is most straightforward fix as users are super confused by A/B instead of Actual/Expected - This can be better and imo isn't worth wrapping. 

Am considering using `go-cmp`(https://pkg.go.dev/github.com/google/go-cmp/cmp?tab=doc#Diff) which diffs line by line (like a traditional diff) instead of just huge blocks as it's hard for users to see the differences between the files.