### PR TITLE
Bug 1895024: Restart ovs-configuration on-abnormal

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -17,6 +17,8 @@ contents: |
   ExecStart=/usr/local/bin/configure-ovs.sh {{.NetworkType}}
   StandardOutput=journal+console
   StandardError=journal+console
+  Restart=on-abnormal
+  RestartSec=90s
 
   [Install]
   WantedBy=network-online.target


### PR DESCRIPTION
We see that ovs-configuration may not start because some dependencies
failed. These dependencies are restarted on failure so we should
re-check later if it has started.

Should fix: #1895024
**- How to verify it**
Unfortunately I do not have a reliable reproducer and I'm not 100% certain that it will actually fix it.
However this should improve stability and I can't think of any scenario where this can cause problems.

**- Description for the changelog**
Restart ovs-configuration on-abnormal failures.

**- What I did**
Force restarting ovs-configuration on-abnormal failures.