### PR TITLE
 daemon: Rework operating system conditionals

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -54,8 +54,8 @@ type Daemon struct {
 	// name is the node name.
 	name string
 
-	// OperatingSystem the operating system the MCD is running on
-	OperatingSystem string
+	// os the operating system the MCD is running on
+	os OperatingSystem
 
 	// IgnitionVersion is the version of the installed Ignition binary on the system
 	IgnitionVersion string
@@ -208,9 +208,9 @@ func New(
 		err        error
 	)
 
-	operatingSystem := "mock"
+	os := OperatingSystem{}
 	if !mock {
-		operatingSystem, err = GetHostRunningOS()
+		os, err = GetHostRunningOS()
 		if err != nil {
 			HostOS.WithLabelValues("unsupported", "").Set(1)
 			return nil, errors.Wrapf(err, "checking operating system")
@@ -218,7 +218,7 @@ func New(
 	}
 
 	// Only pull the osImageURL from OSTree when we are on RHCOS or FCOS
-	if operatingSystem == MachineConfigDaemonOSRHCOS || operatingSystem == MachineConfigDaemonOSFCOS {
+	if os.IsCoreOSVariant() {
 		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %v", err)
@@ -244,7 +244,7 @@ func New(
 	// RHEL 7.6/Centos 7 logger (util-linux) doesn't have the --journald flag
 	loggerSupportsJournal := true
 	if !mock {
-		if operatingSystem == machineConfigDaemonOSRHEL || operatingSystem == machineConfigDaemonOSCENTOS {
+		if os.IsLikeTraditionalRHEL7() {
 			loggerOutput, err := exec.Command("logger", "--help").CombinedOutput()
 			if err != nil {
 				return nil, errors.Wrapf(err, "running logger --help")
@@ -254,13 +254,13 @@ func New(
 	}
 
 	// report OS & version (if RHCOS or FCOS) to prometheus
-	HostOS.WithLabelValues(operatingSystem, osVersion).Set(1)
+	HostOS.WithLabelValues(os.ToPrometheusLabel(), osVersion).Set(1)
 
 	return &Daemon{
 		mock:                  mock,
 		booting:               true,
 		IgnitionVersion:       ignVersion,
-		OperatingSystem:       operatingSystem,
+		os:                    os,
 		NodeUpdaterClient:     nodeUpdaterClient,
 		bootedOSImageURL:      osImageURL,
 		bootID:                bootID,
@@ -854,7 +854,7 @@ func (dn *Daemon) getStateAndConfigs(pendingConfigName string) (*stateAndConfigs
 // dynamically after a reboot.
 func (dn *Daemon) LogSystemData() {
 	// Print status if available
-	if dn.OperatingSystem == MachineConfigDaemonOSRHCOS || dn.OperatingSystem == MachineConfigDaemonOSFCOS {
+	if dn.os.IsCoreOSVariant() {
 		status, err := dn.NodeUpdaterClient.GetStatus()
 		if err != nil {
 			glog.Fatalf("unable to get rpm-ostree status: %s", err)
@@ -1371,7 +1371,7 @@ func compareOSImageURL(current, desired string) bool {
 // Otherwise if `false` is returned, then we need to perform an update.
 func (dn *Daemon) checkOS(osImageURL string) bool {
 	// Nothing to do if we're not on RHCOS or FCOS
-	if dn.OperatingSystem != MachineConfigDaemonOSRHCOS && dn.OperatingSystem != MachineConfigDaemonOSFCOS {
+	if !dn.os.IsCoreOSVariant() {
 		glog.Infof(`Not booted into a CoreOS variant, ignoring target OSImageURL %s`, osImageURL)
 		return true
 	}

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -37,19 +37,17 @@ var tuneableFCOSArgsAllowlist = map[string]bool{
 
 // isArgTuneable returns if the argument provided is allowed to be modified
 func isArgTunable(arg string) (bool, error) {
-	operatingSystem, err := GetHostRunningOS()
+	os, err := GetHostRunningOS()
 	if err != nil {
 		return false, errors.Errorf("failed to get OS for determining whether kernel arg is tuneable: %v", err)
 	}
 
-	switch operatingSystem {
-	case MachineConfigDaemonOSRHCOS:
+	if os.IsRHCOS() {
 		return tuneableRHCOSArgsAllowlist[arg], nil
-	case MachineConfigDaemonOSFCOS:
+	} else if os.IsFCOS() {
 		return tuneableFCOSArgsAllowlist[arg], nil
-	default:
-		return false, nil
 	}
+	return false, nil
 }
 
 // isArgInUse checks to see if the argument is already in use by the system currently

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -31,7 +31,7 @@ func TestUpdateOS(t *testing.T) {
 	d := Daemon{
 		mock:              true,
 		name:              "nodeName",
-		OperatingSystem:   MachineConfigDaemonOSRHCOS,
+		os:                OperatingSystem{},
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		bootedOSImageURL:  "test",
@@ -342,7 +342,7 @@ func TestUpdateSSHKeys(t *testing.T) {
 	d := Daemon{
 		mock:              true,
 		name:              "nodeName",
-		OperatingSystem:   MachineConfigDaemonOSRHCOS,
+		os:                OperatingSystem{},
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		bootedOSImageURL:  "test",
@@ -432,7 +432,7 @@ func TestDropinCheck(t *testing.T) {
 	d := Daemon{
 		mock:              true,
 		name:              "nodeName",
-		OperatingSystem:   MachineConfigDaemonOSRHCOS,
+		os:                OperatingSystem{},
 		NodeUpdaterClient: testClient,
 		kubeClient:        k8sfake.NewSimpleClientset(),
 		bootedOSImageURL:  "test",


### PR DESCRIPTION

A whole lot of our conditionals were "is coreos or not".  Let's rework
things so that we explicitly use that.

Detecting based on the operating system ID is also generally wrong;
e.g. we had an "is this traditional rhel or centos" check that really wanted to be
"is this a rhel7-like system" because both "traditional" RHEL8 and CentOS8 exist.