### PR TITLE
Bug 1891825: Mode mismatch fix for confusing strings

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1530,7 +1530,7 @@ func checkFileContentsAndMode(filePath string, expectedContent []byte, mode os.F
 		return errors.Wrapf(err, "could not stat file %q", filePath)
 	}
 	if fi.Mode() != mode {
-		return errors.Errorf("mode mismatch for file: %q; expected: %v; received: %v", filePath, mode, fi.Mode())
+		return errors.Errorf("mode mismatch for file: %q; expected: %[2]v/%[2]d/%#[2]o; received: %[3]v/%[3]d/%#[3]o", filePath, mode, fi.Mode())
 	}
 	contents, err := ioutil.ReadFile(filePath)
 	if err != nil {


### PR DESCRIPTION
Closes: BZ #1891825

Please provide the following information:

**Reproducer:**

```
package main

import (
	"log"
	"os"
)

func main() {
	file, e := os.Create("a.out")
	if e != nil {
		log.Fatal(e)
	}
	log.Println(file)
	os.Chmod(file.Name(), 0204)
	fi, _ := os.Lstat(file.Name())
	mode := os.FileMode(644)

	if fi.Mode() != mode {
		log.Printf("mode: %v fi.Mode: %v", mode, fi.Mode())
	}
	log.Printf("%v", fi.Mode())
	log.Printf("%v", mode)
	file.Close()

}
```

The reason is that:

chmod 204 on your file represents 0204 
```
chmod 204 test.md
ls -la test.md
--w----r--  1 rrobin  staff  35 14 Jan 08:05 test.md
```

and 644 is 01204

```
chmod 01204 test.md
ls -la test.md
--w----r-T  1 rrobin  staff  35 14 Jan 08:05 test.md
```

That extra 1(T) is not printed, since 01000 is nothing.

If we want to check if this is the real case:

```
chmod 01000 test.md
ls -la test.md
---------T  1 rrobin  staff  35 14 Jan 08:05 test.md
```

```
package main

import (
	"log"
	"os"
)

func main() {
	file, e := os.Create("a.out")
	if e != nil {
		log.Fatal(e)
	}
	log.Println(file)
	os.Chmod(file.Name(), 01000)
	fi, _ := os.Lstat(file.Name())
	log.Printf("%v", fi.Mode())
	file.Close()

}
```

**Outputs:**

`2021/01/14 11:49:13 ----------`

so we know that T is not printed but it is still different.

**Proposed solution:**

Add octet and decimal representation to the output:

```
if fi.Mode() != mode {
	return errors.Errorf("mode mismatch for file: %q; expected: %[2]v/%[2]d/%#[2]o; received: %[3]v/%[3]d/%#[3]o", filePath, mode, fi.Mode())
}
```

