### PR TITLE
Bug 1874399: Pull the image using authfile before creating the container layer

### DIFF
--- a/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
+++ b/templates/master/00-master/_base/files/usr-local-bin-openshift-recovery-tools-sh.yaml
@@ -21,6 +21,7 @@ contents:
     # extract etcdctl binary from container image
     dl_etcdctl() {
       local etcdimg="{{.Images.etcdKey}}"
+      podman image pull "${etcdimg}" --authfile=/var/lib/kubelet/config.json
       local etcdctr=$(podman create "${etcdimg}" --authfile=/var/lib/kubelet/config.json)
       local etcdmnt=$(podman mount "${etcdctr}")
       cp ${etcdmnt}/bin/etcdctl $ASSET_DIR/bin/


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: #1874399 
**- What I did**
Added `podman image pull` prior to `podman create` command.

**- How to verify it**
Install a new machine and try to add it to the etcd cluster using etcd-recover.sh shell script.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
For a new machine, the images are not already pulled, and therefore need an explicit `image pull` command before attempting to create a container using that image. 
