### PR TITLE
Bug 1853735: crio: correct hooks directory

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -27,6 +27,9 @@ contents:
         "SYS_CHROOT",
         "KILL",
     ]
+    hooks_dir = [
+        "/etc/containers/oci/hooks.d",
+    ]
     manage_ns_lifecycle = true
 
     [crio.image]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -27,6 +27,9 @@ contents:
         "SYS_CHROOT",
         "KILL",
     ]
+    hooks_dir = [
+        "/etc/containers/oci/hooks.d",
+    ]
     manage_ns_lifecycle = true
 
     [crio.image]


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
closes https://bugzilla.redhat.com/show_bug.cgi?id=1853735
**- How to verify it**
`crio config` on a MCO managed node will return /etc/containers/oci/hooks.d for hooks_dir
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
