### PR TITLE
Use hostNetwork: true for operator and controller

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -44,6 +44,10 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      # We want to support switching cluster network types "day 2".
+      # This may involve a MachineConfig rollout, so using the
+      # host network will avoid potential deadlocks.
+      hostNetwork: true
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -26,6 +26,10 @@ spec:
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: machine-config-controller
+      # We want to support switching cluster network types "day 2".
+      # This may involve a MachineConfig rollout, so using the
+      # host network will avoid potential deadlocks.
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -793,6 +793,10 @@ spec:
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: machine-config-controller
+      # We want to support switching cluster network types "day 2".
+      # This may involve a MachineConfig rollout, so using the
+      # host network will avoid potential deadlocks.
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"


### PR DESCRIPTION
We want to support switching cluster network types "day 2".
This may involve a MachineConfig rollout, so using the
host network will avoid potential deadlocks.
