### PR TITLE
Bug 1834948: increase eviction time to avoid preventable timeouts

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -298,7 +298,7 @@ func (dn *Daemon) ClusterConnect(
 		IgnoreAllDaemonSets: true,
 		DeleteLocalData:     true,
 		GracePeriodSeconds:  -1,
-		Timeout:             20 * time.Second,
+		Timeout:             90 * time.Second,
 		OnPodDeletedOrEvicted: func(pod *corev1.Pod, usingEviction bool) {
 			verbStr := "Deleted"
 			if usingEviction {


### PR DESCRIPTION
Time of 20s was added when we switched to kubectl drain lib.  This results in consistent error-retries for router pod, which takes ~ 90s each time. Upped timeout to 90s to avoid these preventable and predictable errors.
