### PR TITLE
[WIP] bug: 1866265 [baremetal] Stop keepalived on bootstrap after bootstrap completed

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -80,15 +80,25 @@ spec:
       mountPath: "/etc/keepalived"
     - name: run-dir
       mountPath: "/var/run/keepalived"
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 6443
+        scheme: HTTPS
+      periodSeconds: 1
+      successThreshold: 3
+      failureThreshold: 3
+      timeoutSeconds: 2
     livenessProbe:
       exec:
         command:
         - /bin/bash
         - -c
         - |
-          [[ -s /etc/keepalived/keepalived.conf ]] || \
-          kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+          kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data \
+          && /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz
       initialDelaySeconds: 20
+      failureThreshold: 5
     terminationMessagePolicy: FallbackToLogsOnError
     imagePullPolicy: IfNotPresent
   - name: keepalived-monitor

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -388,15 +388,25 @@ spec:
       mountPath: "/etc/keepalived"
     - name: run-dir
       mountPath: "/var/run/keepalived"
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 6443
+        scheme: HTTPS
+      periodSeconds: 1
+      successThreshold: 3
+      failureThreshold: 3
+      timeoutSeconds: 2
     livenessProbe:
       exec:
         command:
         - /bin/bash
         - -c
         - |
-          [[ -s /etc/keepalived/keepalived.conf ]] || \
-          kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+          kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data \
+          && /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz
       initialDelaySeconds: 20
+      failureThreshold: 5
     terminationMessagePolicy: FallbackToLogsOnError
     imagePullPolicy: IfNotPresent
   - name: keepalived-monitor


### PR DESCRIPTION
When OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP deployment configuration parameter is set to true the bootstrap node won't be destroyed and the infrastructure components (e.g: Keepalived) on the bootstrap continue to run. 

This PR verifies that Keepalived instance on the bootstrap node is shutdown after bootstrap complete phase, this change is important for platforms that run Keepalived in unicast mode (baremetal).
