### PR TITLE
Bug 1829923: etcd-quorum-guard: update containers section in deployment.yaml

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -52,9 +52,9 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-      - image: quay.io/openshift/origin-cli:latest
+      - name: guard
+        image: quay.io/openshift/origin-cli:latest
         imagePullPolicy: IfNotPresent
-        name: guard
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /mnt/kube
@@ -82,10 +82,10 @@ spec:
                 export NSS_SDB_USE_CACHE=no
                 [[ -z $cert || -z $key ]] && exit 1
                 curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
-            initialDelaySecond: 5
-            periodSecond: 5
-            failureThreshold: 3
-            timeoutSeconds: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 3
+          timeoutSeconds: 3
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Made the following changes as settings were not getting
picked up:
- move failure threshold/timeout to nest under readinessProbe
- move and correct initialDelaySeconds and periodSeconds
- reorder container sub-elements to nest image under name