### PR TITLE
Move api-int record from coredns to /etc/hosts

### DIFF
--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -27,13 +27,4 @@ contents:
             match api.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
-        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api-int.{{ .DNS.Spec.BaseDomain }}
-            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ onPremPlatformAPIServerInternalIP . }}"
-            fallthrough
-        }
-        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api-int.{{ .DNS.Spec.BaseDomain }}
-            fallthrough
-        }
     }

--- a/templates/common/on-prem/files/etc-hosts.yaml
+++ b/templates/common/on-prem/files/etc-hosts.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "/etc/hosts"
+contents:
+  inline: |
+      127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+      ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+      {{ onPremPlatformAPIServerInternalIP . }} api-int api-int.ostest.test.metalkube.org


### PR DESCRIPTION
This is to enable more flexibility about when the networking services
are deployed. With the api-int record in /etc/hosts we don't need
coredns to be running for a node to connect to the cluster.

