### PR TITLE
Bug 1930620: support trace loglevel

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -447,9 +447,10 @@ func validateUserContainerRuntimeConfig(cfg *mcfgv1.ContainerRuntimeConfig) erro
 			"warn":  true,
 			"info":  true,
 			"debug": true,
+			"trace": true,
 		}
 		if !validLogLevels[ctrcfg.LogLevel] {
-			return fmt.Errorf("invalid LogLevel %q, must be one of error, fatal, panic, warn, info, or debug", ctrcfg.LogLevel)
+			return fmt.Errorf("invalid LogLevel %q, must be one of error, fatal, panic, warn, info, debug, or trace", ctrcfg.LogLevel)
 		}
 	}
 


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fix Bug 1930620 https://bugzilla.redhat.com/show_bug.cgi?id=1930620
**- What I did**
Add trace loglevel as valid level for ContainerRuntimeConfig as documented and current crio can support this level.
**- How to verify it**
Apply the containerRuntiemConfig with `logLevel: trace`.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add trace loglevel as valid level for ContainerRuntimeConfig.