### PR TITLE
Bug 1883508: [ Baremetal and friends] wrap Keepalived chk_ingress script with timeout

### DIFF
--- a/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -5,7 +5,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/openstack/files/openstack-keepalived-keepalived.yaml
@@ -5,7 +5,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/ovirt/files/ovirt-keepalived-keepalived.yaml
@@ -5,7 +5,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }

--- a/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/vsphere/files/vsphere-keepalived-keepalived.yaml
@@ -10,7 +10,7 @@ contents:
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
-        script "/usr/bin/curl -o /dev/null -kLfs http://0:1936/healthz"
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 50
     }


### PR DESCRIPTION
This commit wraps chk_ingress script with timeout to workaround [1]

[1] https://github.com/acassen/keepalived/issues/1364
