### PR TITLE
Skip drain on Single Node deployment

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -135,6 +135,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 		),
 		// The node controller consumes data written by the above
 		node.New(
+			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -175,6 +175,14 @@ spec:
                         like the web console to tell users where to find the Kubernetes
                         API.
                       type: string
+                    controlPlaneTopology:
+                      description: controlPlaneTopology expresses the expectations for
+                        operands that normally run on control nodes. The default is
+                        HighlyAvailable, which represents the behavior operators have
+                        in a normal cluster. The SingleReplica mode will be used in
+                        single-node deployments and the operators should not configure
+                        the operand for highly-available operation.
+                      type: string
                     etcdDiscoveryDomain:
                       description: 'etcdDiscoveryDomain is the domain used to fetch
                         the SRV records for discovering etcd servers and clients.

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -811,7 +811,7 @@ func (ctrl *Controller) getNodesForPool(pool *mcfgv1.MachineConfigPool) ([]*core
 
 // setClusterConfigAnnotation reads cluster configs set into controllerConfig
 // and add/updates required annotation to node such as ControlPlaneTopology
-// from infrastrcture object.
+// from infrastructure object.
 func (ctrl *Controller) setClusterConfigAnnotation(nodes []*corev1.Node) error {
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
@@ -819,15 +819,15 @@ func (ctrl *Controller) setClusterConfigAnnotation(nodes []*corev1.Node) error {
 	}
 
 	for _, node := range nodes {
-		glog.Infof("Initiating controlPlaneTopology annotation %s\n", string(cc.Spec.Infra.Status.ControlPlaneTopology))
 		if node.Annotations[daemonconsts.ClusterControlPlaneTopologyAnnotationKey] != string(cc.Spec.Infra.Status.ControlPlaneTopology) {
+			oldAnn := node.Annotations[daemonconsts.ClusterControlPlaneTopologyAnnotationKey]
 			_, err := internal.UpdateNodeRetry(ctrl.kubeClient.CoreV1().Nodes(), ctrl.nodeLister, node.Name, func(node *corev1.Node) {
 				node.Annotations[daemonconsts.ClusterControlPlaneTopologyAnnotationKey] = string(cc.Spec.Infra.Status.ControlPlaneTopology)
-				glog.Infof("Updated controlPlaneTopology annotations\n")
 			})
 			if err != nil {
 				return err
 			}
+			glog.Infof("Updated controlPlaneTopology annotation of node %s from %s to %s", node.Name, oldAnn, node.Annotations[daemonconsts.ClusterControlPlaneTopologyAnnotationKey])
 		}
 	}
 	return nil

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -14,8 +14,8 @@ const (
 	DesiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
 	// MachineConfigDaemonStateAnnotationKey is used to fetch the state of the daemon on the machine.
 	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
-	// ClusterControlPlaneTopologyAnnotationKey is set by node controller by reading value from
-	// controllerConfig. MCD uses the annotation value to decide drain action on node.
+	// ClusterControlPlaneTopologyAnnotationKey is set by the node controller by reading value from
+	// controllerConfig. MCD uses the annotation value to decide drain action on the node.
 	ClusterControlPlaneTopologyAnnotationKey = "machineconfiguration.openshift.io/controlPlaneTopology"
 	// OpenShiftOperatorManagedLabel is used to filter out kube objects that don't need to be synced by the MCO
 	OpenShiftOperatorManagedLabel = "openshift.io/operator-managed"

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -14,6 +14,9 @@ const (
 	DesiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
 	// MachineConfigDaemonStateAnnotationKey is used to fetch the state of the daemon on the machine.
 	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
+	// ClusterControlPlaneTopologyAnnotationKey is set by node controller by reading value from
+	// controllerConfig. MCD uses the annotation value to decide drain action on node.
+	ClusterControlPlaneTopologyAnnotationKey = "machineconfiguration.openshift.io/controlPlaneTopology"
 	// OpenShiftOperatorManagedLabel is used to filter out kube objects that don't need to be synced by the MCO
 	OpenShiftOperatorManagedLabel = "openshift.io/operator-managed"
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1625,7 +1625,7 @@ func isSingleNodeTopology(topology configv1.TopologyMode) bool {
 
 // getControlPlaneTopology reads from node annotation and returns
 // controlPlaneTopology value set in the cluster. If annotation value
-// is unrecognized, we considere it as highly available cluster.
+// is unrecognized, we consider it as a highly available cluster.
 func (dn *Daemon) getControlPlaneTopology() configv1.TopologyMode {
 	controlPlaneTopology := dn.node.Annotations[constants.ClusterControlPlaneTopologyAnnotationKey]
 	switch configv1.TopologyMode(controlPlaneTopology) {

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubectl/pkg/drain"
+)
+
+func (dn *Daemon) drainRequired() bool {
+	// Drain operation is not useful on single node cluster, save time by skipping drain.
+	// These cluster can take advantage of graceful node shutdown feature.
+	// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+	return !isSingleNodeTopology(dn.getControlPlaneTopology())
+}
+
+func (dn *Daemon) cordonOrUncordonNode(desired bool) error {
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 10 * time.Second,
+		Factor:   2,
+	}
+	var lastErr error
+	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := drain.RunCordonOrUncordon(dn.drainer, dn.node, desired)
+		if err != nil {
+			lastErr = err
+			glog.Infof("cordon/uncordon failed with: %v, retrying", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		if err == wait.ErrWaitTimeout {
+			return errors.Wrapf(lastErr, "failed to cordon/uncordon node (%d tries): %v", backoff.Steps, err)
+		}
+		return errors.Wrap(err, "failed to cordon/uncordon node")
+	}
+	return nil
+}
+
+func (dn *Daemon) drain() error {
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 10 * time.Second,
+		Factor:   2,
+	}
+	var lastErr error
+	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := drain.RunNodeDrain(dn.drainer, dn.node.Name)
+		if err != nil {
+			lastErr = err
+			glog.Infof("Draining failed with: %v, retrying", err)
+			return false, nil
+		}
+		return true, nil
+
+	}); err != nil {
+		if err == wait.ErrWaitTimeout {
+			failMsg := fmt.Sprintf("%d tries: %v", backoff.Steps, lastErr)
+			MCDDrainErr.WithLabelValues(dn.node.Name, "WaitTimeout").Set(float64(backoff.Steps))
+			dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeWarning, "FailedToDrain", failMsg)
+			return errors.Wrapf(lastErr, "failed to drain node (%d tries): %v", backoff.Steps, err)
+		}
+		MCDDrainErr.WithLabelValues(dn.node.Name, "UnknownError").Set(float64(backoff.Steps))
+		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeWarning, "FailedToDrain", err.Error())
+		return errors.Wrap(err, "failed to drain node")
+	}
+
+	return nil
+}
+
+func (dn *Daemon) performDrain() error {
+	// Skip drain process when we're not cluster driven
+	if dn.kubeClient == nil {
+		return nil
+	}
+
+	if !dn.drainRequired() {
+		if isSingleNodeTopology(dn.getControlPlaneTopology()) {
+			if err := dn.cordonOrUncordonNode(false); err != nil {
+				return err
+			}
+			dn.logSystem("Node has been successfully cordoned")
+			dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Cordon", "Cordoned node to apply update")
+		}
+		dn.logSystem("Drain not required, skipping")
+		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Drain", "Drain not required, skipping")
+		return nil
+	}
+
+	// We are here, that means we need to cordon and drain node
+	if err := dn.cordonOrUncordonNode(true); err != nil {
+		return err
+	}
+	dn.logSystem("Node has been successfully cordoned")
+	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Cordon", "Cordoned node to perform drain")
+
+	MCDDrainErr.WithLabelValues(dn.node.Name, "").Set(0)
+	dn.logSystem("Update prepared; beginning drain")
+	startTime := time.Now()
+
+	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Drain", "Draining node to update config.")
+
+	if err := dn.drain(); err != nil {
+		return err
+	}
+
+	dn.logSystem("drain complete")
+	t := time.Since(startTime).Seconds()
+	glog.Infof("Successful drain took %v seconds", t)
+	MCDDrainErr.WithLabelValues(dn.node.Name, "").Set(0)
+
+	return nil
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -343,6 +343,14 @@ spec:
                         like the web console to tell users where to find the Kubernetes
                         API.
                       type: string
+                    controlPlaneTopology:
+                      description: controlPlaneTopology expresses the expectations for
+                        operands that normally run on control nodes. The default is
+                        HighlyAvailable, which represents the behavior operators have
+                        in a normal cluster. The SingleReplica mode will be used in
+                        single-node deployments and the operators should not configure
+                        the operand for highly-available operation.
+                      type: string
                     etcdDiscoveryDomain:
                       description: 'etcdDiscoveryDomain is the domain used to fetch
                         the SRV records for discovering etcd servers and clients.


### PR DESCRIPTION
With the introduction of different ControlPlaneTopology types
in the OpenShift cluster, the behaviour of the cluster may differ
based on cluster type. For example: cluster with Single
controlPlane node, it doesn't make sense to perform workload drain.

ControllerConfig now understands ControlPlaneTopology:TopologyMode
set in the cluster. Node controller later on reads the value from
controllerConfig and sets value into node annotation
`machineconfiguration.openshift.io/controlPlaneTopology`.

While performing a configuration update, machine-config-daemon
will read the annotation and based on controlPlaneTopology
type, it will decide drain action.
MCD skips drain if controlPlaneTopology is SingleReplica.

Part of - https://github.com/openshift/enhancements/pull/560/

This PR also:
- refactors drain logic
- adds related unit tests
