### PR TITLE
server: More unit testing for MCS Ignition version

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ github.com/coreos/ignition v0.35.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/Pkr
 github.com/coreos/ignition/v2 v2.1.1/go.mod h1:RqmqU64zxarUJa3l4cHtbhcSwfQLpUhv0WVziZwoXvE=
 github.com/coreos/ignition/v2 v2.3.0 h1:TK+STbzVe6KZp4tQ2IaNSRMiWX4/diNngep1F7tP7Zk=
 github.com/coreos/ignition/v2 v2.3.0/go.mod h1:85dmM/CERMZXNrJsXqtNLIxR/dn8G9qlL1CmEjCugp0=
+github.com/coreos/ignition/v2 v2.7.0 h1:JCKxJllVtnk1lQY1uisxrtFSHG5L2NI1LRzc8wBEk84=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068 h1:y2aHj7QqyAJ6YBBONTAr17YxHHiogDkYnTsJvFNhxwY=

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,14 +3,18 @@ package server
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
+	ign2 "github.com/coreos/ignition/config/v2_2"
+	ign3 "github.com/coreos/ignition/v2/config/v3_1"
 	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
 	yaml "github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -84,7 +88,9 @@ func TestEncapsulated(t *testing.T) {
 	assert.Equal(t, mcIgnCfg.Storage.Files[1].Path, daemonconsts.MachineConfigEncapsulatedPath)
 
 	vers := []*semver.Version{semver.New("3.1.0"), semver.New("2.2.0")}
+	t.Logf("vers: %v\n", vers)
 	for _, v := range vers {
+		major := v.Slice()[0]
 		mcIgnCfg, err = ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 		assert.Nil(t, err)
 		err = appendEncapsulated(&mcIgnCfg, mc, v)
@@ -94,7 +100,26 @@ func TestEncapsulated(t *testing.T) {
 		assert.Equal(t, 1, len(origIgnCfg.Storage.Files))
 		assert.Equal(t, 2, len(mcIgnCfg.Storage.Files))
 		assert.Equal(t, mcIgnCfg.Storage.Files[0].Path, "/etc/coreos/update.conf")
-		assert.Equal(t, mcIgnCfg.Storage.Files[1].Path, daemonconsts.MachineConfigEncapsulatedPath)
+		encapF := &mcIgnCfg.Storage.Files[1]
+		assert.Equal(t, encapF.Path, daemonconsts.MachineConfigEncapsulatedPath)
+		encapSource := *encapF.Contents.Source
+		dataPrefix := "data:,"
+		assert.True(t, strings.HasPrefix(encapSource, dataPrefix))
+		encapEncoded := encapSource[len(dataPrefix):]
+		encapDataStr, err := url.PathUnescape(encapEncoded)
+		assert.Nil(t, err)
+		t.Logf("encapData: %s", encapDataStr)
+		encapData := []byte(encapDataStr)
+		var mc mcfgv1.MachineConfig
+		err = json.Unmarshal(encapData, &mc)
+		assert.Nil(t, err)
+		if major == 3 {
+			_, _, err := ign3.Parse(mc.Spec.Config.Raw)
+			assert.Nil(t, err)
+		} else {
+			_, _, err := ign2.Parse(mc.Spec.Config.Raw)
+			assert.Nil(t, err)
+		}
 	}
 }
 


### PR DESCRIPTION
In between the master and 4.6 PRs I added more unit testing;
this "forward ports" the additional unit testing to master.

At the time I didn't re-push to the master PR because I didn't want to
re-trigger CI, but now we can.
