### PR TITLE
Bug 1907636: [vsphere, openstack] Add missing proxy settings to resolv-prepender

### DIFF
--- a/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/master/00-master/openstack/files/NetworkManager-resolv-prepender.yaml
@@ -7,6 +7,19 @@ contents:
     set -eo pipefail
     IFACE=$1
     STATUS=$2
+
+    {{if .Proxy -}}
+    {{if .Proxy.HTTPProxy -}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    export NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}
+
     case "$STATUS" in
         up|down|dhcp4-change|dhcp6-change)
         logger -s "NM resolv-prepender triggered by ${1} ${2}."

--- a/templates/worker/00-worker/vsphere/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/worker/00-worker/vsphere/files/NetworkManager-resolv-prepender.yaml
@@ -11,6 +11,19 @@ contents:
     #!/bin/bash
     IFACE=$1
     STATUS=$2
+
+    {{if .Proxy -}}
+    {{if .Proxy.HTTPProxy -}}
+    export HTTP_PROXY={{.Proxy.HTTPProxy}}
+    {{end -}}
+    {{if .Proxy.HTTPSProxy -}}
+    export HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+    {{end -}}
+    {{if .Proxy.NoProxy -}}
+    export NO_PROXY={{.Proxy.NoProxy}}
+    {{end -}}
+    {{end -}}
+
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
     [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
     case "$STATUS" in


### PR DESCRIPTION
Apparently in 4.5 the vsphere and openstack platforms had separate
templates for the resolv-prepender. This caused the backports for
the proxy settings to only apply to either the master or the worker
instead of both. We should have those settings everywhere, so this
change adds the appropriate env vars.
