### PR TITLE
WIP Allow tuning cgroupv2 and mitigation arguments

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -37,7 +37,9 @@ const (
 // TODO: fill out the allowlists
 // tuneableRHCOSArgsAllowlist contains allowed keys for tunable kernel arguments on RHCOS
 var tuneableRHCOSArgsAllowlist = map[string]bool{
-	"nosmt": true,
+	"nosmt":                              true,
+	"systemd.unified_cgroup_hierarchy=0": true,
+	"mitigations=auto,nosmt":             true,
 }
 
 // tuneableFCOSArgsAllowlist contains allowed keys for tunable kernel arguments on FCOS


### PR DESCRIPTION
This is required for Fedora CoreOS installs, which set `mitigations=auto`
and may enable unified cgroups


**- What I did**
Updated tuneable whitelist to include params necessary for OKD-on-FCOS:
* `mitigations=auto,nosmt`
* `systemd.unified_cgroup_hierarchy=0`

**- How to verify it**
Modify `systemd.unified_cgroup_hierarchy` or `mitigations` kernel args

**- Description for the changelog**
Whitelist `systemd.unified_cgroup_hierarchy` and `mitigations=auto,nosmt` kernel args

cc @LorbusChris 

TODO:
* Ensure these arguments are allowed in !rhcos only

Supersedes #1497