### PR TITLE
Bug 1880259: ovs-configuration: use NM default ethernet route metric

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -77,9 +77,15 @@ contents:
         echo "MTU found for iface: ${iface}: ${iface_mtu}"
       fi
 
-      # create bridge
+      # create bridge; use NM's ethernet device default route metric (100)
       if ! nmcli connection show br-ex &> /dev/null; then
-        nmcli c add type ovs-bridge conn.interface br-ex con-name br-ex 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac}
+        nmcli c add type ovs-bridge \
+            con-name br-ex \
+            conn.interface br-ex \
+            802-3-ethernet.mtu ${iface_mtu} \
+            802-3-ethernet.cloned-mac-address ${iface_mac} \
+            ipv4.route-metric 100 \
+            ipv6.route-metric 100
       fi
 
       # store old conn for later


### PR DESCRIPTION
Instead of the default OVS interface route metric, which is much lower,
and causes problems when secondary interfaces are added to the machine.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1880259

@trozet @knobunc 