### PR TITLE
Bug 1896898: Fix awk syntax in configure-ovs.sh

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -34,13 +34,13 @@ contents:
       # find default interface
       while [ $counter -lt 12 ]; do
         # check ipv4
-        iface=$(ip route show default | awk '{if ($4 == "dev") print $5; exit}')
+        iface=$(ip route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
         if [[ -n "$iface" ]]; then
           echo "IPv4 Default gateway interface found: ${iface}"
           break
         fi
         # check ipv6
-        iface=$(ip -6 route show default | awk '{if ($4 == "dev") print $5; exit}')
+        iface=$(ip -6 route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
         if [[ -n "$iface" ]]; then
           echo "IPv6 Default gateway interface found: ${iface}"
           break


### PR DESCRIPTION
The script did

    iface=$(ip route show default | awk '{if ($4 == "dev") print $5; exit}')

which is to say:

    iface=$(ip route show default | awk '{
        if ($4 == "dev")
            print $5;
        exit
    }')

ie, it was unconditionally exiting after the first line (which actually worked most of the time...)