### PR TITLE
Bug 1939740: Use new --prefer-ipv6 flag to "runtimecfg node-ip" as appropriate

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -21,7 +21,11 @@ contents: |
     --volume /etc/systemd/system:/etc/systemd/system:z \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
-    set --retry-on-failure; \
+    set \
+    {{if eq .IPFamilies "IPv6" -}}
+    --prefer-ipv6 \
+    {{end -}}
+    --retry-on-failure; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
**- What I did**
Make MCO templates use new `runtimecfg node-ip --prefer-ipv6` flag when on single-stack IPv6, so that we pick the correct node IP when bringing up a single-stack IPv6 cluster on a node that happens to also have IPv4 IPs.

**- How to verify it**
Our infra doesn't currently create any such clusters anywhere but we can confirm that the option gets passed (and accepted) in single-stack IPv6 clusters, and not elsewhere. (Of course, I don't think MCO has a single-stack IPv6 presubmit job, so...)

**- Description for the changelog**
(Why does the template ask for this? What changelog?)

/hold
for testing