### PR TITLE
[baremetal, openstack, ovirt, vsphere] Change keepalived VIP subnet mask to host mask

### DIFF
--- a/manifests/on-prem/keepalived.conf.tmpl
+++ b/manifests/on-prem/keepalived.conf.tmpl
@@ -24,6 +24,6 @@
         auth_pass {{.Cluster.Name}}_api_vip
     }
     virtual_ipaddress {
-        {{ .Cluster.APIVIP }}/{{ .Cluster.VIPNetmask }}
+        {{ .Cluster.APIVIP }}
     }
 }`}}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1772,7 +1772,7 @@ var _manifestsOnPremKeepalivedConfTmpl = []byte(`# Configuration template for Ke
         auth_pass {{.Cluster.Name}}_api_vip
     }
     virtual_ipaddress {
-        {{ .Cluster.APIVIP }}/{{ .Cluster.VIPNetmask }}
+        {{ .Cluster.APIVIP }}
     }
 }`+"`"+`}}
 `)

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -63,7 +63,7 @@ contents:
             auth_pass {{`{{ .Cluster.Name }}`}}_api_vip
         }
         virtual_ipaddress {
-            {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+            {{`{{ .Cluster.APIVIP }}`}}
         }
         track_script {
             chk_ocp_lb
@@ -90,7 +90,7 @@ contents:
             auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
-            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+            {{`{{ .Cluster.IngressVIP }}`}}
         }
         track_script {
             chk_ingress

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -31,7 +31,7 @@ contents:
             auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
-            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+            {{`{{ .Cluster.IngressVIP }}`}}
         }
         track_script {
             chk_ingress


### PR DESCRIPTION
To work around [1] bug in network manager the subnet mask of Keepalived VIP address was set to the
value of control plane netmask.
So, after the network manager bug was resolved we can safely change VIP subnet mask to a host subnet mask.

Additionally, we noticed that sometimes after moving the control plane IP from the physical interface to
a bridge there were old routes still pointing to the physical interface, and that messed up the node's connectivity.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1700415

