### PR TITLE
ovs/ovn: sync systemd service name with script name

### DIFF
--- a/templates/common/_base/units/configure-ovs.service.yaml
+++ b/templates/common/_base/units/configure-ovs.service.yaml
@@ -1,4 +1,4 @@
-name: ovs-configuration.service
+name: configure-ovs.service
 enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else}}false{{end}}
 contents: |
   [Unit]


### PR DESCRIPTION
Makes grepping for issues show all relevant hits, instead of
needing two different greps, one for service and one for the
script itself.

@vrutkovs @trozet 