### PR TITLE
Bug 1881137: vsphere - update haproxy interval

### DIFF
--- a/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
+++ b/templates/master/00-master/vsphere/files/vsphere-haproxy-haproxy.yaml
@@ -40,7 +40,7 @@ contents:
        option  log-health-checks
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}
-       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 3s fall 2 rise 3
+       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 1s fall 2 rise 3
     {{- end }}`}}
     {{ end -}}
     {{ end -}}


### PR DESCRIPTION
When updating vSphere for baremetal changes
of keepalived and haproxy I missed the interval change
for haproxy backend masters.

