### PR TITLE
Bug 1920027: daemon: handle zero-length dropins/units

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1406,7 +1406,20 @@ func checkV3Units(units []ign3types.Unit) error {
 	for _, u := range units {
 		for j := range u.Dropins {
 			path := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[j].Name)
-			if err := checkFileContentsAndMode(path, []byte(*u.Dropins[j].Contents), defaultFilePermissions); err != nil {
+
+			var content string
+			if u.Dropins[j].Contents == nil {
+				content = ""
+			} else {
+				content = *u.Dropins[j].Contents
+			}
+
+			// Backwards compatibility check: the new behavior is to noop when a drop-in for zero length.
+			// However, to maintain backwards compatibility, we allow existing zero length files to exist.
+			if err := checkFileContentsAndMode(path, []byte(content), defaultFilePermissions); err != nil {
+				if content == "" && os.IsNotExist(err) {
+					continue
+				}
 				return err
 			}
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1502,12 +1502,23 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 	for _, u := range units {
 		// write the dropin to disk
 		for i := range u.Dropins {
+			dpath := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[i].Name)
 			if u.Dropins[i].Contents == nil || *u.Dropins[i].Contents == "" {
 				glog.Infof("Dropin for %s has no content, skipping write", u.Dropins[i].Name)
+				if _, err := os.Stat(dpath); err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
+					return err
+				}
+				glog.Infof("Removing %q, updated file has zero length", dpath)
+				if err := os.Remove(dpath); err != nil {
+					return err
+				}
 				continue
 			}
+
 			glog.Infof("Writing systemd unit dropin %q", u.Dropins[i].Name)
-			dpath := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[i].Name)
 			if _, err := os.Stat("/usr" + dpath); err == nil &&
 				dn.os.IsCoreOSVariant() {
 				if err := createOrigFile("/usr"+dpath, dpath); err != nil {


### PR DESCRIPTION
This fixes a problem were a previous dropin/unit is replaced with zero
length file by ensuring that drops/units have actual content.
