### PR TITLE
[OCPCLOUD-1106] Add afterburn task to update AWS hostname to match instance metadata

### DIFF
--- a/templates/common/_base/files/usr-local-bin-mco-hostname.yaml
+++ b/templates/common/_base/files/usr-local-bin-mco-hostname.yaml
@@ -22,6 +22,16 @@ contents:
         exit 0
     }
 
+    set_aws_hostname() {
+        /usr/bin/afterburn --provider aws --hostname=/run/afterburn.hostname
+
+        local host_name=$(cat /run/afterburn.hostname)
+
+        echo "setting transient hostname to ${host_name}"
+        /bin/hostnamectl --transient set-hostname "${host_name}"
+        exit 0
+    }
+
     set_gcp_hostname() {
         /usr/bin/afterburn --provider gcp --hostname=/run/afterburn.hostname
 
@@ -59,6 +69,7 @@ contents:
     case "${arg}" in
         --wait) wait_localhost;;
         --gcp) set_gcp_hostname;;
+        --aws) set_aws_hostname;;
         *) echo "Unhandled arg $arg"; exit 1
     esac
 

--- a/templates/common/aws/files/etc-networkmanager-conf.d-hostname.yaml
+++ b/templates/common/aws/files/etc-networkmanager-conf.d-hostname.yaml
@@ -1,0 +1,10 @@
+mode: 0644
+path: "/etc/NetworkManager/conf.d/hostname.conf"
+contents:
+  inline: |
+    # The following configuration allows 90-long-hostname.sh
+    # to manage setting transient hostname instead of NetworkManager itself.
+    # See: https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html
+    #      https://bugzilla.redhat.com/show_bug.cgi?id=1872885
+    [main]
+    hostname-mode=none

--- a/templates/common/aws/units/aws-hostname.service.yaml
+++ b/templates/common/aws/units/aws-hostname.service.yaml
@@ -1,0 +1,20 @@
+name: aws-hostname.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Set AWS Transient Hostname
+  # Block services relying on networking being up.
+  Before=network-online.target
+  # Wait for NetworkManager to report it's online
+  After=NetworkManager-wait-online.service
+  # Run before hostname checks
+  Before=node-valid-hostname.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/usr/local/bin/mco-hostname --aws
+
+  [Install]
+  WantedBy=multi-user.target
+  WantedBy=network-online.target


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

During kubelet migration from `--cloud-provider=aws` to `--cloud-provider=external` kubelet determines `Node` name by the hostname of the machine where it is running. AWS hostname is mismatched, usually it is a reversed DNS mapping of machine ip, like  `ip-10-0-195-176`. This results in node name mismatch in kubelet, and API server admission plugin rejects changes for the object.

This fixes the issue.

**- How to verify it**

- Ensure that new nodes provisioned by kubelet will report hostname with aws prefix, typically reversed IP mapping + `<region>.compute.internal` even when the cloud-provider is set to `external`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
