### PR TITLE
templates: move recycler pod out of kubelet manifests directory

### DIFF
--- a/templates/master/00-master/_base/files/recycler_pod_bad.yaml
+++ b/templates/master/00-master/_base/files/recycler_pod_bad.yaml
@@ -1,5 +1,5 @@
 mode: 0644
-path: "/etc/kubernetes/recycler-pod.yaml"
+path: "/etc/kubernetes/manifests/recycler-pod.yaml"
 contents:
   inline: |
     apiVersion: v1


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1896226

This is the first step in resolving a bug introduced by https://github.com/openshift/machine-config-operator/pull/1687 and https://github.com/openshift/cluster-kube-controller-manager-operator/pull/405

`/etc/kubernetes/manifests` is the kubelet's static pod manifests directory.  The kubelet will try to start pods defined in this location as static pods.  The recycler pod is not a static pod and the kubelet continuously fails to start it.

The solution is to move the recycler pod manifests to a different directory.

The fix is a 3-step process (as I see it):
- Change location of the recycler pod in the MCO template (this PR)
- Change KCM to use the new location
- Delete (or empty out) the file in the old location

@runcom @sttts @rphillips 