### PR TITLE
Bug 1875237: Add etcdDiscoveryDomain back to controllerconfig crd

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -68,6 +68,9 @@ spec:
             clusterDNSIP:
               description: clusterDNSIP is the cluster DNS IP address
               type: string
+            etcdDiscoveryDomain:
+              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
+              type: string
             images:
               description: images is map of images that are used by the controller
                 to render templates under ./templates/

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -618,6 +618,9 @@ spec:
             clusterDNSIP:
               description: clusterDNSIP is the cluster DNS IP address
               type: string
+            etcdDiscoveryDomain:
+              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
+              type: string
             images:
               description: images is map of images that are used by the controller
                 to render templates under ./templates/


### PR DESCRIPTION
This was only deprecated in 4.6, and removing it completely in the
same release breaks upgrades of platforms that use the value in
their 4.5 templates. It appears that the controllerconfig is getting
upgraded before the templates, so when MCO goes to re-render the
old templates with the new controllerconfig we end up with a blank
value for EtcdDiscoveryDomain references. This value should stay in
the crd until 4.7 when it can be safely removed because the 4.6
templates no longer have any references to it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
