### PR TITLE
Add kubelet CA to no-reboot action list/Do not drain for non-reboot actions

### DIFF
--- a/docs/MachineConfigDaemon.md
+++ b/docs/MachineConfigDaemon.md
@@ -116,7 +116,7 @@ When starting, MachineConfigDaemon verifies that contents and existence of the f
 
 ## Machine reboot
 
-MachineConfigDaemon reboots the machine after applying the updated machine configuration.
+MachineConfigDaemon reboots the machine in most cases after applying the updated machine configuration. For rebootless updates, see [Rebootless Updates](#rebootless-updates) section below.
 
 ### Node drain
 
@@ -143,6 +143,22 @@ The draining of pods on the only master node will not evict the control plane as
 ### Node drain etcd static pods on masters
 
 Etcd is co-located on master nodes as static pods. The draining behavior defined above prevents draining of static pods to prevent interference to etcd cluster by the daemon.
+
+### Rebootless Updates
+
+As of Openshift 4.7, the MCD gained the functionality to not reboot for select MachineConfig updates. The updated list and behaviour (as of Openshift 4.8) is as follows:
+
+"None" action: only performs the corresponding file write. This does NOT trigger a drain. Available for changes to:
+
+1. sshkeys (updating ignition/passwd/users/sshAuthorizedKeys section in a MachineConfig)
+2. kube-apiserver-to-kubelet-signer CA cert (located at /etc/kubernetes/kubelet-ca.crt, 1 year expiry autorotated by the openshift-kubeapiserver operator)
+3. pull secret (cluster-wide, located at /var/lib/kubelet/config.json)
+
+"Crio Reload" action: performs the file write, and runs a systemctl reload crio. This does trigger a drain. Available for changes to:
+
+1. registries.conf (/etc/containers/registries.conf, e.g. ICSP changes)
+
+The action is calculated as a diff between current and desired configurations. For any MachineConfig diff detected that is not listed above, or if a forcefile was set, the MCD will trigger the full reboot flow (drain -> update -> reboot).
 
 ## Annotating on SSH access
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -132,8 +132,7 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			if dn.recorder != nil {
 				dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeWarning, "FailedServiceReload", fmt.Sprintf("Reloading %s service failed. Error: %v", serviceName, err))
 			}
-			dn.logSystem("Reloading %s configuration failed, node will reboot instead. Error: %v", serviceName, err)
-			dn.reboot(fmt.Sprintf("Node will reboot into config %s", configName))
+			return fmt.Errorf("Could not apply update: reloading %s configuration failed. Error: %v", serviceName, err)
 		}
 
 		if dn.recorder != nil {
@@ -147,14 +146,12 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 	// Get current state of node, in case of an error reboot
 	state, err := dn.getStateAndConfigs(configName)
 	if err != nil {
-		glog.Errorf("Error processing state and configs, node will reboot instead. Error: %v", err)
-		return dn.reboot(fmt.Sprintf("Node will reboot into config %s", configName))
+		return fmt.Errorf("Could not apply update: error processing state and configs. Error: %v", err)
 	}
 
 	var inDesiredConfig bool
 	if inDesiredConfig, err = dn.updateConfigAndState(state); err != nil {
-		glog.Errorf("Setting node's state to Done failed, node will reboot instead. Error: %v", err)
-		return dn.reboot(fmt.Sprintf("Node will reboot into config %s", configName))
+		return fmt.Errorf("Could not apply update: setting node's state to Done failed. Error: %v", err)
 	}
 	if inDesiredConfig {
 		return nil
@@ -476,8 +473,8 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 
 func calculatePostConfigChangeActionFromFileDiffs(oldIgnConfig, newIgnConfig ign3types.Config) (actions []string) {
 	filesPostConfigChangeActionNone := []string{
-		"/var/lib/kubelet/config.json",
 		"/etc/kubernetes/kubelet-ca.crt",
+		"/var/lib/kubelet/config.json",
 	}
 	filesPostConfigChangeActionReloadCrio := []string{
 		"/etc/containers/registries.conf",
@@ -621,8 +618,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		return err
 	}
 
-	if err := dn.drain(); err != nil {
-		return err
+	// Drain if we need to reboot or reload crio configuration
+	if ctrlcommon.InSlice(postConfigChangeActionReboot, actions) || ctrlcommon.InSlice(postConfigChangeActionReloadCrio, actions) {
+		if err := dn.drain(); err != nil {
+			return err
+		}
+	} else {
+		glog.Info("Changes do not require drain, skipping.")
 	}
 
 	// update files on disk that need updating

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -477,6 +477,7 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 func calculatePostConfigChangeActionFromFileDiffs(oldIgnConfig, newIgnConfig ign3types.Config) (actions []string) {
 	filesPostConfigChangeActionNone := []string{
 		"/var/lib/kubelet/config.json",
+		"/etc/kubernetes/kubelet-ca.crt",
 	}
 	filesPostConfigChangeActionReloadCrio := []string{
 		"/etc/containers/registries.conf",

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -534,6 +534,26 @@ func TestCalculatePostConfigChangeAction(t *testing.T) {
 				},
 			},
 		},
+		"kubeletCA1": ign3types.File{
+			Node: ign3types.Node{
+				Path: "/etc/kubernetes/kubelet-ca.crt",
+			},
+			FileEmbedded1: ign3types.FileEmbedded1{
+				Contents: ign3types.Resource{
+					Source: helpers.StrToPtr(dataurl.EncodeBytes([]byte("kubeletCA1\n"))),
+				},
+			},
+		},
+		"kubeletCA2": ign3types.File{
+			Node: ign3types.Node{
+				Path: "/etc/kubernetes/kubelet-ca.crt",
+			},
+			FileEmbedded1: ign3types.FileEmbedded1{
+				Contents: ign3types.Resource{
+					Source: helpers.StrToPtr(dataurl.EncodeBytes([]byte("kubeletCA2\n"))),
+				},
+			},
+		},
 	}
 
 	tests := []struct {
@@ -566,6 +586,12 @@ func TestCalculatePostConfigChangeAction(t *testing.T) {
 			expectedAction: []string{postConfigChangeActionReloadCrio},
 		},
 		{
+			// test that a kubelet CA change is none
+			oldConfig:      helpers.NewMachineConfig("00-test", nil, "dummy://", []ign3types.File{files["kubeletCA1"]}),
+			newConfig:      helpers.NewMachineConfig("01-test", nil, "dummy://", []ign3types.File{files["kubeletCA2"]}),
+			expectedAction: []string{postConfigChangeActionNone},
+		},
+		{
 			// test that a registries change (reload) overwrites pull secret (none)
 			oldConfig:      helpers.NewMachineConfig("00-test", nil, "dummy://", []ign3types.File{files["registries1"], files["pullsecret1"]}),
 			newConfig:      helpers.NewMachineConfig("01-test", nil, "dummy://", []ign3types.File{files["registries2"], files["pullsecret2"]}),
@@ -592,7 +618,7 @@ func TestCalculatePostConfigChangeAction(t *testing.T) {
 		{
 			// mixed test - final should be reboot due to kargs changes
 			oldConfig:      helpers.NewMachineConfigExtended("00-test", nil, []ign3types.File{files["registries1"]}, []ign3types.Unit{}, []ign3types.SSHAuthorizedKey{"key1"}, []string{}, false, []string{}, "default", "dummy://"),
-			newConfig:      helpers.NewMachineConfigExtended("01-test", nil, []ign3types.File{files["pullsecret2"]}, []ign3types.Unit{}, []ign3types.SSHAuthorizedKey{"key2"}, []string{}, false, []string{"karg1"}, "default", "dummy://"),
+			newConfig:      helpers.NewMachineConfigExtended("01-test", nil, []ign3types.File{files["pullsecret2"], files["kubeletCA1"]}, []ign3types.Unit{}, []ign3types.SSHAuthorizedKey{"key2"}, []string{}, false, []string{"karg1"}, "default", "dummy://"),
 			expectedAction: []string{postConfigChangeActionReboot},
 		},
 	}

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -129,7 +129,6 @@ func RenderBootstrap(
 	bundle = append(bundle, filesData[rootCAFile]...)
 	// Append the kube-ca if given.
 	if _, ok := filesData[kubeAPIServerServingCA]; ok {
-		bundle = append(bundle, filesData[kubeAPIServerServingCA]...)
 		spec.KubeAPIServerServingCAData = filesData[kubeAPIServerServingCA]
 	}
 	// Set the cloud-provider CA if given.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -207,7 +207,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 
 	bundle := make([]byte, 0)
 	bundle = append(bundle, rootCA...)
-	bundle = append(bundle, kubeAPIServerServingCABytes...)
 
 	// sync up os image url
 	// TODO: this should probably be part of the imgs


### PR DESCRIPTION
Incorporates https://github.com/openshift/machine-config-operator/pull/2294 and https://github.com/openshift/machine-config-operator/pull/2290, such that a kubelet cert signer rotation causes a "none" action.

In 4.7 we introduced non-reboot updates for select cases, but still drained nodes for safety. This is still a major workload disruption, and non-reboot updates do not require draining for correctness. This PR will also introduce the ability to not drain at all for non-reboot updates, and in case of error, return the error directly instead of rebooting in an attempt to fix it.

This will cause updates to effectively to not cordon nodes at all, and on AWS a change to e.g. kubelet ca would talk ~20 seconds to apply to a 3-node pool.

One last thing to consider is what behaviour we want for changes to `/etc/containers/registries.conf`, since not draining may cause a mismatch of image reference between existing and new containers.