### PR TITLE
Bug 1877448: pkg/daemon/update: allow installing os-extensions on FCOS

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -302,29 +302,10 @@ func InSlice(elem string, slice []string) bool {
 	return false
 }
 
-func validateExtensions(exts []string) error {
-	supportedExtensions := []string{"usbguard", "kernel-devel"}
-	invalidExts := []string{}
-	for _, ext := range exts {
-		if !InSlice(ext, supportedExtensions) {
-			invalidExts = append(invalidExts, ext)
-		}
-	}
-	if len(invalidExts) != 0 {
-		return fmt.Errorf("invalid extensions found: %v", invalidExts)
-	}
-	return nil
-
-}
-
 // ValidateMachineConfig validates that given MachineConfig Spec is valid.
 func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
 	if !(cfg.KernelType == "" || cfg.KernelType == KernelTypeDefault || cfg.KernelType == KernelTypeRealtime) {
 		return errors.Errorf("kernelType=%s is invalid", cfg.KernelType)
-	}
-
-	if err := validateExtensions(cfg.Extensions); err != nil {
-		return err
 	}
 
 	if cfg.Config.Raw != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -338,7 +338,7 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 		// Delete extracted OS image once we are done.
 		defer os.RemoveAll(osImageContentDir)
 
-		if dn.OperatingSystem == MachineConfigDaemonOSRHCOS {
+		if dn.OperatingSystem == MachineConfigDaemonOSRHCOS || dn.OperatingSystem == MachineConfigDaemonOSFCOS {
 			if err := addExtensionsRepo(osImageContentDir); err != nil {
 				return err
 			}
@@ -880,9 +880,9 @@ func (dn *Daemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConfig) er
 		(reflect.DeepEqual(oldConfig.Spec.Extensions, newConfig.Spec.Extensions) && oldConfig.Spec.OSImageURL == newConfig.Spec.OSImageURL) {
 		return nil
 	}
-	// Right now, we support extensions only on RHCOS nodes
-	if dn.OperatingSystem != MachineConfigDaemonOSRHCOS {
-		return fmt.Errorf("extensions is not supported on non-RHCOS nodes ")
+	// Right now, we support extensions only on CoreOS nodes
+	if dn.OperatingSystem != MachineConfigDaemonOSRHCOS && dn.OperatingSystem != MachineConfigDaemonOSFCOS {
+		return fmt.Errorf("extensions is not supported on non-CoreOS nodes ")
 	}
 
 	args := generateExtensionsArgs(oldConfig, newConfig)


### PR DESCRIPTION
Support installing OS Extensions on FCOS nodes too.

TODO:
* [x] Rework `validateExtensions` to allow any extensions on FCOS

/cc @LorbusChris @sinnykumari 