### PR TITLE
[MCO] Ignore Windows Nodes

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -118,6 +118,10 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 
 // isNodeManaged checks whether the MCD has ever run on a node
 func isNodeManaged(node *corev1.Node) bool {
+	if isWindows(node) {
+		glog.V(4).Infof("Node %v is a windows node so won't be managed by MCO", node.Name)
+		return false
+	}
 	if node.Annotations == nil {
 		return false
 	}


### PR DESCRIPTION
As of now, MCC is watching for all the nodes in the cluster. While this is not
a problem, with the introduction of worker Windows Nodes in the cluster, MCC
will react to changes happening to the Windows Node objects. This commit ensures
that MCC ignores the changes for the Windows node objects by not assigning them
to the worker pool

**- What I did**
Make MCC ignore Windows worker node events.

**- How to verify it**
Updated the unit tests to exercise those scenarios.

**- Description for the changelog**
MCO should watch only for Linux node events


 I couldn't write a e2e to validate the changes as it requires bringing a Windows Worker node. Here is the ref for the [label](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-os)
xref: https://issues.redhat.com/browse/GRPA-2259, https://issues.redhat.com/browse/GRPA-2213