### PR TITLE
Bug 1935539: vSphere: Disable tx udp_csum segmentation

### DIFF
--- a/templates/common/vsphere/files/vsphere-disable-vmxnet3v4-features.yaml
+++ b/templates/common/vsphere/files/vsphere-disable-vmxnet3v4-features.yaml
@@ -1,0 +1,9 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/pre-up.d/disable-tx-checksum-offload.sh"
+contents:
+    inline: |
+      #!/bin/bash
+      #    # This is a workaround for BZ#1935539
+      nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-udp_tnl-segmentation off;
+      nmcli con modify ${CONNECTION_UUID} ethtool.feature-tx-udp_tnl-csum-segmentation off;


### PR DESCRIPTION
Based on one of VMware's recommendations disable
both:

tx-udp_tnl-segmentation
tx-udp_tnl-csum-segmentation

This could potentially replace the more generic offload disable.
