### PR TITLE
[WIP] Bug 1875005: On-Prem: No longer check for apiserver in keepalived

### DIFF
--- a/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-keepalived.yaml
@@ -8,7 +8,7 @@ contents:
     }
 
     vrrp_script chk_ocp {
-        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:50936/readyz"
         interval 1
         weight 50
     }

--- a/templates/master/00-master/openstack/files/openstack-keepalived-script.yaml
+++ b/templates/master/00-master/openstack/files/openstack-keepalived-script.yaml
@@ -1,6 +1,0 @@
-mode: 0755
-path: "/etc/keepalived/chk_ocp_script.sh"
-contents:
-  inline: |
-    #!/bin/bash 
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:6443/readyz && /usr/bin/curl -o /dev/null -kLfs http://localhost:50936/readyz


### PR DESCRIPTION
There is no good reason for keepalived to query the kube-apiserver for
its liveliness since all requests are proxied by haproxy anyway that
balances the requests among backends in a roundrobin fashion. Keepalived
should only care about the status of the local HAProxy instance, and
HAProxy should be the one to care about the backend status.

Having keepalived check for API status causes frequent failovers and
connection drops when the API is a bit busy.