### PR TITLE
cleanup unused code as a result of extensions and OS update rework

### DIFF
--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	// Enable sha256 in container image references
@@ -13,7 +12,6 @@ import (
 
 	"github.com/golang/glog"
 	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
-	"github.com/openshift/machine-config-operator/pkg/daemon/pivot/types"
 	errors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -93,10 +91,6 @@ func Execute(cmd *cobra.Command, args []string) {
 	err := run(cmd, args)
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
-		os.MkdirAll(filepath.Dir(types.PivotFailurePath), 0755)
-		// write a pivot failure file that we'll read from MCD since we start this with systemd
-		// and we just follow logs
-		ioutil.WriteFile(types.PivotFailurePath, []byte(err.Error()), 0644)
 		os.Exit(1)
 	}
 }

--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -19,8 +19,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// flag storage
-var keep bool
 var fromEtcPullSpec bool
 
 const (
@@ -40,7 +38,6 @@ var pivotCmd = &cobra.Command{
 // init executes upon import
 func init() {
 	rootCmd.AddCommand(pivotCmd)
-	pivotCmd.PersistentFlags().BoolVarP(&keep, "keep", "k", false, "Do not remove container image")
 	pivotCmd.PersistentFlags().BoolVarP(&fromEtcPullSpec, "from-etc-pullspec", "P", false, "Parse /etc/pivot/image-pullspec")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
@@ -84,19 +81,8 @@ func run(_ *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
-	// Check to see if we need to tune kernel arguments
-	tuningChanged, err := daemon.UpdateTuningArgs(daemon.KernelTuningFile, daemon.CmdLineFile)
-	if err != nil {
-		return err
-	}
-	// If tuning changes but the oscontainer didn't we still denote we changed
-	// for the reboot
-	if tuningChanged {
-		changed = true
-	}
-
 	if !changed {
-		glog.Info("No changes; already at target oscontainer, no kernel args provided")
+		glog.Info("No changes; already at target oscontainer")
 	}
 
 	return nil

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -562,14 +562,6 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 		return errors.Wrap(err, "failed to rename encapsulated MachineConfig after processing on firstboot")
 	}
 
-	tuningChanged, err := UpdateTuningArgs(KernelTuningFile, CmdLineFile)
-	if err != nil {
-		return err
-	}
-	if !tuningChanged {
-		glog.Info("No changes; already at target oscontainer, no kernel args provided")
-	}
-
 	dn.skipReboot = false
 	return dn.reboot(fmt.Sprintf("Completing firstboot provisioning to %s", mc.GetName()))
 }

--- a/pkg/daemon/pivot/types/imageinspection.go
+++ b/pkg/daemon/pivot/types/imageinspection.go
@@ -3,9 +3,4 @@ package types
 const (
 	// PivotNamePrefix is literally the name prefix of the new pivot
 	PivotNamePrefix = "ostree-container-pivot-"
-
-	// PivotFailurePath is the path pivot writes its error to when it fails. We need this to bubble
-	// up any errors since we only log those errors in MCD. If we don't do this then the error messages
-	// don't get visibility up the stack.
-	PivotFailurePath = "/run/pivot/failure"
 )

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -18,7 +18,6 @@ type GetBootedOSImageURLReturn struct {
 // hold return values that will be returned when their corresponding methods are called.
 type RpmOstreeClientMock struct {
 	GetBootedOSImageURLReturns []GetBootedOSImageURLReturn
-	RunPivotReturns            []error
 }
 
 // GetBootedOSImageURL implements a test version of RpmOStreeClients GetBootedOSImageURL.
@@ -29,16 +28,6 @@ func (r RpmOstreeClientMock) GetBootedOSImageURL() (string, string, error) {
 		r.GetBootedOSImageURLReturns = r.GetBootedOSImageURLReturns[1:]
 	}
 	return returnValues.OsImageURL, returnValues.Version, returnValues.Error
-}
-
-// RunPivot implements a test version of RpmOstreeClients RunPivot. It returns errors as defined
-// in the instances RunPivotReturns field in order.
-func (r RpmOstreeClientMock) RunPivot(string) error {
-	err := r.RunPivotReturns[0]
-	if len(r.RunPivotReturns) > 1 {
-		r.RunPivotReturns = r.RunPivotReturns[1:]
-	}
-	return err
 }
 
 // PullAndRebase is a mock

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -406,6 +406,16 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		}
 	}()
 
+	// Ideally we would want to update kernelArguments only via MachineConfigs.
+	// We are keeping this to maintain compatibility and OKD requirement.
+	tuningChanged, err := UpdateTuningArgs(KernelTuningFile, CmdLineFile)
+	if err != nil {
+		return err
+	}
+	if tuningChanged {
+		glog.Info("Updated kernel tuning arguments")
+	}
+
 	return dn.finalizeAndReboot(newConfig)
 }
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1318,7 +1318,7 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig, osImageContentDir strin
 	glog.Infof("Updating OS to %s", newURL)
 	client := NewNodeUpdaterClient()
 	if _, err := client.Rebase(newURL, osImageContentDir); err != nil {
-		return err
+		return fmt.Errorf("failed to update OS to %s : %v", newURL, err)
 	}
 
 	return nil

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -25,11 +25,6 @@ func TestUpdateOS(t *testing.T) {
 	// calls to update the host.
 	testClient := RpmOstreeClientMock{
 		GetBootedOSImageURLReturns: []GetBootedOSImageURLReturn{},
-		RunPivotReturns: []error{
-			// First run will return no error
-			nil,
-			// Second run will return our expected error
-			expectedError},
 	}
 
 	// Create a Daemon instance with mocked clients
@@ -371,18 +366,12 @@ func TestReconcilableSSH(t *testing.T) {
 }
 
 func TestUpdateSSHKeys(t *testing.T) {
-	// expectedError is the error we will use when expecting an error to return
-	expectedError := fmt.Errorf("broken")
 	// testClient is the NodeUpdaterClient mock instance that will front
 	// calls to update the host.
 	testClient := RpmOstreeClientMock{
 		GetBootedOSImageURLReturns: []GetBootedOSImageURLReturn{},
-		RunPivotReturns: []error{
-			// First run will return no error
-			nil,
-			// Second rrun will return our expected error
-			expectedError},
 	}
+
 	// Create a Daemon instance with mocked clients
 	d := Daemon{
 		mock:              true,


### PR DESCRIPTION
As we are waiting on e2e-gcp-upgrade test go green, this PR is built on top of https://github.com/openshift/machine-config-operator/pull/1941 and hence includes commits from PR#1941 too.

Don't know how merge works, perhaps PR#1941 goes in first and then rebase this PR again or github does all the magic.