### PR TITLE
Bug 1895385: Drop kubelet logging back down to level 3

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=3"
 {{- if .KubeletIPv6}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  Environment="KUBELET_LOG_LEVEL=4"
+  Environment="KUBELET_LOG_LEVEL=3"
 {{- if .KubeletIPv6}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}


### PR DESCRIPTION
KUBELET_LOG_LEVEL was bumped to level 4 to aid in
debugging some issue by node team (see https://github.com/openshift/machine-config-operator/pull/1672).
However customers upgrading to 4.5 in prod, are seeing this bump
causing extra GBs of data to be saved.

Closes: BZ 1895385
