### PR TITLE
[OKD] Proxy for machine config daemon firstboot

### DIFF
--- a/templates/common/_base/files/etc-systemd-system-machine-config-daemon-firstboot.service.d-10-default-env.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system-machine-config-daemon-firstboot.service.d-10-default-env.conf.yaml
@@ -1,0 +1,17 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/system/machine-config-daemon-firstboot.service.d/10-default-env.conf"
+contents:
+  inline: |
+    {{if .Proxy -}}
+    [Service]
+    {{if .Proxy.HTTPProxy -}}
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}


### PR DESCRIPTION
This PR fixes https://github.com/openshift/okd/issues/19. On fcos the machine-config-daemon-firstboot cannot pull images when behind a proxy.
This PR configures the proxy settings for the machine-config-daemon-firstboot service.

**- How to verify it**
Start an OKD installation using proxy settings in the install-config.yaml. The master would fail with
```
Error: unable to pull quay.io/openshift/okd-content@sha256:6625bb97a35604080af348340f0788df36455352b1a039f073cb6894c548fb78: unable to pull image: Error initializing source docker://quay.io/openshift/okd-content@sha256:6625bb97a35604080af348340f0788df36455352b1a039f073cb6894c548fb78: pinging docker registry returned: Get https://quay.io/v2/: dial tcp 3.230.48.144:443: i/o timeout
```
After the PR the image should be pulled using the configured proxy.

**- Description for the changelog**
<!--
Fix for installation using a proxy. machine-config-daemon-firstboot now uses the configured proxy
-->
