### PR TITLE
Bug 1845903: gcp-routes: decrease downfile poll to be faster than LB on recovery

### DIFF
--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -139,7 +139,7 @@ contents:
                         break 2
                     fi
                 done
-                sleep 5
+                sleep 1 # keep this small enough to not make gcp-routes slower than LBs on recovery
             done
         fi
     }


### PR DESCRIPTION
When the local kube-apiserver becomes ready, the GCP LBs pick up the endpoint and route traffic to the IP. In parallel the gcp-routes service notices the local, green readyz and stops sending traffic to that LB.

The second step must happen *BEFORE* the first. Otherwise, local requests still go to the GCP LB that already picked up the endpoint. We risk to blackhole 1/3 of the requests (because GCP has no hairpinning support).

The reason is that the gcp-routes script polls every 5s (without inotify which isn't installed in the image as we know) such that we end up with 1*2s + 1.9999s + 5s until the gcp-routes script updates iptables (1.9999s because the readyz polling happens at an unfortunate time, and the 5s for the poll script to notice). Hence, 9s >> 6s of the LB. Hence, for 3s we might lose 1/3 of the requests originating from the local host.

Compare: https://github.com/openshift/installer/pull/3512/files#diff-3aaac4ae7d381237a540f05371931b76R10