### PR TITLE
templates/master/00-master/_base/files: remove etcd-root-ca

### DIFF
--- a/templates/master/00-master/_base/files/etcd-root-ca.yaml
+++ b/templates/master/00-master/_base/files/etcd-root-ca.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/static-pod-resources/etcd-member/root-ca.crt"
-contents:
-  inline: |
-{{.RootCAData | toString | indent 4}}


### PR DESCRIPTION
This CA is not used by the product and causes confusion.