### PR TITLE
Bug 1849583: [openstack,bm,ovirt,vsphere] Adjust HAProxy liveness probe to initial timing 

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -98,7 +98,7 @@ contents:
         - name: run-dir
           mountPath: "/var/run/haproxy"
         livenessProbe:
-          initialDelaySeconds: 10
+          initialDelaySeconds: 50
           httpGet:
             path: /haproxy_ready
             port: 50936

--- a/templates/master/00-master/openstack/files/openstack-haproxy.yaml
+++ b/templates/master/00-master/openstack/files/openstack-haproxy.yaml
@@ -96,7 +96,7 @@ contents:
         - name: run-dir
           mountPath: "/var/run/haproxy"
         livenessProbe:
-          initialDelaySeconds: 10
+          initialDelaySeconds: 50
           httpGet:
             path: /readyz
             port: 50936

--- a/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
+++ b/templates/master/00-master/ovirt/files/ovirt-haproxy.yaml
@@ -76,7 +76,7 @@ contents:
         - name: run-dir
           mountPath: "/var/run/haproxy"
         livenessProbe:
-          initialDelaySeconds: 10
+          initialDelaySeconds: 50
           httpGet:
             path: /readyz
             port: 50936

--- a/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy.yaml
@@ -103,7 +103,7 @@ contents:
         - name: run-dir
           mountPath: "/var/run/haproxy"
         livenessProbe:
-          initialDelaySeconds: 10
+          initialDelaySeconds: 50
           httpGet:
             path: /readyz
             port: 50936


### PR DESCRIPTION
    
The Liveness probe of haproxy container monitors the health of the HAProxy LoadBalancer.
    Since HAProxy LoadBalancer starts running only after haproxy-monitor container rendered
    the config file (which might take 30-40 seconds) the liveness probe of haproxy container
    initial timing should be adjusted.




