### PR TITLE
Bug 1925698: not allow healthcheck traffic to loop through the node

### DIFF
--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -64,6 +64,21 @@ contents:
         # balanced, even if the DNAT entry is removed
         ensure_rule filter INPUT -m comment --comment 'gcp LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
 
+        # bz1925698: GCP LBs can create stale entries causing apiservers disruption
+        # The GCP LB Health Check polls continuously the LB VIP assigned to the VM
+        # but, if the LB VIP is down, we are not handling the VIP traffic and
+        # the traffic can hairpin, leaving stale conntrack entries on the host.
+        # xref: https://bugzilla.redhat.com/show_bug.cgi?id=1925698#c29
+        # Deleting conntrack entries solves the problem, but it also affects other connections
+        # directed to the LB vips, causing unexpected networks disruptions.
+        # The solution is to not FORWARD GCP HealthCheckers traffic, because that traffic 
+        # is only directed to the host, and it must go to the INPUT chain.
+        # xref: https://bugzilla.redhat.com/show_bug.cgi?id=1930457#c8
+        # The HealthCheck origin ip-ranges are documented: 130.211.0.0/22 and 35.191.0.0/16
+        # xref: https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+        ensure_rule filter FORWARD -m comment --comment 'gcp HealthCheck traffic' -s 35.191.0.0/16 -j DROP
+        ensure_rule filter FORWARD -m comment --comment 'gcp HealthCheck traffic' -s 130.211.0.0/22 -j DROP
+
         mkdir -p "${RUN_DIR}"
     }
 


### PR DESCRIPTION
Sometimes, the host can have stale conntrack entries towards the
apiserver, that cause random network interruptions.

This is caused by the GCP healtchecker traffic, that only must be valid when is 
directed to the node and it can never loop through it.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

