### PR TITLE
Bug 1842603: Fix runLoginMonitor

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -632,6 +632,9 @@ func (dn *Daemon) runLoginMonitor(stopCh <-chan struct{}, exitCh chan<- error) {
 			case <-worker:
 				return
 			default:
+				if dn.node == nil {
+					continue
+				}
 				buf := make([]byte, 1024)
 				l, err := stdout.Read(buf)
 				if err != nil {


### PR DESCRIPTION
_This PR contains the following commits:_

__pkg/daemon: skip runLoginMonitor if node isn't set__

This whole function runs too early for the node object to be set in the daemon struct, resulting
in:

```
W0709 14:35:40.458777  237119 daemon.go:556] Got an error from auxiliary tools: error: cannot apply annotation for SSH access due to: unable to update node "nil": node "ci-ln-t6mdh42-f76d1-9qqj4-worker-c-l75p7" not found
```

just ignore that, we can't do anything until we have the node set anyway, which we always do eventually

Signed-off-by: Antonio Murdaca <runcom@linux.com>

__pkg/daemon: workaround new sessions detection__

First, this may be a journalctl bug (systemd 239 on RHCOS)

Let me explain with a simple reproducer:

- deploy a bastion to be able to SSH to nodes
- jump on a (random) target node with `oc debug` (this won't trigger anything ssh related)
- run `journalctl -f -o cat -b -u systemd-logind.service MESSAGE_ID=8d45620c1a4348dbb17410da57c60c66` (this is what the MCD uses to follow new ssh sessions)
- in another tab, do run an ssh login command (core@...) against that target node
- notice nothing showed up from step 3
- keep ssh'ing and keep noticing nothing shows up in that journalctl command
- now, ctrl^c from step 3, re-run that command (now it has the login sessions we did before)
- in the other tab, do run an ssh login command (core@...) against that target node
- notice the log follow is _only now_ working and streaming the new ssh sessions

If step 3 is stuck, we don't get anything until we restart the MCD __after__ a successful ssh session,
otherwise we'll be perpetually stuck from detecting new sessions.

See BZ https://bugzilla.redhat.com/show_bug.cgi?id=1842603#c9

Signed-off-by: Antonio Murdaca <runcom@linux.com>

__Note__

Notice the second commit is a stopgap/workaround - I'm digging the journalctl behavior, if anybody knows more, please let me know :) (everybody dislikes strings matching right?)