### PR TITLE
Bug 1910165: [baremetal] Correctly handle multiple ipv6 addresses on interface

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
@@ -11,7 +11,8 @@ contents:
         exit 0
     fi
 
-    LEASE_TIME=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r '.[].addr_info[] | select(.scope=="global") | select(.deprecated!=true) | .preferred_life_time')
+    LEASE_TIME=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r ".[].addr_info[] | select(.scope==\"global\") | select(.deprecated!=true) | select(.local==\"$DHCP6_IP6_ADDRESS\") | .preferred_life_time")
+    PREFIX_LEN=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r ".[].addr_info[] | select(.scope==\"global\") | select(.deprecated!=true) | select(.local==\"$DHCP6_IP6_ADDRESS\") | .prefixlen")
 
     if [ ${LEASE_TIME:-0} -lt 4294967295 ]
     then
@@ -27,15 +28,7 @@ contents:
         exit 0
     fi
 
-    IPS=($IP6_ADDRESS_0)
-    # For ipv6 we have two addresses: DHCP and link-local. Make sure we're using the right one.
-    CHECK_STR="^${DHCP6_IP6_ADDRESS}/"
-    if [[ $IP6_ADDRESS_1 =~ ${CHECK_STR} ]]
-    then
-        IPS=($IP6_ADDRESS_1)
-    fi
-    CIDR=${IPS[0]}
-
+    CIDR="$DHCP6_IP6_ADDRESS/$PREFIX_LEN"
     nmcli con mod "$CONNECTION_ID" ipv6.addresses "$CIDR"
     nmcli con mod "$CONNECTION_ID" connection.autoconnect "yes"
     nmcli con mod "$CONNECTION_ID" ipv6.method "manual"


### PR DESCRIPTION
Generally speaking there should only be one address configured per
interface. However, in some ipv6 environments a node may get an
address from both DHCP and SLAAC. In this case, we need to make sure
that the ipv6 DHCP to static dispatcher script can handle the inputs
it gets.

Previously, the lease time check would get back a single string
with multiple values. This caused the if to always fail, which
meant we would do static configuration even if the DHCP lease was
not infinite.

This change further filters the lease time query to ensure it only
returns the value for the specific DHCP address in question. It also
improves the address assignment logic to ensure that we get the
correct address no matter how many are present on the interface.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
