### PR TITLE
[Baremetal, Openstack,Vsphere, Ovirt] Update fall and rise values in keepalived check scripts

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -7,6 +7,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     # TODO: Improve this check. The port is assumed to be alive.
@@ -15,6 +17,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://localhost:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -7,11 +7,15 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
     vrrp_script chk_dns {
         script "/usr/bin/host -t SRV _etcd-server-ssl._tcp.{{ .EtcdDiscoveryDomain }} localhost"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -13,6 +13,8 @@ contents:
         script "/usr/bin/host -t SRV _etcd-server-ssl._tcp.{{ .EtcdDiscoveryDomain }} localhost"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     # TODO: Improve this check. The port is assumed to be alive.
@@ -21,6 +23,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -9,6 +9,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     # TODO: Improve this check. The port is assumed to be alive.
@@ -17,6 +19,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://localhost:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {

--- a/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -9,6 +9,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {

--- a/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
@@ -9,6 +9,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
         state BACKUP

--- a/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -9,6 +9,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -11,6 +11,8 @@ contents:
         script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {


### PR DESCRIPTION
Keepalived runs a check script every interval (1 Sec in our case) to calculate VRRP instance's status.
The check script must succeed 'rise' times for the instance to be considered  as 'healthy and fail 'fall'
time to be considered as 'non healthy'.

This change updates 'rise' and 'fall' values from the default (1 for both of them) to 3 and 2.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
