### PR TITLE
pkg/daemon: drop nodeWriter interface + set resourceVersion when patching

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -456,6 +456,7 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 			daemonconsts.CurrentMachineConfigAnnotationKey,
 			daemonconsts.DesiredMachineConfigAnnotationKey,
 			daemonconsts.MachineConfigDaemonStateAnnotationKey,
+			daemonconsts.MachineConfigDaemonReasonAnnotationKey,
 		}
 		for _, anno := range annos {
 			if oldNode.Annotations[anno] != curNode.Annotations[anno] {

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -32,7 +32,7 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 		currentOnDisk, err := dn.getCurrentConfigOnDisk()
 		if err == nil {
 			glog.Infof("Setting initial node config based on current configuration on disk: %s", currentOnDisk.GetName())
-			return setNodeAnnotations(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, node.Name, map[string]string{constants.CurrentMachineConfigAnnotationKey: currentOnDisk.GetName()})
+			return dn.setNodeAnnotations(map[string]string{constants.CurrentMachineConfigAnnotationKey: currentOnDisk.GetName()})
 		}
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 	}
 
 	glog.Infof("Setting initial node config: %s", initial[constants.CurrentMachineConfigAnnotationKey])
-	n, err := setNodeAnnotations(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, node.Name, initial)
+	n, err := dn.setNodeAnnotations(initial)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set initial annotations: %v", err)
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -259,13 +259,13 @@ func (dn *Daemon) compareMachineConfig(oldConfig, newConfig *mcfgv1.MachineConfi
 func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
 	oldConfig = canonicalizeEmptyMC(oldConfig)
 
-	if dn.nodeWriter != nil {
+	if dn.kubeClient != nil {
 		state, err := getNodeAnnotationExt(dn.node, constants.MachineConfigDaemonStateAnnotationKey, true)
 		if err != nil {
 			return err
 		}
 		if state != constants.MachineConfigDaemonStateDegraded && state != constants.MachineConfigDaemonStateUnreconcilable {
-			if err := dn.nodeWriter.SetWorking(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name); err != nil {
+			if err := dn.setWorking(); err != nil {
 				return errors.Wrap(err, "error setting node's state to Working")
 			}
 		}

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -7,67 +7,16 @@ import (
 	"github.com/openshift/machine-config-operator/internal"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	corev1 "k8s.io/api/core/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
 const (
-	// defaultWriterQueue the number of pending writes to queue
-	defaultWriterQueue = 25
-
 	// machineConfigDaemonSSHAccessAnnotationKey is used to mark a node after it has been accessed via SSH
 	machineConfigDaemonSSHAccessAnnotationKey = "machineconfiguration.openshift.io/ssh"
 	// MachineConfigDaemonSSHAccessValue is the annotation value applied when ssh access is detected
 	machineConfigDaemonSSHAccessValue = "accessed"
 )
 
-// message wraps a client and responseChannel
-type message struct {
-	client          corev1client.NodeInterface
-	lister          corev1lister.NodeLister
-	node            string
-	annos           map[string]string
-	responseChannel chan error
-}
-
-// clusterNodeWriter is a single writer to Kubernetes to prevent race conditions
-type clusterNodeWriter struct {
-	writer chan message
-}
-
-// NodeWriter is the interface to implement a single writer to Kubernetes to prevent race conditions
-type NodeWriter interface {
-	Run(stop <-chan struct{})
-	SetDone(client corev1client.NodeInterface, lister corev1lister.NodeLister, node string, dcAnnotation string) error
-	SetWorking(client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error
-	SetUnreconcilable(err error, client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error
-	SetDegraded(err error, client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error
-	SetSSHAccessed(client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error
-}
-
-// newNodeWriter Create a new NodeWriter
-func newNodeWriter() NodeWriter {
-	return &clusterNodeWriter{
-		writer: make(chan message, defaultWriterQueue),
-	}
-}
-
-// Run reads from the writer channel and sets the node annotation. It will
-// return if the stop channel is closed. Intended to be run via a goroutine.
-func (nw *clusterNodeWriter) Run(stop <-chan struct{}) {
-	for {
-		select {
-		case <-stop:
-			return
-		case msg := <-nw.writer:
-			_, err := setNodeAnnotations(msg.client, msg.lister, msg.node, msg.annos)
-			msg.responseChannel <- err
-		}
-	}
-}
-
-// SetDone sets the state to Done.
-func (nw *clusterNodeWriter) SetDone(client corev1client.NodeInterface, lister corev1lister.NodeLister, node, dcAnnotation string) error {
+func (dn *Daemon) setDone(dcAnnotation string) error {
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateDone,
 		constants.CurrentMachineConfigAnnotationKey:     dcAnnotation,
@@ -75,36 +24,20 @@ func (nw *clusterNodeWriter) SetDone(client corev1client.NodeInterface, lister c
 		constants.MachineConfigDaemonReasonAnnotationKey: "",
 	}
 	MCDState.WithLabelValues(constants.MachineConfigDaemonStateDone, "").SetToCurrentTime()
-	respChan := make(chan error, 1)
-	nw.writer <- message{
-		client:          client,
-		lister:          lister,
-		node:            node,
-		annos:           annos,
-		responseChannel: respChan,
-	}
-	return <-respChan
+	_, err := dn.setNodeAnnotations(annos)
+	return err
 }
 
-// SetWorking sets the state to Working.
-func (nw *clusterNodeWriter) SetWorking(client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error {
+func (dn *Daemon) setWorking() error {
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateWorking,
 	}
 	MCDState.WithLabelValues(constants.MachineConfigDaemonStateWorking, "").SetToCurrentTime()
-	respChan := make(chan error, 1)
-	nw.writer <- message{
-		client:          client,
-		lister:          lister,
-		node:            node,
-		annos:           annos,
-		responseChannel: respChan,
-	}
-	return <-respChan
+	_, err := dn.setNodeAnnotations(annos)
+	return err
 }
 
-// SetUnreconcilable sets the state to Unreconcilable.
-func (nw *clusterNodeWriter) SetUnreconcilable(err error, client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error {
+func (dn *Daemon) setUnreconcilable(err error) error {
 	glog.Errorf("Marking Unreconcilable due to: %v", err)
 	// truncatedErr caps error message at a reasonable length to limit the risk of hitting the total
 	// annotation size limit (256 kb) at any point
@@ -114,24 +47,11 @@ func (nw *clusterNodeWriter) SetUnreconcilable(err error, client corev1client.No
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
 	MCDState.WithLabelValues(constants.MachineConfigDaemonStateUnreconcilable, truncatedErr).SetToCurrentTime()
-	respChan := make(chan error, 1)
-	nw.writer <- message{
-		client:          client,
-		lister:          lister,
-		node:            node,
-		annos:           annos,
-		responseChannel: respChan,
-	}
-	clientErr := <-respChan
-	if clientErr != nil {
-		glog.Errorf("Error setting Unreconcilable annotation for node %s: %v", node, clientErr)
-	}
-	return clientErr
+	_, err = dn.setNodeAnnotations(annos)
+	return err
 }
 
-// SetDegraded logs the error and sets the state to Degraded.
-// Returns an error if it couldn't set the annotation.
-func (nw *clusterNodeWriter) SetDegraded(err error, client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error {
+func (dn *Daemon) setDegraded(err error) error {
 	glog.Errorf("Marking Degraded due to: %v", err)
 	// truncatedErr caps error message at a reasonable length to limit the risk of hitting the total
 	// annotation size limit (256 kb) at any point
@@ -141,43 +61,31 @@ func (nw *clusterNodeWriter) SetDegraded(err error, client corev1client.NodeInte
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
 	MCDState.WithLabelValues(constants.MachineConfigDaemonStateDegraded, truncatedErr).SetToCurrentTime()
-	respChan := make(chan error, 1)
-	nw.writer <- message{
-		client:          client,
-		lister:          lister,
-		node:            node,
-		annos:           annos,
-		responseChannel: respChan,
-	}
-	clientErr := <-respChan
-	if clientErr != nil {
-		glog.Errorf("Error setting Degraded annotation for node %s: %v", node, clientErr)
-	}
-	return clientErr
+	_, err = dn.setNodeAnnotations(annos)
+	return err
 }
 
-// SetSSHAccessed sets the ssh annotation to accessed
-func (nw *clusterNodeWriter) SetSSHAccessed(client corev1client.NodeInterface, lister corev1lister.NodeLister, node string) error {
+func (dn *Daemon) setSSHAccessed() error {
 	MCDSSHAccessed.Inc()
 	annos := map[string]string{
 		machineConfigDaemonSSHAccessAnnotationKey: machineConfigDaemonSSHAccessValue,
 	}
-	respChan := make(chan error, 1)
-	nw.writer <- message{
-		client:          client,
-		lister:          lister,
-		node:            node,
-		annos:           annos,
-		responseChannel: respChan,
-	}
-	return <-respChan
+	_, err := dn.setNodeAnnotationsRetry(annos)
+	return err
 }
 
-func setNodeAnnotations(client corev1client.NodeInterface, lister corev1lister.NodeLister, nodeName string, m map[string]string) (*corev1.Node, error) {
-	node, err := internal.UpdateNodeRetry(client, lister, nodeName, func(node *corev1.Node) {
+func (dn *Daemon) setNodeAnnotations(m map[string]string) (*corev1.Node, error) {
+	return internal.UpdateNode(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, func(node *corev1.Node) {
 		for k, v := range m {
 			node.Annotations[k] = v
 		}
 	})
-	return node, err
+}
+
+func (dn *Daemon) setNodeAnnotationsRetry(m map[string]string) (*corev1.Node, error) {
+	return internal.UpdateNodeRetry(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, func(node *corev1.Node) {
+		for k, v := range m {
+			node.Annotations[k] = v
+		}
+	})
 }


### PR DESCRIPTION
tl;dr; refer to https://github.com/openshift/machine-config-operator/pull/1923#issuecomment-657735033 for a detailed diagnosis of the issue

These patches do two (major) things:

- remove the nodeWriter interface, not needed now that the daemon runs as a real controller and we can afford to fail and retry
- set node's resourceVersion when patching, making sure we get a 409 on conflict and retry

Minor changes in different commits:

- react to Reason annotation changes (why we never did that is a unknown to me, so far, we're sticking to an old degraded reason if the reason changes but we're still degraded, it's just wrong...)
- use a faster workqueue for the render controller (see commit message specifically)

Long story:

The second point above is crucial as it's the source of a bug, let me try to explain what happens:

- resync on an informer means: replay the in-memory state that I have.  It does not mean relist from the apiserver
- the lister.get is based on the cached state, so if the watch hasn't observed the change, the lister.Get won't have it

Given the assumptions above (thanks deads for explaining):

- the daemon update the node object when it degrades
- it immediately retries the action, lister.get yielding an _old_ cached state
- that defeats guards like "switch to working only when not degraded"

Explanation to last above above: because of how we patch node objects, we may end up checking
the state annotation with an _old_ object (passing the guard) but then updating the right object
with states that don't make sense anymore (like a Working state and a real Degraded reason).

The fix for all that madness is pretty simple (after speaking to deads):

- use resourceVersion when patching the node object

That makes sure that if we try to patch an object using an old resouce version we'll get a conflict error,
we then exit the guard we entered, and retry with a fresher object, all good.

This can be tested with (credits to deads again)

- oc get ns/foo -ojson
- build your patch with RV
- oc annotate ns/foo something-to-change-rv=true
- oc patch with RV

step four should get a conflict error

Signed-off-by: Antonio Murdaca <runcom@linux.com>