### PR TITLE
Bug 1805019: KubeletConfig: Verify EvictionSoftGracePeriod is set when EvictionSof…

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -120,6 +120,18 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 		return fmt.Errorf("KubeletConfiguration: staticPodPath is not allowed to be set, but contains: %s", kcDecoded.StaticPodPath)
 	}
 
+	if kcDecoded.EvictionSoft != nil && len(kcDecoded.EvictionSoft) > 0 {
+		if kcDecoded.EvictionSoftGracePeriod == nil || len(kcDecoded.EvictionSoftGracePeriod) == 0 {
+			return fmt.Errorf("KubeletConfiguration: EvictionSoftGracePeriod must be set when evictionSoft is defined, evictionSoft: %v", kcDecoded.EvictionSoft)
+		}
+
+		for k := range kcDecoded.EvictionSoft {
+			if _, ok := kcDecoded.EvictionSoftGracePeriod[k]; !ok {
+				return fmt.Errorf("KubeletConfiguration: evictionSoft[%s] is defined but EvictionSoftGracePeriod[%s] is not set", k, k)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -478,6 +478,25 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "evictionSoft cannot be supplied without evictionSoftGracePeriod",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionSoft: map[string]string{
+					"memory.available": "90%",
+				},
+			},
+		},
+		{
+			name: "evictionSoft cannot be supplied without corresponding evictionSoftGracePeriod",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionSoft: map[string]string{
+					"memory.available": "90%",
+				},
+				EvictionSoftGracePeriod: map[string]string{
+					"nodefs.inodesFree": "1h",
+				},
+			},
+		},
 	}
 
 	successTests := []struct {


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes - https://bugzilla.redhat.com/show_bug.cgi?id=1805019

**- How to verify it**
Try to create a KubeletConfig with `EvictionSoft` but without `EvictionSoftGracePeriod` and  while describing the kubeletconfig, `oc describe KubeletConfig worker-kubeconfig-fix` you should be able to see the error,
```sh
      Custom - Kubelet:  small-pods
Status:
  Conditions:
    Last Transition Time:  2020-06-30T11:57:34Z
    Message:               Error: KubeletConfiguration: EvictionSoftGracePeriod must be set when evictionSoft is defined, evictionSoft: map[memory.available:90% nodefs.available:90% nodefs.inodesFree:90%]
    Status:                False
    Type:                  Failure

```

**- Description for the changelog**
Making sure `EvictionSoftGracePeriod` is specified when `EvictionSoft` in KubeletConfig