### PR TITLE
Add new extension for qemu-kiwi

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -201,7 +201,7 @@ spec:
 **Note:** The RT kernel lowers throughput (performance) in return for improved worst-case latency bounds. This feature is intended only for use cases that require consistent low latency. For more information, see the [Linux Foundation wiki](https://wiki.linuxfoundation.org/realtime/start) and the [RHEL RT portal](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/).
 
 ### RHCOS Extensions
-RHCOS is a minimal OCP focused OS which provides capabilities common across all the platforms. With extensions support, OCP 4.6 and onward users can enable a limited set of additional functionality on the RHCOS nodes. In OCP 4.6 the supported extensions is `usbguard`.
+RHCOS is a minimal OCP focused OS which provides capabilities common across all the platforms. With extensions support, OCP 4.6 and onward users can enable a limited set of additional functionality on the RHCOS nodes. In OCP 4.6 the supported extensions is `usbguard`. In OCP 4.8 the supported extensions are `usbguard` and `qemu-kiwi`.
 
 Extensions can be installed by creating a MachineConfig object. Extensions can be enabled as both day1 and day2. Check [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Enabling-RHCOS-Extensions) to enable extensions during cluster install.
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1101,6 +1101,7 @@ func getSupportedExtensions() map[string][]string {
 	return map[string][]string{
 		"usbguard":     {"usbguard"},
 		"kernel-devel": {"kernel-devel", "kernel-headers"},
+		"qemu-kiwi": {"ipxe-roms-qemu", "libpmem", "pixman", "qemu-kiwi", "qemu-kvm-common", "seabios-bin", "seavgabios-bin", "sgabios-bin"},
 	}
 }
 

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -259,7 +259,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"usbguard", "kernel-devel"},
+			Extensions: []string{"usbguard", "kernel-devel", "qemu-kiwi"},
 		},
 	}
 
@@ -286,8 +286,8 @@ func TestExtensions(t *testing.T) {
 		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "usbguard", "kernel-devel")
 		expectedPackages = []string{"usbguard", "kernel-devel"}
 	} else {
-		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "usbguard", "kernel-devel", "kernel-headers")
-		expectedPackages = []string{"usbguard", "kernel-devel", "kernel-headers"}
+		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "usbguard", "kernel-devel", "kernel-headers", "ipxe-roms-qemu", "libpmem", "pixman", "qemu-kiwi", "qemu-kvm-common", "seabios-bin", "seavgabios-bin", "sgabios-bin")
+		expectedPackages = []string{"usbguard", "kernel-devel", "kernel-headers", "ipxe-roms-qemu", "libpmem", "pixman", "qemu-kiwi", "qemu-kvm-common", "seabios-bin", "seavgabios-bin", "sgabios-bin"}
 	}
 	for _, v := range expectedPackages {
 		if !strings.Contains(installedPackages, v) {
@@ -317,9 +317,9 @@ func TestExtensions(t *testing.T) {
 
 	if isOKD {
 		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
-		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel")
+		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "ipxe-roms-qemu", "libpmem", "pixman", "qemu-kiwi", "qemu-kvm-common", "seabios-bin", "seavgabios-bin", "sgabios-bin")
 	} else {
-		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers")
+		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers", "ipxe-roms-qemu", "libpmem", "pixman", "qemu-kiwi", "qemu-kvm-common", "seabios-bin", "seavgabios-bin", "sgabios-bin")
 	}
 	for _, v := range expectedPackages {
 		if strings.Contains(installedPackages, v) {


### PR DESCRIPTION
**- What I did**
This adds support for a new RHCOS extension called
"qemu-kiwi". It will install qemu-kiwi and its
dependencies, 8 RPMs with a total size of 20MB when installed.

It will allow users to run lightweight virtual machines using QEMU.

**- How to verify it**
We tested it by building MCO and building a machine-os-content image with the new RPMs included.

```oc image extract -a ~/.openshift/pull-secret  --path /:/extracted-oscontent quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ecfac365596289b8474e6a0f0bffea996e04b0bdd1379e8fb4776b8e3ef2af1b```

Then we build the image with this Dockerfile:

```
FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ecfac365596289b8474e6a0f0bffea996e04b0bdd1379e8fb4776b8e3ef2af1b
RUN dnf install -y createrepo
RUN dnf install -y --downloadonly --downloaddir=/extensions/qemu-img qemu-img
RUN createrepo /extensions
ENTRYPOINT ["bin/bash"]
```

Create a new release image:

```
oc adm release new -n origin  --from-release=quay.io/openshift-release-dev/ocp-release-nightly@sha256:d1a968a86cf04a0e621c8ed265d932f365c5a3bc7977a8c0b1c6679d79f3b864  --to-image=docker.io/bpradipt/ocp-release:v4.7.1 machine-config-operator=quay.io/bpradipt/machine-config-operator:latest machine-os-content=quay.io/bpradipt/extension-test@sha256:83aae59f986b376813916807e3d19716e9df8f06b56661fce327c9e27c3e5896
```

Do an update:

```
oc adm upgrade --force --to-image  docker.io/bpradipt/ocp-release:v4.7.1 --allow-explicit-upgrade
```
Verify osImage URL points to overridden machine-os-content:
```
oc -n openshift-machine-config-operator edit configmap/machine-config-osimageurl


apiVersion: v1
data:
  osImageURL: quay.io/bpradipt/extension-test@sha256:83aae59f986b376813916807e3d19716e9df8f06b56661fce327c9e27c3e5896
  releaseVersion: 4.7.0-0.nightly-2021-01-19-083458
kind: ConfigMap
metadata:
  annotations:
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
  creationTimestamp: "2021-01-19T10:12:44Z"
  name: machine-config-osimageurl
  namespace: openshift-machine-config-operator
  resourceVersion: "44890"
  selfLink: /api/v1/namespaces/openshift-machine-config-operator/configmaps/machine-config-osimageurl
  uid: ff1ed7b1-bf9c-414d-8384-42d66633d0e7
```
Create a machine config and apply it.
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 80-worker-extensions
spec:
  config:
    ignition:
      version: 3.1.0
  extensions:
    - qemu-img
```
Wait until machine config pool is updated. Then log into one of the nodes and, chroot to host filesystem and check if the qemu-kiwi RPM is installed with ```rpm -qa|grep qemu-kiwi```

**- Description for the changelog**
Added support for a new RHCOS extension to install qemu-kiwi.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>