### PR TITLE
Bug 1879099: Inject version into controllerconfig, refuse mismatches

### DIFF
--- a/manifests/machineconfigcontroller/controllerconfig.yaml
+++ b/manifests/machineconfigcontroller/controllerconfig.yaml
@@ -2,5 +2,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: ControllerConfig
 metadata:
   name: machine-config-controller
+  annotations:
+    machineconfiguration.openshift.io/generated-by-version: "{{ .Version }}"
 spec:
 {{toYAML .ControllerConfig | toString | indent 2}}

--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -2,6 +2,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: ControllerConfig
 metadata:
   name: machine-config-controller
+  annotations:
+    machineconfiguration.openshift.io/generated-by-version: "v0.0.0-was-not-built-properly"
 spec:
   additionalTrustBundle: null
   cloudProviderConfig: ""

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -26,8 +26,10 @@ import (
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
@@ -222,7 +224,7 @@ func (f *fixture) expectUpdateMachineConfigPoolStatus(pool *mcfgv1.MachineConfig
 func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 	return &mcfgv1.ControllerConfig{
 		TypeMeta:   metav1.TypeMeta{APIVersion: mcfgv1.SchemeGroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5))},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{daemonconsts.GeneratedByVersionAnnotationKey: version.Raw}, Name: name, UID: types.UID(utilrand.String(5))},
 		Spec: mcfgv1.ControllerConfigSpec{
 			Infra: &configv1.Infrastructure{
 				Status: configv1.InfrastructureStatus{
@@ -382,6 +384,25 @@ func TestGenerateMachineConfigNoOverrideOSImageURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "dummy", gmc.Spec.OSImageURL)
+}
+
+func TestVersionSkew(t *testing.T) {
+	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
+	mcs := []*mcfgv1.MachineConfig{
+		helpers.NewMachineConfig("00-test-cluster-master", map[string]string{"node-role/master": ""}, "dummy-test-1", []ign3types.File{}),
+		helpers.NewMachineConfig("00-test-cluster-master-0", map[string]string{"node-role/master": ""}, "dummy-change", []ign3types.File{}),
+	}
+
+	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
+	cc.Annotations[daemonconsts.GeneratedByVersionAnnotationKey] = "different-version"
+	_, err := generateRenderedMachineConfig(mcp, mcs, cc)
+	require.NotNil(t, err)
+
+	// Now the same thing without overriding the version
+	cc = newControllerConfig(ctrlcommon.ControllerConfigName)
+	gmc, err := generateRenderedMachineConfig(mcp, mcs, cc)
+	require.Nil(t, err)
+	require.NotNil(t, gmc)
 }
 
 func TestDoNothing(t *testing.T) {

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -16,6 +16,10 @@ const (
 	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
 	// OpenShiftOperatorManagedLabel is used to filter out kube objects that don't need to be synced by the MCO
 	OpenShiftOperatorManagedLabel = "openshift.io/operator-managed"
+
+	// GeneratedByVersionAnnotationKey is used to tag the controllerconfig to synchronize the MCO and MCC
+	GeneratedByVersionAnnotationKey = "machineconfiguration.openshift.io/generated-by-version"
+
 	// MachineConfigDaemonStateWorking is set by daemon when it is applying an update.
 	MachineConfigDaemonStateWorking = "Working"
 	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -746,6 +746,8 @@ var _manifestsMachineconfigcontrollerControllerconfigYaml = []byte(`apiVersion: 
 kind: ControllerConfig
 metadata:
   name: machine-config-controller
+  annotations:
+    machineconfiguration.openshift.io/generated-by-version: "{{ .Version }}"
 spec:
 {{toYAML .ControllerConfig | toString | indent 2}}
 `)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/machine-config-operator/lib/resourceread"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	templatectrl "github.com/openshift/machine-config-operator/pkg/controller/template"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/operator/assets"
 	"github.com/openshift/machine-config-operator/pkg/version"
 )
@@ -391,6 +392,11 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig) error {
 		return err
 	}
 	cc := resourceread.ReadControllerConfigV1OrDie(ccBytes)
+	// Propagate our binary version into the controller config to help
+	// suppress rendered config generation until a corresponding
+	// new controller can roll out too.
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1879099
+	cc.Annotations[daemonconsts.GeneratedByVersionAnnotationKey] = version.Raw
 	_, _, err = resourceapply.ApplyControllerConfig(optr.client.MachineconfigurationV1(), cc)
 	if err != nil {
 		return err


### PR DESCRIPTION
Should fix: https://bugzilla.redhat.com/show_bug.cgi?id=1879099

Basically we only want to roll out new machineconfigs if
the controllerconfig (generated by the operator) and the
controller are at matching versions.

Per Jerry's comment in Bugzilla:

> 1. The new MCO rolls out. It first syncs the controllerconfig to the new one as part of the RenderConfig step above.
> 2. The running (old) MCC's template controller has an informer on the controllerconfig, which since the previous step updated the config, calls a syncControllerConfig. This re-generates the base master config (00-master MC)
> 3. The running (old) MCC now sees a MC change which calls another sync call to generate a new rendered config, and instructs the master pool to start an update
> 4. The new MCC rolls out, and does the whole rendering process, creating the actual updated MC for the master pool, which it waits until the previous one is finished, and starts the new (real) update.

After this patch, the old MCC will refuse to render from a controllerconfig generated by the new MCO.
