### PR TITLE
WIP: Bug 1898169: pkg/controller/template: handle >=2048 units line size for noProxy

### DIFF
--- a/templates/common/_base/files/proxy.yaml
+++ b/templates/common/_base/files/proxy.yaml
@@ -1,0 +1,15 @@
+mode: 0600
+path: "/somewhere/proxy"
+contents:
+  inline: |
+      {{if .Proxy -}}
+      {{if .Proxy.HTTPProxy -}}
+      HTTP_PROXY={{.Proxy.HTTPProxy}}
+      {{end -}}
+      {{if .Proxy.HTTPSProxy -}}
+      HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      {{end -}}
+      {{if .Proxy.NoProxy -}}
+      NO_PROXY={{.Proxy.NoProxy}}
+      {{end -}}
+      {{end -}}

--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -3,15 +3,5 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      {{if .Proxy -}}
       [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
-      {{end -}}
+      EnvironmentFile=/somewhere/proxy

--- a/templates/common/_base/units/kubelet.service.yaml
+++ b/templates/common/_base/units/kubelet.service.yaml
@@ -3,15 +3,6 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      {{if .Proxy -}}
       [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
-      {{end -}}
+      EnvironmentFile=/somewhere/proxy
+

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -18,17 +18,7 @@ contents: |
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
 
-  {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
-  {{end -}}
+  EnvironmentFile=/somewhere/proxy
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -20,17 +20,7 @@ contents: |
   ExecStart=/bin/sh -c "/usr/bin/podman run --rm --quiet --net=host --entrypoint=cat '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon > /run/bin/machine-config-daemon.tmp"
   ExecStart=/bin/sh -c '/usr/bin/chmod a+x /run/bin/machine-config-daemon.tmp && mv /run/bin/machine-config-daemon.tmp /run/bin/machine-config-daemon'
 
-  {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
-  {{end -}}
+  EnvironmentFile=/somewhere/proxy
 
   [Install]
   RequiredBy=machine-config-daemon-firstboot.service

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -26,17 +26,7 @@ contents: |
     sleep 5; \
     done"
 
-  {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
-  {{end -}}
+  EnvironmentFile=/somewhere/proxy
 
   [Install]
   RequiredBy=kubelet.service

--- a/templates/common/_base/units/pivot.service.yaml
+++ b/templates/common/_base/units/pivot.service.yaml
@@ -3,15 +3,5 @@ dropins:
   - name: 10-mco-default-env.conf
     contents: |
       [Unit]
-      {{if .Proxy -}}
       [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
-      {{end -}}
+      EnvironmentFile=/somewhere/proxy

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -31,17 +31,7 @@ contents: |
     sleep 5; \
     done"
 
-  {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
-  {{end -}}
+  EnvironmentFile=/somewhere/proxy
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
The noProxy value coming from proxy/cluster can be lenghty and it
happened that it resulted in more than 2048 bytes. The value itself is
comma separated list of cidrs/domains/ips for noProxy. This list can
indeed grow large. When we format that value to a systemd unit or dropin
we're gonna incur into a known systemd line limit (LINE_MAX from glibc
== 2048). The error we're getting on the cluster is:

      failed to syncing towards (13) generation using controller version v4.5.0-202010160047.p0-dirty: failed to create MachineConfig for role master: error transpiling ct config to Ignition config: failed to convert config to Ignition config error: invalid unit content: line too long (max 2048 bytes)

So we're not even at the systemd level but the config transpiler has a
built-in check that fails with the above.

Now, we know splitting the line with backslashes is a workaround, and
that's what this PR does which will get rid (effectively) of the limit.

How to test:

- spin up a cluster with proxy
- `oc edit proxy/cluster`
- under `spec.noProxy` add a bunch of (even dummy) domains/ips to reach >= 2048 bytes
- the configuration resulting from the noProxy additions should roll out just fine (it fails today, see bz)

Signed-off-by: Antonio Murdaca <runcom@linux.com>