### PR TITLE
Bug 1822945: templates: add a file to load legacy iptables kernel modules

### DIFF
--- a/templates/common/_base/files/iptables-modules.yaml
+++ b/templates/common/_base/files/iptables-modules.yaml
@@ -1,0 +1,6 @@
+mode: 0644
+path: "/etc/modules-load.d/iptables.conf"
+contents:
+  inline: |
+    # Force-load legacy iptables so it is usable from pod network namespaces
+    ip_tables


### PR DESCRIPTION
**- What I did**
Added a template file to create `/etc/modules-load.d/iptables.conf` to force the legacy iptables module to be loaded; this guarantees that pods that try to create iptables rules in their own network namespace will be able to, regardless of whether they use iptables-legacy or iptables-nft.

(Specifically, this is about making legacy and third-party pods work. We can't just say "change the pod to do X instead" because this is about fixing the behavior of pods that we don't control.)

**- How to verify it**
Create a privileged, non-hostNetwork pod, verify that "iptables-legacy -L" (or just "iptables -L" with older iptables) works rather than giving an error

**- Description for the changelog**
The legacy iptables kernel module is now loaded by default on OCP nodes, to allow pods to use legacy iptables in their own network namespace.