### PR TITLE
Bug 1919271: NM resolve prepender: Update for systemd-resolved logic. systemd-resolved requires restart after dropin created

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -59,7 +59,7 @@ contents:
                     echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
                     echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
                     echo "Domains=$DOMAIN" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                    if [[ "$(systemctl is-active systemd-resolved)" == "active" ]]; then                
+                    if [[ "$(systemctl is-active systemd-resolved)" == "active" ]]; then
                         >&2 echo "NM resolv-prepender: restarting systemd-resolved"
                         systemctl restart systemd-resolved
                     fi

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -52,11 +52,18 @@ contents:
             "{{ onPremPlatformIngressIP . }}")
         DOMAIN="{{.DNS.Spec.BaseDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
-            source /etc/os-release
-            if [[ "$NAME" == "Fedora" ]]; then
-                echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
-                echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                echo "Domains=$DOMAIN" >> /etc/systemd/resolved.conf.d/60-kni.conf
+            if [[ "$(systemctl is-enabled systemd-resolved)" == "enabled" ]]; then
+                >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"
+                if [[ ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
+                    >&2 echo "NM resolv-prepender: Creating /etc/systemd/resolved.conf.d/60-kni.conf"
+                    echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
+                    echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
+                    echo "Domains=$DOMAIN" >> /etc/systemd/resolved.conf.d/60-kni.conf
+                    if [[ "$(systemctl is-active systemd-resolved)" == "active" ]]; then                
+                        >&2 echo "NM resolv-prepender: restarting systemd-resolved"
+                        systemctl restart systemd-resolved
+                    fi
+                fi
             else
                 >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
                 sed -e "/^search/d" \

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -52,7 +52,7 @@ contents:
             "{{ onPremPlatformIngressIP . }}")
         DOMAIN="{{.DNS.Spec.BaseDomain}}"
         if [[ -n "$NAMESERVER_IP" ]]; then
-            if [[ "$(systemctl is-enabled systemd-resolved)" == "enabled" ]]; then
+            if systemctl -q is-enabled systemd-resolved; then
                 >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"
                 if [[ ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
                     >&2 echo "NM resolv-prepender: Creating /etc/systemd/resolved.conf.d/60-kni.conf"

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -59,7 +59,7 @@ contents:
                     echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
                     echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
                     echo "Domains=$DOMAIN" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                    if [[ "$(systemctl is-active systemd-resolved)" == "active" ]]; then
+                    if systemctl -q is-active systemd-resolved; then
                         >&2 echo "NM resolv-prepender: restarting systemd-resolved"
                         systemctl restart systemd-resolved
                     fi


### PR DESCRIPTION
**- What I did**
- remove OS check.  If node has systemd-resolved enabled this will work
- Check to see if systemd-resolved is enabled.  Otherwise skip
- Check if /etc/systemd/resolved.conf.d/60-kni.conf exists.  If it doesn't create it and restart systemd-resolved if active
- Add logging

**- How to verify it**

**- Description for the changelog**
NM resolve prepender:  Update for systemd-resolved logic
