### PR TITLE
avoid draining if no action is required

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -610,8 +610,11 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		return err
 	}
 
-	if err := dn.drain(); err != nil {
-		return err
+	// if the only action is nothing, then we don't need to drain.
+	if len(actions) != 1 || actions[0] != postConfigChangeActionNone {
+		if err := dn.drain(); err != nil {
+			return err
+		}
 	}
 
 	// update files on disk that need updating


### PR DESCRIPTION
If the only action is none (or perhaps some special value), then we don't need to drain.