### PR TITLE
Bug 1880591: Make ovs-configuration write a file

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -4,6 +4,10 @@ contents:
   inline: |
     #!/bin/bash
     set -eux
+    # Create file to signal that ovs-configuration has executed (we are booted into 4.6)
+    # This is necessary because systemd calls from SDN containers are unreliable, so need to look for a file
+    touch /var/run/ovs-config-executed
+
     if [ "$1" == "OVNKubernetes" ]; then
       # Configures NICs onto OVS bridge "br-ex"
       # Configuration is either auto-detected or provided through a config file written already in Network Manager


### PR DESCRIPTION
In CNO, we have no reliable way to detect if OVS should be running in
systemd or not. Using systemd or dbus is unreliable from the containers.
Checking for file existence is not foolproof because MCO lays the files
down before it reboots into 4.6. This patch makes ovs-configuration
write a file when it executes. We can use this to detect if we should
expect OVS to be running in systemd.

Signed-off-by: Tim Rozet <trozet@redhat.com>

