### PR TITLE
Revert "Bug 1888565: daemon: Explicitly start rpm-ostreed"

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -219,10 +219,6 @@ func New(
 
 	// Only pull the osImageURL from OSTree when we are on RHCOS or FCOS
 	if os.IsCoreOSVariant() {
-		err := nodeUpdaterClient.Start()
-		if err != nil {
-			return nil, err
-		}
 		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %v", err)

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -60,7 +60,6 @@ type imageInspection struct {
 // NodeUpdaterClient is an interface describing how to interact with the host
 // around content deployment
 type NodeUpdaterClient interface {
-	Start() error
 	GetStatus() (string, error)
 	GetBootedOSImageURL() (string, string, error)
 	Rebase(string, string) (bool, error)
@@ -98,18 +97,6 @@ func (r *RpmOstreeClient) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	}
 
 	return nil, fmt.Errorf("not currently booted in a deployment")
-}
-
-// Start ensures the daemon is running; the DBus activation timeout
-// is shorter than the systemd timeout.  xref
-// https://bugzilla.redhat.com/show_bug.cgi?id=1888565#c3
-func (r *RpmOstreeClient) Start() error {
-	_, err := runGetOut("systemctl", "start", "rpm-ostreed")
-	if err != nil {
-		return fmt.Errorf("failed to start rpm-ostreed: %v", err)
-	}
-
-	return nil
 }
 
 // GetStatus returns multi-line human-readable text describing system status

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -30,11 +30,6 @@ func (r RpmOstreeClientMock) GetBootedOSImageURL() (string, string, error) {
 	return returnValues.OsImageURL, returnValues.Version, returnValues.Error
 }
 
-// Start is a mock
-func (r RpmOstreeClientMock) Start() error {
-	return nil
-}
-
 // PullAndRebase is a mock
 func (r RpmOstreeClientMock) Rebase(string, string) (bool, error) {
 	return false, nil

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -10,7 +10,6 @@ contents: |
   After=machine-config-daemon-pull.service
   Before=crio.service crio-wipe.service
   Before=kubelet.service
-  Wants=rpm-ostreed.service
 
   [Service]
   Type=oneshot


### PR DESCRIPTION
Reverts openshift/machine-config-operator#2291

assisted-installer is running MCD inside custom podman container as once from[1].
Reverting this PR until better consider once from usage.

/cc @cgwalters 

[1] https://github.com/openshift/assisted-installer/blob/e3c999d9f16f8c8e9fa6d4105591da33ad84fc62/src/installer/installer.go#L218-L224