### PR TITLE
Bug 1869876: Cluster upgrades silently stall when machine config pools are paused

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -721,6 +721,9 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	}
 
 	if pool.Spec.Paused {
+		if mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating) {
+			glog.Infof("Pool %s is paused and will not update.", pool.Name)
+		}
 		return ctrl.syncStatusOnly(pool)
 	}
 


### PR DESCRIPTION
**- What I did**
Added a log message that is written when the machine config pool is Paused, but is also updating. This message is written when the machine config pool status is being calculated .

**- How to verify it**
1. Configure worker machine config to be 'Paused'
2. Update the 99-worker-ssh machine config with a new SSH key
3. Wait for worker pool to progress to Updating
4. Check machine-config-controller logs for an entry like: W0818 19:49:38.503997 10 status.go:94] Pool worker is Paused, but is 'Updating'. Pool will not progress

**- Description for the changelog**
Logs a warning when a machine config pool is Paused, but also updating