### PR TITLE
Support installing extensions shipped by RHCOS

### DIFF
--- a/cmd/machine-config-daemon/mount_container.go
+++ b/cmd/machine-config-daemon/mount_container.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var mountContainer = &cobra.Command{
+	Use:                   "mount-container",
+	DisableFlagsInUseLine: true,
+	Short:                 "Pull and mount container",
+	Args:                  cobra.ExactArgs(1),
+	Run:                   executeMountContainer,
+}
+
+// init executes upon import
+func init() {
+	rootCmd.AddCommand(mountContainer)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+}
+
+func saveToFile(content, path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("Error creating file %s: %v", path, err)
+	}
+	defer file.Close()
+	if _, err := file.WriteString(content); err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func runMountContainer(_ *cobra.Command, args []string) error {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+	var containerMntLoc, containerImage, containerName string
+	containerImage = args[0]
+
+	var err error
+	if containerMntLoc, containerName, err = daemon.MountOSContainer(containerImage); err != nil {
+		return err
+	}
+	// Save mounted container name and location into file for later to be used
+	// for OS rebase and applying extensions
+	if err := saveToFile(containerName, constants.MountedOSContainerName); err != nil {
+		return fmt.Errorf("Failed saving container name: %v", err)
+	}
+	if err := saveToFile(containerMntLoc, constants.MountedOSContainerLocation); err != nil {
+		return fmt.Errorf("Failed saving mounted container location: %v", err)
+	}
+
+	return nil
+
+}
+
+func executeMountContainer(cmd *cobra.Command, args []string) {
+	err := runMountContainer(cmd, args)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -280,7 +280,7 @@ func run(_ *cobra.Command, args []string) (retErr error) {
 	}
 
 	if !changed {
-		glog.Info("No changes; already at target oscontainer, no kernel args provided")
+		glog.Info("No changes; already at target oscontainer, no kernel args provided, no kernelType switch, no extensions applied")
 	}
 
 	return nil

--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -307,6 +307,12 @@ spec:
                             description: Name is the name of the unit. This must be suffixed with a
                               valid unit type (e.g. 'thing.service')
                             type: string
+            extensions:
+              description: List of additional features that can be enabled on host
+              type: array
+              items:
+               type: string
+              nullable: true
             fips:
               description: FIPS controls FIPS mode
               type: boolean

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -59,6 +59,10 @@ func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec,
 		*modified = true
 		(*existing).FIPS = required.FIPS
 	}
+	if !equality.Semantic.DeepEqual(existing.Extensions, required.Extensions) {
+		*modified = true
+		(*existing).Extensions = required.Extensions
+	}
 }
 
 func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfigSpec, required mcfgv1.ControllerConfigSpec) {

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -176,6 +176,7 @@ type MachineConfigSpec struct {
 
 	// +nullable
 	KernelArguments []string `json:"kernelArguments"`
+	Extensions      []string `json:"extensions"`
 
 	FIPS       bool   `json:"fips"`
 	KernelType string `json:"kernelType"`

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -678,6 +678,11 @@ func (in *MachineConfigSpec) DeepCopyInto(out *MachineConfigSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Extensions != nil {
+		in, out := &in.Extensions, &out.Extensions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -103,6 +103,11 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 		kargs = append(kargs, cfg.Spec.KernelArguments...)
 	}
 
+	extensions := []string{}
+	for _, cfg := range configs {
+		extensions = append(extensions, cfg.Spec.Extensions...)
+	}
+
 	return &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
 			OSImageURL:      osImageURL,
@@ -112,6 +117,7 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 			},
 			FIPS:       fips,
 			KernelType: kernelType,
+			Extensions: extensions,
 		},
 	}, nil
 }

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -111,7 +111,7 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 	// Ensure that kernel-devel extension is applied only with default kernel.
 	if kernelType != KernelTypeDefault {
 		if InSlice("kernel-devel", extensions) {
-			return nil, fmt.Errorf("Installing kernel-devel extension is not supported in kernelType: %s", kernelType)
+			return nil, fmt.Errorf("Installing kernel-devel extension is not supported with kernelType: %s", kernelType)
 		}
 	}
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -108,6 +108,13 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 		extensions = append(extensions, cfg.Spec.Extensions...)
 	}
 
+	// Ensure that kernel-devel extension is applied only with default kernel.
+	if kernelType != KernelTypeDefault {
+		if InSlice("kernel-devel", extensions) {
+			return nil, fmt.Errorf("Installing kernel-devel extension is not supported in kernelType: %s", kernelType)
+		}
+	}
+
 	return &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
 			OSImageURL:      osImageURL,
@@ -291,10 +298,39 @@ func ValidateIgnition(ignconfig interface{}) error {
 	}
 }
 
+// InSlice search for an element in slice and return true if found, otherwise return false
+func InSlice(elem string, slice []string) bool {
+	for _, k := range slice {
+		if k == elem {
+			return true
+		}
+	}
+	return false
+}
+
+func validateExtensions(exts []string) error {
+	supportedExtensions := []string{"usbguard", "kernel-devel"}
+	invalidExts := []string{}
+	for _, ext := range exts {
+		if !InSlice(ext, supportedExtensions) {
+			invalidExts = append(invalidExts, ext)
+		}
+	}
+	if len(invalidExts) != 0 {
+		return fmt.Errorf("Invalid extensions found: %v", invalidExts)
+	}
+	return nil
+
+}
+
 // ValidateMachineConfig validates that given MachineConfig Spec is valid.
 func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
 	if !(cfg.KernelType == "" || cfg.KernelType == KernelTypeDefault || cfg.KernelType == KernelTypeRealtime) {
 		return errors.Errorf("kernelType=%s is invalid", cfg.KernelType)
+	}
+
+	if err := validateExtensions(cfg.Extensions); err != nil {
+		return err
 	}
 
 	if cfg.Config.Raw != nil {

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -55,4 +55,23 @@ const (
 	// "currentConfig" state.  Create this file (empty contents is fine) if you wish the MCD
 	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.
 	MachineConfigDaemonForceFile = "/run/machine-config-daemon-force"
+
+	// NewMachineConfigPath contains all the data from the desired MachineConfig
+	// except the spec/Config. We use this information and compare with old MachineConfig
+	// during pivot to update OS to desired state.
+	NewMachineConfigPath = "/run/newMachineConfig.json"
+
+	// OldMachineConfigPath contains all the data from the MachineConfig from the current state
+	// except the spec/Config. We use this information and compare with new old MachienConfig
+	// during pivot to update OS to desired state.
+	OldMachineConfigPath = "/run/oldMachineConfig.json"
+
+	// MountedOSContainerName contains name of OSContainer which we have already pulled in, created and mounted
+	// while we created extensions repo. We are saving the already created container so that we can further
+	// perform OS rebase or install extensions
+	MountedOSContainerName = "/run/mountedOSContainerName"
+
+	// MountedOSContainerLocation contains the path of mounted container referenced in
+	// MountedOSContainer
+	MountedOSContainerLocation = "/run/mountedOSContainerLocation"
 )

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -228,9 +228,6 @@ func (r *RpmOstreeClient) PerformRpmOSTreeOperations(containerName string, keep 
 		return
 	}
 
-	glog.Info("Old MC extensions %s and imageURL  %s", oldConfig.Spec.Extensions, oldConfig.Spec.OSImageURL)
-	glog.Info("New MC extensions %s and imageURL  %s", newConfig.Spec.Extensions, newConfig.Spec.OSImageURL)
-
 	// FIXME: moved rebase before extension becasue rpm-ostree fails to rebase on top of applied extensions
 	// during firstboot test. Maybe related to https://discussion.fedoraproject.org/t/bus-owner-changed-aborting-when-trying-to-upgrade/1919/
 	// We may need to reset package layering before applying rebase.

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -41,9 +41,14 @@ func (r RpmOstreeClientMock) RunPivot(string) error {
 	return err
 }
 
-// PullAndRebase is a mock
-func (r RpmOstreeClientMock) PullAndRebase(string, bool) (string, bool, error) {
-	return "", false, nil
+// Rebase is a mock
+func (r RpmOstreeClientMock) Rebase(string) (bool, error) {
+	return false, nil
+}
+
+// PerformRpmOSTreeOperations is a mock
+func (r RpmOstreeClientMock) PerformRpmOSTreeOperations(string, bool) (bool, error) {
+	return false, nil
 }
 
 func (r RpmOstreeClientMock) GetStatus() (string, error) {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -686,15 +686,6 @@ func parseKernelArguments(kargs []string) []string {
 	return parsed
 }
 
-func inArray(elem string, array []string) bool {
-	for _, k := range array {
-		if k == elem {
-			return true
-		}
-	}
-	return false
-}
-
 // generateKargsCommand performs a diff between the old/new MC kernelArguments,
 // and generates the command line arguments suitable for `rpm-ostree kargs`.
 // Note what we really should be doing though is also looking at the *current*
@@ -705,12 +696,12 @@ func generateKargsCommand(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
 	newKargs := parseKernelArguments(newConfig.Spec.KernelArguments)
 	cmdArgs := []string{}
 	for _, arg := range oldKargs {
-		if !inArray(arg, newKargs) {
+		if !ctrlcommon.InSlice(arg, newKargs) {
 			cmdArgs = append(cmdArgs, "--delete="+arg)
 		}
 	}
 	for _, arg := range newKargs {
-		if !inArray(arg, oldKargs) {
+		if !ctrlcommon.InSlice(arg, oldKargs) {
 			cmdArgs = append(cmdArgs, "--append="+arg)
 		}
 	}


### PR DESCRIPTION
enhancement doc- https://github.com/openshift/enhancements/pull/317

- Save old and new MachineConfig into json file and process later on host
- Rework the existing PullAndRebase() to run extensions in host context
- Add m-c-d subcommand mount-container which we run in
  host context. Here we pull OSContainer, create a container and mount it.
  We also save the created container name and mount location in /run
  which we will be used later by MCD to rebase the OS and apply extensions
- Install kernel-rt packages from coreos-extensions repo we created earlier.
 This saves us from searching explicitly for kernel-rt packages in the OSContainer.
 Also simplifies updating kernel-rt packages
