### PR TITLE
bug 1861773: Remove IPI checks for vsphere hostname script and systemd unit

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -3,11 +3,6 @@ mode: 0755
 path: "/usr/local/bin/vsphere-hostname.sh"
 contents:
   inline: |
-    {{ if .Infra -}}
-    {{ if .Infra.Status -}}
-    {{ if .Infra.Status.PlatformStatus -}}
-    {{ if .Infra.Status.PlatformStatus.VSphere -}}
-    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     #!/usr/bin/env bash
     set -e
 
@@ -16,9 +11,4 @@ contents:
           /usr/bin/hostnamectl --transient --static set-hostname ${hostname}
       fi
     fi
-    {{ end -}}
-    {{ end -}}
-    {{ end -}}
-    {{ end -}}
-    {{ end -}}
 

--- a/templates/common/vsphere/units/vsphere-hostname.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.yaml
@@ -1,11 +1,6 @@
 name: "vsphere-hostname.service"
 enabled: true
 contents: |
-  {{ if .Infra -}}
-  {{ if .Infra.Status -}}
-  {{ if .Infra.Status.PlatformStatus -}}
-  {{ if .Infra.Status.PlatformStatus.VSphere -}}
-  {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
   [Unit]
   Description=vSphere hostname
   After=vmtoolsd.service
@@ -18,9 +13,4 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
-  {{ end -}}
-  {{ end -}}
-  {{ end -}}
-  {{ end -}}
-  {{ end -}}
 


### PR DESCRIPTION
This PR enables UPI to support MachineSets.
The hostname of the VMware Guest must be set for
CSR approval to work correctly and the node to join the cluster.

Cherry-pick https://github.com/openshift/machine-config-operator/pull/1894
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
