### PR TITLE
Add --release-image flag to bootstrap options

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -32,6 +32,7 @@ var (
 		imagesConfigMapFile       string
 		infraConfigFile           string
 		infraImage                string
+		releaseImage              string
 		keepalivedImage           string
 		kubeCAFile                string
 		kubeClientAgentImage      string
@@ -68,6 +69,8 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.clusterEtcdOperatorImage, "cluster-etcd-operator-image", "", "Image for Cluster Etcd Operator. An empty string here means the cluster boots without CEO.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraImage, "infra-image", "", "Image for Infra Containers.")
 	bootstrapCmd.MarkFlagRequired("infra-image")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.releaseImage, "release-image", "", "Release image used for cluster installation.")
+	// bootstrapCmd.MarkFlagRequired("release-image") - will uncomment this after updating bootkube.sh to use the --release-image flag
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.configFile, "config-file", "", "ClusterConfig ConfigMap file.")
 	bootstrapCmd.MarkFlagRequired("config-file")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.infraConfigFile, "infra-config-file", "/assets/manifests/cluster-infrastructure-02-config.yml", "File containing infrastructure.config.openshift.io manifest.")


### PR DESCRIPTION
Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1835233

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
We want to be able to access the release-image used for
cluster installation so we can avoid setting that registry
as blocked when there is an Image CR at installation. For
this, we need to pass down the release-image info from the
installer to the controller at bootstrap.
This is step 1. After this is merged, will update bootkube.sh
to set the --release-image flag with the information needed.

**- How to verify it**
Same way as mentioned in https://github.com/openshift/machine-config-operator/pull/1866 once that is merged in.

**- Description for the changelog**
Add --release-image as a bootstrap option flag.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
