### PR TITLE
Bug 1882140: KubeletConfig: Add the description to kubelet config CRD

### DIFF
--- a/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
@@ -53,6 +53,9 @@ spec:
               minimum: 1
               maximum: 10
             kubeletConfig:
+              description: The fields of the kubelet configuration are defined in 
+                kubernetes upstream. Please refer to the types defined in the 
+                version/commit used by OpenShift of the upstream kubernetes. 
               type: object
               x-kubernetes-preserve-unknown-fields: true
             machineConfigPoolSelector:


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a description to the kubelet configuration CRD

**- How to verify it**
`oc explain KubeletConfig.spec.kubeletConfig --recursive=true` should show following `DESCRIPTION` field instead of an empty entry.

```
DESCRIPTION:
     The fields of the kubelet configuration are defined in kubernetes upstream.
     Please refer to the types defined in the version/commit used by OpenShift
     of the upstream kubernetes.
```

**- Description for the changelog**
Added the description to kubelet config CRD
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
