### PR TITLE
crio: drop infra container when possible

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -22,6 +22,7 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
+    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -22,6 +22,7 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
+    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
in cri-o 1.19 we introduced a feature to drop the infra container when a pod doesn't have a pod level PID namespace
We have been running with this option in cri-o internal tests and have seen no issues.

Let's enable it by default in 4.7. In addition to being more performant, it also should aid in a race with the kubelet
win-win!

Signed-off-by: Peter Hunt <pehunt@redhat.com>

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Have CRI-O drop the infra container in some cases, which performs better