### PR TITLE
[WIP]Allow all processes to make core dumps

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -157,6 +157,10 @@ contents:
             sed -i '/^\[ethernet\]$/a mtu='"$iface_mtu" ${new_conn_file}
           fi
           cat <<EOF >> ${new_conn_file}
+      
+      #Enable coredumping by all processes, core dump is owned by current user and no security is applied
+      sysctl -w fs.suid_dumpable=1
+    
     [ovs-interface]
     type=internal
     EOF
@@ -228,4 +232,8 @@ contents:
 
       # remove bridges created by ovn-kubernetes, try to delete br-ex again in case NM fail to talk to ovsdb
       ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local -- --if-exists del-br br-ex
+
+      #Enable coredumping by all processes, core dump is owned by current user and no security is applied
+      sysctl -w fs.suid_dumpable=1
+
     fi


### PR DESCRIPTION
Currently we cannot see ovs coredumps when it segfaults

This should fix that and allow us to solve
https://bugzilla.redhat.com/show_bug.cgi?id=1875534

Signed-off-by: Andrew Stoycos <astoycos@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
