### PR TITLE
Bug 1907639: Pass dual-stack node IPs to kubelet in dual-stack clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	k8s.io/code-generator v0.19.2
 	k8s.io/kubectl v0.0.0-20201023045331-0a68e0d30fe9
 	k8s.io/kubelet v0.19.0
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 )
 
 replace (

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -389,15 +389,15 @@ spec:
                                 in the cluster.
                               type: string
               nullable: true
+            ipFamilies:
+              description: ipFamilies indicates the IP families in use by the cluster
+                network
+              type: string
             kubeAPIServerServingCAData:
               description: kubeAPIServerServingCAData managed Kubelet to API Server
                 Cert... Rotated automatically
               type: string
               format: byte
-            kubeletIPv6:
-              description: kubeletIPv6 is true to force a single-stack IPv6 kubelet
-                config
-              type: boolean
             networkType:
               description: networkType holds the type of network the cluster is using
               type: string

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -88,8 +88,8 @@ type ControllerConfigSpec struct {
 	// +nullable
 	DNS *configv1.DNS `json:"dns"`
 
-	// kubeletIPv6 is true to force a single-stack IPv6 kubelet config
-	KubeletIPv6 bool `json:"kubeletIPv6,omitempty"`
+	// ipFamilies indicates the IP families in use by the cluster network
+	IPFamilies IPFamiliesType `json:"ipFamilies"`
 
 	// networkType holds the type of network the cluster is using
 	// XXX: this is temporary and will be dropped as soon as possible in favor of a better support
@@ -98,6 +98,15 @@ type ControllerConfigSpec struct {
 	// regeneration if this changes.
 	NetworkType string `json:"networkType,omitempty"`
 }
+
+// IPFamiliesType indicates whether the cluster network is IPv4-only, IPv6-only, or dual-stack
+type IPFamiliesType string
+
+const (
+	IPFamiliesIPv4      IPFamiliesType = "IPv4"
+	IPFamiliesIPv6      IPFamiliesType = "IPv6"
+	IPFamiliesDualStack IPFamiliesType = "DualStack"
+)
 
 // ControllerConfigStatus is the status for ControllerConfig
 type ControllerConfigStatus struct {

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -207,11 +207,7 @@ func (ctrl *Controller) generateFeatureMap(features *osev1.FeatureGate) (*map[st
 		return &rv, fmt.Errorf("enabled FeatureSet %v does not have a corresponding config", features.Spec.FeatureSet)
 	}
 	for _, featEnabled := range set.Enabled {
-		if featEnabled == "IPv6DualStack" {
-			glog.Infof("Ignoring IPv6DualStack feature gate for kubelet config")
-		} else {
-			rv[featEnabled] = true
-		}
+		rv[featEnabled] = true
 	}
 	for _, featDisabled := range set.Disabled {
 		rv[featDisabled] = false

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -72,34 +72,3 @@ func TestFeaturesDefault(t *testing.T) {
 		})
 	}
 }
-
-func createNewDualStackFeatureGate() *configv1.FeatureGate {
-	return &configv1.FeatureGate{
-		Spec: configv1.FeatureGateSpec{
-			FeatureGateSelection: configv1.FeatureGateSelection{
-				FeatureSet: configv1.IPv6DualStackNoUpgrade,
-			},
-		},
-	}
-}
-
-// Hack for 4.6; don't pass the IPv6DualStack feature gate to kubelet
-func TestFeaturesDualStack(t *testing.T) {
-	f := newFixture(t)
-	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.NonePlatformType)
-	f.ccLister = append(f.ccLister, cc)
-
-	ctrl := f.newController()
-	defaultFeatureGates, err := ctrl.generateFeatureMap(createNewDefaultFeatureGate())
-	if err != nil {
-		t.Errorf("could not generate defaultFeatureGates: %v", err)
-	}
-	dualStackFeatureGates, err := ctrl.generateFeatureMap(createNewDualStackFeatureGate())
-	if err != nil {
-		t.Errorf("could not generate dualStackFeatureGates: %v", err)
-	}
-
-	if !reflect.DeepEqual(dualStackFeatureGates, defaultFeatureGates) {
-		t.Errorf("IPv6DualStack FeatureGates do not match Default FeatureGates: (dualStack=[%v], default=[%v]", dualStackFeatureGates, defaultFeatureGates)
-	}
-}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -557,15 +557,15 @@ spec:
                                 in the cluster.
                               type: string
               nullable: true
+            ipFamilies:
+              description: ipFamilies indicates the IP families in use by the cluster
+                network
+              type: string
             kubeAPIServerServingCAData:
               description: kubeAPIServerServingCAData managed Kubelet to API Server
                 Cert... Rotated automatically
               type: string
               format: byte
-            kubeletIPv6:
-              description: kubeletIPv6 is true to force a single-stack IPv6 kubelet
-                config
-              type: boolean
             networkType:
               description: networkType holds the type of network the cluster is using
               type: string

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 func TestClusterDNSIP(t *testing.T) {
@@ -39,38 +40,38 @@ func TestClusterDNSIP(t *testing.T) {
 	}
 }
 
-func TestIsSingleStackIPv6(t *testing.T) {
+func TestIPFamilies(t *testing.T) {
 	tests := []struct {
 		Ranges []string
-		Output bool
+		Output mcfgv1.IPFamiliesType
 		Error  bool
 	}{{
 		Ranges: []string{"192.168.2.0/20"},
-		Output: false,
+		Output: mcfgv1.IPFamiliesIPv4,
 	}, {
 		Ranges: []string{"2001:db8::/32"},
-		Output: true,
+		Output: mcfgv1.IPFamiliesIPv6,
 	}, {
 		Ranges: []string{"192.168.2.0/20", "2001:db8::/32"},
-		Output: false,
+		Output: mcfgv1.IPFamiliesDualStack,
 	}, {
 		Ranges: []string{"2001:db8::/32", "192.168.2.0/20"},
-		Output: false,
+		Output: mcfgv1.IPFamiliesDualStack,
 	}, {
-		Ranges: []string{"192.168.1.254/32"},
+		Ranges: []string{},
 		Error:  true,
 	}}
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
-			desc := fmt.Sprintf("isSingleStackIPv6(%#v)", test.Ranges)
-			ipv6, err := isSingleStackIPv6(test.Ranges)
+			desc := fmt.Sprintf("ipFamilies(%#v)", test.Ranges)
+			families, err := ipFamilies(test.Ranges)
 			if err != nil {
 				if !test.Error {
 					t.Fatalf("%s failed: %s", desc, err.Error())
 				}
 			}
-			if ipv6 != test.Output {
-				t.Fatalf("%s failed: got = %t want = %t", desc, ipv6, test.Output)
+			if families != test.Output {
+				t.Fatalf("%s failed: got = %s want = %s", desc, families, test.Output)
 			}
 		})
 	}

--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -28,6 +28,9 @@ contents:
       ephemeral-storage: 1Gi
     featureGates:
       APIPriorityAndFairness: true
+{{- if eq .IPFamilies "DualStack"}}
+      IPv6DualStack: true
+{{- end}}
       LegacyNodeRoleBehavior: false
       NodeDisruptionExclusion: true
       RotateKubeletServerCertificate: true

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-{{- if .KubeletIPv6}}
+{{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}
   EnvironmentFile=/etc/os-release
@@ -26,7 +26,11 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+{{- if eq .IPFamilies "DualStack"}}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
         --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -23,7 +23,11 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+{{- if eq .IPFamilies "DualStack"}}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
         --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
         --address=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -28,6 +28,9 @@ contents:
       ephemeral-storage: 1Gi
     featureGates:
       APIPriorityAndFairness: true
+{{- if eq .IPFamilies "DualStack"}}
+      IPv6DualStack: true
+{{- end}}
       LegacyNodeRoleBehavior: false
       NodeDisruptionExclusion: true
       RotateKubeletServerCertificate: true

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-{{- if .KubeletIPv6}}
+{{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}
   EnvironmentFile=/etc/os-release
@@ -26,7 +26,11 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+{{- if eq .IPFamilies "DualStack"}}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
         --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -23,7 +23,11 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+{{- if eq .IPFamilies "DualStack"}}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
         --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
         --address=${KUBELET_NODE_IP} \
         --minimum-container-ttl-duration=6m0s \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \

--- a/vendor/k8s.io/utils/net/ipnet.go
+++ b/vendor/k8s.io/utils/net/ipnet.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IPNetSet maps string to net.IPNet.
+type IPNetSet map[string]*net.IPNet
+
+// ParseIPNets parses string slice to IPNetSet.
+func ParseIPNets(specs ...string) (IPNetSet, error) {
+	ipnetset := make(IPNetSet)
+	for _, spec := range specs {
+		spec = strings.TrimSpace(spec)
+		_, ipnet, err := net.ParseCIDR(spec)
+		if err != nil {
+			return nil, err
+		}
+		k := ipnet.String() // In case of normalization
+		ipnetset[k] = ipnet
+	}
+	return ipnetset, nil
+}
+
+// Insert adds items to the set.
+func (s IPNetSet) Insert(items ...*net.IPNet) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPNetSet) Delete(items ...*net.IPNet) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPNetSet) Has(item *net.IPNet) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPNetSet) HasAll(items ...*net.IPNet) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPNetSet) Difference(s2 IPNetSet) IPNetSet {
+	result := make(IPNetSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPNetSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPNetSet) IsSuperset(s2 IPNetSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPNetSet) Equal(s2 IPNetSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPNetSet) Len() int {
+	return len(s)
+}
+
+// IPSet maps string to net.IP
+type IPSet map[string]net.IP
+
+// ParseIPSet parses string slice to IPSet
+func ParseIPSet(items ...string) (IPSet, error) {
+	ipset := make(IPSet)
+	for _, item := range items {
+		ip := net.ParseIP(strings.TrimSpace(item))
+		if ip == nil {
+			return nil, fmt.Errorf("error parsing IP %q", item)
+		}
+
+		ipset[ip.String()] = ip
+	}
+
+	return ipset, nil
+}
+
+// Insert adds items to the set.
+func (s IPSet) Insert(items ...net.IP) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPSet) Delete(items ...net.IP) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPSet) Has(item net.IP) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPSet) HasAll(items ...net.IP) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPSet) Difference(s2 IPSet) IPSet {
+	result := make(IPSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPSet) IsSuperset(s2 IPSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPSet) Equal(s2 IPSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPSet) Len() int {
+	return len(s)
+}

--- a/vendor/k8s.io/utils/net/net.go
+++ b/vendor/k8s.io/utils/net/net.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strconv"
+)
+
+// ParseCIDRs parses a list of cidrs and return error if any is invalid.
+// order is maintained
+func ParseCIDRs(cidrsString []string) ([]*net.IPNet, error) {
+	cidrs := make([]*net.IPNet, 0, len(cidrsString))
+	for _, cidrString := range cidrsString {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cidr value:%q with error:%v", cidrString, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	return cidrs, nil
+}
+
+// IsDualStackIPs returns if a slice of ips is:
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPs(ips []net.IP) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, ip := range ips {
+		if ip == nil {
+			return false, fmt.Errorf("ip %v is invalid", ip)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(ip) {
+			v6Found = true
+			continue
+		}
+
+		v4Found = true
+	}
+
+	return (v4Found && v6Found), nil
+}
+
+// IsDualStackIPStrings returns if
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPStrings(ips []string) (bool, error) {
+	parsedIPs := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		parsedIPs = append(parsedIPs, parsedIP)
+	}
+	return IsDualStackIPs(parsedIPs)
+}
+
+// IsDualStackCIDRs returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRs(cidrs []*net.IPNet) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, cidr := range cidrs {
+		if cidr == nil {
+			return false, fmt.Errorf("cidr %v is invalid", cidr)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(cidr.IP) {
+			v6Found = true
+			continue
+		}
+		v4Found = true
+	}
+
+	return v4Found && v6Found, nil
+}
+
+// IsDualStackCIDRStrings returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRStrings(cidrs []string) (bool, error) {
+	parsedCIDRs, err := ParseCIDRs(cidrs)
+	if err != nil {
+		return false, err
+	}
+	return IsDualStackCIDRs(parsedCIDRs)
+}
+
+// IsIPv6 returns if netIP is IPv6.
+func IsIPv6(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() == nil
+}
+
+// IsIPv6String returns if ip is IPv6.
+func IsIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv6(netIP)
+}
+
+// IsIPv6CIDRString returns if cidr is IPv6.
+// This assumes cidr is a valid CIDR.
+func IsIPv6CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv6(ip)
+}
+
+// IsIPv6CIDR returns if a cidr is ipv6
+func IsIPv6CIDR(cidr *net.IPNet) bool {
+	ip := cidr.IP
+	return IsIPv6(ip)
+}
+
+// ParsePort parses a string representing an IP port.  If the string is not a
+// valid port number, this returns an error.
+func ParsePort(port string, allowZero bool) (int, error) {
+	portInt, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	if portInt == 0 && !allowZero {
+		return 0, errors.New("0 is not a valid port number")
+	}
+	return int(portInt), nil
+}
+
+// BigForIP creates a big.Int based on the provided net.IP
+func BigForIP(ip net.IP) *big.Int {
+	// NOTE: Convert to 16-byte representation so we can
+	// handle v4 and v6 values the same way.
+	return big.NewInt(0).SetBytes(ip.To16())
+}
+
+// AddIPOffset adds the provided integer offset to a base big.Int representing a net.IP
+// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
+func AddIPOffset(base *big.Int, offset int) net.IP {
+	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
+	r = append(make([]byte, 16), r...)
+	return net.IP(r[len(r)-16:])
+}
+
+// RangeSize returns the size of a range in valid addresses.
+// returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
+func RangeSize(subnet *net.IPNet) int64 {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// this checks that we are not overflowing an int64
+	if bits-ones >= 63 {
+		return math.MaxInt64
+	}
+	return int64(1) << uint(bits-ones)
+}
+
+// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := AddIPOffset(BigForIP(subnet.IP), index)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}

--- a/vendor/k8s.io/utils/net/port.go
+++ b/vendor/k8s.io/utils/net/port.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// IPFamily refers to a specific family if not empty, i.e. "4" or "6".
+type IPFamily string
+
+// Constants for valid IPFamilys:
+const (
+	IPv4 IPFamily = "4"
+	IPv6          = "6"
+)
+
+// Protocol is a network protocol support by LocalPort.
+type Protocol string
+
+// Constants for valid protocols:
+const (
+	TCP Protocol = "TCP"
+	UDP Protocol = "UDP"
+)
+
+// LocalPort represents an IP address and port pair along with a protocol
+// and potentially a specific IP family.
+// A LocalPort can be opened and subsequently closed.
+type LocalPort struct {
+	// Description is an arbitrary string.
+	Description string
+	// IP is the IP address part of a given local port.
+	// If this string is empty, the port binds to all local IP addresses.
+	IP string
+	// If IPFamily is not empty, the port binds only to addresses of this
+	// family.
+	// IF empty along with IP, bind to local addresses of any family.
+	IPFamily IPFamily
+	// Port is the port number.
+	// A value of 0 causes a port to be automatically chosen.
+	Port int
+	// Protocol is the protocol, e.g. TCP
+	Protocol Protocol
+}
+
+// NewLocalPort returns a LocalPort instance and ensures IPFamily and IP are
+// consistent and that the given protocol is valid.
+func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol Protocol) (*LocalPort, error) {
+	if protocol != TCP && protocol != UDP {
+		return nil, fmt.Errorf("Unsupported protocol %s", protocol)
+	}
+	if ipFamily != "" && ipFamily != "4" && ipFamily != "6" {
+		return nil, fmt.Errorf("Invalid IP family %s", ipFamily)
+	}
+	if ip != "" {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			return nil, fmt.Errorf("invalid ip address %s", ip)
+		}
+		asIPv4 := parsedIP.To4()
+		if asIPv4 == nil && ipFamily == IPv4 || asIPv4 != nil && ipFamily == IPv6 {
+			return nil, fmt.Errorf("ip address and family mismatch %s, %s", ip, ipFamily)
+		}
+	}
+	return &LocalPort{Description: desc, IP: ip, IPFamily: ipFamily, Port: port, Protocol: protocol}, nil
+}
+
+func (lp *LocalPort) String() string {
+	ipPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	return fmt.Sprintf("%q (%s/%s%s)", lp.Description, ipPort, strings.ToLower(string(lp.Protocol)), lp.IPFamily)
+}
+
+// Closeable closes an opened LocalPort.
+type Closeable interface {
+	Close() error
+}
+
+// PortOpener can open a LocalPort and allows later closing it.
+type PortOpener interface {
+	OpenLocalPort(lp *LocalPort) (Closeable, error)
+}
+
+type listenPortOpener struct{}
+
+// ListenPortOpener opens ports by calling bind() and listen().
+var ListenPortOpener listenPortOpener
+
+// OpenLocalPort holds the given local port open.
+func (l *listenPortOpener) OpenLocalPort(lp *LocalPort) (Closeable, error) {
+	return openLocalPort(lp)
+}
+
+func openLocalPort(lp *LocalPort) (Closeable, error) {
+	var socket Closeable
+	hostPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	switch lp.Protocol {
+	case TCP:
+		network := "tcp" + string(lp.IPFamily)
+		listener, err := net.Listen(network, hostPort)
+		if err != nil {
+			return nil, err
+		}
+		socket = listener
+	case UDP:
+		network := "udp" + string(lp.IPFamily)
+		addr, err := net.ResolveUDPAddr(network, hostPort)
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP(network, addr)
+		if err != nil {
+			return nil, err
+		}
+		socket = conn
+	default:
+		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
+	}
+	return socket, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1087,6 +1087,7 @@ k8s.io/kubelet/config/v1beta1
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
+k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed


### PR DESCRIPTION
kubelet 1.20 supports, eg,  `--node-ip 10.0.0.5,fd01::5` for bare-metal dual-stack, so pass that when available.

https://github.com/openshift/baremetal-runtimecfg/pull/110 changes runtimecfg to set both `KUBELET_NODE_IP` and `KUBELET_NODE_IPS`, where the latter contains either a single IP (if the node only has one) or dual-stack IPs (if available). Note that we don't tell runtimecfg whether we actually want dual-stack IPs or not, so we have to be careful to only use `KUBELET_NODE_IPS` in the case where we actually expect dual-stack IPs (because kubelet will complain if you pass dual `--node-ip`s on a cloud platform). (Also, restricting the use of `KUBELET_NODE_IPS` to the dual-stack case means we don't have to worry about MCO/runtimecfg version skew during 4.6->4.7 upgrades, because we don't support upgrading from 4.6 dual-stack to 4.7 dual-stack anyway.)

`manifests/controllerconfig.crd.yaml` needs to be regenerated but I couldn't figure out how to do that...

In addition to depending on the runtimecfg PR, this PR should be held until kubelet is rebased to 1.20(-beta), since the 1.19 kubelet won't handle dual-stack `--node-ip`.