### PR TITLE
Bug 1851540: OpenStack: set hostnames on early stages of machine provisioning

### DIFF
--- a/templates/common/openstack/units/afterburn-hostname.service.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.service.yaml
@@ -3,11 +3,11 @@ enabled: true
 contents: |
   [Unit]
   Description=Afterburn Hostname
-  Before=kubelet.service
+  Before=node-valid-hostname.service
 
   [Service]
   ExecStart=/usr/bin/afterburn --provider openstack-metadata --hostname=/etc/hostname
   Type=oneshot
 
   [Install]
-  WantedBy=multi-user.target
+  WantedBy=network-online.target


### PR DESCRIPTION
To prevent possible race conditions with ovn-kubernetes we need to set hostnames before network-online.target and node-valid-hostname.service