### PR TITLE
Bug 1907333: daemon: Revert code to remove rollback

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1029,10 +1029,6 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return fmt.Errorf("error detecting previous SSH accesses: %v", err)
 	}
 
-	if err := dn.removeRollback(); err != nil {
-		return errors.Wrapf(err, "Failed to remove rollback")
-	}
-
 	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -692,20 +692,6 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 	return dn.performPostConfigChangeAction(actions, newConfig.GetName())
 }
 
-// removeRollback removes the rpm-ostree rollback deployment.  It
-// takes up space, and we don't generally expect administrators to
-// use this versus e.g. removing broken configuration.  We only
-// remove the rollback once the MCD pod has landed on a node, so
-// we know kubelet is working.
-func (dn *Daemon) removeRollback() error {
-	if !dn.os.IsCoreOSVariant() {
-		// do not attempt to rollback on non-RHCOS/FCOS machines
-		return nil
-	}
-	_, err := runGetOut("rpm-ostree", "cleanup", "-r")
-	return err
-}
-
 // machineConfigDiff represents an ad-hoc difference between two MachineConfig objects.
 // At some point this may change into holding just the files/units that changed
 // and the MCO would just operate on that.  For now we're just doing this to get


### PR DESCRIPTION
See https://bugzilla.redhat.com/1907333

Doing this when the MCD lands on a node the first time means
we compete for I/O with lots of other containers, and on
slow systems that can cause a timeout.  Then a further
problem is that we were fatally erroring out in the MCD
rather than retrying.

But we don't have control loop in the MCD today outside of
trying to apply an update; let's defer this until we add one.
