### PR TITLE
pools: add default label for master/worker pool

### DIFF
--- a/docs/KubeletConfigDesign.md
+++ b/docs/KubeletConfigDesign.md
@@ -72,12 +72,28 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: small-pods
+      pools.operator.machineconfiguration.openshift.io/worker: ""
   kubeletConfig:
     maxPods: 100
 ```
 
 Save your `kubeletconfig` locally, for example as maxpods.yaml
+
+The label in the above example corresponds to the worker MachineConfigPool. By default the master/worker
+MachineConfigPool has labels pools.operator.machineconfiguration.openshift.io/{worker|master}: "" in OCP 4.6 and later. If you have a custom pool, or have an earlier OCP version, you can instead create a label youself as follows:
+
+```
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-max-pods
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: small-pods
+  kubeletConfig:
+    maxPods: 100
+```
 
 To roll out the pods limit changes to all the worker nodes (can switch this to master for the master nodes), add the label that you created, here: `custom-kubelet: small-pods` under labels in the machineConfigPool config: 
 
@@ -119,9 +135,9 @@ Check to ensure that a new 99-worker-XXX-kubelet is created and that a new rende
 $ oc get machineconfigs
 NAME                                 GENERATEDBYCONTROLLER                      IGNITIONVERSION   AGE
 ...
-99-worker-123-abc-kubelet            fc45f8b73b2fc61e567f2111181d3e802f2565d7   2.2.0             7s
+99-worker-kubelet-managed            fc45f8b73b2fc61e567f2111181d3e802f2565d7   3.1.0             7s
 ...
-rendered-worker-45678XYZ             fc45f8b73b2fc61e567f2111181d3e802f2565d7   2.2.0             2s
+rendered-worker-45678XYZ             fc45f8b73b2fc61e567f2111181d3e802f2565d7   3.1.0             2s
 ...
 ```
 

--- a/manifests/master.machineconfigpool.yaml
+++ b/manifests/master.machineconfigpool.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
     "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/master": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/manifests/worker.machineconfigpool.yaml
+++ b/manifests/worker.machineconfigpool.yaml
@@ -4,6 +4,7 @@ metadata:
   name: worker
   labels:
     "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/worker": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/pkg/controller/bootstrap/testdata/bootstrap/master.machineconfigpool.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/master.machineconfigpool.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
     "machineconfiguration.openshift.io/mco-built-in": ""
-    "pools.operator.machineconfiguration.openshift.io/master": ""
+    pools.operator.machineconfiguration.openshift.io/master: ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/pkg/controller/bootstrap/testdata/bootstrap/master.machineconfigpool.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/master.machineconfigpool.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
     "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/master": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/pkg/controller/bootstrap/testdata/bootstrap/worker.machineconfigpool.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/worker.machineconfigpool.yaml
@@ -4,7 +4,7 @@ metadata:
   name: worker
   labels:
     "machineconfiguration.openshift.io/mco-built-in": ""
-    "pools.operator.machineconfiguration.openshift.io/worker": ""
+    pools.operator.machineconfiguration.openshift.io/worker: ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/pkg/controller/bootstrap/testdata/bootstrap/worker.machineconfigpool.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/worker.machineconfigpool.yaml
@@ -4,6 +4,7 @@ metadata:
   name: worker
   labels:
     "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/worker": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -404,10 +404,8 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
-			mcp.ObjectMeta.Labels["custom-crio"] = "my-config"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
-			mcp2.ObjectMeta.Labels["custom-crio"] = "storage-config"
-			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "custom-crio", "my-config"))
+			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 			ctrCfgKey, _ := getManagedKeyCtrCfg(mcp, nil)
 			mcs1 := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcs2 := mcs1.DeepCopy()
@@ -441,10 +439,8 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
-			mcp.ObjectMeta.Labels["custom-crio"] = "my-config"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
-			mcp2.ObjectMeta.Labels["custom-crio"] = "storage-config"
-			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "custom-crio", "my-config"))
+			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 			keyCtrCfg, _ := getManagedKeyCtrCfg(mcp, nil)
 			mcs := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcsUpdate := mcs.DeepCopy()

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -325,9 +325,8 @@ func TestKubeletConfigCreate(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
-			mcp.ObjectMeta.Labels["kubeletType"] = "small-pods"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
-			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
+			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
 			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
@@ -358,9 +357,8 @@ func TestKubeletConfigUpdates(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
-			mcp.ObjectMeta.Labels["kubeletType"] = "small-pods"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
-			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
+			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
 			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
@@ -634,9 +632,8 @@ func TestKubeletFeatureExists(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
-			mcp.ObjectMeta.Labels["kubeletType"] = "small-pods"
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
-			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "kubeletType", "small-pods"))
+			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 			kubeletConfigKey, _ := getManagedKubeletConfigKey(mcp, nil)
 			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1808,6 +1808,7 @@ metadata:
   labels:
     "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
     "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/master": ""
 spec:
   machineConfigSelector:
     matchLabels:
@@ -2685,6 +2686,7 @@ metadata:
   name: worker
   labels:
     "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/worker": ""
 spec:
   machineConfigSelector:
     matchLabels:

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -1,6 +1,8 @@
 package helpers
 
 import (
+	"fmt"
+
 	"github.com/clarketm/json"
 	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	corev1 "k8s.io/api/core/v1"
@@ -74,7 +76,8 @@ func NewMachineConfigPool(name string, mcSelector, nodeSelector *metav1.LabelSel
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				"machineconfiguration.openshift.io/mco-built-in": "",
+				"machineconfiguration.openshift.io/mco-built-in":                         "",
+				fmt.Sprintf("pools.operator.machineconfiguration.openshift.io/%s", name): "",
 			},
 			UID: types.UID(utilrand.String(5)),
 		},


### PR DESCRIPTION
Today the master/worker MCP does not have any different labels.
This means that if e.g. a user wants to add a kubeletconfig, they
must first create a label for the pool and target the kubeletconfig
against the label. This PR creates a default label for master/worker
pools to skip that step.