### PR TITLE
Bug 1882667: Make ovs-configuration wait for network.service

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -8,7 +8,7 @@ contents: |
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service openvswitch.service
+  After=NetworkManager-wait-online.service openvswitch.service network.service
   Before=network-online.target kubelet.service crio.service node-valid-hostname.service
 
   [Service]


### PR DESCRIPTION
With RHEL 7 worker nodes, network service and NetworkManager will both
exist. network service runs after NetworkManager and may interfere with
ovs-configuration service. Therefore ensure we run ovs-configuration
after network.service is done.

Signed-off-by: Tim Rozet <trozet@redhat.com>
