### PR TITLE
Bug 1886636: update ctrcfg crd to make spec & containerruntimeconfig required

### DIFF
--- a/install/0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml
@@ -30,6 +30,8 @@ spec:
       description: ContainerRuntimeConfig describes a customized Container Runtime
         configuration.
       type: object
+      required:
+      - spec
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -46,6 +48,8 @@ spec:
         spec:
           description: ContainerRuntimeConfigSpec defines the desired state of ContainerRuntimeConfig
           type: object
+          required:
+            - containerRuntimeConfig
           properties:
             containerRuntimeConfig:
               description: ContainerRuntimeConfiguration defines the tuneables of

--- a/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
@@ -27,6 +27,8 @@ spec:
     "openAPIV3Schema":
       description: KubeletConfig describes a customized Kubelet configuration.
       type: object
+      required:
+      - spec
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
All ctrcfgs must have a spec and containerruntimeconfig all kubelet configs and all kubeletconfigs should have a spec (but as the new loglevel  was added as same level, kubeletruntimeconfig not required)