### PR TITLE
Bug 1918440: daemon: add check before updating kernelArgs

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -992,12 +992,12 @@ func parseKernelArguments(kargs []string) []string {
 	return parsed
 }
 
-// generateKargsCommand performs a diff between the old/new MC kernelArguments,
+// generateKargs performs a diff between the old/new MC kernelArguments,
 // and generates the command line arguments suitable for `rpm-ostree kargs`.
 // Note what we really should be doing though is also looking at the *current*
 // kernel arguments in case there was drift.  But doing that requires us knowing
 // what the "base" arguments are. See https://github.com/ostreedev/ostree/issues/479
-func generateKargsCommand(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
+func generateKargs(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
 	oldKargs := parseKernelArguments(oldConfig.Spec.KernelArguments)
 	newKargs := parseKernelArguments(newConfig.Spec.KernelArguments)
 	cmdArgs := []string{}
@@ -1017,15 +1017,15 @@ func generateKargsCommand(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
 
 // updateKernelArguments adjusts the kernel args
 func (dn *Daemon) updateKernelArguments(oldConfig, newConfig *mcfgv1.MachineConfig) error {
-	diff := generateKargsCommand(oldConfig, newConfig)
-	if len(diff) == 0 {
+	kargs := generateKargs(oldConfig, newConfig)
+	if len(kargs) == 0 {
 		return nil
 	}
 	if !dn.os.IsCoreOSVariant() {
-		return fmt.Errorf("updating kargs on non-CoreOS nodes is not supported: %v", diff)
+		return fmt.Errorf("updating kargs on non-CoreOS nodes is not supported: %v", kargs)
 	}
 
-	args := append([]string{"kargs"}, diff...)
+	args := append([]string{"kargs"}, kargs...)
 	dn.logSystem("Running rpm-ostree %v", args)
 	_, err := runGetOut("rpm-ostree", args...)
 	return err

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -451,8 +451,10 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 	}()
 
 	// Apply kargs
-	if err := dn.updateKernelArguments(oldConfig, newConfig); err != nil {
-		return err
+	if mcDiff.kargs {
+		if err := dn.updateKernelArguments(oldConfig, newConfig); err != nil {
+			return err
+		}
 	}
 
 	// Switch to real time kernel

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -273,7 +273,7 @@ func TestKernelAguments(t *testing.T) {
 			newMcfg := helpers.CreateMachineConfigFromIgnition(newIgnCfg)
 			newMcfg.Spec.KernelArguments = test.newKargs
 
-			res := generateKargsCommand(oldMcfg, newMcfg)
+			res := generateKargs(oldMcfg, newMcfg)
 
 			if !reflect.DeepEqual(test.out, res) {
 				t.Errorf("Failed kernel arguments processing: expected: %v but result is: %v", test.out, res)


### PR DESCRIPTION
Today we are unnecessarily calling updateKernelArguments() even when there is no kargs to apply. This doesn't fixes bug 1916169 but discovered in https://bugzilla.redhat.com/show_bug.cgi?id=1916169#c8.
If needed, can file a new bug but for now getting it in as part of BZ#1916169

Update: Created a new bug to track it separately.