### PR TITLE
[release-4.3] Bug 1855879: cherry-pick hostname fixes

### DIFF
--- a/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
+++ b/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
@@ -5,36 +5,29 @@ contents:
   inline: |
     #!/bin/bash
     #
-    # On Google Compute Platform (GCP) the hostname may be too long (>63 chars).
-    # During firstboot the hostname is set in the initramfs before NetworkManager
-    # runs; on reboot affect nodes use 'localhost'. This hook is a simple work
-    # around: if the host name is longer than 63 characters, then the hostname
-    # is truncated at the _first_ dot.
-    #
-    # Additionally, this hook does not break DNS or cluster DNS resolution,
-    # since NetworkManager sets the appropriate /etc/resolv.conf settings.
-
+    # 90-long-hostname is a wrapper around /usr/local/sbin/set-valid-hostname.sh,
+    # which ensures that a node has a valid hostname.
     IF=$1
     STATUS=$2
 
     log() { logger --tag "network-manager/$(basename $0)" "${@}"; }
 
-    # capture all eligible hostnames
-    if [[ ! "$(/bin/hostname)" =~ (localhost|localhost.local) ]]; then
-        log "hostname is already set"
-        exit 0
-    fi
-
     if [[ ! "$STATUS" =~ (up|hostname|dhcp4-change|dhcp6-change) ]]; then
         exit 0
     fi
 
-    default_host="${DHCP4_HOST_NAME:-$DHCP6_HOST_NAME}"
-    # truncate the hostname to the first dot and than 64 characters.
-    host=$(printf ${default_host} | cut -f1 -d'.' | cut -c -63)
-
-    if [ "${#default_host}" -gt 63 ]; then
-        log "discovered hostname is longer than than 63 characters"
-        log "truncating ${default_host} => ${host}"
-        /bin/hostnamectl --transient set-hostname "${host}"
+    if [[ ! "$(< /proc/sys/kernel/hostname)" =~ (localhost|localhost.localdomain) ]]; then
+        log "hostname is already set"
+        exit 0
     fi
+
+    # source the script since NetworkManager execution rules do
+    # allow sourcing from /usr/local. RHCOS has an read-only rootfs
+    # which limits where this can be stashed.
+    source /usr/local/sbin/set-valid-hostname.sh
+    host_name="${DHCP4_HOST_NAME:-$DHCP6_HOST_NAME}"
+
+    if [ -n "${host_name}" ]; then
+        set_valid_hostname "${host_name}"
+    fi
+

--- a/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
+++ b/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
@@ -31,7 +31,7 @@ contents:
 
     default_host="${DHCP4_HOST_NAME:-$DHCP6_HOST_NAME}"
     # truncate the hostname to the first dot and than 64 characters.
-    host=$(echo ${default_host} | cut -f1 -d'.' | cut -c -63)
+    host=$(printf ${default_host} | cut -f1 -d'.' | cut -c -63)
 
     if [ "${#default_host}" -gt 63 ]; then
         log "discovered hostname is longer than than 63 characters"

--- a/templates/common/_base/files/usr-local-sbin-set-valid-hostname.yaml
+++ b/templates/common/_base/files/usr-local-sbin-set-valid-hostname.yaml
@@ -1,0 +1,84 @@
+filesystem: "root"
+mode: 0755
+path: "/usr/local/sbin/set-valid-hostname.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    # On some platforms the hostname may be too long (>63 chars).
+    #  - On firstboot the hostname is set in the initramfs before NetworkManager
+    #    And it may be truncated at 64 characters (too long)
+    #  - On reboot affect nodes use 'localhost'.
+    #
+    # This script is a simple workaround for hostname woes, including
+    #  - NOT a localhost name
+    #  - NOT longer than 63 characters. Names will be truncated at the
+    #    first dot, and then capped at 63 char (which ever is less).
+    #  - Race conditions between truncated hostnames by the dhclient
+    #    and NetworkManager.
+    #
+    # Finally, this script is invoked via:
+    #  - /etc/NetworkManager/dispatcher.d/90-long-hostnames
+    #  - on boot via node-valid-hostname.service
+
+    export PATH="/usr/bin:/usr/local/bin:/sbin:/usr/local/sbin:/bin:${PATH}"
+    log() { logger --tag "$(basename $0)" "${@}"; }
+
+    # wait_localhost waits until the host gets a real hostname.
+    # This will wait indefinately. node-valid-hostname.service will terminate
+    # this after 5m.
+    wait_localhost() {
+        log "waiting for non-localhost hostname to be assigned"
+        while [[ "$(< /proc/sys/kernel/hostname)" =~ (localhost|localhost.localdomain) ]];
+        do
+            sleep 1
+        done
+        log "node identified as $(</proc/sys/kernel/hostname)"
+        exit 0
+    }
+
+    set_valid_hostname() {
+        local host_name=${1}
+        local type_arg="transient"
+
+        # /etc/hostname is used for static hostnames and is authorative.
+        # This will check to make sure that the static hostname is the
+        # less than or equal to 63 characters in length.
+        if [ -f /etc/hostname ] && [ "$(cat /etc/hostname | wc -m)" -gt 0 ]; then
+            etc_name="$(< /etc/hostname)"
+            type_arg="static"
+            if [ "${etc_name}" != "${host_name}" ]; then
+                log "/etc/hostname is set to ${etc_name} but does not match ${host_name}"
+                log "using /etc/hostname as the authorative name"
+                host_name="${etc_name}"
+            fi
+        fi
+
+        # Only mutate the hostname if the length is longer than 63 characters. The
+        # hostname will be the lesser of 63 characters after the first dot in the
+        # FQDN.
+        if [ "${#host_name}" -gt 63 ]; then
+            alt_name=$(printf "${host_name}" | cut -f1 -d'.' | cut -c -63)
+            log "${host_name} is longer than 63 characters, using trunacated hostname"
+            host_name="${alt_name}"
+        fi
+        log "setting ${type_arg} hostname to ${host_name}"
+        /bin/hostnamectl "--${type_arg}" set-hostname "${host_name}"
+        exit 0
+    }
+
+    cli_run() {
+        mode="${1:?mode must be the first argument}"; shift;
+        case "${mode}" in
+                wait_localhost) wait_localhost;;
+            set_valid_hostname) hname="${1:?hostname is a required last argument}";
+                                set_valid_hostname "${hname}";;
+                            *) log "unknown mode ${mode}"; exit 1;;
+        esac
+    }
+
+    # Allow the functions to be sourced. This can be run either as a
+    # standalone command or in systemd or part of NetworkManager.
+    if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+        cli_run ${@}
+    fi
+

--- a/templates/common/_base/units/node-valid-hostname.service
+++ b/templates/common/_base/units/node-valid-hostname.service
@@ -2,19 +2,18 @@ name: node-valid-hostname.service
 enabled: true
 contents: |
   [Unit]
-  Description=Ensure hostname is not localhost
-  # Only run when the host has a localhost name.
-  ConditionHost=|localhost
-  ConditionHost=|localhost.localdomain
+  Description=Ensure the node hostname is valid for the cluster
   Before=network-online.target
 
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStartPre=/bin/echo "Node has localhost hostname. Waiting for new hostname."
-  # Get the short hostname. This is more reliable than a regex.
-  ExecStartPre=/bin/bash -c 'while [ `hostname -s` == "localhost" ]; do sleep 1; done;'
-  ExecStart=/bin/sh -c "echo Node changed hostname to `hostname`"
+  User=root
+
+  # SystemD prevents direct execution of the script in /usr/local/sbin,
+  # so it is sourced. See the script for functionality.
+  ExecStart=/bin/bash -c "source /usr/local/sbin/set-valid-hostname.sh; wait_localhost; set_valid_hostname `hostname`"
+
   # Wait up to 5min for the node to get a real hostname.
   TimeoutSec=300
 
@@ -22,3 +21,4 @@ contents: |
   WantedBy=multi-user.target
   # Ensure that network-online.target will not complete until the node has a real hostname.
   RequiredBy=network-online.target
+

--- a/templates/common/_base/units/node-valid-hostname.service
+++ b/templates/common/_base/units/node-valid-hostname.service
@@ -1,0 +1,24 @@
+name: node-valid-hostname.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Ensure hostname is not localhost
+  # Only run when the host has a localhost name.
+  ConditionHost=|localhost
+  ConditionHost=|localhost.localdomain
+  Before=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStartPre=/bin/echo "Node has localhost hostname. Waiting for new hostname."
+  # Get the short hostname. This is more reliable than a regex.
+  ExecStartPre=/bin/bash -c 'while [ `hostname -s` == "localhost" ]; do sleep 1; done;'
+  ExecStart=/bin/sh -c "echo Node changed hostname to `hostname`"
+  # Wait up to 5min for the node to get a real hostname.
+  TimeoutSec=300
+
+  [Install]
+  WantedBy=multi-user.target
+  # Ensure that network-online.target will not complete until the node has a real hostname.
+  RequiredBy=network-online.target


### PR DESCRIPTION
templates: ensure RHCOS node hostnames are mostly valid

This aims to fix all the edge-cases around invalid hostnames. This can include:
     - localhost as the hostname
     - a static hostname larger than 63 characters
     - slow reverse DNS hostname discovery
     - truncated hostname in initramfs discovery that is 64 characters long

Fixes BZ 1855879

Includes commits:
- cb12bb855b7493f9b1a23dbe9ed13d5dbaa70d51
- cf2db93410f23d3a5099ed6e619cb286affff538
- 9ddd20dcbe04e90df97b6abcdf511ceef3ec1170

This is needed due to the guard condition in the installer being rolled back at https://github.com/openshift/installer/pull/3644. 
 