### PR TITLE
[baremetal & friends] Clean up keepalived script warnings

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -2,6 +2,11 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    global_defs {
+        enable_script_security
+        script_user root
+    }
+
     vrrp_script chk_ocp {
         script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1

--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -2,6 +2,11 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    global_defs {
+        enable_script_security
+        script_user root
+    }
+
     vrrp_script chk_ocp {
         script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz"
         interval 1

--- a/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -2,6 +2,11 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    global_defs {
+        enable_script_security
+        script_user root
+    }
+
     vrrp_script chk_ocp {
         script "/usr/bin/curl -o /dev/null -kLfs https://0:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1

--- a/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -7,6 +7,11 @@ contents:
     {{ if .Infra.Status.PlatformStatus -}}
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
+    global_defs {
+        enable_script_security
+        script_user root
+    }
+
     vrrp_script chk_ocp {
         script "/usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1


### PR DESCRIPTION
Currently we see two ugly messages in the keepalived logs when
starting the service:

WARNING - default user 'keepalived_script' for script execution does
not exist - please create.

and

SECURITY VIOLATION - scripts are being executed but script_security
not enabled.

This patch adds the enable_script_security and script_user options to
our keepalived.conf to suppress those messages.

**- Description for the changelog**
Add configuration options to clean up keepalived warnings.