### PR TITLE
Bug 1899187: run afterburn-hostname only when Network Manager is up

### DIFF
--- a/templates/common/openstack/units/afterburn-hostname.service.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.service.yaml
@@ -3,6 +3,11 @@ enabled: true
 contents: |
   [Unit]
   Description=Afterburn Hostname
+  # Block services relying on Networking being up.
+  Before=network-online.target
+  # Wait for NetworkManager to report its online
+  After=NetworkManager-wait-online.service
+  # Run before hostname checks
   Before=node-valid-hostname.service
 
   [Service]


### PR DESCRIPTION
To correct setting of hostname, afterburn requires Network Manager to be up. To prevent potential race conditions this commit ensures that we start afterburn only when Network Manager is online and blocks services relying on Networking being up.