### PR TITLE
Bug 1904065: [on-prem] export proxy variables to be taken in account

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/baremetal/files/NetworkManager-resolv-prepender.yaml
@@ -9,13 +9,13 @@ contents:
 
     {{if .Proxy -}}
     {{if .Proxy.HTTPProxy -}}
-    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    NO_PROXY={{.Proxy.NoProxy}}
+    export NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}
 

--- a/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -9,13 +9,13 @@ contents:
 
     {{if .Proxy -}}
     {{if .Proxy.HTTPProxy -}}
-    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    NO_PROXY={{.Proxy.NoProxy}}
+    export NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}
 

--- a/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/ovirt/files/NetworkManager-resolv-prepender.yaml
@@ -10,13 +10,13 @@ contents:
 
     {{if .Proxy -}}
     {{if .Proxy.HTTPProxy -}}
-    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    NO_PROXY={{.Proxy.NoProxy}}
+    export NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}
 

--- a/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -14,13 +14,13 @@ contents:
 
     {{if .Proxy -}}
     {{if .Proxy.HTTPProxy -}}
-    HTTP_PROXY={{.Proxy.HTTPProxy}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
     {{end -}}
     {{if .Proxy.HTTPSProxy -}}
-    HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
     {{end -}}
     {{if .Proxy.NoProxy -}}
-    NO_PROXY={{.Proxy.NoProxy}}
+    export NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}
 


### PR DESCRIPTION
Note: manual cherry-pick of #2266 (bot can't handle git conflicts)

In order to have the proxy variables (HTTP_PROXY, HTTPS_PROXY and
NO_PROXY), we need to `export` them otherwise then don't end up being
loaded in the environment and it causes issues if a proxy is used,
when pulling an image from a registry for example.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
(cherry picked from commit f41b1d2ae7feea9aedfbd62143baefdf950c8569)
