### PR TITLE
Bug 1907671: Handle keepalived hangs in liveness probe

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -114,7 +114,7 @@ contents:
             - /bin/bash
             - -c
             - |
-              kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+              echo "State = FAULT" > /tmp/keepalived.data && kill -s SIGUSR1 "$(pgrep -o keepalived)" && for i in $(seq 5); do grep -q "State = FAULT" /tmp/keepalived.data && sleep 1 || exit 0; done && exit 1
           initialDelaySeconds: 20
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Currently, if keepalived stops responding for any reason but the
process is still there, we will never notice because the previous
version of /tmp/keepalived.data will still be present in /tmp.

This change writes the fault string to keepalived.data before doing
the kill -s SIGUSR1 so that we assume failure unless keepalived
overwrites the file as expected. A sleep is added as well to give
it time to do so. This way if keepalived stops responding to the
kill command we will see the default failure and restart keepalived.
