### PR TITLE
Bug 1868536: Watching the networkType in the status of  Network.config.openshift.io

### DIFF
--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -96,7 +96,6 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 	}
 
 	ccSpec := &mcfgv1.ControllerConfigSpec{
-		NetworkType:         network.Spec.NetworkType,
 		ClusterDNSIP:        dnsIP,
 		KubeletIPv6:         ipv6,
 		CloudProviderConfig: "",
@@ -107,6 +106,13 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		// Still populating it here for now until it will be removed eventually
 		Platform: platform,
 		Infra:    infra,
+	}
+	if network.Status.NetworkType == "" {
+		// At install time, when CNO has not started, status is unset, use the value in spec.
+		ccSpec.NetworkType = network.Spec.NetworkType
+	} else {
+		// After installation, the MCO should not assume the network is changing just because the spec changed, it needs to wait until CNO updates the status.
+		ccSpec.NetworkType = network.Status.NetworkType
 	}
 
 	if proxy != nil {


### PR DESCRIPTION
**- What I did**
It prevents the user from breaking the cluster network when configuring an invalid value.

**- How to verify it**
1. oc patch networks.config.openshift.io cluster -p \{\"spec\":\{\"networkType\":\"bad\"\}\} --type=merge

Expect no reboot triggered by MCO

**- Description for the changelog**
Watching the `networkType` in the status of  Network.config.openshift.io if it
is not empty, otherwise use the value in spec. 
