### PR TITLE
Revert "Bug 1844990: pkg/server: default to TLS 1.3"

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -49,7 +49,7 @@ func (a *APIServer) Serve() {
 		Handler: a.handler,
 		// We don't want to allow 1.1 as that's old.  This was flagged in a security audit.
 		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS13,
+			MinVersion: tls.VersionTLS12,
 		},
 	}
 


### PR DESCRIPTION
Reverts openshift/machine-config-operator#1793

```
[core@ci-op-1155yj38-94601-74fmj-bootstrap ~]$ sudo crictl logs 1c601dc2cab8e
I0610 18:43:07.189725       1 bootstrap.go:37] Version: machine-config-daemon-4.6.0-202006101417-2-g65817154-dirty (65817154799c286cacc45bd2724f560784c7748b)
I0610 18:43:07.189866       1 api.go:56] Launching server on :22624
I0610 18:43:07.189872       1 api.go:56] Launching server on :22623
2020/06/10 18:43:07 http: TLS handshake error from 168.63.129.16:53505: tls: client offered only unsupported versions: [303 302 301 300]
2020/06/10 18:43:07 http: TLS handshake error from 168.63.129.16:53506: tls: client offered only unsupported versions: [302 301 300]
2020/06/10 18:43:07 http: TLS handshake error from 168.63.129.16:53507: tls: client offered only unsupported versions: [301 300]
2020/06/10 18:43:07 http: TLS handshake error from 168.63.129.16:53508: EOF
```

bootstrap is failing because the health checks for azure lb don't go green