### PR TITLE
Bug 1933805: Add node label to service monitor

### DIFF
--- a/install/0000_90_machine-config-operator_00_servicemonitor.yaml
+++ b/install/0000_90_machine-config-operator_00_servicemonitor.yaml
@@ -15,6 +15,15 @@ spec:
     port: metrics
     scheme: https
     path: /metrics
+    relabelings:
+    - action: replace
+      regex: ;(.*)
+      replacement: $1
+      separator: ";"
+      sourceLabels:
+      - node
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: machine-config-daemon.openshift-machine-config-operator.svc


### PR DESCRIPTION
In order to associate the metrics of each target, we want to clearly
identify which node the MCD is scheduled on to. This will allow us
to more accurately track target health as it relates to nodes in
order to improve the TargetDown alert during upgrades. In the future,
other alerts should be based on node name, not instance name, which
should simplify behavior.

If the node label is already set, do nothing.

The linked bug reports TargetDown firing for MCD because at least one
instance is down the entire time of the upgrade due to overlapping
control plane / worker updates. We are changing the alert to exclude
instances that are deliberately being upgraded (today by using the
unschedulable flag, in the future potentially by a more targeted MCO
driven metric indicating the phase of node upgrade). We will apply
the fix to all daemonsets in the platform, this is being tested here
first.

**- Description for the changelog**
Metrics reported by the machine config daemon now include a node label for the node the metric originated from, if the metric did not already include a node label.