### PR TITLE
Bug 1840385: pkg/daemon: bubble up pivot errors

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -183,9 +183,17 @@ func updateTuningArgs(tuningFilePath, cmdLinePath string) (bool, error) {
 	return changed, nil
 }
 
-func run(_ *cobra.Command, args []string) error {
+func run(_ *cobra.Command, args []string) (retErr error) {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+
+	defer func() {
+		if retErr != nil {
+			// write a pivot failure file that we'll read from MCD since we start this with systemd
+			// and we just follow logs
+			ioutil.WriteFile(types.PivotFailurePath, []byte(retErr.Error()), 0644)
+		}
+	}()
 
 	var container string
 	if fromEtcPullSpec || len(args) == 0 {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1272,12 +1272,12 @@ func (dn *Daemon) validateOnDiskState(currentConfig *mcfgv1.MachineConfig) error
 		return err
 	}
 	if !osMatch {
-		return errors.Errorf("expected target osImageURL %s", currentConfig.Spec.OSImageURL)
+		return errors.Errorf("expected target osImageURL %q, have %q", currentConfig.Spec.OSImageURL, dn.bootedOSImageURL)
 	}
 	// And the rest of the disk state
 	currentIgnConfig, report, err := ign.Parse(currentConfig.Spec.Config.Raw)
 	if err != nil {
-		return errors.Errorf("Failed to parse Ignition for validation: %s\nReport: %v", err, report)
+		return errors.Errorf("failed to parse Ignition for validation: %s\nReport: %v", err, report)
 	}
 	if err := checkFiles(currentIgnConfig.Storage.Files); err != nil {
 		return err

--- a/pkg/daemon/pivot/types/imageinspection.go
+++ b/pkg/daemon/pivot/types/imageinspection.go
@@ -3,4 +3,9 @@ package types
 const (
 	// PivotNamePrefix is literally the name prefix of the new pivot
 	PivotNamePrefix = "ostree-container-pivot-"
+
+	// PivotFailurePath is the path pivot writes its error to when it fails. We need this to bubble
+	// up any error happning there as we just log those errors in MCD and are useful unless we report
+	// them up the stack
+	PivotFailurePath = "/run/pivot/failure"
 )

--- a/pkg/daemon/pivot/types/imageinspection.go
+++ b/pkg/daemon/pivot/types/imageinspection.go
@@ -5,7 +5,7 @@ const (
 	PivotNamePrefix = "ostree-container-pivot-"
 
 	// PivotFailurePath is the path pivot writes its error to when it fails. We need this to bubble
-	// up any error happning there as we just log those errors in MCD and are useful unless we report
-	// them up the stack
+	// up any errors since we only log those errors in MCD. If we don't do this then the error messages
+	// don't get visibility up the stack.
 	PivotFailurePath = "/run/pivot/failure"
 )

--- a/pkg/daemon/pivot/utils/run_test.go
+++ b/pkg/daemon/pivot/utils/run_test.go
@@ -13,16 +13,13 @@ import (
 // TestRunExt verifies that the wait machinery works, even though we're only
 // just testing a single step here since it's tricky to test retries.
 func TestRunExt(t *testing.T) {
-	RunExt(false, 0, "echo", "echo", "from", "TestRunExt")
-
-	result := RunExt(true, 0, "echo", "hello", "world")
-	assert.Equal(t, "hello world", result)
+	RunExt(0, "echo", "echo", "from", "TestRunExt")
 
 	tmpdir, err := ioutil.TempDir("", "run_test")
 	assert.Nil(t, err)
 	defer os.RemoveAll(tmpdir)
 	tmpf := tmpdir + "/t"
-	runExtBackoff(false, wait.Backoff{Steps: 6,
+	runExtBackoff(wait.Backoff{Steps: 6,
 		Duration: 1 * time.Second,
 		Factor:   1.1},
 		"sh", "-c", "printf x >> "+tmpf+" && test $(wc -c < "+tmpf+") = 3")

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -172,7 +172,10 @@ func (r *RpmOstreeClient) PullAndRebase(container string, keep bool) (imgid stri
 		args := []string{"pull", "-q"}
 		args = append(args, authArgs...)
 		args = append(args, container)
-		pivotutils.RunExt(false, numRetriesNetCommands, "podman", args...)
+		_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
+		if err != nil {
+			return
+		}
 	} else {
 		if previousPivot != "" {
 			var targetMatched bool
@@ -190,7 +193,10 @@ func (r *RpmOstreeClient) PullAndRebase(container string, keep bool) (imgid stri
 		args := []string{"pull", "-q"}
 		args = append(args, authArgs...)
 		args = append(args, container)
-		pivotutils.RunExt(false, numRetriesNetCommands, "podman", args...)
+		_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
+		if err != nil {
+			return
+		}
 	}
 
 	inspectArgs := []string{"inspect", "--type=image"}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1291,7 +1291,7 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig) error {
 			MCDPivotErr.WithLabelValues(newURL, err.Error()).SetToCurrentTime()
 			pivotErr, err := ioutil.ReadFile(pivottypes.PivotFailurePath)
 			if err != nil || len(pivotErr) == 0 {
-				glog.V(2).Info("pivot error file doesn't contain anything or was never written")
+				glog.Warningf("pivot error file doesn't contain anything, it was never written or an error occurred: %v", err)
 			}
 			return fmt.Errorf("failed to run pivot: %v: %v", err, string(pivotErr))
 		}
@@ -1305,7 +1305,7 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig) error {
 		}
 		if !changed {
 			// This really shouldn't happen
-			glog.Warningf("Didn't change when updating to %s ?", newURL)
+			glog.Warningf("Didn't change when updating to %q?", newURL)
 		}
 	}
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1289,9 +1289,9 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig) error {
 	if dn.kubeClient != nil {
 		if err := dn.NodeUpdaterClient.RunPivot(newURL); err != nil {
 			MCDPivotErr.WithLabelValues(newURL, err.Error()).SetToCurrentTime()
-			pivotErr, err := ioutil.ReadFile(pivottypes.PivotFailurePath)
-			if err != nil || len(pivotErr) == 0 {
-				glog.Warningf("pivot error file doesn't contain anything, it was never written or an error occurred: %v", err)
+			pivotErr, err2 := ioutil.ReadFile(pivottypes.PivotFailurePath)
+			if err2 != nil || len(pivotErr) == 0 {
+				glog.Warningf("pivot error file doesn't contain anything, it was never written or an error occurred: %v", err2)
 			}
 			return fmt.Errorf("failed to run pivot: %v: %v", err, string(pivotErr))
 		}


### PR DESCRIPTION
taking a look at BZ 1840385 we can see that we had tons of useful logs in the MCD:

```
2020-05-19T13:06:46.445346629Z I0519 13:06:46.085072 2996778 run.go:16] Running: podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b920c6ed07fa42565949ce61f14b3b9dd7bea64d2cfb13539fcea7068ea799f2
2020-05-19T13:06:46.445346629Z Error: error pulling image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b920c6ed07fa42565949ce61f14b3b9dd7bea64d2cfb13539fcea7068ea799f2": unable to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b920c6ed07fa42565949ce61f14b3b9dd7bea64d2cfb13539fcea7068ea799f2: unable to pull image: Error initializing source docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b920c6ed07fa42565949ce61f14b3b9dd7bea64d2cfb13539fcea7068ea799f2: error pinging docker registry quay.io: Get https://quay.io/v2/: EOF
2020-05-19T13:06:46.445346629Z W0519 13:06:46.222937 2996778 run.go:40] podman failed: exit status 125; retrying...
```

The sad reality is that what we were bubbling up was just:

```
failed to run pivot: failed to start machine-config-daemon-host.service: exit status 1
```

This patch reports everything we get when failing in pivot so that we won't need to ask a must-gather to debug those situations but the error is visible at the MCP/MCO level.

@cgwalters ptal

The test I'm doing is:

- spin up a cluster with this PR
- modify osImageUrl manually to trigger an update (`oc edit cm/machine-config-osimageurl -nopenshift-machine-config-operator`)
- change just the sha256 part of the current osImageUrl to something that would trigger a manifest unknown (i.e. `sha256:5eedf858762c5b42b4fbdef68a29ca2e47d81248c75874b14cb313de19f6b925`) (also, any error from pivot is valid to test this PR)
- check that errors are bubbled up to the MCP with the usual `oc describe mcp/<pool_name>` (that gets later bubbled up to the MCO cluster object if it's master, especially on install like the BZ error)

Signed-off-by: Antonio Murdaca <runcom@linux.com>
