### PR TITLE
Bug 1874671:  Drop the default_capabilities list from the crio template

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -14,18 +14,8 @@ contents:
     ]
     log_level = "info"
     cgroup_manager = "systemd"
-    default_capabilities = [
-        "CHOWN",
-        "DAC_OVERRIDE",
-        "FSETID",
-        "FOWNER",
-        "NET_RAW",
-        "SETGID",
-        "SETUID",
-        "SETPCAP",
-        "NET_BIND_SERVICE",
-        "SYS_CHROOT",
-        "KILL",
+    default_sysctls = [
+        "net.ipv4.ping_group_range=0 2147483647",
     ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -14,18 +14,8 @@ contents:
     ]
     log_level = "info"
     cgroup_manager = "systemd"
-    default_capabilities = [
-        "CHOWN",
-        "DAC_OVERRIDE",
-        "FSETID",
-        "FOWNER",
-        "NET_RAW",
-        "SETGID",
-        "SETUID",
-        "SETPCAP",
-        "NET_BIND_SERVICE",
-        "SYS_CHROOT",
-        "KILL",
+    default_sysctls = [
+        "net.ipv4.ping_group_range=0 2147483647",
     ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",


### PR DESCRIPTION
Fixes #1874671 (https://bugzilla.redhat.com/show_bug.cgi?id=1874671)

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Dropping this list will also drop the NET_RAW and SYS_CHROOT
capabilities from the default list.

**- How to verify it**
Log onto a node and run `crio config`, the list of default_capabilities returned should not have NET_RAW and SYS_CHROOT in it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Drop default_capabilities list from the crio template
