### PR TITLE
Bug 1888565: daemon: Explicitly start rpm-ostreed

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -219,6 +219,10 @@ func New(
 
 	// Only pull the osImageURL from OSTree when we are on RHCOS or FCOS
 	if os.IsCoreOSVariant() {
+		err := nodeUpdaterClient.Start()
+		if err != nil {
+			return nil, err
+		}
 		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %v", err)

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -60,6 +60,7 @@ type imageInspection struct {
 // NodeUpdaterClient is an interface describing how to interact with the host
 // around content deployment
 type NodeUpdaterClient interface {
+	Start() error
 	GetStatus() (string, error)
 	GetBootedOSImageURL() (string, string, error)
 	Rebase(string, string) (bool, error)
@@ -97,6 +98,18 @@ func (r *RpmOstreeClient) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	}
 
 	return nil, fmt.Errorf("not currently booted in a deployment")
+}
+
+// Start ensures the daemon is running; the DBus activation timeout
+// is shorter than the systemd timeout.  xref
+// https://bugzilla.redhat.com/show_bug.cgi?id=1888565#c3
+func (r *RpmOstreeClient) Start() error {
+	_, err := runGetOut("systemctl", "start", "rpm-ostreed")
+	if err != nil {
+		return fmt.Errorf("failed to start rpm-ostreed: %v", err)
+	}
+
+	return nil
 }
 
 // GetStatus returns multi-line human-readable text describing system status

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -30,6 +30,11 @@ func (r RpmOstreeClientMock) GetBootedOSImageURL() (string, string, error) {
 	return returnValues.OsImageURL, returnValues.Version, returnValues.Error
 }
 
+// Start is a mock
+func (r RpmOstreeClientMock) Start() error {
+	return nil
+}
+
 // PullAndRebase is a mock
 func (r RpmOstreeClientMock) Rebase(string, string) (bool, error) {
 	return false, nil

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -10,6 +10,7 @@ contents: |
   After=machine-config-daemon-pull.service
   Before=crio.service crio-wipe.service
   Before=kubelet.service
+  Wants=rpm-ostreed.service
 
   [Service]
   Type=oneshot


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1888565
for one instance of this.  Since the DBus activation timeout is 25s
but the systemd timeout is 90s, let's defer to the latter by explicitly
starting the service.  (This is slightly racy because rpm-ostreed
auto-exits on idle, but when we go to send the DBus message we'll
auto-activate again if really necessary).

Also tell systemd we're going to need the service via the
firstboot unit file.
