### PR TITLE
[WIP] Use same namespace name for kni-networking services on all platforms.

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -13,43 +13,10 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-openstack-infra
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    openshift.io/node-selector: ""
-  labels:
-    name: openshift-openstack-infra
-    openshift.io/run-level: "1"
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: openshift-kni-infra
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
   labels:
     name: openshift-kni-infra
-    openshift.io/run-level: "1"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-ovirt-infra
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    openshift.io/node-selector: ""
-  labels:
-    name: openshift-ovirt-infra
-    openshift.io/run-level: "1"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-vsphere-infra
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    openshift.io/node-selector: ""
-  labels:
-    name: openshift-vsphere-infra
     openshift.io/run-level: "1"

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: openshift-{{ onPremPlatformShortName .ControllerConfig }}-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: openshift-{{ onPremPlatformShortName .ControllerConfig }}-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1644,7 +1644,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: openshift-{{ onPremPlatformShortName .ControllerConfig }}-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
@@ -1797,7 +1797,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: openshift-{{ onPremPlatformShortName .ControllerConfig }}-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -6,7 +6,7 @@ contents:
     apiVersion: v1
     metadata:
       name: coredns
-      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      namespace: openshift-kni-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -6,7 +6,7 @@ contents:
     apiVersion: v1
     metadata:
       name: keepalived
-      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      namespace: openshift-kni-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/common/on-prem/files/mdns-publisher.yaml
+++ b/templates/common/on-prem/files/mdns-publisher.yaml
@@ -6,7 +6,7 @@ contents:
     apiVersion: v1
     metadata:
       name: mdns-publisher
-      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      namespace: openshift-kni-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -6,7 +6,7 @@ contents:
     apiVersion: v1
     metadata:
       name: haproxy
-      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      namespace: openshift-kni-infra
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:


### PR DESCRIPTION
Instead of always creating (on each platform) all the namespaces for irrelevant platforms and use only one of them.

Signed-off-by: Ravid Brown <ravid@redhat.com>
