### PR TITLE
handle interfaces with multiple ips

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
@@ -11,8 +11,8 @@ contents:
         exit 0
     fi
 
-    LEASE_TIME=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r ".[].addr_info[] | select(.scope==\"global\") | select(.deprecated!=true) | select(.local==\"$DHCP6_IP6_ADDRESS\") | .preferred_life_time")
-    PREFIX_LEN=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r ".[].addr_info[] | select(.scope==\"global\") | select(.deprecated!=true) | select(.local==\"$DHCP6_IP6_ADDRESS\") | .prefixlen")
+    LEASE_TIME=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r --arg DHCP6_IP6_ADDRESS "$DHCP6_IP6_ADDRESS" ".[].addr_info[] | select(.local==$DHCP6_IP6_ADDRESS) | select(.scope==\"global\") | select(.deprecated!=true) | select(.local==\"$DHCP6_IP6_ADDRESS\") | .preferred_life_time")
+    PREFIX_LEN=$(ip -j -6 a show "$DEVICE_IFACE" | jq -r --arg DHCP6_IP6_ADDRESS "$DHCP6_IP6_ADDRESS" ".[].addr_info[] | select(.local==$DHCP6_IP6_ADDRESS) | select(.scope==\"global\") | select(.deprecated!=true) | select(.local==\"$DHCP6_IP6_ADDRESS\") | .prefixlen")
 
     if [ ${LEASE_TIME:-0} -lt 4294967295 ]
     then


### PR DESCRIPTION
The network manager script wasn´t discriminating by IP address, hence,
interfaces with multiple addresses broke the scripts.

This was partially fixed by https://github.com/openshift/machine-config-operator/pull/2312
~However, this still carries the problem that the parsing of the interface output return multiples fields, and those should be discriminated by the IP address received as parameter.~

ups, Sorry , I misread the script, I think that it only misses the `jq --argi, at least it failed to me without it

Signed-off-by: Antonio Ojea <aojea@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=1914250
