### PR TITLE
Bug 1871770: Remove extraneous whitespace from keepalived peer list

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -52,10 +52,12 @@ contents:
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
-        unicast_peer {            
-            {{`{{range .LBConfig.Backends -}}
-            {{if ne $nonVirtualIP .Address}}{{.Address}}{{end}}
-            {{end}}`}}
+        unicast_peer {
+            {{`{{- range .LBConfig.Backends -}}
+            {{- if ne $nonVirtualIP .Address}}
+            {{.Address}}
+            {{- end}}
+            {{- end}}`}}
         }
         {{`{{end}}`}}
         authentication {
@@ -80,9 +82,11 @@ contents:
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
-            {{`{{range .IngressConfig.Peers -}}
-            {{if ne $nonVirtualIP .}}{{.}}{{end}}
-            {{end}}`}}
+            {{`{{- range .IngressConfig.Peers}}
+            {{- if ne $nonVirtualIP .}}
+            {{.}}
+            {{- end}}
+            {{- end}}`}}
         }
         {{`{{end}}`}}
         authentication {

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -21,9 +21,11 @@ contents:
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
-            {{`{{range .IngressConfig.Peers}}
-            {{if ne $nonVirtualIP .}}{{.}}{{end}}
-            {{end}}`}}
+            {{`{{- range .IngressConfig.Peers}}
+            {{- if ne $nonVirtualIP .}}
+            {{.}}
+            {{- end}}
+            {{- end}}`}}
         }
         {{`{{end}}`}}
         authentication {


### PR DESCRIPTION
This makes it a little prettier and easier for automation to parse.
