### PR TITLE
Bug 1894477: Fix bash in nodeip-configuration.service

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -21,8 +21,7 @@ contents: |
     --volume /etc/systemd/system:/etc/systemd/system:z \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
-    set --retry-on-failure \
-    ; \
+    set --retry-on-failure; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
The current bash code in the service looks invalid.
```
# on 4.6.0-0.okd-2020-11-03-123207
[root@master-0 ~]# systemctl status nodeip-configuration
● nodeip-configuration.service - Writes IP address configuration so that kubelet and crio services select a valid node IP
     Loaded: loaded (/etc/systemd/system/nodeip-configuration.service; enabled; vendor preset: enabled)
     Active: failed (Result: exit-code) since Wed 2020-11-04 08:22:50 UTC; 22min ago
    Process: 980 ExecStart=/bin/bash -c     until    /usr/bin/podman run --rm    --authfile /var/lib/kubelet/config.json    --net=host    --volume /etc/systemd/system:/etc/systemd/system:z    registry.svc.ci.openshift.org/origin/4.6-2020>
   Main PID: 980 (code=exited, status=1/FAILURE)
        CPU: 4ms
lis 04 08:22:50 master-0 systemd[1]: Starting Writes IP address configuration so that kubelet and crio services select a valid node IP...
lis 04 08:22:50 master-0 bash[980]: /bin/bash: -c: line 0: syntax error near unexpected token `done'
lis 04 08:22:50 master-0 bash[980]: /bin/bash: -c: line 0: `    until    /usr/bin/podman run --rm    --authfile /var/lib/kubelet/config.json    --net=host    --volume /etc/systemd/system:/etc/systemd/system:z    registry.svc.ci.openshift>
lis 04 08:22:50 master-0 systemd[1]: nodeip-configuration.service: Main process exited, code=exited, status=1/FAILURE
lis 04 08:22:50 master-0 systemd[1]: nodeip-configuration.service: Failed with result 'exit-code'.
lis 04 08:22:50 master-0 systemd[1]: Failed to start Writes IP address configuration so that kubelet and crio services select a valid node IP.
```

It borked OKD but somehow got through ocp test suites - is this not covered?

Fixes https://github.com/openshift/machine-config-operator/issues/2179

/cc @danwinship @knobunc @cgwalters 