### PR TITLE
Bug 1865839: daemon: better error reporting for rpm-ostree operations

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -260,8 +260,7 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 func runGetOut(command string, args ...string) ([]byte, error) {
 	glog.Infof("Running captured: %s %s", command, strings.Join(args, " "))
 	cmd := exec.Command(command, args...)
-	cmd.Stderr = os.Stderr
-	rawOut, err := cmd.Output()
+	rawOut, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error running %s %s: %s", command, strings.Join(args, " "), string(rawOut))
 	}


### PR DESCRIPTION
When an error occurs during rpm-ostree operation, we get
returned error as exit status 1 which is not much useful.
Actual failure gets printed on the stdout which we capture
in runGetOut() function.