### PR TITLE
Bug 1895099: Fix VSphere UPI not populating PlatformStatus

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -410,7 +410,12 @@ func onPremPlatformIngressIP(cfg RenderConfig) (interface{}, error) {
 		case configv1.OpenStackPlatformType:
 			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIP, nil
 		case configv1.VSpherePlatformType:
-			return cfg.Infra.Status.PlatformStatus.VSphere.IngressIP, nil
+			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
+				return cfg.Infra.Status.PlatformStatus.VSphere.IngressIP, nil
+			}
+			// VSphere UPI doesn't populate VSphere field. So it's not an error,
+			// and there is also no data
+			return nil, nil
 		default:
 			return nil, fmt.Errorf("invalid platform for Ingress IP")
 		}
@@ -429,7 +434,12 @@ func onPremPlatformAPIServerInternalIP(cfg RenderConfig) (interface{}, error) {
 		case configv1.OpenStackPlatformType:
 			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIP, nil
 		case configv1.VSpherePlatformType:
-			return cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP, nil
+			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
+				return cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIP, nil
+			}
+			// VSphere UPI doesn't populate VSphere field. So it's not an error,
+			// and there is also no data
+			return nil, nil
 		default:
 			return nil, fmt.Errorf("invalid platform for API Server Internal IP")
 		}

--- a/templates/common/on-prem/files/NetworkManager-mdns-hostname.yaml
+++ b/templates/common/on-prem/files/NetworkManager-mdns-hostname.yaml
@@ -2,6 +2,7 @@ mode: 0755
 path: "/etc/NetworkManager/dispatcher.d/40-mdns-hostname"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     #!/bin/bash
     STATUS=$2
     case "$STATUS" in
@@ -19,3 +20,4 @@ contents:
         *)
         ;;
     esac
+    {{ end -}}

--- a/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
+++ b/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/99-{{ onPremPlatformShortName . }}.conf"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     [main]
     rc-manager=unmanaged
     [connection]
@@ -9,3 +10,4 @@ contents:
     ipv6.dhcp-iaid=mac
     [keyfile]
     path=/etc/NetworkManager/system-connections-merged
+    {{ end -}}

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -2,6 +2,7 @@ mode: 0755
 path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     #!/bin/bash
     set -eo pipefail
     IFACE=$1
@@ -63,3 +64,4 @@ contents:
         *)
         ;;
     esac
+    {{ end -}}

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/coredns.yaml"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -116,3 +117,4 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/keepalived.yaml"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -167,3 +168,4 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}

--- a/templates/common/on-prem/files/mdns-publisher.yaml
+++ b/templates/common/on-prem/files/mdns-publisher.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/mdns-publisher.yaml"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -101,3 +102,4 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -1,6 +1,7 @@
 name: nodeip-configuration.service
 enabled: true
 contents: |
+  {{ if (onPremPlatformAPIServerInternalIP .) -}}
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   # This only applies to VIP managing environments where the kubelet and crio IP
@@ -44,4 +45,4 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
-
+  {{ end -}}

--- a/templates/common/vsphere/files/etc-systemd-system-crio-stream-address.conf.yaml
+++ b/templates/common/vsphere/files/etc-systemd-system-crio-stream-address.conf.yaml
@@ -2,11 +2,7 @@ mode: 0644
 path: "/etc/systemd/system/crio.service.d/20-stream-address.conf"
 contents:
   inline: |
-    {{ if .Infra -}}
-    {{ if .Infra.Status -}}
-    {{ if .Infra.Status.PlatformStatus -}}
-    {{ if .Infra.Status.PlatformStatus.VSphere -}}
-    {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     [Service]
     ExecStart=
     ExecStart=/usr/bin/crio \
@@ -14,8 +10,4 @@ contents:
           $CRIO_STORAGE_OPTIONS \
           $CRIO_NETWORK_OPTIONS \
           $CRIO_METRICS_OPTIONS
-    {{ end -}}
-    {{ end -}}
-    {{ end -}}
-    {{ end -}}
     {{ end -}}

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -2,6 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/manifests/haproxy.yaml"
 contents:
   inline: |
+    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -144,3 +145,4 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
+    {{ end -}}


### PR DESCRIPTION
The VSphere UPI install does not fully populate PlatformStatus. When we deduped
the templates, we didn't account for this being nil. This should render these
templates empty when that PlatformStatus is nil.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
