### PR TITLE
Bug 1853890: pkg/daemon: preserve kargs order

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -650,14 +650,23 @@ func splitKernelArguments(args string) []string {
 
 // parseKernelArguments separates out kargs from each entry and returns it as a map for
 // easy comparison
-func parseKernelArguments(kargs []string) map[string]bool {
-	parsed := make(map[string]bool)
+func parseKernelArguments(kargs []string) []string {
+	parsed := []string{}
 	for _, k := range kargs {
 		for _, arg := range splitKernelArguments(k) {
-			parsed[strings.TrimSpace(arg)] = true
+			parsed = append(parsed, strings.TrimSpace(arg))
 		}
 	}
 	return parsed
+}
+
+func inArray(elem string, array []string) bool {
+	for _, k := range array {
+		if k == elem {
+			return true
+		}
+	}
+	return false
 }
 
 // generateKargsCommand performs a diff between the old/new MC kernelArguments,
@@ -669,13 +678,13 @@ func generateKargsCommand(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
 	oldKargs := parseKernelArguments(oldConfig.Spec.KernelArguments)
 	newKargs := parseKernelArguments(newConfig.Spec.KernelArguments)
 	cmdArgs := []string{}
-	for arg := range oldKargs {
-		if !newKargs[arg] {
+	for _, arg := range oldKargs {
+		if !inArray(arg, newKargs) {
 			cmdArgs = append(cmdArgs, "--delete="+arg)
 		}
 	}
-	for arg := range newKargs {
-		if !oldKargs[arg] {
+	for _, arg := range newKargs {
+		if !inArray(arg, oldKargs) {
 			cmdArgs = append(cmdArgs, "--append="+arg)
 		}
 	}

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -285,6 +285,11 @@ func TestKernelAguments(t *testing.T) {
 			additions: []string{"bar=\"hello world\""},
 		},
 		{
+			args:      append([]string{"foo=baz", "foo=bar"}, oldMcfg.Spec.KernelArguments...),
+			deletions: []string{},
+			additions: []string{"foo=baz", "foo=bar"},
+		},
+		{
 			args:      append([]string{"baz=othertest"}, oldMcfg.Spec.KernelArguments...),
 			deletions: []string{},
 			additions: []string{"baz=othertest"},

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -201,7 +201,7 @@ func TestKernelArguments(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			KernelArguments: []string{"nosmt", "foo=bar", " baz=test bar=\"hello world\""},
+			KernelArguments: []string{"nosmt", "foo=bar", "foo=baz", " baz=test bar=\"hello world\""},
 		},
 	}
 
@@ -219,7 +219,7 @@ func TestKernelArguments(t *testing.T) {
 		assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 		assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 		kargs := execCmdOnNode(t, cs, node, "cat", "/rootfs/proc/cmdline")
-		expectedKernelArgs := []string{"nosmt", "foo=bar", "baz=test", "\"bar=hello world\""}
+		expectedKernelArgs := []string{"nosmt", "foo=bar", "foo=baz", "baz=test", "\"bar=hello world\""}
 		for _, v := range expectedKernelArgs {
 			if !strings.Contains(kargs, v) {
 				t.Fatalf("Missing %q in kargs: %q", v, kargs)


### PR DESCRIPTION
Basically what the title says, ~~allow args with same key value and~~ preserve the order we get the args from the MC. Not fully sure if rpm-ostree does some magic there but this should avoid random ranging over a map.

Note: we lost the beauty of checking in O(1) using a map but this isn't gonna be a big deal as the kargs array shouldn't be thousands of elements afaict.

On a second thought, I think we were allowing duplicates already, I'm gonna triple check that.

Signed-off-by: Antonio Murdaca <runcom@linux.com>