### PR TITLE
Bug 1828250: Sync kublelet config across platforms

### DIFF
--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -21,6 +22,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --node-ip=${KUBELET_NODE_IP} \
         --address=${KUBELET_NODE_IP} \
@@ -28,7 +30,9 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
-        --v=3
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --v=${KUBELET_LOG_LEVEL}
 
   Restart=always
   RestartSec=10

--- a/templates/master/01-master-kubelet/openstack/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/openstack/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=3"
+  Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -22,6 +22,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --node-ip=${KUBELET_NODE_IP} \
         --address=${KUBELET_NODE_IP} \
@@ -30,6 +31,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=3"
+  Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -41,6 +41,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always


### PR DESCRIPTION
This came up because of a bug report showing that workloads were
scheduled on masters for the baremetal platform regardless of the
schedulableMasters scheduler configuration.  This is due to the
NoSchedule taint not being applied by default on this platform.  The
baremetal platform specific kubelet caused this behavior.  We were
going to remove the custom kubelet config once this behavior was
configurable (see PR #993), but it was never removed because we ended
up needing to make some IPv6 related customizations in this file.  We
also forgot to re-add the default taint.

Meanwhile, some other changes to the kubelet unit were not applied to
the baremetal version.  I also checked the openstack and vsphere files
and found discrepencies there, as well.

This is the simplest fix, which is to get these files in sync again.
The differences are very minor, so a better follow-up would be to get
back to a single kubelet unit, or at least share the duplicated
content somehow.

I'm leaving that further cleanup as another change, since the most
straight forward fix will be the simpler one to backport.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1828250

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
