### PR TITLE
Bug 1928473: Apply system-connections-merged to all platforms

### DIFF
--- a/templates/common/_base/files/NetworkManager-keyfiles.yaml
+++ b/templates/common/_base/files/NetworkManager-keyfiles.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "/etc/NetworkManager/conf.d/99-keyfiles.conf"
+contents:
+  inline: |
+    [keyfile]
+    path=/etc/NetworkManager/system-connections-merged
+

--- a/templates/common/_base/files/nm-tmpfiles.yaml
+++ b/templates/common/_base/files/nm-tmpfiles.yaml
@@ -1,5 +1,5 @@
 mode: 0644
-path: "/etc/tmpfiles.d/kni.conf"
+path: "/etc/tmpfiles.d/nm.conf"
 contents:
   inline: |
     D /run/nm-system-connections 0755 root root - -

--- a/templates/common/_base/units/nm-system-connections-mount.yaml
+++ b/templates/common/_base/units/nm-system-connections-mount.yaml
@@ -2,6 +2,7 @@ name: etc-NetworkManager-system\x2dconnections\x2dmerged.mount
 enabled: true
 contents: |
   [Unit]
+  Before=NetworkManager.service
   After=systemd-tmpfiles-setup.service
   [Mount]
   Where=/etc/NetworkManager/system-connections-merged

--- a/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
+++ b/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
@@ -8,6 +8,4 @@ contents:
     [connection]
     ipv6.dhcp-duid=ll
     ipv6.dhcp-iaid=mac
-    [keyfile]
-    path=/etc/NetworkManager/system-connections-merged
     {{ end -}}


### PR DESCRIPTION
In order to reduce complexity, and to promote consistency between platforms,
and thereby reducing an opportunity for future issues, this patch introduces
the OverlayFS mounted /etc/NetworkManger/system-connections-merged to all
platforms. It is meant to be a transparent change, and should not change the
functionality of NetworkManager on any platform. The purpose is to make any
NetworkManager configuration that is not performed by Machine Config Operator
be ephemeral.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
