### PR TITLE
Bug 1820305: remove disable checksum workaround for workers

### DIFF
--- a/templates/worker/00-worker/ovirt/files/ovirt-disable-tx-checksum-offload.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-disable-tx-checksum-offload.yaml
@@ -1,9 +1,0 @@
-mode: 0744
-path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-tx-checksum-offload.sh"
-contents:
-  inline: |
-    #!/bin/bash
-    # This is a workaround for BZ#1794714
-    if [[ ! -e /var/lib/cni/bin/ovn-k8s-cni-overlay ]]; then
-      nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-checksum-ip-generic off;
-    fi


### PR DESCRIPTION
This PR removes the disable checksum workaround that was created due to https://bugzilla.redhat.com/show_bug.cgi?id=1794714

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>