### PR TITLE
Bug 1884165: firstboot.service: disable existing repos before pivot

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -14,6 +14,8 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
+  # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
+  ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
 
   {{if .Proxy -}}


### PR DESCRIPTION
On FCOS boot OS extensions are being installed, so in order to use
only shipped RPMs and avoid pulling in updates from public repos existing
repos need to be removed.

TODO:
* [x] Disable repos instead of removing

Keeping this on hold until updated OKD machine-os-content is promoted
