### PR TITLE
Bug 1845885: templates: add node-valid-hostname.service for hostname check

### DIFF
--- a/templates/common/_base/units/node-valid-hostname.service
+++ b/templates/common/_base/units/node-valid-hostname.service
@@ -1,0 +1,24 @@
+name: node-valid-hostname.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Ensure hostname is not localhost
+  # Only run when the host has a localhost name.
+  ConditionHost=|localhost
+  ConditionHost=|localhost.localdomain
+  Before=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStartPre=/bin/echo "Node has localhost hostname. Waiting for new hostname."
+  # Get the short hostname. This is more reliable than a regex.
+  ExecStartPre=/bin/bash -c 'while [ `hostname -s` == "localhost" ]; do sleep 1; done;'
+  ExecStart=/bin/sh -c "echo Node changed hostname to `hostname`"
+  # Wait up to 5min for the node to get a real hostname.
+  TimeoutSec=300
+
+  [Install]
+  WantedBy=multi-user.target
+  # Ensure that network-online.target will not complete until the node has a real hostname.
+  RequiredBy=network-online.target


### PR DESCRIPTION
This seeks to address the problem with "localhost" nodes attempting to
join a cluster by holding up network-online.target until the node gets a
valid hostname (not localhost).

Closes 1845885: race condition during installation between nodes getting their
                            hostnames and crio+kubelet starting