### PR TITLE
Bug 1921937: kubelet.service: start after hostnamed

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -4,7 +4,7 @@ contents: |
   [Unit]
   Description=Kubernetes Kubelet
   Wants=rpc-statd.service network-online.target crio.service
-  After=network-online.target crio.service
+  After=network-online.target crio.service systemd-hostnamed.service
 
   [Service]
   Type=notify

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -4,7 +4,7 @@ contents: |
   [Unit]
   Description=Kubernetes Kubelet
   Wants=rpc-statd.service network-online.target crio.service
-  After=network-online.target crio.service
+  After=network-online.target crio.service systemd-hostnamed.service
 
   [Service]
   Type=notify


### PR DESCRIPTION
There currently exists a race between the Kubelet and hostnamed.
If Kubelet starts a container that bind mounts /etc/hostname before hostnamed finishes creating /etc/hostname,
CRI-O needs to create the not yet created /etc/hostname as a directory (conforming with age-old docker behavior).

This causes hostnamed to perpetually fail, which causes all sorts of trouble

Instead of allowing this race, we can start the kubelet after systemd-hostnamed is finished, so containers
always mount the newly created /etc/hostname

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1921937

Signed-off-by: Peter Hunt <pehunt@redhat.com>