### PR TITLE
Update keepalived ingress check's endpoint

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://0:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://0:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -16,7 +16,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz"
+        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -8,7 +8,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }
@@ -16,7 +16,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }


### PR DESCRIPTION
Based on [1] and [2] we should check for the router's readiness rather than for its liveliness.

This updates the keepalived ingress check query accordingly.

[1] https://github.com/openshift/installer/blob/master/docs/dev/kube-apiserver-health-check.md#load-balancer-health-check-probe
[2] https://github.com/openshift/router/blob/df645b1bb2c4085468845a526ac21cadb54b375d/deploy/router.yaml#L47-L48

