### PR TITLE
Bug 1917282: Explicitly set keyfile as the default plugin of NetworkManager for RHEL7

### DIFF
--- a/templates/common/_base/files/NetworkManager-keyfiles.yaml
+++ b/templates/common/_base/files/NetworkManager-keyfiles.yaml
@@ -2,6 +2,8 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/99-keyfiles.conf"
 contents:
   inline: |
+    [main]
+    plugins=keyfile,ifcfg-rh
     [keyfile]
     path=/etc/NetworkManager/systemConnectionsMerged
 

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -16,9 +16,10 @@ contents:
       dst_path="/etc/NetworkManager/system-connections"
       if [ -d $src_path ]; then
         echo "$src_path exists"
-        fileList=$(echo {br-ex,ovs-if-br-ex,ovs-port-br-ex,ovs-if-phys0,ovs-port-phys0}.nmconnection)
+        # In RHEL7 files in /{etc,run}/NetworkManager/system-connections end without the suffix '.nmconnection', whereas in RHCOS they end with the suffix.
+        fileList=$(echo {br-ex,ovs-if-br-ex,ovs-port-br-ex,ovs-if-phys0,ovs-port-phys0} {br-ex,ovs-if-br-ex,ovs-port-br-ex,ovs-if-phys0,ovs-port-phys0}.nmconnection)
         for file in ${fileList[*]}; do
-          if [ ! -f $dst_path/$file ]; then
+          if [ ! -f $dst_path/$file ] && [ -f $src_path/$file ]; then
             cp $src_path/$file $dst_path/$file
           else
             echo "Skipping $file since it exists in $dst_path"
@@ -179,9 +180,11 @@ contents:
       # bring down any old iface
       nmcli device disconnect $iface
 
+      # use ${extra_phys_args[@]+"${extra_phys_args[@]}"} instead of ${extra_phys_args[@]} to be compatible with bash 4.2 in RHEL7.9
+      extra_args=${extra_phys_args[@]+"${extra_phys_args[@]}"}
       if ! nmcli connection show ovs-if-phys0 &> /dev/null; then
         nmcli c add type ${iface_type} conn.interface ${iface} master ovs-port-phys0 con-name ovs-if-phys0 \
-          connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} "${extra_phys_args[@]}"
+          connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_args}
       fi
 
       # Update connections with master property set to use the new device name


### PR DESCRIPTION
1. Configure keyfile as the default plugin of NetworkManager explicitly for all nodes. It is the default setting in RHCOS.
2. Fix configure-ovs.sh script for RHEL7 workers with old version NetworkManager.
