### PR TITLE
Bug 1872885: always check hostname char count

### DIFF
--- a/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
+++ b/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
@@ -15,7 +15,8 @@ contents:
         exit 0
     fi
 
-    if [[ ! "$(< /proc/sys/kernel/hostname)" =~ (localhost|localhost.localdomain) ]]; then
+    kn="$(< /proc/sys/kernel/hostname)"
+    if [[ ! "${kn}" =~ (localhost|localhost.localdomain) ]] && [ "${#kn}" -le 63 ]; then
         log "hostname is already set"
         exit 0
     fi
@@ -29,4 +30,3 @@ contents:
     if [ -n "${host_name}" ]; then
         set_valid_hostname "${host_name}"
     fi
-


### PR DESCRIPTION
hostnamectl previously refused to assign a long hostname. Since
hostnamectl now allows for longer hostnames, we need to alway check if
the hostname is too long.

Fixes BZ #1872885

