### PR TITLE
Bug 1943329: add tlsSecurityProfile to KubeletConfig manifest

### DIFF
--- a/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
@@ -49,6 +49,105 @@ spec:
             autoSizingReserved:
               description: Automatically set optimal system reserved
               type: boolean
+            tlsSecurityProfile:
+              description: "tlsSecurityProfile specifies settings for TLS connections
+                for ingresscontrollers. \n If unset, the default is based on the
+                apiservers.config.openshift.io/cluster resource. \n Note that when
+                using the Old, Intermediate, and Modern profile types, the effective
+                profile configuration is subject to change between releases. For
+                example, given a specification to use the Intermediate profile deployed
+                on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new
+                profile configuration to be applied to the ingress controller, resulting
+                in a rollout. \n Note that the minimum TLS version for ingress controllers
+                is 1.1, and the maximum TLS version is 1.2.  An implication of this
+                restriction is that the Modern TLS profile type cannot be used because
+                it requires TLS 1.3."
+              properties:
+                custom:
+                  description: "custom is a user-defined TLS security profile. Be
+                    extremely careful using a custom profile as invalid configurations
+                    can be catastrophic. An example custom profile looks like this:
+                    \n   ciphers:     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305
+                    \    - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256
+                    \  minTLSVersion: TLSv1.1"
+                  nullable: true
+                  properties:
+                    ciphers:
+                      description: "ciphers is used to specify the cipher algorithms
+                        that are negotiated during the TLS handshake.  Operators
+                        may remove entries their operands do not support.  For example,
+                        to use DES-CBC3-SHA  (yaml): \n   ciphers:     - DES-CBC3-SHA"
+                      items:
+                        type: string
+                      type: array
+                    minTLSVersion:
+                      description: "minTLSVersion is used to specify the minimal
+                        version of the TLS protocol that is negotiated during the
+                        TLS handshake. For example, to use TLS versions 1.1, 1.2
+                        and 1.3 (yaml): \n   minTLSVersion: TLSv1.1 \n NOTE: currently
+                        the highest minTLSVersion allowed is VersionTLS12"
+                      enum:
+                      - VersionTLS10
+                      - VersionTLS11
+                      - VersionTLS12
+                      - VersionTLS13
+                      type: string
+                  type: object
+                intermediate:
+                  description: "intermediate is a TLS security profile based on:
+                    \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+                    \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256
+                    \    - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256
+                    \    - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256
+                    \    - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384
+                    \    - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305
+                    \    - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384
+                    \  minTLSVersion: TLSv1.2"
+                  nullable: true
+                  type: object
+                modern:
+                  description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+                    \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256
+                    \    - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256
+                    \  minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported."
+                  nullable: true
+                  type: object
+                old:
+                  description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+                    \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256
+                    \    - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256
+                    \    - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256
+                    \    - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384
+                    \    - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305
+                    \    - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384
+                    \    - DHE-RSA-CHACHA20-POLY1305     - ECDHE-ECDSA-AES128-SHA256
+                    \    - ECDHE-RSA-AES128-SHA256     - ECDHE-ECDSA-AES128-SHA
+                    \    - ECDHE-RSA-AES128-SHA     - ECDHE-ECDSA-AES256-SHA384
+                    \    - ECDHE-RSA-AES256-SHA384     - ECDHE-ECDSA-AES256-SHA
+                    \    - ECDHE-RSA-AES256-SHA     - DHE-RSA-AES128-SHA256     -
+                    DHE-RSA-AES256-SHA256     - AES128-GCM-SHA256     - AES256-GCM-SHA384
+                    \    - AES128-SHA256     - AES256-SHA256     - AES128-SHA     -
+                    AES256-SHA     - DES-CBC3-SHA   minTLSVersion: TLSv1.0"
+                  nullable: true
+                  type: object
+                type:
+                  description: "type is one of Old, Intermediate, Modern or Custom.
+                    Custom provides the ability to specify individual TLS security
+                    profile parameters. Old, Intermediate and Modern are TLS security
+                    profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+                    \n The profiles are intent based, so they may change over time
+                    as new ciphers are developed and existing ciphers are found
+                    to be insecure.  Depending on precisely which ciphers are available
+                    to a process, the list may be reduced. \n Note that the Modern
+                    profile is currently not supported because it is not yet well
+                    adopted by common software libraries."
+                  enum:
+                  - Old
+                  - Intermediate
+                  - Modern
+                  - Custom
+                  type: string
+              type: object
             logLevel:
               description: logLevel defines the log level of the Kubelet
               type: integer


### PR DESCRIPTION
**- What I did**
Added the TLSSecurityProfile description to the KubeletConfig manifest. Not sure how I missed this.

**- How to verify it**
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: set-kubelet-tls-security-profile
spec:
  tlsSecurityProfile:
    type: Old
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
```


**- Description for the changelog**
