### PR TITLE
[fcos] templates/common/_base/units: disable docker

### DIFF
--- a/templates/common/_base/units/docker.socket.yml
+++ b/templates/common/_base/units/docker.socket.yml
@@ -1,0 +1,6 @@
+name: docker.socket
+dropins:
+- name: mco-disabled.conf
+  contents: |
+    [Unit]
+    ConditionPathExists=/enoent


### PR DESCRIPTION
`docker` service is not used and takes ~150MB of RAM on all nodes

Fixes https://github.com/openshift/okd/issues/243