### PR TITLE
docs: Fix broken ostree url

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,7 +46,7 @@ If for example you write a daemonset that writes a custom systemd unit into e.g.
 
 Another case today is that the SDN operator will extract some binaries from its container image and drop them in `/opt` (which is really `/var/opt`).
 
-Stated more generally, on an OSTree managed system, all content in `/etc` and `/var` is [preserved by default across upgrades](https://ostree.readthedocs.io/en/latest/manual/adapting-existing/).
+Stated more generally, on an OSTree managed system, all content in `/etc` and `/var` is [preserved by default across upgrades](https://ostreedev.github.io/ostree/adapting-existing/).
 
 Further, rpm-ostree supports package layering and overrides - these will also be preserved by the MCO (currently).  Although note that there is no current mechanism to trigger a MCO-coordinated drain/reboot, which is particularly relevant for `rpm-ostree install/override` changes.
 

--- a/docs/MachineConfigController.md
+++ b/docs/MachineConfigController.md
@@ -107,7 +107,7 @@ Use kubernetes Deployment behavior for LabelSelector to find Pods.
 
 ### Generating desired MachineConfig
 
-Use the merging behavior defined in MachineConfig design document [here](./MachineConfiguration.md#how-to-create-generated-machineconfig) to create a single MachineConfig from all the MachineConfig object that were selected above.
+Use the merging behavior defined in MachineConfig design document [here](./MachineConfiguration.md#how-to-create-generated-machineconfig) to create a single MachineConfig from all the MachineConfig objects that were selected above.
 
 #### Ordering the MachineConfigs
 
@@ -121,7 +121,7 @@ UpdateController watches for changes on MachineConfigPool and runs update if,
 
 1. If the `.Status.CurrentMachineConfig` has been updated.
 
-2. If new nodes can be updated to the current configuration as new Machines are available with old configuration if permitted by `NodeLimit` or the `NodeLimit` has increased allowing more node to be updated.
+2. If new nodes can be updated to the current configuration as new Machines are available with old configuration if permitted by `NodeLimit` or the `NodeLimit` has increased allowing more nodes to be updated.
 
 **Historically** the following annotations were used to coordinate between UpdateController and the MachineConfigDaemon,
 
@@ -171,4 +171,4 @@ The MachineConfigController performs the following operations:
 1. Serializes the KubeletConfig to json
 1. Creates or Updates a MachineConfig (called `99-[role]-kubelet-managed`) with a new /etc/kubernetes/kubelet.conf
 
-The machine will subseqently reboot by the MachineConfigDaemon to apply the new config.
+The machine will subsequently reboot by the MachineConfigDaemon to apply the new config.

--- a/docs/MachineConfigDaemon.md
+++ b/docs/MachineConfigDaemon.md
@@ -72,7 +72,7 @@ care of updating the base operating system.
 Updates are provided via the `OSImageURL` component of a MachineConfig object.
 This should generally be controlled by the
 [cluster-version-operator](https://github.com/openshift/cluster-version-operator/),
-and its current existence in MachineConfig objects should be though of as an
+and its current existence in MachineConfig objects should be thought of as an
 implementation detail.
 
 MachineConfigDaemon only supports updating Red Hat CoreOS, which uses rpm-ostree.

--- a/docs/PullSecret.md
+++ b/docs/PullSecret.md
@@ -3,7 +3,7 @@
 The pull secret is used to pull the release payload image and it's currently stored as a secret in openshift-config/pull-secret.
 The ControllerConfig has an ObjectRefrence pointing to said secret and the Operator sets this up during its sync.
 The reference is then used by the TemplateController to grab the actual pull secret and generate the templates for MachineConfigs using it.
-That results in the pull secret being laid down *on every node*, therefore nodes are now be able to pull the release payload image.
+That results in the pull secret being laid down *on every node*, therefore nodes are now able to pull the release payload image.
 
 The pull secret has an expiration, and when it expires you need to change it as follows:
 


### PR DESCRIPTION
The ostree link is now broken as the site moved
https://ostree.readthedocs.io now redirects to https://ostreedev.github.io/ and the rest of the path changed, so we end up with a 404.