### PR TITLE
Bug 1929160: Add NetworkManager reload to resolv-prepender

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -72,6 +72,10 @@ contents:
                 # Only leave the first 3 nameservers in /etc/resolv.conf
                 sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.tmp
                 mv -f /etc/resolv.tmp /etc/resolv.conf
+                # Workaround for bz 1929160. Reload NetworkManager to force it to
+                # re-run the lookup of the hostname now that we know we have DNS
+                # servers configured correctly in resolv.conf.
+                nmcli general reload dns-rc
             fi
         fi
         ;;


### PR DESCRIPTION
If resolv.conf gets populated after NetworkManager has attempted to
do a reverse lookup on the node IP to get the hostname, we can end
up with a hostname of localhost because the lookup has no DNS servers
to use. To avoid this possibility, reload NetworkManager after we
populate resolv.conf, which should force it to redo the lookup.

**- Description for the changelog**
Reload NetworkManager after populating resolv.conf to ensure we correctly populate the node hostname.