### PR TITLE
Bug 1852047: controller: Emit events

### DIFF
--- a/manifests/machineconfigcontroller/events-clusterrole.yaml
+++ b/manifests/machineconfigcontroller/events-clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: machine-config-controller-events
+  namespace: {{.TargetNamespace}}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]

--- a/manifests/machineconfigcontroller/events-rolebinding-default.yaml
+++ b/manifests/machineconfigcontroller/events-rolebinding-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-controller-events
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: machine-config-controller-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-controller

--- a/manifests/machineconfigcontroller/events-rolebinding-target.yaml
+++ b/manifests/machineconfigcontroller/events-rolebinding-target.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-controller-events
+  namespace: {{.TargetNamespace}}
+roleRef:
+  kind: ClusterRole
+  name: machine-config-controller-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-controller

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -27,6 +27,12 @@ func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
 	newPool := pool
 	newPool.Status = newStatus
 	_, err = ctrl.client.MachineconfigurationV1().MachineConfigPools().UpdateStatus(context.TODO(), newPool, metav1.UpdateOptions{})
+	if pool.Spec.Configuration.Name != newPool.Spec.Configuration.Name {
+		ctrl.eventRecorder.Eventf(pool, corev1.EventTypeNormal, "Updating", "Pool %s now targeting %s", pool.Name, newPool.Spec.Configuration.Name)
+	}
+	if pool.Status.Configuration.Name != newPool.Status.Configuration.Name {
+		ctrl.eventRecorder.Eventf(pool, corev1.EventTypeNormal, "Completed", "Pool %s has completed update to %s", pool.Name, newPool.Status.Configuration.Name)
+	}
 	return err
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -10,6 +10,9 @@
 // manifests/machineconfigcontroller/clusterrolebinding.yaml
 // manifests/machineconfigcontroller/controllerconfig.yaml
 // manifests/machineconfigcontroller/deployment.yaml
+// manifests/machineconfigcontroller/events-clusterrole.yaml
+// manifests/machineconfigcontroller/events-rolebinding-default.yaml
+// manifests/machineconfigcontroller/events-rolebinding-target.yaml
 // manifests/machineconfigcontroller/sa.yaml
 // manifests/machineconfigdaemon/clusterrole.yaml
 // manifests/machineconfigdaemon/clusterrolebinding.yaml
@@ -1168,6 +1171,90 @@ func manifestsMachineconfigcontrollerDeploymentYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "manifests/machineconfigcontroller/deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _manifestsMachineconfigcontrollerEventsClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: machine-config-controller-events
+  namespace: {{.TargetNamespace}}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+`)
+
+func manifestsMachineconfigcontrollerEventsClusterroleYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigcontrollerEventsClusterroleYaml, nil
+}
+
+func manifestsMachineconfigcontrollerEventsClusterroleYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigcontrollerEventsClusterroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigcontroller/events-clusterrole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _manifestsMachineconfigcontrollerEventsRolebindingDefaultYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-controller-events
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: machine-config-controller-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-controller
+`)
+
+func manifestsMachineconfigcontrollerEventsRolebindingDefaultYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigcontrollerEventsRolebindingDefaultYaml, nil
+}
+
+func manifestsMachineconfigcontrollerEventsRolebindingDefaultYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigcontrollerEventsRolebindingDefaultYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigcontroller/events-rolebinding-default.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _manifestsMachineconfigcontrollerEventsRolebindingTargetYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-controller-events
+  namespace: {{.TargetNamespace}}
+roleRef:
+  kind: ClusterRole
+  name: machine-config-controller-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-controller
+`)
+
+func manifestsMachineconfigcontrollerEventsRolebindingTargetYamlBytes() ([]byte, error) {
+	return _manifestsMachineconfigcontrollerEventsRolebindingTargetYaml, nil
+}
+
+func manifestsMachineconfigcontrollerEventsRolebindingTargetYaml() (*asset, error) {
+	bytes, err := manifestsMachineconfigcontrollerEventsRolebindingTargetYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/machineconfigcontroller/events-rolebinding-target.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2772,6 +2859,9 @@ var _bindata = map[string]func() (*asset, error){
 	"manifests/machineconfigcontroller/clusterrolebinding.yaml":              manifestsMachineconfigcontrollerClusterrolebindingYaml,
 	"manifests/machineconfigcontroller/controllerconfig.yaml":                manifestsMachineconfigcontrollerControllerconfigYaml,
 	"manifests/machineconfigcontroller/deployment.yaml":                      manifestsMachineconfigcontrollerDeploymentYaml,
+	"manifests/machineconfigcontroller/events-clusterrole.yaml":              manifestsMachineconfigcontrollerEventsClusterroleYaml,
+	"manifests/machineconfigcontroller/events-rolebinding-default.yaml":      manifestsMachineconfigcontrollerEventsRolebindingDefaultYaml,
+	"manifests/machineconfigcontroller/events-rolebinding-target.yaml":       manifestsMachineconfigcontrollerEventsRolebindingTargetYaml,
 	"manifests/machineconfigcontroller/sa.yaml":                              manifestsMachineconfigcontrollerSaYaml,
 	"manifests/machineconfigdaemon/clusterrole.yaml":                         manifestsMachineconfigdaemonClusterroleYaml,
 	"manifests/machineconfigdaemon/clusterrolebinding.yaml":                  manifestsMachineconfigdaemonClusterrolebindingYaml,
@@ -2858,11 +2948,14 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"bootstrap-pod-v2.yaml":     &bintree{manifestsBootstrapPodV2Yaml, map[string]*bintree{}},
 		"controllerconfig.crd.yaml": &bintree{manifestsControllerconfigCrdYaml, map[string]*bintree{}},
 		"machineconfigcontroller": &bintree{nil, map[string]*bintree{
-			"clusterrole.yaml":        &bintree{manifestsMachineconfigcontrollerClusterroleYaml, map[string]*bintree{}},
-			"clusterrolebinding.yaml": &bintree{manifestsMachineconfigcontrollerClusterrolebindingYaml, map[string]*bintree{}},
-			"controllerconfig.yaml":   &bintree{manifestsMachineconfigcontrollerControllerconfigYaml, map[string]*bintree{}},
-			"deployment.yaml":         &bintree{manifestsMachineconfigcontrollerDeploymentYaml, map[string]*bintree{}},
-			"sa.yaml":                 &bintree{manifestsMachineconfigcontrollerSaYaml, map[string]*bintree{}},
+			"clusterrole.yaml":                &bintree{manifestsMachineconfigcontrollerClusterroleYaml, map[string]*bintree{}},
+			"clusterrolebinding.yaml":         &bintree{manifestsMachineconfigcontrollerClusterrolebindingYaml, map[string]*bintree{}},
+			"controllerconfig.yaml":           &bintree{manifestsMachineconfigcontrollerControllerconfigYaml, map[string]*bintree{}},
+			"deployment.yaml":                 &bintree{manifestsMachineconfigcontrollerDeploymentYaml, map[string]*bintree{}},
+			"events-clusterrole.yaml":         &bintree{manifestsMachineconfigcontrollerEventsClusterroleYaml, map[string]*bintree{}},
+			"events-rolebinding-default.yaml": &bintree{manifestsMachineconfigcontrollerEventsRolebindingDefaultYaml, map[string]*bintree{}},
+			"events-rolebinding-target.yaml":  &bintree{manifestsMachineconfigcontrollerEventsRolebindingTargetYaml, map[string]*bintree{}},
+			"sa.yaml":                         &bintree{manifestsMachineconfigcontrollerSaYaml, map[string]*bintree{}},
 		}},
 		"machineconfigdaemon": &bintree{nil, map[string]*bintree{
 			"clusterrole.yaml":                &bintree{manifestsMachineconfigdaemonClusterroleYaml, map[string]*bintree{}},

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -415,14 +415,34 @@ func (optr *Operator) syncMachineConfigPools(config *renderConfig) error {
 }
 
 func (optr *Operator) syncMachineConfigController(config *renderConfig) error {
-	crBytes, err := renderAsset(config, "manifests/machineconfigcontroller/clusterrole.yaml")
-	if err != nil {
-		return err
+	for _, path := range []string{
+		"manifests/machineconfigcontroller/clusterrole.yaml",
+		"manifests/machineconfigcontroller/events-clusterrole.yaml",
+	} {
+		crBytes, err := renderAsset(config, path)
+		if err != nil {
+			return err
+		}
+		cr := resourceread.ReadClusterRoleV1OrDie(crBytes)
+		_, _, err = resourceapply.ApplyClusterRole(optr.kubeClient.RbacV1(), cr)
+		if err != nil {
+			return err
+		}
 	}
-	cr := resourceread.ReadClusterRoleV1OrDie(crBytes)
-	_, _, err = resourceapply.ApplyClusterRole(optr.kubeClient.RbacV1(), cr)
-	if err != nil {
-		return err
+
+	for _, path := range []string{
+		"manifests/machineconfigcontroller/events-rolebinding-default.yaml",
+		"manifests/machineconfigcontroller/events-rolebinding-target.yaml",
+	} {
+		crbBytes, err := renderAsset(config, path)
+		if err != nil {
+			return err
+		}
+		crb := resourceread.ReadRoleBindingV1OrDie(crbBytes)
+		_, _, err = resourceapply.ApplyRoleBinding(optr.kubeClient.RbacV1(), crb)
+		if err != nil {
+			return err
+		}
 	}
 
 	crbBytes, err := renderAsset(config, "manifests/machineconfigcontroller/clusterrolebinding.yaml")


### PR DESCRIPTION
A while ago I'd invested some time in tweaking the
node controller to have useful logs around what it's
doing; my first "point of contact" when looking at
upgrades was its pod logs. But...we lose most
those on upgrade since the pod gets killed.

Add events to the node controller too.
Currently the MCD emits useful events which
can be queried afterwards (in our CI runs we
dump `events.json`).

With this we can create a "journal/history"
for upgrade/update events just by querying the
event stream.
