### PR TITLE
[wip] [baremetal] Don't change Keepalived mode to unicast automatically after upgrade to 4.6

### DIFF
--- a/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/keepalived/monitor.conf"
-contents:
-  inline: |
-    mode: unicast


### PR DESCRIPTION
In OCP 4.6 Keepalived configuration changed from multicast to unicast,  the Keepalived MCO templates [1] are set to unicast mode in 4.6.

Post upgrade all nodes (that created using previous version)  will continue to run Keepalived in multicast mode while new nodes that will be added post upgrade will use 4.6 MCO templates (multicast).
Now, since multicast and unicast Keepalived considered as separate domains an automatic flip mode process (triggered by [2]) was added in OCP 4.6.

While testing 4.5 to 4.6 upgrade we noticed that sometimes API wasn't available after the automatic flip mode process was applied ( two different masters held the VIP though Keepalived configuration changed to unicast in all nodes).

This PR deletes the automatic flip mode process after upgrade.


[1] https://github.com/openshift/machine-config-operator/blob/master/templates/common/baremetal/files/baremetal-keepalived.yaml#L126-#L127
[2] https://github.com/openshift/machine-config-operator/blob/master/templates/common/baremetal/files/baremetal-keepalived-flip-mode.yaml