### PR TITLE
"Bug 1823950: [baremetal] Don't failover api vip if loadbalanced endpoint is responding"

### DIFF
--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -30,6 +30,29 @@ contents:
       - name: chroot-host
         hostPath:
           path: "/"
+      initContainers:
+      - name: render-config-keepalived
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - runtimecfg
+        - render
+        - "/etc/kubernetes/kubeconfig"
+        - "--api-vip"
+        - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
+        - "--ingress-vip"
+        - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        - "/config"
+        - "--out-dir"
+        - "/etc/keepalived"
+        resources: {}
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/etc/kubernetes"
+        - name: resource-dir
+          mountPath: "/config"
+        - name: conf-dir
+          mountPath: "/etc/keepalived"
+        imagePullPolicy: IfNotPresent
       containers:
       - name: keepalived
         securityContext:

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -27,6 +27,9 @@ contents:
           path: "/etc/keepalived"
       - name: run-dir
         empty-dir: {}
+      - name: chroot-host
+        hostPath:
+          path: "/"
       containers:
       - name: keepalived
         securityContext:
@@ -120,6 +123,8 @@ contents:
           mountPath: "/etc/keepalived"
         - name: run-dir
           mountPath: "/var/run/keepalived"
+        - name: chroot-host
+          mountPath: "/host"
         readinessProbe:
           httpGet:
             path: /readyz

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -16,6 +16,9 @@ contents:
       - name: resource-dir
         hostPath:
           path: "/etc/kubernetes/static-pod-resources/keepalived"
+      - name: script-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/keepalived/scripts"
       - name: kubeconfig
         hostPath:
           path: "/etc/kubernetes"
@@ -48,7 +51,7 @@ contents:
         volumeMounts:
         - name: kubeconfig
           mountPath: "/etc/kubernetes"
-        - name: resource-dir
+        - name: script-dir
           mountPath: "/config"
         - name: conf-dir
           mountPath: "/etc/keepalived"

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -20,7 +20,7 @@ contents:
     listen health_check_http_url
       bind :::50936 v4v6
       mode http
-      monitor-uri /readyz
+      monitor-uri /haproxy_ready
       option dontlognull
     listen stats
       bind localhost:{{`{{ .LBConfig.StatPort }}`}}

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -100,7 +100,7 @@ contents:
         livenessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: /readyz
+            path: /haproxy_ready
             port: 50936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -7,10 +7,31 @@ contents:
         script_user root
     }
 
-    vrrp_script chk_ocp {
+    # These are separate checks to provide the following behavior:
+    # If the loadbalanced endpoint is responding then all is well regardless
+    # of what the local api status is. Both checks will return success and
+    # we'll have the maximum priority. This means as long as there is a node
+    # with a functional loadbalancer it will get the VIP.
+    # If all of the loadbalancers go down but the local api is still running,
+    # the _both check will still succeed and allow any node with a functional
+    # api to take the VIP. This isn't preferred because it means all api
+    # traffic will go through one node, but at least it keeps the api available.
+    vrrp_script chk_ocp_lb {
         script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
         interval 1
-        weight 50
+        weight 20
+        rise 3
+        fall 2
+    }
+
+    vrrp_script chk_ocp_both {
+        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script_both.sh"
+        interval 1
+        # Use a smaller weight for this check so it won't trigger the move from
+        # bootstrap to master by itself.
+        weight 5
+        rise 3
+        fall 2
     }
 
     # TODO: Improve this check. The port is assumed to be alive.
@@ -46,7 +67,8 @@ contents:
             {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
         }
         track_script {
-            chk_ocp
+            chk_ocp_lb
+            chk_ocp_both
         }
     }
 

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script-both.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script-both.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/keepalived/chk_ocp_script_both.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:6443/readyz

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script-both.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script-both.yaml
@@ -1,5 +1,5 @@
 mode: 0755
-path: "/etc/kubernetes/static-pod-resources/keepalived/chk_ocp_script_both.sh.tmpl"
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script_both.sh.tmpl"
 contents:
   inline: |
     #!/bin/bash

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script-both.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script-both.yaml
@@ -1,6 +1,6 @@
 mode: 0755
-path: "/etc/keepalived/chk_ocp_script_both.sh"
+path: "/etc/kubernetes/static-pod-resources/keepalived/chk_ocp_script_both.sh.tmpl"
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:6443/readyz
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:{{`{{ .LBConfig.LbPort }}`}}/readyz && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
@@ -1,6 +1,6 @@
 mode: 0755
-path: "/etc/keepalived/chk_ocp_script.sh"
+path: "/etc/kubernetes/static-pod-resources/keepalived/chk_ocp_script.sh.tmpl"
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && [ -e /var/run/keepalived/iptables-rule-exists ]
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:{{`{{ .LBConfig.LbPort }}`}}/readyz && [ -e /var/run/keepalived/iptables-rule-exists ]

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
@@ -1,5 +1,5 @@
 mode: 0755
-path: "/etc/kubernetes/static-pod-resources/keepalived/chk_ocp_script.sh.tmpl"
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script.sh.tmpl"
 contents:
   inline: |
     #!/bin/bash

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
@@ -2,5 +2,5 @@ mode: 0755
 path: "/etc/keepalived/chk_ocp_script.sh"
 contents:
   inline: |
-    #!/bin/bash 
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz
+    #!/bin/bash
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:9443/readyz && [ -e /var/run/keepalived/iptables-rule-exists ]


### PR DESCRIPTION
We're having some issues in ci with api flakiness that appear to be
related to VIP failover. In order to reduce the need to do failovers
during normal circumstances, we want to leave the VIP alone as long
as the loadbalanced api endpoint on the node is responding. Currently
if the local api service on a node stops responding it will trigger
a failover. This is unnecessary since in most cases haproxy will
continue to distribute the traffic while the local api restarts.

In order to get this behavior, the chk_ocp vrrp_script is split in
two. The reason for this is that we still want to handle the case
where all haproxy instances in the cluster go down, but at least
one api service is still functional. One check looks at the haproxy
endpoint only. This one has a higher weight since it's the preferred
situation. The other check looks for either the haproxy endpoint or
the local endpoint. This means that if haproxy is up then both
checks will succeed and the node will have maximum priority regardless
of the state of its local api. However, if haproxy goes down but
the local api is still working then at least the priority will be
higher than the minimum because the local api is responding.

It was also necessary to add a check that the haproxy firewall rule
is in place. It does us no good to have the loadbalancer working if
traffic isn't being routed to it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
