### PR TITLE
Bug 1869876: Cluster upgrades silently stall when machine config pools are paused

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -89,6 +89,10 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdated)
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("All nodes are updating to %s", pool.Spec.Configuration.Name))
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
+
+		if pool.Spec.Paused == true { // if the pool is Paused and updating, the pool will never progress.
+			glog.Warningf("Pool %s is Paused, but is 'Updating'.  Pool will not progress", pool.Name)
+		}
 	}
 
 	var nodeDegraded bool

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -80,7 +80,6 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", "")
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
-
 		if status.Configuration.Name != pool.Spec.Configuration.Name || !equality.Semantic.DeepEqual(status.Configuration.Source, pool.Spec.Configuration.Source) {
 			glog.Infof("Pool %s: %s", pool.Name, updatedMsg)
 			status.Configuration = pool.Spec.Configuration
@@ -90,9 +89,6 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdated)
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("All nodes are updating to %s", pool.Spec.Configuration.Name))
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
-		if pool.Spec.Paused == true { // if the pool is Paused and updating, the pool will never progress.
-			glog.Warningf("Pool %s is Paused, but is 'Updating'.  Pool will not progress", pool.Name)
-		}
 	}
 
 	var nodeDegraded bool

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -80,6 +80,7 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", "")
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
+
 		if status.Configuration.Name != pool.Spec.Configuration.Name || !equality.Semantic.DeepEqual(status.Configuration.Source, pool.Spec.Configuration.Source) {
 			glog.Infof("Pool %s: %s", pool.Name, updatedMsg)
 			status.Configuration = pool.Spec.Configuration
@@ -89,6 +90,9 @@ func calculateStatus(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdated)
 		supdating := mcfgv1.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("All nodes are updating to %s", pool.Spec.Configuration.Name))
 		mcfgv1.SetMachineConfigPoolCondition(&status, *supdating)
+		if pool.Spec.Paused == true { // if the pool is Paused and updating, the pool will never progress.
+			glog.Warningf("Pool %s is Paused, but is 'Updating'.  Pool will not progress", pool.Name)
+		}
 	}
 
 	var nodeDegraded bool


### PR DESCRIPTION
**- What I did**
Added a log message that is written when the machine config pool is Paused, but is also updating.  This message is written when the machine config pool status is being calculated .

**- How to verify it**
1. Configure `worker` machine config to be 'Paused' 
2. Update the `99-worker-ssh` machine config with a new SSH key
3. Wait for `worker` pool to progress to `Updating`
4. Check machine-config-controller logs for an entry like: W0818 19:49:38.503997      10 status.go:94] Pool worker is Paused, but is 'Updating'.  Pool will not progress

**- Description for the changelog**
Logs a warning when a machine config pool is Paused, but also updating