### PR TITLE
templates: Stop renaming description of crio/kubelet and other units

### DIFF
--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -3,7 +3,6 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      Description=MCO environment configuration
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}

--- a/templates/common/_base/units/kubelet.service.yaml
+++ b/templates/common/_base/units/kubelet.service.yaml
@@ -3,7 +3,6 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      Description=MCO environment configuration
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}

--- a/templates/common/_base/units/machine-config-daemon-host.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-host.service.yaml
@@ -24,7 +24,6 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      Description=MCO environment configuration
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}

--- a/templates/common/_base/units/pivot.service.yaml
+++ b/templates/common/_base/units/pivot.service.yaml
@@ -3,7 +3,6 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      Description=MCO environment configuration
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}


### PR DESCRIPTION
Commit 9b2e4248f5ffeb38710720070018bec1949f88ca made things *really*
confusing to debug looking at the journal because the `Description=`
field doesn't just apply to the drop-in - it overrides the base description.

I only discovered this when I was manually doing `systemctl start machine-config-daemon-host`
to test something and was really confused why I was seeing

`Jun 09 03:49:02 compute-0 machine-config-daemon[1342]: Starting MCO environment configuration...`
in the logs.

Previously when trying to determine timelines I'd been searching
for `Starting Machine` but this override breaks that!

See also https://github.com/systemd/systemd/pull/15957
