### PR TITLE
Bug 1873288: server: Target the spec configuration if we have at least one node

### DIFF
--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -65,7 +65,16 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 		return nil, fmt.Errorf("could not fetch pool. err: %v", err)
 	}
 
-	currConf := mp.Status.Configuration.Name
+	// For new nodes, we roll out the latest if at least one node has successfully updated.
+	// This avoids deadlocks in situations where the old configuration broke somehow
+	// (e.g. pull secret expired)
+	// and also avoids provisioning a new node, only to update it not long thereafter.
+	var currConf string
+	if mp.Status.UpdatedMachineCount > 0 {
+		currConf = mp.Spec.Configuration.Name
+	} else {
+		currConf = mp.Status.Configuration.Name
+	}
 
 	mc, err := cs.machineClient.MachineConfigs().Get(context.TODO(), currConf, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
The CI cluster hit an issue where a pull secret was broken, and
then we hit a deadlock because the MCO failed to drain nodes on
the old config, because other nodes on the old config couldn't
schedule the pod.

It just generally makes sense for new nodes to use the new config;
do so as long as at least one node has successfully joined the
cluster at that config.  This way we still avoid breaking
the cluster (and scaleup) with a bad config.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1873288
