### PR TITLE
Bug 1872444: Run ovs-configuration.service after the node has hostname stabilized

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -7,6 +7,7 @@ contents: |
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
+  Requires=node-valid-hostname.service
   Wants=NetworkManager-wait-online.service
   After=NetworkManager-wait-online.service openvswitch.service node-valid-hostname.service
   Before=network-online.target kubelet.service crio.service


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
If ovs-configuration is enabled it should block crio/kubelet from starting until the node has hostname set. Currently it [races with the kubelet](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/promote-release-openshift-okd-machine-os-content-e2e-aws-4.6/1296266834999250944) in OKD, so often tests fails due to crashlooping OVN/DNS pods and/or worker nodes not joining the cluster

**- How to verify it**
Run OVN-enabled cluster.

OKD has OVN enabled by default, so now results are looking much better: 
* [1](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/2013/pull-ci-openshift-machine-config-operator-master-okd-e2e-aws/1296362803300405248) - storage flakes
* [2](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/2013/pull-ci-openshift-machine-config-operator-master-okd-e2e-aws/1296398459334561792) - minor flakes
* [3](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/2013/pull-ci-openshift-machine-config-operator-master-okd-e2e-aws/1296427427123171328) - pass

**- Description for the changelog**
Configure OVS after hostname has been set