### PR TITLE
Bug 1867080: Revert "[Baremetal] Set Keepalived default mode to unicast"

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -95,7 +95,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "yes"
+        value: "no"
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -400,7 +400,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "yes"
+        value: "no"
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/keepalived/monitor.conf"
-contents:
-  inline: |
-    mode: unicast

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -95,7 +95,7 @@ contents:
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: ENABLE_UNICAST
-            value: "yes"
+            value: "no"
           - name: IS_BOOTSTRAP
             value: "no"
         command:


### PR DESCRIPTION
We're seeing bootstrapping issues in CI, ref:

https://bugzilla.redhat.com/show_bug.cgi?id=1867080

This reverts commit b22920202aa07fba2a2882581a986f12cb7dd4ff.
This reverts commit 37fa01d.
