### PR TITLE
Bug 1920807: [vsphere] set hostname with --static to provide consistent node name for CSR approval

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -5,6 +5,9 @@ contents:
     #!/usr/bin/env bash
     set -e
 
+    # only run if the hostname is not set
+    test -f /etc/hostname && exit 0 || :
+
     if vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
-        /usr/bin/hostnamectl --transient set-hostname ${vm_name}
+        /usr/bin/hostnamectl set-hostname --static ${vm_name}
     fi

--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -3,7 +3,14 @@ enabled: true
 contents: |
   [Unit]
   Description=vSphere hostname
+  Requires=vmtoolsd.service
   After=vmtoolsd.service
+
+  # Only run on first boot and only if the host does not have a name yet
+  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
+  ConditionPathExists=!/etc/hostname
+  ConditionVirtualization=vmware
+  
   Before=kubelet.service
   Before=node-valid-hostname.service
   Before=NetworkManager.service


### PR DESCRIPTION
Fixes: BZ1920807 - when creating a new machine, the node will get an unexpected hostname

**- What I did**
Added the --static flag to `hostnamectl` to prevent DHCP from overriding the hostname sourced from guestinfo.  This is only done once on vsphere nodes on the first boot.

**- How to verify it**
- Configure DHCP to assign a hostname as part of the lease
- Scale a new node
- The node should automatically join the cluster with a node name like ` <cluster>-<clusterid>-worker-<name>`

**- Description for the changelog**
Resolves issue where the hostname provided by the DHCP overrides the guestinfo hostname thus preventing the machine-api-controller from reconciling new nodes which receive a hostname from DHCP.