### PR TITLE
daemon: block reboots during upgrades

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -451,6 +451,16 @@ func (dn *Daemon) syncNode(key string) error {
 	// and then proceeds to check the state of the node, which includes
 	// finalizing an update and/or reconciling the current and desired machine configs.
 	if dn.booting {
+		// Prevent any reboots
+		if err := maskRebootTarget(); err != nil {
+			return err
+		}
+		defer func() {
+			if err := unmaskRebootTarget(); err != nil {
+				glog.Error(err)
+			}
+		}()
+
 		// Be sure only the MCD is running now, disable -firstboot.service
 		if err := upgradeHackFor44AndBelow(); err != nil {
 			return err

--- a/pkg/daemon/systemd.go
+++ b/pkg/daemon/systemd.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+)
+
+// genericCmdFunc describes a function for wrapping commands
+type genericCmdFunc func(args ...string) ([]byte, error)
+
+// systemctlFunc is a either a wrapper around the systemd binary or a mock
+// execSystemctlFunc should be used for the execution of systemctl commands
+var systemctlFunc genericCmdFunc
+
+// execSystemctlFunc executes systemctl or the mocking function.
+func execSystemctlFunc(args ...string) ([]byte, error) {
+	if systemctlFunc != nil {
+		glog.V(2).Info("Using a mocked function for systemctl")
+		return systemctlFunc(args...)
+	}
+	systemdBin := filepath.Join("usr", "bin", "systemctl")
+	return runGetOut(systemdBin, args...)
+}
+
+// reloadSystem restarts systemd
+func reloadSystemd() error {
+	out, err := execSystemctlFunc("daemon-reload")
+	if err != nil {
+		return fmt.Errorf("failed reload of systemd daemon: %s\n%v", string(out), err)
+	}
+	return nil
+}
+
+const (
+	// defaultRebootTargetLink is the backing file for the rebootTarget for systemd
+	defaultRebootTargetLink = "/dev/null"
+	// defaultRebootTarget is the systemd reboot.target filepath used when masking a reboot.
+	defaultRebootTarget = "/run/systemd/system/reboot.target"
+)
+
+var (
+	// rebootTargetLink is the backing file for the rebootTarget for systemd
+	rebootTargetLink = defaultRebootTargetLink
+	// rebootTarget is the systemd reboot.target filepath used when masking a reboot.
+	rebootTarget = defaultRebootTarget
+)
+
+// maskRebootTarget masks the systemd reboot.target to block reboots.
+func maskRebootTarget() error {
+	glog.Info("Setting a reboot.target systemd mask to prevent reboot during update operation")
+	if _, err := os.Lstat(rebootTarget); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to check for existing reboot.target link: %w", err)
+	}
+	if err := os.Symlink(rebootTargetLink, rebootTarget); err != nil {
+		return fmt.Errorf("failed to create %s masking symlink to %s: %v", rebootTargetLink, rebootTarget, err)
+	}
+	return reloadSystemd()
+}
+
+// unmaskRebootTarget removes the reboot mask.
+func unmaskRebootTarget() error {
+	glog.Info("Removing reboot mask")
+	if err := os.Remove(rebootTarget); err != nil && os.IsNotExist(err) {
+		return nil
+	}
+	return reloadSystemd()
+}

--- a/pkg/daemon/systemd_test.go
+++ b/pkg/daemon/systemd_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func unsetSystemctlFunc() {
+	systemctlFunc = nil
+	rebootTarget = defaultRebootTarget
+}
+
+func fakeSystemdFunc(...string) ([]byte, error) {
+	return nil, nil
+}
+
+// TestSystemdExecFunc is a quick check that the systemdFunc is
+// a real function command.
+func TestSystemdExecFunc(t *testing.T) {
+	defer unsetSystemctlFunc()
+	systemctlFunc = fakeSystemdFunc
+	assert.NotNil(t, systemctlFunc)
+}
+
+// TestSystemdReboot checks to make sure that the mask is set and
+// released.
+func TestSystemdReboot(t *testing.T) {
+	defer unsetSystemctlFunc()
+	systemctlFunc = fakeSystemdFunc
+
+	fakeRunDir, err := ioutil.TempDir("", "systemd")
+	if err != nil {
+		t.Fatalf("Failed to create a tempdir")
+	}
+	defer func() {
+		_ = os.RemoveAll(fakeRunDir)
+	}()
+
+	rebootTarget = filepath.Join(fakeRunDir, rebootTarget)
+	if err = os.MkdirAll(filepath.Dir(rebootTarget), 0755); err != nil {
+		t.Fatalf("Failed to create mock systemd runtime directory: %v", err)
+	}
+
+	if err = maskRebootTarget(); err != nil {
+		t.Fatalf("Failed to mask systemd reboot.target: %v", err)
+	}
+	r, err := os.Readlink(rebootTarget)
+	if err != nil {
+		t.Fatalf("Failed to resolve symlink for %s: %v", rebootTarget, err)
+	}
+	if r != rebootTargetLink {
+		t.Errorf("Link target is incorrect:\n  want: %s\n   got: %s\n", rebootTargetLink, r)
+	}
+	if err = unmaskRebootTarget(); err != nil {
+		t.Errorf("Failed to unmask: %v", err)
+	}
+	if _, err = os.Lstat(rebootTarget); err == nil {
+		t.Errorf("Link should have been removed")
+	}
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -584,9 +584,20 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 			}
 		}
 	}
+	// Prevent any reboots
+	if err := maskRebootTarget(); err != nil {
+		return err
+	}
 
 	dn.catchIgnoreSIGTERM()
 	defer func() {
+		umErr := unmaskRebootTarget()
+		if retErr != nil {
+			retErr = fmt.Errorf("failed to unmask reboot.target: %v\n%w", umErr, retErr)
+		} else {
+			retErr = umErr
+		}
+
 		if retErr != nil {
 			dn.cancelSIGTERM()
 		}


### PR DESCRIPTION
This prevents any operator or user from issuing an unsafe `systemctl reboot` or "reboot" by masking the `reboot target` if the MCD is working on a node.  

Any reboot will emit a warning:

```
$ sudo systemctl reboot
Failed to reboot system via logind: Access denied
Failed to start reboot.target: Unit reboot.target is masked.
```

Signed-off-by: Ben Howard <ben.howard@redhat.com>
