### PR TITLE
Bug 1927366: Fixes ovs-configuration with cloned connections

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -43,8 +43,11 @@ contents:
           ifconfig "$intf" allmulti
         fi
       }
-
-      NM_CONN_PATH="/etc/NetworkManager/system-connections"
+      if [ -d "/etc/NetworkManager/system-connections-merged" ]; then
+        NM_CONN_PATH="/etc/NetworkManager/system-connections-merged"
+      else
+        NM_CONN_PATH="/etc/NetworkManager/system-connections"
+      fi
       iface=""
       counter=0
       # find default interface
@@ -196,6 +199,7 @@ contents:
             echo "WARN: existing br-ex interface file found: $new_conn_file, which is not loaded in NetworkManager...overwriting"
           fi
           cp -f ${old_conn_file} ${new_conn_file}
+          restorecon ${new_conn_file}
           if $cloned; then
             nmcli conn delete ${old_conn}-clone
             rm -f ${old_conn_file}


### PR DESCRIPTION
When using nm clone for a connection where we cannot find the current
keyfile, the file is assumed to be in the regular NM keyfile path.
However on platforms using the "merged" keyfile path, this fails,
because the file only exists in the merged directory.

Additionally, after we copy the cloned file to edit for static IP
addressing, NM will fail to load it because of selinux. Therefore we
need to restorecon after we copy it.

Signed-off-by: Tim Rozet <trozet@redhat.com>

