### PR TITLE
Bug 1867080: reduce baremetal keepalived monitor race

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -110,7 +110,7 @@ spec:
     - "--cluster-config"
     - "/opt/openshift/manifests/cluster-config.yaml"
     - "--check-interval"
-    - "5s"
+    - "4s"
     resources:
       requests:
         cpu: 100m

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -415,7 +415,7 @@ spec:
     - "--cluster-config"
     - "/opt/openshift/manifests/cluster-config.yaml"
     - "--check-interval"
-    - "5s"
+    - "4s"
     resources:
       requests:
         cpu: 100m

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -107,6 +107,8 @@ contents:
         - "{{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
         - "--ingress-vip"
         - "{{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
+        - "--check-interval"
+        - "15s"
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>
https://bugzilla.redhat.com/show_bug.cgi?id=1867080


**- What I did**
Change the timings of the bootstrap and node monitors so that bootstrap sees the nodes first

**- How to verify it**
Do a normal deployment. If clustering fails, this didn't fix it.

**- Description for the changelog**
Make bootstrap keepalived monitor check unicast peer membership more often.