### PR TITLE
Bug 1879099: Inject version into controllerconfig, refuse mismatches

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -66,6 +66,7 @@ func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec,
 }
 
 func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfigSpec, required mcfgv1.ControllerConfigSpec) {
+	setStringIfSet(modified, &existing.RendererVersion, required.RendererVersion)
 	setStringIfSet(modified, &existing.ClusterDNSIP, required.ClusterDNSIP)
 	setStringIfSet(modified, &existing.CloudProviderConfig, required.CloudProviderConfig)
 	setStringIfSet(modified, &existing.Platform, required.Platform)

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -441,6 +441,9 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+            rendererVersion:
+              description: operator version
+              type: string
             rootCAData:
               description: rootCAData specifies the root CA data
               type: string

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -31,6 +31,11 @@ type ControllerConfig struct {
 
 // ControllerConfigSpec is the spec for ControllerConfig resource.
 type ControllerConfigSpec struct {
+	// RendererVersion is the operator version that generated this object;
+	// readers (e.g. machine-config-controller) whose version does not
+	// match should ignore this file.
+	RendererVersion string `json:"rendererVersion"`
+
 	// clusterDNSIP is the cluster DNS IP address
 	ClusterDNSIP string `json:"clusterDNSIP"`
 

--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -3,6 +3,7 @@ kind: ControllerConfig
 metadata:
   name: machine-config-controller
 spec:
+  rendererVersion: "v0.0.0-was-not-built-properly"
   additionalTrustBundle: null
   cloudProviderConfig: ""
   clusterDNSIP: 172.30.0.10

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -529,6 +529,12 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 
 // generateRenderedMachineConfig takes all MCs for a given pool and returns a single rendered MC. For ex master-XXXX or worker-XXXX
 func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig) (*mcfgv1.MachineConfig, error) {
+	// Suppress rendered config generation until a corresponding new controller can roll out too.
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1879099
+	if cconfig.Spec.RendererVersion != version.Raw {
+		return nil, fmt.Errorf("Ignoring controller config generated from %s (my version: %s)", cconfig.Spec.RendererVersion, version.Raw)
+	}
+
 	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid
 	for _, config := range configs {
 		if err := ctrlcommon.ValidateMachineConfig(config.Spec); err != nil {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -609,6 +609,9 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+            rendererVersion:
+              description: operator version
+              type: string
             rootCAData:
               description: rootCAData specifies the root CA data
               type: string

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	templatectrl "github.com/openshift/machine-config-operator/pkg/controller/template"
+	"github.com/openshift/machine-config-operator/pkg/version"
 )
 
 type manifest struct {
@@ -99,6 +100,8 @@ func RenderBootstrap(
 	if err != nil {
 		return err
 	}
+
+	spec.RendererVersion = version.Raw
 
 	additionalTrustBundleData, err := ioutil.ReadFile(additionalTrustBundleFile)
 	if err != nil && !os.IsNotExist(err) {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -220,6 +220,12 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		return err
 	}
 
+	// Propagate our binary version into the controller config to help
+	// suppress rendered config generation until a corresponding
+	// new controller can roll out too.
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1879099
+	spec.RendererVersion = version.Raw
+
 	var trustBundle []byte
 	certPool := x509.NewCertPool()
 	// this is the generic trusted bundle for things like self-signed registries.


### PR DESCRIPTION
Should fix: https://bugzilla.redhat.com/show_bug.cgi?id=1879099

Basically we only want to roll out new machineconfigs if
the controllerconfig (generated by the operator) and the
controller are at matching versions.

Per Jerry's comment in Bugzilla:

> 1. The new MCO rolls out. It first syncs the controllerconfig to the new one as part of the RenderConfig step above.
> 2. The running (old) MCC's template controller has an informer on the controllerconfig, which since the previous step updated the config, calls a syncControllerConfig. This re-generates the base master config (00-master MC)
> 3. The running (old) MCC now sees a MC change which calls another sync call to generate a new rendered config, and instructs the master pool to start an update
> 4. The new MCC rolls out, and does the whole rendering process, creating the actual updated MC for the master pool, which it waits until the previous one is finished, and starts the new (real) update.

After this patch, the old MCC will refuse to render from a controllerconfig generated by the new MCO.

