### PR TITLE
Remove instructions around removing the worker node label 

### DIFF
--- a/docs/custom-pools.md
+++ b/docs/custom-pools.md
@@ -25,14 +25,6 @@ ip-10-0-151-146.us-west-1.compute.internal   Ready     master         43m   v1.1
 ip-10-0-152-59.us-west-1.compute.internal    Ready     worker         37m   v1.14.0+e020ea5b3
 ```
 
-When we create infra nodes, we apply them to existing worker nodes first. If you want to use the node as a purely infra node, you can remove the worker pool as follows:
-
-```
-oc label node ip-10-0-130-218.us-west-1.compute.internal node-role.kubernetes.io/worker-
-```
-
-This will not change the files on the node itself: the infra pool inherits from workers by default. This means that if you add a new MachineConfig to update workers, a purely infra node will still get updated. However this will mean that workloads scheduled for workers will no longer be scheduled on this node, as it no longer has the worker label.
-
 Next you need to create a MachineConfigPool that contains both the `worker` role and your custom one as MachineConfig selector as follows:
 
 ```console


### PR DESCRIPTION
...when creating a custom infra pool.

This particular solution, when removing the node label manually like this, is incorrect.  Every new "infra" member of this infra custom pool will begin with a worker node label because of the nature of the MachineConfigs it inherits from the worker pool itself, and this is not desirable behavior (it is inconsistent since it requires manual intervention).  So there is always a manual step to remove the worker node label.  I think it also has been shown to have consequences during upgrades (came across BZs but I'll have to go back looking for them for evidence).  In addition, during some reboot sequences on cloud that use the _base template, the kubelet will reapply the worker label anyways:

https://github.com/openshift/machine-config-operator/blob/master/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml#L28

I may not have the analysis 100% correct, but it would be good to review this.