### PR TITLE
Bug 1861404: sync Infra in ControllerConfigSpec

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -78,6 +78,11 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
 	setBytesIfSet(modified, &existing.CloudProviderCAData, required.CloudProviderCAData)
 
+	if required.Infra != nil && !equality.Semantic.DeepEqual(existing.Infra, required.Infra) {
+		*modified = true
+		existing.Infra = required.Infra
+	}
+
 	if existing.Infra.Status.PlatformStatus != nil && required.Infra.Status.PlatformStatus != nil {
 		if !equality.Semantic.DeepEqual(existing.Infra.Status.PlatformStatus.Type, required.Infra.Status.PlatformStatus.Type) {
 			*modified = true


### PR DESCRIPTION
Born in 4.1 clusters have Platform and EtcdDiscoveryDomain in their ControllerConfigSpec both deprecated: Platform(Infra.Status.PlatformStatus.Type) and EtcdDiscovery(Infra.Status.EtcdDiscoveryDomain)

As such on upgrade to 4.6 the upgrade was failing as Infra was empty.

This PR syncs Infra in the ControllerConfigSpec to allow the 4.1 clusters to update and upgrade successfully.