### PR TITLE
[wip] monitor install

### DIFF
--- a/templates/common/_base/units/atop-monitor.service
+++ b/templates/common/_base/units/atop-monitor.service
@@ -1,0 +1,18 @@
+name: atop-monitor.service
+enabled: true
+contents: |
+  [Unit]
+  Description=atop performance monitor
+  [Service]
+  Type=simple
+  Restart=always
+  RestartSec=3
+  DefaultDependencies=no
+
+  ExecStart=/usr/bin/podman run --rm \
+    --volume /var/log/kube-apiserver:/var/log/kube-apiserver:z \
+    --pid=host \
+    docker.io/sttts/atop:latest \
+    /usr/bin/atop -w /var/log/kube-apiserver/atop 1
+  [Install]
+  WantedBy=sysinit.target


### PR DESCRIPTION
atop monitor of 4.6 cluster install. the premise here is that I/O contention is happening during cluster install.