### PR TITLE
Setting kubelet log level to recommended defaults

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
 {{- if .KubeletIPv6}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/master/01-master-kubelet/baremetal/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/baremetal/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/master/01-master-kubelet/openstack/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/openstack/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
 {{- if .KubeletIPv6}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/worker/01-worker-kubelet/baremetal/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/baremetal/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/worker/01-worker-kubelet/openstack/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/openstack/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=2"
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The current kubelet log level is set to debug (`KUBELET_LOG_LEVEL=4`), per this Red Hat Knowledgebase article [^1].  For default settings of a cluster, I'm proposing to set the log level to a more appropriate value (`KUBELET_LOG_LEVEL=2`).  I've **bolded** the description of the proposed log level below:

| Verbosity | Description |
| --- | --- |
| --v=0 | Generally useful so it is ALWAYS visible to an operator. |
| --v=1 | A reasonable default log level if you don't want verbosity. |
| **--v=2** | **Useful steady state information about the service and important log messages that may correlate to significant changes in the system. This is the recommended default log level.** |
| --v=3 | Extended information about changes. |
| --v=4 | Debug level verbosity. |
| --v=6 | Display requested resources. |
| --v=7 | Display HTTP request headers. |
| --v=8 | Display HTTP request contents. |


[^1]: https://access.redhat.com/solutions/4619431

**- How to verify it**
Steps to verify are provided in this Knowledgebase article: https://access.redhat.com/solutions/4619431

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Setting kubelet log level to recommended defaults