### PR TITLE
Bug 1917187: [release-4.5][vsphere] Remove prepend domain-name-servers option from…

### DIFF
--- a/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
+++ b/templates/master/00-master/vsphere/files/dhcp-dhclient-conf.yaml
@@ -9,7 +9,6 @@ contents:
     {{ if .Infra.Status.PlatformStatus.VSphere -}}
     {{ if .Infra.Status.PlatformStatus.VSphere.APIServerInternalIP -}}
     supersede domain-search "{{ .EtcdDiscoveryDomain }}";
-    prepend domain-name-servers {{ .Infra.Status.PlatformStatus.VSphere.NodeDNSIP }};
     {{ end -}}
     {{ end -}}
     {{ end -}}


### PR DESCRIPTION
… dhclient.conf

In this release, nameserver prepending is handled by a NetworkManager
dispatcher script. The existence of this option is causing render
errors on vsphere deployments, which causes some weird DHCP behavior.
All of the other on-prem platforms had already removed this option
in 4.5, so we should get rid of it here too.
