### PR TITLE
Bug 1884195: etcd-quorum-guard remove toleration timeouts

### DIFF
--- a/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
+++ b/install/0000_80_machine-config-operator_07_etcdquorumguard_deployment.yaml
@@ -43,11 +43,9 @@ spec:
       - key: node.kubernetes.io/not-ready
         effect: NoExecute
         operator: Exists
-        tolerationSeconds: 120
       - key: node.kubernetes.io/unreachable
         effect: NoExecute
         operator: Exists
-        tolerationSeconds: 120
       - key: node-role.kubernetes.io/etcd
         operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/cluster-etcd-operator/pull/426 in OCP 4.5. Because we moved quorum-guard to cluster-etcd-operator in 4.6 the backport needs to traverse repos.

More details on the original bug and conversations. I really think this warrants backport given the possible failure case.

- https://bugzilla.redhat.com/show_bug.cgi?id=1840358
- https://github.com/openshift/cluster-etcd-operator/pull/426 

depends on openshift/origin#25700