### PR TITLE
[baremetal & friends] Move api-int to /etc/hosts

### DIFF
--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -27,13 +27,4 @@ contents:
             match api.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
-        template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api-int.{{ .DNS.Spec.BaseDomain }}
-            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ onPremPlatformAPIServerInternalIP . }}"
-            fallthrough
-        }
-        template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api-int.{{ .DNS.Spec.BaseDomain }}
-            fallthrough
-        }
     }

--- a/templates/common/on-prem/units/api-int-service.yaml
+++ b/templates/common/on-prem/units/api-int-service.yaml
@@ -8,4 +8,4 @@ contents: |
 
   [Service]
   Type=oneshot
-  ExecStart=/bin/bash -c "grep -q {{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }} /etc/hosts || echo '{{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }}' >> /etc/hosts"
+  ExecStart=/bin/bash -c "grep -q -e '{{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }}' -F /etc/hosts || echo '{{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }}' >> /etc/hosts"

--- a/templates/common/on-prem/units/api-int-service.yaml
+++ b/templates/common/on-prem/units/api-int-service.yaml
@@ -1,0 +1,11 @@
+name: api-int.service
+# This service is run by a timer
+enabled: false
+contents: |
+  [Unit]
+  Description=Ensure api-int entry exists in /etc/hosts
+  Before=kubelet.service crio.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/bin/bash -c "grep -q {{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }} /etc/hosts || echo '{{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }}' >> /etc/hosts"

--- a/templates/common/on-prem/units/api-int-timer.yaml
+++ b/templates/common/on-prem/units/api-int-timer.yaml
@@ -1,0 +1,12 @@
+name: api-int.timer
+enabled: true
+contents: |
+  [Unit]
+  Description=Run api-int service periodically
+
+  [Timer]
+  OnBootSec=10sec
+  OnUnitActiveSec=1min
+
+  [Install]
+  WantedBy=timers.target


### PR DESCRIPTION
Instead of relying on coredns to provide the api-int record, which
requires our coredns to be deployed as a static pod so it will be
available before the node tries to register with the api, we can
put the api-int record in /etc/hosts. This way the node can register
without coredns running and then coredns can be started at a later
point in the deployment. This makes our coredns deployment much more
flexible.

Since I'm told we should not try to template all of /etc/hosts because
other service may be trying to add entries to it as well, this
change adds a systemd service and timer to ensure that the correct
entry is in /etc/hosts. It will run once per minute and append the
api-int line if it doesn't already find one there.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
