### PR TITLE
machineconfigcontroller: add proxy annotation to deployment

### DIFF
--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: machine-config-controller
   namespace: {{.TargetNamespace}}
+  annotations:
+    config.openshift.io/inject-proxy: machine-config-controller
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The proxy annotation is required so the proxy env vars are injected into
machine config controller properly.
The controller need added to cloud provider API's which it can't without
proper proxy.

This also breaks the CI proxy job as we can't get worker nodes created.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
