### PR TITLE
Bug 1940207: create the ovs-config-executed file to signal ovs is running on the host

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -4,6 +4,11 @@ contents:
   inline: |
     #!/bin/bash
     set -eux
+    
+    # This file is not needed anymore in 4.7+, but when rolling back to 4.6
+    # the ovs pod needs it to know ovs is running on the host.
+    touch /var/run/ovs-config-executed
+
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
     copy_nm_conn_files() {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The file is not needed by 4.7+ ovs pods, but when rolling back from 4.7
to 4.6 CNO is updated before MCO. The 4.6 version of the pod does not
find the file, executes ovs in a pod with the result that two ovs
instances are running at the same time.

**- How to verify it**

Need to test the downgrade with this PR in

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
