### PR TITLE
Bug 1871970: OpenStack: Align haproxy config with other on-prem platforms

### DIFF
--- a/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy-haproxy.yaml
@@ -8,13 +8,12 @@ contents:
       log     /var/run/haproxy/haproxy-log.sock local0
       option  dontlognull
       retries 3
-      timeout http-keep-alive 10s
-      timeout http-request    1m
-      timeout queue           1m
-      timeout connect         10s
-      timeout client          86400s
-      timeout server          86400s
-      timeout tunnel          86400s
+      timeout http-request 10s
+      timeout queue        1m
+      timeout connect      10s
+      timeout client       86400s
+      timeout server       86400s
+      timeout tunnel       86400s
     frontend  main
       bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters


### PR DESCRIPTION
The high value for `timeout http-keep-alive` was probably messing with
the `[sig-api-machinery] API data in etcd should be stored at the
correct location and version for all resources [Serial]` test causing
it to fail frequently on OpenStack platform.

It's also better to have consistency between platforms.

This reverts commit d34b2750341f90163bf92be7bfe017f28811be7b.