### PR TITLE
Bug 1829453: check for localhost fqdn before kubelet starts up

### DIFF
--- a/templates/common/_base/files/kubelet-hostname.yaml
+++ b/templates/common/_base/files/kubelet-hostname.yaml
@@ -1,0 +1,21 @@
+filesystem: "root"
+mode: 0744
+path: "/usr/local/bin/kubelet-hostname-check"
+contents:
+  inline: |
+    #!/bin/bash
+    # This is a workaround for BZ#1829453
+    name=$(hostname -f)
+    if [[ "$name" =~ ^localhost.* ]] ; then
+      cat << EOF
+    The machine's fully qualified domain name ($name) is set to localhost.
+    Openshift is not supported with a localhost FQDN, but this should
+    automatically resolve within a short period of time with a proper network
+    configuration.
+
+    https://bugzilla.redhat.com/show_bug.cgi?id=1829453
+    https://docs.openshift.com/container-platform/4.4/installing/installing_bare_metal/installing-bare-metal-network-customizations.html
+    EOF
+      exit 1
+    fi
+    exit 0

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet-hostname-check
   Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/usr/local/bin/kubelet-hostname-check
   Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround


### PR DESCRIPTION
**- What I did**
Adds a kubelet-hostname-check bash script to check to see if the hostname on the machine is a relative of `localhost`. This will prevent the kubelet from registering a 'localhost' machine, and wait for the proper fqdn to be applied to the machine.

**- How to verify it**

**- Description for the changelog**
