### PR TITLE
Bug 1861876: telemetry: change MCDDrainErr from critical to warning

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -22,7 +22,7 @@ spec:
           expr: |
             mcd_drain > 0
           labels:
-            severity: critical
+            severity: warning
           annotations:
             message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details:  oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon"
     - name: mcd-pivot-error


### PR DESCRIPTION
This was initially made critical, but that seems to be overkill so move to warning (probably should have been from the start). Prom rules are going to be refactored, so will bake in more nuance at that time.