### PR TITLE
Bug 1840222: [baremetal] Mount /var/run/NetworkManager in init containers

### DIFF
--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -48,6 +48,8 @@ contents:
           mountPath: "/config"
         - name: conf-dir
           mountPath: "/etc/coredns"
+        - name: nm-resolv
+          mountPath: "/var/run/NetworkManager"
         imagePullPolicy: IfNotPresent
       containers:
       - name: coredns

--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -23,6 +23,9 @@ contents:
       - name: conf-dir
         hostPath:
           path: "/etc/mdns"
+      - name: nm-resolv
+        hostPath:
+          path: "/var/run/NetworkManager"
       initContainers:
       - name: verify-hostname
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -76,6 +79,8 @@ contents:
           mountPath: "/config"
         - name: conf-dir
           mountPath: "/etc/mdns"
+        - name: nm-resolv
+          mountPath: "/var/run/NetworkManager"
         imagePullPolicy: IfNotPresent
       containers:
       - name: mdns-publisher


### PR DESCRIPTION
For some reason our early containers are sometimes getting empty
/etc/resolv.conf files. This is problematic because it means the
coredns init container will generate an invalid configuration with
no upstream servers. The init container resolv.conf never seems to
update either unless we mount in /var/run/NetworkManager (which also
contains resolv.conf).

This mounts /var/run/NetworkManager in both the coredns and
mdns-publisher init containers to allow them to generate valid
configurations even when they get an initially empty resolv.conf.

Note that this is more of a workaround than a fix. The empty resolv.conf
issue is likely to cause other issues, but hopefully this will at least unblock
ci for baremetal.