### PR TITLE
Bug 1915235: add imagefs.inodesFree to resourceFields

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -183,7 +183,7 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 		}
 	}
 
-	resourceFields := []string{"memory.available", "nodefs.available", "nodefs.inodesFree", "imagefs.available"}
+	resourceFields := []string{"memory.available", "nodefs.available", "nodefs.inodesFree", "imagefs.available", "imagefs.inodesFree", "pid.available"}
 
 	if kcDecoded.EvictionSoft != nil && len(kcDecoded.EvictionSoft) > 0 {
 		if kcDecoded.EvictionSoftGracePeriod == nil || len(kcDecoded.EvictionSoftGracePeriod) == 0 {


### PR DESCRIPTION
**- What I did**
This is preventing upgrades in certain cases where the imagefs.inodesFree resource field is used.

**- How to verify it**
Upgrade from 4.6.12 to 4.7.nightly with the following custom resource:

```
spec:
  kubeletConfig:
    evictionHard:
      imagefs.available: 10%
      imagefs.inodesFree: 5%
      memory.available: 200Mi
      nodefs.available: 5%
      nodefs.inodesFree: 4%
    evictionPressureTransitionPeriod: 0s
    evictionSoft:
      imagefs.available: 15%
      imagefs.inodesFree: 10%
      memory.available: 500Mi
      nodefs.available: 10%
      nodefs.inodesFree: 5%
    evictionSoftGracePeriod:
      imagefs.available: 1m30s
      imagefs.inodesFree: 1m30s
      memory.available: 1m30s
      nodefs.available: 1m30s
      nodefs.inodesFree: 1m30s
    imageGCHighThresholdPercent: 80
    imageGCLowThresholdPercent: 75
    imageMinimumGCAge: 5m
    maxPods: 240
    podsPerCore: 80
  machineConfigPoolSelector:
    matchLabels:
      custom-kubelet: small-pods
```

**- Description for the changelog**

