### PR TITLE
Configure OVS after firstboot is done

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -3,6 +3,8 @@ enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Configures OVS with proper host networking configuration
+  # Removal of this file signals firstboot completion
+  ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
   Wants=NetworkManager-wait-online.service


### PR DESCRIPTION
Run OVS configuration only after the machine has pivoted. This is crucial for OKD installs which uses standard FCOS image with no OVS pre-installed.