### PR TITLE
Bug 1899057: configure-ovs-network: fix spurious OVS warnings

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -174,11 +174,7 @@ contents:
           else
             sed -i '/^\[connection\]$/a interface-name=br-ex' ${new_conn_file}
           fi
-          if ! grep 'cloned-mac-address=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[ethernet\]$/,/^\[/ s/^cloned-mac-address=.*$/cloned-mac-address='"$iface_mac"'/' ${new_conn_file}
-          else
-            sed -i '/^\[ethernet\]$/a cloned-mac-address='"$iface_mac" ${new_conn_file}
-          fi
+          sed -i '/^cloned-mac-address=.*$/d' ${new_conn_file}
           if grep 'mtu=' ${new_conn_file} &> /dev/null; then
             sed -i '/^\[ethernet\]$/,/^\[/ s/^mtu=.*$/mtu='"$iface_mtu"'/' ${new_conn_file}
           else
@@ -192,7 +188,7 @@ contents:
           echo "Loaded new ovs-if-br-ex connection file: ${new_conn_file}"
         else
           nmcli c add type ovs-interface slave-type ovs-port conn.interface br-ex master ovs-port-br-ex con-name \
-            ovs-if-br-ex 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac}
+            ovs-if-br-ex 802-3-ethernet.mtu ${iface_mtu}
         fi
       fi
 


### PR DESCRIPTION
We see spurious errors in ovs-vswitchd.log when using OVN:

    2020-11-17T12:20:50.895Z|00033|bridge|ERR|interface br-ex: ignoring mac in Interface record (use Bridge record to set local port's mac)

This is caused by how we're creating `br-ex`; we specify the (same) MAC on the bridge record and the local port record but OVS doesn't want you do specify it on the latter (since the port isn't allowed to have a different MAC from the bridge itself anyway).

/assign @trozet 