### PR TITLE
Refactor kernel argument handling

### DIFF
--- a/pkg/daemon/not_cos.go
+++ b/pkg/daemon/not_cos.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// NotCoreOSClient is a wrapper around RpmOstreeClient that implements NodeUpdaterClient
+// safely on unsupported and legacy Operating systems.
+type notCoreOSClient struct {
+	r *RpmOstreeClient
+}
+
+// NewNodeUpdaterClientNotCoreOS returns a NodeUpdaterClient for legacy and non-CoreOS
+// operating systems like RHEL 7.
+func NewNodeUpdaterClientNotCoreOS() NodeUpdaterClient {
+	return &notCoreOSClient{
+		r: &RpmOstreeClient{},
+	}
+}
+
+var (
+	// notCoreOSClient is a NodeUpdaterClient.
+	_ NodeUpdaterClient = &notCoreOSClient{}
+
+	// ErrNotCoreosVariant is a generic error for un-supported tasks on legacy systems.
+	ErrNotCoreosVariant = errors.New("operating system is not a CoreOS Variant")
+)
+
+// GetBootedDeployment returns the booted demployment.
+func (noCos *notCoreOSClient) GetBootedDeployment() (*RpmOstreeDeployment, error) {
+	return noCos.r.GetBootedDeployment()
+}
+
+// Rebase calls rpm-ostree status
+func (noCos *notCoreOSClient) Rebase(a, b string) (bool, error) {
+	return noCos.r.Rebase(a, b)
+}
+
+// GetStatus returns the rpm-ostree status
+func (noCos *notCoreOSClient) GetStatus() (string, error) {
+	return noCos.r.GetStatus()
+}
+
+// GetBootedOSImageURL returns the rpmOstree Booted OS Image
+func (noCos *notCoreOSClient) GetBootedOSImageURL() (string, string, error) {
+	return noCos.r.GetBootedOSImageURL()
+}
+
+// GetKernelArgs returns the real kernel arguments since we can't use rpmOstree
+func (noCos *notCoreOSClient) GetKernelArgs() ([]string, error) {
+	content, err := ioutil.ReadFile(CmdLineFile)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(content), " "), nil
+}

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -18,6 +18,7 @@ type GetBootedOSImageURLReturn struct {
 // hold return values that will be returned when their corresponding methods are called.
 type RpmOstreeClientMock struct {
 	GetBootedOSImageURLReturns []GetBootedOSImageURLReturn
+	ExpectKernelArgs           []string
 }
 
 // GetBootedOSImageURL implements a test version of RpmOStreeClients GetBootedOSImageURL.
@@ -41,4 +42,8 @@ func (r RpmOstreeClientMock) GetStatus() (string, error) {
 
 func (r RpmOstreeClientMock) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	return &RpmOstreeDeployment{}, nil
+}
+
+func (r RpmOstreeClientMock) GetKernelArgs() ([]string, error) {
+	return r.ExpectKernelArgs, nil
 }

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -273,7 +273,10 @@ func TestKernelAguments(t *testing.T) {
 			newMcfg := helpers.CreateMachineConfigFromIgnition(newIgnCfg)
 			newMcfg.Spec.KernelArguments = test.newKargs
 
-			res := generateKargsCommand(oldMcfg, newMcfg)
+			rMock := RpmOstreeClientMock{ExpectKernelArgs: test.oldKargs}
+			nc := NodeUpdaterClient(rMock)
+
+			res := generateKargsCommand(oldMcfg, newMcfg, nc)
 
 			if !reflect.DeepEqual(test.out, res) {
 				t.Errorf("Failed kernel arguments processing: expected: %v but result is: %v", test.out, res)


### PR DESCRIPTION
The command to add or remove a kernel tunable is the same command with
different flags. This change simplifies and removes duplicate logic.

This also fixes a problem with using the `/proc/cmdline` for checking if
a kernel commandline in use. Running `rpm-ostree kargs` is safer since
is shows the kargs that will be used next boot instead of the current
boot (which could be ephemeral to boot).

Finally, due to difficulties with legacy systems, this introduces a
NodeUpdaterClient of `notCoreOSClient` to start putting differences
between CoreOS and RHEL 7. The first stub out is for the Kernel
Commandline handling.

Signed-off-by: Ben Howard <ben.howard@redhat.com>
