### PR TITLE
DNM: Migrate internals to Ignition spec v3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 
 replace (
 	github.com/InVisionApp/go-health => github.com/InVisionApp/go-health v1.1.7-0.20190926150048-b5cab38233bb
+	github.com/coreos/ign-converter => github.com/LorbusChris/ign-converter v0.0.0-20200701232648-56880ed0a25d
 	github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb
 	github.com/godbus/dbus => github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v0.1.2-0.20190408193819-a1b50f621a48

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/InVisionApp/go-health v1.1.7-0.20190926150048-b5cab38233bb h1:hWMXKLe
 github.com/InVisionApp/go-health v1.1.7-0.20190926150048-b5cab38233bb/go.mod h1:l1F5lzgPxAQwAPIrj5HJT+pWj9gfX1uMFWM/Y2gCHcU=
 github.com/InVisionApp/go-logger v1.0.1 h1:WFL19PViM1mHUmUWfsv5zMo379KSWj2MRmBlzMFDRiE=
 github.com/InVisionApp/go-logger v1.0.1/go.mod h1:+cGTDSn+P8105aZkeOfIhdd7vFO5X1afUHcjvanY0L8=
+github.com/LorbusChris/ign-converter v0.0.0-20200701232648-56880ed0a25d h1:mexPxjDu43XhrPAxXjvRm0Oe3WLkswINjXS7JPi5JMU=
+github.com/LorbusChris/ign-converter v0.0.0-20200701232648-56880ed0a25d/go.mod h1:LNu0WTt8iVH/WJH15R/SjZw7AdyY2qAyf9ILZTCBvho=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
@@ -114,8 +116,6 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/ign-converter v0.0.0-20200629171308-e40a44f244c5 h1:rBga8xIJ7MzGbTfruI8Kfxu1X3FlIquMRuW9yLsW5Mc=
-github.com/coreos/ign-converter v0.0.0-20200629171308-e40a44f244c5/go.mod h1:LNu0WTt8iVH/WJH15R/SjZw7AdyY2qAyf9ILZTCBvho=
 github.com/coreos/ignition v0.33.0 h1:rYJoGv5v/5rCJAzyMaE9gU8pn7w7pv0M4rDzHvDK6T4=
 github.com/coreos/ignition v0.33.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/PkrDqSpz+bA=
 github.com/coreos/ignition v0.35.0 h1:UFodoYq1mOPrbEjtxIsZbThcDyQwAI1owczRDqWmKkQ=

--- a/lib/resourceapply/machineconfig_test.go
+++ b/lib/resourceapply/machineconfig_test.go
@@ -4,17 +4,23 @@ import (
 	"fmt"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/davecgh/go-spew/spew"
-	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
-	"github.com/openshift/machine-config-operator/test/helpers"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	clienttesting "k8s.io/client-go/testing"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/openshift/machine-config-operator/test/helpers"
 )
+
+// Golang :cry:
+func strToPtr(s string) *string {
+	return &s
+}
 
 func TestApplyMachineConfig(t *testing.T) {
 	tests := []struct {
@@ -180,7 +186,7 @@ func TestApplyMachineConfig(t *testing.T) {
 					Raw: helpers.MarshalOrDie(&igntypes.Config{
 						Passwd: igntypes.Passwd{
 							Users: []igntypes.PasswdUser{{
-								HomeDir: "/home/dummy",
+								HomeDir: strToPtr("/home/dummy"),
 							}},
 						},
 					}),
@@ -206,7 +212,7 @@ func TestApplyMachineConfig(t *testing.T) {
 						Raw: helpers.MarshalOrDie(&igntypes.Config{
 							Passwd: igntypes.Passwd{
 								Users: []igntypes.PasswdUser{{
-									HomeDir: "/home/dummy",
+									HomeDir: strToPtr("/home/dummy"),
 								}},
 							},
 						}),
@@ -227,7 +233,7 @@ func TestApplyMachineConfig(t *testing.T) {
 						Raw: helpers.MarshalOrDie(&igntypes.Config{
 							Passwd: igntypes.Passwd{
 								Users: []igntypes.PasswdUser{{
-									HomeDir: "/home/dummy-prev",
+									HomeDir: strToPtr("/home/dummy-prev"),
 								}},
 							},
 						}),
@@ -242,7 +248,7 @@ func TestApplyMachineConfig(t *testing.T) {
 					Raw: helpers.MarshalOrDie(&igntypes.Config{
 						Passwd: igntypes.Passwd{
 							Users: []igntypes.PasswdUser{{
-								HomeDir: "/home/dummy",
+								HomeDir: strToPtr("/home/dummy"),
 							}},
 						},
 					}),
@@ -268,7 +274,7 @@ func TestApplyMachineConfig(t *testing.T) {
 						Raw: helpers.MarshalOrDie(&igntypes.Config{
 							Passwd: igntypes.Passwd{
 								Users: []igntypes.PasswdUser{{
-									HomeDir: "/home/dummy",
+									HomeDir: strToPtr("/home/dummy"),
 								}},
 							},
 						}),

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
@@ -159,7 +159,7 @@ func TestBootstrapRun(t *testing.T) {
 				}
 			}
 			require.NotNil(t, registriesConfig)
-			dataURL, err := dataurl.DecodeString(registriesConfig.Contents.Source)
+			dataURL, err := dataurl.DecodeString(*registriesConfig.Contents.Source)
 			require.NoError(t, err)
 			// Only a minimal presence check; more comprehensive tests that the contents correspond to the ICSP semantics are
 			// maintained in pkg/controller/continer-runtime-config.

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -90,38 +90,40 @@ func TestConvertIgnition3to2(t *testing.T) {
 
 func TestIgnParseWrapper(t *testing.T) {
 	// Make a new Ign3.1 config
-	testIgn3Config := ign3types.Config{}
+	testIgn3Config := NewIgnConfig()
 	tempUser := ign3types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{"5678", "abc"}}
 	testIgn3Config.Passwd.Users = []ign3types.PasswdUser{tempUser}
 	testIgn3Config.Ignition.Version = "3.1.0"
 
 	// Make a Ign2 comp config
-	testIgn2Config := NewIgnConfig()
+	testIgn2Config := ign2types.Config{}
 	tempUser2 := ign2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ign2types.SSHAuthorizedKey{"5678", "abc"}}
 	testIgn2Config.Passwd.Users = []ign2types.PasswdUser{tempUser2}
+	testIgn2Config.Ignition.Version = "2.2.0"
 
 	// turn v2.2 config into a raw []byte
 	rawIgn := helpers.MarshalOrDie(testIgn2Config)
 	// check that it was parsed successfully
 	convertedIgn, err := IgnParseWrapper(rawIgn)
 	require.Nil(t, err)
-	assert.Equal(t, testIgn2Config, convertedIgn)
+	assert.Equal(t, testIgn3Config, convertedIgn)
 
 	// turn v3.1 config into a raw []byte
 	rawIgn = helpers.MarshalOrDie(testIgn3Config)
 	// check that it was parsed successfully
 	convertedIgn, err = IgnParseWrapper(rawIgn)
 	require.Nil(t, err)
-	assert.Equal(t, testIgn2Config, convertedIgn)
+	assert.Equal(t, testIgn3Config, convertedIgn)
 
 	// Make a valid Ign 3.0 cfg
-	testIgn3Config.Ignition.Version = "3.0.0"
+	testIgn3_0Config := testIgn3Config
+	testIgn3_0Config.Ignition.Version = "3.0.0"
 	// turn it into a raw []byte
-	rawIgn = helpers.MarshalOrDie(testIgn3Config)
+	rawIgn = helpers.MarshalOrDie(testIgn3_0Config)
 	// check that it was parsed successfully
 	convertedIgn, err = IgnParseWrapper(rawIgn)
 	require.Nil(t, err)
-	assert.Equal(t, testIgn2Config, convertedIgn)
+	assert.Equal(t, testIgn3Config, convertedIgn)
 
 	// Make a bad Ign3 cfg
 	testIgn3Config.Ignition.Version = "21.0.0"
@@ -129,5 +131,5 @@ func TestIgnParseWrapper(t *testing.T) {
 	// check that it failed since this is an invalid cfg
 	convertedIgn, err = IgnParseWrapper(rawIgn)
 	require.NotNil(t, err)
-	assert.Equal(t, ign2types.Config{}, convertedIgn)
+	assert.Equal(t, ign3types.Config{}, convertedIgn)
 }

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/golang/glog"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
@@ -597,7 +597,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 // mergeConfigChanges retrieves the original/default config data from the templates, decodes it and merges in the changes given by the Custom Resource.
 // It then encodes the new data and returns it.
 func (ctrl *Controller) mergeConfigChanges(origFile *igntypes.File, cfg *mcfgv1.ContainerRuntimeConfig, update updateConfigFunc) ([]byte, error) {
-	dataURL, err := dataurl.DecodeString(origFile.Contents.Source)
+	dataURL, err := dataurl.DecodeString(*origFile.Contents.Source)
 	if err != nil {
 		return nil, ctrl.syncStatusOnly(cfg, err, "could not decode original Container Runtime config: %v", err)
 	}
@@ -755,7 +755,7 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 	}
 
 	if insecureRegs != nil || blockedRegs != nil || len(icspRules) != 0 {
-		dataURL, err := dataurl.DecodeString(originalRegistriesIgn.Contents.Source)
+		dataURL, err := dataurl.DecodeString(*originalRegistriesIgn.Contents.Source)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode original registries config: %v", err)
 		}
@@ -765,7 +765,7 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 		}
 	}
 	if blockedRegs != nil || allowedRegs != nil {
-		dataURL, err := dataurl.DecodeString(originalPolicyIgn.Contents.Source)
+		dataURL, err := dataurl.DecodeString(*originalPolicyIgn.Contents.Source)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode original policy json: %v", err)
 		}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	fakeconfigv1client "github.com/openshift/client-go/config/clientset/versioned/fake"
@@ -371,7 +371,7 @@ func verifyRegistriesConfigAndPolicyJSONContents(t *testing.T, mc *mcfgv1.Machin
 		regfile = ignCfg.Storage.Files[1]
 	}
 	assert.Equal(t, registriesConfigPath, regfile.Node.Path)
-	registriesConf, err := dataurl.DecodeString(regfile.Contents.Source)
+	registriesConf, err := dataurl.DecodeString(*regfile.Contents.Source)
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedRegistriesConf), string(registriesConf.Data))
 
@@ -386,7 +386,7 @@ func verifyRegistriesConfigAndPolicyJSONContents(t *testing.T, mc *mcfgv1.Machin
 			policyfile = ignCfg.Storage.Files[0]
 		}
 		assert.Equal(t, policyConfigPath, policyfile.Node.Path)
-		policyJSON, err := dataurl.DecodeString(policyfile.Contents.Source)
+		policyJSON, err := dataurl.DecodeString(*policyfile.Contents.Source)
 		require.NoError(t, err)
 		assert.Equal(t, string(expectedPolicyJSON), string(policyJSON.Data))
 	}

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/containers/image/pkg/sysregistriesv2"
 	signature "github.com/containers/image/signature"
 	storageconfig "github.com/containers/storage/pkg/config"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/golang/glog"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
@@ -113,13 +113,12 @@ func createNewIgnition(configs []generatedConfigFile) igntypes.Config {
 		configdu.Encoding = dataurl.EncodingASCII
 		configTempFile := igntypes.File{
 			Node: igntypes.Node{
-				Filesystem: "root",
-				Path:       ignConf.filePath,
+				Path: ignConf.filePath,
 			},
 			FileEmbedded1: igntypes.FileEmbedded1{
 				Mode: &mode,
-				Contents: igntypes.FileContents{
-					Source: configdu.String(),
+				Contents: igntypes.Resource{
+					Source: ctrlcommon.StrToPtr(configdu.String()),
 				},
 			},
 		}

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	osev1 "github.com/openshift/api/config/v1"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
@@ -32,13 +32,12 @@ func createNewKubeletIgnition(jsonConfig []byte) igntypes.Config {
 	du.Encoding = dataurl.EncodingASCII
 	tempFile := igntypes.File{
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/etc/kubernetes/kubelet.conf",
+			Path: "/etc/kubernetes/kubelet.conf",
 		},
 		FileEmbedded1: igntypes.FileEmbedded1{
 			Mode: &mode,
-			Contents: igntypes.FileContents{
-				Source: du.String(),
+			Contents: igntypes.Resource{
+				Source: ctrlcommon.StrToPtr(du.String()),
 			},
 		},
 	}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 	"github.com/vincent-petithory/dataurl"
@@ -453,7 +453,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		if err != nil {
 			return ctrl.syncStatusOnly(cfg, err, "could not generate the original Kubelet config: %v", err)
 		}
-		dataURL, err := dataurl.DecodeString(originalKubeletIgn.Contents.Source)
+		dataURL, err := dataurl.DecodeString(*originalKubeletIgn.Contents.Source)
 		if err != nil {
 			return ctrl.syncStatusOnly(cfg, err, "could not decode the original Kubelet source string: %v", err)
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -25,7 +25,7 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	oseinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	oseconfigfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -106,7 +106,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		if err != nil {
 			return err
 		}
-		dataURL, err := dataurl.DecodeString(originalKubeletIgn.Contents.Source)
+		dataURL, err := dataurl.DecodeString(*originalKubeletIgn.Contents.Source)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/vincent-petithory/dataurl"
 
@@ -24,7 +24,7 @@ func TestFeatureGateDrift(t *testing.T) {
 			if err != nil {
 				t.Errorf("could not generate kubelet config from templates %v", err)
 			}
-			dataURL, _ := dataurl.DecodeString(kubeletConfig.Contents.Source)
+			dataURL, _ := dataurl.DecodeString(*kubeletConfig.Contents.Source)
 			originalKubeConfig, _ := decodeKubeletConfig(dataURL.Data)
 			defaultFeatureGates, err := ctrl.generateFeatureMap(createNewDefaultFeatureGate())
 			if err != nil {

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -275,13 +275,11 @@ func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	files := []igntypes.File{{
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/0",
+			Path: "/dummy/0",
 		},
 	}, {
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/1",
+			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
@@ -321,13 +319,11 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	files := []igntypes.File{{
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/0",
+			Path: "/dummy/0",
 		},
 	}, {
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/1",
+			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
@@ -393,13 +389,11 @@ func TestDoNothing(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	files := []igntypes.File{{
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/0",
+			Path: "/dummy/0",
 		},
 	}, {
 		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/1",
+			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
@@ -60,14 +60,15 @@ func TestOverwrittenFile(t *testing.T) {
 	fileMode := int(fi.Mode().Perm())
 
 	// validate single file
+	duString := dataurl.EncodeBytes([]byte("hello world\n"))
 	files := []igntypes.File{
 		{
 			Node: igntypes.Node{
 				Path: "fixtures/test1.txt",
 			},
 			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
-					Source: dataurl.EncodeBytes([]byte("hello world\n")),
+				Contents: igntypes.Resource{
+					Source: &duString,
 				},
 				Mode: &fileMode,
 			},
@@ -79,14 +80,15 @@ func TestOverwrittenFile(t *testing.T) {
 	}
 
 	// validate overwritten file
+	duString2 := dataurl.EncodeBytes([]byte("hello\n"))
 	files = []igntypes.File{
 		{
 			Node: igntypes.Node{
 				Path: "fixtures/test1.txt",
 			},
 			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
-					Source: dataurl.EncodeBytes([]byte("hello\n")),
+				Contents: igntypes.Resource{
+					Source: &duString2,
 				},
 				Mode: &fileMode,
 			},
@@ -96,8 +98,8 @@ func TestOverwrittenFile(t *testing.T) {
 				Path: "fixtures/test1.txt",
 			},
 			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
-					Source: dataurl.EncodeBytes([]byte("hello world\n")),
+				Contents: igntypes.Resource{
+					Source: &duString,
 				},
 				Mode: &fileMode,
 			},

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -129,11 +129,12 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// the internally saved config is always spec v2.2
-	// so translation is only necessary when spec v3.1 is requested
+	// the internally saved config is always spec v3.1
+	// so translation is only necessary when spec v2.2 is requested
 	var serveConf *runtime.RawExtension
-	if reqConfigVer.Equal(*semver.New("3.1.0")) {
-		converted3, err := ctrlcommon.ConvertRawExtIgnition2to3(conf)
+	if reqConfigVer.Equal(*semver.New("2.2.0")) {
+		glog.Infof("converting config from spec v3.1 to v2.2 for request")
+		converted2, err := ctrlcommon.ConvertRawExtIgnition3to2(conf)
 		if err != nil {
 			w.Header().Set("Content-Length", "0")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -141,7 +142,7 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		serveConf = &converted3
+		serveConf = &converted2
 	} else {
 		serveConf = conf
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/vincent-petithory/dataurl"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -27,11 +27,6 @@ const (
 	// need this is that on bootstrap + first install we don't have the MCD
 	// running and writing that file.
 	machineConfigContentPath = "/etc/mcs-machine-config-content.json"
-
-	// defaultFileSystem defines the default file system to be
-	// used for writing the ignition files created by the
-	// server.
-	defaultFileSystem = "root"
 )
 
 // kubeconfigFunc fetches the kubeconfig that needs to be served.
@@ -138,12 +133,11 @@ func appendFileToRawIgnition(rawExt *runtime.RawExtension, outPath, contents str
 	fileMode := int(420)
 	file := igntypes.File{
 		Node: igntypes.Node{
-			Filesystem: defaultFileSystem,
-			Path:       outPath,
+			Path: outPath,
 		},
 		FileEmbedded1: igntypes.FileEmbedded1{
-			Contents: igntypes.FileContents{
-				Source: getEncodedContent(contents),
+			Contents: igntypes.Resource{
+				Source: ctrlcommon.StrToPtr(getEncodedContent(contents)),
 			},
 			Mode: &fileMode,
 		},

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	yaml "github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -270,7 +270,7 @@ func TestClusterServer(t *testing.T) {
 		}
 		foundEncapsulated = true
 		encapMc := new(mcfgv1.MachineConfig)
-		contents, err := getDecodedContent(f.Contents.Source)
+		contents, err := getDecodedContent(*f.Contents.Source)
 		assert.Nil(t, err)
 		err = yaml.Unmarshal([]byte(contents), encapMc)
 		assert.Nil(t, err)
@@ -331,7 +331,7 @@ func createUnitMap(units []igntypes.Unit) map[string]igntypes.Unit {
 func createFileMap(files []igntypes.File) map[string]igntypes.File {
 	m := make(map[string]igntypes.File)
 	for i := range files {
-		file := path.Join(files[i].Filesystem, files[i].Path)
+		file := files[i].Path
 		m[file] = files[i]
 	}
 	return m

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/coreos/go-semver/semver
 github.com/coreos/go-systemd/unit
 # github.com/coreos/go-systemd/v22 v22.0.0
 github.com/coreos/go-systemd/v22/unit
-# github.com/coreos/ign-converter v0.0.0-20200629171308-e40a44f244c5
+# github.com/coreos/ign-converter v0.0.0-20200629171308-e40a44f244c5 => github.com/LorbusChris/ign-converter v0.0.0-20200701232648-56880ed0a25d
 github.com/coreos/ign-converter/translate/v23tov30
 github.com/coreos/ign-converter/translate/v31tov22
 github.com/coreos/ign-converter/util


### PR DESCRIPTION
This migrates all internal on-disk state representation over to
Ignition config spec v3.1.

Compatibilty with older boot images is retained:
In the MCS, the User Agent on the request is inspected so it can
respond with a supported version, translated in needed.

Contains all 3 commits from #1703.

Will be superseded by https://github.com/openshift/machine-config-operator/pull/1873 