### PR TITLE
Fixes: Bug 1942207: [vsphere] hostnames are changed when upgrading from 4.6 to 4.7.x causing upgrades to fail

### DIFF
--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -6,8 +6,6 @@ contents: |
   Requires=vmtoolsd.service
   After=vmtoolsd.service
 
-  # Only run on first boot and only if the host does not have a name yet
-  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
   ConditionPathExists=!/etc/hostname
   ConditionVirtualization=vmware
   


### PR DESCRIPTION
**- What I did**
Removed condition which ensures vsphere-hostname.service only runs on the first boot.

**- How to verify it**
- Install latest version of 4.6.22
- Configure DHCP to assign a hostname to nodes in the cluster
- Upgrade with the fix included

**- Description for the changelog**
Addresses issue which causes hostnames to be lost when upgrading from 4.6 to 4.7 on vSphere IPI clusters.