### PR TITLE
Bug 1899350: Include dhcp client-id and bond options during ovs-configuration

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -85,7 +85,7 @@ contents:
       fi
 
       # store old conn for later
-      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | grep ${iface} | awk '{print $1}')
+      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | awk "/\s${iface}\s*\$/ {print \$1}")
 
       extra_brex_args=""
       # check for dhcp client ids

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -137,6 +137,11 @@ contents:
         extra_phys_args="dev ${vlan_parent} id ${vlan_id}"
       elif [ $(nmcli --get-values connection.type conn show ${old_conn}) == "bond" ]; then
         iface_type=bond
+        # check bond options
+        bond_opts=$(nmcli --get-values bond.options conn show ${old_conn})
+        if [ -n "$bond_opts" ]; then
+          extra_phys_args+="bond.options ${bond_opts} "
+        fi
       else
         iface_type=802-3-ethernet
       fi

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -84,6 +84,21 @@ contents:
         echo "MTU found for iface: ${iface}: ${iface_mtu}"
       fi
 
+      # store old conn for later
+      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | grep ${iface} | awk '{print $1}')
+
+      extra_brex_args=""
+      # check for dhcp client ids
+      dhcp_client_id=$(nmcli --get-values ipv4.dhcp-client-id conn show ${old_conn})
+      if [ -n "$dhcp_client_id" ]; then
+        extra_brex_args+="ipv4.dhcp-client-id ${dhcp_client_id} "
+      fi
+
+      dhcp6_client_id=$(nmcli --get-values ipv6.dhcp-duid conn show ${old_conn})
+      if [ -n "$dhcp6_client_id" ]; then
+        extra_brex_args+="ipv6.dhcp-duid ${dhcp6_client_id} "
+      fi
+
       # create bridge; use NM's ethernet device default route metric (100)
       if ! nmcli connection show br-ex &> /dev/null; then
         nmcli c add type ovs-bridge \
@@ -92,11 +107,9 @@ contents:
             802-3-ethernet.mtu ${iface_mtu} \
             802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric 100 \
-            ipv6.route-metric 100
+            ipv6.route-metric 100 \
+            ${extra_brex_args}
       fi
-
-      # store old conn for later
-      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | grep ${iface} | awk '{print $1}')
 
       # find default port to add to bridge
       if ! nmcli connection show ovs-port-phys0 &> /dev/null; then


### PR DESCRIPTION
Adds copying over the dhcp client-id as well as bond options from the interface being migrated over to OVS.
