### PR TITLE
Bug 1923874: KubeletConfig: Drop validation for kubeletconfig

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -11,8 +11,6 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -201,62 +199,6 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 	}
 	if kcDecoded.StaticPodPath != "" {
 		return fmt.Errorf("KubeletConfiguration: staticPodPath is not allowed to be set, but contains: %s", kcDecoded.StaticPodPath)
-	}
-
-	if kcDecoded.EvictionSoft != nil && len(kcDecoded.EvictionSoft) > 0 {
-		if kcDecoded.EvictionSoftGracePeriod == nil || len(kcDecoded.EvictionSoftGracePeriod) == 0 {
-			return fmt.Errorf("KubeletConfiguration: EvictionSoftGracePeriod must be set when evictionSoft is defined, evictionSoft: %v", kcDecoded.EvictionSoft)
-		}
-
-		for k := range kcDecoded.EvictionSoft {
-			if _, ok := kcDecoded.EvictionSoftGracePeriod[k]; !ok {
-				return fmt.Errorf("KubeletConfiguration: evictionSoft[%s] is defined but EvictionSoftGracePeriod[%s] is not set", k, k)
-			}
-		}
-	}
-
-	reservedResources := []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, v1.ResourceEphemeralStorage}
-
-	if kcDecoded.KubeReserved != nil && len(kcDecoded.KubeReserved) > 0 {
-		for _, rr := range reservedResources {
-			if val, ok := kcDecoded.KubeReserved[rr.String()]; ok {
-				q, err := resource.ParseQuantity(val)
-				if err != nil {
-					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in kubeReserved, %s", rr.String(), val)
-				}
-				if q.Sign() == -1 {
-					return fmt.Errorf("KubeletConfiguration: %s reservation value cannot be negative in kubeReserved", rr.String())
-				}
-			}
-		}
-	}
-
-	if kcDecoded.SystemReserved != nil && len(kcDecoded.SystemReserved) > 0 {
-		for _, rr := range reservedResources {
-			if val, ok := kcDecoded.SystemReserved[rr.String()]; ok {
-				q, err := resource.ParseQuantity(val)
-				if err != nil {
-					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in systemReserved, %s", rr.String(), val)
-				}
-				if q.Sign() == -1 {
-					return fmt.Errorf("KubeletConfiguration: %s reservation value cannot be negative in systemReserved", rr.String())
-				}
-			}
-		}
-	}
-
-	if kcDecoded.EvictionHard != nil && len(kcDecoded.EvictionHard) > 0 {
-		for _, rr := range reservedResources {
-			if val, ok := kcDecoded.EvictionHard[rr.String()]; ok {
-				q, err := resource.ParseQuantity(val)
-				if err != nil {
-					return fmt.Errorf("KubeletConfiguration: invalid value specified for %s reservation in evictionHard, %s", rr.String(), val)
-				}
-				if q.Sign() == -1 {
-					return fmt.Errorf("KubeletConfiguration: %s eviction value cannot be negative in evictionHard", rr.String())
-				}
-			}
-		}
 	}
 
 	return nil

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -11,7 +11,6 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	oseconfigfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	oseinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -514,121 +513,6 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				FeatureGates: map[string]bool{
 					"SomeFeatureGate": true,
-				},
-			},
-		},
-		{
-			name: "evictionSoft cannot be supplied without evictionSoftGracePeriod",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionSoft: map[string]string{
-					"memory.available": "90%",
-				},
-			},
-		},
-		{
-			name: "evictionSoft cannot be supplied without corresponding evictionSoftGracePeriod",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				EvictionSoft: map[string]string{
-					"memory.available": "90%",
-				},
-				EvictionSoftGracePeriod: map[string]string{
-					"nodefs.inodesFree": "1h",
-				},
-			},
-		},
-		{
-			name: "kubeReserved cpu value cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceCPU.String(): "-20",
-				},
-			},
-		},
-		{
-			name: "systemReserved cpu value cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceCPU.String(): "-20",
-				},
-			},
-		},
-		{
-			name: "kubeReserved memory value cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceMemory.String(): "-20M",
-				},
-			},
-		},
-		{
-			name: "systemReserved memory value cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceMemory.String(): "-20M",
-				},
-			},
-		},
-		{
-			name: "kubeReserved cpu value fails to parse",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceCPU.String(): "Peter Griffin",
-				},
-			},
-		},
-		{
-			name: "systemReserved cpu value fails to parse",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceCPU.String(): "Stewie Griffin",
-				},
-			},
-		},
-		{
-			name: "kubeReserved memory value fails to parse",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceMemory.String(): "Brian Griffin",
-				},
-			},
-		},
-		{
-			name: "systemReserved memory value fails to parse",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceMemory.String(): "Meg Griffin",
-				},
-			},
-		},
-		{
-			name: "kubeReserved ephemeral-storage value fails to parse",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceEphemeralStorage.String(): "Lois Griffin",
-				},
-			},
-		},
-		{
-			name: "kubeReserved ephemeral-storage value cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				KubeReserved: map[string]string{
-					v1.ResourceEphemeralStorage.String(): "-20M",
-				},
-			},
-		},
-		{
-			name: "systemReserved ephemeral-storage value fails to parse",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceEphemeralStorage.String(): "Glenn Quagmire",
-				},
-			},
-		},
-		{
-			name: "systemReserved ephemeral-storage value cannot be negative",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				SystemReserved: map[string]string{
-					v1.ResourceEphemeralStorage.String(): "-20M",
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Fixes: https://github.com/openshift/machine-config-operator/issues/2357

**- What I did**
Drop all the validation for `KubeletConfig`

**- How to verify it**
```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: set-max-pods
spec:
  logLevel: 5
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
  kubeletConfig:
      evictionHard:
        imagefs.available: 10%
        imagefs.inodesFree: 5%
        memory.available: 200Mi
        nodefs.available: 5%
        nodefs.inodesFree: 4%
      evictionPressureTransitionPeriod: 0s
      evictionSoft:
        imagefs.available: 15%
        imagefs.inodesFree: 10%
        memory.available: 500Mi
        nodefs.available: 10%
        nodefs.inodesFree: 5%
      evictionSoftGracePeriod:
        imagefs.available: 1m30s
        imagefs.inodesFree: 1m30s
        memory.available: 1m30s
        nodefs.available: 1m30s
        nodefs.inodesFree: 1m30s
      imageGCHighThresholdPercent: 80
      imageGCLowThresholdPercent: 75
      imageMinimumGCAge: 5m
      maxPods: 240
      podsPerCore: 80
```
Try to apply above kubeletconfig and the validation should pass fine like this,

```
Name:         set-max-pods
Namespace:    
Labels:       <none>
Annotations:  API Version:  machineconfiguration.openshift.io/v1
Kind:         KubeletConfig
Metadata:
  Creation Timestamp:  2021-02-04T06:34:03Z
  Finalizers:
    99-worker-generated-kubelet
  Generation:  1
  Managed Fields:
    API Version:  machineconfiguration.openshift.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"99-worker-generated-kubelet":
      f:status:
        .:
        f:conditions:
    Manager:      machine-config-controller
    Operation:    Update
    Time:         2021-02-04T06:34:03Z
    API Version:  machineconfiguration.openshift.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:kubeletConfig:
          .:
          f:evictionHard:
          f:evictionPressureTransitionPeriod:
          f:evictionSoft:
          f:evictionSoftGracePeriod:
          f:imageGCHighThresholdPercent:
          f:imageGCLowThresholdPercent:
          f:imageMinimumGCAge:
          f:maxPods:
          f:podsPerCore:
        f:logLevel:
        f:machineConfigPoolSelector:
          .:
          f:matchLabels:
            .:
            f:pools.operator.machineconfiguration.openshift.io/worker:
    Manager:         oc
    Operation:       Update
    Time:            2021-02-04T06:34:03Z
  Resource Version:  404911
  Self Link:         /apis/machineconfiguration.openshift.io/v1/kubeletconfigs/set-max-pods
  UID:               b07988d1-01c7-44de-b70e-3ca9911aaf52
Spec:
  Kubelet Config:
    Eviction Hard:
      imagefs.available:                  10%
      imagefs.inodesFree:                 5%
      memory.available:                   200Mi
      nodefs.available:                   5%
      nodefs.inodesFree:                  4%
    Eviction Pressure Transition Period:  0s
    Eviction Soft:
      imagefs.available:   15%
      imagefs.inodesFree:  10%
      memory.available:    500Mi
      nodefs.available:    10%
      nodefs.inodesFree:   5%
    Eviction Soft Grace Period:
      imagefs.available:              1m30s
      imagefs.inodesFree:             1m30s
      memory.available:               1m30s
      nodefs.available:               1m30s
      nodefs.inodesFree:              1m30s
    Image GC High Threshold Percent:  80
    Image GC Low Threshold Percent:   75
    Image Minimum GC Age:             5m
    Max Pods:                         240
    Pods Per Core:                    80
  Log Level:                          5
  Machine Config Pool Selector:
    Match Labels:
      pools.operator.machineconfiguration.openshift.io/worker:  
Status:
  Conditions:
    Last Transition Time:  2021-02-04T06:34:03Z
    Message:               Success
    Status:                True
    Type:                  Success
Events:                    <none>
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Drop all validation for kubeletconfig