### PR TITLE
Bug 1865839: daemon/update: print error causing rollback

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -357,7 +357,8 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 		// In case of an error during any rpm-ostree transaction, removing pending deployment
 		// should be sufficient to discard any applied changes.
 		if retErr != nil {
-			glog.Infof("Rolling back applied changes to OS")
+			// Print out the error now so that if we fail to cleanup -p, we don't lose it.
+			glog.Infof("Rolling back applied changes to OS due to error: %v", retErr)
 			if err := removePendingDeployment(); err != nil {
 				retErr = errors.Wrapf(retErr, "error removing staged deployment: %v", err)
 				return


### PR DESCRIPTION
Right now, we `cleanup -p` if we hit an error. But if we hit another
error during the cleanup, we lose what the original error was. Let's log
it to help debugging.

Related: rhbz#1865839