### PR TITLE
Bug 1851226: Refactor mastersSchedulable reconciliation checks

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -40,6 +40,12 @@ import (
 )
 
 const (
+	// MasterLabel defines the label associated with master node. The master taint uses the same label as taint's key
+	MasterLabel = "node-role.kubernetes.io/master"
+
+	// WorkerLabel defines the label associated with worker node.
+	WorkerLabel = "node-role.kubernetes.io/worker"
+
 	// maxRetries is the number of times a machineconfig pool will be retried before it is dropped out of the queue.
 	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the times
 	// a machineconfig pool is going to be requeued:
@@ -51,14 +57,8 @@ const (
 	// https://github.com/openshift/machine-config-operator/issues/301
 	updateDelay = 5 * time.Second
 
-	// masterLabel defines the label associated with master node. The master taint uses the same label as taint's key
-	masterLabel = "node-role.kubernetes.io/master"
-
 	// osLabel is used to identify which type of OS the node has
 	osLabel = "kubernetes.io/os"
-
-	// workerLabel defines the label associated with worker node.
-	workerLabel = "node-role.kubernetes.io/worker"
 
 	// schedulerCRName that we're interested in watching.
 	schedulerCRName = "cluster"
@@ -159,7 +159,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 }
 
 func (ctrl *Controller) getCurrentMasters() ([]*corev1.Node, error) {
-	nodeList, err := ctrl.nodeLister.List(labels.SelectorFromSet(labels.Set{masterLabel: ""}))
+	nodeList, err := ctrl.nodeLister.List(labels.SelectorFromSet(labels.Set{MasterLabel: ""}))
 	if err != nil {
 		return nil, fmt.Errorf("error while listing master nodes %v", err)
 	}
@@ -218,9 +218,6 @@ func (ctrl *Controller) checkMasterNodesOnUpdate(old, cur interface{}) {
 func (ctrl *Controller) makeMastersUnSchedulable(currentMasters []*corev1.Node) []error {
 	var errs []error
 	for _, node := range currentMasters {
-		if !CheckMasterIsAlreadySchedulable(node) {
-			continue
-		}
 		if err := ctrl.makeMasterNodeUnSchedulable(node); err != nil {
 			errs = append(errs, fmt.Errorf("failed making node %v schedulable with error %v", node.Name, err))
 		}
@@ -235,33 +232,28 @@ func (ctrl *Controller) makeMasterNodeUnSchedulable(node *corev1.Node) error {
 	_, err := internal.UpdateNodeRetry(ctrl.kubeClient.CoreV1().Nodes(), ctrl.nodeLister, node.Name, func(node *corev1.Node) {
 		// Remove worker label
 		newLabels := node.Labels
-		if _, hasWorkerLabel := newLabels[workerLabel]; hasWorkerLabel {
-			delete(newLabels, workerLabel)
+		if _, hasWorkerLabel := newLabels[WorkerLabel]; hasWorkerLabel {
+			delete(newLabels, WorkerLabel)
 		}
 		node.Labels = newLabels
 		// Add master taint
-		newTaints := node.Spec.Taints
-		masterUnSchedulableTaint := corev1.Taint{Key: masterLabel, Effect: corev1.TaintEffectNoSchedule}
-		newTaints = append(newTaints, masterUnSchedulableTaint)
-		node.Spec.Taints = newTaints
+		hasMasterTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == MasterLabel && taint.Effect == corev1.TaintEffectNoSchedule {
+				hasMasterTaint = true
+			}
+		}
+		if !hasMasterTaint {
+			newTaints := node.Spec.Taints
+			masterUnSchedulableTaint := corev1.Taint{Key: MasterLabel, Effect: corev1.TaintEffectNoSchedule}
+			newTaints = append(newTaints, masterUnSchedulableTaint)
+			node.Spec.Taints = newTaints
+		}
 	})
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-// CheckMasterIsAlreadySchedulable checks if the given node has a worker label and doesn't have NoSchedule master
-// taint
-func CheckMasterIsAlreadySchedulable(node *corev1.Node) bool {
-	_, hasWorkerLabel := node.Labels[workerLabel]
-	hasMasterTaint := false
-	for _, taint := range node.Spec.Taints {
-		if taint.Key == masterLabel && taint.Effect == corev1.TaintEffectNoSchedule {
-			hasMasterTaint = true
-		}
-	}
-	return hasWorkerLabel && !hasMasterTaint
 }
 
 // makeMasterNodeSchedulable makes master node schedulable by removing NoSchedule master taint and
@@ -270,14 +262,14 @@ func (ctrl *Controller) makeMasterNodeSchedulable(node *corev1.Node) error {
 	_, err := internal.UpdateNodeRetry(ctrl.kubeClient.CoreV1().Nodes(), ctrl.nodeLister, node.Name, func(node *corev1.Node) {
 		// Add worker label
 		newLabels := node.Labels
-		if _, hasWorkerLabel := newLabels[workerLabel]; !hasWorkerLabel {
-			newLabels[workerLabel] = ""
+		if _, hasWorkerLabel := newLabels[WorkerLabel]; !hasWorkerLabel {
+			newLabels[WorkerLabel] = ""
 		}
 		node.Labels = newLabels
 		// Remove master taint
 		newTaints := []corev1.Taint{}
 		for _, t := range node.Spec.Taints {
-			if t.Key == masterLabel && t.Effect == corev1.TaintEffectNoSchedule {
+			if t.Key == MasterLabel && t.Effect == corev1.TaintEffectNoSchedule {
 				continue
 			}
 			newTaints = append(newTaints, t)
@@ -338,7 +330,7 @@ func (ctrl *Controller) getMastersSchedulable() (bool, error) {
 
 // Determine if a given Node is a master
 func (ctrl *Controller) isMaster(node *corev1.Node) bool {
-	_, master := node.ObjectMeta.Labels[masterLabel]
+	_, master := node.ObjectMeta.Labels[MasterLabel]
 	return master
 }
 
@@ -363,14 +355,13 @@ func (ctrl *Controller) reconcileMaster(node *corev1.Node) {
 		goerrs.Wrap(err, "Getting scheduler config failed")
 		return
 	}
-	alreadySchedulable := CheckMasterIsAlreadySchedulable(node)
-	if mastersSchedulable && !alreadySchedulable {
+	if mastersSchedulable {
 		err = ctrl.makeMasterNodeSchedulable(node)
 		if err != nil {
 			goerrs.Wrap(err, "Failed making master Node schedulable")
 			return
 		}
-	} else if !mastersSchedulable && alreadySchedulable {
+	} else if !mastersSchedulable {
 		err = ctrl.makeMasterNodeUnSchedulable(node)
 		if err != nil {
 			goerrs.Wrap(err, "Failed making master Node unschedulable")
@@ -380,6 +371,7 @@ func (ctrl *Controller) reconcileMaster(node *corev1.Node) {
 }
 
 // Get a list of current masters and apply scheduler config to them
+// TODO: Taint reconciliation should happen elsewhere, in a generic taint/label reconciler
 func (ctrl *Controller) reconcileMasters() {
 	currentMasters, err := ctrl.getCurrentMasters()
 	if err != nil {


### PR DESCRIPTION
**- What I did**
Fixes https://github.com/openshift/machine-config-operator/issues/1875
The `CheckMasterIsAlreadySchedulable` check is redundant in these cases, because both `makeMasterNode(Un)Schedulable` functions already check if the worker label exists before adding/removing it, and `make..Schedulable` checks for the taint, so we just need to add the taint check to `make...UnSchedulable`.

This also cleans up the logic where if a master taint was removed (effectively making the master nodes schedulable), it could conflict with a `mastersSchedulable: false` setting in the schedule, and would never be reconciled (because `CheckMasterIsAlreadySchedulable` always returned `false` without the master taint.

This makes the `mastersSchedulable: false` setting the ultimate source-of-truth for whether these taints should be applied to nodes, and while this removes any use cases for making only certaint master nodes schedulable it will also resolve some confusion from users.

**- How to verify it**
1. Set `mastersSchedulable: false` in the scheduler
2. Remove the master taint from a master 
3. The master taint should be re-applied by node controller

**- Description for the changelog**
`mastersSchedulable: false` will now re-apply the master NoSchedule taint to any master node missing it

