### PR TITLE
Bug 1857162: daemon: inject proxy vars into MCD container

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -34,6 +34,20 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{if .ControllerConfig.Proxy}}
+          {{if .ControllerConfig.Proxy.HTTPProxy}}
+          - name: HTTP_PROXY
+            value: {{.ControllerConfig.Proxy.HTTPProxy}}
+          {{end}}
+          {{if .ControllerConfig.Proxy.HTTPSProxy}}
+          - name: HTTPS_PROXY
+            value: {{.ControllerConfig.Proxy.HTTPSProxy}}
+          {{end}}
+          {{if .ControllerConfig.Proxy.NoProxy}}
+          - name: NO_PROXY
+            value: {{.ControllerConfig.Proxy.NoProxy}}
+          {{end}}
+          {{end}}
       - name: oauth-proxy
         image: {{.Images.OauthProxy}}
         ports:

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -271,6 +271,8 @@ func podmanCopy(imgURL, osImageContentDir string) (err error) {
 
 // ExtractOSImage extracts OS image content in a temporary directory under /run/machine-os-content/
 // and returns the path on successful extraction.
+// Note that since we do this in the MCD container, cluster proxy configuration must also be injected
+// into the container. See the MCD daemonset.
 func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 	var registryConfig []string
 	if _, err := os.Stat(kubeletAuthFile); err == nil {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1429,6 +1429,20 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{if .ControllerConfig.Proxy}}
+          {{if .ControllerConfig.Proxy.HTTPProxy}}
+          - name: HTTP_PROXY
+            value: {{.ControllerConfig.Proxy.HTTPProxy}}
+          {{end}}
+          {{if .ControllerConfig.Proxy.HTTPSProxy}}
+          - name: HTTPS_PROXY
+            value: {{.ControllerConfig.Proxy.HTTPSProxy}}
+          {{end}}
+          {{if .ControllerConfig.Proxy.NoProxy}}
+          - name: NO_PROXY
+            value: {{.ControllerConfig.Proxy.NoProxy}}
+          {{end}}
+          {{end}}
       - name: oauth-proxy
         image: {{.Images.OauthProxy}}
         ports:


### PR DESCRIPTION
With the introduction of extensions and reworking of OS updates in
https://github.com/openshift/machine-config-operator/pull/1941,
we now run `oc/podman` directly in the MCD to fetch the OS image.
Thus we need to inject the proxy env vars into the container via the
daemonset definition, otherwise image pulls will fail.

