### PR TITLE
daemon: Remove rollback deployment

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1022,6 +1022,10 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return fmt.Errorf("error detecting previous SSH accesses: %v", err)
 	}
 
+	if err := dn.removeRollback(); err != nil {
+		return errors.Wrapf(err, "Failed to remove rollback")
+	}
+
 	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -512,6 +512,16 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 	return dn.finalizeAndReboot(newConfig)
 }
 
+// removeRollback removes the rpm-ostree rollback deployment.  It
+// takes up space, and we don't generally expect administrators to
+// use this versus e.g. removing broken configuration.  We only
+// remove the rollback once the MCD pod has landed on a node, so
+// we know kubelet is working.
+func (dn *Daemon) removeRollback() error {
+	_, err := runGetOut("rpm-ostree", "cleanup", "-r")
+	return err
+}
+
 // machineConfigDiff represents an ad-hoc difference between two MachineConfig objects.
 // At some point this may change into holding just the files/units that changed
 // and the MCO would just operate on that.  For now we're just doing this to get


### PR DESCRIPTION
Came out of concerns from compliance about having bootloader
entries that may not have expected parameters.
