### PR TITLE
Bug 1938084: configure-ovs.sh:incorrect setting of cloned-mac-address field

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -219,9 +219,9 @@ contents:
             sed -i '/^\[connection\]$/a interface-name=br-ex' ${new_conn_file}
           fi
           if ! grep 'cloned-mac-address=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[ethernet\]$/,/^\[/ s/^cloned-mac-address=.*$/cloned-mac-address='"$iface_mac"'/' ${new_conn_file}
-          else
             sed -i '/^\[ethernet\]$/a cloned-mac-address='"$iface_mac" ${new_conn_file}
+          else
+            sed -i '/^\[ethernet\]$/,/^\[/ s/^cloned-mac-address=.*$/cloned-mac-address='"$iface_mac"'/' ${new_conn_file}
           fi
           if grep 'mtu=' ${new_conn_file} &> /dev/null; then
             sed -i '/^\[ethernet\]$/,/^\[/ s/^mtu=.*$/mtu='"$iface_mtu"'/' ${new_conn_file}


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

This issue seen with UPI deployment on vsphere where mac address field was never been populated
this PR Fixes: 1938084

**- What I did**
fix logical issue in the script such that if cloned-mac-address field doesn't exits it will create it and assign ovs port
the same mac as ethernet device
**- How to verify it**
- UPI vsphere deployment
- manually by running the right command and saw filed get populate
- original file
[ethernet]
mtu=1500
mtu=
mac-address-blacklist=

- run fix manually
sed -i '/^\[ethernet\]$/,/^\[/ s/^cloned-mac-address=.*$/cloned-mac-address=00:50:56:ac:55:06/' /etc/NetworkManager/system-connections-merged/ovs-if-br-ex.nmconnection
- check results
[ethernet]
cloned-mac-address=00:50:56:ac:55:06
mtu=1500
mtu=
mac-address-blacklist=


**- Description for the changelog**
configure-ovs.sh:incorrect setting for cloned-mac-address field"
