### PR TITLE
Bug 1940594: [baremetal and friends] Drop unnecessary readiness probes

### DIFF
--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -63,16 +63,6 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 18080
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /health

--- a/templates/common/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/common/baremetal/files/baremetal-keepalived.yaml
@@ -151,16 +151,6 @@ contents:
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 6443
-            scheme: HTTPS
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:

--- a/templates/common/openstack/files/openstack-coredns.yaml
+++ b/templates/common/openstack/files/openstack-coredns.yaml
@@ -60,16 +60,6 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 18080
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /health

--- a/templates/common/ovirt/files/ovirt-coredns.yaml
+++ b/templates/common/ovirt/files/ovirt-coredns.yaml
@@ -60,16 +60,6 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 18080
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /health

--- a/templates/common/vsphere/files/vsphere-coredns.yaml
+++ b/templates/common/vsphere/files/vsphere-coredns.yaml
@@ -68,16 +68,6 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 18080
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
Now that we are using the loadbalanced endpoint for keepalived
healthchecks, it is not correct to be using the local apiserver for
readiness checks. Also, I don't think there's any need for readiness
checks on the monitor. Kubernetes isn't routing any traffic to this
pod, so its ready status is meaningless.

**- Description for the changelog**
Removed unnecessary readiness probes for on-prem services. This should clear up warnings about unready containers.