### PR TITLE
Bug 1899600: daemon: Only switch to bfq scheduler when we have an OS update

### DIFF
--- a/pkg/daemon/controlplane.go
+++ b/pkg/daemon/controlplane.go
@@ -64,14 +64,10 @@ func updateOstreeObjectSync() error {
 }
 
 // initializeControlPlane performs setup for the node that should
-// only occur on the control plane.  Currently this switches the IO
-// scheduler and starts a goroutine acting as a small controller
-// for reflecting the etcd leader status in the node object to help
-// the MCC coordinate control plane updates.
+// only occur on the control plane.  This used to set the IO
+// scheduler too but we now only do that late in the process when
+// we go to start an OS update.
 func (dn *Daemon) initializeControlPlane() error {
-	if err := setRootDeviceSchedulerBFQ(); err != nil {
-		return err
-	}
 	if err := updateOstreeObjectSync(); err != nil {
 		return err
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -327,6 +327,12 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 
 	var osImageContentDir string
 	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType {
+		// When we're going to apply an OS update, switch the block
+		// scheduler to BFQ to apply more fairness between etcd
+		// and the OS update.
+		if err := setRootDeviceSchedulerBFQ(); err != nil {
+			return err
+		}
 		// We emitted this event before, so keep it
 		if dn.recorder != nil {
 			dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "InClusterUpgrade", fmt.Sprintf("Updating from oscontainer %s", newConfig.Spec.OSImageURL))


### PR DESCRIPTION
Using bfq by default reportedly causes etcd latency regressions
when we're not doing an OS update.  Change the logic so we
only do the switch when we want to balance update speed while running
etcd.

(I still think schedulable masters may want this but they can
 configure it manually with a systemd unit)
