### PR TITLE
Bug 1890362: mcs: Ensure that the encapsulated config is spec 2 if requested

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ github.com/coreos/ignition v0.35.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/Pkr
 github.com/coreos/ignition/v2 v2.1.1/go.mod h1:RqmqU64zxarUJa3l4cHtbhcSwfQLpUhv0WVziZwoXvE=
 github.com/coreos/ignition/v2 v2.3.0 h1:TK+STbzVe6KZp4tQ2IaNSRMiWX4/diNngep1F7tP7Zk=
 github.com/coreos/ignition/v2 v2.3.0/go.mod h1:85dmM/CERMZXNrJsXqtNLIxR/dn8G9qlL1CmEjCugp0=
+github.com/coreos/ignition/v2 v2.7.0 h1:JCKxJllVtnk1lQY1uisxrtFSHG5L2NI1LRzc8wBEk84=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068 h1:y2aHj7QqyAJ6YBBONTAr17YxHHiogDkYnTsJvFNhxwY=

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -27,6 +27,7 @@ const (
 
 type poolRequest struct {
 	machineConfigPool string
+	version           *semver.Version
 }
 
 // APIServer provides the HTTP(s) endpoint
@@ -110,13 +111,10 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cr := poolRequest{
-		machineConfigPool: path.Base(r.URL.Path),
-	}
-
+	poolName := path.Base(r.URL.Path)
 	useragent := r.Header.Get("User-Agent")
 	acceptHeader := r.Header.Get("Accept")
-	glog.Infof("Pool %s requested by address:%q User-Agent:%q Accept-Header: %q", cr.machineConfigPool, r.RemoteAddr, useragent, acceptHeader)
+	glog.Infof("Pool %s requested by address:%q User-Agent:%q Accept-Header: %q", poolName, r.RemoteAddr, useragent, acceptHeader)
 
 	reqConfigVer, err := detectSpecVersionFromAcceptHeader(acceptHeader)
 	if err != nil {
@@ -124,6 +122,11 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		glog.Error(err)
 		return
+	}
+
+	cr := poolRequest{
+		machineConfigPool: poolName,
+		version:           reqConfigVer,
 	}
 
 	conf, err := sh.server.GetConfig(cr)

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -103,7 +103,7 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 		return nil, fmt.Errorf("parsing Ignition config failed with error: %v", err)
 	}
 
-	appenders := getAppenders(currConf, bsc.kubeconfigFunc)
+	appenders := getAppenders(currConf, nil, bsc.kubeconfigFunc)
 	for _, a := range appenders {
 		if err := a(&ignConf, mc); err != nil {
 			return nil, err

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -78,7 +78,7 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 		return nil, fmt.Errorf("parsing Ignition config failed with error: %v", err)
 	}
 
-	appenders := getAppenders(currConf, cs.kubeconfigFunc)
+	appenders := getAppenders(currConf, cr.version, cs.kubeconfigFunc)
 	for _, a := range appenders {
 		if err := a(&ignConf, mc); err != nil {
 			return nil, err


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1890250

Basically adding new workers during the window when:

- control plane has upgraded to 4.6
- worker pool is still rolling out

Will fail for clusters whose bootimage is older than 4.6 because
the MCD-on-host will find the `3.1.0` version in
`/etc/ignition-machine-config-encapsulated.json`
and barf.
