### PR TITLE
Bug 1891460: KubeletConfig: Allow only positive values for KubeReserved, SystemReserved, EvictionHard and EvictionSoft

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -534,6 +534,90 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "evictionSoft memory available cannot be negative",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionSoft: map[string]string{
+					"memory.available": "-1M",
+				},
+				EvictionSoftGracePeriod: map[string]string{
+					"memory.available": "1h",
+				},
+			},
+		},
+		{
+			name: "evictionSoft memory available must be positive",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionSoft: map[string]string{
+					"memory.available": "0M",
+				},
+				EvictionSoftGracePeriod: map[string]string{
+					"memory.available": "1h",
+				},
+			},
+		},
+		{
+			name: "evictionSoft field cannot be invalid",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionSoft: map[string]string{
+					"memory111.available": "500M",
+				},
+				EvictionSoftGracePeriod: map[string]string{
+					"memory.available": "1h",
+				},
+			},
+		},
+		{
+			name: "evictionSoft field value cannot be invalid",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionSoft: map[string]string{
+					"memory.available": "&#jk789",
+				},
+				EvictionSoftGracePeriod: map[string]string{
+					"memory.available": "1h",
+				},
+			},
+		},
+		{
+			name: "evictionHard memory available cannot be negative",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionHard: map[string]string{
+					"memory.available": "-1M",
+				},
+			},
+		},
+		{
+			name: "evictionHard memory available must be positive",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionHard: map[string]string{
+					"memory.available": "0M",
+				},
+			},
+		},
+		{
+			name: "evictionHard field cannot be invalid",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionHard: map[string]string{
+					"memory111.available": "500M",
+				},
+			},
+		},
+		{
+			name: "evictionHard field value cannot be invalid",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				EvictionHard: map[string]string{
+					"memory.available": "&#jk789",
+				},
+			},
+		},
+		{
+			name: "kubeReserved cpu value must be positive",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				KubeReserved: map[string]string{
+					v1.ResourceCPU.String(): "0",
+				},
+			},
+		},
+		{
 			name: "kubeReserved cpu value cannot be negative",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				KubeReserved: map[string]string{
@@ -550,6 +634,14 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "systemReserved cpu value must be positive",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				SystemReserved: map[string]string{
+					v1.ResourceCPU.String(): "0",
+				},
+			},
+		},
+		{
 			name: "kubeReserved memory value cannot be negative",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				KubeReserved: map[string]string{
@@ -558,10 +650,26 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "kubeReserved memory value must be positive",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				KubeReserved: map[string]string{
+					v1.ResourceMemory.String(): "0M",
+				},
+			},
+		},
+		{
 			name: "systemReserved memory value cannot be negative",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				SystemReserved: map[string]string{
 					v1.ResourceMemory.String(): "-20M",
+				},
+			},
+		},
+		{
+			name: "systemReserved memory value must be positive",
+			config: &kubeletconfigv1beta1.KubeletConfiguration{
+				SystemReserved: map[string]string{
+					v1.ResourceMemory.String(): "0M",
 				},
 			},
 		},


### PR DESCRIPTION
Allow only positive values for KubeReserved, SystemReserved and EvictionHard

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1891460

Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Validate if KubeReserved, SystemReserved and EvictionHard in KubeletConfig are positive or not. 

**- How to verify it**
https://bugzilla.redhat.com/show_bug.cgi?id=1891460#c0

**- Description for the changelog**
Allow only positive values for KubeReserved, SystemReserved, EvictionHard and EvictionSoft
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
