### PR TITLE
Bug 1823967: Set the pod-infra-container-image flag in kubelet to ocp pause image

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -32,6 +32,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -31,6 +31,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always


### PR DESCRIPTION
Fixes #1823967 (https://bugzilla.redhat.com/show_bug.cgi?id=1823967)
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
By default, kubelet sets the pod-infra-container-image flag to k8s.gcr.io/pause:3.1.
The kubelet does an image status call for this image every few minutes and that is
why we were seeing the warning logs in cri-o saying this pause image is not found.
Overriding the pod-infra-container-image flag here to ensure the image status calls
we get from the kubelet is for the ocp pause image.

**- How to verify it**
Start a cluster and check the crio logs for any warnings about the k8s.gcr.io/pause:3.1 image not being found.

**- Description for the changelog**
Set the pod-infra-container-image flag in kubelet to the correct ocp pause image
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>