### PR TITLE
Add management workload annotations

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-machine-config-operator
     openshift.io/run-level: "1"
@@ -20,6 +21,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-openstack-infra
     openshift.io/run-level: "1"
@@ -32,6 +34,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-kni-infra
     openshift.io/run-level: "1"
@@ -44,6 +47,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-ovirt-infra
     openshift.io/run-level: "1"
@@ -56,6 +60,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-vsphere-infra
     openshift.io/run-level: "1"

--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         k8s-app: machine-config-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-operator

--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: bootstrap-machine-config-operator
   namespace: {{.TargetNamespace}}
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   initContainers:
   - name: machine-config-controller

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         k8s-app: machine-config-controller
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-controller

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
       name: machine-config-daemon
       labels:
         k8s-app: machine-config-daemon
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-daemon

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -12,6 +12,8 @@ spec:
       name: machine-config-server
       labels:
         k8s-app: machine-config-server
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-server

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -8,6 +8,8 @@ metadata:
   deletionGracePeriodSeconds: 65
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-mdns
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -8,6 +8,8 @@ metadata:
   deletionGracePeriodSeconds: 65
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-vrrp
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -90,6 +90,8 @@ kind: Pod
 metadata:
   name: bootstrap-machine-config-operator
   namespace: {{.TargetNamespace}}
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   initContainers:
   - name: machine-config-controller
@@ -808,6 +810,8 @@ spec:
     metadata:
       labels:
         k8s-app: machine-config-controller
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-controller
@@ -1102,6 +1106,8 @@ spec:
       name: machine-config-daemon
       labels:
         k8s-app: machine-config-daemon
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-daemon
@@ -1182,7 +1188,8 @@ spec:
             secretName: cookie-secret
       tolerations:
       # MCD needs to run everywhere. Tolerate all taints.
-      - operator: Exists`)
+      - operator: Exists
+`)
 
 func manifestsMachineconfigdaemonDaemonsetYamlBytes() ([]byte, error) {
 	return _manifestsMachineconfigdaemonDaemonsetYaml, nil
@@ -1438,6 +1445,8 @@ spec:
       name: machine-config-server
       labels:
         k8s-app: machine-config-server
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-server
@@ -1681,6 +1690,8 @@ metadata:
   deletionGracePeriodSeconds: 65
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-mdns
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir
@@ -1824,6 +1835,8 @@ metadata:
   deletionGracePeriodSeconds: 65
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-vrrp
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir


### PR DESCRIPTION
In support of the workload partitioning feature (https://github.com/openshift/enhancements/pull/703), we need to add annotations to all management pods and namespaces so they can be properly identified and assigned to segregated management cores on clusters configured to do so.

**- What I did**

Added the new workload identification annotations to all namespaces, pods, and pod templates to support the workload partitioning feature (https://github.com/openshift/enhancements/pull/703)

**- How to verify it**

This will be verified by the team performing the work for the workload partitioning feature; but it should be as simple as verifying that all machine-config-operator namespaces have the `workload.openshift.io/allowed: "management"` annotation, and all machine-config-operator pods running have the `workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'` annotation.

An e2e test is being worked on that will help verify this overall (https://github.com/openshift/origin/pull/25992)

**- Description for the changelog**

Added management workload identification annotations
