### PR TITLE
Minimal DHCP fix to unblock baremetal ci

### DIFF
--- a/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
+++ b/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
@@ -3,7 +3,7 @@ path: "/etc/NetworkManager/conf.d/99-kni.conf"
 contents:
   inline: |
     [main]
-    dhcp=dhclient
     rc-manager=unmanaged
     [connection]
     ipv6.dhcp-duid=ll
+    ipv6.dhcp-iaid=mac


### PR DESCRIPTION
The full fix for all platforms is #1840, but as this is completely
blocking baremetal ci and dev right now and we're having ci issues
with the other platforms on the full fix, this is just the bit that
is needed to get baremetal working again. We'll still want to get
1840 in eventually, but that will be less critical if we merge this
in the meantime.
