### PR TITLE
controller: remove etcd quorum-guard check on master pool

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -944,21 +944,12 @@ func maxUnavailable(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) (int, 
 	if pool.Spec.MaxUnavailable != nil {
 		intOrPercent = *pool.Spec.MaxUnavailable
 	}
-	maxunavail, err := intstrutil.GetValueFromIntOrPercent(&intOrPercent, len(nodes), false)
+	maxunavail, err := intstrutil.GetScaledValueFromIntOrPercent(&intOrPercent, len(nodes), false)
 	if err != nil {
 		return 0, err
 	}
 	if maxunavail == 0 {
 		maxunavail = 1
-	}
-	if pool.Name == masterPoolName {
-		// calculate the fault tolerance dynamically for the master pool
-		// to avoid risking losing etcd quorum.
-		tolerance := len(nodes) - ((len(nodes) / 2) + 1)
-		if maxunavail > tolerance {
-			glog.Warningf("Refusing to honor master pool maxUnavailable %d to prevent losing etcd quorum, using %d instead", maxunavail, tolerance)
-			return tolerance, nil
-		}
 	}
 	return maxunavail, nil
 }

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -454,30 +454,15 @@ func TestMaxUnavailable(t *testing.T) {
 			expected:   0,
 			err:        true,
 		}, {
-			poolName:   "master",
-			maxUnavail: intStrPtr(intstr.FromInt(1)),
-			nodes:      newNodeSet(5),
-			expected:   1,
-			err:        false,
+			maxUnavail: intStrPtr(intstr.FromString("60")),
+			nodes:      newNodeSet(4),
+			expected:   0,
+			err:        true,
 		}, {
-			poolName:   "master",
-			maxUnavail: intStrPtr(intstr.FromInt(2)),
-			nodes:      newNodeSet(3),
-			expected:   1,
-			err:        false,
-		}, {
-			poolName:   "master",
-			maxUnavail: intStrPtr(intstr.FromInt(2)),
-			nodes:      newNodeSet(5),
-			expected:   2,
-			err:        false,
-		},
-		{
-			poolName:   "master",
-			maxUnavail: intStrPtr(intstr.FromInt(4)),
-			nodes:      newNodeSet(7),
-			expected:   3,
-			err:        false,
+			maxUnavail: intStrPtr(intstr.FromString("40 %")),
+			nodes:      newNodeSet(4),
+			expected:   0,
+			err:        true,
 		},
 	}
 


### PR DESCRIPTION
etcd-quorum-guard has been part of cluster-etcd-operator
for a while and it already guards against node drain to
prevent from quorum loss.

With having support for different types of cluster like
SingleReplica and HighlyAvailable, it allows MCO to not
think about what quorum guard behaviour should be
depending upon cluster type.

Also use GetScaledValueFromIntOrPercent() instead of
deprecated function GetValueFromIntOrPercent() and
update unit tests accordingly.
