### PR TITLE
Bug 1862979: daemon: fallback to podman copy when oc fails to extract image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.9
 	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723
 	github.com/openshift/library-go v0.0.0-20200320155611-2a351bebf158

--- a/pkg/daemon/image-inspect.go
+++ b/pkg/daemon/image-inspect.go
@@ -13,11 +13,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// Number of retry we want to perform
+	cmdRetriesCount = 2
+)
+
 func retryIfNecessary(ctx context.Context, operation func() error) error {
 	err := operation()
-	for attempt := 0; err != nil && attempt < numRetriesNetCommands; attempt++ {
+	for attempt := 0; err != nil && attempt < cmdRetriesCount; attempt++ {
 		delay := time.Duration(int(math.Pow(2, float64(attempt)))) * time.Second
-		fmt.Printf("Warning: failed, retrying in %s ... (%d/%d)", delay, attempt+1, numRetriesNetCommands)
+		fmt.Printf("Warning: failed, retrying in %s ... (%d/%d)", delay, attempt+1, cmdRetriesCount)
 		select {
 		case <-time.After(delay):
 			break

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -179,11 +179,12 @@ func (r *RpmOstreeClient) Rebase(container, osImageContentDir string) (changed b
 
 	// RPM-OSTree can now directly slurp from the mounted container!
 	// https://github.com/projectatomic/rpm-ostree/pull/1732
-	err = exec.Command("rpm-ostree", "rebase", "--experimental",
+	out, err := exec.Command("rpm-ostree", "rebase", "--experimental",
 		fmt.Sprintf("%s:%s", repo, ostreeCsum),
 		"--custom-origin-url", customURL,
-		"--custom-origin-description", "Managed by machine-config-operator").Run()
+		"--custom-origin-description", "Managed by machine-config-operator").CombinedOutput()
 	if err != nil {
+		err = errors.Wrapf(err, "failed to run rpm-ostree rebase: %v", string(out))
 		return
 	}
 

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/containers/image/v5/types"
 	"github.com/golang/glog"
+	"github.com/opencontainers/go-digest"
+	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
 	"github.com/pkg/errors"
 )
 
@@ -37,6 +40,21 @@ type RpmOstreeDeployment struct {
 	Booted       bool     `json:"booted"`
 	Origin       string   `json:"origin"`
 	CustomOrigin []string `json:"custom-origin"`
+}
+
+// imageInspection is a public implementation of
+// https://github.com/containers/skopeo/blob/82186b916faa9c8c70cfa922229bafe5ae024dec/cmd/skopeo/inspect.go#L20-L31
+type imageInspection struct {
+	Name          string `json:",omitempty"`
+	Tag           string `json:",omitempty"`
+	Digest        digest.Digest
+	RepoDigests   []string
+	Created       *time.Time
+	DockerVersion string
+	Labels        map[string]string
+	Architecture  string
+	Os            string
+	Layers        []string
 }
 
 // NodeUpdaterClient is an interface describing how to interact with the host
@@ -111,8 +129,44 @@ func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, error) {
 	return osImageURL, bootedDeployment.Version, nil
 }
 
+func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
+	// Pull the container image if not already available
+	var authArgs []string
+	if _, err := os.Stat(kubeletAuthFile); err == nil {
+		authArgs = append(authArgs, "--authfile", kubeletAuthFile)
+	}
+	args := []string{"pull", "-q"}
+	args = append(args, authArgs...)
+	args = append(args, imgURL)
+	_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
+	if err != nil {
+		return
+	}
+
+	inspectArgs := []string{"inspect", "--type=image"}
+	inspectArgs = append(inspectArgs, fmt.Sprintf("%s", imgURL))
+	var output []byte
+	output, err = runGetOut("podman", inspectArgs...)
+	if err != nil {
+		return
+	}
+	var imagedataArray []imageInspection
+	err = json.Unmarshal(output, &imagedataArray)
+	if err != nil {
+		err = errors.Wrapf(err, "unmarshaling podman inspect")
+		return
+	}
+	imgdata = &imagedataArray[0]
+	return
+
+}
+
 // Rebase potentially rebases system if not already rebased.
-func (r *RpmOstreeClient) Rebase(container, osImageContentDir string) (changed bool, err error) {
+func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool, err error) {
+	var (
+		ostreeCsum    string
+		ostreeVersion string
+	)
 	defaultDeployment, err := r.GetBootedDeployment()
 	if err != nil {
 		return
@@ -131,18 +185,29 @@ func (r *RpmOstreeClient) Rebase(container, osImageContentDir string) (changed b
 	}
 
 	var imageData *types.ImageInspectInfo
-	imageData, err = imageInspect(container)
-	if err != nil {
-		return
+	if imageData, err = imageInspect(imgURL); err != nil {
+		if err != nil {
+			var podmanImgData *imageInspection
+			glog.Infof("Falling back to using podman inspect")
+			if podmanImgData, err = podmanInspect(imgURL); err != nil {
+				return
+			}
+			ostreeCsum = podmanImgData.Labels["com.coreos.ostree-commit"]
+			ostreeVersion = podmanImgData.Labels["version"]
+		}
+	} else {
+		ostreeCsum = imageData.Labels["com.coreos.ostree-commit"]
+		ostreeVersion = imageData.Labels["version"]
 	}
+	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
+	defer exec.Command("podman", "rmi", imgURL).Run()
 
 	repo := fmt.Sprintf("%s/srv/repo", osImageContentDir)
 
 	// Now we need to figure out the commit to rebase to
 	// Commit label takes priority
-	ostreeCsum, ok := imageData.Labels["com.coreos.ostree-commit"]
-	if ok {
-		if ostreeVersion, ok := imageData.Labels["version"]; ok {
+	if ostreeCsum != "" {
+		if ostreeVersion != "" {
 			glog.Infof("Pivoting to: %s (%s)", ostreeVersion, ostreeCsum)
 		} else {
 			glog.Infof("Pivoting to: %s", ostreeCsum)
@@ -174,7 +239,7 @@ func (r *RpmOstreeClient) Rebase(container, osImageContentDir string) (changed b
 	}
 
 	// This will be what will be displayed in `rpm-ostree status` as the "origin spec"
-	customURL := fmt.Sprintf("pivot://%s", container)
+	customURL := fmt.Sprintf("pivot://%s", imgURL)
 	glog.Infof("Executing rebase from repo path %s with customImageURL %s and checksum %s", repo, customURL, ostreeCsum)
 
 	args := []string{"rebase", "--experimental", fmt.Sprintf("%s:%s", repo, ostreeCsum),

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -294,7 +294,7 @@ func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 	args := []string{"image", "extract", "--path", "/:" + osImageContentDir}
 	args = append(args, registryConfig...)
 	args = append(args, imgURL)
-	if _, err = pivotutils.RunExt(numRetriesNetCommands, "oc", args...); err != nil {
+	if _, err = pivotutils.RunExt(cmdRetriesCount, "oc", args...); err != nil {
 		// Workaround fixes for the environment where oc image extract fails.
 		// See https://bugzilla.redhat.com/show_bug.cgi?id=1862979
 		glog.Infof("Falling back to using podman cp to fetch OS image content")

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -251,12 +251,8 @@ func podmanCopy(imgURL, osImageContentDir string) (err error) {
 		return
 	}
 
-	defer func() {
-		// Delete container and remove image once we are done with using rpms available in OSContainer
-		podmanRemove(containerName)
-		exec.Command("podman", "rmi", imgURL).Run()
-		glog.Info("Deleted container and removed OSContainer image")
-	}()
+	// only delete created container, we will delete container image later as we may need it for podmanInspect()
+	defer podmanRemove(containerName)
 
 	// copy the content from create container locally into a temp directory under /run/machine-os-content/
 	cid := strings.TrimSpace(string(cidBuf))


### PR DESCRIPTION
This PR fixes:
1. Fallback to podman copy when oc fails to extract image
2. Fallback to podman inspect if imageInspect doesn't work
2. Reduce oc and imageInspect retry to 2. Time to retry grows exponentially, so let's keep a balance.