### PR TITLE
[ovirt/vsphere] Favor EtcdDiscoveryDomain in ControllerConfig.Infra.Status

### DIFF
--- a/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -22,7 +22,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.Ovirt.IngressIP}}")
-        DOMAIN="{{.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/master/00-master/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -28,7 +28,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.VSphere.IngressIP}}")
-        DOMAIN="{{.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \


### PR DESCRIPTION
The EtcdDiscoveryDomain field on ControllerConfig CRD was deprecated in
[1] in favor of `ControllerConfig.Infra.Status.EtcdDiscoveryDomain`.
However the originial PR missed two matches.

This fixes it so that there is no surprise in case
`ControllerConfig.EtcdDiscoveryDomain` is effectively removed.

[1] https://github.com/openshift/machine-config-operator/pull/1675

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
