### PR TITLE
Bug 1866117: pkg/server: reduce calls to ignition parse

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -212,12 +212,6 @@ func ConvertRawExtIgnitionToV3(inRawExtIgn *runtime.RawExtension) (runtime.RawEx
 // ConvertRawExtIgnitionToV2 ensures that the Ignition config in
 // the RawExtension is spec v2.2, or translates to it.
 func ConvertRawExtIgnitionToV2(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
-	_, rptV2, errV2 := ign2.Parse(inRawExtIgn.Raw)
-	if errV2 == nil && !rptV2.IsFatal() {
-		// The rawExt is already on V2.2, no need to translate
-		return *inRawExtIgn, nil
-	}
-
 	ignCfg, rpt, err := ign3.Parse(inRawExtIgn.Raw)
 	if err != nil || rpt.IsFatal() {
 		return runtime.RawExtension{}, errors.Errorf("parsing Ignition config spec v3.1 failed with error: %v\nReport: %v", err, rpt)

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -138,21 +138,11 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-
-	// the internally saved config should be v3.1, but to eliminate the
-	// potential of race conditions, translate to the requested version
-	// to make sure
+	// we know we're at 3.1 in code.. serve directly, parsing is expensive...
+	// we're doing it during an HTTP request, and most notably before we write the HTTP headers
 	var serveConf *runtime.RawExtension
 	if reqConfigVer.Equal(*semver.New("3.1.0")) {
-		converted3, err := ctrlcommon.ConvertRawExtIgnitionToV3(conf)
-		if err != nil {
-			w.Header().Set("Content-Length", "0")
-			w.WriteHeader(http.StatusInternalServerError)
-			glog.Errorf("couldn't convert config for req: %v, error: %v", cr, err)
-			return
-		}
-
-		serveConf = &converted3
+		serveConf = conf
 	} else {
 		// Can only be 2.2 here
 		converted2, err := ctrlcommon.ConvertRawExtIgnitionToV2(conf)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/clarketm/json"
-	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/vincent-petithory/dataurl"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -33,7 +33,7 @@ const (
 type kubeconfigFunc func() (kubeconfigData []byte, rootCAData []byte, err error)
 
 // appenderFunc appends Config.
-type appenderFunc func(*mcfgv1.MachineConfig) error
+type appenderFunc func(*igntypes.Config, *mcfgv1.MachineConfig) error
 
 // Server defines the interface that is implemented by different
 // machine config server implementations.
@@ -44,68 +44,71 @@ type Server interface {
 func getAppenders(currMachineConfig string, f kubeconfigFunc) []appenderFunc {
 	appenders := []appenderFunc{
 		// append machine annotations file.
-		func(mc *mcfgv1.MachineConfig) error { return appendNodeAnnotations(&mc.Spec.Config, currMachineConfig) },
+		func(cfg *igntypes.Config, mc *mcfgv1.MachineConfig) error {
+			return appendNodeAnnotations(cfg, currMachineConfig)
+		},
 		// append kubeconfig.
-		func(mc *mcfgv1.MachineConfig) error { return appendKubeConfig(&mc.Spec.Config, f) },
+		func(cfg *igntypes.Config, mc *mcfgv1.MachineConfig) error { return appendKubeConfig(cfg, f) },
 		// append the machineconfig content
-		//nolint:gocritic
-		func(mc *mcfgv1.MachineConfig) error { return appendInitialMachineConfig(mc) },
+		appendInitialMachineConfig,
+		// This has to come last!!!
+		appendEncapsulated,
 	}
 	return appenders
 }
 
-// machineConfigToRawIgnition converts a MachineConfig object into raw Ignition.
-func machineConfigToRawIgnition(mccfg *mcfgv1.MachineConfig) (*runtime.RawExtension, error) {
-	tmpcfg := mccfg.DeepCopy()
+func appendEncapsulated(conf *igntypes.Config, mc *mcfgv1.MachineConfig) error {
+	// since we're encapsulating the MC, we don't need the whole ignition section, that's why
+	// we do this dance here to empty out the ignition section itself. We're just interested into the MC fields
 	tmpIgnCfg := ctrlcommon.NewIgnConfig()
 	rawTmpIgnCfg, err := json.Marshal(tmpIgnCfg)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling Ignition config: %v", err)
+		return fmt.Errorf("error marshalling Ignition config: %v", err)
 	}
+	tmpcfg := mc.DeepCopy()
 	tmpcfg.Spec.Config.Raw = rawTmpIgnCfg
 	serialized, err := json.Marshal(tmpcfg)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling MachineConfig: %v", err)
+		return fmt.Errorf("error marshalling MachineConfig: %v", err)
 	}
-	err = appendFileToRawIgnition(&mccfg.Spec.Config, daemonconsts.MachineConfigEncapsulatedPath, string(serialized))
+	err = appendFileToIgnition(conf, daemonconsts.MachineConfigEncapsulatedPath, string(serialized))
 	if err != nil {
-		return nil, fmt.Errorf("error appending file to raw Ignition config: %v", err)
+		return fmt.Errorf("error appending file to raw Ignition config: %v", err)
 	}
-	return &mccfg.Spec.Config, nil
+	return nil
 }
 
 // appendInitialMachineConfig saves the full serialized MachineConfig that was served
 // by the MCS when the node first booted.  This currently is only used as a debugging aid
 // in cases where there is unexpected "drift" between the initial bootstrap MC/Ignition and the one
 // computed by the cluster.
-func appendInitialMachineConfig(mc *mcfgv1.MachineConfig) error {
+func appendInitialMachineConfig(conf *igntypes.Config, mc *mcfgv1.MachineConfig) error {
 	mcJSON, err := json.MarshalIndent(mc, "", "    ")
 	if err != nil {
 		return err
 	}
-	appendFileToRawIgnition(&mc.Spec.Config, machineConfigContentPath, string(mcJSON))
+	appendFileToIgnition(conf, machineConfigContentPath, string(mcJSON))
 	return nil
 }
 
-func appendKubeConfig(rawExt *runtime.RawExtension, f kubeconfigFunc) error {
+func appendKubeConfig(conf *igntypes.Config, f kubeconfigFunc) error {
 	kcData, _, err := f()
 	if err != nil {
 		return err
 	}
-	err = appendFileToRawIgnition(rawExt, defaultMachineKubeConfPath, string(kcData))
+	err = appendFileToIgnition(conf, defaultMachineKubeConfPath, string(kcData))
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func appendNodeAnnotations(rawExt *runtime.RawExtension, currConf string) error {
-
+func appendNodeAnnotations(conf *igntypes.Config, currConf string) error {
 	anno, err := getNodeAnnotation(currConf)
 	if err != nil {
 		return err
 	}
-	err = appendFileToRawIgnition(rawExt, daemonconsts.InitialNodeAnnotationsFilePath, anno)
+	err = appendFileToIgnition(conf, daemonconsts.InitialNodeAnnotationsFilePath, anno)
 	if err != nil {
 		return err
 	}
@@ -125,34 +128,26 @@ func getNodeAnnotation(conf string) (string, error) {
 	return string(contents), nil
 }
 
-func appendFileToRawIgnition(rawExt *runtime.RawExtension, outPath, contents string) error {
-	conf, err := ctrlcommon.ParseAndConvertConfig(rawExt.Raw)
-	if err != nil {
-		return fmt.Errorf("failed to append file. Parsing Ignition config failed with error: %v", err)
-	}
+func appendFileToIgnition(conf *igntypes.Config, outPath, contents string) error {
 	fileMode := int(420)
 	overwrite := true
 	source := getEncodedContent(contents)
-	file := ign3types.File{
-		Node: ign3types.Node{
+	file := igntypes.File{
+		Node: igntypes.Node{
 			Path:      outPath,
 			Overwrite: &overwrite,
 		},
-		FileEmbedded1: ign3types.FileEmbedded1{
-			Contents: ign3types.Resource{
+		FileEmbedded1: igntypes.FileEmbedded1{
+			Contents: igntypes.Resource{
 				Source: &source,
 			},
 			Mode: &fileMode,
 		},
 	}
 	if len(conf.Storage.Files) == 0 {
-		conf.Storage.Files = make([]ign3types.File, 0)
+		conf.Storage.Files = make([]igntypes.File, 0)
 	}
 	conf.Storage.Files = append(conf.Storage.Files, file)
-	rawExt.Raw, err = json.Marshal(conf)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
There's no need to parse the whole ignition section from the MC every
time we're about to append a file in the MCS. This leads to a performance
regression when the ignition section contains a lot of files as
discovered in https://bugzilla.redhat.com/show_bug.cgi?id=1866117
compared to pre 4.5.
Also removed some parse call where it's obvious that in code we're
dealing with a particular version and there's no need to test against
something we know it can't be.

Signed-off-by: Antonio Murdaca <runcom@linux.com>
