### PR TITLE
Bug 1901472: Only enable unicast mode on platform that asked for it

### DIFF
--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -105,7 +105,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "yes"
+        value: "{{ onPremPlatformKeepalivedEnableUnicast .ControllerConfig }}"
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1919,7 +1919,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "yes"
+        value: "{{ onPremPlatformKeepalivedEnableUnicast .ControllerConfig }}"
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -41,6 +41,7 @@ func renderAsset(config *renderConfig, path string) ([]byte, error) {
 	funcs["onPremPlatformAPIServerInternalIP"] = onPremPlatformAPIServerInternalIP
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
+	funcs["onPremPlatformKeepalivedEnableUnicast"] = onPremPlatformKeepalivedEnableUnicast
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(objBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse asset %s: %v", path, err)
@@ -178,6 +179,19 @@ func onPremPlatformShortName(cfg mcfgv1.ControllerConfigSpec) interface{} {
 		}
 	} else {
 		return ""
+	}
+}
+
+func onPremPlatformKeepalivedEnableUnicast(cfg mcfgv1.ControllerConfigSpec) (interface{}, error) {
+	if cfg.Infra.Status.PlatformStatus != nil {
+		switch cfg.Infra.Status.PlatformStatus.Type {
+		case configv1.BareMetalPlatformType, configv1.KubevirtPlatformType:
+			return "yes", nil
+		default:
+			return "no", nil
+		}
+	} else {
+		return "no", nil
 	}
 }
 


### PR DESCRIPTION
The bootstrap node was unconditionally setting the ENABLE_UNICAST
environment variable to yes on all on-prem platforms, causing it to use
unicast_src_ip and unicast_peer settings in keeepalived.conf, while it
should have used the output of the
`onPremPlatformKeepalivedEnableUnicast` function as done on the control
plane nodes.