### PR TITLE
[release-4.5] Bug 1856529: Create a drop-in file for cri-o's default_capabilities

### DIFF
--- a/cmd/machine-config-controller/main.go
+++ b/cmd/machine-config-controller/main.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	componentName = "machine-config-controller"
+	componentName      = "machine-config-controller"
+	componentNamespace = "openshift-machine-config-operator"
 )
 
 var (

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -113,6 +113,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.ClientBuilder.MachineConfigClientOrDie("kubelet-config-controller"),
 		),
 		containerruntimeconfig.New(
+			componentNamespace,
 			rootOpts.templates,
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -128,6 +128,12 @@ func (b *Bootstrap) Run(destDir string) error {
 	}
 	configs = append(configs, rconfigs...)
 
+	capsconfigs, err := containerruntimeconfig.RunCapsBootstrap(pools)
+	if err != nil {
+		return err
+	}
+	configs = append(configs, capsconfigs...)
+
 	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig)
 	if err != nil {
 		return err

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -68,10 +68,11 @@ var updateBackoff = wait.Backoff{
 
 // Controller defines the container runtime config controller.
 type Controller struct {
-	templatesDir string
+	namespace, templatesDir string
 
 	client        mcfgclientset.Interface
 	configClient  configclientset.Interface
+	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
 
 	syncHandler                   func(mcp string) error
@@ -106,7 +107,7 @@ type Controller struct {
 
 // New returns a new container runtime config controller
 func New(
-	templatesDir string,
+	namespace, templatesDir string,
 	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	ccInformer mcfginformersv1.ControllerConfigInformer,
 	mcrInformer mcfginformersv1.ContainerRuntimeConfigInformer,
@@ -122,9 +123,11 @@ func New(
 	eventBroadcaster.StartRecordingToSink(&coreclientsetv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 
 	ctrl := &Controller{
+		namespace:     namespace,
 		templatesDir:  templatesDir,
 		client:        mcfgClient,
 		configClient:  configClient,
+		kubeClient:    kubeClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-containerruntimeconfigcontroller"}),
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigcontroller-containerruntimeconfigcontroller"),
 		imgQueue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
@@ -171,6 +174,10 @@ func New(
 	ctrl.clusterVersionListerSynced = clusterVersionInformer.Informer().HasSynced
 
 	ctrl.patchContainerRuntimeConfigsFunc = ctrl.patchContainerRuntimeConfigs
+	// Add to the queue to trigger a sync when an upgrade happens
+	// this ensures that the capabilities MC is created on an upgrade
+	// This will be removed in the next version
+	ctrl.queue.Add("force-sync-on-upgrade")
 
 	return ctrl
 }
@@ -461,6 +468,17 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		glog.V(4).Infof("Finished syncing ContainerRuntimeconfig %q (%v)", key, time.Since(startTime))
 	}()
 
+	// First let's create the MC for the default capabilities file
+	// This will be removed in the next version
+	if err := ctrl.createCapabilitiesMC(); err != nil {
+		return fmt.Errorf("failed to create the crio capabilitie MC: %v", err)
+	}
+	// If the key is set to force-sync-on-upgrade, then we can return after creating
+	// the capabilities MC.
+	if key == "force-sync-on-upgrade" {
+		return nil
+	}
+
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -504,12 +522,6 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		return ctrl.syncStatusOnly(cfg, err)
 	}
 
-	if len(mcpPools) == 0 {
-		err := fmt.Errorf("containerRuntimeConfig %v does not match any MachineConfigPools", key)
-		glog.V(2).Infof("%v", err)
-		return ctrl.syncStatusOnly(cfg, err)
-	}
-
 	for _, pool := range mcpPools {
 		role := pool.Name
 		// Get MachineConfig
@@ -522,9 +534,8 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		// If we have seen this generation and the sync didn't fail, then skip
 		if !isNotFound && cfg.Status.ObservedGeneration >= cfg.Generation && cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Type == mcfgv1.ContainerRuntimeConfigSuccess {
 			// But we still need to compare the generated controller version because during an upgrade we need a new one
-			mcCtrlVersion := mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey]
-			if mcCtrlVersion == version.Hash {
-				return nil
+			if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] == version.Hash {
+				continue
 			}
 		}
 		// Generate the original ContainerRuntimeConfig
@@ -605,6 +616,95 @@ func (ctrl *Controller) mergeConfigChanges(origFile *igntypes.File, cfg *mcfgv1.
 		return nil, ctrl.syncStatusOnly(cfg, err, "could not update container runtime config with new changes: %v", err)
 	}
 	return cfgTOML, ctrl.syncStatusOnly(cfg, nil)
+}
+
+// createCapabilitiesMC creates a Machine Config for the crio drop-in capabilities file.
+// We are dropping the NET_RAW and SYS_CHROOT capabilitie by default and in order to not break
+// existing clusters, we are creating a drop-in file at /etc/crio/crio.conf.d that has NET_RAW
+// and SYS_CHROOT as part of the default capabilities list. Users then have the option to delete the
+// capabilities MC that creates this drop-in file.
+// Create a crio-capabilities config map to keep track of whether this capabilities MC was already created
+// once. This ensures that if the user deletes the capabilities MC, the controller doesn't recreate it on a
+// resync.
+func (ctrl *Controller) createCapabilitiesMC() error {
+	var configMapName = "crio-capabilities"
+
+	// Check if the crio-capabilities config map exists in the openshift-machine-config-operator namespace
+	capCM, err := ctrl.kubeClient.CoreV1().ConfigMaps(ctrl.namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	capCMIsNotFound := errors.IsNotFound(err)
+	if err != nil && !capCMIsNotFound {
+		return fmt.Errorf("error checking for %s config map: %v", configMapName, err)
+	}
+	// If the crio-capabilities config map exists, that means the capabilities MC was already created
+	// so we should not create this MC again and return
+	if capCM != nil && !capCMIsNotFound {
+		return nil
+	}
+
+	sel, err := metav1.LabelSelectorAsSelector(metav1.AddLabelToSelector(&metav1.LabelSelector{}, builtInLabelKey, ""))
+	if err != nil {
+		return err
+	}
+	// Find all the MachineConfigPools
+	mcpPoolsAll, err := ctrl.mcpLister.List(sel)
+	if err != nil {
+		return err
+	}
+
+	// Create the capabilities MC for all the available pools
+	for _, pool := range mcpPoolsAll {
+		managedKey := getManagedKeyCaps(pool)
+		mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
+		isNotFound := errors.IsNotFound(err)
+		if err != nil && !isNotFound {
+			return fmt.Errorf("error checking for %s machine config: %v", managedKey, err)
+		}
+		// continue to the next MC if this already exists
+		if mc != nil && !isNotFound {
+			continue
+		}
+
+		tempIgnCfg := ctrlcommon.NewIgnConfig()
+		mc, err = mtmpl.MachineConfigFromIgnConfig(pool.Name, managedKey, tempIgnCfg)
+		if err != nil {
+			return fmt.Errorf("could not create capabilities MachineConfig from new Ignition config: %v", err)
+		}
+		rawCapsIgnition, err := json.Marshal(createNewIgnition(createDefaultCapsFile()))
+		if err != nil {
+			return fmt.Errorf("error marshalling capabilities config ignition: %v", err)
+		}
+		mc.Spec.Config.Raw = rawCapsIgnition
+		// Create the capabilities MC
+		if err := retry.RetryOnConflict(updateBackoff, func() error {
+			_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
+			return err
+		}); err != nil {
+			return fmt.Errorf("could not create MachineConfig for capabilities: %v", err)
+		}
+		glog.Infof("Applied Capabilities MC %v on MachineConfigPool %v", managedKey, pool.Name)
+	}
+
+	// Create the config map for capabilities so we know that the capabilities MC has been created
+	capCM.Name = configMapName
+	capCM.Namespace = ctrl.namespace
+	if _, err := ctrl.kubeClient.CoreV1().ConfigMaps(ctrl.namespace).Create(context.TODO(), capCM, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("error creating %s config map: %v", configMapName, err)
+	}
+	return nil
+}
+
+// RunCapsBootstrap creates the capabilities mc on bootstrap
+func RunCapsBootstrap(mcpPools []*mcfgv1.MachineConfigPool) ([]*mcfgv1.MachineConfig, error) {
+	var res []*mcfgv1.MachineConfig
+	for _, pool := range mcpPools {
+		capsIgn := createNewIgnition(createDefaultCapsFile())
+		mc, err := mtmpl.MachineConfigFromIgnConfig(pool.Name, getManagedKeyCaps(pool), capsIgn)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mc)
+	}
+	return res, nil
 }
 
 func (ctrl *Controller) syncImageConfig(key string) error {

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -15,18 +15,8 @@ contents:
     ]
     log_level = "info"
     cgroup_manager = "systemd"
-    default_capabilities = [
-        "CHOWN",
-        "DAC_OVERRIDE",
-        "FSETID",
-        "FOWNER",
-        "NET_RAW",
-        "SETGID",
-        "SETUID",
-        "SETPCAP",
-        "NET_BIND_SERVICE",
-        "SYS_CHROOT",
-        "KILL",
+    default_sysctls = [
+        "net.ipv4.ping_group_range=0 2147483647",
     ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -15,18 +15,8 @@ contents:
     ]
     log_level = "info"
     cgroup_manager = "systemd"
-    default_capabilities = [
-        "CHOWN",
-        "DAC_OVERRIDE",
-        "FSETID",
-        "FOWNER",
-        "NET_RAW",
-        "SETGID",
-        "SETUID",
-        "SETPCAP",
-        "NET_BIND_SERVICE",
-        "SYS_CHROOT",
-        "KILL",
+    default_sysctls = [
+        "net.ipv4.ping_group_range=0 2147483647",
     ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",


### PR DESCRIPTION
Fixes #1856529 (https://bugzilla.redhat.com/show_bug.cgi?id=1856529)
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Split out the default_capabilities list from the default.conf
file to a spearate drop-in file under /etc/crio/crio.conf.d.
cri-o enables the NET_RAW and SYS_CHROOT capabilities by default
in the config the MCO lays down. We want to drop these capabilities,
but need to make sure that we don't break existing clusters by doing so.
Thus, split out the default capabilities list to its own drop-in file and
create an MC for it. This way, the user has the ability to delete this MC
once they believe that removing these capabilities will not affect their
cluster.

We will drop this logic in the following version as the capabilities
MC would have already been created. It will then be up to the user on
when they want to drop these capabilities.

The upgrade flow will be:
4.5.x --> 4.5.y+capabilities MC logic (this will be mandatory upgrade point)
4.5.y+capabilities MC logic --> 4.5.z

Also drop the default_capabilities list from the crio template.

**- How to verify it**

1. Start a 4.5 cluster
2. Create a custom release image with the changes from this PR and upgrade your cluster to it.
3. Check that you have 2 MCs created `00-worker/master-capabilities` and a `crio-capabilities` config map is create in the openshift-machine-config-operator namespace. Log onto the nodes and verify that the `/etc/crio/crio.conf.d/01-mc-defaultCapabilities` file exists.
4. Delete one of the capabilities MC and reboot a node, restart the MCC pod etc and check that the capabilities MC you deleted wasn't created again. Log on the node for which you deleted the MC and run `crio config`, check the `default_capabilities` list in the output, it should not have the NET_RAW or SYS_CHROOT capabilities in it.
5. Upgrade your cluster to 4.5.x or 4.6 and check that the capabilities MC that you did not delete still exists. Log onto a node and look at the `/etc/crio/crio.conf.d/00-default` file to ensure that the `default_capabilities` list is no longer there.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Split out the default_capabilities list to a separate MC and drop-in file at crio.conf.d.
