### PR TITLE
Bug 1872885: add template for NM to not manage hostname on GCP

### DIFF
--- a/templates/common/gcp/files/etc-networkmanager-conf.d-hostname.yaml
+++ b/templates/common/gcp/files/etc-networkmanager-conf.d-hostname.yaml
@@ -1,0 +1,12 @@
+mode: 0644
+path: "/etc/NetworkManager/conf.d/hostname.conf"
+contents:
+  inline: |
+    # On GCP the hostname is likely to be longer than 63 chars.
+    # /etc/networkmanager/dispatcher.d/90-long-hostname.sh will set
+    # the hostname. The following configuration allows 90-long-hostname.sh
+    # to manage setting transient hostname instead of NetworkManager itself.
+    # See: https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html
+    #      https://bugzilla.redhat.com/show_bug.cgi?id=1872885
+    [main]
+    hostname-mode=none


### PR DESCRIPTION
In cases where NetworkManager can set an otherwise invalid cluster
hostname, but valid for NM (between 63 and 65 characters),
NetworkManager will bypass the dispatcher hook.

This config tells NetworkManager to not set the transient hostname.
Instead, the dispatcher.d hook script will set the hostname.

Signed-off-by: Ben Howard <ben.howard@redhat.com>