### PR TITLE
Bug 1879156: Check that resolv.conf actually has nameservers

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -25,7 +25,6 @@ contents:
         up|dhcp4-change|dhcp6-change)
         >&2 echo "NM resolv-prepender triggered by ${1} ${2}."
 
-        # Ensure resolv.conf exists before we try to run podman
         # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
         timeout 45s /bin/bash <<EOF
             if [[ "$STATUS" == dhcp* ]]; then
@@ -36,8 +35,8 @@ contents:
                 done
             fi
     EOF
-        # Ensure resolv.conf exists before we try to run podman
-        if [[ ! -e /etc/resolv.conf ]]; then
+        # Ensure resolv.conf exists and contains nameservers before we try to run podman
+        if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
 

--- a/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -24,7 +24,7 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
 
         # Ensure resolv.conf exists before we try to run podman
-        if [[ ! -e /etc/resolv.conf ]]; then
+        if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
 

--- a/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -25,7 +25,7 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
 
         # Ensure resolv.conf exists before we try to run podman
-        if [[ ! -e /etc/resolv.conf ]]; then
+        if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
 

--- a/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -31,7 +31,7 @@ contents:
         logger -s "NM resolv-prepender triggered by ${1} ${2}."
 
         # Ensure resolv.conf exists before we try to run podman
-        if [[ ! -e /etc/resolv.conf ]]; then
+        if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
 


### PR DESCRIPTION
If /etc/resolv.conf existed but didn't have nameservers, the prepender
wouldn't copy the resolv.conf.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Check that either resolv.conf does not exist OR does not contain nameservers
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
