### PR TITLE
Bug 1945017: Increase system reserved memory from 1Gi to 1.8Gi to support single node clusters

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -85,7 +85,7 @@ contents:
     }
     function static_node_sizing {
         rm -f ${NODE_SIZES_ENV}
-        echo "SYSTEM_RESERVED_MEMORY=1Gi" >> ${NODE_SIZES_ENV}
+        echo "SYSTEM_RESERVED_MEMORY=1.8Gi" >> ${NODE_SIZES_ENV}
         echo "SYSTEM_RESERVED_CPU=500m" >> ${NODE_SIZES_ENV}
     }
 


### PR DESCRIPTION
When running E2E tests on single node clusters, the 1Gi reserved for
system memory is insufficient.

During this PR: https://github.com/openshift/machine-config-operator/pull/2501 -

I had 3 e2e test runs on AWS single node, the peak recorded system memory
usage during those tests was 1.40, 1.31 and 1.19 GiB respectively. In
this PR I also saw a run that peaked at 1.56 GiB:

![image](https://user-images.githubusercontent.com/10882062/113160294-0b4e9f00-9246-11eb-85e0-5f87a70a8ade.png)

![image](https://user-images.githubusercontent.com/10882062/113260524-0d147300-92d7-11eb-82ca-7d60a46f8905.png)


The SystemMemoryExceedsReservation alerts demands that the actual usage
would be less than 90% of the amount reserved, so that means the
corresponding thresholds that should be set are at least 1.44, 1.46, 1.32 and
1.74 GiB.

Or in short, the reserved memory should be increased to 1.8GiB to
support single node (with some hopefully sufficient padding).

Possible future improvements -

1) Different threshold depending on whether the cluster is a single node
cluster or not

2) Find a way to lower single node system memory usage
