### PR TITLE
Bug 1865743: Add a prestart line to change ownership of openvswitch dir

### DIFF
--- a/templates/common/_base/units/ovs-vswitchd.service.yaml
+++ b/templates/common/_base/units/ovs-vswitchd.service.yaml
@@ -4,3 +4,6 @@ dropins:
     contents: |
       [Service]
       Restart=always
+      ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /var/lib/openvswitch'
+      ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /etc/openvswitch'
+      ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /run/openvswitch'


### PR DESCRIPTION
Temporary fix for making sure the ownership of openvswitch directory is set to `openvswitch` user till we fix https://github.com/coreos/rpm-ostree/issues/49.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

