### PR TITLE
[baremetal & friends] Move on-prem api-int record to dnsmasq

### DIFF
--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -2,7 +2,7 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/coredns/Corefile.tmpl"
 contents:
   inline: |
-    . {
+    .:5333 {
         errors
         health :18080
         mdns {{ .DNS.Spec.BaseDomain }} 0 {{`{{.Cluster.Name}}`}} {{`{{.NonVirtualIP}}`}}

--- a/templates/common/on-prem/files/dnsmasq-api-int.yaml
+++ b/templates/common/on-prem/files/dnsmasq-api-int.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/api-int.host"
+contents:
+  inline: |
+    {{ onPremPlatformAPIServerInternalIP . }} api-int api-int.{{ .DNS.Spec.BaseDomain }}

--- a/templates/common/on-prem/files/dnsmasq-forward.yaml
+++ b/templates/common/on-prem/files/dnsmasq-forward.yaml
@@ -1,0 +1,6 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/dnsmasq/cluster-forward.conf.tmpl"
+contents:
+  inline: |
+    server=/{{ .DNS.Spec.BaseDomain }}/{{`{{.NonVirtualIP}}`}}#5333
+    addn-hosts=/etc/api-int.host

--- a/templates/common/on-prem/units/on-prem-dnsmasq.yaml
+++ b/templates/common/on-prem/units/on-prem-dnsmasq.yaml
@@ -1,0 +1,28 @@
+name: on-prem-dnsmasq.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Run dnsmasq to provide local
+  Before=kubelet.service crio.service
+  [Service]
+  ExecStartPre=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
+    --authfile /var/lib/kubelet/config.json \
+    --net=host \
+    --volume /etc/kubernetes:/etc/kubernetes:z \
+    --volume /etc/dnsmasq.d:/etc/dnsmasq.d:z \
+    {{ .Images.baremetalRuntimeCfgImage }} \
+    render \
+    /etc/kubernetes/kubeconfig \
+    --api-vip {{ onPremPlatformAPIServerInternalIP . }} \
+    --ingress-vip {{ onPremPlatformIngressIP . }} \
+    /etc/kubernetes/static-pod-resources/dnsmasq \
+    --out-dir /etc/dnsmasq.d; \
+    do \
+      sleep 5; \
+    done; \
+    restorecon -rF /etc/dnsmasq.d"
+  ExecStart=/usr/sbin/dnsmasq -k
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
This is in preparation for moving the cluster-hosted network services
to a separate operator. With coredns no longer running as a static
pod, it will not be usable for providing the api-int record needed
for the node to register.

We decided to use dnsmasq instead of /etc/hosts because when a
deployer wants to use an external loadbalancer it will be necessary
to change the api-int record. If it's in /etc/hosts, that will require
restarting many/all of the pods to pick up the change. Using dnsmasq
allows us to just change the record in dnsmasq and SIGHUP it.

To allow dnsmasq and coredns to coexist on the node, coredns is moved
to port 5333 and dnsmasq has a server entry added to send queries
for the cluster domain to coredns.

**- Description for the changelog**
Move api-int record for on-prem platforms to dnsmasq service.