### PR TITLE
DNM: Test keepalived without api healthcheck

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -4,7 +4,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://0:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://0:9443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -8,7 +8,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLs https://localhost:9443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
         interval 1
         weight 50
     }


### PR DESCRIPTION
To see if unnecessary failovers are triggering our api flakes. The
    haproxy healthcheck should cover most cases where we actually need
    to failover.