### PR TITLE
Bug 1821800: Revert "OpenStack: disable tx checksum offload for workers"

### DIFF
--- a/templates/worker/00-worker/openstack/files/openstack-disable-tx-checksum-offload.yaml
+++ b/templates/worker/00-worker/openstack/files/openstack-disable-tx-checksum-offload.yaml
@@ -1,9 +1,0 @@
-mode: 0744
-path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-tx-checksum-offload.sh"
-contents:
-  inline: |
-    #!/bin/bash
-    # This is a workaround for BZ#1794714
-    if [[ ! -e /var/lib/cni/bin/ovn-k8s-cni-overlay ]]; then
-      nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-checksum-ip-generic off;
-    fi


### PR DESCRIPTION
RHCOS image now contains the fix for nodeport service running on
different hosts, allowing us to remove the partial workaround.

The fix landed in kernel-4.18.0-202.el8 [1],
kernel-4.18.0-193.10.1.el8_2 [2], and kernel-4.18.0-147.21.1.el8_1 [3].

This reverts commit 270bb6748152824754d34b9f83bed1f4fbf98a8c.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1794714
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1847128
[3] https://bugzilla.redhat.com/show_bug.cgi?id=1847127