### PR TITLE
operator: allow kube-cloud-config cm with CA data but no cloud config

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -119,30 +119,33 @@ func isCloudConfigRequired(infra *configv1.Infrastructure) bool {
 
 // Sync cloud config on supported platform from cloud.conf available in openshift-config-managed/kube-cloud-config ConfigMap.
 func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *configv1.Infrastructure) error {
-	if _, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-cloud-config"); err != nil {
+	cm, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-cloud-config")
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if isCloudConfigRequired(infra) {
-				// Return error only if cloud config is required, otherwise prceeds further.
+				// Return error only if cloud config is required, otherwise proceeds further.
 				return fmt.Errorf("%s/%s configmap is required on platform %s but not found: %v",
 					"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
 			}
-		} else {
-			return err
+			return nil
 		}
-
+		return err
+	}
+	// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
+	cc, err := getCloudConfigFromConfigMap(cm, "cloud.conf")
+	if err != nil {
+		if isCloudConfigRequired(infra) {
+			// Return error only if cloud config is required, otherwise proceeds further.
+			return fmt.Errorf("%s/%s configmap must have the %s key on platform %s but not found",
+				"openshift-config-managed", "kube-cloud-config", "cloud.conf", infra.Status.PlatformStatus.Type)
+		}
 	} else {
-		// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
-		cc, err := optr.getCloudConfigFromConfigMap("openshift-config-managed", "kube-cloud-config", "cloud.conf")
-		if err != nil {
-			return err
-		}
-
 		spec.CloudProviderConfig = cc
+	}
 
-		caCert, err := optr.getCAsFromConfigMap("openshift-config-managed", "kube-cloud-config", "ca-bundle.pem")
-		if err == nil {
-			spec.CloudProviderCAData = caCert
-		}
+	caCert, err := getCAsFromConfigMap(cm, "ca-bundle.pem")
+	if err == nil {
+		spec.CloudProviderCAData = caCert
 	}
 	return nil
 }
@@ -758,6 +761,10 @@ func (optr *Operator) getCAsFromConfigMap(namespace, name, key string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
+	return getCAsFromConfigMap(cm, key)
+}
+
+func getCAsFromConfigMap(cm *corev1.ConfigMap, key string) ([]byte, error) {
 	if bd, bdok := cm.BinaryData[key]; bdok {
 		return bd, nil
 	} else if d, dok := cm.Data[key]; dok {
@@ -769,7 +776,7 @@ func (optr *Operator) getCAsFromConfigMap(namespace, name, key string) ([]byte, 
 		}
 		return raw, nil
 	} else {
-		return nil, fmt.Errorf("%s not found in %s/%s", key, namespace, name)
+		return nil, fmt.Errorf("%s not found in %s/%s", key, cm.Namespace, cm.Name)
 	}
 }
 
@@ -778,10 +785,14 @@ func (optr *Operator) getCloudConfigFromConfigMap(namespace, name, key string) (
 	if err != nil {
 		return "", err
 	}
+	return getCloudConfigFromConfigMap(cm, key)
+}
+
+func getCloudConfigFromConfigMap(cm *corev1.ConfigMap, key string) (string, error) {
 	if cc, ok := cm.Data[key]; ok {
 		return cc, nil
 	}
-	return "", fmt.Errorf("%s not found in %s/%s", key, namespace, name)
+	return "", fmt.Errorf("%s not found in %s/%s", key, cm.Namespace, cm.Name)
 }
 
 // getGlobalConfig gets global configuration for the cluster, namely, the Infrastructure and Network types.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
When installed on C2S regions on AWS, a CA bundle is needed for communication with the AWS API. This CA bundle will be placed in the kube-cloud-config ConfigMap in the openshift-config-managed namespace. When that ConfigMap is present, the machine-config-operator assumes that it will contain a cloud provider config in the "cloud.conf" key. However, for AWS, the cloud provider config is not required.

With these changes, the machine-config-operator will accept a ConfigMap that does not have the "cloud.conf" key. The MCO will still error when the "cloud.conf" key is absent for a platform where the cloud provider config is required.

https://issues.redhat.com/browse/CORS-1584

**- How to verify it**
Add a cloud-provider-config ConfigMap in the openshift-config namespace. Verify that a kube-cloud-config ConfigMap is created in the openshift-config-managed namespace. Restart the machine-config-operator pod. Verify in the logs of the new machine-config-operator pod that the RenderConfig is synced.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Accept a kube-cloud-config ConfigMap without "cloud.conf" on platforms that do not require a cloud provider config.