### PR TITLE
Add new extension for sandboxed-containers

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -201,7 +201,7 @@ spec:
 **Note:** The RT kernel lowers throughput (performance) in return for improved worst-case latency bounds. This feature is intended only for use cases that require consistent low latency. For more information, see the [Linux Foundation wiki](https://wiki.linuxfoundation.org/realtime/start) and the [RHEL RT portal](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/).
 
 ### RHCOS Extensions
-RHCOS is a minimal OCP focused OS which provides capabilities common across all the platforms. With extensions support, OCP 4.6 and onward users can enable a limited set of additional functionality on the RHCOS nodes. In OCP 4.6 the supported extensions is `usbguard`.
+RHCOS is a minimal OCP focused OS which provides capabilities common across all the platforms. With extensions support, OCP 4.6 and onward users can enable a limited set of additional functionality on the RHCOS nodes. In OCP 4.6 the supported extensions is `usbguard`. In OCP 4.8 the supported extensions are `usbguard` and `sandboxed-containers`.
 
 Extensions can be installed by creating a MachineConfig object. Extensions can be enabled as both day1 and day2. Check [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Enabling-RHCOS-Extensions) to enable extensions during cluster install.
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1048,8 +1048,9 @@ func getSupportedExtensions() map[string][]string {
 	// These are RHCOS supported extensions.
 	// Each extension keeps a list of packages required to get enabled on host.
 	return map[string][]string{
-		"usbguard":     {"usbguard"},
-		"kernel-devel": {"kernel-devel", "kernel-headers"},
+		"usbguard":             {"usbguard"},
+		"kernel-devel":         {"kernel-devel", "kernel-headers"},
+		"sandboxed-containers": {"kata-containers"},
 	}
 }
 

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -259,7 +259,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"usbguard", "kernel-devel"},
+			Extensions: []string{"usbguard", "kernel-devel", "sandboxed-containers"},
 		},
 	}
 
@@ -283,11 +283,12 @@ func TestExtensions(t *testing.T) {
 	var expectedPackages []string
 	if isOKD {
 		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
+		// "sandboxed-containers" extension is not available on OKD
 		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "usbguard", "kernel-devel")
 		expectedPackages = []string{"usbguard", "kernel-devel"}
 	} else {
-		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "usbguard", "kernel-devel", "kernel-headers")
-		expectedPackages = []string{"usbguard", "kernel-devel", "kernel-headers"}
+		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "usbguard", "kernel-devel", "kernel-headers", "kata-containers")
+		expectedPackages = []string{"usbguard", "kernel-devel", "kernel-headers", "kata-containers"}
 	}
 	for _, v := range expectedPackages {
 		if !strings.Contains(installedPackages, v) {
@@ -317,9 +318,10 @@ func TestExtensions(t *testing.T) {
 
 	if isOKD {
 		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
+		// "sandboxed-containers" extension is not available on OKD
 		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel")
 	} else {
-		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers")
+		installedPackages = execCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers", "kata-containers")
 	}
 	for _, v := range expectedPackages {
 		if strings.Contains(installedPackages, v) {


### PR DESCRIPTION
**- What I did**
This adds support for a new RHCOS extension called
"sandboxed-containres". It will install kata-containers  and its
dependencies, 9 RPMs with a total size of ~55MB when downloaded, ~150MB
when installed.

It will allow users to run kernel isolated containers via the Sandboxed
Containers operator.

**- How to verify it**
TBD

**- Description for the changelog**
 Added support for a new RHCOS extension to install `sandboxed-containers`.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**IMPORTANT:**
Let me add a big note here that I'm experimenting with the fact of having a kata-containers extension, superseding https://github.com/openshift/machine-config-operator/pull/2376, and it comes from a suggestion made by @cgwalters while reviewing https://github.com/openshift/enhancements/pull/677#discussion_r588732079 (also, refer to: https://coreos.slack.com/archives/CK1AE4ZCK/p1614974860056400).

While modifying https://github.com/openshift/enhancements/pull/677 according to the reviewers suggestions, I'm experimenting, I'm trying to have all the pieces together, so we can make the proposal solid and based on work that's either done or close to be done, rather than basing it on what we think that should be done.