### PR TITLE
Bug 1909943: check for scheduler support before setting

### DIFF
--- a/pkg/daemon/controlplane.go
+++ b/pkg/daemon/controlplane.go
@@ -35,8 +35,19 @@ func setRootDeviceSchedulerBFQ() error {
 		return err
 	}
 	schedulerContents := string(schedulerContentsBuf)
-	if strings.Contains(schedulerContents, fmt.Sprintf("[%s]", sched)) {
-		glog.Infof("Device %s already uses scheduler %s", rootDevSysfs, sched)
+	schedSupported := false
+	for _, v := range strings.Split(schedulerContents, " ") {
+		switch v {
+		case fmt.Sprintf("[%s]", sched):
+			glog.Infof("Device %s already uses scheduler %s", rootDevSysfs, sched)
+			return nil
+		case sched:
+			schedSupported = true
+			break
+		}
+	}
+	if !schedSupported {
+		glog.Infof("Device %s does not support the %s scheduler", rootDevSysfs, sched)
 		return nil
 	}
 


### PR DESCRIPTION
RHEL7 worker nodes do not support bfq. Rather than assuming the block
device supports bfq, this checks before applying the setting.

Signed-off-by: Ben Howard <ben.howard@redhat.com>
