### PR TITLE
baremetal: bootstrap api vip until down

### DIFF
--- a/manifests/baremetal/keepalived.conf.tmpl
+++ b/manifests/baremetal/keepalived.conf.tmpl
@@ -4,21 +4,18 @@
 # For more information, see installer/data/data/bootstrap/baremetal/README.md
 # in the installer repo.
 
-{{`{{$nonVirtualIP := .NonVirtualIP}}`}}
-
 {{`vrrp_instance {{.Cluster.Name}}_API {
     state BACKUP
     interface {{.VRRPInterface}}
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 50
     advert_int 1
+    nopreempt
     {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {
-        {{range .LBConfig.Backends}}
-        {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
-        {{else}}
-        {{.NonVirtualIP}}
+        {{range .LBConfig.Backends -}}
+        {{.Address}}
         {{end}}
     }
     {{end}}

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -17,7 +17,8 @@ spec:
     hostPath:
       path: "/etc/kubernetes/kubeconfig"
   - name: conf-dir
-    empty-dir: {}
+    hostPath:
+      path: "/etc/keepalived"
   - name: manifests
     hostPath:
       path: "/opt/openshift/manifests"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -260,21 +260,18 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
 # For more information, see installer/data/data/bootstrap/baremetal/README.md
 # in the installer repo.
 
-{{`+"`"+`{{$nonVirtualIP := .NonVirtualIP}}`+"`"+`}}
-
 {{`+"`"+`vrrp_instance {{.Cluster.Name}}_API {
     state BACKUP
     interface {{.VRRPInterface}}
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 50
     advert_int 1
+    nopreempt
     {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {
-        {{range .LBConfig.Backends}}
-        {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
-        {{else}}
-        {{.NonVirtualIP}}
+        {{range .LBConfig.Backends -}}
+        {{.Address}}
         {{end}}
     }
     {{end}}
@@ -322,7 +319,8 @@ spec:
     hostPath:
       path: "/etc/kubernetes/kubeconfig"
   - name: conf-dir
-    empty-dir: {}
+    hostPath:
+      path: "/etc/keepalived"
   - name: manifests
     hostPath:
       path: "/opt/openshift/manifests"

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -33,7 +33,7 @@ contents:
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
             {{`{{ .BootstrapIP }}`}}
-            {{`{{range .LBConfig.Backends}}
+            {{`{{range .LBConfig.Backends -}}
             {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
             {{end}}`}}
         }
@@ -59,7 +59,7 @@ contents:
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
-            {{`{{range .IngressConfig.Peers}}
+            {{`{{range .IngressConfig.Peers -}}
             {{if ne $nonVirtualIP .}}{{.}}{{end}}
             {{end}}`}}
         }


### PR DESCRIPTION
Now that the cluster is grown from boostrap to the master nodes, it
should make the clustering easier if we just keep the API vip in the
bootstrap until we're done bootstrapping.

**- What I did**
We used to transition the API VIP to the master nodes as soon as
we could. This was necessary with the way Etcd used to cluster. Now
that the clustering starts with the bootstrap node and grows to the
master nodes, it should be possible to reduce deployment instability
by keeping the VIP in the bootstrap until the bootstrap is taken down.

**- How to verify it**
Make a deployment and see that the clustering succeeds.

**- Description for the changelog**
Keep API VIP in the bootstrap while it exists.