### PR TITLE
Bug 1842952: vsphere templates check if Infra is nil

### DIFF
--- a/templates/common/vsphere/files/NetworkManager-mdns-hostname.yaml
+++ b/templates/common/vsphere/files/NetworkManager-mdns-hostname.yaml
@@ -2,6 +2,7 @@ mode: 0755
 path: "/etc/NetworkManager/dispatcher.d/40-mdns-hostname"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -23,6 +24,7 @@ contents:
         *)
         ;;
     esac
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/etc-systemd-system-crio-stream-address.conf.yaml
+++ b/templates/common/vsphere/files/etc-systemd-system-crio-stream-address.conf.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/systemd/system/crio.service.d/20-stream-address.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -13,6 +14,7 @@ contents:
           $CRIO_STORAGE_OPTIONS \
           $CRIO_NETWORK_OPTIONS \
           $CRIO_METRICS_OPTIONS
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
+++ b/templates/common/vsphere/files/vsphere-NetworkManager-kni-conf.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/99-kni.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -11,6 +12,7 @@ contents:
     rc-manager=unmanaged
     [connection]
     ipv6.dhcp-duid=ll
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/coredns/Corefile.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -24,6 +25,7 @@ contents:
             fallthrough
         }
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/coredns.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -120,6 +121,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -2,6 +2,7 @@ mode: 0755
 path: "/usr/local/bin/vsphere-hostname.sh"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -14,6 +15,7 @@ contents:
           /usr/bin/hostnamectl --transient --static set-hostname ${hostname}
       fi
     fi
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-keepalived.yaml
+++ b/templates/common/vsphere/files/vsphere-keepalived.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/keepalived.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -121,6 +122,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
+++ b/templates/common/vsphere/files/vsphere-mdns-publisher.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/mdns-publisher.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -105,6 +106,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/common/vsphere/units/nodeip-configuration.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration.service.yaml
@@ -1,6 +1,9 @@
 name: nodeip-configuration.service
 enabled: true
 contents: |
+  {{ if .Infra -}}
+  {{ if .Infra.Status -}}
+  {{ if .Infra.Status.PlatformStatus -}}
   {{ if .Infra.Status.PlatformStatus.VSphere -}}
   {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
   [Unit]
@@ -19,6 +22,9 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
+  {{ end -}}
+  {{ end -}}
+  {{ end -}}
   {{ end -}}
   {{ end -}}
 

--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -1,6 +1,9 @@
 name: vsphere-hostname.service
 enabled: true
 contents: |
+  {{ if .Infra -}}
+  {{ if .Infra.Status -}}
+  {{ if .Infra.Status.PlatformStatus -}}
   {{ if .Infra.Status.PlatformStatus.VSphere -}}
   {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
   [Unit]
@@ -15,6 +18,9 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
+  {{ end -}}
+  {{ end -}}
+  {{ end -}}
   {{ end -}}
   {{ end -}}
 

--- a/templates/master/00-master/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -2,6 +2,7 @@ mode: 0755
 path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -34,6 +35,7 @@ contents:
         *)
         ;;
     esac
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
@@ -2,12 +2,14 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/haproxy/haproxy.cfg.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -41,6 +42,7 @@ contents:
     {{`{{- range .LBConfig.Backends }}
        server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
     {{- end }}`}}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/haproxy.yaml"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -141,6 +142,7 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -55,6 +56,7 @@ contents:
             chk_ingress
         }
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-mdns-config.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -26,6 +27,7 @@ contents:
         port = 42424
         ttl = 3200
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
@@ -24,12 +24,14 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        {{ if .Infra -}}
         {{ if .Infra.Status -}}
         {{ if .Infra.Status.PlatformStatus -}}
         {{ if .Infra.Status.PlatformStatus.VSphere -}}
         {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
         --node-ip=${KUBELET_NODE_IP} \
         --address=${KUBELET_NODE_IP} \
+        {{ end -}}
         {{ end -}}
         {{ end -}}
         {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -2,6 +2,7 @@ mode: 0755
 path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -32,6 +33,7 @@ contents:
         *)
         ;;
     esac
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/worker/00-worker/vsphere/files/dhcp-dhclient-conf.yaml
@@ -2,12 +2,14 @@ mode: 0644
 path: "/etc/dhcp/dhclient.conf"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
     prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -31,6 +32,7 @@ contents:
             chk_ingress
         }
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-mdns-config.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/mdns/config.hcl.tmpl"
 contents:
   inline: |
+    {{ if .Infra -}}
     {{ if .Infra.Status -}}
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
@@ -17,6 +18,7 @@ contents:
         port = 42424
         ttl = 3200
     }
+    {{ end -}}
     {{ end -}}
     {{ end -}}
     {{ end -}}

--- a/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
@@ -24,12 +24,14 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+   {{ if .Infra -}}
    {{ if .Infra.Status -}}
    {{ if .Infra.Status.PlatformStatus -}}
    {{ if .Infra.Status.PlatformStatus.VSphere -}}
    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
         --node-ip=${KUBELET_NODE_IP} \
         --address=${KUBELET_NODE_IP} \
+   {{ end -}}
    {{ end -}}
    {{ end -}}
    {{ end -}}


### PR DESCRIPTION
In an upgrade from 4.1 to 4.4 the .Infra can be nil
This causes templating to fail and the MCO rollout in an
upgrade to fail.

