### PR TITLE
Bug 1941936: drop LogSizeMax and OverlaySize in ContainerRuntimeConfiguration when not used

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -448,11 +448,11 @@ type ContainerRuntimeConfiguration struct {
 	// logSizeMax specifies the Maximum size allowed for the container log file.
 	// Negative numbers indicate that no size limit is imposed.
 	// If it is positive, it must be >= 8192 to match/exceed conmon's read buffer.
-	LogSizeMax resource.Quantity `json:"logSizeMax"`
+	LogSizeMax resource.Quantity `json:"logSizeMax,omitempty"`
 
 	// overlaySize specifies the maximum size of a container image.
 	// This flag can be used to set quota on the size of container images. (default: 10GB)
-	OverlaySize resource.Quantity `json:"overlaySize"`
+	OverlaySize resource.Quantity `json:"overlaySize,omitempty"`
 }
 
 // ContainerRuntimeConfigStatus defines the observed state of a ContainerRuntimeConfig


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1941936
**- What I did**
Made `LogSizeMax` and `OverlaySize` in `ContainerRuntimeConfiguration` omit when not used. 


**- How to verify it**
https://bugzilla.redhat.com/show_bug.cgi?id=1941936#c0

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Drop LogSizeMax and OverlaySize in ContainerRuntimeConfiguration when not used