### PR TITLE
Bug 1882674: Escape systemd proxy strings

### DIFF
--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -6,12 +6,12 @@ dropins:
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+      Environment=HTTP_PROXY='{{.Proxy.HTTPProxy}}'
       {{end -}}
       {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      Environment=HTTPS_PROXY='{{.Proxy.HTTPSProxy}}'
       {{end -}}
       {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
+      Environment=NO_PROXY='{{.Proxy.NoProxy}}'
       {{end -}}
       {{end -}}

--- a/templates/common/_base/units/kubelet.service.yaml
+++ b/templates/common/_base/units/kubelet.service.yaml
@@ -6,12 +6,12 @@ dropins:
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+      Environment=HTTP_PROXY='{{.Proxy.HTTPProxy}}'
       {{end -}}
       {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      Environment=HTTPS_PROXY='{{.Proxy.HTTPSProxy}}'
       {{end -}}
       {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
+      Environment=NO_PROXY='{{.Proxy.NoProxy}}'
       {{end -}}
       {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -20,13 +20,13 @@ contents: |
 
   {{if .Proxy -}}
   {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  Environment=HTTP_PROXY='{{.Proxy.HTTPProxy}}'
   {{end -}}
   {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  Environment=HTTPS_PROXY='{{.Proxy.HTTPSProxy}}'
   {{end -}}
   {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  Environment=NO_PROXY='{{.Proxy.NoProxy}}'
   {{end -}}
   {{end -}}
 

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -22,13 +22,13 @@ contents: |
 
   {{if .Proxy -}}
   {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  Environment=HTTP_PROXY='{{.Proxy.HTTPProxy}}'
   {{end -}}
   {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  Environment=HTTPS_PROXY='{{.Proxy.HTTPSProxy}}'
   {{end -}}
   {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  Environment=NO_PROXY='{{.Proxy.NoProxy}}'
   {{end -}}
   {{end -}}
 

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -28,13 +28,13 @@ contents: |
 
   {{if .Proxy -}}
   {{if .Proxy.HTTPProxy -}}
-  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  Environment=HTTP_PROXY='{{.Proxy.HTTPProxy}}'
   {{end -}}
   {{if .Proxy.HTTPSProxy -}}
-  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  Environment=HTTPS_PROXY='{{.Proxy.HTTPSProxy}}'
   {{end -}}
   {{if .Proxy.NoProxy -}}
-  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  Environment=NO_PROXY='{{.Proxy.NoProxy}}'
   {{end -}}
   {{end -}}
 

--- a/templates/common/_base/units/pivot.service.yaml
+++ b/templates/common/_base/units/pivot.service.yaml
@@ -6,12 +6,12 @@ dropins:
       {{if .Proxy -}}
       [Service]
       {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+      Environment=HTTP_PROXY='{{.Proxy.HTTPProxy}}'
       {{end -}}
       {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      Environment=HTTPS_PROXY='{{.Proxy.HTTPSProxy}}'
       {{end -}}
       {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
+      Environment=NO_PROXY='{{.Proxy.NoProxy}}'
       {{end -}}
       {{end -}}


### PR DESCRIPTION
Fixes: #1882674

Systemd does not allow single % characters followed by
a number of a character.  Systemd requires escaping '%'
by adding preceding percent to appear as '%%'. This is
an attepmt to escape the proxy string when applied in
/etc/systemd path.

**- What I did**
I added a simple template rendering function to double escape the `%` characters with `%%`.

**- How to verify it**
(Tested in Azure)
1. Create a cluster
2. Create a separate proxy host in a different resource group.
3. Peer the vnets
4. Setup squid proxy on the proxy vm with authentication and a user that has a `%` in the password.
5. Edit the cluster's proxy object (oc edit proxy cluster) and specify the proxy cluster's IP with auth.
```
spec:
  httpProxy: http://proxy:this%is%my%password@10.3.0.4:3128
  readinessEndpoints:
  - http://www.google.com
  trustedCA:
    name: user-ca-bundle
```
6. Verify that the unit files are **not** showing up in dmesg as failed and verify the password is escaped propertly (includes `%%`).

**- Description for the changelog**
An attempt to properly escape % characters for systemd proxy files.
