### PR TITLE
Bug 1817430: Parse the kubelet.conf data after an update

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -2,6 +2,7 @@ package kubeletconfig
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	ign "github.com/coreos/ignition/config/v2_2"
@@ -19,8 +20,12 @@ import (
 )
 
 func createNewKubeletIgnition(jsonConfig []byte) igntypes.Config {
+	// Want the kubelet.conf file to have the pretty JSON formatting
+	buf := new(bytes.Buffer)
+	json.Indent(buf, jsonConfig, "", "  ")
+
 	mode := 0644
-	du := dataurl.New(jsonConfig, "text/plain")
+	du := dataurl.New(buf.Bytes(), "text/plain")
 	du.Encoding = dataurl.EncodingASCII
 	tempFile := igntypes.File{
 		Node: igntypes.Node{


### PR DESCRIPTION
Fixes #1817430 (https://bugzilla.redhat.com/show_bug.cgi?id=1817430)

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
After a kubeletconfig CR rolls out updates to the
kubelet.conf, we want to parse the contents so that
it is printed out in a pretty format.

**- How to verify it**
Create a kubeletconfig CR and check the nodes to ensure that /etc/kubernetes/kubelet.conf is formatted correctly with the tabs and all

**- Description for the changelog**
Parse the contents of the kubelet.conf after a CR update to ensure it is pretty printed
