### PR TITLE
Bug 1872632: allow overriding kubelet --node-ip in the _base templates

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -25,7 +25,9 @@ contents: |
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
 {{- if .KubeletIPv6}}
-        --node-ip :: \
+        --node-ip=${KUBELET_NODE_IP:-::} \
+{{- else}}
+        --node-ip=${KUBELET_NODE_IP:-} \
 {{- end}}
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -25,7 +25,9 @@ contents: |
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
 {{- if .KubeletIPv6}}
-        --node-ip :: \
+        --node-ip=${KUBELET_NODE_IP:-::} \
+{{- else}}
+        --node-ip=${KUBELET_NODE_IP:-} \
 {{- end}}
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \


### PR DESCRIPTION
This is not a complete fix for bug 1872632. However, regardless of the approach taken there, it seems like there needs to be some way for platform-none UPI users to override an incorrect guess by kubelet regarding the node IP. Currently we allowing overriding it (based on `nodeip-configuration.service`) in bare metal IPI, openstack, and vsphere, but not anywhere else.

This just patches the _base kubelet service files so that if `KUBELET_NODE_IP` has been set, somewhere, we pass it to kubelet. It does not actually provide any simple way to set it yet. (`nodeip-configuration.service` won't work on UPI because it requires there to be an apiserver VIP.)

The idea of making `--node-ip` configurable was somewhat rejected in #944 although in that case it was clear that the user only needed it to work around a bug somewhere else (which may or may not also be true for bz 1872632, but it's certainly the case that in _some_ platform-none UPI installs, kubelet will not be able to correctly guess the node IP). But we could add `{{ if eq .Infra.Status.PlatformStatus.Type "None" }}` around the new code if we wanted to not allow overriding `--node-ip` on cloud platforms...

(I believe I'm correctly differentiating "bare metal platform" / "no platform" / IPI / UPI here but I may have gotten some of the details wrong)

cc @kikisdeliveryservice 