### PR TITLE
WIP templates: autoinject GOGC in containers using crio default_env

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -11,6 +11,7 @@ contents:
     conmon_cgroup = "pod"
     default_env = [
         "NSS_SDB_USE_CACHE=no",
+        "GOGC=10"
     ]
     log_level = "info"
     cgroup_manager = "systemd"

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -11,7 +11,7 @@ contents:
     conmon_cgroup = "pod"
     default_env = [
         "NSS_SDB_USE_CACHE=no",
-        "GOGC=10"
+        "GOGC=50"
     ]
     log_level = "info"
     cgroup_manager = "systemd"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -11,6 +11,7 @@ contents:
     conmon_cgroup = "pod"
     default_env = [
         "NSS_SDB_USE_CACHE=no",
+        "GOGC=10"
     ]
     log_level = "info"
     cgroup_manager = "systemd"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -11,7 +11,7 @@ contents:
     conmon_cgroup = "pod"
     default_env = [
         "NSS_SDB_USE_CACHE=no",
-        "GOGC=10"
+        "GOGC=50"
     ]
     log_level = "info"
     cgroup_manager = "systemd"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Updated default `default_env` for crio containers to tweak golang GC setting.
This should result into decreased memory consumption of some components (i.e. Prometheus, KAS).

This change is merely for testing, if this setting would be deemed useful it should be implemented via [setting the env var in base images](https://github.com/openshift/images/pull/76)

**- How to verify it**
Start a cluster, compare CPU/memory metrics with "standard" cluster

Test results:
* [AWS run 1](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1351126012162740224)
* [AWS run 2](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1351126027748773888)
* [AWS run 3](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1351126039748677632)
* [AWS Compact cluster](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1350367133107752960)
* [Single node](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1350367249537437696)
