### PR TITLE
operator: upgradeable false when pools are still updating

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -624,10 +624,6 @@ func (optr *Operator) syncRequiredMachineConfigPools(_ *renderConfig) error {
 				return false, nil
 			}
 		}
-		syncstatuserr := optr.syncUpgradeableStatus()
-		if syncstatuserr != nil {
-			glog.Errorf("Error syncingUpgradeableStatus: %q", syncstatuserr)
-		}
 		glog.Info("required machine-config pools synchronized")
 		return true, nil
 	}); err != nil {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -611,6 +611,10 @@ func (optr *Operator) syncRequiredMachineConfigPools(_ *renderConfig) error {
 				if err := isMachineConfigPoolConfigurationValid(pool, version.Hash, optr.mcLister.Get); err != nil {
 					lastErr = fmt.Errorf("pool %s has not progressed to latest configuration: %v, retrying", pool.Name, err)
 					glog.Info(lastErr.Error())
+					syncerr := optr.syncUpgradeableStatus()
+					if syncerr != nil {
+						glog.Errorf("Error syncingUpgradeableStatus: %q", syncerr)
+					}
 					return false, nil
 				}
 
@@ -621,6 +625,10 @@ func (optr *Operator) syncRequiredMachineConfigPools(_ *renderConfig) error {
 				}
 				lastErr = fmt.Errorf("error required pool %s is not ready, retrying. Status: (total: %d, ready %d, updated: %d, unavailable: %d, degraded: %d)", pool.Name, pool.Status.MachineCount, pool.Status.ReadyMachineCount, pool.Status.UpdatedMachineCount, pool.Status.UnavailableMachineCount, pool.Status.DegradedMachineCount)
 				glog.Info(lastErr.Error())
+				syncerr := optr.syncUpgradeableStatus()
+				if syncerr != nil {
+					glog.Errorf("Error syncingUpgradeableStatus: %q", syncerr)
+				}
 				return false, nil
 			}
 		}


### PR DESCRIPTION
Sets machine-config clusteroperator Upgradeable: False when pools are updating (covering future upgrades), does not block current upgrade from reporting finished on all completing.

To verify roll out a mcp then once pool is updating, verify Upgradeable: False:
```oc get co/machine-config -oyaml```

when pool finished, should toggle back to Upgradeable: True


