### PR TITLE
Bug 1835974: Update keepalived API script to monitor also LB health

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://0:6443/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://0:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -6,7 +6,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }


### PR DESCRIPTION
This PR updates Keepalived API check script to monitor both kube-api-server health and HAProxy LB health.
With this change, the API VIP should failover to another master if local LB isn't healthy.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
