### PR TITLE
Bug 1834895: Bump waitForPoolComplete to 30 mins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,4 +109,4 @@ Dockerfile.rhel7: Dockerfile Makefile
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operator
 test-e2e:
-	go test -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -failfast -timeout 240m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -64,7 +64,7 @@ func waitForRenderedConfig(t *testing.T, cs *framework.ClientSet, pool, mcName s
 // waitForPoolComplete polls a pool until it has completed an update to target
 func waitForPoolComplete(t *testing.T, cs *framework.ClientSet, pool, target string) error {
 	startTime := time.Now()
-	if err := wait.Poll(2*time.Second, 20*time.Minute, func() (bool, error) {
+	if err := wait.Poll(2*time.Second, 30*time.Minute, func() (bool, error) {
 		mcp, err := cs.MachineConfigPools().Get(context.TODO(), pool, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Tests are timing out for e2e-gcp-op due to hitting this timeout,
which takes just a little over 20 minutes at the moment.
