### PR TITLE
Bug 1851344: Pass proxy settings nodeip-configuration service for baremetal, vsphere, openstack

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -16,6 +16,18 @@ contents: |
   RemainAfterExit=yes
   ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
 
+  {{if .Proxy -}}
+  {{if .Proxy.HTTPProxy -}}
+  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  {{end -}}
+  {{if .Proxy.HTTPSProxy -}}
+  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  {{end -}}
+  {{if .Proxy.NoProxy -}}
+  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  {{end -}}
+  {{end -}}
+
   [Install]
   WantedBy=multi-user.target
   RequiredBy=crio.service kubelet.service

--- a/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -6,6 +6,19 @@ contents:
     set -eo pipefail
     IFACE=$1
     STATUS=$2
+
+    {{if .Proxy -}}
+    {{if .Proxy.HTTPProxy -}}
+    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}
+
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
     [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
     case "$STATUS" in

--- a/templates/common/baremetal/units/nodeip-configuration.service.yaml
+++ b/templates/common/baremetal/units/nodeip-configuration.service.yaml
@@ -22,6 +22,18 @@ contents: |
     set --retry-on-failure \
     {{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}
 
+  {{if .Proxy -}}
+  {{if .Proxy.HTTPProxy -}}
+  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  {{end -}}
+  {{if .Proxy.HTTPSProxy -}}
+  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  {{end -}}
+  {{if .Proxy.NoProxy -}}
+  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  {{end -}}
+  {{end -}}
+
   [Install]
   WantedBy=multi-user.target
 

--- a/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -6,6 +6,19 @@ contents:
     set -eo pipefail
     IFACE=$1
     STATUS=$2
+
+    {{if .Proxy -}}
+    {{if .Proxy.HTTPProxy -}}
+    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}
+
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."

--- a/templates/common/openstack/units/nodeip-configuration.service.yaml
+++ b/templates/common/openstack/units/nodeip-configuration.service.yaml
@@ -22,6 +22,18 @@ contents: |
     set --retry-on-failure \
     {{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }}
 
+  {{if .Proxy -}}
+  {{if .Proxy.HTTPProxy -}}
+  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  {{end -}}
+  {{if .Proxy.HTTPSProxy -}}
+  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  {{end -}}
+  {{if .Proxy.NoProxy -}}
+  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  {{end -}}
+  {{end -}}
+
   [Install]
   WantedBy=multi-user.target
 

--- a/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -7,6 +7,19 @@ contents:
     set -eo pipefail
     IFACE=$1
     STATUS=$2
+
+    {{if .Proxy -}}
+    {{if .Proxy.HTTPProxy -}}
+    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}
+
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."

--- a/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -11,6 +11,19 @@ contents:
     set -eo pipefail
     IFACE=$1
     STATUS=$2
+
+    {{if .Proxy -}}
+    {{if .Proxy.HTTPProxy -}}
+    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}
+
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
     [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
     case "$STATUS" in

--- a/templates/common/vsphere/units/nodeip-configuration.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration.service.yaml
@@ -28,6 +28,18 @@ contents: |
     {{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }}
   ExecStart=/bin/systemctl daemon-reload
 
+  {{if .Proxy -}}
+  {{if .Proxy.HTTPProxy -}}
+  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  {{end -}}
+  {{if .Proxy.HTTPSProxy -}}
+  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  {{end -}}
+  {{if .Proxy.NoProxy -}}
+  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  {{end -}}
+  {{end -}}
+
   [Install]
   WantedBy=multi-user.target
   {{ end -}}


### PR DESCRIPTION
The nodeip-configuration service used in on-premise platforms needs to
follow proxy settings otherwise it may not be able to download
container image.