### PR TITLE
Bug 1874448: [BM, OpenStack, vSphere]: Sync compute kubelet

### DIFF
--- a/templates/worker/01-worker-kubelet/baremetal/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/baremetal/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=3"
+  Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -22,6 +22,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --node-ip=${KUBELET_NODE_IP} \
         --address=${KUBELET_NODE_IP} \
@@ -29,6 +30,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/worker/01-worker-kubelet/openstack/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=3"
+  Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -22,6 +22,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
         --node-ip=${KUBELET_NODE_IP} \
         --address=${KUBELET_NODE_IP} \
@@ -29,6 +30,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=3"
+  Environment="KUBELET_LOG_LEVEL=4"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -40,6 +40,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always


### PR DESCRIPTION
Patch at https://github.com/openshift/machine-config-operator/pull/1817
addressed the drift of kubelet configuration for control plane nodes but
didn't update compute nodes' kubelet to catch up changes made to the
main kubelet unit.

We're currently missing a number of fixes for the worker nodes on
Baremetal, OpenStack and vSphere platforms:
- https://bugzilla.redhat.com/show_bug.cgi?id=1823967
- https://bugzilla.redhat.com/show_bug.cgi?id=1806027
- https://bugzilla.redhat.com/show_bug.cgi?id=1828622

This change sync the custom kubelet unit files accross platforms.