### PR TITLE
vsphere: check for nil platform in getIgnitionHost

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -333,7 +333,7 @@ func getIgnitionHost(infraStatus *configv1.InfrastructureStatus) (string, error)
 		case configv1.OvirtPlatformType:
 			ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.Ovirt.APIServerInternalIP, securePortStr)
 		case configv1.VSpherePlatformType:
-			if infraStatus.PlatformStatus.VSphere.APIServerInternalIP != "" {
+			if infraStatus.PlatformStatus.VSphere != nil && infraStatus.PlatformStatus.VSphere.APIServerInternalIP != "" {
 				ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIP, securePortStr)
 			}
 		}


### PR DESCRIPTION
For UPI workflow installer not set the vSphere platform [1] when no API / Ingress VIP are provided
by the user as they intend to setup their own load balancing etc.

Therefore we should make sure we check for nil vSphere platform.

[1]: https://github.com/openshift/installer/blob/c72e5026b06e8d810fb8f911c6ece8ada7d4c957/pkg/asset/manifests/infrastructure.go#L150-L157
