### PR TITLE
Bug 1867992: Support RHEL7 workers by removing 'jq' commands from ovs setup

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -15,14 +15,14 @@ contents:
     # find default interface
     while [ $counter -lt 12 ]; do
       # check ipv4
-      iface=$(ip -j route show default | jq -r '.[0].dev')
-      if [[ -n "$iface"  && "$iface" != "null" ]]; then
+      iface=$(ip route show default | awk '{if ($4 == "dev") print $5; exit}')
+      if [[ -n "$iface" ]]; then
         echo "IPv4 Default gateway interface found: ${iface}"
         break
       fi
       # check ipv6
-      iface=$(ip -6 -j route show default | jq -r '.[0].dev')
-      if [[ -n "$iface"  && "$iface" != "null" ]]; then
+      iface=$(ip -6 route show default | awk '{if ($4 == "dev") print $5; exit}')
+      if [[ -n "$iface" ]]; then
         echo "IPv6 Default gateway interface found: ${iface}"
         break
       fi
@@ -51,8 +51,8 @@ contents:
     echo "MAC address found for iface: ${iface}: ${iface_mac}"
 
     # find MTU from original iface
-    iface_mtu=$(ip -j link show "$iface" | jq -r '.[0].mtu')
-    if [[ -z "$iface_mtu" ||  "$iface_mtu" == "null" ]]; then
+    iface_mtu=$(ip link show "$iface" | awk '{print $5; exit}')
+    if [[ -z "$iface_mtu" ]]; then
       echo "Unable to determine default interface MTU, defaulting to 1500"
       iface_mtu=1500
     else


### PR DESCRIPTION
RHEL7 does not have 'jq' by default or a version of the ip command that supports the
"-j" option. To support RHEL7 worker nodes it is required to remove the unsupported actions
from the setup scripts

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

Fixes: 1867992
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**
Run the script in the yaml on a RHEL7 system with ovs installed and an updated network manager (so far not in an official release https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=30784728#)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
