### PR TITLE
Bug 1835145: crio: add temporary hooks directory

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -29,6 +29,7 @@ contents:
     ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
+        "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -29,6 +29,7 @@ contents:
     ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
+        "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a temporary directory for cri-o to read hooks dir, so a node powercycle would allow hooks to be recreated rather than use old state
Note: this needs https://github.com/cri-o/cri-o/pull/4052 which should be in nightlies soon. It will probably fail before that
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
