### PR TITLE
[DO NOT MERGE] Running tests with the NET_RAW and SYS_CHROOT capabilities dropped

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -15,19 +15,6 @@ contents:
     ]
     log_level = "info"
     cgroup_manager = "systemd"
-    default_capabilities = [
-        "CHOWN",
-        "DAC_OVERRIDE",
-        "FSETID",
-        "FOWNER",
-        "NET_RAW",
-        "SETGID",
-        "SETUID",
-        "SETPCAP",
-        "NET_BIND_SERVICE",
-        "SYS_CHROOT",
-        "KILL",
-    ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
     ]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -15,19 +15,6 @@ contents:
     ]
     log_level = "info"
     cgroup_manager = "systemd"
-    default_capabilities = [
-        "CHOWN",
-        "DAC_OVERRIDE",
-        "FSETID",
-        "FOWNER",
-        "NET_RAW",
-        "SETGID",
-        "SETUID",
-        "SETPCAP",
-        "NET_BIND_SERVICE",
-        "SYS_CHROOT",
-        "KILL",
-    ]
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
     ]


### PR DESCRIPTION
Want to ensure that the core OpenShift components are working fine
without those 2 capabilities.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
