### PR TITLE
daemon: selectively reboot based on diffs of applied MCs

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -165,14 +165,6 @@ const (
 	onceFromRemoteConfig
 )
 
-type rebootAction int
-
-const (
-	rebootActionReboot rebootAction = iota
-	rebootActionNone
-	rebootActionReloadCrio
-)
-
 var (
 	defaultRebootTimeout = 24 * time.Hour
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1144,6 +1144,12 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 		state.currentConfig = state.pendingConfig
 	}
 
+	if state.bootstrapping {
+		if err := dn.storeCurrentConfigOnDisk(state.currentConfig); err != nil {
+			return false, err
+		}
+	}
+
 	// In case of node reboot, it may be the case that desiredConfig changed while we
 	// were coming up, so we next look at that before uncordoning the node (so
 	// we don't uncordon and then immediately re-cordon)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1176,9 +1176,9 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 
 		glog.Infof("In desired config %s", state.currentConfig.GetName())
 		MCDUpdateState.WithLabelValues(state.currentConfig.GetName(), "").SetToCurrentTime()
-
-		// All good!
 	}
+
+	// No errors have occurred. Returns true if currentConfig == desiredConfig, false otherwise (needs update)
 	return inDesiredConfig, nil
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1103,9 +1103,6 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		glog.Info("Validated on-disk state")
 	} else {
 		glog.Infof("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
-		if err := os.Remove(constants.MachineConfigDaemonForceFile); err != nil {
-			return errors.Wrap(err, "failed to remove force validation file")
-		}
 		return dn.triggerUpdateWithMachineConfig(state.currentConfig, state.desiredConfig)
 	}
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -481,8 +481,7 @@ func calculatePostConfigChangeActionFromFileDiffs(oldIgnConfig, newIgnConfig ign
 			// debug: remove
 			glog.Infof("File diff: %v was added", path)
 			diffFileSet = append(diffFileSet, path)
-		}
-		if !reflect.DeepEqual(oldFile, newFile) {
+		} else if !reflect.DeepEqual(oldFile, newFile) {
 			// debug: remove
 			glog.Infof("File diff: detected change to %v", newFile.Path)
 			diffFileSet = append(diffFileSet, path)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -99,8 +99,8 @@ func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
 	}
 }
 
-func reloadCrioConfig() error {
-	_, err := runGetOut("pkill", "-HUP", "crio")
+func reloadService(name string) error {
+	_, err := runGetOut("systemctl", "reload", name)
 	return err
 }
 
@@ -117,11 +117,12 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 		dn.logSystem("Node has Desired Config %s, skipping reboot", configName)
 	}
 	if ctrlcommon.InSlice(postConfigChangeActionReloadCrio, postConfigChangeActions) {
-		if err := reloadCrioConfig(); err != nil {
-			dn.logSystem("Reloading crio configuration failed, rebooting: %v", err)
+		serviceName := "crio"
+		if err := reloadService(serviceName); err != nil {
+			dn.logSystem("Reloading %s configuration failed, rebooting: %v", serviceName, err)
 			dn.reboot(fmt.Sprintf("Node will reboot into config %s", configName))
 		}
-		dn.logSystem("crio config reloaded successfully! Desired config %s has been applied, skipping reboot", configName)
+		dn.logSystem("%s config reloaded successfully! Desired config %s has been applied, skipping reboot", serviceName, configName)
 	}
 
 	// We are here, which means reboot was not needed to apply the configuration.

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -334,7 +334,6 @@ func TestNoReboot(t *testing.T) {
 	infraNode := getSingleNodeByRole(t, cs, "infra")
 
 	output := execCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
-	t.Logf("Debug: Initial uptime file content %s", output)
 	oldTime := strings.Split(output, " ")[0]
 	t.Logf("Node %s initial uptime: %s", infraNode.Name, oldTime)
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -166,21 +167,24 @@ func createMC(name, role string) *mcfgv1.MachineConfig {
 
 // execCmdOnNode finds a node's mcd, and oc rsh's into it to execute a command on the node
 // all commands should use /rootfs as root
-func execCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, args ...string) string {
+func execCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subArgs ...string) string {
 	mcd, err := mcdForNode(cs, &node)
 	require.Nil(t, err)
 	mcdName := mcd.ObjectMeta.Name
 
 	entryPoint := "oc"
-	cmd := []string{"rsh",
+	args := []string{"rsh",
 		"-n", "openshift-machine-config-operator",
 		"-c", "machine-config-daemon",
 		mcdName}
-	cmd = append(cmd, args...)
+	args = append(args, subArgs...)
 
-	b, err := exec.Command(entryPoint, cmd...).CombinedOutput()
-	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", args, node.Name, string(b))
-	return string(b)
+	cmd := exec.Command(entryPoint, args...)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
+	return string(out)
 }
 
 func mcLabelForRole(role string) map[string]string {

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -35,6 +35,32 @@ func BoolToPtr(b bool) *bool {
 
 // NewMachineConfig returns a basic machine config with supplied labels, osurl & files added
 func NewMachineConfig(name string, labels map[string]string, osurl string, files []ign3types.File) *mcfgv1.MachineConfig {
+	return NewMachineConfigExtended(
+		name,
+		labels,
+		files,
+		[]ign3types.Unit{},
+		[]ign3types.SSHAuthorizedKey{},
+		[]string{},
+		false,
+		[]string{},
+		"",
+		osurl,
+	)
+}
+
+// NewMachineConfigExtended returns a more comprehensive machine config
+func NewMachineConfigExtended(
+	name string,
+	labels map[string]string,
+	files []ign3types.File,
+	units []ign3types.Unit,
+	sshkeys []ign3types.SSHAuthorizedKey,
+	extensions []string,
+	fips bool,
+	kernelArguments []string,
+	kernelType, osurl string,
+) *mcfgv1.MachineConfig {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -45,6 +71,17 @@ func NewMachineConfig(name string, labels map[string]string, osurl string, files
 			},
 			Storage: ign3types.Storage{
 				Files: files,
+			},
+			Systemd: ign3types.Systemd{
+				Units: units,
+			},
+			Passwd: ign3types.Passwd{
+				Users: []ign3types.PasswdUser{
+					{
+						Name:              "core",
+						SSHAuthorizedKeys: sshkeys,
+					},
+				},
 			},
 		},
 	)
@@ -59,10 +96,14 @@ func NewMachineConfig(name string, labels map[string]string, osurl string, files
 			UID:    types.UID(utilrand.String(5)),
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL: osurl,
 			Config: runtime.RawExtension{
 				Raw: rawIgnition,
 			},
+			Extensions:      extensions,
+			FIPS:            fips,
+			KernelArguments: kernelArguments,
+			KernelType:      kernelType,
+			OSImageURL:      osurl,
 		},
 	}
 }


### PR DESCRIPTION
Adds to/supercedes https://github.com/openshift/machine-config-operator/pull/2254

This is the overall PR for the reboot epic work, which aims to allow "rebootless updates" when certain changes happen.

Currently supported:
No action (drain, update files, uncordon)
 - ssh keys
 - pull secret

Reload crio
 - registries.conf changes

Reboot
 - all other scenarios

Also add corresponding unit and e2e tests