### PR TITLE
[release-4.3] Bug 1801430: Write environment variables needed for etcdctl execution into ~/.profile

### DIFF
--- a/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
+++ b/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml
@@ -125,12 +125,21 @@ contents:
           mountPath: /var/lib/etcd/
         - name: conf
           mountPath: /etc/etcd/
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - echo 'export ETCDCTL_CACERT=/etc/ssl/etcd/ca.crt ETCDCTL_CERT=$(find /etc/ssl/ -name *peer*crt) ETCDCTL_KEY=$(find /etc/ssl/ -name *peer*key)' >> /root/.profile
 
         env:
         - name: ETCDCTL_API
           value: "3"
         - name: ETCD_DATA_DIR
           value: "/var/lib/etcd"
+        - name: ENV
+          value: "/root/.profile"
         - name: ETCD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added the environment variables needed for straightforward execution of etcdctl into /root/.profile, so that oc rsh has the ready-made environment.

**- How to verify it**
Install cluster
1. oc rsh -n openshift-etcd etcd-member-pod
2. Run etcdctl commands such as etcdctl member list
Should work right off the bat.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Provide environment variables for straightforward execution of etcdctl commands on pods.
