### PR TITLE
Bug 1872632: templates: add nodeip-configuration.service for bare metal UPI

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -1,0 +1,43 @@
+name: nodeip-configuration.service
+enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
+  Wants=network-online.target
+  After=network-online.target ignition-firstboot-complete.service
+  Before=kubelet.service crio.service
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
+    --authfile /var/lib/kubelet/config.json \
+    --net=host \
+    --volume /etc/systemd/system:/etc/systemd/system:z \
+    {{ .Images.baremetalRuntimeCfgImage }} \
+    node-ip \
+    set --retry-on-failure \
+    ; \
+    do \
+    sleep 5; \
+    done"
+
+  {{if .Proxy -}}
+  {{if .Proxy.HTTPProxy -}}
+  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  {{end -}}
+  {{if .Proxy.HTTPSProxy -}}
+  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  {{end -}}
+  {{if .Proxy.NoProxy -}}
+  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  {{end -}}
+  {{end -}}
+
+  [Install]
+  RequiredBy=kubelet.service


### PR DESCRIPTION
#2088 / #2100 updated kubelet.service to allow manually overriding the node IP on bare metal UPI (to deal with the fact that kubelet's node IP autodetection does the wrong thing in the presence of ovn-kubernetes now). This finishes this fix by running an updated version of the nodeip-configuration service to _automatically_ override the IP.

Two open questions:

1. What should trigger this? Currently the patch says `{{ if eq .Infra.Status.PlatformStatus.Type "None" }}`, which covers the reporter's use case, but if we wanted to just _always_ bypass kubelet's not-very-good node-IP-detection code, we should check `{{ if eq cloudProvider "" }}`. (ie, in that case we would always pass _either_ a non-empty `--cloud-provider`, causing kubelet to get the IP from the CloudProvider; _or_ a non-empty `--node-ip`, causing kubelet to use that IP rather than trying to detect one itself). (Given the nearness to code freeze, we could possible fix just the "platform none" case now but think about fixing the rest later?)

2. Should I merge `templates/common/{_base,baremetal,openstack,vsphere}/units/nodeip-configuration.service.yaml` into a single file? I originally tried to do that, but [the vsphere version has a whole bunch of additional template `if`s](https://github.com/openshift/machine-config-operator/blob/master/templates/common/vsphere/units/nodeip-configuration.service.yaml#L4) that the others don't and I wasn't sure what to do with that. (Also, FTR, the vsphere version calls `systemctl daemon-reload` at the end, which I'm _assuming_ is unnecessary since the openstack and baremetal versions seem to work without it?)

   At any rate, as I understand it, having `nodeip-configuration.service.yaml` in both `_base` and `{baremetal,openstack,vsphere}` should not be a problem, as the more-specific versions will just override the `_base` version, right?

/hold
depends on https://github.com/openshift/baremetal-runtimecfg/pull/101 to get the new "find the node IP associated with the default route" mode of `runtimecfg node-ip`