### PR TITLE
Bug 1907929: enable madvdontneed in system components

### DIFF
--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -6,3 +6,7 @@ dropins:
       [Service]
       EnvironmentFile=/etc/mco/proxy.env
       {{end -}}
+  - name: 10-mco-default-madv.conf
+    contents: |
+      [Service]
+      Environment="GODEBUG=x509ignoreCN=0,madvdontneed=1"

--- a/templates/common/_base/units/kubelet.service.yaml
+++ b/templates/common/_base/units/kubelet.service.yaml
@@ -6,3 +6,7 @@ dropins:
       [Service]
       EnvironmentFile=/etc/mco/proxy.env
       {{end -}}
+  - name: 10-mco-default-madv.conf
+    contents: |
+      [Service]
+      Environment="GODEBUG=x509ignoreCN=0,madvdontneed=1"


### PR DESCRIPTION
Golang 1.12 changed to use MADV_FREE. MADV_FREE is somewhat faster than 
MADV_DONTNEED; however, the kernel will not try and reclaim memory in golang processes until the system is memory constrained. Cloud servers can potentially page out executable caches, which can cause IOPS throttles. Since golang 1.16  will be changing the default to MADV_DONTNEED, we are going to enable the flag by default.

https://github.com/golang/go/issues/42330