### PR TITLE
[release-4.7] Bug 1929257: Fix 1:1 mapping for kubeletconfig:MC and some e2e test fixes

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -126,15 +126,18 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 
 	// If we are here, this means that a new kubelet config was created, so we have to calculate the suffix value for its MC name
 	suffixNum := 0
-	// Get the suffix value of the second to last item in the kubelet config list. We use the second to last item because
-	// the most recent kubelet config being created has already been added to the list and is the kubelet config object that we are
-	// trying to figure out the suffix value for
-	val, ok := kcList.Items[len(kcList.Items)-2].GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
-	if ok {
-		// Convert the suffix value to int so we can add 1 to it for the MC name for the latest kubelet config object
-		suffixNum, err = strconv.Atoi(val)
-		if err != nil {
-			return "", fmt.Errorf("error converting %s to int: %v", val, err)
+	// Go through the list of kubelet config objects created and get the max suffix value currently created
+	for _, item := range kcList.Items {
+		val, ok := item.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
+		if ok {
+			// Convert the suffix value to int so we can look through the list and grab the max suffix created so far
+			intVal, err := strconv.Atoi(val)
+			if err != nil {
+				return "", fmt.Errorf("error converting %s to int: %v", val, err)
+			}
+			if intVal > suffixNum {
+				suffixNum = intVal
+			}
 		}
 	}
 	// The max suffix value that we can go till with this logic is 9 - this means that a user can create up to 10 different kubelet config CRs.

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -114,7 +114,7 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		}
 		val, ok := kc.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
 		// If we find a matching kubelet config and it is the only one in the list, then return the default MC name with no suffix
-		if !ok && len(kcList.Items) < 9 {
+		if !ok && len(kcList.Items) < 2 {
 			return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 		}
 		// Otherwise if an MC name suffix exists, append it to the default MC name and return that as this kubelet config exists and
@@ -142,7 +142,7 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 	// then if the user creates a kc-new it will map to mc-3. This is what we want as the latest kubelet config created should be higher in priority
 	// so that those changes can be rolled out to the nodes. But users will have to be mindful of how many kubelet config CRs they create. Don't think
 	// anyone should ever have the need to create 10 when they can simply update an existing kubelet config unless it is to apply to another pool.
-	if suffixNum+1 > 2 {
+	if suffixNum+1 > 9 {
 		return "", fmt.Errorf("max number of supported kubelet config (10) has been reached. Please delete old kubelet configs before retrying")
 	}
 	// Return the default MC name with the suffixNum+1 value appended to it


### PR DESCRIPTION
Fixes #1929257

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fix 1:1 mapping for kubeletconfig:MC and make getting the suffix of a kubeletconfig MC more robust.
Cherry-pick of https://github.com/openshift/machine-config-operator/pull/2408 and https://github.com/openshift/machine-config-operator/pull/2459.
