### PR TITLE
Bug 1867608: ds/machine-config-daemon: Set maxUnavailable 10%

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -7,6 +7,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: machine-config-daemon
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       name: machine-config-daemon

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1411,6 +1411,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: machine-config-daemon
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       name: machine-config-daemon


### PR DESCRIPTION
This daemonset is not critical to availability like SDN or DNS pods therefore
allow maxUnavailable to scale with cluster size. This roughly increases rollout
speed by 10x on a 250 node cluster.

How to verify this, provision a cluster with 20 or more hosts. Confirm that updates
to the machine-config-daemonset allows for up to 10% to update at once but otherwise
operates normally.