### PR TITLE
[baremetal] Create and enable overlay mount point for NetworkManager

### DIFF
--- a/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
+++ b/templates/common/baremetal/files/baremetal-NetworkManager-kni-conf.yaml
@@ -7,3 +7,5 @@ contents:
     [connection]
     ipv6.dhcp-duid=ll
     ipv6.dhcp-iaid=mac
+    [keyfile]
+    path=/etc/NetworkManager/system-connections-merged

--- a/templates/common/baremetal/files/baremetal-kni-tmpfiles.yaml
+++ b/templates/common/baremetal/files/baremetal-kni-tmpfiles.yaml
@@ -1,0 +1,8 @@
+mode: 0644
+path: "/etc/tmpfiles.d/kni.conf"
+contents:
+  inline: |
+    D /run/nm-system-connections 0755 root root - -
+    D /run/nm-system-connections-work 0755 root root - -
+    d /etc/NetworkManager/system-connections-merged 0755 root root - -
+

--- a/templates/common/baremetal/units/baremetal-system-connections-mount.yaml
+++ b/templates/common/baremetal/units/baremetal-system-connections-mount.yaml
@@ -1,0 +1,13 @@
+name: etc-NetworkManager-system\x2dconnections\x2dmerged.mount
+enabled: true
+contents: |
+  [Unit]
+  After=systemd-tmpfiles-setup.service
+  [Mount]
+  Where=/etc/NetworkManager/system-connections-merged
+  What=overlay
+  Type=overlay
+  Options=lowerdir=/etc/NetworkManager/system-connections,upperdir=/run/nm-system-connections,workdir=/run/nm-system-connections-work
+  [Install]
+  WantedBy=multi-user.target
+  


### PR DESCRIPTION
This does 4 things for the baremetal platform:

1. Configures NetworkManager to look for it's keyfiles in /etc/NetworkManager/system-connections-merged
2. Creates that directory
3. Adds two temporary directories for systemd-tmpfiles to process. These are the storage and work locations for the overlay.
4. Mount an overlay filesystem at /etc/NetworkManager/system-connections-merged that uses /etc/NetworkManager/system-connections as the lower filesystem, and the temporary directory as the upper.

Any changes made outside of a MachineConfig will result in it being ephemeral. This maintains the idea that MCO will own the configuration of a machine before kubelet runs. MCO changes would go into /etc/NetworkManager/system-connections.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Mount an overlay directory to make NetworkManager changes ephemeral.