### PR TITLE
Bug 1939270: pkg/operator/status: Use 'DegradedPool' reason for Upgradeable=False

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -266,7 +266,8 @@ func (optr *Operator) syncUpgradeableStatus() error {
 		degraded := isPoolStatusConditionTrue(pool, mcfgv1.MachineConfigPoolDegraded)
 		if degraded {
 			coStatus.Status = configv1.ConditionFalse
-			coStatus.Reason = "One or more machine config pool is degraded, please see `oc get mcp` for further details and resolve before upgrading"
+			coStatus.Reason = "DegradedPool"
+			coStatus.Message = "One or more machine config pool is degraded, please see `oc get mcp` for further details and resolve before upgrading"
 		}
 	}
 


### PR DESCRIPTION
c6e2fa8674 (#2231) added this check, but [`Reason` is supposed to be a machine-readable slug, while the human-oriented string goes in `Message`][1].  Possibly worth a backport to 4.7?

[1]: https://github.com/openshift/api/blob/4b79815405ec40f1d72c3a74bae0ae7da543e435/config/v1/types_cluster_operator.go#L128-L136