### PR TITLE
cmd: Configure klog to match glog

### DIFF
--- a/cmd/gcp-routes-controller/run.go
+++ b/cmd/gcp-routes-controller/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"flag"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,7 +17,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/openshift/machine-config-operator/internal"
 )
 
 var (
@@ -45,11 +44,7 @@ func init() {
 }
 
 func runRunCmd(cmd *cobra.Command, args []string) error {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	if runOpts.rootMount != "" {
 		glog.Infof(`Calling chroot("%s")`, runOpts.rootMount)

--- a/cmd/gcp-routes-controller/version.go
+++ b/cmd/gcp-routes-controller/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -22,9 +21,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "GCP Routes Controller"
 	version := version.Raw + "-" + version.Hash
 

--- a/cmd/machine-config-controller/bootstrap.go
+++ b/cmd/machine-config-controller/bootstrap.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/pkg/controller/bootstrap"
-	"github.com/openshift/machine-config-operator/pkg/version"
 )
 
 var (
@@ -33,11 +31,7 @@ func init() {
 }
 
 func runbootstrapCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	if bootstrapOpts.manifestsDir == "" || bootstrapOpts.destinationDir == "" {
 		glog.Fatalf("--dest-dir or --manifest-dir not set")

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"flag"
 
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/cmd/common"
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	containerruntimeconfig "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
@@ -13,7 +13,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/controller/node"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
-	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +42,7 @@ func init() {
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	cb, err := clients.NewBuilder(startOpts.kubeconfig)
 	if err != nil {

--- a/cmd/machine-config-controller/version.go
+++ b/cmd/machine-config-controller/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -22,9 +21,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "MachineConfigController"
 	version := version.Raw + "-" + version.Hash
 

--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift/machine-config-operator/internal"
 	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -25,8 +26,7 @@ func init() {
 }
 
 func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
+	internal.InitLogging()
 
 	exitCh := make(chan error)
 	defer close(exitCh)

--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -13,6 +13,7 @@ import (
 	_ "crypto/sha256"
 
 	"github.com/golang/glog"
+	"github.com/openshift/machine-config-operator/internal"
 	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
 	"github.com/openshift/machine-config-operator/pkg/daemon/pivot/types"
 	errors "github.com/pkg/errors"
@@ -185,8 +186,7 @@ func updateTuningArgs(tuningFilePath, cmdLinePath string) (bool, error) {
 }
 
 func run(_ *cobra.Command, args []string) error {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
+	internal.InitLogging()
 
 	var container string
 	if fromEtcPullSpec || len(args) == 0 {

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -1,17 +1,16 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
 
 	"github.com/golang/glog"
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
-	"github.com/openshift/machine-config-operator/pkg/version"
 	errors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -65,13 +64,8 @@ func bindPodMounts(rootMount string) error {
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
+	internal.InitLogging()
 	glog.V(2).Infof("Options parsed: %+v", startOpts)
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
 	onceFromMode := startOpts.onceFrom != ""
 	if !onceFromMode {

--- a/cmd/machine-config-daemon/version.go
+++ b/cmd/machine-config-daemon/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -22,9 +21,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "MachineConfigDaemon"
 	version := version.Raw + "-" + version.Hash
 

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/pkg/operator"
-	"github.com/openshift/machine-config-operator/pkg/version"
 )
 
 var (
@@ -86,11 +84,7 @@ func init() {
 }
 
 func runBootstrapCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -2,18 +2,16 @@ package main
 
 import (
 	"context"
-	"flag"
-	"os"
 
 	"github.com/golang/glog"
 	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	operatorv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	"github.com/openshift/machine-config-operator/cmd/common"
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/operator"
-	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/leaderelection"
 )
@@ -39,11 +37,7 @@ func init() {
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %s (Raw: %s, Hash: %s)", os.Getenv("RELEASE_VERSION"), version.Raw, version.Hash)
+	internal.InitLogging()
 
 	if startOpts.imagesFile == "" {
 		glog.Fatal("--images-json cannot be empty")

--- a/cmd/machine-config-operator/version.go
+++ b/cmd/machine-config-operator/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -22,9 +21,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "MachineConfigOperator"
 	version := version.Raw + "-" + version.Hash
 

--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/golang/glog"
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/pkg/server"
-	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -30,11 +28,7 @@ func init() {
 }
 
 func runBootstrapCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	bs, err := server.NewBootstrapServer(bootstrapOpts.serverBaseDir, bootstrapOpts.serverKubeConfig)
 

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/golang/glog"
+	"github.com/openshift/machine-config-operator/internal"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/server"
-	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +29,7 @@ func init() {
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	if startOpts.apiserverURL == "" {
 		glog.Exitf("--apiserver-url cannot be empty")

--- a/cmd/machine-config-server/version.go
+++ b/cmd/machine-config-server/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -22,9 +21,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "MachineConfigServer"
 	version := version.Raw + "-" + version.Hash
 

--- a/cmd/setup-etcd-environment/run.go
+++ b/cmd/setup-etcd-environment/run.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -17,7 +16,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/joho/godotenv"
 	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
-	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/openshift/machine-config-operator/internal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -102,11 +101,7 @@ func newSetupEnv(runOpts *opts, etcdName, etcdDataDir string, ips []string) (*Se
 }
 
 func runRunCmd(cmd *cobra.Command, args []string) error {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
-	// To help debugging, immediately log version
-	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+	internal.InitLogging()
 
 	if runOpts.discoverySRV == "" {
 		return errors.New("--discovery-srv cannot be empty")

--- a/cmd/setup-etcd-environment/version.go
+++ b/cmd/setup-etcd-environment/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -22,9 +21,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "Setup Etcd Environment"
 	version := version.Raw + "-" + version.Hash
 

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	k8s.io/apimachinery v0.18.0
 	k8s.io/client-go v0.18.0
 	k8s.io/code-generator v0.18.0
+	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0
 	k8s.io/kubelet v0.18.0
 )

--- a/internal/cliutils.go
+++ b/internal/cliutils.go
@@ -1,0 +1,39 @@
+package internal
+
+import (
+	"flag"
+	"os"
+
+	"github.com/golang/glog"
+	"k8s.io/klog"
+
+	"github.com/openshift/machine-config-operator/pkg/version"
+)
+
+// InitLogging parses options already registered to the flag package,
+// setting up glog, klog, and any additional flags which the
+// machine-config command may have configured.  It also logs the
+// current machine-config version.
+func InitLogging() {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+
+	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+		f2 := klogFlags.Lookup(f1.Name)
+		if f2 != nil {
+			value := f1.Value.String()
+			f2.Value.Set(value)
+		}
+	})
+
+	// To help debugging, immediately log version
+	releaseVersion := os.Getenv("RELEASE_VERSION")
+	if releaseVersion == "" {
+		glog.Infof("Version: %s (%s)", version.Raw, version.Hash)
+	} else {
+		glog.Infof("Version: %s (Raw: %s, Hash: %s)", releaseVersion, version.Raw, version.Hash)
+	}
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -1,0 +1,2 @@
+// Package internal collects assorted utilities which can be shared among machine-config executables.
+package internal


### PR DESCRIPTION
To try and understand why compute nodes sometimes have a long delay between informer initialization and the initial MachineConfig retrieval in getStateAndConfigs.

https://bugzilla.redhat.com/show_bug.cgi?id=1834895