### PR TITLE
[Baremetal] Remove BootstrapIP from Keepalived template

### DIFF
--- a/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived-keepalived.yaml
@@ -52,8 +52,7 @@ contents:
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
-        unicast_peer {
-            {{`{{ .BootstrapIP }}`}}
+        unicast_peer {            
             {{`{{range .LBConfig.Backends -}}
             {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
             {{end}}`}}


### PR DESCRIPTION
Since we eliminate the need for the master nodes to know the bootstrap IP address
for unicast Keepalived, we can delete BootstrapIP from Keepalived template.

