### PR TITLE
[release-4.4] Bug 1855895: templates: add a file to load legacy iptables

### DIFF
--- a/templates/common/_base/files/iptables-modules.yaml
+++ b/templates/common/_base/files/iptables-modules.yaml
@@ -1,0 +1,7 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/modules-load.d/iptables.conf"
+contents:
+  inline: |
+    # Force-load legacy iptables so it is usable from pod network namespaces
+    ip_tables


### PR DESCRIPTION
We need to load the iptables modules so that containers can use the legacy iptables interface.  Since 4.4 uses v2 Ignition, I needed to add fields to conform to the older format when I did the backport.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Backport of a change to make RHCOS load the iptables compatibility modules.

**- How to verify it**

With this, the egress router pods should work.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
We need to load the iptables modules so that containers can use the legacy iptables interface.