### PR TITLE
WIP: [DO NOT MERGE] Bump sleep in ctrcfg_test.go

### DIFF
--- a/test/e2e/ctrcfg_test.go
+++ b/test/e2e/ctrcfg_test.go
@@ -107,7 +107,7 @@ func runTestWithCtrcfg(t *testing.T, testName, regexKey, expectedConfValue strin
 	t.Logf("Deleted ContainerRuntimeConfig %s", ctrcfgName)
 	// there's a weird race where we observe the pool is updated when in reality
 	// that update is from before. Sleeping allows a new update cycle to start
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 
 	// ensure config rolls back as expected
 	waitForConfigAndPoolComplete(t, cs, poolName, oldMCConfig.Name)


### PR DESCRIPTION
Looks like even with the 5 second sleep, we were hitting
the race where we see that the pool is updated when
it is actually from a previous update.
Testing to see if increasing the sleep helps here.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
