### PR TITLE
Bug 1899603: daemon: do not roll back on non-*COS machines

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -518,6 +518,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 // remove the rollback once the MCD pod has landed on a node, so
 // we know kubelet is working.
 func (dn *Daemon) removeRollback() error {
+	if dn.OperatingSystem != MachineConfigDaemonOSRHCOS && dn.OperatingSystem != MachineConfigDaemonOSFCOS {
+		// do not attempt to rollback on non-RHCOS/FCOS machines
+		return nil
+	}
 	_, err := runGetOut("rpm-ostree", "cleanup", "-r")
 	return err
 }


### PR DESCRIPTION
This breaks RHEL7 jobs as they do not have rpm-ostree.