### PR TITLE
Bug 1849543: Use mc name as finalizer for kubelet config

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/clarketm/json"
@@ -574,17 +575,24 @@ func (ctrl *Controller) addFinalizerToKubeletConfig(kc *mcfgv1.KubeletConfig, mc
 			return err
 		}
 
-		uid := string(mc.ObjectMeta.GetUID())
-
-		// if the finalizer is already set then skip
+		kcTmp := newcfg.DeepCopy()
+		// We want to use the mc name as the finalizer instead of the uid because
+		// every time a resync happens, a new uid is generated. This is why the list
+		// of finalizers had multiple entries. So check if the list of finalizers consists
+		// of uids, if it does then clear the list of finalizers and we will add the mc
+		// name to it, ensuring we don't have duplicate or multiple finalizers.
 		for _, finalizerName := range newcfg.Finalizers {
-			if finalizerName == mc.Name || finalizerName == uid {
-				return nil
+			if !strings.Contains(finalizerName, "kubelet") {
+				kcTmp.ObjectMeta.SetFinalizers([]string{})
 			}
 		}
-
-		kcTmp := newcfg.DeepCopy()
-		kcTmp.ObjectMeta.Finalizers = append(kcTmp.ObjectMeta.Finalizers, uid)
+		// Only append the mc name if it is not already in the list of finalizers.
+		// When we update an existing kubeletconfig, the generation number increases causing
+		// a resync to happen. When this happens, the mc name is the same, so we don't
+		// want to add duplicate entries to the list of finalizers.
+		if !ctrlcommon.InSlice(mc.Name, kcTmp.ObjectMeta.Finalizers) {
+			kcTmp.ObjectMeta.Finalizers = append(kcTmp.ObjectMeta.Finalizers, mc.Name)
+		}
 
 		modJSON, err := json.Marshal(kcTmp)
 		if err != nil {


### PR DESCRIPTION
Fixes #1849543 (https://bugzilla.redhat.com/show_bug.cgi?id=1849543) 

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The uid was being used as the entry for the finalizer list
but everytime an update happens it generates a new uid, which
is why we were ending up with multiple uids in the finalizers
list. So use the mc name for the list of finalizer instead as
the mc name stays the same for each kubelet config.


**- How to verify it**
1) Start a cluster with this patch and create a kubeletconfig CR. The description of the CR should not have duplicate entries in the list of finalizers.
2) Start a cluster without this patch and create a kubeletconfig CR - there will be multiple entries in the list of finalizers. Upgrade the cluster to a version with this patch, the list of finalizers should only have entries for the pools that the CR is applied to and no duplicates.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use MC name for the list of finalizers to avoid duplicate and multiple entries for the same MCP
