### PR TITLE
bug 1878129: add node collection for oc adm inspect

### DIFF
--- a/install/0000_80_machine-config-operator_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config-operator_06_clusteroperator.yaml
@@ -23,3 +23,5 @@ status:
       resource: kubeletconfigs
     - group: machineconfiguration.openshift.io
       resource: containerruntimeconfigs
+    - group: ""
+      resource: nodes

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -70,6 +70,8 @@ func (optr *Operator) syncRelatedObjects() error {
 		{Group: "machineconfiguration.openshift.io", Resource: "kubeletconfigs"},
 		{Group: "machineconfiguration.openshift.io", Resource: "containerruntimeconfigs"},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigs"},
+		// gathered because the machineconfigs created container bootstrap credentials and node configuration that gets reflected via the API and is needed for debugging
+		{Group: "", Resource: "nodes"},
 	}
 
 	if !equality.Semantic.DeepEqual(coCopy.Status.RelatedObjects, co.Status.RelatedObjects) {


### PR DESCRIPTION
MCO holds kubelet config, which leads to node creation.  This adds node collection for related resources because the MCO configuration has a direct impact on the node resources.