### PR TITLE
Bug 1931615: OVS Config: fixes detecting bond NM files with static IP

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -179,8 +179,8 @@ contents:
         if nmcli --fields ipv4.method,ipv6.method conn show $old_conn | grep manual; then
           echo "Static IP addressing detected on default gateway connection: ${old_conn}"
           # find and copy the old connection to get the address settings
-          if egrep -l --include=*.nmconnection $old_conn ${NM_CONN_PATH}/*; then
-            old_conn_file=$(egrep -l --include=*.nmconnection $old_conn ${NM_CONN_PATH}/*)
+          if egrep -l --include=*.nmconnection uuid=$old_conn ${NM_CONN_PATH}/*; then
+            old_conn_file=$(egrep -l --include=*.nmconnection uuid=$old_conn ${NM_CONN_PATH}/*)
             cloned=false
           else
             echo "WARN: unable to find NM configuration file for conn: ${old_conn}. Attempting to clone conn"


### PR DESCRIPTION
With static IP addressing we try to copy the original NM keyfile so that
we can modify it and retain the original IP settings. In the case where
a bond was configured with a static IP address we grep for the UUID in
the keyfiles to determine which keyfile belongs to the original
connection. However, bond slaves will also contain the UUID in their
keyfile, and the grep was accidentally returning multiple files which
causes the script to fail.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit e73bd012f14fe5025ccae35059c02d4835ecf4e8)

