### PR TITLE
[baremetal] Move keepalived OCP_API check script to a separate file

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
+        script "/etc/keepalived/chk_ocp_script.sh"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/keepalived/chk_ocp_script.sh"
+contents:
+  inline: |
+    #!/bin/bash 
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz  && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz


### PR DESCRIPTION
With the latest Keepalived version (2.0.0) seems that current API track_script [1] doesn't work, as a result of that the CI is broken. 
This PR moves the track script to a file.

[1] https://github.com/openshift/machine-config-operator/blob/master/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml#L6