### PR TITLE
Change manifest file mode to 0644

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -205,7 +205,7 @@ func RenderBootstrap(
 		if err := os.MkdirAll(dirname, 0655); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(path, b, 0655); err != nil {
+		if err := ioutil.WriteFile(path, b, 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
It doesn't make much sense to set the executable bit only for group
and other, and this causes problems for services like keepalived
that won't start if the executable bit is set on their config file.
