### PR TITLE
Remove pivot invocations of systemctl reboot

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -22,12 +22,12 @@ import (
 
 // flag storage
 var keep bool
-var reboot bool
 var fromEtcPullSpec bool
 
 const (
-	etcPivotFile       = "/etc/pivot/image-pullspec"
-	runPivotRebootFile = "/run/pivot/reboot-needed"
+	// etcPivotFile is used for 4.1 bootimages and is how the MCD
+	// currently communicated with this service.
+	etcPivotFile = "/etc/pivot/image-pullspec"
 	// File containing kernel arg changes for tuning
 	kernelTuningFile = "/etc/pivot/kernel-args"
 	cmdLineFile      = "/proc/cmdline"
@@ -51,7 +51,6 @@ var pivotCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(pivotCmd)
 	pivotCmd.PersistentFlags().BoolVarP(&keep, "keep", "k", false, "Do not remove container image")
-	pivotCmd.PersistentFlags().BoolVarP(&reboot, "reboot", "r", false, "Reboot if changed")
 	pivotCmd.PersistentFlags().BoolVarP(&fromEtcPullSpec, "from-etc-pullspec", "P", false, "Parse /etc/pivot/image-pullspec")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
@@ -232,29 +231,8 @@ func run(_ *cobra.Command, args []string) error {
 
 	if !changed {
 		glog.Info("No changes; already at target oscontainer, no kernel args provided")
-		return nil
 	}
 
-	if reboot {
-		glog.Infof("Rebooting as requested by cmdline flag")
-	} else {
-		// Otherwise see if it's specified by the file
-		_, err = os.Stat(runPivotRebootFile)
-		if err != nil && !os.IsNotExist(err) {
-			return errors.Wrapf(err, "Checking %s", runPivotRebootFile)
-		}
-		if err == nil {
-			glog.Infof("Rebooting due to %s", runPivotRebootFile)
-			reboot = true
-		}
-	}
-	if reboot {
-		// Reboot the machine if asked to do so
-		err := exec.Command("systemctl", "reboot").Run()
-		if err != nil {
-			return errors.Wrapf(err, "rebooting")
-		}
-	}
 	return nil
 }
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -317,7 +317,8 @@ func (r *RpmOstreeClient) RunPivot(osImageURL string) error {
 	defer close(journalStopCh)
 	go followPivotJournalLogs(journalStopCh)
 
-	// This is written by code injected by the MCS, but we always want the MCD to be in control of reboots
+	// This is written by code injected by the MCS for compatibility with 4.1 bootimages,
+	// remove it to clean things up.
 	if err := os.Remove("/run/pivot/reboot-needed"); err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "deleting pivot reboot-needed file")
 	}


### PR DESCRIPTION
While chasing https://bugzilla.redhat.com/show_bug.cgi?id=1842906
I thought at one point this code might be invoked and was causing
a reboot that shouldn't be happening.

That turned out not to be the case.  But since nothing uses
the `--reboot` or stamp file anymore (we use the `-firstboot`)
code, the MCD code is always controlling reboots, delete this code.

Code that doesn't exist can't have (potential) bugs.
