### PR TITLE
Bug 1913582: fix IsLikeTraditionalRhel7() to account for minor versions

### DIFF
--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -38,6 +38,9 @@ func (os OperatingSystem) IsCoreOSVariant() bool {
 // yum based + kickstart/cloud-init (not Ignition).
 func (os OperatingSystem) IsLikeTraditionalRHEL7() bool {
 	// Today nothing else is going to show up with a version ID of 7
+	if len(os.VersionID) > 2 {
+		return strings.HasPrefix(os.VersionID, "7.")
+	}
 	return os.VersionID == "7"
 }
 

--- a/pkg/daemon/osrelease_test.go
+++ b/pkg/daemon/osrelease_test.go
@@ -1,0 +1,18 @@
+package daemon
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsLikeTraditionalRHEL7(t *testing.T) {
+	var testOS OperatingSystem
+	testOS.VersionID = "7"
+	assert.True(t, testOS.IsLikeTraditionalRHEL7())
+	testOS.VersionID = "7.5"
+	assert.True(t, testOS.IsLikeTraditionalRHEL7())
+	testOS.VersionID = "8"
+	assert.False(t, testOS.IsLikeTraditionalRHEL7())
+	testOS.VersionID = "6.8"
+	assert.False(t, testOS.IsLikeTraditionalRHEL7())
+}


### PR DESCRIPTION
Bug Summary: 
The VERSION_ID was 7.5 but our check IsLikeTraditionalRhel7() did not account for minor versions (only for "7" not for 7.x) and so returned false. This resulted in dn.loggerSupportsJournal being set to true which is the relevant value when selecting which logger to use. So instead of using storePendingStateLegacyLogger() (for cases where journald isn't avail) we used normal logger resulting in the --journald flag erroneously being used for a rhel7 node.

Also added a unit test for this func to keep it working going forward.  Pre-fix unit new test failed and returned false for 7.5, now it correctly returns true.