### PR TITLE
Bug 1804067: Prevent etcd-member-add.sh from running on an active master

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-etcd-member-add-sh.yaml
@@ -41,6 +41,11 @@ contents:
     source "/usr/local/bin/openshift-recovery-tools"
     
     function run {
+      if [ ! -z "$(crictl ps -name etcd-member --state running -q)" ]; then
+        echo "etcd-member container is already running and active on this master."
+        echo "Please make sure you run this script on the new master host to be added to the etcd cluster. Exiting!"
+        exit 1
+      fi
       init
       dl_etcdctl
       backup_manifest


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: #1804067

**- What I did**
Added an extra check to make sure etcd-member container is not already running on the master.

**- How to verify it**
Try to run etcd-member-add.sh script on an active etcd-member. It should print an error and exit.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Prevent users from running the etcd-member-add.sh script on a wrong master.