### PR TITLE
Update hostname when transient hostname is fedora

### DIFF
--- a/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
+++ b/templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml
@@ -15,7 +15,7 @@ contents:
         exit 0
     fi
 
-    if [[ ! "$(< /proc/sys/kernel/hostname)" =~ (localhost|localhost.localdomain) ]]; then
+    if [[ ! "$(< /proc/sys/kernel/hostname)" =~ (fedora|localhost|localhost.localdomain) ]]; then
         log "hostname is already set"
         exit 0
     fi


### PR DESCRIPTION
A recent change, perhaps the adoption of fcos 33 broke hostname assignment (at least in GCP) because the transient hostname was set to fedora on boot.  We need to use the dhcp provided hostname in this case.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Modified templates/common/_base/files/etc-networkmanager-dispatcher.d-90-long-hostname.yaml so that the string fedora is treated like localhost when we check to see if the hostname was previously set.

**- How to verify it**
Build a 4.6 cluster in GCP.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use dhcp provided hostname when transient hostname is fedora