### PR TITLE
Bug 1907333: daemon: Move rollback removal to update loop

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1029,10 +1029,6 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return fmt.Errorf("error detecting previous SSH accesses: %v", err)
 	}
 
-	if err := dn.removeRollback(); err != nil {
-		return errors.Wrapf(err, "Failed to remove rollback")
-	}
-
 	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -422,9 +422,14 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 	}
 
 	// Update OS
-	if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
-		MCDPivotErr.WithLabelValues(dn.node.Name, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
-		return err
+	if mcDiff.osUpdate {
+		if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
+			MCDPivotErr.WithLabelValues(dn.node.Name, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
+			return err
+		}
+		if err := dn.removeRollback(); err != nil {
+			return err
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
See https://bugzilla.redhat.com/1907333

This needs to be a more proper part of the control loop so that
we retry, rather than having the MCD die.

Also by doing it here it will happen on firstboot when there's
no I/O contention with other processes.
