### PR TITLE
Bug 1922454: Enable crio pprof profile over unix socket

### DIFF
--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -10,3 +10,7 @@ dropins:
     contents: |
       [Service]
       Environment="GODEBUG=x509ignoreCN=0,madvdontneed=1"
+  - name: 10-mco-profile-unix-socket.conf
+    contents: |
+      [Service]
+      Environment="ENABLE_PROFILE_UNIX_SOCKET=true"


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


**- What I did**
Added a drop-in for crio service to enable pprof profile by default.

**- How to verify it**
```
curl --unix-socket /var/run/crio/crio.sock http://localhost/debug/pprof/goroutine?debug=1
```

**- Description for the changelog**
Enable crio pprof profile over unix socket

cc: @rphillips 