### PR TITLE
Bug 1931507: ovsdb-server: chown when restarting ovsdb-server

### DIFF
--- a/templates/common/_base/units/ovsdb-server.service.yaml
+++ b/templates/common/_base/units/ovsdb-server.service.yaml
@@ -5,3 +5,6 @@ dropins:
     contents: |
       [Service]
       Restart=always
+      ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /var/lib/openvswitch'
+      ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /etc/openvswitch'
+      ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /run/openvswitch'


### PR DESCRIPTION
**- What I did**
Added a dropin which sets permissions for openvswitch files in `ovsdb-server` service.

In OVN `ovsdb-server` service starts before `ovs-vswitchd`, so chown
needs to run there. Unlike a dropin in `ovsdb-server` setting a group
is insufficient - user needs to own the OVS DB lock file too.

**- How to verify it**
Upgrade 4.6 OVN to 4.7. All nodes boot correctly after MCD updates the node.

**- Description for the changelog**
Permissions for openvswitch files are being updated for OVN installs on upgrade.