### PR TITLE
templates: Fix for NM dispatcher script miscounting length

### DIFF
--- a/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
+++ b/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
@@ -30,7 +30,7 @@ contents:
 
     default_host="${DHCP4_HOST_NAME:-$DHCP6_HOST_NAME}"
     # truncate the hostname to the first dot and than 64 characters.
-    host=$(echo ${default_host} | cut -f1 -d'.' | cut -c -63)
+    host=$(printf ${default_host} | cut -f1 -d'.' | cut -c -63)
 
     if [ "${#default_host}" -gt 63 ]; then
         log "discovered hostname is longer than than 63 characters"


### PR DESCRIPTION
Use `printf` instead of `echo` when truncating the hostname. `echo` adds
line termination that gets counted as a character. Example:
   $ echo test | wc -c
   5
   $ printf test | wc -c
   4

Signed-off-by: Ben Howard <ben.howard@redhat.com