### PR TITLE
Bug 1904124: [baremetal] Add check for default connection id to static DHCPv6 script

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
@@ -19,6 +19,14 @@ contents:
         exit 0
     fi
 
+    # We don't want this to run before OVNKubernetes creates its bridge. If we
+    # see the default CONNECTION_ID we know to wait.
+    if [ "$CONNECTION_ID" == "Wired Connection" ]
+    then
+        >&2 echo "Refusing to modify default connection."
+        exit 0
+    fi
+
     IPS=($IP6_ADDRESS_0)
     # For ipv6 we have two addresses: DHCP and link-local. Make sure we're using the right one.
     CHECK_STR="^${DHCP6_IP6_ADDRESS}/"


### PR DESCRIPTION
If infinite leases are used on initial boot, we will attempt to
modify the default connection because OVNKubernetes hasn't created
the br-ex bridge yet. We want to wait for that to happen, so if
we see that we're operating on the default "Wired Connection" id
then we want to exit the script.
