### PR TITLE
Bug 1823950: Reverse haproxy and keepalived check timings

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-haproxy.yaml
@@ -35,5 +35,5 @@ contents:
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}
-       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
+       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 1s fall 2 rise 3
     {{- end }}`}}

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -17,16 +17,16 @@ contents:
     # api to take the VIP. This isn't preferred because it means all api
     # traffic will go through one node, but at least it keeps the api available.
     vrrp_script chk_ocp_lb {
-        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script.sh"
-        interval 1
+        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script.sh"
+        interval 2
         weight 20
         rise 3
         fall 2
     }
 
     vrrp_script chk_ocp_both {
-        script "/usr/bin/timeout 0.9 /etc/keepalived/chk_ocp_script_both.sh"
-        interval 1
+        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script_both.sh"
+        interval 2
         # Use a smaller weight for this check so it won't trigger the move from
         # bootstrap to master by itself.
         weight 5


### PR DESCRIPTION
Since we moved to keepalived healthchecking against haproxy, we want
haproxy to handle most failures so the VIP doesn't have to move.
However, previously the time it took for haproxy to recognize an
outage on a node was longer than it was for keepalived, which resulted
in the VIP moving before haproxy removed the failing backend.

This change makes the haproxy interval 1 second, so it should notice
outages in 2 seconds or less (because it has a fall value of 2).
The keepalived interval is changed to 2, which means it will detect
failures in 2 to 4 seconds (also a fall value of 2). This means
haproxy should deal with api outages before keepalived does and
allow the VIP to stay on the same node.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
