### PR TITLE
Bug 1871769: [baremetal] keep API VIP in the bootstrap node until the bootstrap’s node API goes away

### DIFF
--- a/manifests/baremetal/keepalived.conf.tmpl
+++ b/manifests/baremetal/keepalived.conf.tmpl
@@ -10,7 +10,7 @@
     state BACKUP
     interface {{.VRRPInterface}}
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
-    priority 50
+    priority 70
     advert_int 1
     {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -52,13 +52,23 @@ spec:
             /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
         fi
       }
+      stop_keepalived()
+      {
+        echo "Keepalived process stopped" >> /var/run/keepalived/stopped
+        if pid=$(pgrep -o keepalived); then
+            kill -s TERM "$pid"
+        fi
+      }
+
       msg_handler()
       {
         while read -r line; do
           echo "The client sent: $line" >&2
-          # currently only 'reload' msg is supported
+          # currently only 'reload' and 'stop' msgs are supported
           if [ "$line" = reload ]; then
               reload_keepalived
+          elif  [ "$line" = stop ]; then
+              stop_keepalived
           fi
         done
       }
@@ -66,6 +76,12 @@ spec:
       declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
       export -f msg_handler
       export -f reload_keepalived
+      export -f stop_keepalived
+
+      while [ -s "/var/run/keepalived/stopped" ]; do
+         echo "Container stopped"
+         sleep 60
+      done
       if [ -s "/etc/keepalived/keepalived.conf" ]; then
           /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
       fi
@@ -87,6 +103,7 @@ spec:
         - -c
         - |
           [[ -s /etc/keepalived/keepalived.conf ]] || \
+          [[ -s /var/run/keepalived/stopped ]] || \
           kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
       initialDelaySeconds: 20
     terminationMessagePolicy: FallbackToLogsOnError

--- a/manifests/baremetal/keepalived.yaml
+++ b/manifests/baremetal/keepalived.yaml
@@ -24,14 +24,6 @@ spec:
   - name: run-dir
     empty-dir: {}
   containers:
-  - name: keepalived-unicast
-    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
-    command:
-    - unicastipserver
-    - "--api-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-    - "--ingress-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
   - name: keepalived
     securityContext:
       privileged: true

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -269,7 +269,7 @@ var _manifestsBaremetalKeepalivedConfTmpl = []byte(`# Configuration template for
     state BACKUP
     interface {{.VRRPInterface}}
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
-    priority 50
+    priority 70
     advert_int 1
     {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
@@ -332,14 +332,6 @@ spec:
   - name: run-dir
     empty-dir: {}
   containers:
-  - name: keepalived-unicast
-    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
-    command:
-    - unicastipserver
-    - "--api-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
-    - "--ingress-vip"
-    - "{{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
   - name: keepalived
     securityContext:
       privileged: true

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -360,13 +360,23 @@ spec:
             /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
         fi
       }
+      stop_keepalived()
+      {
+        echo "Keepalived process stopped" >> /var/run/keepalived/stopped
+        if pid=$(pgrep -o keepalived); then
+            kill -s TERM "$pid"
+        fi
+      }
+
       msg_handler()
       {
         while read -r line; do
           echo "The client sent: $line" >&2
-          # currently only 'reload' msg is supported
+          # currently only 'reload' and 'stop' msgs are supported
           if [ "$line" = reload ]; then
               reload_keepalived
+          elif  [ "$line" = stop ]; then
+              stop_keepalived
           fi
         done
       }
@@ -374,6 +384,12 @@ spec:
       declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
       export -f msg_handler
       export -f reload_keepalived
+      export -f stop_keepalived
+
+      while [ -s "/var/run/keepalived/stopped" ]; do
+         echo "Container stopped"
+         sleep 60
+      done
       if [ -s "/etc/keepalived/keepalived.conf" ]; then
           /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
       fi
@@ -395,6 +411,7 @@ spec:
         - -c
         - |
           [[ -s /etc/keepalived/keepalived.conf ]] || \
+          [[ -s /var/run/keepalived/stopped ]] || \
           kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
       initialDelaySeconds: 20
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
    Keeping the API VIP in the bootstrap node until the bootstrap’s node API goes away eliminates
    the need for master nodes to specify the bootstrap as one of their peers in the unicast
    Keepalived case, see [1].
    
    Additionally, it makes the deployment flow more deterministic so other components
    (e.g: remove the requirement for provisioning static IP, see [2] ) can benefit from it.
    
    [1] https://docs.google.com/document/d/1jPIOYuK1J3PKYS8ff8waHWeHqzgl5OZeOkWngUxHtR8/edit?usp=sharing
    [2] https://docs.google.com/document/d/18DVr7Ikw_gSJsiQvG8zV2oBEqlG070MzyIElcK94LJI/edit#
