### PR TITLE
Bug 1834194: vsphere: 4.1 to 4.4 upgrade bug

### DIFF
--- a/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
+++ b/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
@@ -3,12 +3,14 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/99-kni.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     [main]
     dhcp=dhclient
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/coredns/Corefile.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -16,6 +17,7 @@ contents:
         reload
         file /etc/coredns/node-dns-db {{ .EtcdDiscoveryDomain }}
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns-db.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-db.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/coredns/node-dns-db"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -19,6 +20,7 @@ contents:
     api IN A {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
 
     *.apps  IN  A {{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/coredns.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -93,6 +94,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-keepalived.yaml
+++ b/templates/common/vsphere/files/vsphere-keepalived.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/keepalived.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -120,6 +121,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
+++ b/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/mdns-publisher.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -77,6 +78,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
@@ -3,12 +3,14 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/haproxy/haproxy.cfg.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -42,6 +43,7 @@ contents:
     {{`{{- range .LBConfig.Backends }}
        server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
     {{- end }}`}}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/haproxy.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -120,6 +121,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -80,6 +81,7 @@ contents:
             chk_ingress
         }
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -36,6 +37,7 @@ contents:
         port = 42424
         ttl = 300
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
@@ -3,12 +3,14 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -32,6 +33,7 @@ contents:
             chk_ingress
         }
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
@@ -3,6 +3,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -18,6 +19,7 @@ contents:
         port = 42424
         ttl = 3200
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-non-virtual-ip.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-non-virtual-ip.yaml
@@ -3,6 +3,7 @@ mode: 0755
 path: "/usr/local/bin/non_virtual_ip"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -140,6 +141,7 @@ contents:
 
     if __name__ == '__main__':
         main()
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}


### PR DESCRIPTION
v4.1 did not include the `.Infra` see: https://github.com/openshift/machine-config-operator/blob/master-4.1/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L111-L136

Add a check to make sure that it is not nil.