### PR TITLE
test: increase e2e test run with 15 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,4 +109,4 @@ Dockerfile.rhel7: Dockerfile Makefile
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operator
 test-e2e:
-	go test -failfast -timeout 75m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/
+	go test -failfast -timeout 90m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/


### PR DESCRIPTION
fixes e2e-gcp-op test failing in ci due to timeout