### PR TITLE
Bug 1909502: pkg/operator: tolerate removal of etcd records from proxy config

### DIFF
--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -13,6 +13,46 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
+func TestRemoveEtcdNoProxyConfig(t *testing.T) {
+	cases := []struct {
+		name            string
+		proxy           string
+		expectedNoProxy string
+	}{
+		{
+			name:            "empty NoProxy",
+			proxy:           "",
+			expectedNoProxy: "",
+		},
+		{
+			name:            "NoProxy etcd with domain",
+			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.a.com,etcd-1.a.com,etcd-2.a.com,localhost",
+			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,localhost",
+		},
+		{
+			name:            "NoProxy etcd last with domain",
+			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.a.com,etcd-1.a.com,etcd-2.a.com",
+			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com",
+		},
+		{
+			name:            "NoProxy etcd without domain",
+			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.,etcd-1.,etcd-2.,localhost",
+			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,localhost",
+		},
+		{
+			name:            "NoProxy etcd last without domain",
+			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.,etcd-1.,etcd-2.",
+			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			noProxy := removeEtcdNoProxyConfig(tc.proxy)
+			assert.Equal(t, tc.expectedNoProxy, noProxy)
+		})
+	}
+}
+
 func TestSyncCloudConfig(t *testing.T) {
 	cases := []struct {
 		name                        string


### PR DESCRIPTION
Since 4.4 etcd no longer has a DNS dependency. Currently, we are still passing etcd records to the proxy config which should be removed.

In order to remove the deprecated etcd records from the proxy config, we must tolerate the old etcd records.
This PR allows the toleration of this divergence providing the user a chance to update the NoProxy config and in the meantime allow CI to pass for the below PRs.

blocks:
- https://github.com/openshift/installer/pull/4518
- https://github.com/openshift/cluster-network-operator/pull/930