### PR TITLE
Bug 1890074: pkg/daemon: avoid duplicate extension verification

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -56,3 +56,12 @@ const (
 	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.
 	MachineConfigDaemonForceFile = "/run/machine-config-daemon-force"
 )
+
+var (
+	// SupportedPackages lists RPMs available in machine-os-content for RHCOS
+	SupportedPackages = []string{"kernel-headers", "usbguard"}
+	// SupportedPackageAliases expands allowed aliases to a list of RPMs to install
+	SupportedPackageAliases = map[string][]string{
+		"kernel-devel": {"kernel-headers", "kernel-devel"},
+	}
+)


### PR DESCRIPTION
When package aliases (or groups) were introduced [recently](https://github.com/openshift/machine-config-operator/pull/2170),
this list is now being verified twice - during `validateExtensions` on
MCC and in `generateExtensionsArgs` on MCD. This breaks OKD installs,
as we'd like to avoid verifying a pre-approved list of RPMs on FCOS.

However, MCC can't know which systems it would manage, so it applies
RHCOS allowlist on all systems unknowingly.

This commit refactors extensions verification and application:

* available packages are listed in `constants.SupportedPackages`
* groups/aliases MCD knows about are listed in `constants.SupportedPackageAliases`
* `validateExtensions` ensures that `spec.extensions` items are in either list
* `generateExtensionsArgs` expands aliases into a list of RPMs

On OKD `validateExtensions` is not called, however `generateExtensionsArgs`
would still apply (so `kernel-devel` would automatically bring in `kernel-headers`).
This might bite us in the future, but at least it won't block
installs, so its safe to merge now.

/cc @cgwalters @sinnykumari @kikisdeliveryservice 
