### PR TITLE
Bug 1865839: daemon: Set RPMOSTREE_CLIENT_ID again

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -107,6 +107,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
+	// See https://github.com/coreos/rpm-ostree/pull/1880
+	os.Setenv("RPMOSTREE_CLIENT_ID", "machine-config-operator")
+
 	onceFromMode := startOpts.onceFrom != ""
 	if !onceFromMode {
 		// in the daemon case


### PR DESCRIPTION
This way we know in the systemd journal that it's the MCO making
changes, as distinct from any other process running `rpm-ostree`
as a binary.

I added this in 1e08e0c02a692d7749651636e23d6f56c0191be9
but then it was removed in a99a12315e422bc46cf95d3b9dcceeb87bd1f69e

Came up as part of https://bugzilla.redhat.com/show_bug.cgi?id=1865839
so we can more easily identify which other project is calling rpm-ostree.
