### PR TITLE
pkg/daemon: make force use the force

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1027,7 +1027,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	if currentOnDisk != nil && state.currentConfig.GetName() != currentOnDisk.GetName() {
 		// The on disk state (if available) is always considered truth.
 		// We want to handle the case where etcd state was restored from a backup.
-		dn.logSystem("Disk currentConfig %s overrides node annotation %s", currentOnDisk.GetName(), state.currentConfig.GetName())
+		dn.logSystem("Disk currentConfig %s overrides node's currentConfig annotation %s", currentOnDisk.GetName(), state.currentConfig.GetName())
 		state.currentConfig = currentOnDisk
 	}
 
@@ -1048,6 +1048,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		glog.Infof("Validating against current config %s", state.currentConfig.GetName())
 		expectedConfig = state.currentConfig
 	}
+
 	if _, err := os.Stat(constants.MachineConfigDaemonForceFile); err != nil {
 		if err := dn.validateOnDiskState(expectedConfig); err != nil {
 			return fmt.Errorf("unexpected on-disk state validating against %s: %v", expectedConfig.GetName(), err)
@@ -1058,6 +1059,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		if err := os.Remove(constants.MachineConfigDaemonForceFile); err != nil {
 			return errors.Wrap(err, "failed to remove force validation file")
 		}
+		return dn.triggerUpdateWithMachineConfig(state.currentConfig, state.desiredConfig)
 	}
 
 	// We've validated our state.  In the case where we had a pendingConfig,


### PR DESCRIPTION
force does 2 things mainly: skip validation and "force" update to the desiredConfig. That doesn't mean the MCD can't fail anymore, we're just forcing a rollout that wouldn't have normally happened. The usual cases are: pivot not booting into the right ostree, someone writes the force file and the update is retryed (but still can fail!) or somebody touches files on disk, use the force file to bring the system back to desiredConfig w/o validating (and degrading)

cc @cgwalters related to https://github.com/openshift/machine-config-operator/pull/1086#issuecomment-652592586

Testing with:

- `oc debug node/<worker>`
- edit `/etc/crio/crio.conf.d/00-default` and add a dummy comment
- check MCD degraded because of the above
- touch the file, reboot the MCD
- watch it recover to the correct file

Signed-off-by: Antonio Murdaca <runcom@linux.com>