### PR TITLE
Bug 1872313: controller: improve merging of MCs during rendering

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -65,11 +65,6 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 	}
 
 	for idx := 1; idx < len(configs); idx++ {
-		// if any of the config has FIPS enabled, it'll be set
-		if configs[idx].Spec.FIPS {
-			fips = true
-		}
-
 		if configs[idx].Spec.Config.Raw != nil {
 			mergedIgn, err := ParseAndConvertConfig(configs[idx].Spec.Config.Raw)
 			if err != nil {
@@ -85,7 +80,11 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 
 	// sets the KernelType if specified in any of the MachineConfig
 	// Setting kerneType to realtime in any of MachineConfig takes priority
+	// also if any of the config has FIPS enabled, it'll be set
 	for _, cfg := range configs {
+		if cfg.Spec.FIPS {
+			fips = true
+		}
 		if cfg.Spec.KernelType == KernelTypeRealtime {
 			kernelType = cfg.Spec.KernelType
 			break


### PR DESCRIPTION
During rendering of rendered-configs for the pools, specify spec
version if the first merged machineconfig does not contain an ignition
snippet, and ignore other machineconfigs without an ignition snippet.

Fixes an issue where if the last alphanumerical machineconfig doesn't
contain an explicit ignition spec version, the ignition Merge() function
merges the final config to have no spec version, degrading the MCO.

