### PR TITLE
Bug 1899057: configure-ovs-network: fix spurious OVS warnings

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -124,7 +124,6 @@ contents:
             con-name br-ex \
             conn.interface br-ex \
             802-3-ethernet.mtu ${iface_mtu} \
-            802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric 100 \
             ipv6.route-metric 100 \
             ${extra_brex_args}


### PR DESCRIPTION
Fixes the following error:
ERR|interface br-ex: ignoring mac in Interface record

While benign, this error would fill up the OVS logs. Old versions of
Network Manager required the cloned-mac to be set on both the bridge and
the bridge interface. However, in newer versions of NM this has been
fixed and it only needs to be set on the interface. See:

https://bugzilla.redhat.com/show_bug.cgi?id=1899745#c8

Signed-off-by: Tim Rozet <trozet@redhat.com>
