### PR TITLE
Port to crd v1 API

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -59,7 +59,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().ServiceAccounts(),
-			ctrlctx.APIExtInformerFactory.Apiextensions().V1beta1().CustomResourceDefinitions(),
+			ctrlctx.APIExtInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 			ctrlctx.KubeNamespacedInformerFactory.Apps().V1().Deployments(),
 			ctrlctx.KubeNamespacedInformerFactory.Apps().V1().DaemonSets(),
 			ctrlctx.KubeNamespacedInformerFactory.Rbac().V1().ClusterRoles(),

--- a/docs/ContainerRuntimeConfigDesign.md
+++ b/docs/ContainerRuntimeConfigDesign.md
@@ -27,7 +27,7 @@ Extend the Machine Config Operator to include a ContainerRuntimeConfig CRD and C
 ## CRD
 
 ```
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
  name: containerruntimeconfigs.machineconfiguration.openshift.io

--- a/docs/KubeletConfigDesign.md
+++ b/docs/KubeletConfigDesign.md
@@ -33,7 +33,7 @@ Extend the Machine Config Operator to include a KubetletConfig CRD and KubeletCo
 ## CRD
 
 ```
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubeletconfigs.machineconfiguration.openshift.io

--- a/examples/controllerconfig.crd.yaml
+++ b/examples/controllerconfig.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/examples/machineconfig.crd.yaml
+++ b/examples/machineconfig.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/examples/machineconfigpool.crd.yaml
+++ b/examples/machineconfigpool.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
@@ -13,10 +13,11 @@ spec:
       served: true
       # One and only one version must be marked as the storage version.
       storage: true
+      subresources:
+        status: {}
   # either Namespaced or Cluster
   scope: Namespaced
-  subresources:
-    status: {}
+
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: machineconfigpools

--- a/install/0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: containerruntimeconfigs.machineconfiguration.openshift.io

--- a/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubeletconfigs.machineconfiguration.openshift.io

--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
@@ -7,16 +7,16 @@ metadata:
     "openshift.io/operator-managed": ""
 spec:
   additionalPrinterColumns:
-  - JSONPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
+  - jsonPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
     description: Version of the controller that generated the machineconfig. This
       will be empty if the machineconfig is not managed by a controller.
     name: GeneratedByController
     type: string
-  - JSONPath: .spec.config.ignition.version
+  - jsonPath: .spec.config.ignition.version
     description: Version of the Ignition Config defined in the machineconfig.
     name: IgnitionVersion
     type: string
-  - JSONPath: .metadata.creationTimestamp
+  - jsonPath: .metadata.creationTimestamp
     name: Age
     type: date
   # group name to use for REST API: /apis/<group>/<version>

--- a/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
@@ -7,42 +7,42 @@ metadata:
     "openshift.io/operator-managed": ""
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.configuration.name
+  - jsonPath: .status.configuration.name
     name: Config
     type: string
-  - JSONPath: .status.conditions[?(@.type=="Updated")].status
+  - jsonPath: .status.conditions[?(@.type=="Updated")].status
     description: When all the machines in the pool are updated to the correct machine
       config.
     name: Updated
     type: string
-  - JSONPath: .status.conditions[?(@.type=="Updating")].status
+  - jsonPath: .status.conditions[?(@.type=="Updating")].status
     description: When at least one of machine is not either not updated or is in the
       process of updating to the desired machine config.
     name: Updating
     type: string
-  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+  - jsonPath: .status.conditions[?(@.type=="Degraded")].status
     description: When progress is blocked on updating one or more nodes, or the pool
       configuration is failing.
     name: Degraded
     type: string
-  - JSONPath: .status.machineCount
+  - jsonPath: .status.machineCount
     description: Total number of machines in the machine config pool
     name: MachineCount
     type: number
-  - JSONPath: .status.readyMachineCount
+  - jsonPath: .status.readyMachineCount
     description: Total number of ready machines targeted by the pool
     name: ReadyMachineCount
     type: number
-  - JSONPath: .status.updatedMachineCount
+  - jsonPath: .status.updatedMachineCount
     description: Total number of machines targeted by the pool that have the CurrentMachineConfig
       as their config
     name: UpdatedMachineCount
     type: number
-  - JSONPath: .status.degradedMachineCount
+  - jsonPath: .status.degradedMachineCount
     description: Total number of machines marked degraded (or unreconcilable)
     name: DegradedMachineCount
     type: number
-  - JSONPath: .metadata.creationTimestamp
+  - jsonPath: .metadata.creationTimestamp
     name: Age
     type: date
   # group name to use for REST API: /apis/<group>/<version>
@@ -57,8 +57,6 @@ spec:
   # either Namespaced or Cluster
   scope: Cluster
   preserveUnknownFields: false
-  subresources:
-    status: {}
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: machineconfigpools

--- a/lib/resourceapply/apiext.go
+++ b/lib/resourceapply/apiext.go
@@ -3,14 +3,14 @@ package resourceapply
 import (
 	"context"
 	"github.com/openshift/machine-config-operator/lib/resourcemerge"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ApplyCustomResourceDefinition applies the required CustomResourceDefinition to the cluster.
-func ApplyCustomResourceDefinition(client apiextclientv1beta1.CustomResourceDefinitionsGetter, required *apiextv1beta1.CustomResourceDefinition) (*apiextv1beta1.CustomResourceDefinition, bool, error) {
+func ApplyCustomResourceDefinition(client apiextclientv1.CustomResourceDefinitionsGetter, required *apiextv1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, bool, error) {
 	existing, err := client.CustomResourceDefinitions().Get(context.TODO(), required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.CustomResourceDefinitions().Create(context.TODO(), required, metav1.CreateOptions{})

--- a/lib/resourcemerge/apiext.go
+++ b/lib/resourcemerge/apiext.go
@@ -1,13 +1,13 @@
 package resourcemerge
 
 import (
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // EnsureCustomResourceDefinition ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
-func EnsureCustomResourceDefinition(modified *bool, existing *apiextv1beta1.CustomResourceDefinition, required apiextv1beta1.CustomResourceDefinition) {
+func EnsureCustomResourceDefinition(modified *bool, existing *apiextv1.CustomResourceDefinition, required apiextv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
 	// we stomp everything

--- a/lib/resourceread/apiext.go
+++ b/lib/resourceread/apiext.go
@@ -1,7 +1,7 @@
 package resourceread
 
 import (
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
@@ -12,16 +12,16 @@ var (
 )
 
 func init() {
-	if err := apiextv1beta1.AddToScheme(apiExtensionsScheme); err != nil {
+	if err := apiextv1.AddToScheme(apiExtensionsScheme); err != nil {
 		panic(err)
 	}
 }
 
-// ReadCustomResourceDefinitionV1Beta1OrDie reads crd object from bytes. Panics on error.
-func ReadCustomResourceDefinitionV1Beta1OrDie(objBytes []byte) *apiextv1beta1.CustomResourceDefinition {
-	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextv1beta1.SchemeGroupVersion), objBytes)
+// ReadCustomResourceDefinitionV1OrDie reads crd object from bytes. Panics on error.
+func ReadCustomResourceDefinitionV1OrDie(objBytes []byte) *apiextv1.CustomResourceDefinition {
+	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}
-	return requiredObj.(*apiextv1beta1.CustomResourceDefinition)
+	return requiredObj.(*apiextv1.CustomResourceDefinition)
 }

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -548,7 +548,7 @@ func manifestsBootstrapPodV2Yaml() (*asset, error) {
 	return a, nil
 }
 
-var _manifestsControllerconfigCrdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1beta1
+var _manifestsControllerconfigCrdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -11,8 +11,8 @@ import (
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextinformersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
-	apiextlistersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1"
+	apiextinformersv1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	apiextlistersv1 "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -69,7 +69,7 @@ type Operator struct {
 
 	syncHandler func(ic string) error
 
-	crdLister        apiextlistersv1beta1.CustomResourceDefinitionLister
+	crdLister        apiextlistersv1.CustomResourceDefinitionLister
 	mcpLister        mcfglistersv1.MachineConfigPoolLister
 	ccLister         mcfglistersv1.ControllerConfigLister
 	mcLister         mcfglistersv1.MachineConfigLister
@@ -114,7 +114,7 @@ func New(
 	mcInformer mcfginformersv1.MachineConfigInformer,
 	controllerConfigInformer mcfginformersv1.ControllerConfigInformer,
 	serviceAccountInfomer coreinformersv1.ServiceAccountInformer,
-	crdInformer apiextinformersv1beta1.CustomResourceDefinitionInformer,
+	crdInformer apiextinformersv1.CustomResourceDefinitionInformer,
 	deployInformer appsinformersv1.DeploymentInformer,
 	daemonsetInformer appsinformersv1.DaemonSetInformer,
 	clusterRoleInformer rbacinformersv1.ClusterRoleInformer,
@@ -209,7 +209,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer optr.queue.ShutDown()
 
-	apiClient := optr.apiExtClient.ApiextensionsV1beta1()
+	apiClient := optr.apiExtClient.ApiextensionsV1()
 	_, err := apiClient.CustomResourceDefinitions().Get(context.TODO(), "controllerconfigs.machineconfiguration.openshift.io", metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -21,7 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -334,8 +334,8 @@ func (optr *Operator) syncCustomResourceDefinitions() error {
 		if err != nil {
 			return fmt.Errorf("error getting asset %s: %v", crd, err)
 		}
-		c := resourceread.ReadCustomResourceDefinitionV1Beta1OrDie(crdBytes)
-		_, updated, err := resourceapply.ApplyCustomResourceDefinition(optr.apiExtClient.ApiextensionsV1beta1(), c)
+		c := resourceread.ReadCustomResourceDefinitionV1OrDie(crdBytes)
+		_, updated, err := resourceapply.ApplyCustomResourceDefinition(optr.apiExtClient.ApiextensionsV1(), c)
 		if err != nil {
 			return err
 		}
@@ -706,7 +706,7 @@ const (
 	controllerConfigCompletedTimeout  = 5 * time.Minute
 )
 
-func (optr *Operator) waitForCustomResourceDefinition(resource *apiextv1beta1.CustomResourceDefinition) error {
+func (optr *Operator) waitForCustomResourceDefinition(resource *apiextv1.CustomResourceDefinition) error {
 	var lastErr error
 	if err := wait.Poll(customResourceReadyInterval, customResourceReadyTimeout, func() (bool, error) {
 		crd, err := optr.crdLister.Get(resource.Name)
@@ -716,7 +716,7 @@ func (optr *Operator) waitForCustomResourceDefinition(resource *apiextv1beta1.Cu
 		}
 
 		for _, condition := range crd.Status.Conditions {
-			if condition.Type == apiextv1beta1.Established && condition.Status == apiextv1beta1.ConditionTrue {
+			if condition.Type == apiextv1.Established && condition.Status == apiextv1.ConditionTrue {
 				return true, nil
 			}
 		}

--- a/test/e2e/framework/clientset.go
+++ b/test/e2e/framework/clientset.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/glog"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientmachineconfigv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
-	clientapiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	clientapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -18,7 +18,7 @@ type ClientSet struct {
 	appsv1client.AppsV1Interface
 	clientconfigv1.ConfigV1Interface
 	clientmachineconfigv1.MachineconfigurationV1Interface
-	clientapiextensionsv1beta1.ApiextensionsV1beta1Interface
+	clientapiextensionsv1.ApiextensionsV1Interface
 }
 
 // NewClientSet returns a *ClientBuilder with the given kubeconfig.
@@ -45,7 +45,7 @@ func NewClientSet(kubeconfig string) *ClientSet {
 	clientSet.CoreV1Interface = corev1client.NewForConfigOrDie(config)
 	clientSet.ConfigV1Interface = clientconfigv1.NewForConfigOrDie(config)
 	clientSet.MachineconfigurationV1Interface = clientmachineconfigv1.NewForConfigOrDie(config)
-	clientSet.ApiextensionsV1beta1Interface = clientapiextensionsv1beta1.NewForConfigOrDie(config)
+	clientSet.ApiextensionsV1Interface = clientapiextensionsv1.NewForConfigOrDie(config)
 	clientSet.AppsV1Interface = appsv1client.NewForConfigOrDie(config)
 
 	return clientSet


### PR DESCRIPTION
While debugging something else I noticed a spam of
`W0923 18:00:16.220308       1 warnings.go:67] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition`
in the operator logs, see e.g.
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-kube-apiserver-operator/955/pull-ci-openshift-cluster-kube-apiserver-operator-master-k8s-e2e-gcp-serial/1308823867334070272/artifacts/k8s-e2e-gcp-serial/gather-extra/pods/openshift-machine-config-operator_machine-config-operator-66b996d58f-wmp5l_machine-config-operator.log

For changes that need to be done, see:
https://github.com/kubernetes/kubernetes/pull/79604

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
