### PR TITLE
Bug 1866873: update MCDDrainErr to reduce cardinality & fix nodename

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -20,7 +20,7 @@ spec:
       rules:
         - alert: MCDDrainError
           expr: |
-            mcd_drain > 0
+            mcd_drain_err > 0
           labels:
             severity: warning
           annotations:

--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -23,6 +23,7 @@ spec:
             mcd_drain_err > 0
           labels:
             severity: warning
+          for: 15m
           annotations:
             message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details:  oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon"
     - name: mcd-pivot-error

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -30,9 +30,9 @@ var (
 	// MCDDrainErr logs errors received during failed drain
 	MCDDrainErr = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "mcd_drain",
+			Name: "mcd_drain_err",
 			Help: "errors from failed drain",
-		}, []string{"drain_time", "err"})
+		}, []string{"node", "err"})
 
 	// MCDPivotErr shows errors encountered during pivot
 	MCDPivotErr = prometheus.NewGaugeVec(

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -39,7 +39,7 @@ var (
 		prometheus.GaugeOpts{
 			Name: "mcd_pivot_err",
 			Help: "errors encountered during pivot",
-		}, []string{"pivot_target", "err"})
+		}, []string{"node", "pivot_target", "err"})
 
 	// MCDState is state of mcd for indicated node (ex: degraded)
 	MCDState = prometheus.NewGaugeVec(
@@ -59,7 +59,7 @@ var (
 	MCDRebootErr = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "mcd_reboot_err",
-		}, []string{"message", "err"})
+		}, []string{"node", "message", "err"})
 
 	// MCDUpdateState logs completed update or error
 	MCDUpdateState = prometheus.NewGaugeVec(
@@ -88,9 +88,9 @@ func registerMCDMetrics() error {
 		}
 	}
 
-	MCDPivotErr.WithLabelValues("", "").Set(0)
+	MCDPivotErr.WithLabelValues("", "", "").Set(0)
 	KubeletHealthState.Set(0)
-	MCDRebootErr.WithLabelValues("", "").Set(0)
+	MCDRebootErr.WithLabelValues("", "", "").Set(0)
 	MCDUpdateState.WithLabelValues("", "").Set(0)
 
 	return nil

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -88,7 +88,6 @@ func registerMCDMetrics() error {
 		}
 	}
 
-	MCDDrainErr.WithLabelValues("", "").Set(0)
 	MCDPivotErr.WithLabelValues("", "").Set(0)
 	KubeletHealthState.Set(0)
 	MCDRebootErr.WithLabelValues("", "").Set(0)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -123,6 +123,7 @@ func (dn *Daemon) drain() error {
 	if dn.kubeClient == nil {
 		return nil
 	}
+	MCDDrainErr.WithLabelValues(dn.node.Name, "").Set(0)
 
 	dn.logSystem("Update prepared; beginning drain")
 	startTime := time.Now()

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1614,13 +1614,13 @@ func (dn *Daemon) reboot(rationale string) error {
 	// either, we just have one for the MCD itself.
 	if err := rebootCmd.Run(); err != nil {
 		dn.logSystem("failed to run reboot: %v", err)
-		MCDRebootErr.WithLabelValues("failed to run reboot", err.Error()).SetToCurrentTime()
+		MCDRebootErr.WithLabelValues(dn.node.Name, "failed to run reboot", err.Error()).SetToCurrentTime()
 	}
 
 	// wait to be killed via SIGTERM from the kubelet shutting down
 	time.Sleep(defaultRebootTimeout)
 
 	// if everything went well, this should be unreachable.
-	MCDRebootErr.WithLabelValues("reboot failed", "this error should be unreachable, something is seriously wrong").SetToCurrentTime()
+	MCDRebootErr.WithLabelValues(dn.node.Name, "reboot failed", "this error should be unreachable, something is seriously wrong").SetToCurrentTime()
 	return fmt.Errorf("reboot failed; this error should be unreachable, something is seriously wrong")
 }


### PR DESCRIPTION
This fix does the following:

- fixes bug where node name was missing for MCDDrainErr
- reduces cardinality of MCDDrainErr via set err messages & value
- adds a duration to the metric (15m) to give time for the failed drain to resolve
- fixes labels on other metrics (minor)

This fixes some Drain metric pain points have have been going on forever..
see: https://bugzilla.redhat.com/show_bug.cgi?id=1866873#c3 for screenshot