### PR TITLE
Bug 1842906: pkg/daemon: run 4.4 upgrade hack on MCD cluster boot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -419,6 +419,10 @@ func (dn *Daemon) syncNode(key string) error {
 	// and then proceeds to check the state of the node, which includes
 	// finalizing an update and/or reconciling the current and desired machine configs.
 	if dn.booting {
+		// Be sure only the MCD is running now, disable -firstboot.service
+		if err := upgradeHackFor44AndBelow(); err != nil {
+			return err
+		}
 		if err := dn.checkStateOnFirstRun(); err != nil {
 			return err
 		}
@@ -990,11 +994,6 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 
 	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {
-		// Be sure only the MCD is running now, disable -firstboot.service
-		if err := upgradeHackFor44AndBelow(); err != nil {
-			return err
-		}
-
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL
 		osMatch, err := dn.checkOS(targetOSImageURL)
 		if err != nil {


### PR DESCRIPTION
It seems `upgradeHackFor44AndBelow` was running inside an if statement
that only runs on cluster installation. The bug we got happens on
upgrade so what we really want is to run the hack once the MCD is
running from within the cluster (e.g. during an upgrade).

This PR still targets the now-verified 4.6 BZ - if we confirm this fix (and the verification was then flacky) we'll have to move 1842906 back to POST

@cgwalters @sinnykumari ptal

Signed-off-by: Antonio Murdaca <runcom@linux.com>