### PR TITLE
Bug 1923874: KubeletConfig: Revert "Fix KubeletConfig validation for invalid values"

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -203,6 +203,18 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 		return fmt.Errorf("KubeletConfiguration: staticPodPath is not allowed to be set, but contains: %s", kcDecoded.StaticPodPath)
 	}
 
+	if kcDecoded.EvictionSoft != nil && len(kcDecoded.EvictionSoft) > 0 {
+		if kcDecoded.EvictionSoftGracePeriod == nil || len(kcDecoded.EvictionSoftGracePeriod) == 0 {
+			return fmt.Errorf("KubeletConfiguration: EvictionSoftGracePeriod must be set when evictionSoft is defined, evictionSoft: %v", kcDecoded.EvictionSoft)
+		}
+
+		for k := range kcDecoded.EvictionSoft {
+			if _, ok := kcDecoded.EvictionSoftGracePeriod[k]; !ok {
+				return fmt.Errorf("KubeletConfiguration: evictionSoft[%s] is defined but EvictionSoftGracePeriod[%s] is not set", k, k)
+			}
+		}
+	}
+
 	reservedResources := []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, v1.ResourceEphemeralStorage}
 
 	if kcDecoded.KubeReserved != nil && len(kcDecoded.KubeReserved) > 0 {
@@ -212,8 +224,8 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 				if err != nil {
 					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in kubeReserved, %s", rr.String(), val)
 				}
-				if q.Sign() < 0 || q.IsZero() {
-					return fmt.Errorf("KubeletConfiguration: %s reservation value must be positive in kubeReserved", rr.String())
+				if q.Sign() == -1 {
+					return fmt.Errorf("KubeletConfiguration: %s reservation value cannot be negative in kubeReserved", rr.String())
 				}
 			}
 		}
@@ -226,72 +238,22 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 				if err != nil {
 					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in systemReserved, %s", rr.String(), val)
 				}
-				if q.Sign() < 0 || q.IsZero() {
-					return fmt.Errorf("KubeletConfiguration: %s reservation value must be positive in systemReserved", rr.String())
-				}
-			}
-		}
-	}
-
-	resourceFields := []string{"memory.available", "nodefs.available", "nodefs.inodesFree", "imagefs.available", "imagefs.inodesFree", "pid.available"}
-
-	if kcDecoded.EvictionSoft != nil && len(kcDecoded.EvictionSoft) > 0 {
-		if kcDecoded.EvictionSoftGracePeriod == nil || len(kcDecoded.EvictionSoftGracePeriod) == 0 {
-			return fmt.Errorf("KubeletConfiguration: EvictionSoftGracePeriod must be set when evictionSoft is defined, evictionSoft: %v", kcDecoded.EvictionSoft)
-		}
-
-		for k := range kcDecoded.EvictionSoft {
-			found := false
-			for _, r := range resourceFields {
-				if k == r {
-					found = true
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("KubeletConfiguration: unknown resource %s defined in evictionSoft", k)
-			}
-
-			if _, ok := kcDecoded.EvictionSoftGracePeriod[k]; !ok {
-				return fmt.Errorf("KubeletConfiguration: evictionSoft[%s] is defined but EvictionSoftGracePeriod[%s] is not set", k, k)
-			}
-		}
-
-		for _, r := range resourceFields {
-			if val, ok := kcDecoded.EvictionSoft[r]; ok {
-				q, err := resource.ParseQuantity(val)
-				if err != nil {
-					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in evictionSoft, %s", r, val)
-				}
-				if q.Sign() < 0 || q.IsZero() {
-					return fmt.Errorf("KubeletConfiguration: %s eviction value must be positive in evictionSoft", r)
+				if q.Sign() == -1 {
+					return fmt.Errorf("KubeletConfiguration: %s reservation value cannot be negative in systemReserved", rr.String())
 				}
 			}
 		}
 	}
 
 	if kcDecoded.EvictionHard != nil && len(kcDecoded.EvictionHard) > 0 {
-		for k := range kcDecoded.EvictionHard {
-			found := false
-			for _, r := range resourceFields {
-				if k == r {
-					found = true
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("KubeletConfiguration: unknown resource %s defined in evictionHard", k)
-			}
-		}
-
-		for _, r := range resourceFields {
-			if val, ok := kcDecoded.EvictionHard[r]; ok {
+		for _, rr := range reservedResources {
+			if val, ok := kcDecoded.EvictionHard[rr.String()]; ok {
 				q, err := resource.ParseQuantity(val)
 				if err != nil {
-					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in evictionHard, %s", r, val)
+					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in evictionHard, %s", rr.String(), val)
 				}
-				if q.Sign() < 0 || q.IsZero() {
-					return fmt.Errorf("KubeletConfiguration: %s eviction value must be positive in evictionHard", r)
+				if q.Sign() == -1 {
+					return fmt.Errorf("KubeletConfiguration: %s eviction value cannot be negative in evictionHard", rr.String())
 				}
 			}
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -537,90 +537,6 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "evictionSoft memory available cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionSoft: map[string]string{
-					"memory.available": "-1M",
-				},
-				EvictionSoftGracePeriod: map[string]string{
-					"memory.available": "1h",
-				},
-			},
-		},
-		{
-			name: "evictionSoft memory available must be positive",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionSoft: map[string]string{
-					"memory.available": "0M",
-				},
-				EvictionSoftGracePeriod: map[string]string{
-					"memory.available": "1h",
-				},
-			},
-		},
-		{
-			name: "evictionSoft field cannot be invalid",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionSoft: map[string]string{
-					"memory111.available": "500M",
-				},
-				EvictionSoftGracePeriod: map[string]string{
-					"memory.available": "1h",
-				},
-			},
-		},
-		{
-			name: "evictionSoft field value cannot be invalid",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionSoft: map[string]string{
-					"memory.available": "&#jk789",
-				},
-				EvictionSoftGracePeriod: map[string]string{
-					"memory.available": "1h",
-				},
-			},
-		},
-		{
-			name: "evictionHard memory available cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionHard: map[string]string{
-					"memory.available": "-1M",
-				},
-			},
-		},
-		{
-			name: "evictionHard memory available must be positive",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionHard: map[string]string{
-					"memory.available": "0M",
-				},
-			},
-		},
-		{
-			name: "evictionHard field cannot be invalid",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionHard: map[string]string{
-					"memory111.available": "500M",
-				},
-			},
-		},
-		{
-			name: "evictionHard field value cannot be invalid",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionHard: map[string]string{
-					"memory.available": "&#jk789",
-				},
-			},
-		},
-		{
-			name: "kubeReserved cpu value must be positive",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceCPU.String(): "0",
-				},
-			},
-		},
-		{
 			name: "kubeReserved cpu value cannot be negative",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				KubeReserved: map[string]string{
@@ -637,14 +553,6 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "systemReserved cpu value must be positive",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceCPU.String(): "0",
-				},
-			},
-		},
-		{
 			name: "kubeReserved memory value cannot be negative",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				KubeReserved: map[string]string{
@@ -653,26 +561,10 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "kubeReserved memory value must be positive",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceMemory.String(): "0M",
-				},
-			},
-		},
-		{
 			name: "systemReserved memory value cannot be negative",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				SystemReserved: map[string]string{
 					v1.ResourceMemory.String(): "-20M",
-				},
-			},
-		},
-		{
-			name: "systemReserved memory value must be positive",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceMemory.String(): "0M",
 				},
 			},
 		},


### PR DESCRIPTION
This reverts commit 1eb4bd3fca7ad32bf74f436f494c431000e13716.

Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1923874

**- What I did**
Reverting https://github.com/openshift/machine-config-operator/pull/2314

**- How to verify it**
Percentage values should be allowed in kubeletconfig

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
None