### PR TITLE
Drop kernel-devel from supported extensions

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -106,13 +106,6 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 		extensions = append(extensions, cfg.Spec.Extensions...)
 	}
 
-	// Ensure that kernel-devel extension is applied only with default kernel.
-	if kernelType != KernelTypeDefault {
-		if InSlice("kernel-devel", extensions) {
-			return nil, fmt.Errorf("installing kernel-devel extension is not supported with kernelType: %s", kernelType)
-		}
-	}
-
 	return &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
 			OSImageURL:      osImageURL,

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -876,7 +876,7 @@ func generateExtensionsArgs(oldConfig, newConfig *mcfgv1.MachineConfig) []string
 }
 
 func validateExtensions(exts []string) error {
-	supportedExtensions := []string{"usbguard", "kernel-devel"}
+	supportedExtensions := []string{"usbguard"}
 	invalidExts := []string{}
 	for _, ext := range exts {
 		if !ctrlcommon.InSlice(ext, supportedExtensions) {


### PR DESCRIPTION
We only ship this in the oscontainer so that other tooling can
pull the oscontainer and use it to build kernel modules in a
container image.  People shouldn't install it to the host
system because that would lead to a desire for installing e.g.
`gcc` and `make` on the host system too.  Builds should
be done in a container image.
