### PR TITLE
[fcos] templates/common/_base: disable Zincati service via dropin

### DIFF
--- a/templates/common/_base/files/etc-zincati-configd-90-disable-feature.yaml
+++ b/templates/common/_base/files/etc-zincati-configd-90-disable-feature.yaml
@@ -1,6 +1,0 @@
-mode: 0755
-path: "/etc/zincati/config.d/90-disable-feature.toml"
-contents:
-  inline: |
-    [updates]
-    enabled = false

--- a/templates/common/_base/units/zincati.service.yaml
+++ b/templates/common/_base/units/zincati.service.yaml
@@ -1,0 +1,6 @@
+name: zincati.service
+dropins:
+- name: mco-disabled.conf
+  contents: |
+    [Unit]
+    ConditionPathExists=/enoent


### PR DESCRIPTION
Disabling zincati update feature still requires ostree labels. OKD is using ostree dev overlay to create a new commit, so it not yet possible to add basearch label required by Zincati

Fixes https://github.com/openshift/okd/issues/219

/cc @LorbusChris 