### PR TITLE
Bug 1935539: vSphere: Disable tx checksum offload

### DIFF
--- a/templates/common/vsphere/files/vsphere-disable-tx-checksum-offload.yaml
+++ b/templates/common/vsphere/files/vsphere-disable-tx-checksum-offload.yaml
@@ -1,0 +1,8 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-tx-checksum-offload.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    # This is a workaround for BZ#1935539
+    nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-checksum-ip-generic off;


### PR DESCRIPTION
Based on customer reports and internal testing
checksum offload introduced with VMXNET34 v4 is
causing checksum issues with openshift-apiserver and
various other components causing installations and upgrades
to fail when using greater than guest hardware version 14.
