### PR TITLE
Bug 1881057: ignore the IPv6DualStack feature gate for the kubelet config

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -204,7 +204,11 @@ func (ctrl *Controller) generateFeatureMap(features *osev1.FeatureGate) (*map[st
 		return &rv, fmt.Errorf("enabled FeatureSet %v does not have a corresponding config", features.Spec.FeatureSet)
 	}
 	for _, featEnabled := range set.Enabled {
-		rv[featEnabled] = true
+		if featEnabled == "IPv6DualStack" {
+			glog.Infof("Ignoring IPv6DualStack feature gate for kubelet config")
+		} else {
+			rv[featEnabled] = true
+		}
 	}
 	for _, featDisabled := range set.Disabled {
 		rv[featDisabled] = false

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -72,3 +72,34 @@ func TestFeaturesDefault(t *testing.T) {
 		})
 	}
 }
+
+func createNewDualStackFeatureGate() *configv1.FeatureGate {
+	return &configv1.FeatureGate{
+		Spec: configv1.FeatureGateSpec{
+			FeatureGateSelection: configv1.FeatureGateSelection{
+				FeatureSet: configv1.IPv6DualStackNoUpgrade,
+			},
+		},
+	}
+}
+
+// Hack for 4.6; don't pass the IPv6DualStack feature gate to kubelet
+func TestFeaturesDualStack(t *testing.T) {
+	f := newFixture(t)
+	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.NonePlatformType)
+	f.ccLister = append(f.ccLister, cc)
+
+	ctrl := f.newController()
+	defaultFeatureGates, err := ctrl.generateFeatureMap(createNewDefaultFeatureGate())
+	if err != nil {
+		t.Errorf("could not generate defaultFeatureGates: %v", err)
+	}
+	dualStackFeatureGates, err := ctrl.generateFeatureMap(createNewDualStackFeatureGate())
+	if err != nil {
+		t.Errorf("could not generate dualStackFeatureGates: %v", err)
+	}
+
+	if !reflect.DeepEqual(dualStackFeatureGates, defaultFeatureGates) {
+		t.Errorf("IPv6DualStack FeatureGates do not match Default FeatureGates: (dualStack=[%v], default=[%v]", dualStackFeatureGates, defaultFeatureGates)
+	}
+}


### PR DESCRIPTION
To install a dual-stack cluster you must set the IPv6DualStack feature gate at install time. MCO currently does not process feature gates provided as install-time manifests and so the bootstrap configs will not match the post-install configs and the operator will become Degraded because the masters are stuck unable to move to the expected config.

As it happens, kubelet does not use the IPv6DualStack feature gate unless you are using dockershim, so to work around this problem for now, just ignore that feature gate when generating the kubelet config, so that the "real" generated config will match the config expected by the bootstrap code.

(Not yet tested, but I think this will fix things in 4.6, and then it can be reverted and fixed correctly in 4.7, since kubelet will need the feature gate then.)