### PR TITLE
templates: add apiserver-url.env file

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,15 @@
+package constants
+
+// constants defines some file paths that are shared outside of the
+// MCO package; and thus consumed by other users
+
+const (
+	// APIServerURLFile is the path to the apiserver url environment file.
+	// See templates/master/00-master/_base/files/apiserver-url-env.yaml
+	APIServerURLFile = "/etc/kubernetes/apiserver-url.env"
+)
+
+// ConstantsByName is a map of constants for ease of templating
+var ConstantsByName = map[string]string{
+	"APIServerURLFile": APIServerURLFile,
+}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -111,6 +111,8 @@ func newControllerConfig(name string, platform apicfgv1.PlatformType) *mcfgv1.Co
 					PlatformStatus: &apicfgv1.PlatformStatus{
 						Type: platform,
 					},
+					APIServerURL:         fmt.Sprintf("https://api.%s.tt.testing:6443", name),
+					APIServerInternalURL: fmt.Sprintf("https://api-int.%s.tt.testing:6443", name),
 				},
 			},
 			ReleaseImage: "release-reg.io/myuser/myimage:test",

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -106,6 +106,8 @@ func newControllerConfig(name string, platform osev1.PlatformType) *mcfgv1.Contr
 					PlatformStatus: &osev1.PlatformStatus{
 						Type: platform,
 					},
+					APIServerURL:         fmt.Sprintf("https://api.%s.tt.testing:6443", name),
+					APIServerInternalURL: fmt.Sprintf("https://api-int.%s.tt.testing:6443", name),
 				},
 			},
 		},

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -67,7 +67,7 @@ func TestCloudProvider(t *testing.T) {
 					},
 				},
 			}
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -135,7 +135,7 @@ func TestCloudConfigFlag(t *testing.T) {
 					CloudProviderConfig: c.content,
 				},
 			}
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`}, name, dummyTemplate)
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -222,14 +222,14 @@ func TestInvalidPlatform(t *testing.T) {
 
 	// we must treat unrecognized constants as "none"
 	controllerConfig.Spec.Infra.Status.PlatformStatus.Type = "_bad_"
-	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
 	if err != nil {
 		t.Errorf("expect nil error, got: %v", err)
 	}
 
 	// explicitly blocked
 	controllerConfig.Spec.Infra.Status.PlatformStatus.Type = "_base"
-	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
 	expectErr(err, "failed to create MachineConfig for role master: platform _base unsupported")
 }
 
@@ -240,7 +240,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 			t.Fatalf("failed to get controllerconfig config: %v", err)
 		}
 
-		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`}, templateDir)
+		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
 		if err != nil {
 			t.Fatalf("failed to generate machine configs: %v", err)
 		}

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -67,6 +67,8 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.LibvirtPlatformType,
 					},
+					APIServerURL:         fmt.Sprintf("https://api.%s.tt.testing:6443", name),
+					APIServerInternalURL: fmt.Sprintf("https://api-int.%s.tt.testing:6443", name),
 				},
 			},
 			PullSecret: &corev1.ObjectReference{

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -16,6 +16,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/constants"
 	"github.com/openshift/machine-config-operator/pkg/operator/assets"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
@@ -28,6 +29,7 @@ type renderConfig struct {
 	Images                 *RenderConfigImages
 	KubeAPIServerServingCA string
 	Infra                  configv1.Infrastructure
+	Constants              map[string]string
 }
 
 func renderAsset(config *renderConfig, path string) ([]byte, error) {
@@ -42,6 +44,11 @@ func renderAsset(config *renderConfig, path string) ([]byte, error) {
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
 	funcs["onPremPlatformKeepalivedEnableUnicast"] = onPremPlatformKeepalivedEnableUnicast
+
+	if config.Constants == nil {
+		config.Constants = constants.ConstantsByName
+	}
+
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(objBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse asset %s: %v", path, err)

--- a/templates/master/00-master/_base/files/apiserver-url-env.yaml
+++ b/templates/master/00-master/_base/files/apiserver-url-env.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "{{.Constants.APIServerURLFile}}"
+# used by the cluster network operator to learn the URL to the internal apiserver load balancer
+contents:
+ inline: |
+   KUBERNETES_SERVICE_HOST='{{urlHost .Infra.Status.APIServerInternalURL}}'
+   KUBERNETES_SERVICE_PORT='{{urlPort .Infra.Status.APIServerInternalURL}}'


### PR DESCRIPTION
A few components need to know the URL of the internal apiserver load balancer. Most notably, the network operator does.

Right now, the only way to get this is to parse the kubelet's kubeconfig, but this is fragile. So, write down an environment file that just sets the "usual" service environment variables. Then we can just seamlessly source the environment file.

Ref: [SDN-1347](https://issues.redhat.com/browse/SDN-1347)

