### PR TITLE
Bug 1882674: use environment file for proxy settings

### DIFF
--- a/templates/common/_base/files/etc-mco-proxy.yaml
+++ b/templates/common/_base/files/etc-mco-proxy.yaml
@@ -1,0 +1,22 @@
+filesystem: "root"
+mode: 0644
+path: "/etc/mco/proxy.env"
+contents:
+  inline: |
+      # Proxy environment variables will be populated in this file. Properly
+      # url encoded passwords with special characters will use '%<HEX><HEX>'.
+      # Systemd requires that any % used in a password be represented as
+      # %% in a unit file since % is a prefix for macros; this restriction does not
+      # apply for environment files. Templates that need the proxy set should use
+      # 'EnvironmentFile=/etc/mco/proxy.env'.
+      {{if .Proxy -}}
+      {{if .Proxy.HTTPProxy -}}
+      HTTP_PROXY={{.Proxy.HTTPProxy}}
+      {{end -}}
+      {{if .Proxy.HTTPSProxy -}}
+      HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      {{end -}}
+      {{if .Proxy.NoProxy -}}
+      NO_PROXY={{.Proxy.NoProxy}}
+      {{end -}}
+      {{end -}}

--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -2,16 +2,7 @@ name: crio.service
 dropins:
   - name: 10-mco-default-env.conf
     contents: |
-      [Unit]
       {{if .Proxy -}}
       [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
+      EnvironmentFile=/etc/mco/proxy.env
       {{end -}}

--- a/templates/common/_base/units/kubelet.service.yaml
+++ b/templates/common/_base/units/kubelet.service.yaml
@@ -2,16 +2,7 @@ name: kubelet.service
 dropins:
   - name: 10-mco-default-env.conf
     contents: |
-      [Unit]
       {{if .Proxy -}}
       [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
+      EnvironmentFile=/etc/mco/proxy.env
       {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -17,17 +17,8 @@ contents: |
   # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
-
   {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
+  EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
 
   [Install]

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -19,17 +19,8 @@ contents: |
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
   ExecStart=/bin/sh -c "/usr/bin/podman run --rm --quiet --net=host --entrypoint=cat '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon > /run/bin/machine-config-daemon.tmp"
   ExecStart=/bin/sh -c '/usr/bin/chmod a+x /run/bin/machine-config-daemon.tmp && mv /run/bin/machine-config-daemon.tmp /run/bin/machine-config-daemon'
-
   {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
+  EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
 
   [Install]

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -27,15 +27,7 @@ contents: |
     done"
 
   {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
+  EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
 
   [Install]

--- a/templates/common/_base/units/pivot.service.yaml
+++ b/templates/common/_base/units/pivot.service.yaml
@@ -2,16 +2,7 @@ name: pivot.service
 dropins:
   - name: 10-mco-default-env.conf
     contents: |
-      [Unit]
       {{if .Proxy -}}
       [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
+      EnvironmentFile=/etc/mco/proxy.env
       {{end -}}

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -31,15 +31,7 @@ contents: |
     done"
 
   {{if .Proxy -}}
-  {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-  {{end -}}
-  {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-  {{end -}}
-  {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
-  {{end -}}
+  EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
 
   [Install]


### PR DESCRIPTION
Proxies that are url encoded represent sepcial characters with a '%'.
However, systemd uses '%' as control character in unit files and
dropins [1]. This moves the environment varialbes into a file and uses a
EnviromentFile stanza in the units which cannot safely contain '%' and
avoids adding complicated logic to the MCO for mangling the proxy
passwords (detecting if its URL encoded and special character handling).

Closes: 1882674
