### PR TITLE
Bug 1872632: templates: fix --node-ip override

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -11,6 +11,9 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   Environment="KUBELET_LOG_LEVEL=4"
+{{- if .KubeletIPv6}}
+  Environment="KUBELET_NODE_IP=::"
+{{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -24,11 +27,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
-{{- if .KubeletIPv6}}
-        --node-ip=${KUBELET_NODE_IP:-::} \
-{{- else}}
-        --node-ip=${KUBELET_NODE_IP:-} \
-{{- end}}
+        --node-ip=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -11,6 +11,9 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   Environment="KUBELET_LOG_LEVEL=4"
+{{- if .KubeletIPv6}}
+  Environment="KUBELET_NODE_IP=::"
+{{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
@@ -24,11 +27,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
-{{- if .KubeletIPv6}}
-        --node-ip=${KUBELET_NODE_IP:-::} \
-{{- else}}
-        --node-ip=${KUBELET_NODE_IP:-} \
-{{- end}}
+        --node-ip=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \


### PR DESCRIPTION
#2088 was broken because I tried to use shell syntax in a systemd unit file where shell syntax isn't parsed _and_ I forgot that kubelet will just treat a bogus `--node-ip` value (eg, passing literally `--node-ip='${KUBELET_NODE_IP:-}'`) the same as not passing any value so my assumption that it would break CI if it was wrong failed.