### PR TITLE
Bug 1826021: Fix a problem with a greedy regular expression matching more than needed

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -426,7 +426,7 @@ contents:
 
     # validate_etcd_name uses regex to return the etcd member name key from ETCD_INITIAL_CLUSTER matching the local ETCD_DNS_NAME.
     validate_etcd_name() {
-      ETCD_NAME=$(echo ${ETCD_INITIAL_CLUSTER} | grep -oP "(?<=)[^,,\s]*(?==[^=]*${ETCD_DNS_NAME}\b)") || true
+      ETCD_NAME=$(echo ${ETCD_INITIAL_CLUSTER} | grep -oP "(?<=)[^,\s]*(?==[^=,]*${ETCD_DNS_NAME}\b)") || true
       if [ -z "$ETCD_NAME" ]; then
         echo "Validating INITIAL_CLUSTER failed: ${ETCD_DNS_NAME} is not found in ${ETCD_INITIAL_CLUSTER}" >&2
         exit 1


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: 1826021
**- What I did**
Fixed a problem with a greedy regular expression.
**- How to verify it**
Run restore on a master which is not the first one in the ETCD_INITIAL_CLUSTER. It should finish successfully.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Current restore shell script results in an error "Error: snapshot restore requires exactly one argument" if the attempted master in not the first member listed in the ETCD_INITIAL_CLUSTER. This is due to a bug in the regular expression.