### PR TITLE
Bug 1932105: operator/sync.go restore err when required pools not leveled

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -617,6 +617,8 @@ func (optr *Operator) syncRequiredMachineConfigPools(_ *renderConfig) error {
 					isPoolStatusConditionTrue(pool, mcfgv1.MachineConfigPoolUpdated) {
 					continue
 				}
+				lastErr = fmt.Errorf("error required pool %s is not ready, retrying. Status: (total: %d, ready %d, updated: %d, unavailable: %d, degraded: %d)", pool.Name, pool.Status.MachineCount, pool.Status.ReadyMachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount, pool.Status.DegradedMachineCount)
+				return false, nil
 			}
 		}
 		syncstatuserr := optr.syncUpgradeableStatus()


### PR DESCRIPTION
In the course of working on wait for all pools (#2231) an error when a required pool isn't yet finished updating was inadvertently removed. Restoring it here.

Replaces  #2433