### PR TITLE
Bug 1946513: Fix Auto node sizing to honor user input

### DIFF
--- a/templates/common/_base/files/kubelet-auto-node-sizing-enabled.yaml
+++ b/templates/common/_base/files/kubelet-auto-node-sizing-enabled.yaml
@@ -3,3 +3,5 @@ path: "/etc/node-sizing-enabled.env"
 contents:
   inline: |
     NODE_SIZING_ENABLED=false
+    SYSTEM_RESERVED_MEMORY=1Gi
+    SYSTEM_RESERVED_CPU=500m

--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -85,14 +85,14 @@ contents:
     }
     function static_node_sizing {
         rm -f ${NODE_SIZES_ENV}
-        echo "SYSTEM_RESERVED_MEMORY=1Gi" >> ${NODE_SIZES_ENV}
-        echo "SYSTEM_RESERVED_CPU=500m" >> ${NODE_SIZES_ENV}
+        echo "SYSTEM_RESERVED_MEMORY=$1" >> ${NODE_SIZES_ENV}
+        echo "SYSTEM_RESERVED_CPU=$2" >> ${NODE_SIZES_ENV}
     }
 
     if [ $1 == "true" ]; then
         dynamic_node_sizing
     elif [ $1 == "false" ]; then
-        static_node_sizing
+        static_node_sizing $2 $3
     else
         echo "Unrecongnized command line option. Valid options are \"true\" or \"false\""
     fi

--- a/templates/common/_base/units/kubelet-auto-node-size.service.yaml
+++ b/templates/common/_base/units/kubelet-auto-node-size.service.yaml
@@ -11,6 +11,6 @@ contents: |
   Type=oneshot
   RemainAfterExit=yes
   EnvironmentFile=/etc/node-sizing-enabled.env
-  ExecStart=/bin/bash /usr/local/sbin/dynamic-system-reserved-calc.sh ${NODE_SIZING_ENABLED}
+  ExecStart=/bin/bash /usr/local/sbin/dynamic-system-reserved-calc.sh ${NODE_SIZING_ENABLED} ${SYSTEM_RESERVED_MEMORY} ${SYSTEM_RESERVED_CPU}
   [Install]
   RequiredBy=kubelet.service


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1946513

**- What I did**
Fix auto node sizing to honor user specified system reserved. 

**- How to verify it**
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: single-node-reserve-sys-mem
spec:
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/master: ""
  kubeletConfig: 
    systemReserved:
      memory: 3Gi
```
When the MCO has done rolling out that kubeletconfig, the node should come up with 3Gi systemd reserved. 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix Auto node sizing to honor user input