### PR TITLE
templates: convert kubelet proxy config into a dropin

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -40,3 +40,20 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
+dropins:
+- name: 10-mco-default-env.conf
+  contents: |
+    [Unit]
+    Description=MCO environment configuration
+    {{if .Proxy -}}
+    [Service]
+    {{if .Proxy.HTTPProxy -}}
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -39,3 +39,20 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
+dropins:
+- name: 10-mco-default-env.conf
+  contents: |
+    [Unit]
+    Description=MCO environment configuration
+    {{if .Proxy -}}
+    [Service]
+    {{if .Proxy.HTTPProxy -}}
+    Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    Environment=NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}


### PR DESCRIPTION
This ensures OKD 4.5 -> 4.6 upgrade can complete. Currently kubelet config is considered to be a file, but in 4.6 config its a drop in, so MCD can't properly create it.