### PR TITLE
Bug 1943320: configure-ovs doesn't handle bond interfaces correctly for OVNKubernetes

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -173,6 +173,15 @@ contents:
           connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args}
       fi
 
+      # Update connections with master property set to use the new device name
+      new_device=$(nmcli --get-values connection.interface-name conn show ovs-if-phys0)
+      for conn_uuid in $(nmcli -g UUID connection show) ; do
+        if [ "$(nmcli -g connection.master connection show uuid "$conn_uuid")" != "$old_conn" ]; then
+          continue
+        fi
+        nmcli conn mod uuid ${conn_uuid} connection.master ${new_device}
+      done
+
       nmcli conn up ovs-if-phys0
 
       if ! nmcli connection show ovs-if-br-ex &> /dev/null; then


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

update all existing connection with master set to use the new devices name.

**- What I did**
Walk through all existing connection and modify any connection with master to use the new connection device's name.

**- How to verify it**
follow repro steps doc in 1943320

**- Description for the changelog**
update connection UUID for bond interfaces for OVNKubernetes