### PR TITLE
Bug 1861095: daemon: Log when we validate that FIPS is on

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -629,11 +629,14 @@ func checkFIPS(current, desired *mcfgv1.MachineConfig) error {
 		return errors.Wrapf(err, "Error parsing FIPS file at %s", fipsFile)
 	}
 	if desired.Spec.FIPS == nodeFIPS {
+		if desired.Spec.FIPS {
+			glog.Infof("FIPS is configured and enabled")
+		}
 		// Check if FIPS on the system is at the desired setting
 		current.Spec.FIPS = nodeFIPS
 		return nil
 	}
-	return errors.New("detected change to FIPS flag. Refusing to modify FIPS on a running cluster")
+	return errors.New("detected change to FIPS flag; refusing to modify FIPS on a running cluster")
 }
 
 // checks for white-space characters in "C" and "POSIX" locales.


### PR DESCRIPTION
I was surprised we weren't logging anything related to this when
I went to double-check the node state while working on
https://github.com/openshift/origin/pull/25362

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1861095