### PR TITLE
Bug 1844387: Fail healthz/readyz curls on non-200 http errors

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://localhost:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://localhost:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://0:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://0:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -8,7 +8,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -16,7 +16,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://localhost:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -5,7 +5,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
@@ -5,7 +5,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -5,7 +5,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -10,7 +10,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLs http://0:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
         interval 1
         weight 50
     }


### PR DESCRIPTION
Before this `curl -s´ only failed when the tcp connection failed, not on http non-200 errors.