### PR TITLE
Bug 1840366: [baremetal] Switch to /readyz for haproxy healthchecking

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -21,7 +21,7 @@ contents:
     listen health_check_http_url
       bind :::50936 v4v6
       mode http
-      monitor-uri /healthz
+      monitor-uri /readyz
       option dontlognull
     listen stats
       bind localhost:{{`{{ .LBConfig.StatPort }}`}}
@@ -32,7 +32,7 @@ contents:
       stats refresh 30s
       stats auth Username:Password
     backend masters
-       option  httpchk GET /healthz HTTP/1.0
+       option  httpchk GET /readyz HTTP/1.0
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -101,7 +101,7 @@ contents:
         livenessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 50936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent

--- a/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
@@ -22,7 +22,7 @@ contents:
     listen health_check_http_url
       bind :::50936 v4v6
       mode http
-      monitor-uri /healthz
+      monitor-uri /readyz
       option dontlognull
     listen stats
       bind 127.0.0.1:{{`{{ .LBConfig.StatPort }}`}}
@@ -33,7 +33,7 @@ contents:
       stats refresh 30s
       stats auth Username:Password
     backend masters
-       option  httpchk GET /healthz HTTP/1.0
+       option  httpchk GET /readyz HTTP/1.0
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -99,7 +99,7 @@ contents:
         livenessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 50936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy-haproxy.yaml
@@ -21,7 +21,7 @@ contents:
     listen health_check_http_url
       bind :::50936 v4v6
       mode http
-      monitor-uri /healthz
+      monitor-uri /readyz
       option dontlognull
     listen stats
       bind 127.0.0.1:{{`{{ .LBConfig.StatPort }}`}}
@@ -32,7 +32,7 @@ contents:
       stats refresh 30s
       stats auth Username:Password
     backend masters
-       option  httpchk GET /healthz HTTP/1.0
+       option  httpchk GET /readyz HTTP/1.0
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -79,7 +79,7 @@ contents:
         livenessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 50936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
@@ -26,7 +26,7 @@ contents:
     listen health_check_http_url
       bind :50936
       mode http
-      monitor-uri /healthz
+      monitor-uri /readyz
       option dontlognull
     listen stats
       bind 127.0.0.1:{{`{{ .LBConfig.StatPort }}`}}
@@ -37,7 +37,7 @@ contents:
       stats refresh 30s
       stats auth Username:Password
     backend masters
-       option  httpchk GET /healthz HTTP/1.0
+       option  httpchk GET /readyz HTTP/1.0
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -84,7 +84,7 @@ contents:
         livenessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 50936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This is a backport of the 4.5 fix #1724 by @cybertron 
(cherry picked from commit 022933c07a4e37bed097f1cd1fa4cd2d637decc0)

Per [0], the /readyz endpoint is how the api communicates that it
is gracefully shutting down. Once /readyz starts to report failure,
we want to stop sending traffic to that backend. If we wait for
/healthz, it may be too late because once /healthz starts failing
the api is already not accepting connections.

I also moved the liveness probe for haproxy itself to use a /readyz
endpoint for consistency. This isn't strictly necessary, but I think
it will be less confusing if there aren't multiple health check
endpoints in the config.

0: https://github.com/openshift/installer/pull/3537