### PR TITLE
pkg/operator: report pools statuses

### DIFF
--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -36,10 +36,10 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 
 		err error
 	}{{
-		err: errors.New("configuration spec for pool dummy-pool is empty"),
+		err: errors.New("configuration spec for pool dummy-pool is empty: <unknown>"),
 	}, {
 		generated: "g",
-		err:       errors.New("list of MachineConfigs that were used to generate configuration for pool dummy-pool is empty"),
+		err:       errors.New("list of MachineConfigs that were used to generate configuration for pool dummy-pool is empty: <unknown>"),
 	}, {
 		knownConfigs: nil,
 		source:       []string{"c-0", "u-0"},
@@ -51,7 +51,7 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 		}},
 		source:    []string{"c-0", "u-0"},
 		generated: "g",
-		err:       errors.New("g must be created by controller version v2"),
+		err:       errors.New("g must be created by controller version v2: <unknown>"),
 	}, {
 		knownConfigs: []config{{
 			name:    "g",
@@ -59,7 +59,7 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 		}},
 		source:    []string{"c-0", "u-0"},
 		generated: "g",
-		err:       errors.New("controller version mismatch for g expected v2 has v1"),
+		err:       errors.New("controller version mismatch for g expected v2 has v1: <unknown>"),
 	}, {
 		knownConfigs: []config{{
 			name:    "g",
@@ -72,7 +72,7 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 		}},
 		source:    []string{"c-0", "u-0"},
 		generated: "g",
-		err:       errors.New("controller version mismatch for c-0 expected v2 has v1"),
+		err:       errors.New("controller version mismatch for c-0 expected v2 has v1: <unknown>"),
 	}, {
 		knownConfigs: []config{{
 			name:    "g",


### PR DESCRIPTION
This func is called only from within `setOperatorStatusExtension` which
in turns is called in some other operator routines. The thing is, this
doesn't work, the `Status.Extension` field of the CO is never set and
I'm looking at why as we speak. Besides that, this function should
report pools statuses regardless of the correctness of the pool
(controller version mismatch anyone? :troll:).
This will ensure, once we fix the CO issue, that we'll always have
something to immediately look at when looking at the MCO cluster
operator object.

This is meant to be the "improve controller version mismatch errors" as
from now on, we'll have users differentiate on the exact error by
looking at the CO.Status.Extension field (which, as you can see from the
code, reports the pools statuses, including any MCD error, see https://github.com/openshift/machine-config-operator/pull/1857 also).

Signed-off-by: Antonio Murdaca <runcom@linux.com>
