### PR TITLE
Bug 1826150: Bootstrap Machine Config ordering issue

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -295,8 +295,8 @@ func MachineConfigFromRawIgnConfig(role, name string, rawIgnCfg []byte) (*mcfgv1
 }
 
 // GetManagedKey returns the managed key for sub-controllers, handling any migration needed
-func GetManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface, suffix, deprecatedKey string) (string, error) {
-	managedKey := fmt.Sprintf("99-%s-%s", pool.Name, suffix)
+func GetManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface, prefix, suffix, deprecatedKey string) (string, error) {
+	managedKey := fmt.Sprintf("%s-%s-%s", prefix, pool.Name, suffix)
 	// if we don't have a client, we're installing brand new, and we don't need to adjust for backward compatibility
 	if client == nil {
 		return managedKey, nil

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -296,7 +296,7 @@ func MachineConfigFromRawIgnConfig(role, name string, rawIgnCfg []byte) (*mcfgv1
 
 // GetManagedKey returns the managed key for sub-controllers, handling any migration needed
 func GetManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface, prefix, suffix, deprecatedKey string) (string, error) {
-	managedKey := fmt.Sprintf("%s-%s-%s", prefix, pool.Name, suffix)
+	managedKey := fmt.Sprintf("%s-%s-generated-%s", prefix, pool.Name, suffix)
 	// if we don't have a client, we're installing brand new, and we don't need to adjust for backward compatibility
 	if client == nil {
 		return managedKey, nil

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -33,7 +33,7 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 	if len(configs) == 0 {
 		return nil, nil
 	}
-	sort.Slice(configs, func(i, j int) bool { return configs[i].Name < configs[j].Name })
+	sort.SliceStable(configs, func(i, j int) bool { return configs[i].Name < configs[j].Name })
 
 	var fips, ok bool
 	var kernelType string

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"reflect"
@@ -19,9 +20,12 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 )
 
 // MergeMachineConfigs combines multiple machineconfig objects into one object.
@@ -260,4 +264,63 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign2types.Config, error
 	}
 
 	return &convertedIgnCfgV2, nil
+}
+
+// MachineConfigFromIgnConfig creates a MachineConfig with the provided Ignition config
+func MachineConfigFromIgnConfig(role, name string, ignCfg interface{}) (*mcfgv1.MachineConfig, error) {
+	rawIgnCfg, err := json.Marshal(ignCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling Ignition config: %v", err)
+	}
+	return MachineConfigFromRawIgnConfig(role, name, rawIgnCfg)
+}
+
+// MachineConfigFromRawIgnConfig creates a MachineConfig with the provided raw Ignition config
+func MachineConfigFromRawIgnConfig(role, name string, rawIgnCfg []byte) (*mcfgv1.MachineConfig, error) {
+	labels := map[string]string{
+		mcfgv1.MachineConfigRoleLabelKey: role,
+	}
+	return &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: labels,
+			Name:   name,
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			OSImageURL: "",
+			Config: runtime.RawExtension{
+				Raw: rawIgnCfg,
+			},
+		},
+	}, nil
+}
+
+// GetManagedKey returns the managed key for sub-controllers, handling any migration needed
+func GetManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface, suffix, deprecatedKey string) (string, error) {
+	managedKey := fmt.Sprintf("99-%s-%s", pool.Name, suffix)
+	// if we don't have a client, we're installing brand new, and we don't need to adjust for backward compatibility
+	if client == nil {
+		return managedKey, nil
+	}
+	if _, err := client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{}); err == nil {
+		return managedKey, nil
+	}
+	old, err := client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), deprecatedKey, metav1.GetOptions{})
+	if err != nil && !kerr.IsNotFound(err) {
+		return "", fmt.Errorf("could not get MachineConfig %q: %v", deprecatedKey, err)
+	}
+	// this means no previous CR config were here, so we can start fresh
+	if kerr.IsNotFound(err) {
+		return managedKey, nil
+	}
+	// if we're here, we'll grab the old CR config, dupe it and patch its name
+	mc, err := MachineConfigFromRawIgnConfig(pool.Name, managedKey, old.Spec.Config.Raw)
+	if err != nil {
+		return "", err
+	}
+	_, err = client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+	err = client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), deprecatedKey, metav1.DeleteOptions{})
+	return managedKey, err
 }

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -555,7 +555,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 
 			if isNotFound {
 				tempIgnCfg := ctrlcommon.NewIgnConfig()
-				mc, err = mtmpl.MachineConfigFromIgnConfig(role, managedKey, tempIgnCfg)
+				mc, err = ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, tempIgnCfg)
 				if err != nil {
 					return ctrl.syncStatusOnly(cfg, err, "could not create MachineConfig from new Ignition config: %v", err)
 				}
@@ -705,7 +705,7 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 			}
 			if isNotFound {
 				tempIgnCfg := ctrlcommon.NewIgnConfig()
-				mc, err = mtmpl.MachineConfigFromIgnConfig(role, managedKey, tempIgnCfg)
+				mc, err = ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, tempIgnCfg)
 				if err != nil {
 					return fmt.Errorf("could not create MachineConfig from new Ignition config: %v", err)
 				}
@@ -802,7 +802,7 @@ func RunImageBootstrap(templateDir string, controllerConfig *mcfgv1.ControllerCo
 		if err != nil {
 			return nil, err
 		}
-		mc, err := mtmpl.MachineConfigFromIgnConfig(role, managedKey, registriesIgn)
+		mc, err := ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, registriesIgn)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -2,7 +2,6 @@ package containerruntimeconfig
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,13 +19,10 @@ import (
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
-	mtmpl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/openshift/runtime-utils/pkg/registries"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
-	kerr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -173,43 +169,13 @@ func findPolicyJSON(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	return nil, fmt.Errorf("could not find Policy JSON")
 }
 
-func getManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface, suffix, deprecatedKey string) (string, error) {
-	managedKey := fmt.Sprintf("99-%s-%s", pool.Name, suffix)
-	// if we don't have a client, we're installing brand new, and we don't need to adjust for backward compatibility
-	if client == nil {
-		return managedKey, nil
-	}
-	if _, err := client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{}); err == nil {
-		return managedKey, nil
-	}
-	old, err := client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), deprecatedKey, metav1.GetOptions{})
-	if err != nil && !kerr.IsNotFound(err) {
-		return "", fmt.Errorf("could not get MachineConfig %q: %v", deprecatedKey, err)
-	}
-	// this means no previous CR config were here, so we can start fresh
-	if kerr.IsNotFound(err) {
-		return managedKey, nil
-	}
-	// if we're here, we'll grab the old CR config, dupe it and patch its name
-	mc, err := mtmpl.MachineConfigFromRawIgnConfig(pool.Name, managedKey, old.Spec.Config.Raw)
-	if err != nil {
-		return "", err
-	}
-	_, err = client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
-	if err != nil {
-		return "", err
-	}
-	err = client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), deprecatedKey, metav1.DeleteOptions{})
-	return managedKey, err
-}
-
 // Deprecated: use getManagedKeyCtrCfg
 func getManagedKeyCtrCfgDeprecated(pool *mcfgv1.MachineConfigPool) string {
 	return fmt.Sprintf("99-%s-%s-containerruntime", pool.Name, pool.ObjectMeta.UID)
 }
 
 func getManagedKeyCtrCfg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return getManagedKey(pool, client, "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
+	return ctrlcommon.GetManagedKey(pool, client, "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
 }
 
 // Deprecated: use getManagedKeyReg
@@ -218,7 +184,7 @@ func getManagedKeyRegDeprecated(pool *mcfgv1.MachineConfigPool) string {
 }
 
 func getManagedKeyReg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return getManagedKey(pool, client, "registries", getManagedKeyRegDeprecated(pool))
+	return ctrlcommon.GetManagedKey(pool, client, "registries", getManagedKeyRegDeprecated(pool))
 }
 
 func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.ContainerRuntimeConfigCondition {

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -175,7 +175,7 @@ func getManagedKeyCtrCfgDeprecated(pool *mcfgv1.MachineConfigPool) string {
 }
 
 func getManagedKeyCtrCfg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return ctrlcommon.GetManagedKey(pool, client, "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
+	return ctrlcommon.GetManagedKey(pool, client, "99", "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
 }
 
 // Deprecated: use getManagedKeyReg
@@ -184,7 +184,7 @@ func getManagedKeyRegDeprecated(pool *mcfgv1.MachineConfigPool) string {
 }
 
 func getManagedKeyReg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return ctrlcommon.GetManagedKey(pool, client, "registries", getManagedKeyRegDeprecated(pool))
+	return ctrlcommon.GetManagedKey(pool, client, "99", "registries", getManagedKeyRegDeprecated(pool))
 }
 
 func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.ContainerRuntimeConfigCondition {

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -10,6 +10,7 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,11 +68,21 @@ func findKubeletConfig(mc *mcfgv1.MachineConfig) (*igntypes.File, error) {
 	return nil, fmt.Errorf("Could not find Kubelet Config")
 }
 
-func getManagedFeaturesKey(pool *mcfgv1.MachineConfigPool) string {
+func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
+	return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+}
+
+func getManagedFeaturesKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
+	return ctrlcommon.GetManagedKey(pool, client, "98", "kubelet", getManagedFeaturesKeyDeprecated(pool))
+}
+
+// Deprecated: use getManagedFeaturesKey
+func getManagedFeaturesKeyDeprecated(pool *mcfgv1.MachineConfigPool) string {
 	return fmt.Sprintf("98-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID)
 }
 
-func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool) string {
+// Deprecated: use getManagedKubeletConfigKey
+func getManagedKubeletConfigKeyDeprecated(pool *mcfgv1.MachineConfigPool) string {
 	return fmt.Sprintf("99-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID)
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -474,7 +474,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		}
 		if isNotFound {
 			ignConfig := ctrlcommon.NewIgnConfig()
-			mc, err = mtmpl.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
+			mc, err = ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
 			if err != nil {
 				return ctrl.syncStatusOnly(cfg, err, "could not create MachineConfig from new Ignition config: %v", err)
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -434,7 +434,10 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 	for _, pool := range mcpPools {
 		role := pool.Name
 		// Get MachineConfig
-		managedKey := getManagedKubeletConfigKey(pool)
+		managedKey, err := getManagedKubeletConfigKey(pool, ctrl.client)
+		if err != nil {
+			return err
+		}
 		mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
 		if err != nil && !macherrors.IsNotFound(err) {
 			return ctrl.syncStatusOnly(cfg, err, "could not find MachineConfig: %v", managedKey)

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -325,7 +325,10 @@ func TestKubeletConfigCreate(t *testing.T) {
 			mcp.ObjectMeta.Labels["kubeletType"] = "small-pods"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
-			mcs := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -333,6 +336,8 @@ func TestKubeletConfigCreate(t *testing.T) {
 			f.mckLister = append(f.mckLister, kc1)
 			f.objects = append(f.objects, kc1)
 
+			f.expectGetMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcsDeprecated)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, []uint8{0x7b, 0x22, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x3a, 0x7b, 0x22, 0x66, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x72, 0x73, 0x22, 0x3a, 0x5b, 0x22, 0x39, 0x39, 0x2d, 0x6d, 0x61, 0x73, 0x74, 0x65, 0x72, 0x2d, 0x68, 0x35, 0x35, 0x32, 0x6d, 0x2d, 0x73, 0x6d, 0x61, 0x6c, 0x6c, 0x65, 0x72, 0x2d, 0x6d, 0x61, 0x78, 0x2d, 0x70, 0x6f, 0x64, 0x73, 0x2d, 0x6b, 0x75, 0x62, 0x65, 0x6c, 0x65, 0x74, 0x22, 0x5d, 0x7d, 0x7d})
@@ -353,7 +358,10 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			mcp.ObjectMeta.Labels["kubeletType"] = "small-pods"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
-			mcs := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -361,6 +369,8 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			f.mckLister = append(f.mckLister, kc1)
 			f.objects = append(f.objects, kc1)
 
+			f.expectGetMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcsDeprecated)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, []uint8{0x7b, 0x22, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x3a, 0x7b, 0x22, 0x66, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x72, 0x73, 0x22, 0x3a, 0x5b, 0x22, 0x39, 0x39, 0x2d, 0x6d, 0x61, 0x73, 0x74, 0x65, 0x72, 0x2d, 0x68, 0x35, 0x35, 0x32, 0x6d, 0x2d, 0x73, 0x6d, 0x61, 0x6c, 0x6c, 0x65, 0x72, 0x2d, 0x6d, 0x61, 0x78, 0x2d, 0x70, 0x6f, 0x64, 0x73, 0x2d, 0x6b, 0x75, 0x62, 0x65, 0x6c, 0x65, 0x74, 0x22, 0x5d, 0x7d, 0x7d})
@@ -410,6 +420,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 				t.Errorf("syncHandler returned: %v", err)
 			}
 
+			f.expectGetMachineConfigAction(mcs)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kcUpdate, []uint8{0x7b, 0x22, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x3a, 0x7b, 0x22, 0x66, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x72, 0x73, 0x22, 0x3a, 0x5b, 0x22, 0x39, 0x39, 0x2d, 0x6d, 0x61, 0x73, 0x74, 0x65, 0x72, 0x2d, 0x6d, 0x77, 0x77, 0x74, 0x67, 0x2d, 0x6b, 0x75, 0x62, 0x65, 0x6c, 0x65, 0x74, 0x22, 0x5d, 0x7d, 0x7d})
@@ -508,7 +519,10 @@ func TestKubeletFeatureExists(t *testing.T) {
 			mcp.ObjectMeta.Labels["kubeletType"] = "small-pods"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
-			mcs := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -519,6 +533,8 @@ func TestKubeletFeatureExists(t *testing.T) {
 			features := newFeatures("cluster", []string{"DynamicAuditing"}, []string{"ExpandPersistentVolumes"}, nil)
 			f.featLister = append(f.featLister, features)
 
+			f.expectGetMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcsDeprecated)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, []uint8{0x7b, 0x22, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x3a, 0x7b, 0x22, 0x66, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x72, 0x73, 0x22, 0x3a, 0x5b, 0x22, 0x39, 0x39, 0x2d, 0x6d, 0x61, 0x73, 0x74, 0x65, 0x72, 0x2d, 0x68, 0x35, 0x35, 0x32, 0x6d, 0x2d, 0x73, 0x6d, 0x61, 0x6c, 0x6c, 0x65, 0x72, 0x2d, 0x6d, 0x61, 0x78, 0x2d, 0x70, 0x6f, 0x64, 0x73, 0x2d, 0x6b, 0x75, 0x62, 0x65, 0x6c, 0x65, 0x74, 0x22, 0x5d, 0x7d, 0x7d})

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -85,7 +85,10 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		role := pool.Name
 
 		// Get MachineConfig
-		managedKey := getManagedFeaturesKey(pool)
+		managedKey, err := getManagedFeaturesKey(pool, ctrl.client)
+		if err != nil {
+			return err
+		}
 		mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			return err

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -20,7 +20,6 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
-	mtmpl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	"github.com/openshift/machine-config-operator/pkg/version"
 )
 
@@ -94,7 +93,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		isNotFound := errors.IsNotFound(err)
 		if isNotFound {
 			ignConfig := ctrlcommon.NewIgnConfig()
-			mc, err = mtmpl.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
+			mc, err = ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -44,8 +44,14 @@ func TestFeaturesDefault(t *testing.T) {
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
-			mcs := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp), map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
-			mcs2 := helpers.NewMachineConfig(getManagedKubeletConfigKey(mcp2), map[string]string{"node-role/worker": ""}, "dummy://", []igntypes.File{{}})
+			kubeletConfigKey1, _ := getManagedKubeletConfigKey(mcp, nil)
+			kubeletConfigKey2, _ := getManagedKubeletConfigKey(mcp2, nil)
+			mcs := helpers.NewMachineConfig(kubeletConfigKey1, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcs2 := helpers.NewMachineConfig(kubeletConfigKey2, map[string]string{"node-role/worker": ""}, "dummy://", []igntypes.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = getManagedFeaturesKeyDeprecated(mcp)
+			mcs2Deprecated := mcs2.DeepCopy()
+			mcs2Deprecated.Name = getManagedFeaturesKeyDeprecated(mcp2)
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -55,6 +61,10 @@ func TestFeaturesDefault(t *testing.T) {
 			f.featLister = append(f.featLister, features)
 
 			f.expectGetMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcsDeprecated)
+			f.expectGetMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2Deprecated)
 			f.expectGetMachineConfigAction(mcs2)
 
 			f.runFeature(getKeyFromFeatureGate(features, t))

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -569,8 +569,15 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 			return nil, nil, err
 		}
 
+		source := []corev1.ObjectReference{}
+		for _, cfg := range configs {
+			source = append(source, corev1.ObjectReference{Kind: machineconfigKind.Kind, Name: cfg.GetName(), APIVersion: machineconfigKind.GroupVersion().String()})
+		}
+
 		pool.Spec.Configuration.Name = generated.Name
+		pool.Spec.Configuration.Source = source
 		pool.Status.Configuration.Name = generated.Name
+		pool.Status.Configuration.Source = source
 		opools = append(opools, pool)
 		oconfigs = append(oconfigs, generated)
 	}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -282,6 +282,11 @@ func MachineConfigFromIgnConfig(role, name string, ignCfg interface{}) (*mcfgv1.
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling Ignition config: %v", err)
 	}
+	return MachineConfigFromRawIgnConfig(role, name, rawIgnCfg)
+}
+
+// MachineConfigFromRawIgnConfig creates a MachineConfig with the provided raw Ignition config
+func MachineConfigFromRawIgnConfig(role, name string, rawIgnCfg []byte) (*mcfgv1.MachineConfig, error) {
 	labels := map[string]string{
 		mcfgv1.MachineConfigRoleLabelKey: role,
 	}


### PR DESCRIPTION
This is a funny bug...and it's tricky to explain as well but I'll try.

Scenario: installation with custom chrony conf user provided with name (remember it):

99-master-etc-chrony-conf

Install the cluster with the above and 1/(probably an high number) fails with the usual:

Node master-0-0.ocp-edge08-0.qe.lab.redhat.com is reporti
ng: \"machineconfig.machineconfiguration.openshift.io \\\"rendered-master-a2dacf21a0e43d86e8495317ad36ae98\\\" not found\"

So master and workers go up, but masters somehow have a diff between what the bootstrap generated
for rendered-master and what the MCO did once it was up and running in the cluster.

Now, taking a look at the diff between what's on bootstrap and what the MCO generated yields
nothing in file contents diff, everything is same EXCEPT a file name ordering.
File name ordering means that the slice that contains the files and their names is different.
Upon inspecting the renderd-master on the bootstrap, I found the following:

        path: /etc/containers/registries.conf
        path: /etc/chrony.conf

So, on the bootstrap I had the above list (registries comes first, then chrony).
Upon inspecting the rendered master on the MCO, I found:

        path: /etc/chrony.conf
        path: /etc/containers/registries.conf

Boom, it's clear now that the real diff is how the files are ordered within the rendered machine config itself.

Let's look at what we do in `RunBootstrap.generateRenderedMachineConfig` _before_ my patches:

- get all the machine configs
- sort them by name
- merge the result together to create the rendered config

and then we do this:

		pool.Spec.Configuration.Name = generated.Name
		pool.Status.Configuration.Name = generated.Name

So what we're doing above in the bootstrap is just setting the generated config name. That yields
the following manifest on bootstrap:

[root@localhost bootstrap]# cat machine-pools/master.yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
  creationTimestamp: null
  labels:
    machineconfiguration.openshift.io/mco-built-in: ""
    operator.machineconfiguration.openshift.io/required-for-upgrade: ""
  name: master
spec:
  configuration:
    name: rendered-master-a2dacf21a0e43d86e8495317ad36ae98
  machineConfigSelector:
    matchLabels:
      machineconfiguration.openshift.io/role: master
  nodeSelector:
    matchLabels:
      node-role.kubernetes.io/master: ""
  paused: false
status:
  conditions: null
  configuration:
    name: rendered-master-a2dacf21a0e43d86e8495317ad36ae98
  degradedMachineCount: 0
  machineCount: 0
  readyMachineCount: 0
  unavailableMachineCount: 0
  updatedMachineCount: 0

Now let's look at the above and we can see that the main difference from the master MCP
in the cluster is that:

- it's missing the Source field which contains the configs it was generated from
- it's missing the UID (!!!)

Now, let's dive into how the registries MC name is constructed:

	return fmt.Sprintf("99-%s-%s-registries", pool.Name, pool.ObjectMeta.UID)

Ok, so for the registries MC on the bootstrap, since we don't have an UUID we get this name:

99-master--registries

So, when that MCP manifest it's applied to kube, it auto gets an UUID, and the MCO registies controller generates:

99-master-f7818c63-cd84-4ca6-954c-274fbdc5f71d-registries

So, those are different but they 1/{high number} it's ok and I'll tell you why.

Remember the user provided the chrony conf? the file name was `99-master-etc-chrony-conf`.
So, on the boostrap, following how `generateRenderedMachineConfig` sort the names, we get this order:

99-master--registries
99-master-etc-chrony-conf

On the MCO we get:

99-master-etc-chrony-conf
99-master-f7818c63-cd84-4ca6-954c-274fbdc5f71d-registries

So they're flipped!!! and that's because the generated UUID for the registries conf starts with "f" which is > than "e" (ofc)

So, everything should be clear now, and the bug is that we're not providing an UUID at bootstrap
which COULD lead to ordering issues and thus, masters won't be able to re-construct what the boostrap did.

Signed-off-by: Antonio Murdaca <runcom@linux.com>