### PR TITLE
Bug 1897361: ctrcfg_test: Wait for our prior target config

### DIFF
--- a/test/e2e/ctrcfg_test.go
+++ b/test/e2e/ctrcfg_test.go
@@ -84,7 +84,7 @@ func runTestWithCtrcfg(t *testing.T, testName, regexKey, expectedConfValue strin
 		err := cs.MachineConfigs().Delete(context.TODO(), oldMCConfig.Name, metav1.DeleteOptions{})
 		require.Nil(t, err, "machine config deletion failed")
 	})
-	waitForConfigAndPoolComplete(t, cs, poolName, oldMCConfig.Name)
+	lastTarget := waitForConfigAndPoolComplete(t, cs, poolName, oldMCConfig.Name)
 
 	// create our ctrcfg and attach it to our created node pool
 	cleanupCtrcfgFunc := createCtrcfgWithConfig(t, cs, ctrcfgName, poolName, cfg)
@@ -103,14 +103,10 @@ func runTestWithCtrcfg(t *testing.T, testName, regexKey, expectedConfValue strin
 	// cleanup ctrcfg and make sure it doesn't error
 	err = cleanupCtrcfgFunc()
 	require.Nil(t, err)
-
 	t.Logf("Deleted ContainerRuntimeConfig %s", ctrcfgName)
-	// there's a weird race where we observe the pool is updated when in reality
-	// that update is from before. Sleeping allows a new update cycle to start
-	time.Sleep(time.Second * 5)
 
 	// ensure config rolls back as expected
-	waitForConfigAndPoolComplete(t, cs, poolName, oldMCConfig.Name)
+	waitForPoolComplete(t, cs, poolName, lastTarget)
 
 	restoredConfValue := getValueFromCrioConfig(t, cs, node, regexKey, defaultPath)
 	require.Equal(t, restoredConfValue, oldConfValue, "ctrcfg deletion didn't cause node to roll back config")

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -32,12 +32,14 @@ func getMcName(t *testing.T, cs *framework.ClientSet, poolName string) string {
 	return mcp.Status.Configuration.Name
 }
 
-// waitForConfigAndPoolComplete is a helper function that gets a renderedConfig and waits for its pool to complete
-func waitForConfigAndPoolComplete(t *testing.T, cs *framework.ClientSet, pool, mcName string) {
+// waitForConfigAndPoolComplete is a helper function that gets a renderedConfig and waits for its pool to complete.
+// The return value is the final rendered config.
+func waitForConfigAndPoolComplete(t *testing.T, cs *framework.ClientSet, pool, mcName string) string {
 	config, err := waitForRenderedConfig(t, cs, pool, mcName)
 	require.Nil(t, err, "failed to render machine config %s from pool %s", mcName, pool)
 	err = waitForPoolComplete(t, cs, pool, config)
 	require.Nil(t, err, "pool %s did not update to config %s", pool, config)
+	return config
 }
 
 // waitForRenderedConfig polls a MachineConfigPool until it has


### PR DESCRIPTION
Waiting for the previous MC isn't right here; we're deleting
a config and so what we want to wait for is the previous pool
target.

Drop the racy `sleep()`.

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
