### PR TITLE
[release-4.2] Bug 1840461: Update the crio.conf template to have log_dir

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -12,6 +12,8 @@ contents:
     # want to modify just crio, you can change the storage configuration in this
     # file.
 
+    log_dir = "/var/log/crio/pods"
+
     # root is a path to the "root directory". CRIO stores all of its data,
     # including container images, in this directory.
     #root = "/var/lib/containers/storage"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -12,6 +12,8 @@ contents:
     # want to modify just crio, you can change the storage configuration in this
     # file.
 
+    log_dir = "/var/log/crio/pods"
+
     # root is a path to the "root directory". CRIO stores all of its data,
     # including container images, in this directory.
     #root = "/var/lib/containers/storage"


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
Fixes #1840461 (https://bugzilla.redhat.com/show_bug.cgi?id=1840461)

Please provide the following information:
-->

**- What I did**
Update the crio.conf template to add log_dir and its
value. This ensures that we don't break on an empty value
when a ctrcfg is created and the cluster is upgraded to 4.3.

**- How to verify it**
Create a ctrcfg CR and then upgrade to 4.3.x

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update the crio.conf template to include log_dir

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
