### PR TITLE
Bug 1838984: [release-4.3] templates: Don't enable machine-config-daemon-host.service by default

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot-v42.service
+++ b/templates/common/_base/units/machine-config-daemon-firstboot-v42.service
@@ -1,22 +1,21 @@
-name: "machine-config-daemon-firstboot.service"
+name: "machine-config-daemon-firstboot-v42.service"
 enabled: true
 contents: |
   [Unit]
-  Description=Machine Config Daemon Firstboot
+  Description=Machine Config Daemon Firstboot (4.2 bootimage)
   # Make sure it runs only on OSTree booted system
   ConditionPathExists=/run/ostree-booted
   BindsTo=ignition-firstboot-complete.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
-  # We only want to run on 4.3 clusters and above; this came from
-  # https://github.com/coreos/coreos-assembler/pull/768
-  ConditionPathExists=/sysroot/.coreos-aleph-version.json
+  # Note the opposite of this in machine-config-daemon-firstboot
+  ConditionPathExists=!/sysroot/.coreos-aleph-version.json
   After=ignition-firstboot-complete.service
   Before=kubelet.service
 
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/libexec/machine-config-daemon firstboot-complete-machineconfig
+  ExecStart=/usr/libexec/machine-config-daemon pivot
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/common/_base/units/machine-config-daemon-host.service
+++ b/templates/common/_base/units/machine-config-daemon-host.service
@@ -1,5 +1,5 @@
 name: "machine-config-daemon-host.service"
-enabled: true
+enabled: false
 contents: |
   [Unit]
   Description=Machine Config Daemon Initial


### PR DESCRIPTION
Also, add machine-config-daemon-firstboot-v42.service so that new
nodes through machine-api comes up as expected on a 4.2 to 4.3
upgraded cluster

Backport of PRs:
- https://github.com/openshift/machine-config-operator/pull/1366
- https://github.com/openshift/machine-config-operator/pull/1706
