### PR TITLE
Bug 1913154: update.go: only set BFQ scheduler for masters

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -399,9 +399,17 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType {
 		// When we're going to apply an OS update, switch the block
 		// scheduler to BFQ to apply more fairness between etcd
-		// and the OS update.
-		if err := setRootDeviceSchedulerBFQ(); err != nil {
-			return err
+		// and the OS update. Only do this on masters since etcd
+		// only operates on masters, and RHEL compute nodes can't
+		// do this.
+		// Add nil check since firstboot also goes through this path,
+		// which doesn't have a node object yet.
+		if dn.node != nil {
+			if _, isControlPlane := dn.node.Labels[ctrlcommon.MasterLabel]; isControlPlane {
+				if err := setRootDeviceSchedulerBFQ(); err != nil {
+					return err
+				}
+			}
 		}
 		// We emitted this event before, so keep it
 		if dn.recorder != nil {


### PR DESCRIPTION
In https://github.com/openshift/machine-config-operator/pull/2243
we made it so that we switch to BFQ during updates, but unintentially
made it also apply to workers. This does not work on RHEL7 since it
breaks on both trying to set the scheduler as well as finding the root
device.

Change the behaviour back to master only, which also implies that only
CoreOS variants will do this.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>
