### PR TITLE
*: Ign spec 3 upgrade

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068 h1:y2aHj7QqyAJ6YBB
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
 github.com/coreos/vcontext v0.0.0-20191017033345-260217907eb5 h1:DjoHHi6+9J7DGYPvBdmszKZLY+ucx2bnA77jf8KIk9M=
 github.com/coreos/vcontext v0.0.0-20191017033345-260217907eb5/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
+github.com/coreos/vcontext v0.0.0-20200225161404-ee043618d38d h1:Nu473BdYOxcnhFfPrl1ihpCtxI/VZr2IfhVIHDGP43Y=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/lib/resourceapply/machineconfig_test.go
+++ b/lib/resourceapply/machineconfig_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/davecgh/go-spew/spew"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
@@ -177,10 +177,10 @@ func TestApplyMachineConfig(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			Spec: mcfgv1.MachineConfigSpec{
 				Config: runtime.RawExtension{
-					Raw: helpers.MarshalOrDie(&igntypes.Config{
-						Passwd: igntypes.Passwd{
-							Users: []igntypes.PasswdUser{{
-								HomeDir: "/home/dummy",
+					Raw: helpers.MarshalOrDie(&ign3types.Config{
+						Passwd: ign3types.Passwd{
+							Users: []ign3types.PasswdUser{{
+								HomeDir: helpers.StrToPtr("/home/dummy"),
 							}},
 						},
 					}),
@@ -203,10 +203,10 @@ func TestApplyMachineConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Spec: mcfgv1.MachineConfigSpec{
 					Config: runtime.RawExtension{
-						Raw: helpers.MarshalOrDie(&igntypes.Config{
-							Passwd: igntypes.Passwd{
-								Users: []igntypes.PasswdUser{{
-									HomeDir: "/home/dummy",
+						Raw: helpers.MarshalOrDie(&ign3types.Config{
+							Passwd: ign3types.Passwd{
+								Users: []ign3types.PasswdUser{{
+									HomeDir: helpers.StrToPtr("/home/dummy"),
 								}},
 							},
 						}),
@@ -224,10 +224,10 @@ func TestApplyMachineConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Spec: mcfgv1.MachineConfigSpec{
 					Config: runtime.RawExtension{
-						Raw: helpers.MarshalOrDie(&igntypes.Config{
-							Passwd: igntypes.Passwd{
-								Users: []igntypes.PasswdUser{{
-									HomeDir: "/home/dummy-prev",
+						Raw: helpers.MarshalOrDie(&ign3types.Config{
+							Passwd: ign3types.Passwd{
+								Users: []ign3types.PasswdUser{{
+									HomeDir: helpers.StrToPtr("/home/dummy-prev"),
 								}},
 							},
 						}),
@@ -239,10 +239,10 @@ func TestApplyMachineConfig(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			Spec: mcfgv1.MachineConfigSpec{
 				Config: runtime.RawExtension{
-					Raw: helpers.MarshalOrDie(&igntypes.Config{
-						Passwd: igntypes.Passwd{
-							Users: []igntypes.PasswdUser{{
-								HomeDir: "/home/dummy",
+					Raw: helpers.MarshalOrDie(&ign3types.Config{
+						Passwd: ign3types.Passwd{
+							Users: []ign3types.PasswdUser{{
+								HomeDir: helpers.StrToPtr("/home/dummy"),
 							}},
 						},
 					}),
@@ -265,10 +265,10 @@ func TestApplyMachineConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Spec: mcfgv1.MachineConfigSpec{
 					Config: runtime.RawExtension{
-						Raw: helpers.MarshalOrDie(&igntypes.Config{
-							Passwd: igntypes.Passwd{
-								Users: []igntypes.PasswdUser{{
-									HomeDir: "/home/dummy",
+						Raw: helpers.MarshalOrDie(&ign3types.Config{
+							Passwd: ign3types.Passwd{
+								Users: []ign3types.PasswdUser{{
+									HomeDir: helpers.StrToPtr("/home/dummy"),
 								}},
 							},
 						}),

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
@@ -149,8 +149,8 @@ func TestBootstrapRun(t *testing.T) {
 			require.NoError(t, err)
 
 			// Ensure that generated registries.conf corresponds to the testdata ImageContentSourcePolicy
-			var registriesConfig *igntypes.File
-			ignCfg, err := ctrlcommon.IgnParseWrapper(mc.Spec.Config.Raw)
+			var registriesConfig *ign3types.File
+			ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 			require.NoError(t, err)
 			for i := range ignCfg.Storage.Files {
 				f := &ignCfg.Storage.Files[i]
@@ -159,7 +159,7 @@ func TestBootstrapRun(t *testing.T) {
 				}
 			}
 			require.NotNil(t, registriesConfig)
-			dataURL, err := dataurl.DecodeString(registriesConfig.Contents.Source)
+			dataURL, err := dataurl.DecodeString(*registriesConfig.Contents.Source)
 			require.NoError(t, err)
 			// Only a minimal presence check; more comprehensive tests that the contents correspond to the ICSP semantics are
 			// maintained in pkg/controller/continer-runtime-config.

--- a/pkg/controller/bootstrap/testdata/bootstrap/99_openshift-machineconfig_master.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/99_openshift-machineconfig_master.yaml
@@ -13,8 +13,7 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
-    networkd: {}
+      version: 3.1.0
     passwd:
       users:
       - name: core

--- a/pkg/controller/bootstrap/testdata/bootstrap/99_openshift-machineconfig_worker.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/99_openshift-machineconfig_worker.yaml
@@ -13,8 +13,7 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
-    networkd: {}
+      version: 3.1.0
     passwd:
       users:
       - name: core

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -48,13 +48,13 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 
 	var fips bool
 	var kernelType string
-	var outIgn ign2types.Config
+	var outIgn ign3types.Config
 	var err error
 
 	if configs[0].Spec.Config.Raw == nil {
-		outIgn = ign2types.Config{}
+		outIgn = ign3types.Config{}
 	} else {
-		outIgn, err = IgnParseWrapper(configs[0].Spec.Config.Raw)
+		outIgn, err = ParseAndConvertConfig(configs[0].Spec.Config.Raw)
 		if err != nil {
 			return nil, err
 		}
@@ -66,16 +66,16 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 			fips = true
 		}
 
-		var appendIgn ign2types.Config
+		var mergedIgn ign3types.Config
 		if configs[idx].Spec.Config.Raw == nil {
-			appendIgn = ign2types.Config{}
+			mergedIgn = ign3types.Config{}
 		} else {
-			appendIgn, err = IgnParseWrapper(configs[idx].Spec.Config.Raw)
+			mergedIgn, err = ParseAndConvertConfig(configs[idx].Spec.Config.Raw)
 			if err != nil {
 				return nil, err
 			}
 		}
-		outIgn = ign2.Append(outIgn, appendIgn)
+		outIgn = ign3.Merge(outIgn, mergedIgn)
 	}
 	rawOutIgn, err := json.Marshal(outIgn)
 	if err != nil {
@@ -150,10 +150,10 @@ func PointerConfig(ignitionHost string, rootCA []byte) (ign2types.Config, error)
 }
 
 // NewIgnConfig returns an empty ignition config with version set as latest version
-func NewIgnConfig() ign2types.Config {
-	return ign2types.Config{
-		Ignition: ign2types.Ignition{
-			Version: ign2types.MaxVersion.String(),
+func NewIgnConfig() ign3types.Config {
+	return ign3types.Config{
+		Ignition: ign3types.Ignition{
+			Version: ign3types.MaxVersion.String(),
 		},
 	}
 }
@@ -165,10 +165,17 @@ func WriteTerminationError(err error) {
 	glog.Fatal(msg)
 }
 
-// ConvertRawExtIgnition2to3 converts a RawExtension containing Ignition spec v2.2 config
-// into a RawExtension containing Ignition spec v3.1 config
-func ConvertRawExtIgnition2to3(inRawExtIgnV2 *runtime.RawExtension) (runtime.RawExtension, error) {
-	ignCfg, rpt, err := ign2.Parse(inRawExtIgnV2.Raw)
+// ConvertRawExtIgnitionToV3 ensures that the Ignition config in
+// the RawExtension is spec v3.1, or translates to it.
+func ConvertRawExtIgnitionToV3(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
+	// This function is only used by the MCServer so we don't need to consider v3.0
+	_, rptV3, errV3 := ign3.Parse(inRawExtIgn.Raw)
+	if errV3 == nil && !rptV3.IsFatal() {
+		// The rawExt is already on V3.1, no need to translate
+		return *inRawExtIgn, nil
+	}
+
+	ignCfg, rpt, err := ign2.Parse(inRawExtIgn.Raw)
 	if err != nil || rpt.IsFatal() {
 		return runtime.RawExtension{}, errors.Errorf("parsing Ignition config spec v2.2 failed with error: %v\nReport: %v", err, rpt)
 	}
@@ -184,6 +191,36 @@ func ConvertRawExtIgnition2to3(inRawExtIgnV2 *runtime.RawExtension) (runtime.Raw
 
 	outRawExt := runtime.RawExtension{}
 	outRawExt.Raw = outIgnV3
+
+	return outRawExt, nil
+}
+
+// ConvertRawExtIgnitionToV2 ensures that the Ignition config in
+// the RawExtension is spec v2.2, or translates to it.
+func ConvertRawExtIgnitionToV2(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
+	_, rptV2, errV2 := ign2.Parse(inRawExtIgn.Raw)
+	if errV2 == nil && !rptV2.IsFatal() {
+		// The rawExt is already on V2.2, no need to translate
+		return *inRawExtIgn, nil
+	}
+
+	ignCfg, rpt, err := ign3.Parse(inRawExtIgn.Raw)
+	if err != nil || rpt.IsFatal() {
+		return runtime.RawExtension{}, errors.Errorf("parsing Ignition config spec v3.1 failed with error: %v\nReport: %v", err, rpt)
+	}
+
+	converted2, err := convertIgnition3to2(ignCfg)
+	if err != nil {
+		return runtime.RawExtension{}, errors.Errorf("failed to convert config from spec v3.1 to v2.2: %v", err)
+	}
+
+	outIgnV2, err := json.Marshal(converted2)
+	if err != nil {
+		return runtime.RawExtension{}, errors.Errorf("failed to marshal converted config: %v", err)
+	}
+
+	outRawExt := runtime.RawExtension{}
+	outRawExt.Raw = outIgnV2
 
 	return outRawExt, nil
 }
@@ -265,36 +302,24 @@ func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
 	return nil
 }
 
-// IgnParseWrapper parses rawIgn for v2.2, v3.1 and v3.0 Ignition configs and returns
-// a spec v2.2 or an error
-// This wrapper is necessary since each version uses a different parser.
-func IgnParseWrapper(rawIgn []byte) (ign2types.Config, error) {
+// IgnParseWrapper parses rawIgn for both V2 and V3 ignition configs and returns
+// a V2 or V3 Config or an error. This wrapper is necessary since V2 and V3 use different parsers.
+func IgnParseWrapper(rawIgn []byte) (interface{}, error) {
 	ignCfg, rpt, err := ign2.Parse(rawIgn)
 	if err == nil && !rpt.IsFatal() {
-		// this is an ign spec v2.2 config that was successfully parsed
+		// this is an ignv2cfg that was successfully parsed
 		return ignCfg, nil
 	}
 	if err.Error() == ign2error.ErrUnknownVersion.Error() {
-		// check to see if this is ign config spec v3.1
 		ignCfgV3, rptV3, errV3 := ign3.Parse(rawIgn)
 		if errV3 == nil && !rptV3.IsFatal() {
-			convertedIgnV2, err := convertIgnition3to2(ignCfgV3)
-			if err != nil {
-				return ign2types.Config{}, errors.Errorf("failed to convert Ignition config spec v3 to v2: %v", err)
-			}
-			return convertedIgnV2, nil
-
-		} else if errV3.Error() == ign3error.ErrUnknownVersion.Error() {
-			// unlike spec v2.x parsers, v3.x parsers aren't chained by default,
-			// so try with spec v3.0 parser as well
+			return ignCfgV3, nil
+		}
+		// unlike spec v2 parsers, v3 parsers aren't chained by default so we need to try parsing as spec v3.0 as well
+		if errV3.Error() == ign3error.ErrUnknownVersion.Error() {
 			ignCfgV3_0, rptV3_0, errV3_0 := ign3_0.Parse(rawIgn)
 			if errV3_0 == nil && !rptV3_0.IsFatal() {
-				convertedIgnV2, err := convertIgnition3to2(translate3.Translate(ignCfgV3_0))
-				if err != nil {
-					return ign2types.Config{}, errors.Errorf("failed to convert Ignition config spec v3 to v2: %v", err)
-				}
-
-				return convertedIgnV2, nil
+				return translate3.Translate(ignCfgV3_0), nil
 			}
 
 			return ign2types.Config{}, errors.Errorf("parsing Ignition config spec v3.0 failed with error: %v\nReport: %v", errV3_0, rptV3_0)
@@ -306,11 +331,102 @@ func IgnParseWrapper(rawIgn []byte) (ign2types.Config, error) {
 	return ign2types.Config{}, errors.Errorf("parsing Ignition config spec v2 failed with error: %v\nReport: %v", err, rpt)
 }
 
+// ParseAndConvertConfig parses rawIgn for both V2 and V3 ignition configs and returns
+// a V3 or an error.
+func ParseAndConvertConfig(rawIgn []byte) (ign3types.Config, error) {
+	ignconfigi, err := IgnParseWrapper(rawIgn)
+	if err != nil {
+		return ign3types.Config{}, errors.Wrapf(err, "failed to parse Ignition config")
+	}
+
+	switch typedConfig := ignconfigi.(type) {
+	case ign3types.Config:
+		return ignconfigi.(ign3types.Config), nil
+	case ign2types.Config:
+		ignconfv2 := removeIgnDuplicateFilesAndUnits(ignconfigi.(ign2types.Config))
+		convertedIgnV3, err := convertIgnition2to3(ignconfv2)
+		if err != nil {
+			return ign3types.Config{}, errors.Wrapf(err, "failed to convert Ignition config spec v2 to v3")
+		}
+		return convertedIgnV3, nil
+	default:
+		return ign3types.Config{}, errors.Errorf("unexpected type for ignition config: %v", typedConfig)
+	}
+}
+
+// Function to remove duplicated files/units from a V2 MC, since the translator
+// (and ignition spec V3) does not allow for duplicated entries in one MC.
+// This should really not change the actual final behaviour, since it keeps
+// ordering into consideration and has contents from the highest alphanumeric
+// MC's final version of a file.
+// Note:
+// Append is not considered since we do not allow for appending
+// Units have one exception: dropins are concat'ed
+
+func removeIgnDuplicateFilesAndUnits(ignConfig ign2types.Config) ign2types.Config {
+
+	files := ignConfig.Storage.Files
+	units := ignConfig.Systemd.Units
+
+	filePathMap := map[string]bool{}
+	var outFiles []ign2types.File
+	for i := len(files) - 1; i >= 0; i-- {
+		// We do not actually support to other filesystems so we make the assumption that there is only 1 here
+		path := files[i].Path
+		if _, isDup := filePathMap[path]; isDup {
+			continue
+		}
+		outFiles = append(outFiles, files[i])
+		filePathMap[path] = true
+	}
+
+	unitNameMap := map[string]bool{}
+	var outUnits []ign2types.Unit
+	for i := len(units) - 1; i >= 0; i-- {
+		unitName := units[i].Name
+		if _, isDup := unitNameMap[unitName]; isDup {
+			// this is a duplicated unit by name, so let's check for the dropins and append them
+			if len(units[i].Dropins) > 0 {
+				for j := range outUnits {
+					if outUnits[j].Name == unitName {
+						// outUnits[j] is the highest priority entry with this unit name
+						// now loop over the new unit's dropins and append it if the name
+						// isn't duplicated in the existing unit's dropins
+						for _, newDropin := range units[i].Dropins {
+							hasExistingDropin := false
+							for _, existingDropins := range outUnits[j].Dropins {
+								if existingDropins.Name == newDropin.Name {
+									hasExistingDropin = true
+									break
+								}
+							}
+							if !hasExistingDropin {
+								outUnits[j].Dropins = append(outUnits[j].Dropins, newDropin)
+							}
+						}
+						continue
+					}
+				}
+				glog.V(2).Infof("Found duplicate unit %v, appending dropin section", unitName)
+			}
+			continue
+		}
+		outUnits = append(outUnits, units[i])
+		unitNameMap[unitName] = true
+	}
+
+	// outFiles and outUnits should now have all duplication removed
+	ignConfig.Storage.Files = outFiles
+	ignConfig.Systemd.Units = outUnits
+
+	return ignConfig
+}
+
 // TranspileCoreOSConfigToIgn transpiles Fedora CoreOS config to ignition
-// internally it transpiles to Ign spec v3 config and translates to spec v2
-func TranspileCoreOSConfigToIgn(files, units []string) (*ign2types.Config, error) {
-	var ctCfg fcctbase.Config
+// internally it transpiles to Ign spec v3 config
+func TranspileCoreOSConfigToIgn(files, units []string) (*ign3types.Config, error) {
 	overwrite := true
+	outConfig := ign3types.Config{}
 	// Convert data to Ignition resources
 	for _, d := range files {
 		f := new(fcctbase.File)
@@ -320,7 +436,14 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign2types.Config, error
 		f.Overwrite = &overwrite
 
 		// Add the file to the config
+		var ctCfg fcctbase.Config
 		ctCfg.Storage.Files = append(ctCfg.Storage.Files, *f)
+		ign3_0config, tSet, err := ctCfg.ToIgn3_0()
+		if err != nil {
+			return nil, fmt.Errorf("failed to transpile config to Ignition config %s\nTranslation set: %v", err, tSet)
+		}
+		ign3_1config := translate3.Translate(ign3_0config)
+		outConfig = ign3.Merge(outConfig, ign3_1config)
 	}
 
 	for _, d := range units {
@@ -330,23 +453,17 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign2types.Config, error
 		}
 
 		// Add the unit to the config
+		var ctCfg fcctbase.Config
 		ctCfg.Systemd.Units = append(ctCfg.Systemd.Units, *u)
+		ign3_0config, tSet, err := ctCfg.ToIgn3_0()
+		if err != nil {
+			return nil, fmt.Errorf("failed to transpile config to Ignition config %s\nTranslation set: %v", err, tSet)
+		}
+		ign3_1config := translate3.Translate(ign3_0config)
+		outConfig = ign3.Merge(outConfig, ign3_1config)
 	}
 
-	ign3_0config, tSet, err := ctCfg.ToIgn3_0()
-	if err != nil {
-		return nil, fmt.Errorf("failed to transpile config to Ignition config %s\nTranslation set: %v", err, tSet)
-	}
-
-	// Workaround to get a v3.1 config
-	ign3config := translate3.Translate(ign3_0config)
-
-	converted2, errV3 := convertIgnition3to2(ign3config)
-	if errV3 != nil {
-		return nil, errors.Errorf("converting Ignition spec v3 config to v2 failed with error: %v", errV3)
-	}
-
-	return &converted2, nil
+	return &outConfig, nil
 }
 
 // MachineConfigFromIgnConfig creates a MachineConfig with the provided Ignition config

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 	"github.com/vincent-petithory/dataurl"
@@ -326,7 +326,7 @@ func (ctrl *Controller) handleFeatureErr(err error, key interface{}) {
 	ctrl.featureQueue.AddAfter(key, 1*time.Minute)
 }
 
-func (ctrl *Controller) generateOriginalKubeletConfig(role string) (*igntypes.File, error) {
+func (ctrl *Controller) generateOriginalKubeletConfig(role string) (*ign3types.File, error) {
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
 		return nil, fmt.Errorf("could not get ControllerConfig %v", err)
@@ -453,7 +453,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		if err != nil {
 			return ctrl.syncStatusOnly(cfg, err, "could not generate the original Kubelet config: %v", err)
 		}
-		dataURL, err := dataurl.DecodeString(originalKubeletIgn.Contents.Source)
+		dataURL, err := dataurl.DecodeString(*originalKubeletIgn.Contents.Source)
 		if err != nil {
 			return ctrl.syncStatusOnly(cfg, err, "could not decode the original Kubelet source string: %v", err)
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -25,7 +25,7 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	oseinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	oseconfigfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -329,7 +329,7 @@ func TestKubeletConfigCreate(t *testing.T) {
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
 			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
-			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
 			mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
 
@@ -362,7 +362,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
 			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
-			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
 			mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
 
@@ -638,7 +638,7 @@ func TestKubeletFeatureExists(t *testing.T) {
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
 			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
-			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
 			mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
 

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -106,7 +106,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		if err != nil {
 			return err
 		}
-		dataURL, err := dataurl.DecodeString(originalKubeletIgn.Contents.Source)
+		dataURL, err := dataurl.DecodeString(*originalKubeletIgn.Contents.Source)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/vincent-petithory/dataurl"
 
@@ -24,7 +24,7 @@ func TestFeatureGateDrift(t *testing.T) {
 			if err != nil {
 				t.Errorf("could not generate kubelet config from templates %v", err)
 			}
-			dataURL, _ := dataurl.DecodeString(kubeletConfig.Contents.Source)
+			dataURL, _ := dataurl.DecodeString(*kubeletConfig.Contents.Source)
 			originalKubeConfig, _ := decodeKubeletConfig(dataURL.Data)
 			defaultFeatureGates, err := ctrl.generateFeatureMap(createNewDefaultFeatureGate())
 			if err != nil {
@@ -47,8 +47,8 @@ func TestFeaturesDefault(t *testing.T) {
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			kubeletConfigKey1, _ := getManagedKubeletConfigKey(mcp, nil)
 			kubeletConfigKey2, _ := getManagedKubeletConfigKey(mcp2, nil)
-			mcs := helpers.NewMachineConfig(kubeletConfigKey1, map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{{}})
-			mcs2 := helpers.NewMachineConfig(kubeletConfigKey2, map[string]string{"node-role/worker": ""}, "dummy://", []igntypes.File{{}})
+			mcs := helpers.NewMachineConfig(kubeletConfigKey1, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
+			mcs2 := helpers.NewMachineConfig(kubeletConfigKey2, map[string]string{"node-role/worker": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
 			mcsDeprecated.Name = getManagedFeaturesKeyDeprecated(mcp)
 			mcs2Deprecated := mcs2.DeepCopy()

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -535,6 +535,7 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 			return nil, err
 		}
 	}
+
 	merged, err := ctrlcommon.MergeMachineConfigs(configs, cconfig.Spec.OSImageURL)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,18 +245,18 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 func TestCreatesGeneratedMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
-	files := []igntypes.File{{
-		Node: igntypes.Node{
+	files := []ign3types.File{{
+		Node: ign3types.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: igntypes.Node{
+		Node: ign3types.Node{
 			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{files[0]}),
-		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []igntypes.File{files[1]}),
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{files[0]}),
+		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []ign3types.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -273,29 +273,27 @@ func TestCreatesGeneratedMachineConfig(t *testing.T) {
 // generateRenderedMachineConfig should return an error when one of the MCs in configs contains an invalid ignconfig.
 func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
-	files := []igntypes.File{{
-		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/0",
+	files := []ign3types.File{{
+		Node: ign3types.Node{
+			Path: "/dummy/0",
 		},
 	}, {
-		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/1",
+		Node: ign3types.Node{
+			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{files[0]}),
-		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []igntypes.File{files[1]}),
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{files[0]}),
+		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []ign3types.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
 	_, err := generateRenderedMachineConfig(mcp, mcs, cc)
 	require.Nil(t, err)
 
-	// verify that an invalid igntion config (here a config with content and an empty version,
+	// verify that an invalid ignition config (here a config with content and an empty version,
 	// will fail validation
-	ignCfg, err := ctrlcommon.IgnParseWrapper(mcs[1].Spec.Config.Raw)
+	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mcs[1].Spec.Config.Raw)
 	require.Nil(t, err)
 	ignCfg.Ignition.Version = ""
 	rawIgnCfg, err := json.Marshal(ignCfg)
@@ -319,20 +317,18 @@ func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
-	files := []igntypes.File{{
-		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/0",
+	files := []ign3types.File{{
+		Node: ign3types.Node{
+			Path: "/dummy/0",
 		},
 	}, {
-		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/1",
+		Node: ign3types.Node{
+			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{files[0]}),
-		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []igntypes.File{files[1]}),
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{files[0]}),
+		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []ign3types.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -375,8 +371,8 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 func TestGenerateMachineConfigNoOverrideOSImageURL(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	mcs := []*mcfgv1.MachineConfig{
-		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy-test-1", []igntypes.File{}),
-		helpers.NewMachineConfig("00-test-cluster-master-0", map[string]string{"node-role/master": ""}, "dummy-change", []igntypes.File{}),
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy-test-1", []ign3types.File{}),
+		helpers.NewMachineConfig("00-test-cluster-master-0", map[string]string{"node-role/master": ""}, "dummy-change", []ign3types.File{}),
 	}
 
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
@@ -391,20 +387,18 @@ func TestGenerateMachineConfigNoOverrideOSImageURL(t *testing.T) {
 func TestDoNothing(t *testing.T) {
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
-	files := []igntypes.File{{
-		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/0",
+	files := []ign3types.File{{
+		Node: ign3types.Node{
+			Path: "/dummy/0",
 		},
 	}, {
-		Node: igntypes.Node{
-			Filesystem: "root",
-			Path:       "/dummy/1",
+		Node: ign3types.Node{
+			Path: "/dummy/1",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{files[0]}),
-		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []igntypes.File{files[1]}),
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{files[0]}),
+		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []ign3types.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
 
@@ -439,23 +433,23 @@ func TestDoNothing(t *testing.T) {
 
 func TestGetMachineConfigsForPool(t *testing.T) {
 	masterPool := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
-	files := []igntypes.File{{
-		Node: igntypes.Node{
+	files := []ign3types.File{{
+		Node: ign3types.Node{
 			Path: "/dummy/0",
 		},
 	}, {
-		Node: igntypes.Node{
+		Node: ign3types.Node{
 			Path: "/dummy/1",
 		},
 	}, {
-		Node: igntypes.Node{
+		Node: ign3types.Node{
 			Path: "/dummy/2",
 		},
 	}}
 	mcs := []*mcfgv1.MachineConfig{
-		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []igntypes.File{files[0]}),
-		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []igntypes.File{files[1]}),
-		helpers.NewMachineConfig("00-test-cluster-worker", map[string]string{"node-role/worker": ""}, "dummy://2", []igntypes.File{files[2]}),
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{files[0]}),
+		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []ign3types.File{files[1]}),
+		helpers.NewMachineConfig("00-test-cluster-worker", map[string]string{"node-role/worker": ""}, "dummy://2", []ign3types.File{files[2]}),
 	}
 	masterConfigs, err := getMachineConfigsForPool(masterPool, mcs)
 	if err != nil {
@@ -485,7 +479,7 @@ func getKey(config *mcfgv1.MachineConfigPool, t *testing.T) string {
 
 func TestMachineConfigsNoBailWithoutPool(t *testing.T) {
 	f := newFixture(t)
-	mc := helpers.NewMachineConfig("00-test-cluster-worker", map[string]string{"node-role/worker": ""}, "dummy://2", []igntypes.File{})
+	mc := helpers.NewMachineConfig("00-test-cluster-worker", map[string]string{"node-role/worker": ""}, "dummy://2", []ign3types.File{})
 	oref := metav1.NewControllerRef(newControllerConfig("test"), mcfgv1.SchemeGroupVersion.WithKind("ControllerConfig"))
 	mc.SetOwnerReferences([]metav1.OwnerReference{*oref})
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.WorkerSelector, nil, "")

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -328,7 +328,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 				t.Fatal("role label missing")
 			}
 
-			ign, err := ctrlcommon.IgnParseWrapper(cfg.Spec.Config.Raw)
+			ign, err := ctrlcommon.ParseAndConvertConfig(cfg.Spec.Config.Raw)
 			if err != nil {
 				t.Errorf("Failed to parse Ignition config")
 			}
@@ -382,7 +382,7 @@ func controllerConfigFromFile(path string) (*mcfgv1.ControllerConfig, error) {
 	return cc, nil
 }
 
-func findIgnFile(files []igntypes.File, path string, t *testing.T) bool {
+func findIgnFile(files []ign3types.File, path string, t *testing.T) bool {
 	for _, f := range files {
 		if f.Path == path {
 			return true
@@ -391,7 +391,7 @@ func findIgnFile(files []igntypes.File, path string, t *testing.T) bool {
 	return false
 }
 
-func findIgnUnit(units []igntypes.Unit, name string, t *testing.T) bool {
+func findIgnUnit(units []ign3types.Unit, name string, t *testing.T) bool {
 	for _, u := range units {
 		if u.Name == name {
 			return true

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign2types "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
@@ -52,51 +53,51 @@ func TestValidPath(t *testing.T) {
 	}
 }
 
-func TestOverwrittenFile(t *testing.T) {
+func TestValidateFiles(t *testing.T) {
 	fi, err := os.Lstat("fixtures/test1.txt")
 	if err != nil {
 		t.Errorf("Could not Lstat file: %v", err)
 	}
 	fileMode := int(fi.Mode().Perm())
 
-	// validate single file
-	files := []igntypes.File{
+	// validate single file in spec 3
+	filesV3 := []ign3types.File{
 		{
-			Node: igntypes.Node{
+			Node: ign3types.Node{
 				Path: "fixtures/test1.txt",
 			},
-			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
-					Source: dataurl.EncodeBytes([]byte("hello world\n")),
+			FileEmbedded1: ign3types.FileEmbedded1{
+				Contents: ign3types.Resource{
+					Source: helpers.StrToPtr(dataurl.EncodeBytes([]byte("hello world\n"))),
 				},
 				Mode: &fileMode,
 			},
 		},
 	}
 
-	if err := checkFiles(files); err != nil {
+	if err := checkV3Files(filesV3); err != nil {
 		t.Errorf("Invalid files: %v", err)
 	}
 
-	// validate overwritten file
-	files = []igntypes.File{
+	// validate overwritten file in spec 2
+	filesV2 := []ign2types.File{
 		{
-			Node: igntypes.Node{
+			Node: ign2types.Node{
 				Path: "fixtures/test1.txt",
 			},
-			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
+			FileEmbedded1: ign2types.FileEmbedded1{
+				Contents: ign2types.FileContents{
 					Source: dataurl.EncodeBytes([]byte("hello\n")),
 				},
 				Mode: &fileMode,
 			},
 		},
 		{
-			Node: igntypes.Node{
+			Node: ign2types.Node{
 				Path: "fixtures/test1.txt",
 			},
-			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
+			FileEmbedded1: ign2types.FileEmbedded1{
+				Contents: ign2types.FileContents{
 					Source: dataurl.EncodeBytes([]byte("hello world\n")),
 				},
 				Mode: &fileMode,
@@ -104,7 +105,7 @@ func TestOverwrittenFile(t *testing.T) {
 		},
 	}
 
-	if err := checkFiles(files); err != nil {
+	if err := checkV2Files(filesV2); err != nil {
 		t.Errorf("Validating an overwritten file failed: %v", err)
 	}
 }

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"github.com/clarketm/json"
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,17 +21,27 @@ var (
 	InfraSelector = metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/infra", "")
 )
 
+// StrToPtr returns a pointer to a string
+func StrToPtr(s string) *string {
+	return &s
+}
+
+// BoolToPtr returns a pointer to a bool
+func BoolToPtr(b bool) *bool {
+	return &b
+}
+
 // NewMachineConfig returns a basic machine config with supplied labels, osurl & files added
-func NewMachineConfig(name string, labels map[string]string, osurl string, files []igntypes.File) *mcfgv1.MachineConfig {
+func NewMachineConfig(name string, labels map[string]string, osurl string, files []ign3types.File) *mcfgv1.MachineConfig {
 	if labels == nil {
 		labels = map[string]string{}
 	}
 	rawIgnition := MarshalOrDie(
-		&igntypes.Config{
-			Ignition: igntypes.Ignition{
-				Version: igntypes.MaxVersion.String(),
+		&ign3types.Config{
+			Ignition: ign3types.Ignition{
+				Version: ign3types.MaxVersion.String(),
 			},
-			Storage: igntypes.Storage{
+			Storage: ign3types.Storage{
 				Files: files,
 			},
 		},


### PR DESCRIPTION
Based on https://github.com/openshift/machine-config-operator/pull/1703, this is a (messy and hacky) MCO that renders all existing configs to spec 3. Currently tested to work with a default install upgrading to this.

Unit and e2e tests not included