### PR TITLE
Bug 1934443: Fix ovs-configure script to detect team interface

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -139,8 +139,8 @@ contents:
         nmcli c add type ovs-port conn.interface br-ex master br-ex con-name ovs-port-br-ex
       fi
 
-      extra_phys_args=""
-      # check if this interface is a vlan, bond, or ethernet type
+      extra_phys_args=()
+      # check if this interface is a vlan, bond, team, or ethernet type
       if [ $(nmcli --get-values connection.type conn show ${old_conn}) == "vlan" ]; then
         iface_type=vlan
         vlan_id=$(nmcli --get-values vlan.id conn show ${old_conn})
@@ -153,13 +153,20 @@ contents:
           echo "ERROR: unable to determine vlan_parent for vlan connection: ${old_conn}"
           exit 1
         fi
-        extra_phys_args="dev ${vlan_parent} id ${vlan_id}"
+        extra_phys_args=( dev "${vlan_parent}" id "${vlan_id}" )
       elif [ $(nmcli --get-values connection.type conn show ${old_conn}) == "bond" ]; then
         iface_type=bond
         # check bond options
         bond_opts=$(nmcli --get-values bond.options conn show ${old_conn})
         if [ -n "$bond_opts" ]; then
-          extra_phys_args+="bond.options ${bond_opts} "
+          extra_phys_args+=( bond.options "${bond_opts}" )
+        fi
+      elif [ $(nmcli --get-values connection.type conn show ${old_conn}) == "team" ]; then
+        iface_type=team
+        # check team config options
+        team_config_opts=$(nmcli --get-values team.config -e no conn show ${old_conn})
+        if [ -n "$team_config_opts" ]; then
+          extra_phys_args+=( team.config "${team_config_opts}" )
         fi
       else
         iface_type=802-3-ethernet
@@ -170,7 +177,7 @@ contents:
 
       if ! nmcli connection show ovs-if-phys0 &> /dev/null; then
         nmcli c add type ${iface_type} conn.interface ${iface} master ovs-port-phys0 con-name ovs-if-phys0 \
-          connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args}
+          connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} "${extra_phys_args[@]}"
       fi
 
       nmcli conn up ovs-if-phys0


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

configure-ovs script doesn't detect team interface and incorrectly mark it as 802-3-type, this leads to failure
when try to install OCP with ovnkubernetes.

**- What I did**
Added team interface and its options detection
**- How to verify it**
install OCP with OVNKubernetes with team interface.

**- Description for the changelog**
Modify the script to check for team interface type and its options

**- Unit Testing**
manually created team interface and set team config options
``` 
nmcli connection add type team autoconnect no con-name my-team
nmcli connection modify my-team team.runner activebackup team.link-watchers "name=ethtool delay-up=5, name=nsna_ping target-host=target.host"
```

wrote a script the minmic the changes in the PR and echo the generated extra_phys_args
```
#!/bin/bash

set +x

extra_phys_args=()
old_conn="my-team"
if [ $(nmcli --get-values connection.type conn show ${old_conn}) == "team" ]; then
        iface_type=team
        # check team config options
        team_config_opts=$(nmcli --get-values team.config -e no conn show ${old_conn})
        if [ -n "$team_config_opts" ]; then
          extra_phys_args+=( team.config "${team_config_opts}" )
        fi
fi
echo "${extra_phys_args[@]}"
nmcli c modify ${old_conn} "${extra_phys_args[@]}"

```
