### PR TITLE
Update Update-SSHKeys.md

### DIFF
--- a/docs/Update-SSHKeys.md
+++ b/docs/Update-SSHKeys.md
@@ -100,7 +100,7 @@ spec:
 Export the `99-worker-ssh` to edit the `SSHAuthorizedKeys`.
 
 ```sh
-oc get machineconfigs 99-worker-ssh -oyaml --export > update-ssh-worker.yaml
+oc get machineconfigs 99-worker-ssh -oyaml > update-ssh-worker.yaml
 ```
 
 Update the `sshAuthorizedKeys` for `core` user in `update-ssh-worker.yaml`.


### PR DESCRIPTION
Remove unexitsing --export option.

oc version
Client Version: 4.6.8
Server Version: 4.6.17
Kubernetes Version: v1.19.0+e405995

 oc get mc 99-worker-ssh -oyaml --export 
Error: unknown flag: --export
See 'oc get --help' for usage

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
