### PR TITLE
Bug 1918677: templates: use valid binary in AuthorizedKeysCommand

### DIFF
--- a/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
+++ b/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
@@ -3,4 +3,4 @@ path: "/etc/ssh/sshd_config.d/10-disable-ssh-key-dir.conf"
 contents:
   inline: |
     # disable key lookup from ~/.ssh/authorized_keys.d/ on FCOS
-    AuthorizedKeysCommand none
+    AuthorizedKeysCommand /bin/true


### PR DESCRIPTION
Setting `AuthorizedKeysCommand` with invalid path breaks ssh on hosts:
```
Jan 21 10:55:36 ip-10-0-137-119 sshd[130647]: error: AuthorizedKeysCommand path is not absolute
Jan 21 10:55:36 ip-10-0-137-119 sshd[130647]: Connection closed by authenticating user core 10.0.188.12 port 41306 [preauth]
```
This PR would set it to `/bin/true`

Reverts #2087 