### PR TITLE
Bug 1882209: baremetal & friends: Set coredns forward policy to sequential

### DIFF
--- a/manifests/on-prem/coredns-corefile.tmpl
+++ b/manifests/on-prem/coredns-corefile.tmpl
@@ -2,7 +2,9 @@
     errors
     health :18080
     mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
-    forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+    forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+        policy sequential
+    }
     cache 30
     reload
     template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1591,7 +1591,9 @@ var _manifestsOnPremCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
     mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
-    forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
+    forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}} {
+        policy sequential
+    }
     cache 30
     reload
     template IN {{`+"`"+`{{ .Cluster.IngressVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {

--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -6,7 +6,9 @@ contents:
         errors
         health :18080
         mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
-        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+            policy sequential
+        }
         cache 30
         reload
         template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {

--- a/templates/common/ovirt/files/coredns-corefile.yaml
+++ b/templates/common/ovirt/files/coredns-corefile.yaml
@@ -6,7 +6,9 @@ contents:
         errors
         health :18080
         mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
-        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+            policy sequential
+        }
         cache 30
         reload
         file /etc/coredns/node-dns-db {{ .DNS.Spec.BaseDomain }}

--- a/templates/common/vsphere/files/coredns-corefile.yaml
+++ b/templates/common/vsphere/files/coredns-corefile.yaml
@@ -7,7 +7,9 @@ contents:
         errors
         health :18080
         mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
-        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
+        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+            policy sequential
+        }
         cache 30
         reload
         hosts {


### PR DESCRIPTION
This was already done for openstack in #1527, but not for baremetal
because we don't have any separation between external and internal
hostnames. However, in environments where the DNS servers are
misconfigured such that the second one listed in resolv.conf does
not properly resolve external names, this can cause intermittent
resolution failures from our coredns because it randomly chooses to
use the broken server.

Switching the forward policy to sequential will avoid potentially
confusing issues where a set of DNS servers works fine standalone
but breaks when configured as the forwarding upstreams in coredns.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
