### PR TITLE
Revert "Revert "crio: drop infra container when possible""

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,7 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
+    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,7 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
+    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION
This reverts commit 4554713bef99dcfc80ef9fc48788f4042881083e.

Attempt to drop infra container again, now with a test that verifies we don't regress in the same way that
caused us to revert before

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
