### PR TITLE
Bug 1880603: controller/helpers.go: de-duplicate ign spec 2 passwdUsers

### DIFF
--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -350,7 +350,8 @@ func TestRemoveIgnDuplicateFilesAndUnits(t *testing.T) {
 	unitThree.Dropins = append(unitThree.Dropins, dropinThree)
 	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitThree)
 
-	convertedIgn2Config := removeIgnDuplicateFilesAndUnits(testIgn2Config)
+	convertedIgn2Config, err := removeIgnDuplicateFilesUnitsUsers(testIgn2Config)
+	require.Nil(t, err)
 
 	expectedIgn2Config := ign2types.Config{}
 	expectedIgn2Config.Storage.Files = append(expectedIgn2Config.Storage.Files, fileNew)


### PR DESCRIPTION
In spec 2 MC merging, the passwd user sections are merged into each
other. This means in practice that there will be multiple entries
for a "core" user if you define multiple ssh keys via multiple MCs.
This will fail the translation to spec 3 upon upgrading, so we need
to also de-duplicate this section by merging sshkeys into one "core"
user. Also add explicit check for other users here (since we don't
support them).
