### PR TITLE
Bug 1852047: daemon: Remove "compare digest" code for OS updates

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -114,25 +114,20 @@ func TestCompareOSImageURL(t *testing.T) {
 	refA := "registry.example.com/foo/bar@sha256:0743a3cc3bcf3b4aabb814500c2739f84cb085ff4e7ec7996aef7977c4c19c7f"
 	refB := "registry.example.com/foo/baz@sha256:0743a3cc3bcf3b4aabb814500c2739f84cb085ff4e7ec7996aef7977c4c19c7f"
 	refC := "registry.example.com/foo/bar@sha256:2a76681fd15bfc06fa4aa0ff6913ba17527e075417fc92ea29f6bcc2afca24ff"
-	m, err := compareOSImageURL(refA, refA)
+	m := compareOSImageURL(refA, refA)
 	if !m {
 		t.Fatalf("Expected refA ident")
 	}
-	m, err = compareOSImageURL(refA, refB)
-	if !m {
-		t.Fatalf("Expected refA = refB")
+	m = compareOSImageURL(refA, refB)
+	if m {
+		t.Fatalf("Expected refA != refB")
 	}
-	m, err = compareOSImageURL(refA, refC)
+	m = compareOSImageURL(refA, refC)
 	if m {
 		t.Fatalf("Expected refA != refC")
 	}
-	m, err = compareOSImageURL(refA, "registry.example.com/foo/bar")
-	if m || err == nil {
-		t.Fatalf("Expected err")
-	}
-	m, err = compareOSImageURL("", refA)
+	m = compareOSImageURL("", refA)
 	assert.False(t, m)
-	assert.Nil(t, err)
 }
 
 type fixture struct {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1294,11 +1294,7 @@ func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig, osImageContentDir strin
 	}
 
 	newURL := config.Spec.OSImageURL
-	osMatch, err := compareOSImageURL(dn.bootedOSImageURL, newURL)
-	if err != nil {
-		return err
-	}
-	if osMatch {
+	if compareOSImageURL(dn.bootedOSImageURL, newURL) {
 		return nil
 	}
 	if dn.recorder != nil {


### PR DESCRIPTION
We don't need to do this special casing anymore.  This
corner case only arises for the synthetic `e2e-gcp-upgrade`
test, and we actually want to test the OS update path there.

Closes: https://github.com/openshift/machine-config-operator/issues/1964
