### PR TITLE
Bug 1858907: add nil check for infra.Status.PlatformStatus in isCloudConfigReqd

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -102,13 +102,18 @@ func isCloudConfigRequired(infra *configv1.Infrastructure) bool {
 	if infra.Spec.CloudConfig.Name != "" {
 		return true
 	}
-	switch infra.Status.PlatformStatus.Type {
-	case configv1.AzurePlatformType,
-		configv1.GCPPlatformType,
-		configv1.OpenStackPlatformType,
-		configv1.VSpherePlatformType:
-		return true
-	default:
+
+	if infra.Status.PlatformStatus != nil {
+		switch infra.Status.PlatformStatus.Type {
+		case configv1.AzurePlatformType,
+			configv1.GCPPlatformType,
+			configv1.OpenStackPlatformType,
+			configv1.VSpherePlatformType:
+			return true
+		default:
+			return false
+		}
+	} else {
 		return false
 	}
 }

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -1,0 +1,14 @@
+package operator
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsCloudConfigRequired(t *testing.T) {
+	testInfra := configv1.Infrastructure{}
+	testInfra.Status.Platform = "None"
+	required := isCloudConfigRequired(&testInfra)
+	assert.False(t, required)
+}


### PR DESCRIPTION
backport of https://github.com/openshift/machine-config-operator/pull/1935

infra.Status.PlatformStatus is *PlatformStatus and in some <4.5.x setups this entire thing is empty and only platform is set to none. So when we hit the switch statement in the MCO we panic bc pointers, so check that it's really there before you do the switch stmt case comparisions. Before my fix, the unit test I added failed with same panic, now it passes and func returns false. This behavior was seen in bm clusters updating from 4.4.12->4.5.2, which is also when Platform was deprecated in favor of PlatformStatus and the MCO was missing the check. The checks do exist in the MCC transitioning them to the new type.

As for why we saw this with users but not in CI, AFAIK there isn't an e2e metal upgrade job accounting for this anywhere and I believe the existing metal job would just install a 4.5.x cluster with the new PlatformStatus.
