### PR TITLE
pkg/daemon: refresh the node object

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -411,7 +411,7 @@ func (dn *Daemon) syncNode(key string) error {
 		return nil
 	}
 
-	// Deep-copy otherwise we are mutating our cache.
+	// Deep-copy otherwise we are mutating our cache when modifying it.
 	node = node.DeepCopy()
 	// Update our cached copy of the node
 	dn.node = node
@@ -1227,6 +1227,9 @@ func (dn *Daemon) prepUpdateFromCluster() (*mcfgv1.MachineConfig, *mcfgv1.Machin
 // been completed.
 func (dn *Daemon) completeUpdate(node *corev1.Node, desiredConfigName string) error {
 	if err := drain.RunCordonOrUncordon(dn.drainer, node, false); err != nil {
+		return err
+	}
+	if err := dn.refreshNode(); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -59,6 +59,7 @@ func getNodeAnnotation(node *corev1.Node, k string) (string, error) {
 func getNodeAnnotationExt(node *corev1.Node, k string, allowNoent bool) (string, error) {
 	v, ok := node.Annotations[k]
 	if !ok {
+		glog.Warningf("Annotation %q missing from node object", k)
 		if !allowNoent {
 			return "", fmt.Errorf("%s annotation not found on node '%s'", k, node.Name)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,7 +100,6 @@ func appendKubeConfig(rawExt *runtime.RawExtension, f kubeconfigFunc) error {
 }
 
 func appendNodeAnnotations(rawExt *runtime.RawExtension, currConf string) error {
-
 	anno, err := getNodeAnnotation(currConf)
 	if err != nil {
 		return err


### PR DESCRIPTION
Somehow, and it's not fully clear why as I'm not an expert on the k8s API side of the world, I imagine the indexers getting confused somehow and bringing us here:

```
"metadata": {
        "annotations": {
            "machine.openshift.io/machine": "openshift-machine-api/ci-ln-zic4ylt-f76d1-68jfg-worker-b-46p64",
            "machineconfiguration.openshift.io/currentConfig": "rendered-worker-84b8fd86e2cb32a272b2ea9871bbfa87",
            "machineconfiguration.openshift.io/desiredConfig": "rendered-worker-e8f5eab633c34a53702b0efc7abaaa50",
            "machineconfiguration.openshift.io/reason": "failed to run pivot: failed to run pivot: exit status 1: failed to run command podman (6 tries): timed out waiting for the condition: running podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d746ebe14faaa6d1a1847c0d939373b74306c38c39f77315e559a7ec676fbbb8 failed: Error: error pulling image \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d746ebe14faaa6d1a1847c0d939373b74306c38c39f77315e559a7ec676fbbb8\": unable to pull quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d746ebe14faaa6d1a1847c0d939373b74306c38c39f77315e559a7ec676fbbb8: unable to pull image: Error initializing source docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d746ebe14faaa6d1a1847c0d939373b74306c38c39f77315e559a7ec676fbbb8: Error reading manifest sha256:d746ebe14faaa6d1a1847c0d939373b74306c38c39f77315e559a7ec676fbbb8 in quay.io/openshift-release-dev/ocp-v4.0-art-dev: manifest unknown: manifest unknown\n: exit status 125",
            "machineconfiguration.openshift.io/state": "Working",
            "volumes.kubernetes.io/controller-managed-attach-detach": "true"
        },
```

The above is totally unexpected unless something goes wrong when managing the object
at the kube level. Our code makes sure that "if we're degraded, we never switch to working".
So the above, I think, must be the result of some weird Strategic Patch edge case
where, despite being told to update Degraded and Reason, it only does it for Reason.
It gets messier if you directly look at the code as the code seems to be right... This patch does the right thing anyway
by refreshing the node object before updating it at the API level and it works in my testing (we should have always done this, this bug is a side effect I found 🤷‍♂️ ).

The above also happens only on workers, masters do go through a "refresh" at the API level at startup cause the initial MC isn't even there yet - so it seems ok there.

Reproducer:

TODO(runcom) - I have a reproducer and I'm trying to get more clues, otherwise, this fixes things, somehow...

Signed-off-by: Antonio Murdaca <runcom@linux.com>