### PR TITLE
Bug 1870343: machine-config-daemon-pull: Retry pulling image

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -16,7 +16,7 @@ contents: |
   RemainAfterExit=yes
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
-  ExecStart=/bin/sh -c "/usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.gcpRoutesControllerKey }}'"
+  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.gcpRoutesControllerKey }}'; do sleep 1; done"
   ExecStart=/bin/sh -c "/usr/bin/podman run --rm --quiet --net=host --entrypoint=cat '{{ .Images.gcpRoutesControllerKey }}' /usr/bin/machine-config-daemon > /run/bin/machine-config-daemon.tmp"
   ExecStart=/bin/sh -c '/usr/bin/chmod a+x /run/bin/machine-config-daemon.tmp && mv /run/bin/machine-config-daemon.tmp /run/bin/machine-config-daemon'
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1870343

Pulling the image can flake, we need to retry.  Today the
bootstrap node will retry indefinitely, see
https://github.com/openshift/installer/blob/18e286bfc0120142a480f6239191e90c6bf69d4f/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template

Let's do the same.  It's not elegant but eh.
