### PR TITLE
Revert "templates: Disable SSH keys lookup from authorized_keys.d"

### DIFF
--- a/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
+++ b/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
@@ -1,6 +1,0 @@
-mode: 0644
-path: "/etc/ssh/sshd_config.d/10-disable-ssh-key-dir.conf"
-contents:
-  inline: |
-    # disable key lookup from ~/.ssh/authorized_keys.d/ on FCOS
-    AuthorizedKeysCommand none


### PR DESCRIPTION
This reverts commit 5ed6fa3a68acd572fd69be8531012807db59e241.

Not having SSH access to the bootstrap node/before MCO starts successfully on OKD is hindering the ability to debug installation related failures immensely.

We'll need to find another way to solve this properly.
/cc @bgilbert 
