### PR TITLE
[baremetal and friends] Drop unnecessary readiness probes

### DIFF
--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -63,16 +63,6 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
-    readinessProbe:
-      httpGet:
-        path: /health
-        port: 18080
-        scheme: HTTP
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 3
-      timeoutSeconds: 10
     livenessProbe:
       httpGet:
         path: /health

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -136,16 +136,6 @@ spec:
       mountPath: "/var/run/keepalived"
     - name: manifests
       mountPath: "/opt/openshift/manifests"
-    readinessProbe:
-      httpGet:
-        path: /readyz
-        port: 6443
-        scheme: HTTPS
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 3
-      timeoutSeconds: 10
     imagePullPolicy: IfNotPresent
   hostNetwork: true
   tolerations:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1704,16 +1704,6 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
-    readinessProbe:
-      httpGet:
-        path: /health
-        port: 18080
-        scheme: HTTP
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 3
-      timeoutSeconds: 10
     livenessProbe:
       httpGet:
         path: /health
@@ -1930,16 +1920,6 @@ spec:
       mountPath: "/var/run/keepalived"
     - name: manifests
       mountPath: "/opt/openshift/manifests"
-    readinessProbe:
-      httpGet:
-        path: /readyz
-        port: 6443
-        scheme: HTTPS
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 3
-      timeoutSeconds: 10
     imagePullPolicy: IfNotPresent
   hostNetwork: true
   tolerations:

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -63,16 +63,6 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 18080
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /health

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -151,16 +151,6 @@ contents:
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 6443
-            scheme: HTTPS
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:


### PR DESCRIPTION
Now that we are using the loadbalanced endpoint for keepalived
healthchecks, it is not correct to be using the local apiserver for
readiness checks. Also, I don't think there's any need for readiness
checks on the monitor. Kubernetes isn't routing any traffic to this
pod, so its ready status is meaningless.
