### PR TITLE
Bug 1920670: [Baremetal and friends] Properly handle SIGTERM - Keepalived container

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -70,6 +70,13 @@ contents:
         - -c
         - |
           #/bin/bash
+          sigterm_handler()
+          {
+            if pid=$(pgrep -o keepalived); then
+              kill -s SIGTERM "$pid"
+            fi
+          }
+
           reload_keepalived()
           {
             if pid=$(pgrep -o keepalived); then
@@ -94,6 +101,9 @@ contents:
           declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
           export -f msg_handler
           export -f reload_keepalived
+          export -f sigterm_handler
+
+          trap sigterm_handler SIGTERM
           if [ -s "/etc/keepalived/keepalived.conf" ]; then
               /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
           fi


### PR DESCRIPTION
When Keepalived container that holds VIP being SIGTERMed that should trigger a priority 0 advertisement
message to allow faster VIP migration.

This PR forwards the SIGTERM to child processes (the Keepalived processes) in Keepalived container
in order for SIGTERM to cause a VRRP priority 0 message to be sent.

