### PR TITLE
Bug 1948022: Add on-prem namespaces to relatedObjects

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -72,6 +72,11 @@ func (optr *Operator) syncRelatedObjects() error {
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigs"},
 		// gathered because the machineconfigs created container bootstrap credentials and node configuration that gets reflected via the API and is needed for debugging
 		{Group: "", Resource: "nodes"},
+		// Gathered for the on-prem services running in static pods.
+		{Resource: "namespaces", Name: "openshift-kni-infra"},
+		{Resource: "namespaces", Name: "openshift-openstack-infra"},
+		{Resource: "namespaces", Name: "openshift-ovirt-infra"},
+		{Resource: "namespaces", Name: "openshift-vsphere-infra"},
 	}
 
 	if !equality.Semantic.DeepEqual(coCopy.Status.RelatedObjects, co.Status.RelatedObjects) {


### PR DESCRIPTION
Previously the kni namespace was explicitly listed in must-gather,
but when I went to add the other on-prem ones it was pointed out
that this should probably be done with relatedObjects. This adds
the namespaces here so we don't need anything in must-gather itself.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
Added on-prem service namespaces to relatedObjects so they will be included in must-gather.