### PR TITLE
[release-4.5] Bug 1842906: vSphere: Disable restart.service

### DIFF
--- a/templates/common/vsphere/units/restart.service.yaml
+++ b/templates/common/vsphere/units/restart.service.yaml
@@ -1,0 +1,2 @@
+name: restart.service
+enabled: false


### PR DESCRIPTION
The restart.service is a remnant from initial installer provisioning 
on vpshere machines before version 4.4.

Ensure it is disabled so it never runs again, interfering with updates.


**- What I did**
Disable restart.service on vSphere

**- How to verify it**
Upgrades to 4.5 succeed on vSphere

**- Description for the changelog**
vSphere: Disable restart.service
