### PR TITLE
Bug 1941246: vSphere: Disable tx-udp-tnl offload

### DIFF
--- a/templates/common/vsphere/files/vsphere-disable-vmxnet3v4-features.yaml
+++ b/templates/common/vsphere/files/vsphere-disable-vmxnet3v4-features.yaml
@@ -1,0 +1,17 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/99-vsphere-disable-tx-udp-tnl"
+contents:
+    inline: |
+      #!/bin/bash
+      # Workaround:
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1941714
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+
+      driver=$(nmcli -t -m tabular -f general.driver dev show "${DEVICE_IFACE}")
+
+      if [[ "$2" == "up" && "${driver}" == "vmxnet3" ]]; then
+        logger -s "99-vsphere-disable-tx-udp-tnl triggered by ${2} on device ${DEVICE_IFACE}."
+        ethtool -K ${DEVICE_IFACE} tx-udp_tnl-segmentation off
+        ethtool -K ${DEVICE_IFACE} tx-udp_tnl-csum-segmentation off
+      fi


### PR DESCRIPTION
backport PR: #2482

There is an issue (tbd) with the VMXNET3 v4 driver causing
network traffic between various openshift services to be dropped.

With the addition of VMXNET3 v4 in RHCOS 4.7 (RHEL 8.3 kernel)
this workaround needs to be in place for customers running on
vSphere 6.7, OpenShift 4.7 and virtual hardware version 14 or higher.
