### PR TITLE
Bug 1866265: [baremetal] Stop Keepalived on bootstrap after bootstrap completed

### DIFF
--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -52,13 +52,23 @@ spec:
             /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
         fi
       }
+      stop_keepalived()
+      {
+        echo "Keepalived process stopped" >> /var/run/keepalived/stopped
+        if pid=$(pgrep -o keepalived); then
+            kill -s TERM "$pid"
+        fi
+      }
+
       msg_handler()
       {
         while read -r line; do
           echo "The client sent: $line" >&2
-          # currently only 'reload' msg is supported
+          # currently only 'reload' and 'stop' msgs are supported
           if [ "$line" = reload ]; then
               reload_keepalived
+          elif  [ "$line" = stop ]; then
+              stop_keepalived
           fi
         done
       }
@@ -66,6 +76,12 @@ spec:
       declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
       export -f msg_handler
       export -f reload_keepalived
+      export -f stop_keepalived
+
+      while [ -s "/var/run/keepalived/stopped" ]; do
+         echo "Container stopped"
+         sleep 60
+      done
       if [ -s "/etc/keepalived/keepalived.conf" ]; then
           /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
       fi
@@ -87,6 +103,7 @@ spec:
         - -c
         - |
           [[ -s /etc/keepalived/keepalived.conf ]] || \
+          [[ -s /var/run/keepalived/stopped ]] || \
           kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
       initialDelaySeconds: 20
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -360,13 +360,23 @@ spec:
             /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
         fi
       }
+      stop_keepalived()
+      {
+        echo "Keepalived process stopped" >> /var/run/keepalived/stopped
+        if pid=$(pgrep -o keepalived); then
+            kill -s TERM "$pid"
+        fi
+      }
+
       msg_handler()
       {
         while read -r line; do
           echo "The client sent: $line" >&2
-          # currently only 'reload' msg is supported
+          # currently only 'reload' and 'stop' msgs are supported
           if [ "$line" = reload ]; then
               reload_keepalived
+          elif  [ "$line" = stop ]; then
+              stop_keepalived
           fi
         done
       }
@@ -374,6 +384,12 @@ spec:
       declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
       export -f msg_handler
       export -f reload_keepalived
+      export -f stop_keepalived
+
+      while [ -s "/var/run/keepalived/stopped" ]; do
+         echo "Container stopped"
+         sleep 60
+      done
       if [ -s "/etc/keepalived/keepalived.conf" ]; then
           /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
       fi
@@ -395,6 +411,7 @@ spec:
         - -c
         - |
           [[ -s /etc/keepalived/keepalived.conf ]] || \
+          [[ -s /var/run/keepalived/stopped ]] || \
           kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
       initialDelaySeconds: 20
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
When OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP deployment configuration parameter is set to true the
bootstrap node won't be destroyed and infrastructure components including Keepalived on the bootstrap continue to run.

With this PR the Keepalived process is stopped when a stop message is received in Keepalived control socket.

This change is important for platforms that run Keepalived in unicast mode (baremetal).

This PR should be merged after [this baremetal-runtimecfg PR](https://github.com/openshift/baremetal-runtimecfg/pull/92) is merged