### PR TITLE
Bug 1780318: MCD: tolerate all taints

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -63,13 +63,6 @@ spec:
       hostPID: true
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 600
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/etcd
-        operator: Exists
-        effect: NoSchedule
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
@@ -83,3 +76,6 @@ spec:
         - name: cookie-secret
           secret:
             secretName: cookie-secret
+      tolerations:
+      # MCD needs to run everywhere. Tolerate all taints.
+      - operator: Exists

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1288,13 +1288,6 @@ spec:
       hostPID: true
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 600
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/etcd
-        operator: Exists
-        effect: NoSchedule
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
@@ -1308,7 +1301,9 @@ spec:
         - name: cookie-secret
           secret:
             secretName: cookie-secret
-`)
+      tolerations:
+      # MCD needs to run everywhere. Tolerate all taints.
+      - operator: Exists`)
 
 func manifestsMachineconfigdaemonDaemonsetYamlBytes() ([]byte, error) {
 	return _manifestsMachineconfigdaemonDaemonsetYaml, nil


### PR DESCRIPTION
This is supposed to fix the BZ in $subject and it's the same as BZs like https://bugzilla.redhat.com/show_bug.cgi?id=1813479. The impact of a change like this isn't fully clear as mentioned in the DNS PR as well https://github.com/openshift/cluster-dns-operator/pull/171#issuecomment-622110777

I'm opening this PR to get some more eyes and testing on this - @derekwaynecarr @smarterclayton ptal

The BZ has been pushed to 4.6 following what the DNS team did as well.