### PR TITLE
Bug 1910738: [on-prem] fix nodeip-configuration.service template

### DIFF
--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -1,7 +1,6 @@
 name: nodeip-configuration.service
-enabled: true
+enabled: {{if (onPremPlatformAPIServerInternalIP .)}}true{{else}}false{{end}}
 contents: |
-  {{ if (onPremPlatformAPIServerInternalIP .) -}}
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   # This only applies to VIP managing environments where the kubelet and crio IP
@@ -45,4 +44,3 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
-  {{ end -}}


### PR DESCRIPTION
**- What I did**
Updates the on-prem nodeip-configuration.service template so content is always written but enabled is toggled based on onPremPlatformAPIServerInternalIP. Prior to this change, if onPremPlatformAPIServerInternalIP is nil the enabled is true but content is empty. This change puts the template to be consistent with /pkg/templates/common/_base/units/nodeip-configuration.service.yaml.

**- How to verify it**
The product of the template can be verified in vSphere UPI CI (and another platform to check the opposite case).

**- Description for the changelog**
Updates the on-prem nodeip-configuration.service template so content is always written but enabled is toggled based on onPremPlatformAPIServerInternalIP.

Discussion:
I believe this change will mitigate the issues in bz-1917038 but it is not clear to me why vSphere UPI CI does not encounter this issue. Comparing the [must-gather from a successful UPI CI run ](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.7-e2e-vsphere-upi/1346946367452352512/artifacts/e2e-vsphere-upi/gather-must-gather/) vs the must gather from the BZ I see that the BZ cluster encounters the error in the machine-config-daemon and it looks like there is some sort of update being triggered:

```
2020-12-24T06:59:46.241456713Z I1224 06:59:46.241389    2389 update.go:588] Checking Reconcilable for config rendered-worker-c255d81fe61657c3062da9e2cfbaee99 to rendered-worker-36aba62b3fbb0fe978bc6a3521af0c3d
2020-12-24T06:59:46.268478900Z I1224 06:59:46.268447    2389 update.go:1844] Starting update from rendered-worker-c255d81fe61657c3062da9e2cfbaee99 to rendered-worker-36aba62b3fbb0fe978bc6a3521af0c3d: &{osUpdate:false kargs:false fips:false passwd:false files:true units:false kernelType:false extensions:false}
```
This seems to set off the writing of files which leads to the encountered error, but if anyone could shed some light on why this update happens in the BZ but not in CI that would be helpful.

cc @jcpowermac 
cc @bcrochet 

/test e2e-vsphere-upi