### PR TITLE
bug 1865308 : [baremetal] Create conf file to flip Keepalived mode to unicast post-upgrade

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -95,7 +95,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "no"
+        value: "yes"
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -400,7 +400,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "no"
+        value: "yes"
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/keepalived/monitor.conf"
+contents:
+  inline: |
+    mode: unicast

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -95,7 +95,7 @@ contents:
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: ENABLE_UNICAST
-            value: "no"
+            value: "yes"
           - name: IS_BOOTSTRAP
             value: "no"
         command:


### PR DESCRIPTION
    Starting from 4.6 Keepalived will run in unicast mode by default, in case of upgrade to 4.6 the Keepalived configuration
    should be updated to run in unicast mode.

    But since multicast and unicast are considered as separate Keepalived domains and will
    not interoperate, the updated configuration should be simultaneously reloaded in all the relevant
    Keepalived instances. This option is feasible since the nodes run NTP.
    
    In upgrade process, the Keepalived config already generated by the previous SW version, so Keepalived will
    continue first to run in a mode determined in accordance with the existing config file.
    
    The MCO should render a new file (/etc/keepalived/monitor.conf) in all nodes, this file will trigger a synchronized
    configuration update, the content of the file will determine the desired mode.
    
    Once the file has been identified by the keepalived-monitor container the following actions will be carried out:
    - Verification that desired mode is different from current mode (otherwise exit)
    - Verification that upgrade process is completed, by the comparison between values of machineconfiguration.openshift.io/currentConfig and machineconfiguration.openshift.io/desiredConfig in all nodes annotations.
    - Generation of updated configuration file and initiation of reload message at the desired calculated time.
    
    This PR creates the /etc/keepalived/monitor.conf file that should force mode flip to unicast only for post upgrade case.
