### PR TITLE
Bug 1825417: Make the ctrcfg CR to MC mapping 1:1

### DIFF
--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -15,4 +15,7 @@ const (
 
 	// MasterLabel defines the label associated with master node. The master taint uses the same label as taint's key
 	MasterLabel = "node-role.kubernetes.io/master"
+
+	// MCNameSuffixAnnotationKey is used to keep track of the machine config name associated with a CR
+	MCNameSuffixAnnotationKey = "machineconfiguration.openshift.io/mc-name-suffix"
 )

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -417,12 +417,13 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
 		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
+			f.newController()
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
-			ctrCfgKey, _ := getManagedKeyCtrCfg(mcp, nil)
+			ctrCfgKey, _ := getManagedKeyCtrCfg(mcp, f.client, ctrcfg1)
 			mcs1 := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcs2 := mcs1.DeepCopy()
 			mcs2.Name = ctrCfgKey
@@ -452,12 +453,13 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
 		t.Run(string(platform), func(t *testing.T) {
 			f := newFixture(t)
+			f.newController()
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			ctrcfg1 := newContainerRuntimeConfig("set-log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug", LogSizeMax: resource.MustParse("9k"), OverlaySize: resource.MustParse("3G")}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
-			keyCtrCfg, _ := getManagedKeyCtrCfg(mcp, nil)
+			keyCtrCfg, _ := getManagedKeyCtrCfg(mcp, f.client, ctrcfg1)
 			mcs := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcsUpdate := mcs.DeepCopy()
 			mcsUpdate.Name = keyCtrCfg


### PR DESCRIPTION
Fixes #1825417 (https://bugzilla.redhat.com/show_bug.cgi?id=1825417)
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Create a new MC object for each ctrcfg object created.
Before we were only creating 1 MC object for every ctrcfg
created, this would override the previouse ctrcfg CR options
causing a rollback to go all the way back to the default values
when the latest ctrcfg CR was deleted.
So if there was ctrcfg-1, ctrcfg-2 and we deleted ctrcfg-2, it would
skip over ctrcfg-1 and go back to the defaults.
Having a 1:1 mapping of ctrcfg to MC prevents this from happening.
So ctrcfg-1 will have mc-1 and ctrcfg-2 will have [mc-2](https://issues.redhat.com/browse/mc-2) - if ctrcfg-2
is deleted, the changes will roll back to mc-1, which is from ctrcfg-1
and not the initial defaults.

**- How to verify it**
Start a cluster and create multiple ctrcfg CRs, then delete them and see that the changes on the node rolls back to the previous ctrcfg CR and not directly to the defaults. Also, each ctrcfg CR will have its own MC and the suffix of the MC name will be stored as annotation in the ctrcfg CR.

**- Description for the changelog**
Create a new MC for each ctrcfg object created.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
