### PR TITLE
Bug 1854009: remove err cardinality from mcd_kubelet_state metrics

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -138,9 +138,8 @@ const (
 	// also retrieve the pending config after a reboot
 	pendingStateMessageID = "machine-config-daemon-pending-state"
 
-	kubeletHealthzPollingInterval  = 30 * time.Second
-	kubeletHealthzTimeout          = 30 * time.Second
-	kubeletHealthzFailureThreshold = 3
+	kubeletHealthzPollingInterval = 30 * time.Second
+	kubeletHealthzTimeout         = 30 * time.Second
 
 	// updateDelay is the baseline speed at which we react to changes.  We don't
 	// need to react in milliseconds as any change would involve rebooting the node.
@@ -686,25 +685,21 @@ func (dn *Daemon) applySSHAccessedAnnotation() error {
 
 func (dn *Daemon) runKubeletHealthzMonitor(stopCh <-chan struct{}, exitCh chan<- error) {
 	failureCount := 0
-	KubeletHealthState.WithLabelValues("").Set(float64(failureCount))
+	KubeletHealthState.Set(float64(failureCount))
 	for {
 		select {
 		case <-stopCh:
 			return
 		case <-time.After(kubeletHealthzPollingInterval):
-			if err := dn.getHealth(); err != nil {
-				glog.Warningf("Failed kubelet health check: %v", err)
+			err := dn.getHealth()
+			if err != nil {
 				failureCount++
-				KubeletHealthState.WithLabelValues(err.Error()).Set(float64(failureCount))
-				if failureCount >= kubeletHealthzFailureThreshold {
-					thresholdMessage := "kubelet health failure threshold reached"
-					KubeletHealthState.WithLabelValues(thresholdMessage).Set(float64(failureCount))
-					exitCh <- fmt.Errorf(thresholdMessage)
-				}
+				exitCh <- fmt.Errorf("kubelet health check has failed %d times: %v", failureCount, err)
 			} else {
-				failureCount = 0 // reset failure count on success
-				KubeletHealthState.WithLabelValues("").Set(float64(failureCount))
+				// reset failure count on success
+				failureCount = 0
 			}
+			KubeletHealthState.Set(float64(failureCount))
 		}
 	}
 }

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -49,11 +49,11 @@ var (
 		}, []string{"state", "reason"})
 
 	// KubeletHealthState logs kubelet health failures and tallys count
-	KubeletHealthState = prometheus.NewGaugeVec(
+	KubeletHealthState = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "mcd_kubelet_state",
 			Help: "state of kubelet health monitor",
-		}, []string{"err"})
+		})
 
 	// MCDRebootErr logs success/failure of reboot and errors
 	MCDRebootErr = prometheus.NewGaugeVec(
@@ -90,7 +90,7 @@ func registerMCDMetrics() error {
 
 	MCDDrainErr.WithLabelValues("", "").Set(0)
 	MCDPivotErr.WithLabelValues("", "").Set(0)
-	KubeletHealthState.WithLabelValues("").Set(0)
+	KubeletHealthState.Set(0)
 	MCDRebootErr.WithLabelValues("", "").Set(0)
 	MCDUpdateState.WithLabelValues("", "").Set(0)
 


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1854009

Using the err message as a label introduces a bug in resetting the metrics to 0 when the kubelet health returns to normal.

Test by ssh'nig into node, stopping kubelet, waiting for alert to fire, restart kubelet, ensure the alert goes away and the `mcd_kubelet_state` metric returns to 0.

@runcom