### PR TITLE
[release-4.6] Bug 1899622: backport bond options fixes

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -140,6 +140,11 @@ contents:
         extra_phys_args="dev ${vlan_parent} id ${vlan_id}"
       elif [ $(nmcli --get-values connection.type conn show ${old_conn}) == "bond" ]; then
         iface_type=bond
+        # check bond options
+        bond_opts=$(nmcli --get-values bond.options conn show ${old_conn})
+        if [ -n "$bond_opts" ]; then
+          extra_phys_args+="bond.options ${bond_opts} "
+        fi
       else
         iface_type=802-3-ethernet
       fi

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -89,13 +89,30 @@ contents:
         echo "MTU found for iface: ${iface}: ${iface_mtu}"
       fi
 
-      # create bridge
-      if ! nmcli connection show br-ex &> /dev/null; then
-        nmcli c add type ovs-bridge conn.interface br-ex con-name br-ex 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac}
-      fi
-
       # store old conn for later
       old_conn=$(nmcli --fields UUID,DEVICE conn show --active | grep ${iface} | awk '{print $1}')
+
+      extra_brex_args=""
+      # check for dhcp client ids
+      dhcp_client_id=$(nmcli --get-values ipv4.dhcp-client-id conn show ${old_conn})
+      if [ -n "$dhcp_client_id" ]; then
+        extra_brex_args+="ipv4.dhcp-client-id ${dhcp_client_id} "
+      fi
+
+      dhcp6_client_id=$(nmcli --get-values ipv6.dhcp-duid conn show ${old_conn})
+      if [ -n "$dhcp6_client_id" ]; then
+        extra_brex_args+="ipv6.dhcp-duid ${dhcp6_client_id} "
+      fi
+
+      # create bridge
+      if ! nmcli connection show br-ex &> /dev/null; then
+        nmcli c add type ovs-bridge \
+            con-name br-ex \
+            conn.interface br-ex \
+            802-3-ethernet.mtu ${iface_mtu} \
+            802-3-ethernet.cloned-mac-address ${iface_mac} \
+            ${extra_brex_args}
+      fi
 
       # find default port to add to bridge
       if ! nmcli connection show ovs-port-phys0 &> /dev/null; then

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -90,7 +90,7 @@ contents:
       fi
 
       # store old conn for later
-      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | grep ${iface} | awk '{print $1}')
+      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | awk "/\s${iface}\s*\$/ {print \$1}")
 
       extra_brex_args=""
       # check for dhcp client ids


### PR DESCRIPTION
Includes fixes for bond options, dhcp client id, and iface parsing.
