### PR TITLE
Bug 1854801: Make sure openvswitch related services are always restarted

### DIFF
--- a/templates/common/_base/units/ovs-vswitchd.service.yaml
+++ b/templates/common/_base/units/ovs-vswitchd.service.yaml
@@ -1,0 +1,6 @@
+name: ovs-vswitchd.service
+dropins:
+  - name: 10-ovs-vswitchd-restart.conf
+    contents: |
+      [Service]
+      Restart=always

--- a/templates/common/_base/units/ovsdb-server.service
+++ b/templates/common/_base/units/ovsdb-server.service
@@ -1,2 +1,7 @@
 name: "ovsdb-server.service"
 enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else if eq .NetworkType "OpenShiftSDN"}}true{{else}}false{{end}}
+dropins:
+  - name: 10-ovsdb-restart.conf
+    contents: |
+      [Service]
+      Restart=always


### PR DESCRIPTION
**- What I did**
Set Restart=always in service files

**- How to verify it**
By manually killing the ovs-vswitchd process on rhcos and verifying
it gets started automatically by systemd.

**- Description for the changelog**

OVS services (openvswitch and ovsd-bserver) are run without the
--monitor option. As a result, when the underlying daemon gets
killed by SIGTERM, the process is not automatically restarted
unless the Restart tag is set to always. This is critical for
system services such as OVS which need to be always up for traffic
forwarding. This fixes BZ: 1854801

