### PR TITLE
Bug 1931505: [on-prem] Cleanup keepalived vips before starting service

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -97,7 +97,21 @@ contents:
             done
           }
 
+          remove_vip()
+          {
+            address=$1
+            interface=$(ip -o a | grep '\s${address}/' | awk '{print $2}')
+            cidr=$(ip -o a | grep '\s${address}/' | awk '{print $4}')
+            if [ -n "$interface" ]; then
+                ip a del $cidr dev $interface
+            fi
+          }
+
           set -ex
+          # Ensure that we don't have stale VIPs configured
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=1931505
+          remove_vip "{{ onPremPlatformAPIServerInternalIP . }}"
+          remove_vip "{{ onPremPlatformIngressIP . }}"
           declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
           export -f msg_handler
           export -f reload_keepalived


### PR DESCRIPTION
Due to a bug in keepalived 2.0.10, if the liveness probe kills
keepalived, any vips that were assigned to the system remain and
are not cleaned up when keepalived restarts. Until we get a fixed
version of keepalived, let's clean up the VIPs ourselves before
starting keepalived. If the node is supposed to have the VIP it will
configure it again when keepalived starts.

This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1931505

**- Description for the changelog**
Under some circumstances, a VIP may be configured on a node it shouldn't be due to keepalived exiting uncleanly. To avoid this, remove any existing VIPs before starting keepalived.
