### PR TITLE
Bug 1842906: daemon: Remove encapsulated config when joining the cluster

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -914,6 +914,24 @@ func (dn *Daemon) storeCurrentConfigOnDisk(current *mcfgv1.MachineConfig) error 
 	return writeFileAtomicallyWithDefaults(dn.currentConfigPath, mcJSON)
 }
 
+// https://bugzilla.redhat.com/show_bug.cgi?id=1842906
+// If we didn't successfully complete -firstboot.service, because
+// 4.5 and newer removed the BindsTo=, the service may start downgrading
+// things.  At this point we should have already applied all target
+// changes, so just rename the file to .bak the same as the -firstboot
+// path does.
+func upgradeHackFor44AndBelow() error {
+	_, err := os.Stat(constants.MachineConfigEncapsulatedPath)
+	if err == nil {
+		glog.Warningf("Failed to complete machine-config-daemon-firstboot before joining cluster!")
+		// Removing this file signals completion of the initial MC processing.
+		if err := os.Rename(constants.MachineConfigEncapsulatedPath, constants.MachineConfigEncapsulatedBakPath); err != nil {
+			return errors.Wrap(err, "failed to rename encapsulated MachineConfig after processing on firstboot")
+		}
+	}
+	return nil
+}
+
 // checkStateOnFirstRun is a core entrypoint for our state machine.
 // It determines whether we're in our desired state, or if we're
 // transitioning between states, and whether or not we need to update
@@ -971,7 +989,13 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return fmt.Errorf("error detecting previous SSH accesses: %v", err)
 	}
 
+	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {
+		// Be sure only the MCD is running now, disable -firstboot.service
+		if err := upgradeHackFor44AndBelow(); err != nil {
+			return err
+		}
+
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL
 		osMatch, err := dn.checkOS(targetOSImageURL)
 		if err != nil {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1842906

The removal of `BindsTo=` in https://github.com/openshift/machine-config-operator/pull/1762/commits/75dbab9c54c6cb3470075af1da1b139ecea02d38
I think was completely correct for *new* installs, but creates
an upgrade hazard if we happened to be interrupted when
the cluster was originally installed as 4.4 or below.

Basically the scenario is:

- 1st boot: 4.4 install, machine boots the first time
- restart.service kills machine-config-daemon-firstboot before it upgrades, or before it unlinks the file
- 2nd boot: We stumble on without having pivoted, node joins cluster
  MCD starts a reboot into 44.81.202006062030-0 which we *should* have updated to before joining the cluster
- Cluster upgrade to 4.5 starts, new MCO starts an updated OS rollout
- 3rd boot: Prepared new root with 4.5, and the new machine-config-daemon-firstboot without BindsTo= gets laid down in /etc
- 4th boot (current): In 4.5, and -firstboot triggers again, trying to finally apply the original config

When the MCD (running as a pod) is going we shouldn't run `-firstboot` again,
the MCD should handle everything.  So just rename the file to
signal completion.
