### PR TITLE
Bug 1875388: Have ovs-configuration.service run before node-valid-hostname

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -8,8 +8,8 @@ contents: |
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service openvswitch.service node-valid-hostname.service
-  Before=network-online.target kubelet.service crio.service
+  After=NetworkManager-wait-online.service openvswitch.service
+  Before=network-online.target kubelet.service crio.service node-valid-hostname.service
 
   [Service]
   # Need oneshot to delay kubelet


### PR DESCRIPTION
In ipv6 deployments on baremetal we're seeing the following sequence
when deploying nodes:

* node-valid-hostname runs
* node gets a hostname, so node-valid-hostname succeeds
* ovs-configuration runs
* it unconfigures the physical interface so it can be added to the
  bridge. When this happens, NetworkManager removes the hostname that
  was set using the DHCP address on that interface, which puts us
  back at localhost.localdomain
* kubelet starts, sees localhost.localdomain and madness ensues
* the node gets its hostname back using the address now on br-ex

This means all nodes try to register as localhost.localdomain, which
obviously does not work. This change switches the ordering of
ovs-configuration and node-valid-hostname so that ovs-configuration
has to run before node-valid-hostname starts. This means that the
whole "hostname,no hostname,hostname again" dance is done before
node-valid-hostname ever starts, and so the hostname should be
stable from that point on. Since ovs-configuration is not dependent
on the hostname, there shouldn't be any need for it to follow
node-valid-hostname.
