### PR TITLE
Bump haproxy http-request timeout to 30 seconds

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -8,7 +8,7 @@ contents:
       log     /var/run/haproxy/haproxy-log.sock local0
       option  dontlognull
       retries 3
-      timeout http-request 10s
+      timeout http-request 30s
       timeout queue        1m
       timeout connect      10s
       timeout client       86400s


### PR DESCRIPTION
Per the request in our discussion with the api team, we want to try
increasing this timeout to see if it helps with our api flakiness.

Note that I did not change the openstack platform's timeout because
they were already using 1 minute.

**- Description for the changelog**
Increase the http-request timeout in haproxy on platforms that use that to loadbalance the api.