### PR TITLE
 Bug 1873321: Check the version hash so we resync on an upgrade

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -218,3 +218,13 @@ func IgnParseWrapper(rawIgn []byte) (ignconfig interface{}, err error) {
 	}
 	return ign2types.Config{}, errors.Errorf("parsing Ignition config failed with error: %v\nReport: %v", err, rpt)
 }
+
+// InSlice search for an element in slice and return true if found, otherwise return false
+func InSlice(elem string, slice []string) bool {
+	for _, k := range slice {
+		if k == elem {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -423,17 +423,25 @@ func generateOriginalContainerRuntimeConfigs(templateDir string, cc *mcfgv1.Cont
 
 func (ctrl *Controller) syncStatusOnly(cfg *mcfgv1.ContainerRuntimeConfig, err error, args ...interface{}) error {
 	statusUpdateErr := retry.RetryOnConflict(updateBackoff, func() error {
-		if cfg.GetGeneration() != cfg.Status.ObservedGeneration {
-			cfg.Status.ObservedGeneration = cfg.GetGeneration()
-			cfg.Status.Conditions = append(cfg.Status.Conditions, wrapErrorWithCondition(err, args...))
-		} else if cfg.GetGeneration() == cfg.Status.ObservedGeneration && err == nil {
-			// If the CR was created before a matching label was added, the CR would be in failure state
-			// However the observed generation would be the same, so check if err is nil as well
-			// Which means that, the ctrcfg was finally successfully able to sync. In that case update the status
-			// to success and clear the previous failure status
-			cfg.Status.Conditions = []mcfgv1.ContainerRuntimeConfigCondition{wrapErrorWithCondition(err, args...)}
+		newcfg, getErr := ctrl.mccrLister.Get(cfg.Name)
+		if getErr != nil {
+			return getErr
 		}
-		_, updateErr := ctrl.client.MachineconfigurationV1().ContainerRuntimeConfigs().UpdateStatus(context.TODO(), cfg, metav1.UpdateOptions{})
+		// Update the observedGeneration
+		if newcfg.GetGeneration() != newcfg.Status.ObservedGeneration {
+			newcfg.Status.ObservedGeneration = newcfg.GetGeneration()
+		}
+		// To avoid a long list of same statuses, only append a status if it is the first status
+		// or if the status message is different from the message of the last status recorded
+		// If the last status message is the same as the new one, then update the last status to
+		// reflect the latest time stamp from the new status message.
+		newStatusCondition := wrapErrorWithCondition(err, args...)
+		if len(newcfg.Status.Conditions) == 0 || newStatusCondition.Message != newcfg.Status.Conditions[len(newcfg.Status.Conditions)-1].Message {
+			newcfg.Status.Conditions = append(newcfg.Status.Conditions, newStatusCondition)
+		} else if newcfg.Status.Conditions[len(newcfg.Status.Conditions)-1].Message == newStatusCondition.Message {
+			newcfg.Status.Conditions[len(newcfg.Status.Conditions)-1] = newStatusCondition
+		}
+		_, updateErr := ctrl.client.MachineconfigurationV1().ContainerRuntimeConfigs().UpdateStatus(context.TODO(), newcfg, metav1.UpdateOptions{})
 		return updateErr
 	})
 	// If an error occurred in updating the status just log it
@@ -479,11 +487,6 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		return nil
 	}
 
-	// If we have seen this generation and the sync didn't fail, then skip
-	if cfg.Status.ObservedGeneration >= cfg.Generation && cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Type == mcfgv1.ContainerRuntimeConfigSuccess {
-		return nil
-	}
-
 	// Validate the ContainerRuntimeConfig CR
 	if err := validateUserContainerRuntimeConfig(cfg); err != nil {
 		return ctrl.syncStatusOnly(cfg, err)
@@ -511,70 +514,78 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		role := pool.Name
 		// Get MachineConfig
 		managedKey := getManagedKeyCtrCfg(pool)
+		mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
+		isNotFound := errors.IsNotFound(err)
+		if err != nil && !isNotFound {
+			return ctrl.syncStatusOnly(cfg, err, "could not find MachineConfig: %v", managedKey)
+		}
+		// If we have seen this generation and the sync didn't fail, then skip
+		if !isNotFound && cfg.Status.ObservedGeneration >= cfg.Generation && cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Type == mcfgv1.ContainerRuntimeConfigSuccess {
+			// But we still need to compare the generated controller version because during an upgrade we need a new one
+			mcCtrlVersion := mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey]
+			if mcCtrlVersion == version.Hash {
+				return nil
+			}
+		}
+		// Generate the original ContainerRuntimeConfig
+		originalStorageIgn, _, _, err := generateOriginalContainerRuntimeConfigs(ctrl.templatesDir, controllerConfig, role)
+		if err != nil {
+			return ctrl.syncStatusOnly(cfg, err, "could not generate origin ContainerRuntime Configs: %v", err)
+		}
+
+		var configFileList []generatedConfigFile
+		ctrcfg := cfg.Spec.ContainerRuntimeConfig
+		if ctrcfg.OverlaySize != (resource.Quantity{}) {
+			storageTOML, err := ctrl.mergeConfigChanges(originalStorageIgn, cfg, updateStorageConfig)
+			if err != nil {
+				glog.V(2).Infoln(cfg, err, "error merging user changes to storage.conf: %v", err)
+			} else {
+				configFileList = append(configFileList, generatedConfigFile{filePath: storageConfigPath, data: storageTOML})
+			}
+		}
+
+		// Create the cri-o drop-in files
+		if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != 0 || ctrcfg.LogSizeMax != (resource.Quantity{}) {
+			crioFileConfigs := createCRIODropinFiles(cfg)
+			configFileList = append(configFileList, crioFileConfigs...)
+		}
+
+		if isNotFound {
+			tempIgnCfg := ctrlcommon.NewIgnConfig()
+			mc, err = mtmpl.MachineConfigFromIgnConfig(role, managedKey, tempIgnCfg)
+			if err != nil {
+				return ctrl.syncStatusOnly(cfg, err, "could not create MachineConfig from new Ignition config: %v", err)
+			}
+		}
+
+		ctrRuntimeConfigIgn := createNewIgnition(configFileList)
+		rawCtrRuntimeConfigIgn, err := json.Marshal(ctrRuntimeConfigIgn)
+		if err != nil {
+			return ctrl.syncStatusOnly(cfg, err, "error marshalling container runtime config Ignition: %v", err)
+		}
+		mc.Spec.Config.Raw = rawCtrRuntimeConfigIgn
+
+		mc.SetAnnotations(map[string]string{
+			ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,
+		})
+		oref := metav1.NewControllerRef(cfg, controllerKind)
+		mc.SetOwnerReferences([]metav1.OwnerReference{*oref})
+
+		// Create or Update, on conflict retry
 		if err := retry.RetryOnConflict(updateBackoff, func() error {
-			mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
-				return ctrl.syncStatusOnly(cfg, err, "could not find MachineConfig: %v", managedKey)
-			}
-			isNotFound := errors.IsNotFound(err)
-			// Generate the original ContainerRuntimeConfig
-			originalStorageIgn, _, _, err := generateOriginalContainerRuntimeConfigs(ctrl.templatesDir, controllerConfig, role)
-			if err != nil {
-				return ctrl.syncStatusOnly(cfg, err, "could not generate origin ContainerRuntime Configs: %v", err)
-			}
-
-			var configFileList []generatedConfigFile
-			ctrcfg := cfg.Spec.ContainerRuntimeConfig
-			if ctrcfg.OverlaySize != (resource.Quantity{}) {
-				storageTOML, err := ctrl.mergeConfigChanges(originalStorageIgn, cfg, updateStorageConfig)
-				if err != nil {
-					glog.V(2).Infoln(cfg, err, "error merging user changes to storage.conf: %v", err)
-				} else {
-					configFileList = append(configFileList, generatedConfigFile{filePath: storageConfigPath, data: storageTOML})
-				}
-			}
-
-			// Create the cri-o drop-in files
-			if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != 0 || ctrcfg.LogSizeMax != (resource.Quantity{}) {
-				crioFileConfigs := createCRIODropinFiles(cfg)
-				configFileList = append(configFileList, crioFileConfigs...)
-			}
-
-			if isNotFound {
-				tempIgnCfg := ctrlcommon.NewIgnConfig()
-				mc, err = mtmpl.MachineConfigFromIgnConfig(role, managedKey, tempIgnCfg)
-				if err != nil {
-					return ctrl.syncStatusOnly(cfg, err, "could not create MachineConfig from new Ignition config: %v", err)
-				}
-			}
-
-			ctrRuntimeConfigIgn := createNewIgnition(configFileList)
-			rawCtrRuntimeConfigIgn, err := json.Marshal(ctrRuntimeConfigIgn)
-			if err != nil {
-				return ctrl.syncStatusOnly(cfg, err, "error marshalling container runtime config Ignition: %v", err)
-			}
-			mc.Spec.Config.Raw = rawCtrRuntimeConfigIgn
-
-			mc.SetAnnotations(map[string]string{
-				ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,
-			})
-			oref := metav1.NewControllerRef(cfg, controllerKind)
-			mc.SetOwnerReferences([]metav1.OwnerReference{*oref})
-
-			// Create or Update, on conflict retry
+			var err error
 			if isNotFound {
 				_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
 			} else {
 				_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Update(context.TODO(), mc, metav1.UpdateOptions{})
 			}
-
-			// Add Finalizers to the ContainerRuntimeConfigs
-			if err := ctrl.addFinalizerToContainerRuntimeConfig(cfg, mc); err != nil {
-				return ctrl.syncStatusOnly(cfg, err, "could not add finalizers to ContainerRuntimeConfig: %v", err)
-			}
 			return err
 		}); err != nil {
 			return ctrl.syncStatusOnly(cfg, err, "could not Create/Update MachineConfig: %v", err)
+		}
+		// Add Finalizers to the ContainerRuntimeConfigs
+		if err := ctrl.addFinalizerToContainerRuntimeConfig(cfg, mc); err != nil {
+			return ctrl.syncStatusOnly(cfg, err, "could not add finalizers to ContainerRuntimeConfig: %v", err)
 		}
 		glog.Infof("Applied ContainerRuntimeConfig %v on MachineConfigPool %v", key, pool.Name)
 	}
@@ -854,7 +865,13 @@ func (ctrl *Controller) addFinalizerToContainerRuntimeConfig(ctrCfg *mcfgv1.Cont
 		}
 
 		ctrCfgTmp := newcfg.DeepCopy()
-		ctrCfgTmp.Finalizers = append(ctrCfgTmp.Finalizers, mc.Name)
+		// Only append the mc name if it is already not in the list of finalizers.
+		// When we update an existing ctrcfg, the generation number increases causing
+		// a resync to happen. When this happens, the mc name is the same, so we don't
+		// want to add duplicate entries to the list of finalizers.
+		if !ctrlcommon.InSlice(mc.Name, ctrCfgTmp.Finalizers) {
+			ctrCfgTmp.Finalizers = append(ctrCfgTmp.Finalizers, mc.Name)
+		}
 
 		modJSON, err := json.Marshal(ctrCfgTmp)
 		if err != nil {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/clarketm/json"
-	ign "github.com/coreos/ignition/config/v2_2"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/golang/glog"
 	apicfgv1 "github.com/openshift/api/config/v1"
@@ -482,16 +481,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 
 	// If we have seen this generation and the sync didn't fail, then skip
 	if cfg.Status.ObservedGeneration >= cfg.Generation && cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Type == mcfgv1.ContainerRuntimeConfigSuccess {
-		// This is the scenario for upgrades where we are moving from crio.conf to crio.conf.d
-		// this can be removed in the next release
-		fromOldCrio, err := ctrl.isUpdatingFromOldCRIOConf(cfg)
-		if err != nil {
-			return fmt.Errorf("error checking if we are updating from crio.conf: %v", err)
-		}
-		// We want to trigger a resync if we are updating from a version where crio.conf.d didn't exist
-		if !fromOldCrio {
-			return nil
-		}
+		return nil
 	}
 
 	// Validate the ContainerRuntimeConfig CR
@@ -904,37 +894,4 @@ func (ctrl *Controller) getPoolsForContainerRuntimeConfig(config *mcfgv1.Contain
 	}
 
 	return pools, nil
-}
-
-// isUpdatingFromOldCRIOConf returns true if the mc associated with cfg has /etc/crio/crio.conf as
-// its file path.
-func (ctrl *Controller) isUpdatingFromOldCRIOConf(cfg *mcfgv1.ContainerRuntimeConfig) (bool, error) {
-	mcpPools, err := ctrl.getPoolsForContainerRuntimeConfig(cfg)
-	if err != nil {
-		return false, fmt.Errorf("could not get list of machine config pools: %v", err)
-	}
-	if len(mcpPools) == 0 {
-		return false, nil
-	}
-
-	for _, pool := range mcpPools {
-		managedKey := getManagedKeyCtrCfg(pool)
-		mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return false, fmt.Errorf("could not get mc with name %q: %v", managedKey, err)
-		}
-		if mc.Spec.Config.Raw != nil {
-			conf, _, err := ign.Parse(mc.Spec.Config.Raw)
-			if err != nil {
-				return false, fmt.Errorf("error parsing ignition: %v", err)
-			}
-			// If the filepath matches /etc/crio/crio.conf return true
-			for _, file := range conf.Storage.Files {
-				if file.Path == "/etc/crio/crio.conf" {
-					return true, nil
-				}
-			}
-		}
-	}
-	return false, nil
 }


### PR DESCRIPTION
Backport of https://github.com/openshift/machine-config-operator/pull/1984

Fixes #1873321 (https://bugzilla.redhat.com/show_bug.cgi?id=1873321)
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add a check for the version hash to ensure that we resync
and generate a new controller version during an upgrade.

Update the way we append the status for a ctrcfg as well -
ensure that we don't have mutliple of the same status recorded.

Add a check to avoid adding the same mc name more than once in
the list of finalizers. When we update an existing ctrcfg, the
generation number changes causing a resync and we don't need to add
the same name to the list of finalizers every time this happens.
And remove the check for cri-o drop-in files.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

**- How to verify it**
1. Create a 4.5 cluster
2. Create a ctrcfg CR on it and apply it to both master and worker pools.
e.g:
```
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
  name: set-log
spec:
  machineConfigPoolSelector:
    matchLabels:
      custom-crio: set-log
  containerRuntimeConfig:
    logLevel: debug
```
3. Upgrade the cluster to a version that has the changes from this PR. The upgrade should be successful with the ctrcfg CR changes intact. Check the controller version for the MCs, it should have been updated to the new one.

**- Description for the changelog**
Check the generated controller version to ensure that we resync and create a new one on upgrades.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
