### PR TITLE
[release-4.6] Bug 1933075: backport systemd dropin/units zero-length handling

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1389,12 +1389,16 @@ func checkV3Units(units []ign3types.Unit) error {
 				content = *u.Dropins[j].Contents
 			}
 
-			// Backwards compatibility check: the new behavior is to noop when a drop-in for zero length.
-			// However, to maintain backwards compatibility, we allow existing zero length files to exist.
-			if err := checkFileContentsAndMode(path, []byte(content), defaultFilePermissions); err != nil {
-				if content == "" && os.IsNotExist(err) {
+			if _, err := os.Stat(path); content == "" && err != nil {
+				if os.IsNotExist(err) {
 					continue
 				}
+				return err
+			}
+
+			// To maintain backwards compatibility, we allow existing zero length files to exist.
+			// Thus we are also ok if the dropin exists but has no content
+			if err := checkFileContentsAndMode(path, []byte(content), defaultFilePermissions); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Dependency backports for Bug 1933077.

This fixes a problem were a previous dropin/unit is replaced with zero
length file by ensuring that drops/units have actual content.

Signed-off-by: Ben Howard <ben.howard@redhat.com>
(cherry picked from commit c6df6d8)

The previous commit checks for IsNotExist as a return of
checkFileContentsAndMode, which since we wrap the error, will
never be the case, thus always erroring there. Instead check
for the error in a separate case.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.