### PR TITLE
Bug 1873556: [on-prem] inject the proxy into the env for NetworkManager.service

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -10,13 +10,13 @@ contents:
 
     {{if .Proxy -}}
     {{if .Proxy.HTTPProxy -}}
-    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    NO_PROXY={{.Proxy.NoProxy}}
+    export NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}
 


### PR DESCRIPTION
In order to have the proxy variables (HTTP_PROXY, HTTPS_PROXY and
NO_PROXY), we need to `export` them otherwise then don't end up being
loaded in the environment and it causes issues if a proxy is used,
when pulling an image from a registry for example.