### PR TITLE
crio: add builder runtime class

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -22,6 +22,19 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
+    [crio.runtime.runtimes]
+    [crio.runtime.runtimes.runc]
+    runtime_path = ""
+    runtime_type = "oci"
+    runtime_root = "/run/runc"
+    [crio.runtime.runtimes.builder]
+    runtime_path = "/usr/bin/runc"
+    runtime_type = "oci"
+    runtime_root = "/run/runc"
+    allowed_annotations = [
+       "io.kubernetes.cri-o.userns-mode",
+       "io.kubernetes.cri-o.Devices",
+    ]
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -22,6 +22,19 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
+    [crio.runtime.runtimes]
+    [crio.runtime.runtimes.runc]
+    runtime_path = ""
+    runtime_type = "oci"
+    runtime_root = "/run/runc"
+    [crio.runtime.runtimes.builder]
+    runtime_path = "/usr/bin/runc"
+    runtime_type = "oci"
+    runtime_root = "/run/runc"
+    allowed_annotations = [
+       "io.kubernetes.cri-o.userns-mode",
+       "io.kubernetes.cri-o.Devices",
+    ]
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
to allow unprivileged builds in openshift, we need to give pods a way to pass in /dev/fuse and allocate user user namespaces.
However, we don't want every pod to have that behavior.

We've created an option for admins to specify runtime classes that interpret pod annotations for each of these fields.
For the builder team to take advantage of it, we need to add it to the crio templates.

Note: if we omit the plain "runc" entry, then the runtimes map will only container the builder class. We need to add both to append the builder class

Signed-off-by: Peter Hunt <pehunt@redhat.com>

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
