### PR TITLE
tighten the /etc/kubernetes/ca.crt

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -129,7 +129,6 @@ func RenderBootstrap(
 	bundle = append(bundle, filesData[rootCAFile]...)
 	// Append the kube-ca if given.
 	if _, ok := filesData[kubeAPIServerServingCA]; ok {
-		bundle = append(bundle, filesData[kubeAPIServerServingCA]...)
 		spec.KubeAPIServerServingCAData = filesData[kubeAPIServerServingCA]
 	}
 	// Set the cloud-provider CA if given.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -205,7 +205,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 
 	bundle := make([]byte, 0)
 	bundle = append(bundle, rootCA...)
-	bundle = append(bundle, kubeAPIServerServingCABytes...)
 
 	// sync up os image url
 	// TODO: this should probably be part of the imgs


### PR DESCRIPTION
`/etc/kubernetes/ca.crt` appears to have certificates used to terminate kube-apiserver client connections, which doesn't seem necessary.