### PR TITLE
Bug 1854249: [On-Prem] Workaround issues with keepalived v2.0.10

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
+        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/keepalived/chk_ocp_script.sh"
+contents:
+  inline: |
+    #!/bin/bash 
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
+        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-script.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/keepalived/chk_ocp_script.sh"
+contents:
+  inline: |
+    #!/bin/bash 
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -3,7 +3,7 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://0:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
+        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
         interval 1
         weight 50
     }
@@ -11,7 +11,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-script.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/keepalived/chk_ocp_script.sh"
+contents:
+  inline: |
+    #!/bin/bash 
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -8,7 +8,7 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     vrrp_script chk_ocp {
-        script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
+        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
         interval 1
         weight 50
     }
@@ -16,7 +16,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-script.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/keepalived/chk_ocp_script.sh"
+contents:
+  inline: |
+    #!/bin/bash 
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz


### PR DESCRIPTION
**- What I did**

This commit extracts the chk_ocp script into a separate file and wraps
the check scripts with the timeout command to workaround
acassen/keepalived#1364.

This PR supersedes #1908.

Co-Authored-By: Yossi Boaron <yboaron@redhat.com>
Co-Authored-By: Ben Nemec <bnemec@redhat.com>

**- How to verify it**

Installer can deploy OCP on on-prem platform again.

**- Description for the changelog**

Wrap keepalived checks with timeout to workaround known issue with keepalived v2.0.10.
