### PR TITLE
[common] inject proxy into system wide environment

### DIFF
--- a/templates/common/_base/files/etc-profile.d-proxy.env.yaml
+++ b/templates/common/_base/files/etc-profile.d-proxy.env.yaml
@@ -1,0 +1,10 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/profile.d/proxy.env"
+contents:
+  inline: |
+    {{if .Proxy -}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    export NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}

--- a/templates/common/_base/files/etc-systemd-system.conf.d-10-default-env-proxy.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system.conf.d-10-default-env-proxy.conf.yaml
@@ -1,0 +1,9 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/systemd/system.conf.d/10-default-env-proxy.conf"
+contents:
+  inline: |
+    {{if .Proxy -}}
+    [Manager]
+    DefaultEnvironment=HTTP_PROXY={{.Proxy.HTTPProxy}} HTTPS_PROXY={{.Proxy.HTTPSProxy}} NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}


### PR DESCRIPTION
Following the official manual:
https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#other-examples

In order to load the proxy variables (HTTP_PROXY, HTTPS_PROXY and
NO_PROXY), we now load them at systemd level and in a profile for system
wide impact.

By doing so, we allow the proxy to be used generally by all the services
or commands which look for them.

Closes #2271
Signed-off-by: Emilien Macchi <emilien@redhat.com>