### PR TITLE
Bug 1876216: Check if /etc/resolv.conf is present before overriding

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -36,7 +36,11 @@ contents:
                 done
             fi
     EOF
-        cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        # Ensure resolv.conf exists before we try to run podman
+        if [[ ! -e /etc/resolv.conf ]]; then
+            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        fi
+
 
         NAMESERVER_IP=$(/usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \

--- a/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -24,7 +24,9 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
 
         # Ensure resolv.conf exists before we try to run podman
-        cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        if [[ ! -e /etc/resolv.conf ]]; then
+            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        fi
 
         NAMESERVER_IP=$(/usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \

--- a/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -25,7 +25,9 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
 
         # Ensure resolv.conf exists before we try to run podman
-        cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        if [[ ! -e /etc/resolv.conf ]]; then
+            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        fi
 
         NAMESERVER_IP=$(/usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \

--- a/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -31,7 +31,9 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
 
         # Ensure resolv.conf exists before we try to run podman
-        cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        if [[ ! -e /etc/resolv.conf ]]; then
+            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+        fi
 
         NAMESERVER_IP=$(/usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \


### PR DESCRIPTION
We copy /var/run/NetworkManager/resolv.conf to /etc/resolv.conf for the case that /etc/resolv.conf is not present, but if it is present we override it.
On oVirt this causes the api-int to not be resolvable for a short period of time, causing failures and events.
This PR adds a check to override cp only if it is not present.

Notice that at the end of this script we replace it with a new file anyway but that is ok.

** Sent this fix to all the platforms that have similar logic to be consistent

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added a check to see if /etc/resolv.conf exist before overriding it

**- Description for the changelog**

Check if /etc/resolv.conf is present before overriding at the beginning of NetworkManager-resolv-prepender
