### PR TITLE
Bug 1828112: remove quotes around kubelet_node_ip to account for rhel7

### DIFF
--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
@@ -22,8 +22,8 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
-        --node-ip="${KUBELET_NODE_IP}" \
-        --address="${KUBELET_NODE_IP}" \
+        --node-ip=${KUBELET_NODE_IP} \
+        --address=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/master/01-master-kubelet/openstack/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/openstack/units/kubelet.yaml
@@ -23,8 +23,8 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
-        --node-ip="${KUBELET_NODE_IP}" \
-        --address="${KUBELET_NODE_IP}" \
+        --node-ip=${KUBELET_NODE_IP} \
+        --address=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/master/01-master-kubelet/vsphere/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/vsphere/units/kubelet.yaml
@@ -26,8 +26,8 @@ contents: |
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         {{ if .Infra.Status.PlatformStatus.VSphere -}}
         {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
-        --node-ip="${KUBELET_NODE_IP}" \
-        --address="${KUBELET_NODE_IP}" \
+        --node-ip=${KUBELET_NODE_IP} \
+        --address=${KUBELET_NODE_IP} \
         {{ end -}}
         {{ end -}}
         --minimum-container-ttl-duration=6m0s \

--- a/templates/worker/01-worker-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/baremetal/units/kubelet.yaml
@@ -23,8 +23,8 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
-        --node-ip="${KUBELET_NODE_IP}" \
-        --address="${KUBELET_NODE_IP}" \
+        --node-ip=${KUBELET_NODE_IP} \
+        --address=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/units/kubelet.yaml
@@ -23,8 +23,8 @@ contents: |
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
-        --node-ip="${KUBELET_NODE_IP}" \
-        --address="${KUBELET_NODE_IP}" \
+        --node-ip=${KUBELET_NODE_IP} \
+        --address=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/vsphere/units/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/vsphere/units/kubelet.yaml
@@ -26,8 +26,8 @@ contents: |
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
    {{ if .Infra.Status.PlatformStatus.VSphere -}}
    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
-        --node-ip="${KUBELET_NODE_IP}" \
-        --address="${KUBELET_NODE_IP}" \
+        --node-ip=${KUBELET_NODE_IP} \
+        --address=${KUBELET_NODE_IP} \
    {{ end -}}
    {{ end -}}
         --minimum-container-ttl-duration=6m0s \


### PR DESCRIPTION
Using approach from https://github.com/openshift/machine-config-operator/pull/1439 by removing quotes around kubelet_node_ip for rhel7.


Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1828112