### PR TITLE
Bug 1892448: daemon: add back metrics for pivot error

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -347,6 +347,7 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 
 	// Update OS
 	if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
+		MCDPivotErr.WithLabelValues(dn.node.Name, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
 		return err
 	}
 


### PR DESCRIPTION
It accidentally got removed in https://github.com/openshift/machine-config-operator/commit/6757381f09358f05fe5eefedfa85480ce09b3720#diff-349c0748c3f52201852d3027c29daf618b45300b949482728df6666a3f9ba245L1325 . Thanks to @kikisdeliveryservice for noticing this.