### PR TITLE
daemon: safer signal handling for shutdown

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 3600
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1158,7 +1158,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 3600
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"


### PR DESCRIPTION
This armors the signal handling for the daemon blocking any shutdown until _after_ an update is complete.
   
The old functions `catchIgnoreSIGTERM` and `cancelSIGTERM` really didn't do much (they used the mutex and then set a bool) but there were no checks in the signal handling.

This also increases the time for the MCD to shutdown from 5min to a 1hr. Since the MCD will shut down immediately when safe to do so this shouldn't have negative effects except in the case of an already unhappy node.