### PR TITLE
Bug 1848195: daemon: fix formating in eviction message

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -319,8 +319,7 @@ func (dn *Daemon) ClusterConnect(
 			if usingEviction {
 				verbStr = "Evicted"
 			}
-			glog.Info(fmt.Sprintf("%s pod from Node", verbStr),
-				"pod", fmt.Sprintf("%s/%s", pod.Name, pod.Namespace))
+			glog.Infof("%s pod %s/%s", verbStr, pod.Namespace, pod.Name)
 		},
 		Out:    writer{glog.Info},
 		ErrOut: writer{glog.Error},


### PR DESCRIPTION
We seem to be missing some spaces:
```
I0617 21:04:50.776559    6609 daemon.go:307] Evicted pod from Nodepodrevision-pruner-2-ip-10-0-194-55.us-east-2.compute.internal/openshift-kube-scheduler
```
Ahh I see the order is also off... will fix