### PR TITLE
templates/common/_base/units: disable Zincati service

### DIFF
--- a/templates/common/_base/units/zincati.service.yaml
+++ b/templates/common/_base/units/zincati.service.yaml
@@ -1,0 +1,6 @@
+name: zincati.service
+dropins:
+- name: mco-disabled.conf
+  contents: |
+    [Unit]
+    ConditionPathExists=/enoent


### PR DESCRIPTION
This disables Zincati updates on FCOS nodes - no-op on RHCOS.