### PR TITLE
templates: Set vSphere hostname from guestinfo before NM starts

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -5,9 +5,6 @@ contents:
     #!/usr/bin/env bash
     set -e
 
-    if [ $(hostname -s) = "localhost" ]; then
-      if hostname=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
-          /usr/bin/hostnamectl --transient --static set-hostname ${hostname}
-      fi
+    if vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
+        /usr/bin/hostnamectl --transient set-hostname ${vm_name}
     fi
-

--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -5,6 +5,8 @@ contents: |
   Description=vSphere hostname
   After=vmtoolsd.service
   Before=kubelet.service
+  Before=node-valid-hostname.service
+  Before=NetworkManager.service
 
   [Service]
   ExecStart=/usr/local/bin/vsphere-hostname.sh


### PR DESCRIPTION
In Fedora 33, a change was introduced to set the hostname to "fedora" as a fallback instead of the default "localhost", so the current script does not work in OKD as NM will assign the fallback hostname.

This change makes it so the hostname is set to vSphere's
guestinfo.hostname if that's defined, before NetworkManager is started.