### PR TITLE
OpenStack: Minimal DHCP fix to unblock CI

### DIFF
--- a/templates/common/openstack/files/openstack-NetworkManager-conf.yaml
+++ b/templates/common/openstack/files/openstack-NetworkManager-conf.yaml
@@ -3,7 +3,7 @@ path: "/etc/NetworkManager/conf.d/99-openstack.conf"
 contents:
   inline: |
     [main]
-    dhcp=dhclient
     rc-manager=unmanaged
     [connection]
     ipv6.dhcp-duid=ll
+    ipv6.dhcp-iaid=mac


### PR DESCRIPTION
The full fix for all platforms is #1840, but as this is completely
blocking openstack ci and dev right now and we're having ci issues with
the other platforms on the full fix, this is just the bit that is
needed to get openstack working again. We'll still want to get
1840 in eventually, but that will be less critical if we merge this in
the meantime.

Similar to what Baremetal did in https://github.com/openshift/machine-config-operator/pull/1851
