### PR TITLE
Bug 1868158: machine-config-daemon-pull: Use the MCO image

### DIFF
--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -1,6 +1,9 @@
 package template
 
 const (
+	// MachineConfigOperatorKey is our own image used by e.g. machine-config-daemon-pull.service
+	MachineConfigOperatorKey string = "machineConfigOperator"
+
 	// GCPRoutesControllerKey is the key that references the gcp-routes-controller image in the controller
 	GCPRoutesControllerKey string = "gcpRoutesControllerKey"
 

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -132,6 +132,8 @@ func RenderBootstrap(
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
+		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,
+
 		templatectrl.GCPRoutesControllerKey: imgs.MachineConfigOperator,
 		templatectrl.InfraImageKey:          imgs.InfraImage,
 		templatectrl.KeepalivedKey:          imgs.Keepalived,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -268,6 +268,8 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	spec.PullSecret = &corev1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.Images = map[string]string{
+		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,
+
 		templatectrl.GCPRoutesControllerKey: imgs.MachineConfigOperator,
 		templatectrl.InfraImageKey:          imgs.InfraImage,
 		templatectrl.KeepalivedKey:          imgs.Keepalived,

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -16,8 +16,8 @@ contents: |
   RemainAfterExit=yes
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
-  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.gcpRoutesControllerKey }}'; do sleep 1; done"
-  ExecStart=/bin/sh -c "/usr/bin/podman run --rm --quiet --net=host --entrypoint=cat '{{ .Images.gcpRoutesControllerKey }}' /usr/bin/machine-config-daemon > /run/bin/machine-config-daemon.tmp"
+  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
+  ExecStart=/bin/sh -c "/usr/bin/podman run --rm --quiet --net=host --entrypoint=cat '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon > /run/bin/machine-config-daemon.tmp"
   ExecStart=/bin/sh -c '/usr/bin/chmod a+x /run/bin/machine-config-daemon.tmp && mv /run/bin/machine-config-daemon.tmp /run/bin/machine-config-daemon'
 
   {{if .Proxy -}}


### PR DESCRIPTION
Splitting this out from https://github.com/openshift/machine-config-operator/pull/2011 so we can test/review it independently.

I *think* this will work although I find the split between `RenderConfigImages` and `ControllerConfigImages` confusing because it certainly looks like we will use both of them when rendering both `manifests/` and `templates/`.
