### PR TITLE
Update kernel args on firstboot-complete

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -29,22 +27,7 @@ const (
 	// etcPivotFile is used for 4.1 bootimages and is how the MCD
 	// currently communicated with this service.
 	etcPivotFile = "/etc/pivot/image-pullspec"
-	// File containing kernel arg changes for tuning
-	kernelTuningFile = "/etc/pivot/kernel-args"
-	cmdLineFile      = "/proc/cmdline"
 )
-
-// TODO: fill out the allowlists
-// tuneableRHCOSArgsAllowlist contains allowed keys for tunable kernel arguments on RHCOS
-var tuneableRHCOSArgsAllowlist = map[string]bool{
-	"nosmt": true,
-}
-
-// tuneableFCOSArgsAllowlist contains allowed keys for tunable kernel arguments on FCOS
-var tuneableFCOSArgsAllowlist = map[string]bool{
-	"systemd.unified_cgroup_hierarchy=0": true,
-	"mitigations=auto,nosmt":             true,
-}
 
 var pivotCmd = &cobra.Command{
 	Use:                   "pivot",
@@ -60,154 +43,6 @@ func init() {
 	pivotCmd.PersistentFlags().BoolVarP(&keep, "keep", "k", false, "Do not remove container image")
 	pivotCmd.PersistentFlags().BoolVarP(&fromEtcPullSpec, "from-etc-pullspec", "P", false, "Parse /etc/pivot/image-pullspec")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-}
-
-// isArgTuneable returns if the argument provided is allowed to be modified
-func isArgTunable(arg string) (bool, error) {
-	operatingSystem, err := daemon.GetHostRunningOS()
-	if err != nil {
-		return false, errors.Errorf("failed to get OS for determining whether kernel arg is tuneable: %v", err)
-	}
-
-	switch operatingSystem {
-	case daemon.MachineConfigDaemonOSRHCOS:
-		return tuneableRHCOSArgsAllowlist[arg], nil
-	case daemon.MachineConfigDaemonOSFCOS:
-		return tuneableFCOSArgsAllowlist[arg], nil
-	default:
-		return false, nil
-	}
-}
-
-// isArgInUse checks to see if the argument is already in use by the system currently
-func isArgInUse(arg, cmdLinePath string) (bool, error) {
-	if cmdLinePath == "" {
-		cmdLinePath = cmdLineFile
-	}
-	content, err := ioutil.ReadFile(cmdLinePath)
-	if err != nil {
-		return false, err
-	}
-
-	checkable := string(content)
-	if strings.Contains(checkable, arg) {
-		return true, nil
-	}
-	return false, nil
-}
-
-// parseTuningFile parses the kernel argument tuning file
-func parseTuningFile(tuningFilePath, cmdLinePath string) ([]types.TuneArgument, []types.TuneArgument, error) {
-	addArguments := []types.TuneArgument{}
-	deleteArguments := []types.TuneArgument{}
-	if tuningFilePath == "" {
-		tuningFilePath = kernelTuningFile
-	}
-	if cmdLinePath == "" {
-		cmdLinePath = cmdLineFile
-	}
-	// Read and parse the file
-	file, err := os.Open(tuningFilePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// It's ok if the file doesn't exist
-			return addArguments, deleteArguments, nil
-		}
-		return addArguments, deleteArguments, errors.Wrapf(err, "reading %s", tuningFilePath)
-	}
-	// Clean up
-	defer file.Close()
-
-	// Parse the tuning lines
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "ADD ") {
-			// NOTE: Today only specific bare kernel arguments are allowed so
-			// there is not a need to split on =.
-			key := strings.TrimSpace(line[len("ADD "):])
-			tuneableKarg, err := isArgTunable(key)
-			if err != nil {
-				return addArguments, deleteArguments, err
-			}
-			if tuneableKarg {
-				// Find out if the argument is in use
-				inUse, err := isArgInUse(key, cmdLinePath)
-				if err != nil {
-					return addArguments, deleteArguments, err
-				}
-				if !inUse {
-					addArguments = append(addArguments, types.TuneArgument{Key: key, Bare: true})
-				} else {
-					glog.Infof(`skipping "%s" as it is already in use`, key)
-				}
-			} else {
-				glog.Infof("%s not an allowlisted kernel argument", key)
-			}
-		} else if strings.HasPrefix(line, "DELETE ") {
-			// NOTE: Today only specific bare kernel arguments are allowed so
-			// there is not a need to split on =.
-			key := strings.TrimSpace(line[len("DELETE "):])
-			tuneableKarg, err := isArgTunable(key)
-			if err != nil {
-				return addArguments, deleteArguments, err
-			}
-			if tuneableKarg {
-				inUse, err := isArgInUse(key, cmdLinePath)
-				if err != nil {
-					return addArguments, deleteArguments, err
-				}
-				if inUse {
-					deleteArguments = append(deleteArguments, types.TuneArgument{Key: key, Bare: true})
-				} else {
-					glog.Infof(`skipping "%s" as it is not present in the current argument list`, key)
-				}
-			} else {
-				glog.Infof("%s not an allowlisted kernel argument", key)
-			}
-		} else {
-			glog.V(2).Infof(`skipping malformed line in %s: "%s"`, tuningFilePath, line)
-		}
-	}
-	return addArguments, deleteArguments, nil
-}
-
-// updateTuningArgs executes additions and removals of kernel tuning arguments
-func updateTuningArgs(tuningFilePath, cmdLinePath string) (bool, error) {
-	if cmdLinePath == "" {
-		cmdLinePath = cmdLineFile
-	}
-	changed := false
-	additions, deletions, err := parseTuningFile(tuningFilePath, cmdLinePath)
-	if err != nil {
-		return changed, err
-	}
-
-	// Execute additions
-	for _, toAdd := range additions {
-		if toAdd.Bare {
-			changed = true
-			err := exec.Command("rpm-ostree", "kargs", fmt.Sprintf("--append=%s", toAdd.Key)).Run()
-			if err != nil {
-				return false, errors.Wrapf(err, "adding karg")
-			}
-		} else {
-			panic("Not supported")
-		}
-	}
-	// Execute deletions
-	for _, toDelete := range deletions {
-		if toDelete.Bare {
-			changed = true
-			err := exec.Command("rpm-ostree", "kargs", fmt.Sprintf("--delete=%s", toDelete.Key)).Run()
-			if err != nil {
-				return false, errors.Wrapf(err, "deleting karg")
-			}
-		} else {
-			panic("Not supported")
-		}
-	}
-	return changed, nil
 }
 
 func run(_ *cobra.Command, args []string) (retErr error) {
@@ -246,7 +81,7 @@ func run(_ *cobra.Command, args []string) (retErr error) {
 	}
 
 	// Check to see if we need to tune kernel arguments
-	tuningChanged, err := updateTuningArgs(kernelTuningFile, cmdLineFile)
+	tuningChanged, err := daemon.UpdateTuningArgs(daemon.KernelTuningFile, daemon.CmdLineFile)
 	if err != nil {
 		return err
 	}

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/emicklei/go-restful v2.10.0+incompatible h1:l6Soi8WCOOVAeCo4W98iBFC6O
 github.com/emicklei/go-restful v2.10.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -544,6 +544,14 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 		return errors.Wrap(err, "failed to rename encapsulated MachineConfig after processing on firstboot")
 	}
 
+	tuningChanged, err := UpdateTuningArgs(KernelTuningFile, CmdLineFile)
+	if err != nil {
+		return err
+	}
+	if !tuningChanged {
+		glog.Info("No changes; already at target oscontainer, no kernel args provided")
+	}
+
 	dn.skipReboot = false
 	return dn.reboot(fmt.Sprintf("Completing firstboot provisioning to %s", mc.GetName()))
 }

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	// Enable sha256 in container image references
+	_ "crypto/sha256"
+
+	"github.com/golang/glog"
+	"github.com/openshift/machine-config-operator/pkg/daemon/pivot/types"
+	errors "github.com/pkg/errors"
+)
+
+const (
+	// KernelTuningFile is a path to the file containing kernel arg changes for tuning
+	KernelTuningFile = "/etc/pivot/kernel-args"
+	// CmdLineFile is a path to file with kernel cmdline
+	CmdLineFile = "/proc/cmdline"
+)
+
+// TODO: fill out the allowlists
+// tuneableRHCOSArgsAllowlist contains allowed keys for tunable kernel arguments on RHCOS
+var tuneableRHCOSArgsAllowlist = map[string]bool{
+	"nosmt": true,
+}
+
+// tuneableFCOSArgsAllowlist contains allowed keys for tunable kernel arguments on FCOS
+var tuneableFCOSArgsAllowlist = map[string]bool{
+	"systemd.unified_cgroup_hierarchy=0": true,
+	"mitigations=auto,nosmt":             true,
+}
+
+// isArgTuneable returns if the argument provided is allowed to be modified
+func isArgTunable(arg string) (bool, error) {
+	operatingSystem, err := GetHostRunningOS()
+	if err != nil {
+		return false, errors.Errorf("failed to get OS for determining whether kernel arg is tuneable: %v", err)
+	}
+
+	switch operatingSystem {
+	case MachineConfigDaemonOSRHCOS:
+		return tuneableRHCOSArgsAllowlist[arg], nil
+	case MachineConfigDaemonOSFCOS:
+		return tuneableFCOSArgsAllowlist[arg], nil
+	default:
+		return false, nil
+	}
+}
+
+// isArgInUse checks to see if the argument is already in use by the system currently
+func isArgInUse(arg, cmdLinePath string) (bool, error) {
+	if cmdLinePath == "" {
+		cmdLinePath = CmdLineFile
+	}
+	content, err := ioutil.ReadFile(cmdLinePath)
+	if err != nil {
+		return false, err
+	}
+
+	checkable := string(content)
+	if strings.Contains(checkable, arg) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// parseTuningFile parses the kernel argument tuning file
+func parseTuningFile(tuningFilePath, cmdLinePath string) ([]types.TuneArgument, []types.TuneArgument, error) {
+	addArguments := []types.TuneArgument{}
+	deleteArguments := []types.TuneArgument{}
+	if tuningFilePath == "" {
+		tuningFilePath = KernelTuningFile
+	}
+	if cmdLinePath == "" {
+		cmdLinePath = CmdLineFile
+	}
+	// Read and parse the file
+	file, err := os.Open(tuningFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// It's ok if the file doesn't exist
+			return addArguments, deleteArguments, nil
+		}
+		return addArguments, deleteArguments, errors.Wrapf(err, "reading %s", tuningFilePath)
+	}
+	// Clean up
+	defer file.Close()
+
+	// Parse the tuning lines
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "ADD ") {
+			// NOTE: Today only specific bare kernel arguments are allowed so
+			// there is not a need to split on =.
+			key := strings.TrimSpace(line[len("ADD "):])
+			tuneableKarg, err := isArgTunable(key)
+			if err != nil {
+				return addArguments, deleteArguments, err
+			}
+			if tuneableKarg {
+				// Find out if the argument is in use
+				inUse, err := isArgInUse(key, cmdLinePath)
+				if err != nil {
+					return addArguments, deleteArguments, err
+				}
+				if !inUse {
+					addArguments = append(addArguments, types.TuneArgument{Key: key, Bare: true})
+				} else {
+					glog.Infof(`skipping "%s" as it is already in use`, key)
+				}
+			} else {
+				glog.Infof("%s not an allowlisted kernel argument", key)
+			}
+		} else if strings.HasPrefix(line, "DELETE ") {
+			// NOTE: Today only specific bare kernel arguments are allowed so
+			// there is not a need to split on =.
+			key := strings.TrimSpace(line[len("DELETE "):])
+			tuneableKarg, err := isArgTunable(key)
+			if err != nil {
+				return addArguments, deleteArguments, err
+			}
+			if tuneableKarg {
+				inUse, err := isArgInUse(key, cmdLinePath)
+				if err != nil {
+					return addArguments, deleteArguments, err
+				}
+				if inUse {
+					deleteArguments = append(deleteArguments, types.TuneArgument{Key: key, Bare: true})
+				} else {
+					glog.Infof(`skipping "%s" as it is not present in the current argument list`, key)
+				}
+			} else {
+				glog.Infof("%s not an allowlisted kernel argument", key)
+			}
+		} else {
+			glog.V(2).Infof(`skipping malformed line in %s: "%s"`, tuningFilePath, line)
+		}
+	}
+	return addArguments, deleteArguments, nil
+}
+
+// UpdateTuningArgs executes additions and removals of kernel tuning arguments
+func UpdateTuningArgs(tuningFilePath, cmdLinePath string) (bool, error) {
+	if cmdLinePath == "" {
+		cmdLinePath = CmdLineFile
+	}
+	changed := false
+	additions, deletions, err := parseTuningFile(tuningFilePath, cmdLinePath)
+	if err != nil {
+		return changed, err
+	}
+
+	// Execute additions
+	for _, toAdd := range additions {
+		if toAdd.Bare {
+			changed = true
+			err := exec.Command("rpm-ostree", "kargs", fmt.Sprintf("--append=%s", toAdd.Key)).Run()
+			if err != nil {
+				return false, errors.Wrapf(err, "adding karg")
+			}
+		} else {
+			panic("Not supported")
+		}
+	}
+	// Execute deletions
+	for _, toDelete := range deletions {
+		if toDelete.Bare {
+			changed = true
+			err := exec.Command("rpm-ostree", "kargs", fmt.Sprintf("--delete=%s", toDelete.Key)).Run()
+			if err != nil {
+				return false, errors.Wrapf(err, "deleting karg")
+			}
+		} else {
+			panic("Not supported")
+		}
+	}
+	return changed, nil
+}


### PR DESCRIPTION
This commits ensures kernel args modifications from /etc/pivot/kernel-args
are being applied on both pivot and firstboot_complete_machineconfig. Currently its only applied on bootstrap (which uses `pivot`), but not on masters/workers. In order to archieve that kargs tuning logic is moved from `cmd/` package to `pkg/daemon`.

OKD requires this so that "mitigations" karg could be removed from cmdline,
as MachineConfig's `kernelArguments` doesn't support removing existing arguments. This should also affect OCP with HyperThreading off, as machineconfigs for that still use `/etc/pivot/kernel-args`