### PR TITLE
Bug 1911632: daemon/update: fix regression in realtime upgrades

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1155,12 +1155,11 @@ func (dn *Daemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig) error
 
 	defaultKernel := []string{"kernel", "kernel-core", "kernel-modules", "kernel-modules-extra"}
 	realtimeKernel := []string{"kernel-rt-core", "kernel-rt-modules", "kernel-rt-modules-extra", "kernel-rt-kvm"}
-	var args []string
 
 	dn.logSystem("Initiating switch from kernel %s to %s", canonicalizeKernelType(oldConfig.Spec.KernelType), canonicalizeKernelType(newConfig.Spec.KernelType))
 
 	if canonicalizeKernelType(oldConfig.Spec.KernelType) == ctrlcommon.KernelTypeRealtime && canonicalizeKernelType(newConfig.Spec.KernelType) == ctrlcommon.KernelTypeDefault {
-		args = []string{"override", "reset"}
+		args := []string{"override", "reset"}
 		args = append(args, defaultKernel...)
 		for _, pkg := range realtimeKernel {
 			args = append(args, "--uninstall", pkg)
@@ -1172,7 +1171,7 @@ func (dn *Daemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig) error
 
 	if canonicalizeKernelType(oldConfig.Spec.KernelType) == ctrlcommon.KernelTypeDefault && canonicalizeKernelType(newConfig.Spec.KernelType) == ctrlcommon.KernelTypeRealtime {
 		// Switch to RT kernel
-		args = []string{"override", "remove"}
+		args := []string{"override", "remove"}
 		args = append(args, defaultKernel...)
 		for _, pkg := range realtimeKernel {
 			args = append(args, "--install", pkg)
@@ -1185,6 +1184,7 @@ func (dn *Daemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig) error
 
 	if canonicalizeKernelType(oldConfig.Spec.KernelType) == ctrlcommon.KernelTypeRealtime && canonicalizeKernelType(newConfig.Spec.KernelType) == ctrlcommon.KernelTypeRealtime {
 		if oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL {
+			args := []string{"update"}
 			dn.logSystem("Updating rt-kernel packages on host: %+q", args)
 			_, err := runGetOut("rpm-ostree", args...)
 			return err


### PR DESCRIPTION
During the extension refactor [1], the upgrade logic that installed the
realtime kernel RPM's was lost. 'rpm-ostree' does not have the ability
to do non-local replacements of installed overrides (the packages are
shipped as a bona-fida repo). The cleanest method for handling the
upgrade is to remove the override and the install the new ones; this
avoids having to calculate the rpm dependencies.
