### PR TITLE
pkg/controller: sync pools configuration source

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -80,7 +80,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", "")
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
-		if status.Configuration.Name != pool.Spec.Configuration.Name {
+		if status.Configuration.Name != pool.Spec.Configuration.Name || !equality.Semantic.DeepEqual(status.Configuration.Source, pool.Spec.Configuration.Source) {
 			glog.Infof("Pool %s: %s", pool.Name, updatedMsg)
 			status.Configuration = pool.Spec.Configuration
 		}


### PR DESCRIPTION
TL;DR; of the Tl;DR; 

> This isn't changing something big, just have the Source field always in sync which if it isn't it can cause problems

This bug is easily reproducible by creating two machine configs which
won't change anything in the Ignition config, thus causing no new hashed
rendered machine config name and finally leaving the pool Source field outdated.

This isn't a real issue for the worker pool, but it becomes an upgrade blocker
when the master pool suffers from this - see https://bugzilla.redhat.com/show_bug.cgi?id=1851965

TL;DR; to reproduce this and verify:

apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 50-examplecorp-chrony
spec:
  config:
    ignition:
      version: 2.2.0

As you may notice, the MC above isn't meant to change anything but what happens is that
if you create it, nothing happens, nor the pool starts an update (which is slightly right...).

The above doesn't cause a real issue per se as that's user generated (and no controller version!).

What happens when something like the above is created _by_ the MCO - like in the registries MCs
is that the machine config __is__ taken into account __in__ the pool Source field.

Now, if you bring up a cluster and delete the default registries MC, nothing happens but the pool still targets
that MC!!! More importantly, for some other bug, if you have an orphan MC which is generated by our controllers
and you upgrade the cluster, you're left on your own with an orphan MC, which is still in the pool's Source field
and if you delete it, nothing happens either and you're basically stuck.

Please refer to the BZ above for further info and clues - this isn't fully meant to "fix" the issues we have/had
with the CRC and KC controllers but it's a safe fix that we should have anyway to keep the Source field always in sync.

Signed-off-by: Antonio Murdaca <runcom@linux.com>