### PR TITLE
Bug 1849432: [baremetal] verify resolv.conf in HAProxy static pod synced with host resolv.conf

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -109,12 +109,11 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-        - monitor
-        - "/var/lib/kubelet/kubeconfig"
-        - "/config/haproxy.cfg.tmpl"
-        - "/etc/haproxy/haproxy.cfg"
-        - "--api-vip"
-        - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+          - "/bin/bash"
+          - "-c"
+          - |            
+            cp /host/etc/resolv.conf /etc/resolv.conf
+            monitor /var/lib/kubelet/kubeconfig  /config/haproxy.cfg.tmpl  /etc/haproxy/haproxy.cfg  --api-vip {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}
         resources:
           requests:
             cpu: 100m
@@ -130,6 +129,14 @@ contents:
           mountPath: "/host"
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+        livenessProbe:
+          initialDelaySeconds: 10
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - |
+                cmp /host/etc/resolv.conf /etc/resolv.conf
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -107,12 +107,11 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-        - monitor
-        - "/var/lib/kubelet/kubeconfig"
-        - "/config/haproxy.cfg.tmpl"
-        - "/etc/haproxy/haproxy.cfg"
-        - "--api-vip"
-        - "{{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}"
+          - "/bin/bash"
+          - "-c"
+          - |            
+            cp /host/etc/resolv.conf /etc/resolv.conf
+            monitor /var/lib/kubelet/kubeconfig  /config/haproxy.cfg.tmpl  /etc/haproxy/haproxy.cfg  --api-vip {{ .Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}
         resources:
           requests:
             cpu: 100m
@@ -128,6 +127,14 @@ contents:
           mountPath: "/host"
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+        livenessProbe:
+          initialDelaySeconds: 10
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - |
+                cmp /host/etc/resolv.conf /etc/resolv.conf
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -87,12 +87,11 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-        - monitor
-        - "/var/lib/kubelet/kubeconfig"
-        - "/config/haproxy.cfg.tmpl"
-        - "/etc/haproxy/haproxy.cfg"
-        - "--api-vip"
-        - "{{ .Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }}"
+          - "/bin/bash"
+          - "-c"
+          - |
+            cp /host/etc/resolv.conf /etc/resolv.conf
+            monitor /var/lib/kubelet/kubeconfig  /config/haproxy.cfg.tmpl  /etc/haproxy/haproxy.cfg  --api-vip {{ .Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }}
         resources:
           requests:
             cpu: 100m
@@ -108,6 +107,14 @@ contents:
           mountPath: "/host"
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+        livenessProbe:
+          initialDelaySeconds: 10
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - |
+                cmp /host/etc/resolv.conf /etc/resolv.conf
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -114,12 +114,11 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-        - monitor
-        - "/var/lib/kubelet/kubeconfig"
-        - "/config/haproxy.cfg.tmpl"
-        - "/etc/haproxy/haproxy.cfg"
-        - "--api-vip"
-        - "{{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}"
+          - "/bin/bash"
+          - "-c"
+          - |
+            cp /host/etc/resolv.conf /etc/resolv.conf
+            monitor /var/lib/kubelet/kubeconfig  /config/haproxy.cfg.tmpl  /etc/haproxy/haproxy.cfg  --api-vip {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
         resources:
           requests:
             cpu: 100m
@@ -135,6 +134,14 @@ contents:
           mountPath: "/host"
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+        livenessProbe:
+          initialDelaySeconds: 10
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - |
+                cmp /host/etc/resolv.conf /etc/resolv.conf
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true


### PR DESCRIPTION
In some cases, we noticed that HAProxy static pod starts running before NM resolv prepend script[1] was applied,
as a result of that the pod's resolv.conf file doesn't point to the local Coredns instance.

In this case, HAProxy pod (actually it's haproxy-monitor container) will fail to retrieve information
from api-int:kube-apiserver (because local Coredns instance his the one that resolves api-int).

With this PR the resolv.conf used by haproxy-monitor should be always synced with node's resolv.conf

[1] https://github.com/openshift/machine-config-operator/blob/master/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml

