### PR TITLE
Bug 1872001: Stop using EtcdDiscoveryDomain in templates

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -41,6 +41,7 @@ var (
 		rootCAFile                string
 		proxyConfigFile           string
 		additionalTrustBundleFile string
+		dnsConfigFile             string
 	}
 )
 
@@ -65,6 +66,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.networkConfigFile, "network-config-file", "/assets/manifests/cluster-network-02-config.yml", "File containing network.config.openshift.io manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.cloudConfigFile, "cloud-config-file", "", "File containing the config map that contains the cloud config for cloudprovider.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.proxyConfigFile, "proxy-config-file", "/assets/manifests/cluster-proxy-01-config.yaml", "File containing proxy.config.openshift.io manifest.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.dnsConfigFile, "dns-config-file", "/assets/manifests/cluster-dns-02-config.yml", "File containing dns.config.openshift.io manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.additionalTrustBundleFile, "additional-trust-bundle-config-file", "/assets/manifests/user-ca-bundle-config.yaml", "File containing the additional user provided CA bundle manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.keepalivedImage, "keepalived-image", "", "Image for Keepalived.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.corednsImage, "coredns-image", "", "Image for CoreDNS.")
@@ -108,6 +110,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.configFile,
 		bootstrapOpts.infraConfigFile,
 		bootstrapOpts.networkConfigFile,
+		bootstrapOpts.dnsConfigFile,
 		bootstrapOpts.cloudConfigFile,
 		bootstrapOpts.cloudProviderCAFile,
 		bootstrapOpts.rootCAFile, bootstrapOpts.kubeCAFile, bootstrapOpts.pullSecretFile,

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -69,6 +69,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Networks(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Proxies(),
+			ctrlctx.ConfigInformerFactory.Config().V1().DNSes(),
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie(componentName),
 			ctrlctx.ClientBuilder.KubeClientOrDie(componentName),
 			ctrlctx.ClientBuilder.APIExtClientOrDie(componentName),

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -100,5 +100,10 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 		*modified = true
 	}
 
+	if existing.DNS != nil && required.DNS != nil && !equality.Semantic.DeepEqual(existing.DNS, required.DNS) {
+		*modified = true
+		existing.DNS = required.DNS
+	}
+
 	mergeMap(modified, &existing.Images, required.Images)
 }

--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -5,31 +5,31 @@
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
-    template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
-    template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
-    template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
         fallthrough
     }
-    template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
-    template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
         fallthrough
     }
-    template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }

--- a/manifests/baremetal/coredns-corefile.tmpl
+++ b/manifests/baremetal/coredns-corefile.tmpl
@@ -1,7 +1,7 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -68,9 +68,47 @@ spec:
             clusterDNSIP:
               description: clusterDNSIP is the cluster DNS IP address
               type: string
-            etcdDiscoveryDomain:
-              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
-              type: string
+            dns:
+              description: dns holds the cluster dns details
+              type: object
+              nullable: true
+              required:
+              - spec
+              properties:
+                spec:
+                  description: spec holds user settable values for configuration
+                  type: object
+                  properties:
+                    baseDomain:
+                      description: baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base.
+                      type: string
+                    publicZone:
+                      description: publicZone is the location where all the DNS records that are publicly accessible to the internet exist.
+                      type: object
+                      properties:
+                        id:
+                          description: id is the identifier that can be used to find the DNS hosted zone.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: tags can be used to query the DNS hosted zone.
+                          type: object
+                    privateZone:
+                      description: privateZone is the location where all the DNS records that are only available internally to the cluster exist.
+                      type: object
+                      properties:
+                        id:
+                          description: id is the identifier that can be used to find the DNS hosted zone.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: tags can be used to query the DNS hosted zone.
+                          type: object
+                status:
+                  description: status holds observed values from the cluster. They may not be overridden.
+                  type: object
             images:
               description: images is map of images that are used by the controller
                 to render templates under ./templates/

--- a/manifests/openstack/coredns-corefile.tmpl
+++ b/manifests/openstack/coredns-corefile.tmpl
@@ -1,14 +1,14 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
         policy sequential
     }
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }} api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }

--- a/manifests/ovirt/coredns-corefile.tmpl
+++ b/manifests/ovirt/coredns-corefile.tmpl
@@ -1,12 +1,12 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }} api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }

--- a/manifests/vsphere/coredns-corefile.tmpl
+++ b/manifests/vsphere/coredns-corefile.tmpl
@@ -1,17 +1,17 @@
 . {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`{{.Cluster.MasterAmount}}`}} {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
     forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
     cache 30
     reload
     hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN A {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         fallthrough
     }

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -84,6 +84,10 @@ type ControllerConfigSpec struct {
 	// +nullable
 	Infra *configv1.Infrastructure `json:"infra"`
 
+	// dns holds the cluster dns details
+	// +nullable
+	DNS *configv1.DNS `json:"dns"`
+
 	// kubeletIPv6 is true to force a single-stack IPv6 kubelet config
 	KubeletIPv6 bool `json:"kubeletIPv6,omitempty"`
 

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -263,6 +263,11 @@ func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 		*out = new(configv1.Infrastructure)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DNS != nil {
+		in, out := &in.DNS, &out.DNS
+		*out = new(configv1.DNS)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/controller/template/test_data/controller_config_baremetal.yaml
+++ b/pkg/controller/template/test_data/controller_config_baremetal.yaml
@@ -31,3 +31,6 @@ spec:
           apiServerInternalIP: 10.0.0.1
           ingressIP: 10.0.0.2
           nodeDNSIP: 10.0.0.3
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/pkg/controller/template/test_data/controller_config_openstack.yaml
+++ b/pkg/controller/template/test_data/controller_config_openstack.yaml
@@ -31,3 +31,6 @@ spec:
           apiServerInternalIP: 10.0.0.1
           ingressIP: 10.0.0.2
           nodeDNSIP: 10.0.0.3
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/pkg/controller/template/test_data/controller_config_ovirt.yaml
+++ b/pkg/controller/template/test_data/controller_config_ovirt.yaml
@@ -27,3 +27,6 @@ spec:
       infrastructureName: my-test-cluster
       platformStatus:
         type: "oVirt"
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/pkg/controller/template/test_data/controller_config_vsphere.yaml
+++ b/pkg/controller/template/test_data/controller_config_vsphere.yaml
@@ -31,3 +31,6 @@ spec:
           apiServerInternalIP: 10.0.0.1
           ingressIP: 10.0.0.2
           nodeDNSIP: 10.0.0.3
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -104,31 +104,31 @@ var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
-    template IN {{`+"`"+`{{ .Cluster.IngressVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.IngressVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
         fallthrough
     }
-    template IN {{`+"`"+`{{ .Cluster.IngressVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.IngressVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
-    template IN {{`+"`"+`{{ .Cluster.APIVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.APIVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
         fallthrough
     }
-    template IN {{`+"`"+`{{ .Cluster.APIVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.APIVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
-    template IN {{`+"`"+`{{ .Cluster.APIVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.APIVIPRecordType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in {{`+"`"+`{{"{{ .Type }}"}}`+"`"+`}} {{ .ControllerConfig.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
         fallthrough
     }
-    template IN {{`+"`"+`{{ .Cluster.APIVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN {{`+"`"+`{{ .Cluster.APIVIPEmptyType }}`+"`"+`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }
@@ -1972,14 +1972,14 @@ func manifestsMasterMachineconfigpoolYaml() (*asset, error) {
 var _manifestsOpenstackCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}} {
         policy sequential
     }
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP }} api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }} api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }
@@ -2245,12 +2245,12 @@ func manifestsOpenstackKeepalivedYaml() (*asset, error) {
 var _manifestsOvirtCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
-    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    hosts /etc/coredns/api-int.hosts {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }} api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }} api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }
@@ -2516,17 +2516,17 @@ func manifestsOvirtKeepalivedYaml() (*asset, error) {
 var _manifestsVsphereCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
     hosts {
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
-        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
-    template IN A {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {
-        match .*.apps.{{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }}
+    template IN A {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`+"`"+`{{"{{ .Name }}"}}`+"`"+`}} 60 in a {{ .ControllerConfig.Infra.Status.PlatformStatus.VSphere.IngressIP }}"
         fallthrough
     }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -100,7 +100,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _manifestsBaremetalCorednsCorefileTmpl = []byte(`. {
     errors
     health :18080
-    mdns {{ .ControllerConfig.Infra.Status.EtcdDiscoveryDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
+    mdns {{ .ControllerConfig.DNS.Spec.BaseDomain }} {{`+"`"+`{{.Cluster.MasterAmount}}`+"`"+`}} {{`+"`"+`{{.Cluster.Name}}`+"`"+`}} {{`+"`"+`{{.NonVirtualIP}}`+"`"+`}}
     forward . {{`+"`"+`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`+"`"+`}}
     cache 30
     reload
@@ -624,9 +624,47 @@ spec:
             clusterDNSIP:
               description: clusterDNSIP is the cluster DNS IP address
               type: string
-            etcdDiscoveryDomain:
-              description: etcdDiscoveryDomain is deprecated, use infra.status.etcdDiscoveryDomain instead
-              type: string
+            dns:
+              description: dns holds the cluster dns details
+              type: object
+              nullable: true
+              required:
+              - spec
+              properties:
+                spec:
+                  description: spec holds user settable values for configuration
+                  type: object
+                  properties:
+                    baseDomain:
+                      description: baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base.
+                      type: string
+                    publicZone:
+                      description: publicZone is the location where all the DNS records that are publicly accessible to the internet exist.
+                      type: object
+                      properties:
+                        id:
+                          description: id is the identifier that can be used to find the DNS hosted zone.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: tags can be used to query the DNS hosted zone.
+                          type: object
+                    privateZone:
+                      description: privateZone is the location where all the DNS records that are only available internally to the cluster exist.
+                      type: object
+                      properties:
+                        id:
+                          description: id is the identifier that can be used to find the DNS hosted zone.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: tags can be used to query the DNS hosted zone.
+                          type: object
+                status:
+                  description: status holds observed values from the cluster. They may not be overridden.
+                  type: object
             images:
               description: images is map of images that are used by the controller
                 to render templates under ./templates/

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -63,7 +63,7 @@ func toYAML(i interface{}) []byte {
 // fields for the controller spec.
 // Infrastructure provides information about the platform, etcd discovery domain.
 // Network provides the service network that is used to calculate the cluster DNS IP.
-func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, network *configv1.Network, proxy *configv1.Proxy) (*mcfgv1.ControllerConfigSpec, error) {
+func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, network *configv1.Network, proxy *configv1.Proxy, dns *configv1.DNS) (*mcfgv1.ControllerConfigSpec, error) {
 	if len(network.Spec.ServiceNetwork) == 0 {
 		return nil, fmt.Errorf("service cidr is empty in Network")
 	}
@@ -105,6 +105,7 @@ func createDiscoveredControllerConfigSpec(infra *configv1.Infrastructure, networ
 		// Still populating it here for now until it will be removed eventually
 		Platform: platform,
 		Infra:    infra,
+		DNS:      dns,
 	}
 	if network.Status.NetworkType == "" {
 		// At install time, when CNO has not started, status is unset, use the value in spec.

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -148,6 +148,7 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 		Infra   *configv1.Infrastructure
 		Network *configv1.Network
 		Proxy   *configv1.Proxy
+		DNS     *configv1.DNS
 		Error   bool
 	}{{
 		Infra: &configv1.Infrastructure{
@@ -162,6 +163,8 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 		Proxy: &configv1.Proxy{
 			Status: configv1.ProxyStatus{
 				HTTPProxy: "test.proxy"}},
+		DNS: &configv1.DNS{
+			Spec: configv1.DNSSpec{BaseDomain: "tt.testing"}},
 	}, {
 		Infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
@@ -172,6 +175,8 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 			}},
 		Network: &configv1.Network{
 			Spec: configv1.NetworkSpec{ServiceNetwork: []string{"192.168.1.1/99999999"}}},
+		DNS: &configv1.DNS{
+			Spec: configv1.DNSSpec{BaseDomain: "tt.testing"}},
 		Error: true,
 	}, {
 		Infra: &configv1.Infrastructure{
@@ -181,6 +186,8 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 			}},
 		Network: &configv1.Network{
 			Spec: configv1.NetworkSpec{ServiceNetwork: []string{"192.168.1.1/24"}}},
+		DNS: &configv1.DNS{
+			Spec: configv1.DNSSpec{BaseDomain: "tt.testing"}},
 	}, {
 		Infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
@@ -191,6 +198,8 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 			}},
 		Network: &configv1.Network{
 			Spec: configv1.NetworkSpec{ServiceNetwork: []string{}}},
+		DNS: &configv1.DNS{
+			Spec: configv1.DNSSpec{BaseDomain: "tt.testing"}},
 		Error: true,
 	}, {
 		// Test old Infra.Status.Platform field instead of Infra.Status.PlatformStatus
@@ -202,12 +211,14 @@ func TestCreateDiscoveredControllerConfigSpec(t *testing.T) {
 		},
 		Network: &configv1.Network{
 			Spec: configv1.NetworkSpec{ServiceNetwork: []string{"192.168.1.1/24"}}},
+		DNS: &configv1.DNS{
+			Spec: configv1.DNSSpec{BaseDomain: "tt.testing"}},
 	}}
 
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
 			desc := fmt.Sprintf("Infra(%#v), Network(%#v)", test.Infra, test.Network)
-			controllerConfigSpec, err := createDiscoveredControllerConfigSpec(test.Infra, test.Network, test.Proxy)
+			controllerConfigSpec, err := createDiscoveredControllerConfigSpec(test.Infra, test.Network, test.Proxy, test.DNS)
 			if err != nil {
 				if !test.Error {
 					t.Fatalf("%s failed: %s", desc, err.Error())

--- a/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -49,7 +49,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.BareMetal.IngressIP}}")
-        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.DNS.Spec.BaseDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -9,31 +9,31 @@ contents:
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
-        template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match .*.apps.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.IngressIP }}"
             fallthrough
         }
-        template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match .*.apps.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
-        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match api.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match api.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
             fallthrough
         }
-        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match api.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match api.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
-        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match api-int.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ .Infra.Status.PlatformStatus.BareMetal.APIServerInternalIP }}"
             fallthrough
         }
-        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match api-int.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
     }

--- a/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns-corefile.yaml
@@ -5,7 +5,7 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+        mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload

--- a/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -36,7 +36,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.OpenStack.IngressIP}}")
-        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.DNS.Spec.BaseDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/common/openstack/files/openstack-coredns-corefile.yaml
+++ b/templates/common/openstack/files/openstack-coredns-corefile.yaml
@@ -5,11 +5,11 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+        mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
             policy sequential
         }
         cache 30
         reload
-        file /etc/coredns/node-dns-db {{ .Infra.Status.EtcdDiscoveryDomain }}
+        file /etc/coredns/node-dns-db {{ .DNS.Spec.BaseDomain }}
     }

--- a/templates/common/openstack/files/openstack-coredns-db.yaml
+++ b/templates/common/openstack/files/openstack-coredns-db.yaml
@@ -2,8 +2,8 @@ mode: 0644
 path: "/etc/coredns/node-dns-db"
 contents:
   inline: |
-    $ORIGIN {{ .Infra.Status.EtcdDiscoveryDomain }}.
-    @    3600 IN SOA host.{{ .Infra.Status.EtcdDiscoveryDomain }}. hostmaster (
+    $ORIGIN {{ .DNS.Spec.BaseDomain }}.
+    @    3600 IN SOA host.{{ .DNS.Spec.BaseDomain }}. hostmaster (
                                     2017042752 ; serial
                                     7200       ; refresh (2 hours)
                                     3600       ; retry (1 hour)

--- a/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -37,7 +37,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.Ovirt.IngressIP}}")
-        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.DNS.Spec.BaseDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/common/ovirt/files/ovirt-coredns-corefile.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns-corefile.yaml
@@ -5,9 +5,9 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+        mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
-        file /etc/coredns/node-dns-db {{ .Infra.Status.EtcdDiscoveryDomain }}
+        file /etc/coredns/node-dns-db {{ .DNS.Spec.BaseDomain }}
     }

--- a/templates/common/ovirt/files/ovirt-coredns-db.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns-db.yaml
@@ -2,8 +2,8 @@ mode: 0644
 path: "/etc/coredns/node-dns-db"
 contents:
   inline: |
-    $ORIGIN {{ .Infra.Status.EtcdDiscoveryDomain }}.
-    @    3600 IN SOA host.{{ .Infra.Status.EtcdDiscoveryDomain }}. hostmaster (
+    $ORIGIN {{ .DNS.Spec.BaseDomain }}.
+    @    3600 IN SOA host.{{ .DNS.Spec.BaseDomain }}. hostmaster (
                                     2017042752 ; serial
                                     7200       ; refresh (2 hours)
                                     3600       ; retry (1 hour)

--- a/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -43,7 +43,7 @@ contents:
             show \
             "{{.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP}}" \
             "{{.Infra.Status.PlatformStatus.VSphere.IngressIP}}")
-        DOMAIN="{{.Infra.Status.EtcdDiscoveryDomain}}"
+        DOMAIN="{{.DNS.Spec.BaseDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
             logger -s "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
             sed -e "/^search/d" \

--- a/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns-corefile.yaml
@@ -10,17 +10,17 @@ contents:
     . {
         errors
         health :18080
-        mdns {{ .Infra.Status.EtcdDiscoveryDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
+        mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}}
         cache 30
         reload
         hosts {
-            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .Infra.Status.EtcdDiscoveryDomain }}
-            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .Infra.Status.EtcdDiscoveryDomain }}
+            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api-int.{{ .DNS.Spec.BaseDomain }}
+            {{ .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP }} api.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
-        template IN A {{ .Infra.Status.EtcdDiscoveryDomain }} {
-            match .*.apps.{{ .Infra.Status.EtcdDiscoveryDomain }}
+        template IN A {{ .DNS.Spec.BaseDomain }} {
+            match .*.apps.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in a {{ .Infra.Status.PlatformStatus.VSphere.IngressIP }}"
             fallthrough
         }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Etcd is no longer using EtcdDiscoveryDomain and as a result the parameter should be removed. However, the baremetal and friends templates reference it to get the cluster domain. This information is also available from the DNS structure, which is not currently wired into the templates.

This is a rebased replica of #2025. 

**- What I did**
This change adds the DNS struct to the resources in the controller config and switches the templates to get the cluster domain from there.
**- How to verify it**
Install a new cluster without etcdDiscoveryDomain (https://github.com/openshift/installer/pull/4067). It should successfully install the cluster.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
