### PR TITLE
Bug 1918471: fix custom featuregates and add a unit test

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -72,6 +73,9 @@ func createNewKubeletIgnition(jsonConfig []byte) *ign3types.File {
 
 func createNewDefaultFeatureGate() *osev1.FeatureGate {
 	return &osev1.FeatureGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterFeatureInstanceName,
+		},
 		Spec: osev1.FeatureGateSpec{
 			FeatureGateSelection: osev1.FeatureGateSelection{
 				FeatureSet: osev1.Default,

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -51,13 +51,8 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		glog.V(4).Infof("Finished syncing feature handler %q (%v)", key, time.Since(startTime))
 	}()
 
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
-	}
-
 	// Fetch the Feature
-	features, err := ctrl.featLister.Get(name)
+	features, err := ctrl.featLister.Get(clusterFeatureInstanceName)
 	if errors.IsNotFound(err) {
 		glog.V(2).Infof("FeatureSet %v is missing, using default", key)
 		features = &osev1.FeatureGate{
@@ -131,8 +126,10 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		if err != nil {
 			return err
 		}
+		tempIgnConfig := ctrlcommon.NewIgnConfig()
 		cfgIgn := createNewKubeletIgnition(cfgJSON)
-		rawCfgIgn, err := json.Marshal(cfgIgn)
+		tempIgnConfig.Storage.Files = append(tempIgnConfig.Storage.Files, *cfgIgn)
+		rawCfgIgn, err := json.Marshal(tempIgnConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -6,7 +6,9 @@ import (
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 	configv1 "github.com/openshift/api/config/v1"
+	osev1 "github.com/openshift/api/config/v1"
 	"github.com/vincent-petithory/dataurl"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/test/helpers"
@@ -68,6 +70,56 @@ func TestFeaturesDefault(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2Deprecated)
 			f.expectGetMachineConfigAction(mcs2)
 
+			f.runFeature(getKeyFromFeatureGate(features, t))
+		})
+	}
+}
+
+func TestFeaturesCustomNoUpgrade(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			kubeletConfigKey1, _ := getManagedKubeletConfigKey(mcp, nil)
+			kubeletConfigKey2, _ := getManagedKubeletConfigKey(mcp2, nil)
+			mcs := helpers.NewMachineConfig(kubeletConfigKey1, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
+			mcs2 := helpers.NewMachineConfig(kubeletConfigKey2, map[string]string{"node-role/worker": ""}, "dummy://", []ign3types.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = getManagedFeaturesKeyDeprecated(mcp)
+			mcs2Deprecated := mcs2.DeepCopy()
+			mcs2Deprecated.Name = getManagedFeaturesKeyDeprecated(mcp2)
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+			f.mcpLister = append(f.mcpLister, mcp2)
+
+			features := &osev1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterFeatureInstanceName,
+				},
+				Spec: osev1.FeatureGateSpec{
+					FeatureGateSelection: osev1.FeatureGateSelection{
+						FeatureSet: osev1.CustomNoUpgrade,
+						CustomNoUpgrade: &osev1.CustomFeatureGates{
+							Enabled: []string{"CSIMigration"},
+						},
+					},
+				},
+			}
+
+			f.featLister = append(f.featLister, features)
+
+			f.expectGetMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcsDeprecated)
+			f.expectGetMachineConfigAction(mcs)
+			f.expectCreateMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2Deprecated)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectCreateMachineConfigAction(mcs2)
 			f.runFeature(getKeyFromFeatureGate(features, t))
 		})
 	}


### PR DESCRIPTION
**- What I did**
Fixed applying Custom FeatureGate to the MCO. Prior to this fix 'CustomNoUpgrade' featuregates would not be injected into ignition correctly. This fix adds a unit test as well.

```
apiVersion: config.openshift.io/v1
kind: FeatureGate
metadata:
  name: cluster
spec:
  featureSet: "CustomNoUpgrade"
  customNoUpgrade:
    enabled:
      - GracefulNodeShutdown
      - APIPriorityAndFairness
      - RotateKubeletServerCertificate
      - SupportPodPidsLimit
      - NodeDisruptionExclusion
      - ServiceNodeExclusion
      - SCTPSupport
    disabled:
      - LegacyNodeRoleBehavior
      - RemoveSelfLink
```

**- How to verify it**
Edit the cluster featuregate and paste in this spec. Also rely on the added unit test.

**- Description for the changelog**

