### PR TITLE
Bug 1849217: Sync kublelet config across platforms

### DIFF
--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.yaml
@@ -10,6 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  Environment="KUBELET_LOG_LEVEL=3"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -21,6 +22,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
         --node-ip="${KUBELET_NODE_IP}" \
         --address="${KUBELET_NODE_IP}" \
@@ -28,7 +30,9 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
-        --v=3
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --v=${KUBELET_LOG_LEVEL}
 
   Restart=always
   RestartSec=10


### PR DESCRIPTION
This came up because of a bug report showing that workloads were
scheduled on masters for the baremetal platform regardless of the
schedulableMasters scheduler configuration. This is due to the
NoSchedule taint not being applied by default on this platform. The
baremetal platform specific kubelet caused this behavior. We were
going to remove the custom kubelet config once this behavior was
configurable (see PR #993), but it was never removed because we ended
up needing to make some IPv6 related customizations in this file. We
also forgot to re-add the default taint.

Meanwhile, some other changes to the kubelet unit were not applied to
the baremetal version.

This is the simplest fix, which is to get these files in sync again.
The differences are very minor, so a better follow-up would be to get
back to a single kubelet unit, or at least share the duplicated
content somehow.

I'm leaving that further cleanup as another change, since the most
straight forward fix will be the simpler one to backport.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1828250

master: #1817 
4.5: #1835 