### PR TITLE
Bug 1925319: configure-ovs: fix bash syntax error

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -141,7 +141,7 @@ contents:
       if [ $(nmcli --get-values connection.type conn show ${old_conn}) == "vlan" ]; then
         iface_type=vlan
         vlan_id=$(nmcli --get-values vlan.id conn show ${old_conn})
-        if [ -z "$vlan_id"]; then
+        if [ -z "$vlan_id" ]; then
           echo "ERROR: unable to determine vlan_id for vlan connection: ${old_conn}"
           exit 1
         fi


### PR DESCRIPTION
Fixes: 1925319

```shell
    if [ -z "$vlan_id"]; then
```

```
configure-ovs-network.sh:140:5: note: The mentioned syntax error was in this if expression. [SC1009]
configure-ovs-network.sh:140:8: error: Couldn't parse this test expression. Fix to allow more checks. [SC1073]
configure-ovs-network.sh:140:13: error: Expected this to be an argument to the unary condition. [SC1019]
configure-ovs-network.sh:140:24: error: You need a space before the ]. [SC1020]
configure-ovs-network.sh:140:24: error: Missing space before ]. Fix any mentioned problems and try again. [SC1072]
```



**- What I did**

**- How to verify it**

Extract inline bash configure-ovs.sh to file, run `shellcheck` on it.

**- Description for the changelog**

Fixed bash syntax error in configure-ovs.sh
