### PR TITLE
Cleanup: remove legacy code used for setting up etcd.

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -103,10 +103,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 			OauthProxy:                   bootstrapOpts.oauthProxyImage,
 		},
 		ControllerConfigImages: operator.ControllerConfigImages{
-			Etcd:                bootstrapOpts.etcdImage,
 			InfraImage:          bootstrapOpts.infraImage,
-			KubeClientAgent:     bootstrapOpts.kubeClientAgentImage,
-			ClusterEtcdOperator: bootstrapOpts.clusterEtcdOperatorImage,
 			Keepalived:          bootstrapOpts.keepalivedImage,
 			Coredns:             bootstrapOpts.corednsImage,
 			MdnsPublisher:       bootstrapOpts.mdnsPublisherImage,
@@ -123,7 +120,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.networkConfigFile,
 		bootstrapOpts.cloudConfigFile,
 		bootstrapOpts.cloudProviderCAFile,
-		bootstrapOpts.etcdCAFile, bootstrapOpts.etcdMetricCAFile, bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
+		bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,
 		&imgs,
 		bootstrapOpts.destinationDir,
 	); err != nil {

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -6,9 +6,6 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
-	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
-	operatorv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -55,15 +52,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 	run := func(ctx context.Context) {
 		ctrlctx := ctrlcommon.CreateControllerContext(cb, ctx.Done(), componentNamespace)
-		operatorClient := cb.OperatorClientOrDie("operator-shared-informer")
-
-		etcdInformer, err := getEtcdInformer(operatorClient, ctrlctx.OperatorInformerFactory)
-		if err != nil {
-			// MCO pod needs to restart for transient apiserver errors
-			glog.Errorf("unable to query discovery API %#v", err)
-			ctrlcommon.WriteTerminationError(err)
-		}
-
 		controller := operator.New(
 			componentNamespace, componentName,
 			startOpts.imagesFile,
@@ -86,7 +74,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.ClientBuilder.APIExtClientOrDie(componentName),
 			ctrlctx.ClientBuilder.ConfigClientOrDie(componentName),
 			ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
-			etcdInformer,
 			ctrlctx.KubeMAOSharedInformer.Core().V1().Secrets(),
 		)
 
@@ -118,19 +105,4 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		},
 	})
 	panic("unreachable")
-}
-
-func getEtcdInformer(operatorClient operatorclientset.Interface, operatorSharedInformer operatorinformers.SharedInformerFactory) (operatorv1.EtcdInformer, error) {
-	operatorGroups, err := operatorClient.Discovery().ServerResourcesForGroupVersion("operator.openshift.io/v1")
-	if err != nil {
-		glog.Errorf("unable to get operatorGroups: %#v", err)
-		return nil, err
-	}
-
-	for _, o := range operatorGroups.APIResources {
-		if o.Kind == "Etcd" {
-			return operatorSharedInformer.Operator().V1().Etcds(), nil
-		}
-	}
-	return nil, nil
 }

--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -34,8 +34,6 @@ spec:
         volumeMounts:
         - name: root-ca
           mountPath: /etc/ssl/kubernetes/ca.crt
-        - name: etcd-ca
-          mountPath: /etc/ssl/etcd/ca.crt
         - name: images
           mountPath: /etc/mco/images
       nodeSelector:
@@ -61,9 +59,6 @@ spec:
       - name: images
         configMap:
           name: machine-config-operator-images
-      - name: etcd-ca
-        hostPath:
-          path: /etc/ssl/etcd/ca.crt
       - name: root-ca
         hostPath:
           path: /etc/kubernetes/ca.crt

--- a/install/image-references
+++ b/install/image-references
@@ -3,15 +3,11 @@ apiVersion: image.openshift.io/v1
 spec:
   tags:
   # machine-config-operator is the new master mco image that contains all of the 
-  # component images:mco, mcc, mcs, mcd & setup etcd
+  # component images:mco, mcc, mcs & mcd 
   - name: machine-config-operator
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:machine-config-operator
-  - name: etcd
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:etcd
   - name: pod
     from:
       kind: DockerImage
@@ -31,10 +27,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:kube-client-agent
-  - name: cluster-etcd-operator
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:cluster-etcd-operator
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -70,8 +70,6 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setStringIfSet(modified, &existing.NetworkType, required.NetworkType)
 
 	setBytesIfSet(modified, &existing.AdditionalTrustBundle, required.AdditionalTrustBundle)
-	setBytesIfSet(modified, &existing.EtcdCAData, required.EtcdCAData)
-	setBytesIfSet(modified, &existing.EtcdMetricCAData, required.EtcdMetricCAData)
 	setBytesIfSet(modified, &existing.RootCAData, required.RootCAData)
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
 	setBytesIfSet(modified, &existing.CloudProviderCAData, required.CloudProviderCAData)

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -68,17 +68,6 @@ spec:
             clusterDNSIP:
               description: clusterDNSIP is the cluster DNS IP address
               type: string
-            etcdCAData:
-              description: etcdCAData specifies the etcd CA data
-              type: string
-              format: byte
-            etcdDiscoveryDomain:
-              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
-              type: string
-            etcdMetricCAData:
-              description: etcdMetricData specifies the etcd metric CA data
-              type: string
-              format: byte
             images:
               description: images is map of images that are used by the controller
                 to render templates under ./templates/

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -48,12 +48,6 @@ type ControllerConfigSpec struct {
 	// kubeAPIServerServingCAData managed Kubelet to API Server Cert... Rotated automatically
 	KubeAPIServerServingCAData []byte `json:"kubeAPIServerServingCAData"`
 
-	// etcdCAData specifies the etcd CA data
-	EtcdCAData []byte `json:"etcdCAData"`
-
-	// etcdMetricData specifies the etcd metric CA data
-	EtcdMetricCAData []byte `json:"etcdMetricCAData"`
-
 	// rootCAData specifies the root CA data
 	RootCAData []byte `json:"rootCAData"`
 

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -226,16 +226,6 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.EtcdCAData != nil {
-		in, out := &in.EtcdCAData, &out.EtcdCAData
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
-	if in.EtcdMetricCAData != nil {
-		in, out := &in.EtcdMetricCAData, &out.EtcdMetricCAData
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
 	if in.RootCAData != nil {
 		in, out := &in.RootCAData, &out.RootCAData
 		*out = make([]byte, len(*in))

--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -6,18 +6,14 @@ spec:
   additionalTrustBundle: null
   cloudProviderConfig: ""
   clusterDNSIP: 172.30.0.10
-  etcdCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkVUQ0QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
-  etcdMetricCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkVUQ0QgTUVUUklDIENBIERBVEEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   images:
     baremetalRuntimeCfgImage: ""
     corednsImage: ""
-    etcdKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     haproxyImage: ""
     infraImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     keepalivedImage: ""
     kubeClientAgentImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     mdnsPublisherImage: ""
-    setupEtcdEnvKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
   infra:
     apiVersion: config.openshift.io/v1
     kind: Infrastructure
@@ -30,7 +26,6 @@ spec:
     status:
       apiServerInternalURI: https://api-int.domain.example.com:6443
       apiServerURL: https://api.domain.example.com:6443
-      etcdDiscoveryDomain: domain.example.com
       infrastructureName: lab-0aaaa
       platformStatus:
         type: None

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -12,4 +12,7 @@ const (
 
 	// KernelTypeRealtime denominates the realtime kernel type
 	KernelTypeRealtime = "realtime"
+
+	// MasterLabel defines the label associated with master node. The master taint uses the same label as taint's key
+	MasterLabel = "node-role.kubernetes.io/master"
 )

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -60,6 +60,9 @@ const (
 
 	// schedulerCRName that we're interested in watching.
 	schedulerCRName = "cluster"
+
+	// masterPoolName is the control plane MachineConfigPool name
+	masterPoolName = "master"
 )
 
 var nodeUpdateBackoff = wait.Backoff{
@@ -553,7 +556,7 @@ func (ctrl *Controller) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.MachineCon
 	var master, worker *mcfgv1.MachineConfigPool
 	var custom []*mcfgv1.MachineConfigPool
 	for _, pool := range pools {
-		if pool.Name == "master" {
+		if pool.Name == masterPoolName {
 			master = pool
 		} else if pool.Name == "worker" {
 			worker = pool
@@ -737,11 +740,12 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return err
 	}
 
-	candidates := getCandidateMachines(pool, nodes, maxunavail)
-	for _, node := range candidates {
-		if err := ctrl.setDesiredMachineConfigAnnotation(node.Name, pool.Spec.Configuration.Name); err != nil {
+	candidates, capacity := getAllCandidateMachines(pool, nodes, maxunavail)
+	if len(candidates) > 0 {
+		glog.Infof("Pool %s: %d candidate nodes for update, capacity: %d", pool.Name, len(candidates), capacity)
+		if err := ctrl.updateCandidateMachines(pool, candidates, capacity); err != nil {
 			if syncErr := ctrl.syncStatusOnly(pool); syncErr != nil {
-				return goerrs.Wrapf(err, "error setting desired machine config annotation for node %q, pool %q, sync error: %v", node.Name, pool.Name, syncErr)
+				return goerrs.Wrapf(err, "error setting desired machine config annotation for pool %q, sync error: %v", pool.Name, syncErr)
 			}
 			return err
 		}
@@ -812,13 +816,15 @@ func (ctrl *Controller) setDesiredMachineConfigAnnotation(nodeName, currentConfi
 	})
 }
 
-func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) []*corev1.Node {
+// getAllCandidateMachines returns all possible nodes which can be updated to the target config, along with a maximum
+// capacity.  It is the reponsibility of the caller to choose a subset of the nodes given the capacity.
+func getAllCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) ([]*corev1.Node, uint) {
 	targetConfig := pool.Spec.Configuration.Name
 
 	unavail := getUnavailableMachines(nodesInPool)
 	// If we're at capacity, there's nothing to do.
 	if len(unavail) >= maxUnavailable {
-		return nil
+		return nil, 0
 	}
 	capacity := maxUnavailable - len(unavail)
 	failingThisConfig := 0
@@ -839,14 +845,71 @@ func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.
 	// availability - it might be a transient issue, and if the issue
 	// clears we don't want multiple to update at once.
 	if failingThisConfig >= capacity {
-		return nil
+		return nil, 0
 	}
 	capacity -= failingThisConfig
 
-	if len(nodes) < capacity {
+	return nodes, uint(capacity)
+}
+
+// getCandidateMachines returns the maximum subset of nodes which can be updated to the target config given availability constraints.
+func getCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) []*corev1.Node {
+	nodes, capacity := getAllCandidateMachines(pool, nodesInPool, maxUnavailable)
+	if uint(len(nodes)) < capacity {
 		return nodes
 	}
 	return nodes[:capacity]
+}
+
+// getCurrentEtcdLeader is not yet implemented
+func (ctrl *Controller) getCurrentEtcdLeader(candidates []*corev1.Node) (*corev1.Node, error) {
+	return nil, nil
+}
+
+// filterControlPlaneCandidateNodes adjusts the candidates and capacity specifically
+// for the control plane, e.g. based on which node is the etcd leader at the time.
+// nolint:unparam
+func (ctrl *Controller) filterControlPlaneCandidateNodes(candidates []*corev1.Node, capacity uint) ([]*corev1.Node, uint, error) {
+	if len(candidates) <= 1 {
+		return candidates, capacity, nil
+	}
+	etcdLeader, err := ctrl.getCurrentEtcdLeader(candidates)
+	if err != nil {
+		glog.Warningf("Failed to find current etcd leader (continuing anyways): %v", err)
+	}
+	var newCandidates []*corev1.Node
+	for _, node := range candidates {
+		if node == etcdLeader {
+			glog.Infof("Deferring update of etcd leader: %s", node.Name)
+			continue
+		}
+		newCandidates = append(newCandidates, node)
+	}
+	return newCandidates, capacity, nil
+}
+
+// updateCandidateMachines sets the desiredConfig annotation the candidate machines
+func (ctrl *Controller) updateCandidateMachines(pool *mcfgv1.MachineConfigPool, candidates []*corev1.Node, capacity uint) error {
+	if pool.Name == masterPoolName {
+		var err error
+		candidates, capacity, err = ctrl.filterControlPlaneCandidateNodes(candidates, capacity)
+		if err != nil {
+			return err
+		}
+		// In practice right now these counts will be 1 but let's stay general to support 5 etcd nodes in the future
+		glog.Infof("Pool %s: filtered to %d candidate nodes for update, capacity: %d", pool.Name, len(candidates), capacity)
+	}
+	if capacity < uint(len(candidates)) {
+		// Arbitrarily pick the first N candidates; no attempt at sorting.
+		// Perhaps later we allow admins to weight somehow, or do something more intelligent.
+		candidates = candidates[:capacity]
+	}
+	for _, node := range candidates {
+		if err := ctrl.setDesiredMachineConfigAnnotation(node.Name, pool.Spec.Configuration.Name); err != nil {
+			return goerrs.Wrapf(err, "setting desired config for node %s", node.Name)
+		}
+	}
+	return nil
 }
 
 func maxUnavailable(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) (int, error) {
@@ -861,7 +924,7 @@ func maxUnavailable(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) (int, 
 	if maxunavail == 0 {
 		maxunavail = 1
 	}
-	if pool.Name == "master" {
+	if pool.Name == masterPoolName {
 		// calculate the fault tolerance dynamically for the master pool
 		// to avoid risking losing etcd quorum.
 		tolerance := len(nodes) - ((len(nodes) / 2) + 1)

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -1,23 +1,11 @@
 package template
 
 const (
-	// EtcdImageKey is the key that references the etcd image in the controller
-	EtcdImageKey string = "etcdKey"
-
-	// SetupEtcdEnvKey is the key that references the setup-etcd-environment image in the controller
-	SetupEtcdEnvKey string = "setupEtcdEnvKey"
-
 	// GCPRoutesControllerKey is the key that references the gcp-routes-controller image in the controller
 	GCPRoutesControllerKey string = "gcpRoutesControllerKey"
 
 	// InfraImageKey is the key that references the infra image in the controller for crio.conf
 	InfraImageKey string = "infraImageKey"
-
-	// KubeClientAgentImageKey is the key that references the kube-client-agent image in the controller
-	KubeClientAgentImageKey string = "kubeClientAgentImageKey"
-
-	// ClusterEtcdOperatorImageKey is the key that references the cluster-etcd-operator image in the controller
-	ClusterEtcdOperatorImageKey string = "clusterEtcdOperatorImageKey"
 
 	// KeepalivedKey is the key that references the keepalived-ipfailover image in the controller
 	KeepalivedKey string = "keepalivedImage"

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -281,11 +281,6 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) {
 	funcs := sprig.TxtFuncMap()
 	funcs["skip"] = skipMissing
-	funcs["etcdServerCertDNSNames"] = etcdServerCertDNSNames
-	funcs["etcdPeerCertDNSNames"] = etcdPeerCertDNSNames
-	funcs["etcdServerCertCommand"] = etcdServerCertCommand
-	funcs["etcdPeerCertCommand"] = etcdPeerCertCommand
-	funcs["etcdMetricCertCommand"] = etcdMetricCertCommand
 	funcs["cloudProvider"] = cloudProvider
 	funcs["cloudConfigFlag"] = cloudConfigFlag
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
@@ -310,115 +305,6 @@ func skipMissing(key string) (interface{}, error) {
 	}
 
 	return fmt.Sprintf("{{.%s}}", key), nil
-}
-
-// Process the {{etcdPeerCertDNSNames}} and {{etcdServerCertDNSNames}}
-func etcdServerCertDNSNames(cfg RenderConfig) (interface{}, error) {
-	var dnsNames = []string{
-		"localhost",
-		"etcd.kube-system.svc",                  // sign for the local etcd service name that cluster-network apiservers use to communicate
-		"etcd.kube-system.svc.cluster.local",    // sign for the local etcd service name that cluster-network apiservers use to communicate
-		"etcd.openshift-etcd.svc",               // sign for the local etcd service name that cluster-network apiservers use to communicate
-		"etcd.openshift-etcd.svc.cluster.local", // sign for the local etcd service name that cluster-network apiservers use to communicate
-		"${ETCD_WILDCARD_DNS_NAME}",
-	}
-	return strings.Join(dnsNames, ","), nil
-}
-
-func etcdPeerCertDNSNames(cfg RenderConfig) (interface{}, error) {
-	if cfg.Infra.Status.EtcdDiscoveryDomain == "" {
-		return nil, fmt.Errorf("invalid configuration")
-	}
-
-	var dnsNames = []string{
-		"${ETCD_DNS_NAME}",
-		cfg.Infra.Status.EtcdDiscoveryDomain, // https://github.com/etcd-io/etcd/blob/583763261f1c843e07c1bf7fea5fb4cfb684fe87/Documentation/op-guide/clustering.md#dns-discovery
-	}
-	return strings.Join(dnsNames, ","), nil
-}
-
-func etcdServerCertCommand(cfg RenderConfig) (interface{}, error) {
-	commands := []string{}
-	if cfg.Images[ClusterEtcdOperatorImageKey] == "" {
-		serverCertDNS, err := etcdServerCertDNSNames(cfg)
-		if err != nil {
-			return nil, err
-		}
-		commands = append(commands, []string{
-			"kube-client-agent \\",
-			"  request \\",
-			"  --kubeconfig=/etc/kubernetes/kubeconfig \\",
-			"  --orgname=system:etcd-servers \\",
-			"  --assetsdir=/etc/ssl/etcd \\",
-			fmt.Sprintf("  --dnsnames=%s \\", serverCertDNS),
-			"  --commonname=system:etcd-server:${ETCD_DNS_NAME} \\",
-			"  --ipaddrs=${ETCD_IPV4_ADDRESS},${ETCD_LOCALHOST_IP} \\",
-		}...)
-	} else {
-		commands = append(commands, []string{
-			"cluster-etcd-operator \\",
-			"  mount \\",
-			"  --assetsdir=/etc/ssl/etcd \\",
-			"  --commonname=system:etcd-server:${ETCD_DNS_NAME} \\",
-		}...)
-	}
-	return commands, nil
-}
-
-func etcdPeerCertCommand(cfg RenderConfig) (interface{}, error) {
-	commands := []string{}
-	if cfg.Images[ClusterEtcdOperatorImageKey] == "" {
-		peerCertDNS, err := etcdPeerCertDNSNames(cfg)
-		if err != nil {
-			return nil, err
-		}
-		commands = append(commands, []string{
-			"kube-client-agent \\",
-			"  request \\",
-			"  --kubeconfig=/etc/kubernetes/kubeconfig \\",
-			"  --orgname=system:etcd-peers \\",
-			"  --assetsdir=/etc/ssl/etcd \\",
-			fmt.Sprintf("  --dnsnames=%s \\", peerCertDNS),
-			"  --commonname=system:etcd-peer:${ETCD_DNS_NAME} \\",
-			"  --ipaddrs=${ETCD_IPV4_ADDRESS} \\",
-		}...)
-	} else {
-		commands = append(commands, []string{
-			"cluster-etcd-operator \\",
-			"  mount \\",
-			"  --assetsdir=/etc/ssl/etcd \\",
-			"  --commonname=system:etcd-peer:${ETCD_DNS_NAME} \\",
-		}...)
-	}
-	return commands, nil
-}
-
-func etcdMetricCertCommand(cfg RenderConfig) (interface{}, error) {
-	commands := []string{}
-	if cfg.Images[ClusterEtcdOperatorImageKey] == "" {
-		metricCertDNS, err := etcdServerCertDNSNames(cfg)
-		if err != nil {
-			return nil, err
-		}
-		commands = append(commands, []string{
-			"kube-client-agent \\",
-			"  request \\",
-			"  --kubeconfig=/etc/kubernetes/kubeconfig \\",
-			"  --orgname=system:etcd-metrics \\",
-			"  --assetsdir=/etc/ssl/etcd \\",
-			fmt.Sprintf("  --dnsnames=%s \\", metricCertDNS),
-			"  --commonname=system:etcd-metric:${ETCD_DNS_NAME} \\",
-			"  --ipaddrs=${ETCD_IPV4_ADDRESS} \\",
-		}...)
-	} else {
-		commands = append(commands, []string{
-			"cluster-etcd-operator \\",
-			"  mount \\",
-			"  --assetsdir=/etc/ssl/etcd \\",
-			"  --commonname=system:etcd-metric:${ETCD_DNS_NAME} \\",
-		}...)
-	}
-	return commands, nil
 }
 
 func cloudProvider(cfg RenderConfig) (interface{}, error) {

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -144,75 +144,6 @@ func TestCloudConfigFlag(t *testing.T) {
 	}
 }
 
-func TestEtcdPeerCertDNSNames(t *testing.T) {
-	dummyTemplate := []byte(`{{etcdPeerCertDNSNames .}}`)
-
-	cases := []struct {
-		etcdDiscoveryDomain string
-
-		url string
-		err bool
-	}{{
-		etcdDiscoveryDomain: "",
-		url:                 "",
-		err:                 true,
-	}, {
-		etcdDiscoveryDomain: "my-test-cluster.tt.testing",
-		url:                 "${ETCD_DNS_NAME},my-test-cluster.tt.testing",
-		err:                 false,
-	}}
-	for idx, c := range cases {
-		name := fmt.Sprintf("case #%d", idx)
-		t.Run(name, func(t *testing.T) {
-			config := &mcfgv1.ControllerConfig{
-				Spec: mcfgv1.ControllerConfigSpec{
-					Infra: &configv1.Infrastructure{
-						Status: configv1.InfrastructureStatus{
-							EtcdDiscoveryDomain: c.etcdDiscoveryDomain,
-						},
-					},
-				},
-			}
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
-			if err != nil && !c.err {
-				t.Fatalf("expected nil error %v", err)
-			}
-
-			if string(got) != c.url {
-				t.Fatalf("mismatch got: %s want: %s", got, c.url)
-			}
-		})
-	}
-}
-
-func TestEtcdServerCertDNSNames(t *testing.T) {
-	dummyTemplate := []byte(`{{etcdServerCertDNSNames .}}`)
-
-	cases := []struct {
-		url string
-		err bool
-	}{{
-		url: "localhost,etcd.kube-system.svc,etcd.kube-system.svc.cluster.local,etcd.openshift-etcd.svc,etcd.openshift-etcd.svc.cluster.local,${ETCD_WILDCARD_DNS_NAME}",
-		err: false,
-	}}
-	for idx, c := range cases {
-		name := fmt.Sprintf("case #%d", idx)
-		t.Run(name, func(t *testing.T) {
-			config := &mcfgv1.ControllerConfig{
-				Spec: mcfgv1.ControllerConfigSpec{},
-			}
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
-			if err != nil && !c.err {
-				t.Fatalf("expected nil error %v", err)
-			}
-
-			if string(got) != c.url {
-				t.Fatalf("mismatch got: %s want: %s", got, c.url)
-			}
-		})
-	}
-}
-
 func TestSkipMissing(t *testing.T) {
 	dummyTemplate := `{{skip "%s"}}`
 
@@ -236,11 +167,8 @@ func TestSkipMissing(t *testing.T) {
 		key: "index",
 		err: false,
 		res: "{{.index}}",
-	}, {
-		key: "etcd_index",
-		err: false,
-		res: "{{.etcd_index}}",
-	}}
+	},
+	}
 
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -111,7 +111,10 @@ type Daemon struct {
 	enqueueNode func(*corev1.Node)
 	syncHandler func(node string) error
 
-	booting bool
+	// isControlPlane is true if this node is a control plane (master).
+	// The machine may also be a worker (with schedulable masters).
+	isControlPlane bool
+	booting        bool
 
 	currentConfigPath string
 
@@ -380,6 +383,17 @@ func (dn *Daemon) updateErrorState(err error) {
 	}
 }
 
+// initializeNode is called the first time we get our node object
+func (dn *Daemon) initializeNode() {
+	// Some parts of the MCO dispatch on whether or not we're managing a control plane node
+	if _, isControlPlane := dn.node.Labels[ctrlcommon.MasterLabel]; isControlPlane {
+		glog.Infof("Node %s is part of the control plane", dn.node.Name)
+		dn.isControlPlane = true
+	} else {
+		glog.Infof("Node %s is not labeled %s", dn.node.Name, ctrlcommon.MasterLabel)
+	}
+}
+
 func (dn *Daemon) syncNode(key string) error {
 	startTime := time.Now()
 	glog.V(4).Infof("Started syncing node %q (%v)", key, startTime)
@@ -413,8 +427,12 @@ func (dn *Daemon) syncNode(key string) error {
 
 	// Deep-copy otherwise we are mutating our cache.
 	node = node.DeepCopy()
-	// Update our cached copy of the node
-	dn.node = node
+	if dn.node == nil {
+		dn.node = node
+		dn.initializeNode()
+	} else {
+		dn.node = node
+	}
 
 	// Take care of the very first sync of the MCD on a node.
 	// This loads the node annotation from the bootstrap (if we're really bootstrapping)
@@ -960,6 +978,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	}
 	// Update our cached copy
 	dn.node = node
+
 	pendingState, err := dn.getPendingState()
 	if err != nil {
 		return err

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -615,17 +615,6 @@ spec:
             clusterDNSIP:
               description: clusterDNSIP is the cluster DNS IP address
               type: string
-            etcdCAData:
-              description: etcdCAData specifies the etcd CA data
-              type: string
-              format: byte
-            etcdDiscoveryDomain:
-              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
-              type: string
-            etcdMetricCAData:
-              description: etcdMetricData specifies the etcd metric CA data
-              type: string
-              format: byte
             images:
               description: images is map of images that are used by the controller
                 to render templates under ./templates/

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -30,7 +30,7 @@ func RenderBootstrap(
 	clusterConfigConfigMapFile,
 	infraFile, networkFile,
 	cloudConfigFile, cloudProviderCAFile,
-	etcdCAFile, etcdMetricCAFile, rootCAFile, kubeAPIServerServingCA, pullSecretFile string,
+	rootCAFile, kubeAPIServerServingCA, pullSecretFile string,
 	imgs *Images,
 	destinationDir string,
 ) error {
@@ -41,8 +41,6 @@ func RenderBootstrap(
 		infraFile,
 		networkFile,
 		rootCAFile,
-		etcdCAFile,
-		etcdMetricCAFile,
 		pullSecretFile,
 	}
 	if kubeAPIServerServingCA != "" {
@@ -137,23 +135,17 @@ func RenderBootstrap(
 		spec.CloudProviderCAData = data
 	}
 
-	spec.EtcdCAData = filesData[etcdCAFile]
-	spec.EtcdMetricCAData = filesData[etcdMetricCAFile]
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
-		templatectrl.EtcdImageKey:                imgs.Etcd,
-		templatectrl.SetupEtcdEnvKey:             imgs.MachineConfigOperator,
-		templatectrl.GCPRoutesControllerKey:      imgs.MachineConfigOperator,
-		templatectrl.InfraImageKey:               imgs.InfraImage,
-		templatectrl.KubeClientAgentImageKey:     imgs.KubeClientAgent,
-		templatectrl.ClusterEtcdOperatorImageKey: imgs.ClusterEtcdOperator,
-		templatectrl.KeepalivedKey:               imgs.Keepalived,
-		templatectrl.CorednsKey:                  imgs.Coredns,
-		templatectrl.MdnsPublisherKey:            imgs.MdnsPublisher,
-		templatectrl.HaproxyKey:                  imgs.Haproxy,
-		templatectrl.BaremetalRuntimeCfgKey:      imgs.BaremetalRuntimeCfg,
+		templatectrl.GCPRoutesControllerKey: imgs.MachineConfigOperator,
+		templatectrl.InfraImageKey:          imgs.InfraImage,
+		templatectrl.KeepalivedKey:          imgs.Keepalived,
+		templatectrl.CorednsKey:             imgs.Coredns,
+		templatectrl.MdnsPublisherKey:       imgs.MdnsPublisher,
+		templatectrl.HaproxyKey:             imgs.Haproxy,
+		templatectrl.BaremetalRuntimeCfgKey: imgs.BaremetalRuntimeCfg,
 	}
 
 	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL, nil)

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -28,10 +28,7 @@ type RenderConfigImages struct {
 
 // ControllerConfigImages are image names used to render templates under ./templates/
 type ControllerConfigImages struct {
-	Etcd                string `json:"etcd"`
 	InfraImage          string `json:"infraImage"`
-	KubeClientAgent     string `json:"kubeClientAgentImage"`
-	ClusterEtcdOperator string `json:"clusterEtcdOperatorImage"`
 	Keepalived          string `json:"keepalivedImage"`
 	Coredns             string `json:"corednsImage"`
 	MdnsPublisher       string `json:"mdnsPublisherImage"`

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	libgoevents "github.com/openshift/library-go/pkg/operator/events"
 	libgoresapply "github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/machine-config-operator/lib/resourceapply"
@@ -189,14 +188,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	}
 
 	// sync up CAs
-	etcdCA, err := optr.getCAsFromConfigMap("openshift-config", "etcd-serving-ca", "ca-bundle.crt")
-	if err != nil {
-		return err
-	}
-	etcdMetricCA, err := optr.getCAsFromConfigMap("openshift-config", "etcd-metric-serving-ca", "ca-bundle.crt")
-	if err != nil {
-		return err
-	}
 	rootCA, err := optr.getCAsFromConfigMap("kube-system", "root-ca", "ca.crt")
 	if err != nil {
 		return err
@@ -272,29 +263,18 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		return err
 	}
 
-	//TODO: alaypatel07 remove after cluster-etcd-operator deployed via CVO as Managed
-	if err = optr.setEtcdOperatorImage(&imgs); err != nil {
-		glog.Errorf("error setting etcd operator images: %#v", err)
-	}
-
 	spec.KubeAPIServerServingCAData = kubeAPIServerServingCABytes
-	spec.EtcdCAData = etcdCA
-	spec.EtcdMetricCAData = etcdMetricCA
 	spec.RootCAData = bundle
 	spec.PullSecret = &corev1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
-		templatectrl.EtcdImageKey:                imgs.Etcd,
-		templatectrl.SetupEtcdEnvKey:             imgs.MachineConfigOperator,
-		templatectrl.GCPRoutesControllerKey:      imgs.MachineConfigOperator,
-		templatectrl.InfraImageKey:               imgs.InfraImage,
-		templatectrl.KubeClientAgentImageKey:     imgs.KubeClientAgent,
-		templatectrl.ClusterEtcdOperatorImageKey: imgs.ClusterEtcdOperator,
-		templatectrl.KeepalivedKey:               imgs.Keepalived,
-		templatectrl.CorednsKey:                  imgs.Coredns,
-		templatectrl.MdnsPublisherKey:            imgs.MdnsPublisher,
-		templatectrl.HaproxyKey:                  imgs.Haproxy,
-		templatectrl.BaremetalRuntimeCfgKey:      imgs.BaremetalRuntimeCfg,
+		templatectrl.GCPRoutesControllerKey: imgs.MachineConfigOperator,
+		templatectrl.InfraImageKey:          imgs.InfraImage,
+		templatectrl.KeepalivedKey:          imgs.Keepalived,
+		templatectrl.CorednsKey:             imgs.Coredns,
+		templatectrl.MdnsPublisherKey:       imgs.MdnsPublisher,
+		templatectrl.HaproxyKey:             imgs.Haproxy,
+		templatectrl.BaremetalRuntimeCfgKey: imgs.BaremetalRuntimeCfg,
 	}
 
 	ignitionHost, err := getIgnitionHost(&infra.Status)
@@ -874,32 +854,6 @@ func (optr *Operator) getGlobalConfig() (*configv1.Infrastructure, *configv1.Net
 		return nil, nil, nil, err
 	}
 	return infra, network, proxy, nil
-}
-
-func (optr *Operator) setEtcdOperatorImage(imgs *Images) error {
-	if optr.etcdLister == nil {
-		// if the resource is not found, i.e. it is not created by CVO
-		// which means cluster-etcd-operator images is not part of CVO
-		imgs.ControllerConfigImages.ClusterEtcdOperator = ""
-		glog.V(4).Info("etcd cr not found")
-		return nil
-	}
-	etcd, err := optr.etcdLister.Get("cluster")
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			imgs.ControllerConfigImages.ClusterEtcdOperator = ""
-			return nil
-		}
-		imgs.ControllerConfigImages.ClusterEtcdOperator = ""
-		return fmt.Errorf("error getting etcd CR: %#v", err)
-	}
-
-	if etcd.Spec.ManagementState == operatorv1.Unmanaged {
-		glog.V(4).Info("etcd cluster in unmanaged")
-		imgs.ControllerConfigImages.ClusterEtcdOperator = ""
-		return nil
-	}
-	return nil
 }
 
 func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *RenderConfigImages, apiServerURL string, pointerConfigData []byte) *renderConfig {

--- a/templates/master/00-master/_base/files/etcd-ca.yaml
+++ b/templates/master/00-master/_base/files/etcd-ca.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/static-pod-resources/etcd-member/ca.crt"
-contents:
-  inline: |
-{{.EtcdCAData | toString | indent 4}}

--- a/templates/master/00-master/_base/files/etcd-metric-ca.yaml
+++ b/templates/master/00-master/_base/files/etcd-metric-ca.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/static-pod-resources/etcd-member/metric-ca.crt"
-contents:
-  inline: |
-{{.EtcdMetricCAData | toString | indent 4}}

--- a/test/e2e/mco_test.go
+++ b/test/e2e/mco_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/controller/node"
 	"github.com/openshift/machine-config-operator/test/e2e/framework"
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,7 @@ func CheckMasterIsAlreadySchedulable(master *corev1.Node) bool {
 	_, hasWorkerLabel := master.Labels[node.WorkerLabel]
 	hasMasterTaint := false
 	for _, taint := range master.Spec.Taints {
-		if taint.Key == node.MasterLabel && taint.Effect == corev1.TaintEffectNoSchedule {
+		if taint.Key == ctrlcommon.MasterLabel && taint.Effect == corev1.TaintEffectNoSchedule {
 			hasMasterTaint = true
 		}
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Cleaned up legacy code used for setting up etcd. This supersedes #1933 
**- How to verify it**
Install and validate etcd startup without requiring the legacy code.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove old legacy code in mco used for setting up etcd environment.
