### PR TITLE
Revert "Bug 1909502: pkg/operator: tolerate removal of etcd records from proxy config"

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"regexp"
 	"strings"
 	"time"
 
@@ -831,23 +830,7 @@ func (optr *Operator) getGlobalConfig() (*configv1.Infrastructure, *configv1.Net
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, nil, nil, err
 	}
-	if proxy != nil && proxy.Status != (configv1.ProxyStatus{}) {
-		proxy.Status.NoProxy = removeEtcdNoProxyConfig(proxy.Status.NoProxy)
-	}
 	return infra, network, proxy, dns, nil
-}
-
-// removeEtcdNoProxyConfig temporarily remove of etcd NoProxy records
-// this allows MCD to tolerate divergence of on disk state until records
-// are removed from installer.
-func removeEtcdNoProxyConfig(lines string) string {
-	filtered := []string{}
-	for _, entry := range strings.Split(lines, ",") {
-		if !regexp.MustCompile(`^etcd-.*$`).MatchString(entry) {
-			filtered = append(filtered, entry)
-		}
-	}
-	return strings.Join(filtered, ",")
 }
 
 func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *RenderConfigImages, apiServerURL string) *renderConfig {

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -13,46 +13,6 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
-func TestRemoveEtcdNoProxyConfig(t *testing.T) {
-	cases := []struct {
-		name            string
-		proxy           string
-		expectedNoProxy string
-	}{
-		{
-			name:            "empty NoProxy",
-			proxy:           "",
-			expectedNoProxy: "",
-		},
-		{
-			name:            "NoProxy etcd with domain",
-			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.a.com,etcd-1.a.com,etcd-2.a.com,localhost",
-			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,localhost",
-		},
-		{
-			name:            "NoProxy etcd last with domain",
-			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.a.com,etcd-1.a.com,etcd-2.a.com",
-			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com",
-		},
-		{
-			name:            "NoProxy etcd without domain",
-			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.,etcd-1.,etcd-2.,localhost",
-			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,localhost",
-		},
-		{
-			name:            "NoProxy etcd last without domain",
-			proxy:           ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com,etcd-0.,etcd-1.,etcd-2.",
-			expectedNoProxy: ".cluster.local,.svc,1001:db8::/120,127.0.0.1,2002:db8::/53,2003:db8::/112,api-int.a.com",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			noProxy := removeEtcdNoProxyConfig(tc.proxy)
-			assert.Equal(t, tc.expectedNoProxy, noProxy)
-		})
-	}
-}
-
 func TestSyncCloudConfig(t *testing.T) {
 	cases := []struct {
 		name                        string


### PR DESCRIPTION
Reverts openshift/machine-config-operator#2315

This reverts the temporary PR #2315 

depends on
- https://github.com/openshift/installer/pull/4518
- https://github.com/openshift/cluster-network-operator/pull/930

/hold
