### PR TITLE
Change keepalived healthcheck to loadbalanced API endpoint

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -20,7 +20,7 @@ contents:
     listen health_check_http_url
       bind :::50936 v4v6
       mode http
-      monitor-uri /readyz
+      monitor-uri /haproxyready
       option dontlognull
     listen stats
       bind localhost:{{`{{ .LBConfig.StatPort }}`}}

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -35,5 +35,5 @@ contents:
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}
-       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
+       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 1s fall 2 rise 3
     {{- end }}`}}

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -100,7 +100,7 @@ contents:
         livenessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: /readyz
+            path: /haproxyready
             port: 50936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/haproxyready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,9 +3,11 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/haproxyready"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/haproxyready"
         interval 1
         weight 50
+        rise 3
+        fall 2
     }
 
     # TODO: Improve this check. The port is assumed to be alive.

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,9 +3,17 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/haproxyready"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz"
         interval 1
-        weight 50
+        weight 6
+        rise 3
+        fall 2
+    }
+
+    vrrp_script chk_haproxy {
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:50936/haproxyready"
+        interval 1
+        weight 6
         rise 3
         fall 2
     }
@@ -33,6 +41,7 @@ contents:
         }
         track_script {
             chk_ocp
+            chk_haproxy
         }
     }
 

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://0:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://0:9443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -8,7 +8,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }


### PR DESCRIPTION
We don't necessarily want to move the API VIP just because the API
server on the local node goes down. HAProxy will happily continue to
distribute traffic to other nodes (as long as one is still up) and
moving the VIP may cause connection disruptions like the ones we are
seeing in CI.

This switches the keepalived healthcheck to look at port 9443, which
is where HAProxy listens, instead of 6443, which is just the local API
server.

**- Description for the changelog**
Change the keepalived healthcheck to avoid unnecessary failover of the API VIP.