### PR TITLE
Bug 1844990: pkg/server: default to TLS 1.3

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -49,7 +49,7 @@ func (a *APIServer) Serve() {
 		Handler: a.handler,
 		// We don't want to allow 1.1 as that's old.  This was flagged in a security audit.
 		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion: tls.VersionTLS13,
 		},
 	}
 


### PR DESCRIPTION
Bumping TLS minimum version to TLS 1.3 as per https://github.com/openshift/machine-config-operator/pull/1649#issuecomment-614031278 and because TLS 1.2 isn't that strong either. Since we know RHCOS supports tls 1.3, we just support the minimum as well.

Signed-off-by: Antonio Murdaca <runcom@linux.com>