### PR TITLE
Add platform aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,18 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
 
 aliases:
+  baremetal-approvers:
+    - bcrochet
+    - celebdor
+    - cybertron
+    - hardys
+    - yboaron
+  baremetal-reviewers:
+    - bcrochet
+    - celebdor
+    - cybertron
+    - hardys
+    - yboaron
   openstack-approvers:
     - EmilienM
     - Fedosin
@@ -17,3 +29,15 @@ aliases:
     - mandre
     - mdbooth
     - pierreprinetti
+  ovirt-approvers:
+    - Gal-Zaidman
+    - rgolangh
+  ovirt-reviewers:
+    - Gal-Zaidman
+    - rgolangh
+  vsphere-approvers:
+    - jcpowermac
+    - patrickdillon
+  vsphere-reviewers:
+    - jcpowermac
+    - patrickdillon

--- a/templates/common/baremetal/OWNERS
+++ b/templates/common/baremetal/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - baremetal-approvers
+
+reviewers:
+  - baremetal-reviewers

--- a/templates/common/on-prem/OWNERS
+++ b/templates/common/on-prem/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - baremetal-reviewers
+  - openstack-reviewers
+  - ovirt-reviewers
+  - vsphere-reviewers

--- a/templates/common/ovirt/OWNERS
+++ b/templates/common/ovirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - ovirt-approvers
+reviewers:
+  - ovirt-reviewers

--- a/templates/common/vsphere/OWNERS
+++ b/templates/common/vsphere/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers
+reviewers:
+  - vsphere-reviewers

--- a/templates/master/00-master/on-prem/OWNERS
+++ b/templates/master/00-master/on-prem/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - baremetal-reviewers
+  - openstack-reviewers
+  - ovirt-reviewers
+  - vsphere-reviewers

--- a/templates/worker/00-worker/on-prem/OWNERS
+++ b/templates/worker/00-worker/on-prem/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - baremetal-reviewers
+  - openstack-reviewers
+  - ovirt-reviewers
+  - vsphere-reviewers


### PR DESCRIPTION
This already exists for openstack, so adding vsphere, baremetal & ovirt.

Did this last night by memory on who does what, lmk if you want any changes...

Also assigned all the aliases as on-prem reviewers (to assist in getting the right eyes on this) but not authors as those prs need signoff from multiple teams.

LMK whatever changes you want, I'll leave this open for a while.

