### PR TITLE
Bug 1874815: pkg/server: reduce calls to ignition parse

### DIFF
--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
+	ign "github.com/coreos/ignition/config/v2_2"
 	yaml "github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,20 +73,23 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch config %s, err: %v", currConf, err)
 	}
+	ignConf, report, err := ign.Parse(mc.Spec.Config.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Ignition config failed with error: %v\nReport: %v", err, report)
+	}
 
 	appenders := getAppenders(currConf, cs.kubeconfigFunc, mc.Spec.OSImageURL)
 	for _, a := range appenders {
-		if err := a(mc); err != nil {
+		if err := a(&ignConf, mc); err != nil {
 			return nil, err
 		}
 	}
 
-	rawIgn, err := machineConfigToRawIgnition(mc)
+	rawConf, err := json.Marshal(ignConf)
 	if err != nil {
-		return nil, fmt.Errorf("server: could not convert MachineConfig to raw Ignition: %v", err)
+		return nil, err
 	}
-
-	return rawIgn, nil
+	return &runtime.RawExtension{Raw: rawConf}, nil
 }
 
 // getClientConfig returns a Kubernetes client Config.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -52,7 +52,7 @@ func TestStringEncode(t *testing.T) {
 	}
 }
 
-func TestMachineConfigToRawIgnition(t *testing.T) {
+func TestEncapsulated(t *testing.T) {
 	mcPath := filepath.Join(testDir, "machine-configs", testConfig+".yaml")
 	mcData, err := ioutil.ReadFile(mcPath)
 	assert.Nil(t, err)
@@ -71,23 +71,14 @@ func TestMachineConfigToRawIgnition(t *testing.T) {
 	if err != nil {
 		t.Errorf("decoding Ignition Config failed: %s", err)
 	}
-	rawIgn, err := machineConfigToRawIgnition(mc)
+	err = appendEncapsulated(&mcIgnCfg, mc)
 	if err != nil {
 		t.Errorf("converting MachineConfig to raw Ignition config failed: %s", err)
 	}
-	ignCfg, _, err := ign.Parse(rawIgn.Raw)
-	if err != nil {
-		t.Errorf("decoding Ignition Config failed: %s", err)
-	}
-	mcIgnCfg, _, err = ign.Parse(mc.Spec.Config.Raw)
-	if err != nil {
-		t.Errorf("decoding Ignition Config failed: %s", err)
-	}
 	assert.Equal(t, 1, len(origIgnCfg.Storage.Files))
 	assert.Equal(t, 2, len(mcIgnCfg.Storage.Files))
-	assert.Equal(t, 2, len(ignCfg.Storage.Files))
-	assert.Equal(t, ignCfg.Storage.Files[0].Path, "/etc/coreos/update.conf")
-	assert.Equal(t, ignCfg.Storage.Files[1].Path, daemonconsts.MachineConfigEncapsulatedPath)
+	assert.Equal(t, mcIgnCfg.Storage.Files[0].Path, "/etc/coreos/update.conf")
+	assert.Equal(t, mcIgnCfg.Storage.Files[1].Path, daemonconsts.MachineConfigEncapsulatedPath)
 }
 
 // TestBootstrapServer tests the behavior of the machine config server
@@ -120,13 +111,17 @@ func TestBootstrapServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while unmarshaling machine-config: %s, err: %v", mcPath, err)
 	}
+	mcIgnCfg, _, err := ign.Parse(mc.Spec.Config.Raw)
+	if err != nil {
+		t.Errorf("decoding Ignition Config failed: %s", err)
+	}
 
 	// add new files, units in the expected Ignition.
 	kc, _, err := getKubeConfigContent(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = appendFileToRawIgnition(&mc.Spec.Config, defaultMachineKubeConfPath, string(kc))
+	err = appendFileToIgnition(&mcIgnCfg, defaultMachineKubeConfPath, string(kc))
 	if err != nil {
 		t.Fatalf("unexpected error while appending file to ignition: %v", err)
 	}
@@ -134,7 +129,7 @@ func TestBootstrapServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating annotations err: %v", err)
 	}
-	err = appendFileToRawIgnition(&mc.Spec.Config, daemonconsts.InitialNodeAnnotationsFilePath, anno)
+	err = appendFileToIgnition(&mcIgnCfg, daemonconsts.InitialNodeAnnotationsFilePath, anno)
 	if err != nil {
 		t.Fatalf("unexpected error while appending file to ignition: %v", err)
 	}
@@ -226,12 +221,16 @@ func TestClusterServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while unmarshaling machine-config: %s, err: %v", mcPath, err)
 	}
+	mcIgnCfg, _, err := ign.Parse(mc.Spec.Config.Raw)
+	if err != nil {
+		t.Errorf("decoding Ignition Config failed: %s", err)
+	}
 
 	kc, _, err := getKubeConfigContent(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = appendFileToRawIgnition(&mc.Spec.Config, defaultMachineKubeConfPath, string(kc))
+	err = appendFileToIgnition(&mcIgnCfg, defaultMachineKubeConfPath, string(kc))
 	if err != nil {
 		t.Fatalf("unexpected error while appending file to ignition: %v", err)
 	}
@@ -239,7 +238,7 @@ func TestClusterServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating annotations err: %v", err)
 	}
-	err = appendFileToRawIgnition(&mc.Spec.Config, daemonconsts.InitialNodeAnnotationsFilePath, anno)
+	err = appendFileToIgnition(&mcIgnCfg, daemonconsts.InitialNodeAnnotationsFilePath, anno)
 	if err != nil {
 		t.Fatalf("unexpected error while appending file to ignition: %v", err)
 	}


### PR DESCRIPTION
There's no need to parse the whole ignition section from the MC every
time we're about to append a file in the MCS. This leads to a performance
regression when the ignition section contains a lot of files as
discovered in https://bugzilla.redhat.com/show_bug.cgi?id=1866117
compared to pre 4.5.

Signed-off-by: Antonio Murdaca <runcom@linux.com>