### PR TITLE
Revert "crio: drop infra container when possible"

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -22,7 +22,6 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
-    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -22,7 +22,6 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
-    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION
This reverts commit 6eb37894974b71080648a92bbb71fd201c5a84f4.

reverts https://github.com/openshift/machine-config-operator/pull/2177, one of two commits that merged before the permafail of e2e-serial on OOMs