### PR TITLE
Bug 1882667: daemon: Unlink encapsulated config in once-from mode

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -517,6 +517,17 @@ func (dn *Daemon) detectEarlySSHAccessesFromBoot() error {
 func (dn *Daemon) RunOnceFrom(onceFrom string, skipReboot bool) error {
 	dn.skipReboot = skipReboot
 
+	// Unconditionally remove this file in the once-from (classic RHEL)
+	// case.  We use this file to suppress things like kubelet and SDN
+	// starting on CoreOS during the firstboot/pivot boot, but there's
+	// no such thing on classic RHEL.
+	_, err := os.Stat(constants.MachineConfigEncapsulatedPath)
+	if err == nil {
+		if err := os.Remove(constants.MachineConfigEncapsulatedPath); err != nil {
+			return errors.Wrapf(err, "failed to remove %s", constants.MachineConfigEncapsulatedPath)
+		}
+	}
+
 	configi, contentFrom, err := dn.senseAndLoadOnceFrom(onceFrom)
 	if err != nil {
 		glog.Warningf("Unable to decipher onceFrom config type: %s", err)


### PR DESCRIPTION
Unconditionally remove this file in the once-from (classic RHEL)
case.  We use this file to suppress things like kubelet and SDN
starting on CoreOS during the firstboot/pivot boot, but there's
no such thing on classic RHEL.
