### PR TITLE
Bug 1934113: Improve error handling for os updates

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -245,10 +245,7 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 	args := []string{"rebase", "--experimental", fmt.Sprintf("%s:%s", repo, ostreeCsum),
 		"--custom-origin-url", customURL, "--custom-origin-description", "Managed by machine-config-operator"}
 
-	var out []byte
-	if out, err = runGetOut("rpm-ostree", args...); err != nil {
-		// capture stdout output as well in case of error
-		err = errors.Wrapf(err, "with stdout output: %v", string(out))
+	if _, err = runGetOut("rpm-ostree", args...); err != nil {
 		return
 	}
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -428,7 +428,11 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 
 	// Update OS
 	if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
-		MCDPivotErr.WithLabelValues(dn.node.Name, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
+		nodeName := ""
+		if dn.node != nil {
+			nodeName = dn.node.Name
+		}
+		MCDPivotErr.WithLabelValues(nodeName, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
 		return err
 	}
 


### PR DESCRIPTION
Add a nil check, so that if a firstboot osupdate fails, the error
is properly captured instead of panicking, since the node object
is nil.

Also just report the error directly if the command fails, since
runGetOut doesn't return stdout when it errors.