### PR TITLE
Bug 1869876: Cluster upgrades silently stall when machine config pools are paused

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
@@ -25,6 +25,10 @@ spec:
       configuration is failing.
     name: Degraded
     type: string
+  - JSONPath: .spec.paused
+    description: When paused, updates to the machineconfigpool will not be processed.
+    name: Paused
+    type: boolean
   - JSONPath: .status.machineCount
     description: Total number of machines in the machine config pool
     name: MachineCount

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -721,6 +721,9 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	}
 
 	if pool.Spec.Paused {
+		if mcfgv1.IsMachineConfigPoolConditionTrue(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating) {
+			glog.Infof("Pool %s is paused and will not update.", pool.Name)
+		}
 		return ctrl.syncStatusOnly(pool)
 	}
 


### PR DESCRIPTION
- What I did
Added a log message that is written when the machine config pool is Paused, but is also updating. This message is written when the machine config pool status is being calculated.  Also, added 'PAUSED' as a table column for `oc get mcp`

- How to verify it

Configure worker machine config to be 'Paused'
Update the 99-worker-ssh machine config with a new SSH key
Wait for worker pool to progress to Updating
Check machine-config-controller logs for an entry like: W0818 19:49:38.503997 10 status.go:94] Pool worker is Paused, but is 'Updating'. Pool will not progress
- Description for the changelog
Logs a warning when a machine config pool is Paused, but also updating
Check `oc get mcp` to see if PAUSED field matches the paused state of the pool