### PR TITLE
Use NetworkManager keyfile on all on-prem platforms

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
+++ b/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
@@ -9,3 +9,6 @@ contents:
     ipv6.dhcp-duid=ll
     ipv6.dhcp-iaid=mac
     {{ end -}}
+    [keyfile]
+    path=/etc/NetworkManager/system-connections-merged
+


### PR DESCRIPTION
Instead of making the entirety of the NetworkManager conf file for on-prem platforms
hinge on the existence of the API VIP, the keyfile setting should be set for on-prem
platforms at all times. This especially is present on the VSphere UPI platform.

This is related to https://github.com/openshift/machine-config-operator/pull/2362
that works around a problem where the overlayfs is mounted, but NetworkMangaer is
not pointed to the overlay.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Made the keyfile setting for NetworkManager present on all on-prem platforms.

**- How to verify it**
The 99-{platform}.conf file in /etc/NetworkManager/conf.d should always contain a [keyfile] section.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Made the keyfile setting for NetworkManager present on all on-prem platforms.
