### PR TITLE
daemon: unit-testable rpm-ostree wrapper and karg improvements

### DIFF
--- a/pkg/daemon/not_cos.go
+++ b/pkg/daemon/not_cos.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"io/ioutil"
+
+	"github.com/golang/glog"
+)
+
+// NotCoreOSClient is a wrapper around RpmOstreeClient that implements NodeUpdaterClient
+// safely on unsupported and legacy Operating systems.
+type notCoreOSClient struct{}
+
+// NewNodeUpdaterClientNotCoreOS returns a NodeUpdaterClient for traditional RHEL.
+func NewNodeUpdaterClientNotCoreOS() NodeUpdaterClient {
+	glog.Warning("Operating System is not a CoreOS Variant. Update functionality is disabled.")
+	return &notCoreOSClient{}
+}
+
+// notCoreOSClient is a NodeUpdateClient
+var _ NodeUpdaterClient = &notCoreOSClient{}
+
+// GetBootedDeployment returns the booted demployment.
+func (noCos *notCoreOSClient) GetBootedDeployment() (*RpmOstreeDeployment, error) {
+	return &RpmOstreeDeployment{}, nil
+}
+
+// Rebase calls rpm-ostree status
+func (noCos *notCoreOSClient) Rebase(a, b string) (bool, error) {
+	glog.Info("Rebase is not supported on this system.")
+	return false, nil
+}
+
+// GetStatus returns the rpm-ostree status
+func (noCos *notCoreOSClient) GetStatus() (string, error) {
+	return "", nil
+}
+
+// GetBootedOSImageURL returns the rpmOstree Booted OS Image
+func (noCos *notCoreOSClient) GetBootedOSImageURL() (string, string, error) {
+	return "", "", nil
+}
+
+// GetKernelArgs returns the real kernel arguments since we can't use rpmOstree
+func (noCos *notCoreOSClient) GetKernelArgs() ([]string, error) {
+	content, err := ioutil.ReadFile(CmdLineFile)
+	if err != nil {
+		return nil, err
+	}
+	return quoteSpaceSplit(string(content)), nil
+}
+
+// SetKernelArgs sets the kernel arguments
+func (noCos *notCoreOSClient) SetKernelArgs([]KernelArgument) (string, error) {
+	return "unsupported", nil
+}
+
+// RemovePendingDeployment is not supported on non-CoreOS machines.
+func (noCos *notCoreOSClient) RemovePendingDeployment() error {
+	return nil
+}
+
+func (noCos *notCoreOSClient) RunRpmOstree(noun string, args ...string) ([]byte, error) {
+	return nil, nil
+}

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -20,6 +20,9 @@ const (
 	numRetriesNetCommands = 5
 	// Pull secret.  Written by the machine-config-operator
 	kubeletAuthFile = "/var/lib/kubelet/config.json"
+
+	// realRpmOstreeCmd is the binary name for rpmOstree
+	realRpmOstreeCmd = "/usr/bin/rpm-ostree"
 )
 
 // rpmOstreeState houses zero or more RpmOstreeDeployments
@@ -60,27 +63,52 @@ type imageInspection struct {
 // NodeUpdaterClient is an interface describing how to interact with the host
 // around content deployment
 type NodeUpdaterClient interface {
-	GetStatus() (string, error)
-	GetBootedOSImageURL() (string, string, error)
-	Rebase(string, string) (bool, error)
 	GetBootedDeployment() (*RpmOstreeDeployment, error)
+	GetBootedOSImageURL() (string, string, error)
+	GetKernelArgs() ([]string, error)
+	GetStatus() (string, error)
+	Rebase(string, string) (bool, error)
+	RemovePendingDeployment() error
+	SetKernelArgs([]KernelArgument) (string, error)
+	RunRpmOstree(string, ...string) ([]byte, error)
 }
 
 // RpmOstreeClient provides all RpmOstree related methods in one structure.
 // This structure implements DeploymentClient
 //
 // TODO(runcom): make this private to pkg/daemon!!!
-type RpmOstreeClient struct{}
+type RpmOstreeClient struct {
+	runRpmOstreeFunc rpmOstreeCommander
+}
 
 // NewNodeUpdaterClient returns a new instance of the default DeploymentClient (RpmOstreeClient)
 func NewNodeUpdaterClient() NodeUpdaterClient {
-	return &RpmOstreeClient{}
+	os, err := GetHostRunningOS()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to query operating system: %v", err))
+	}
+	if !os.IsCoreOSVariant() {
+		glog.Infof("Host operating system %q is not a CoreOS variant", os.ID)
+		return &notCoreOSClient{}
+	}
+
+	return &RpmOstreeClient{
+		runRpmOstreeFunc: runRpmOstree,
+	}
+}
+
+// rpmOstreeCommander is a function for wrapping and mocking 'rpm-ostree'
+type rpmOstreeCommander func(string, ...string) ([]byte, error)
+
+// RunRpmOstree is an rpmOstreeCommander and executes r.rpmOstreeFunc
+func (r *RpmOstreeClient) RunRpmOstree(noun string, args ...string) ([]byte, error) {
+	return r.runRpmOstreeFunc(noun, args...)
 }
 
 // GetBootedDeployment returns the current deployment found
 func (r *RpmOstreeClient) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	var rosState rpmOstreeState
-	output, err := runGetOut("rpm-ostree", "status", "--json")
+	output, err := r.RunRpmOstree("status", "--json")
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +129,7 @@ func (r *RpmOstreeClient) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 
 // GetStatus returns multi-line human-readable text describing system status
 func (r *RpmOstreeClient) GetStatus() (string, error) {
-	output, err := runGetOut("rpm-ostree", "status")
+	output, err := r.RunRpmOstree("status")
 	if err != nil {
 		return "", err
 	}
@@ -127,6 +155,28 @@ func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, error) {
 	}
 
 	return osImageURL, bootedDeployment.Version, nil
+}
+
+// quoteSpaceSplit splits on spaces unless the space is quoted
+// For example, 'boo=bar="YIPPIE KA YAY" baz foo' will split into
+// ['boo=bar="YIPPIE KA YAY"', "baz", "foo"]
+func quoteSpaceSplit(s string) []string {
+	quoted := false
+	return strings.FieldsFunc(s, func(r rune) bool {
+		if r == '"' {
+			quoted = !quoted
+		}
+		return !quoted && r == ' '
+	})
+}
+
+// GetKernelArgs returns the kernel arguments known to rpm-ostree
+func (r *RpmOstreeClient) GetKernelArgs() ([]string, error) {
+	out, err := r.RunRpmOstree("kargs")
+	if err != nil {
+		return nil, err
+	}
+	return quoteSpaceSplit(string(out)), nil
 }
 
 func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
@@ -171,6 +221,8 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 	if err != nil {
 		return
 	}
+
+	glog.Infof("Updating OS to %s", imgURL)
 
 	previousPivot := ""
 	if len(defaultDeployment.CustomOrigin) > 0 {
@@ -245,15 +297,157 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 	args := []string{"rebase", "--experimental", fmt.Sprintf("%s:%s", repo, ostreeCsum),
 		"--custom-origin-url", customURL, "--custom-origin-description", "Managed by machine-config-operator"}
 
-	var out []byte
-	if out, err = runGetOut("rpm-ostree", args...); err != nil {
-		// capture stdout output as well in case of error
-		err = errors.Wrapf(err, "with stdout output: %v", string(out))
-		return
-	}
-
+	_, err = r.RunRpmOstree(args[0], args[1:]...)
 	changed = true
 	return
+}
+
+// constant for describing kernel argument operations
+const (
+	kargRemove int = iota
+	kargAdd
+)
+
+// KernelArgument describes an operation for karg handling
+type KernelArgument struct {
+	Operation int
+	Name      string
+}
+
+// validateRpmOstreeCommand checks the "noun" and arguments to ensure
+// that the expected number of arguments (or lack thereof) are present. This function
+// is not exhaustive of the rpm-ostree commands, just the commands that the MCD uses.
+// The validateRpmOstreeCommand is intended for us in runRpmOstree and mocking functions.
+func validateRpmOstreeCommand(noun string, args ...string) error {
+	errNotEnoughArgs := errors.New("rpm-ostree command does not have enough arguments")
+	errTooManyArgs := errors.New("rpm-ostree command called with too many arguments")
+	errArgsNotSupported := errors.New("daemon does not support specific rpm-ostree command")
+
+	hasArgs := func() bool {
+		if args != nil && len(args) > 0 {
+			return true
+		}
+		return false
+	}
+
+	checker := func(cmd string, supported []string, allowEmpty bool) error {
+		if allowEmpty && !hasArgs() {
+			return nil
+		}
+		if !allowEmpty && !hasArgs() {
+			return fmt.Errorf("'%s': %v", errNotEnoughArgs, cmd)
+		}
+
+		for _, v := range args {
+			found := false
+			for _, s := range supported {
+				if strings.HasPrefix(v, s) {
+					found = true
+					continue
+				}
+			}
+			if !found {
+				return fmt.Errorf("'%s %s': %v", errArgsNotSupported, cmd, v)
+			}
+		}
+		return nil
+	}
+
+	switch noun {
+	// Argless commands
+	case "cancel", "rollback":
+		if hasArgs() {
+			return errTooManyArgs
+		}
+		return nil
+
+	// Check that "kargs" is either a query or a supported append/delete command.
+	case "kargs":
+		return checker("rpm-ostree kargs", []string{"--append=", "--delete"}, true)
+
+	// Dumb checks for package operations.
+	case "install", "rebase", "override", "upgrade", "uninstall":
+		if hasArgs() {
+			return nil
+		}
+		return errNotEnoughArgs
+
+	// cleanup only supports -p
+	case "cleanup":
+		return checker("rpm-ostree cleanup", []string{"-p"}, false)
+
+	case "status":
+		return checker("rpm-ostree status", []string{"--json", "--peer"}, true)
+
+	// known error conditions
+	case "":
+		return errNotEnoughArgs
+	default:
+		return fmt.Errorf("unsupported command 'rpm-ostree %s'", noun)
+	}
+}
+
+// runRpmOStree wraps the rpm-ostree command. Unless mocked, this
+// is the rpmOstreeCommander that is used by RpmOstreeClient.
+func runRpmOstree(noun string, args ...string) ([]byte, error) {
+	fullArgs := []string{noun}
+	fullArgs = append(fullArgs, args...)
+
+	if err := validateRpmOstreeCommand(noun, args...); err != nil {
+		return nil, err
+	}
+
+	glog.Infof("Executing cmd: '%s %s'", realRpmOstreeCmd, fullArgs)
+	out, err := runGetOut(realRpmOstreeCmd, args...)
+	if err != nil {
+		glog.Errorf("'%s %v' failed to run: %v:\n %s", realRpmOstreeCmd, fullArgs, string(out), err)
+	}
+	return out, err
+}
+
+// SetKernelArgs sets kernel arguments on an RPM OStree systeR
+func (r *RpmOstreeClient) SetKernelArgs(args []KernelArgument) (string, error) {
+	var kargs []string
+	for _, v := range args {
+		switch v.Operation {
+		case kargAdd:
+			kargs = append(kargs, fmt.Sprintf("--append=%s", v.Name))
+		case kargRemove:
+			inUse, err := r.isKernelArgInUse(v.Name)
+			if err != nil {
+				return "", err
+			}
+			if inUse {
+				kargs = append(kargs, fmt.Sprintf("--delete=%s", v.Name))
+			}
+		}
+	}
+	if len(kargs) == 0 {
+		return "", nil
+	}
+	out, err := r.RunRpmOstree("kargs", kargs...)
+	return string(out), err
+}
+
+// isKernelArgInUse checks to see if the argument is already in use by the system currently
+func (r RpmOstreeClient) isKernelArgInUse(arg string) (bool, error) {
+	checkable, err := r.GetKernelArgs()
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range checkable {
+		if strings.HasPrefix(v, arg) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// RemovePendingDeployment removes any pending rpm-ostree deployments
+func (r *RpmOstreeClient) RemovePendingDeployment() error {
+	_, err := r.RunRpmOstree("cleanup", "-p")
+	return err
 }
 
 // runGetOut executes a command, logging it, and return the stdout output.

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -1,5 +1,10 @@
 package daemon
 
+import (
+	"fmt"
+	"testing"
+)
+
 /*
  * This file contains test code for the rpm-ostree client. It is meant to be used when
  * testing the daemon and mocking the responses that would normally be executed by the
@@ -18,6 +23,9 @@ type GetBootedOSImageURLReturn struct {
 // hold return values that will be returned when their corresponding methods are called.
 type RpmOstreeClientMock struct {
 	GetBootedOSImageURLReturns []GetBootedOSImageURLReturn
+	ExpectKernelArgs           []string
+	ExpectNewKernelArgs        []string
+	runRpmOstreeFunc           rpmOstreeCommander
 }
 
 // GetBootedOSImageURL implements a test version of RpmOStreeClients GetBootedOSImageURL.
@@ -41,4 +49,202 @@ func (r RpmOstreeClientMock) GetStatus() (string, error) {
 
 func (r RpmOstreeClientMock) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	return &RpmOstreeDeployment{}, nil
+}
+
+func (r RpmOstreeClientMock) GetKernelArgs() ([]string, error) {
+	return r.ExpectKernelArgs, nil
+}
+
+func (r RpmOstreeClientMock) SetKernelArgs(args []KernelArgument) (string, error) {
+	return "", nil
+}
+
+func (r RpmOstreeClientMock) RemovePendingDeployment() error {
+	return nil
+}
+
+func (r RpmOstreeClientMock) RunRpmOstree(a string, b ...string) ([]byte, error) {
+	return r.runRpmOstreeFunc(a, b...)
+}
+
+// TestValidateRPMOstreeCmds ensures that supported 'rpm-ostree' commands
+// are properly validated.
+func TestValidateRPMOstreeCmds(t *testing.T) {
+	tests := []struct {
+		wantErr bool
+		noun    string
+		args    []string
+	}{
+		// kargs
+		{
+			wantErr: false,
+			noun:    "kargs",
+			args:    nil,
+		},
+		{
+			wantErr: true,
+			noun:    "kargs",
+			args:    []string{"this will error"},
+		},
+		{
+			wantErr: false,
+			noun:    "kargs",
+			args:    []string{"--append=foo"},
+		},
+		{
+			wantErr: false,
+			noun:    "kargs",
+			args:    []string{"--append=foo", "--delete=bob"},
+		},
+		{
+			wantErr: true,
+			noun:    "kargs",
+			args:    []string{"--append=foo", "--delete=bob", "--replace=alice"},
+		},
+
+		// Test argless commands
+		{
+			wantErr: false,
+			noun:    "rollback",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "rollback",
+			args:    []string{"no-args allowed"},
+		},
+		{
+			wantErr: false,
+			noun:    "cancel",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "cancel",
+			args:    []string{"no-args allowed"},
+		},
+
+		{
+			wantErr: false,
+			noun:    "override",
+			args:    []string{"--any args go", "srly"},
+		},
+		{
+			wantErr: true,
+			noun:    "override",
+			args:    []string{},
+		},
+		{
+			wantErr: false,
+			noun:    "uninstall",
+			args:    []string{"--uninstall", "the", "world"},
+		},
+		{
+			wantErr: true,
+			noun:    "uninstall",
+			args:    []string{},
+		},
+		{
+			wantErr: false,
+			noun:    "install",
+			args:    []string{"all", "the", "pkgs"},
+		},
+		{
+			wantErr: true,
+			noun:    "install",
+			args:    []string{},
+		},
+
+		// cleanup
+		{
+			wantErr: true,
+			noun:    "cleanup",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "cleanup",
+			args:    []string{"-P"},
+		},
+		{
+			wantErr: false,
+			noun:    "cleanup",
+			args:    []string{"-p"},
+		},
+
+		// rebase
+		{
+			wantErr: false,
+			noun:    "rebase",
+			args:    []string{"--experimental"},
+		},
+		{
+			wantErr: true,
+			noun:    "rebase",
+			args:    []string{},
+		},
+
+		// status
+		{
+			wantErr: false,
+			noun:    "status",
+			args:    []string{"--json"},
+		},
+		{
+			wantErr: false,
+			noun:    "status",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "status",
+			args:    []string{"--JSON"},
+		},
+		{
+			wantErr: false,
+			noun:    "status",
+			args:    []string{"--peer"},
+		},
+		{
+			wantErr: false,
+			noun:    "status",
+			args:    []string{"--peer", "--json"},
+		},
+		{
+			wantErr: false,
+			noun:    "status",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "status",
+			args:    []string{"--PEER"},
+		},
+
+		// Error states
+		{
+			wantErr: true,
+			noun:    "",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "YOLO",
+			args:    []string{},
+		},
+		{
+			wantErr: true,
+			noun:    "",
+			args:    []string{"oof", "this", "is", "impossible"},
+		},
+	}
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			err := validateRpmOstreeCommand(test.noun, test.args...)
+			if (err != nil && !test.wantErr) || (err == nil && test.wantErr) {
+				t.Errorf("validating 'rpm-ostree %s %v':\nwant error: %v\n       got: %v",
+					test.noun, test.args, test.wantErr, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This is a first-step towards unit-testable rpm-ostree commands by
creating a mockable rpm-ostree wrapper. To demonstrate the idea, kernel
arguments were plumbed into the new facility.

The NodeUpdateClient is the top level interface used by the daemon for
doing node updates and configuration. However, not all `rpm-ostree`
commands were using the CoreOS implementation of `RpmOstreeClient.` To
facilate mockability, all `rpm-ostree` commands are now routed
through `RpmOstreeClient`. Mocking of `rpm-ostree` command is done
through the new struct field of `runRpmOstreeFunc`. Unit tests, can use
this faculty to mock output of `rpm-ostree`.

The first unit-test that uses this mocking feature is kernel arguments.
`rpm-ostree kargs --delete` will only delete kargs that it knows about,
and attempting to delete a run-time or missing karg results in an
error. By mocking `rpm-ostree` the logic is of adding, removing and
updating kernel arguments is provable.

Finally, this does introduce a behavior change. Previously if an admin
adjusted the kargs outside of the MCD and upgrade would fail due to the
kargs being missing. The MCD will now tolerate the missing kargs and
apply the expected state. Unit tests have been added deal with
expecting, albeit runtime missing kargs.

Signed-off-by: Ben Howard <ben.howard@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
