### PR TITLE
[Baremetal] Update keepalived liveness probe to check also CPU usage

### DIFF
--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -114,7 +114,7 @@ contents:
             - /bin/bash
             - -c
             - |
-              kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data
+            [ kill -s SIGUSR1 "$(pgrep -o keepalived)" && ! grep -q "State = FAULT" /tmp/keepalived.data ] && [ ps -C keepalived  -o pid=,pcpu= | awk --assign maxcpu=75  '$2>maxcpu {exit 1}' ]
           initialDelaySeconds: 20
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
We noticed sometimes that Keepalived container consumes ~100% of CPU resources,
the root cause for that is [1].

This commit updates Keepalived liveness probe to monitor also CPU usage to work around
the high CPU usage bug until U/S fix will be inherited to D/S repo.

[1]  https://bugzilla.redhat.com/show_bug.cgi?id=1868077
