### PR TITLE
Set NonVirtualIP in non-baremetal mdns platforms

### DIFF
--- a/manifests/openstack/coredns-corefile.tmpl
+++ b/manifests/openstack/coredns-corefile.tmpl
@@ -1,7 +1,7 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
         policy sequential
     }

--- a/manifests/ovirt/coredns-corefile.tmpl
+++ b/manifests/ovirt/coredns-corefile.tmpl
@@ -1,7 +1,7 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload

--- a/manifests/vsphere/coredns-corefile.tmpl
+++ b/manifests/vsphere/coredns-corefile.tmpl
@@ -1,7 +1,7 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1834,7 +1834,7 @@ func manifestsMasterMachineconfigpoolYaml() (*asset, error) {
 var _manifestsOpenstackCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}} {
         policy sequential
     }
@@ -2107,7 +2107,7 @@ func manifestsOpenstackKeepalivedYaml() (*asset, error) {
 var _manifestsOvirtCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
@@ -2404,7 +2404,7 @@ func manifestsUserdata_secretYaml() (*asset, error) {
 var _manifestsVsphereCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}}
+    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload

--- a/templates/common/openstack/files/openstack-coredns-corefile.yaml
+++ b/templates/common/openstack/files/openstack-coredns-corefile.yaml
@@ -5,7 +5,7 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
             policy sequential
         }

--- a/templates/common/ovirt/files/ovirt-coredns-corefile.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns-corefile.yaml
@@ -5,7 +5,7 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -10,7 +10,7 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}}
+        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload


### PR DESCRIPTION
This is applying the change from #1767 to the other platforms that
use mdns. To my knowledge it hasn't been reported as a problem on
any of them, but it's still good to do for consistency and to avoid
sending multicast traffic to interfaces that don't need it.
