### PR TITLE
[baremetal & friends] Give coredns and mdns-publisher init containers unique names

### DIFF
--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -27,7 +27,7 @@ contents:
         hostPath:
           path: "/var/run/NetworkManager"
       initContainers:
-      - name: render-config
+      - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - runtimecfg

--- a/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/common/baremetal/files/baremetal-mdns-publisher.yaml
@@ -51,7 +51,7 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"
-      - name: render-config
+      - name: render-config-mdns-publisher
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: RUNTIMECFG_HOSTNAME_PATH

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -24,7 +24,7 @@ contents:
         hostPath:
           path: "/etc/coredns"
       initContainers:
-      - name: render-config
+      - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - runtimecfg

--- a/templates/common/openstack/files/openstack-mdns-publisher.yaml
+++ b/templates/common/openstack/files/openstack-mdns-publisher.yaml
@@ -53,7 +53,7 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"
-      - name: render-config
+      - name: render-config-mdns-publisher
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: RUNTIMECFG_HOSTNAME_PATH

--- a/templates/common/ovirt/files/ovirt-coredns.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns.yaml
@@ -24,7 +24,7 @@ contents:
         hostPath:
           path: "/etc/coredns"
       initContainers:
-      - name: render-config
+      - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - runtimecfg

--- a/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
+++ b/templates/common/ovirt/files/ovirt-mdns-publisher.yaml
@@ -24,7 +24,7 @@ contents:
         hostPath:
           path: "/etc/mdns"
       initContainers:
-      - name: render-config
+      - name: render-config-mdns-publisher
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - runtimecfg

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -31,7 +31,7 @@ contents:
         hostPath:
           path: "/var/run/NetworkManager"
       initContainers:
-      - name: render-config
+      - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - runtimecfg

--- a/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
+++ b/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
@@ -55,7 +55,7 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"
-      - name: render-config
+      - name: render-config-mdns-publisher
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: RUNTIMECFG_HOSTNAME_PATH


### PR DESCRIPTION
Currently both the coredns and mdns-publisher init containers are
named "render-config". This makes it impossible to tell at a glance
which belongs to which service. This change appends the name of the
service to the init container name so it is clear which service the
container is configuring.

**- Description for the changelog**
Give coredns and mdns-publisher init containers unique names so it
is clear which service they belong to.