### PR TITLE
Bug 1902963: templates: add After=ostree-finalize-staged.service to kubelet.service

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -5,6 +5,7 @@ contents: |
   Description=Kubernetes Kubelet
   Wants=rpc-statd.service network-online.target crio.service
   After=network-online.target crio.service
+  After=ostree-finalize-staged.service
 
   [Service]
   Type=notify

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -5,6 +5,7 @@ contents: |
   Description=Kubernetes Kubelet
   Wants=rpc-statd.service network-online.target crio.service
   After=network-online.target crio.service
+  After=ostree-finalize-staged.service
 
   [Service]
   Type=notify

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -5,6 +5,7 @@ contents: |
   Description=Kubernetes Kubelet
   Wants=rpc-statd.service network-online.target crio.service
   After=network-online.target crio.service
+  After=ostree-finalize-staged.service
 
   [Service]
   Type=notify

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -5,6 +5,7 @@ contents: |
   Description=Kubernetes Kubelet
   Wants=rpc-statd.service network-online.target crio.service
   After=network-online.target crio.service
+  After=ostree-finalize-staged.service
 
   [Service]
   Type=notify


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

We've seen occasional issues during upgrades caused by what seems to be
the kubelet still being active during OSTree finalization. If the
kubelet changes things in `/etc`, it'll confuse OSTree which is trying
to do the `/etc` merge.

We want to be sure that the kubelet is done modifying everything it
needs to in `/etc` and that it exited before we finalize the deployment.

Add a `After=ostree-finalize-staged.service` for this. The way this
works is that that service runs in its `ExecStop`, and shutdown ordering
is the reverse of startup. So this will cause the kubelet to exit before
`ostree-finalize-staged.service` is stopped.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1902963

**- How to verify it**

It's tricky to verify because it's a flake. So verification would be getting this in and not seeing that bug pop up anymore. (Could still at least verify though from the journal logs that the kubelet exited before `ostree-finalize-staged.service`.)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

During upgrades, we now wait for the kubelet to exit before finalizing the staged deployment to ensure no conflicts occur.