### PR TITLE
templates: Disable SSH keys lookup from authorized_keys.d on FCOS

### DIFF
--- a/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
+++ b/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
@@ -1,0 +1,6 @@
+mode: 0644
+path: "/etc/ssh/sshd_config.d/10-disable-ssh-key-dir.conf"
+contents:
+  inline: |
+    # disable key lookup from ~/.ssh/authorized_keys.d/ on FCOS
+    AuthorizedKeysCommand none


### PR DESCRIPTION
**- What I did**
On FCOS, this sshd config dropin ensures that only SSH keys from the
`/home/core/.ssh/authorized_keys` file are picked up, and not ones
present in the `/home/core/.ssh/authorized_keys.d/` directory,
which might be written by Ignition and/or Afterburn.

On RHCOS this is a no-op, as it already looks up SSH keys from the
authorized_keys file only.

**- How to verify it**
CI e2e testing

**- Description for the changelog**
templates: Disable SSH keys lookup from authorized_keys.d on FCOS

/hold
for testing
