### PR TITLE
Add retry loop to nodeip-configuration service

### DIFF
--- a/templates/common/baremetal/units/nodeip-configuration.service.yaml
+++ b/templates/common/baremetal/units/nodeip-configuration.service.yaml
@@ -13,14 +13,22 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/bin/podman run --rm \
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
     --net=host \
     --volume /etc/systemd/system:/etc/systemd/system:z \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set --retry-on-failure \
-    {{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}
+    {{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}; \
+    do \
+    sleep 5; \
+    done"
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/common/openstack/units/nodeip-configuration.service.yaml
+++ b/templates/common/openstack/units/nodeip-configuration.service.yaml
@@ -13,14 +13,22 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/bin/podman run --rm \
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
     --volume /etc/systemd/system:/etc/systemd/system:z \
     --net=host \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set --retry-on-failure \
-    {{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}
+    {{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}; \
+    do \
+    sleep 5; \
+    done"
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/common/vsphere/units/nodeip-configuration.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration.service.yaml
@@ -18,14 +18,22 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
-  ExecStart=/usr/bin/podman run --rm \
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
     --net=host \
     --volume /etc/systemd/system:/etc/systemd/system:z \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set --retry-on-failure \
-    {{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
+    {{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}; \
+    do \
+    sleep 5; \
+    done"
   ExecStart=/bin/systemctl daemon-reload
 
   [Install]


### PR DESCRIPTION
We had a report that podman failed to pull the image, possibly because
the service came up before the interface that had access to the
registry, and as a result the service failed. This results in crio
and kubelet starting without an explicit IP set, which may cause
problems in some environments.

Ideally we would set Restart=on-failure in the unit file, but it looks
like the version of systemd we have right now is too old to support
that. Instead, add an infinite loop around the podman command so it
will retry indefinitely and prevent the deployment from continuing
without proper configuration. Once podman completes successfully it
will break the loop and end the oneshot.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
