### PR TITLE
Bug 1933772: Revert rework of signal handling

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
-      terminationGracePeriodSeconds: 3600
+      terminationGracePeriodSeconds: 600
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -89,7 +89,7 @@ type Daemon struct {
 	kubeletHealthzEnabled  bool
 	kubeletHealthzEndpoint string
 
-	// updateActiveLock is used to signal that an update operation is in progress
+	updateActive     bool
 	updateActiveLock sync.Mutex
 
 	nodeWriter NodeWriter
@@ -338,19 +338,15 @@ func (dn *Daemon) worker() {
 }
 
 func (dn *Daemon) processNextWorkItem() bool {
-	select {
-	case <-dn.stopCh:
+	key, quit := dn.queue.Get()
+	if quit {
 		return false
-	default:
-		key, quit := dn.queue.Get()
-		if quit {
-			return false
-		}
-		defer dn.queue.Done(key)
-
-		err := dn.syncHandler(key.(string))
-		dn.handleErr(err, key)
 	}
+	defer dn.queue.Done(key)
+
+	err := dn.syncHandler(key.(string))
+	dn.handleErr(err, key)
+
 	return true
 }
 
@@ -571,28 +567,29 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	return dn.reboot(fmt.Sprintf("Completing firstboot provisioning to %s", mc.GetName()))
 }
 
-// InterruptHandler ensures that shutdown operations are blocked until an
-// an update operation is finished.
-func (dn *Daemon) InterruptHandler(signaled chan int) {
-	glog.Info("Guarding against sigterm signal")
+// InstallSignalHandler installs the handler for the signals the daemon should act on
+func (dn *Daemon) InstallSignalHandler(signaled chan struct{}) {
+	termChan := make(chan os.Signal, 2048)
+	signal.Notify(termChan, syscall.SIGTERM)
 
 	// Catch SIGTERM - if we're actively updating, we should avoid
 	// having the process be killed.
 	// https://github.com/openshift/machine-config-operator/issues/407
 	go func() {
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
-
-		select {
-		case <-dn.stopCh:
-			glog.Info("sigterm handler function stopped")
-			dn.updateActiveLock.Lock()
-			return
-		case <-sig:
-			glog.Warningf("sigterm received waiting to claim update lock")
-			dn.updateActiveLock.Lock()
-			glog.Info("lock obtained, proceeding to shutdown")
-			signaled <- 15
+		for sig := range termChan {
+			//nolint:gocritic
+			switch sig {
+			case syscall.SIGTERM:
+				dn.updateActiveLock.Lock()
+				updateActive := dn.updateActive
+				dn.updateActiveLock.Unlock()
+				if updateActive {
+					glog.Info("Got SIGTERM, but actively updating")
+				} else {
+					close(signaled)
+					return
+				}
+			}
 		}
 	}()
 }
@@ -607,8 +604,8 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 	glog.Info("Starting MachineConfigDaemon")
 	defer glog.Info("Shutting down MachineConfigDaemon")
 
-	signaled := make(chan int)
-	dn.InterruptHandler(signaled)
+	signaled := make(chan struct{})
+	dn.InstallSignalHandler(signaled)
 
 	if dn.kubeletHealthzEnabled {
 		glog.Info("Enabling Kubelet Healthz Monitor")
@@ -624,16 +621,16 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 
 	go wait.Until(dn.worker, time.Second, stopCh)
 
-	select {
-	case <-stopCh:
-		return nil
-	case sig := <-signaled:
-		glog.Infof("shutdown of machine-config-daemon triggered via signal %d", sig)
-		return nil
-	case err := <-exitCh:
-		// This channel gets errors from auxiliary goroutines like loginmonitor and kubehealth
-		glog.Warningf("Got an error from auxiliary tools: %v", err)
-		return err
+	for {
+		select {
+		case <-stopCh:
+			return nil
+		case <-signaled:
+			return nil
+		case err := <-exitCh:
+			// This channel gets errors from auxiliary goroutines like loginmonitor and kubehealth
+			glog.Warningf("Got an error from auxiliary tools: %v", err)
+		}
 	}
 }
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -521,10 +521,6 @@ func calculatePostConfigChangeAction(oldConfig, newConfig *mcfgv1.MachineConfig)
 func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
 	oldConfig = canonicalizeEmptyMC(oldConfig)
 
-	// signal that an update is active
-	dn.updateActiveLock.Lock()
-	defer dn.updateActiveLock.Unlock()
-
 	if dn.nodeWriter != nil {
 		state, err := getNodeAnnotationExt(dn.node, constants.MachineConfigDaemonStateAnnotationKey, true)
 		if err != nil {
@@ -536,6 +532,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 			}
 		}
 	}
+
+	dn.catchIgnoreSIGTERM()
+	defer func() {
+		if retErr != nil {
+			dn.cancelSIGTERM()
+		}
+	}()
 
 	oldConfigName := oldConfig.GetName()
 	newConfigName := newConfig.GetName()
@@ -1864,11 +1867,29 @@ func (dn *Daemon) logSystem(format string, a ...interface{}) {
 	}
 }
 
+func (dn *Daemon) catchIgnoreSIGTERM() {
+	dn.updateActiveLock.Lock()
+	defer dn.updateActiveLock.Unlock()
+	if dn.updateActive {
+		return
+	}
+	dn.updateActive = true
+}
+
+func (dn *Daemon) cancelSIGTERM() {
+	dn.updateActiveLock.Lock()
+	defer dn.updateActiveLock.Unlock()
+	if dn.updateActive {
+		dn.updateActive = false
+	}
+}
+
 // reboot is the final step. it tells systemd-logind to reboot the machine,
 // cleans up the agent's connections, and then sleeps for 7 days. if it wakes up
 // and manages to return, it returns a scary error message.
 func (dn *Daemon) reboot(rationale string) error {
 	// Now that everything is done, avoid delaying shutdown.
+	dn.cancelSIGTERM()
 	dn.Close()
 
 	if dn.skipReboot {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1166,7 +1166,7 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon
-      terminationGracePeriodSeconds: 3600
+      terminationGracePeriodSeconds: 600
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"


### PR DESCRIPTION
We need to revert the following commits due to Bugzilla 1933772
https://github.com/openshift/machine-config-operator/commit/dd7154131a868ec950e87cdfc74d1b89b3919792
https://github.com/openshift/machine-config-operator/commit/6d92a7bb54f5264f2863fdb6859ea1d4d1bfa9c6
