### PR TITLE
pkg/daemon: Drop unnecessary select from runLoginMonitor

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -685,11 +685,9 @@ func (dn *Daemon) runLoginMonitor(stopCh <-chan struct{}, exitCh chan<- error) {
 			}
 		}
 	}()
-	select {
-	case <-stopCh:
-		close(worker)
-		cmd.Process.Kill()
-	}
+	<-stopCh
+	close(worker)
+	cmd.Process.Kill()
 }
 
 func (dn *Daemon) applySSHAccessedAnnotation() error {


### PR DESCRIPTION
Code is from ec135eee0c (#545), and while it was not wrong, the wrapping `select` isn't necessary for blocking on a single channel read.  I only noticed because I'm working through a SIGQUIT stack trace which included:

```
goroutine 53 [select (no cases), 814 minutes]:
github.com/openshift/machine-config-operator/pkg/daemon.(*Daemon).runLoginMonitor(0xc000582a80, 0x0, 0xc000538480)
  /go/src/github.com/openshift/machine-config-operator/pkg/daemon/daemon.go:689 +0x30f
created by github.com/openshift/machine-config-operator/pkg/daemon.(*Daemon).ClusterConnect
  /go/src/github.com/openshift/machine-config-operator/pkg/daemon/daemon.go:299 +0x578
```

So with this commit, we drop the `select` and get straight into the blocking channel read.