### PR TITLE
Bug 1920027: templates: split crio dropins into separate files

### DIFF
--- a/templates/common/_base/units/crio.service-proxy.yaml
+++ b/templates/common/_base/units/crio.service-proxy.yaml
@@ -1,0 +1,8 @@
+name: crio.service
+dropins:
+  - name: 10-mco-default-env.conf
+    contents: |
+      {{if .Proxy -}}
+      [Service]
+      EnvironmentFile=/etc/mco/proxy.env
+      {{end -}}

--- a/templates/common/_base/units/crio.service-socket.yaml
+++ b/templates/common/_base/units/crio.service-socket.yaml
@@ -1,0 +1,6 @@
+name: crio.service
+dropins:
+  - name: 10-mco-profile-unix-socket.conf
+    contents: |
+      [Service]
+      Environment="ENABLE_PROFILE_UNIX_SOCKET=true"

--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -1,16 +1,6 @@
 name: crio.service
 dropins:
-  - name: 10-mco-default-env.conf
-    contents: |
-      {{if .Proxy -}}
-      [Service]
-      EnvironmentFile=/etc/mco/proxy.env
-      {{end -}}
   - name: 10-mco-default-madv.conf
     contents: |
       [Service]
       Environment="GODEBUG=x509ignoreCN=0,madvdontneed=1"
-  - name: 10-mco-profile-unix-socket.conf
-    contents: |
-      [Service]
-      Environment="ENABLE_PROFILE_UNIX_SOCKET=true"


### PR DESCRIPTION
Somewhere in the template rendering stack the dropin merge logic
is broken, causing only the last dropin defined in a file to get
rendered. Split the dropin templates into separate files for now
to fix CI failures, and revisit later the template rendering logic
to see where this breaks.

Fixes https://github.com/openshift/machine-config-operator/commit/0c7541ec30748c774d1c9e0f27afde2ae6c1e0fb#diff-934bed5b78da27a91177feabe213288a794cc4d1851be77d92c3ff5426f1d88c and https://github.com/openshift/machine-config-operator/commit/fe7fea755afa7f6f1f4706cb4b924a68a0a6a59d#diff-934bed5b78da27a91177feabe213288a794cc4d1851be77d92c3ff5426f1d88c