### PR TITLE
Bug 1879283: *: add nil check when decoding File.Contents.Source

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -199,12 +199,8 @@ spec:
                       items:
                         description: Items is list of files to be written
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                         properties:
-                          append:
-                            description: Append specifies whether to append to the specified file.
-                              Creates a new file if nothing exists at the path. Cannot be set if
-                              overwrite is set to true.
-                            type: boolean
                           contents:
                             description: Contents specifies options related to the contents of
                               the file

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -599,6 +599,9 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 // mergeConfigChanges retrieves the original/default config data from the templates, decodes it and merges in the changes given by the Custom Resource.
 // It then encodes the new data and returns it.
 func (ctrl *Controller) mergeConfigChanges(origFile *ign3types.File, cfg *mcfgv1.ContainerRuntimeConfig, update updateConfigFunc) ([]byte, error) {
+	if origFile.Contents.Source == nil {
+		return nil, ctrl.syncStatusOnly(cfg, fmt.Errorf("original Container Runtime config is empty"))
+	}
 	dataURL, err := dataurl.DecodeString(*origFile.Contents.Source)
 	if err != nil {
 		return nil, ctrl.syncStatusOnly(cfg, err, "could not decode original Container Runtime config: %v", err)
@@ -760,6 +763,9 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 	}
 
 	if insecureRegs != nil || blockedRegs != nil || len(icspRules) != 0 {
+		if originalRegistriesIgn.Contents.Source == nil {
+			return nil, fmt.Errorf("original registries config is empty")
+		}
 		dataURL, err := dataurl.DecodeString(*originalRegistriesIgn.Contents.Source)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode original registries config: %v", err)
@@ -770,6 +776,9 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 		}
 	}
 	if blockedRegs != nil || allowedRegs != nil {
+		if originalPolicyIgn.Contents.Source == nil {
+			return nil, fmt.Errorf("original policy json is empty")
+		}
 		dataURL, err := dataurl.DecodeString(*originalPolicyIgn.Contents.Source)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode original policy json: %v", err)

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -366,6 +366,7 @@ func (ctrl *Controller) syncStatusOnly(cfg *mcfgv1.KubeletConfig, err error, arg
 
 // syncKubeletConfig will sync the kubeletconfig with the given key.
 // This function is not meant to be invoked concurrently with the same key.
+//nolint:gocyclo
 func (ctrl *Controller) syncKubeletConfig(key string) error {
 	startTime := time.Now()
 	glog.V(4).Infof("Started syncing kubeletconfig %q (%v)", key, startTime)
@@ -452,6 +453,9 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		originalKubeletIgn, err := ctrl.generateOriginalKubeletConfig(role)
 		if err != nil {
 			return ctrl.syncStatusOnly(cfg, err, "could not generate the original Kubelet config: %v", err)
+		}
+		if originalKubeletIgn.Contents.Source == nil {
+			return ctrl.syncStatusOnly(cfg, err, "the original Kubelet source string is empty: %v", err)
 		}
 		dataURL, err := dataurl.DecodeString(*originalKubeletIgn.Contents.Source)
 		if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -106,6 +106,9 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		if err != nil {
 			return err
 		}
+		if originalKubeletIgn.Contents.Source == nil {
+			return fmt.Errorf("could not find original Kubelet config to decode")
+		}
 		dataURL, err := dataurl.DecodeString(*originalKubeletIgn.Contents.Source)
 		if err != nil {
 			return err


### PR DESCRIPTION
In ignition spec 3, the File.Contents.Source was changed to a pointer,
thus causing a panic when it is nil when we dereference during decodes.

Also explicitly reject Append sections of Ignition File sections, since
they are not supported anyways and should fail eventually.