### PR TITLE
MCS: Validate provisioning token

### DIFF
--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -7,3 +7,6 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -49,3 +49,9 @@ spec:
       - name: certs
         secret:
           secretName: machine-config-server-tls
+      # See https://github.com/openshift/enhancements/pull/443
+      # This will only exist in 4.7+ clusters by default.
+      - name: provisioning-token
+        secret:
+          secretName: provisioning-token
+          optional: true

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1284,6 +1284,9 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
 `)
 
 func manifestsMachineconfigserverClusterroleYamlBytes() ([]byte, error) {
@@ -1445,6 +1448,12 @@ spec:
       - name: certs
         secret:
           secretName: machine-config-server-tls
+      # See https://github.com/openshift/enhancements/pull/443
+      # This will only exist in 4.7+ clusters by default.
+      - name: provisioning-token
+        secret:
+          secretName: provisioning-token
+          optional: true
 `)
 
 func manifestsMachineconfigserverDaemonsetYamlBytes() ([]byte, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,6 +37,27 @@ type kubeconfigFunc func() (kubeconfigData []byte, rootCAData []byte, err error)
 // appenderFunc appends Config.
 type appenderFunc func(*igntypes.Config, *mcfgv1.MachineConfig) error
 
+// configError is returned by the GetConfig API
+type configError struct {
+	msg       string
+	forbidden bool
+}
+
+// configError returns the string
+func (e *configError) Error() string {
+	return e.msg
+}
+
+// IsForbidden says if err is an configError with forbidden set
+func IsForbidden(err error) bool {
+	switch t := err.(type) {
+	case *configError:
+		return t.forbidden
+	default:
+		return false
+	}
+}
+
 // Server defines the interface that is implemented by different
 // machine config server implementations.
 type Server interface {


### PR DESCRIPTION
Implements: https://github.com/openshift/enhancements/pull/443
Requires: https://github.com/openshift/installer/pull/4372

Basically we need to protect the Ignition config since it
contains secrets (pull secret, kubeconfig) and we can't rely
solely on network firewalling in all cases.

The installer will generate a secret into both the pointer
config and as a secret in our namespace, the MCS checks it.
