### PR TITLE
Bug 1887607: OVS config: check if OVS is installed

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -4,6 +4,14 @@ contents:
   inline: |
     #!/bin/bash
     set -eux
+
+    # Workaround to ensure OVS is installed due to bug in systemd Requires:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
+    if ! rpm -qa | grep -q openvswitch; then
+      echo "Warning: Openvswitch package is not installed!"
+      exit 1
+    fi
+
     # Create file to signal that ovs-configuration has executed (we are booted into 4.6)
     # This is necessary because systemd calls from SDN containers are unreliable, so need to look for a file
     touch /var/run/ovs-config-executed


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/machine-config-operator/pull/2154 on 4.6

With UPI installs, openvswitch package is not installed until after
upgrade. In the ovs-configuration.service there is a Requires
declaration on openvswitch.service. However due to a bug in systemd,
ovs-configuration is started even when openvswitch.service is not
present:

https://bugzilla.redhat.com/show_bug.cgi?id=1888017

As a workaround, this patch checks to ensure OVS is installed in
configure-ovs.sh.

Signed-off-by: Tim Rozet <trozet@redhat.com>
