### PR TITLE
Bug 1901376: Fix upgrade issue with DNS controllerconfig field

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -100,7 +100,7 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 		*modified = true
 	}
 
-	if existing.DNS != nil && required.DNS != nil && !equality.Semantic.DeepEqual(existing.DNS, required.DNS) {
+	if required.DNS != nil && !equality.Semantic.DeepEqual(existing.DNS, required.DNS) {
 		*modified = true
 		existing.DNS = required.DNS
 	}


### PR DESCRIPTION
The initial implementation of this had incorrect logic for handling
merges of configs. Because DNS is a new field, the existing one will
always be nil on upgrade. We need to remove the nil check for the
existing object so that it can be populated with the new object.