### PR TITLE
Revert disabling authorized_keys.d  Pull 2087  

### DIFF
--- a/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
+++ b/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
@@ -3,4 +3,4 @@ path: "/etc/ssh/sshd_config.d/10-disable-ssh-key-dir.conf"
 contents:
   inline: |
     # disable key lookup from ~/.ssh/authorized_keys.d/ on FCOS
-    AuthorizedKeysCommand none
+    ###AuthorizedKeysCommand none


### PR DESCRIPTION
revert  https://github.com/openshift/machine-config-operator/pull/2087
            until https://github.com/openshift/machine-config-operator/issues/2385 is fixed

The authorized_keys file is not being created on cluster install and with authorized_keys.d disabled ssh into the
 cluster nodes is not possible without manual intervention.  Once that issue is fixed authorized_keys.d can be disabled.
    
 The entry has to be commented out so that the original value does not get overwritten.
