### PR TITLE
Bug 1942488: Use new --prefer-ipv6 flag to "runtimecfg node-ip" as appropriate

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -21,7 +21,11 @@ contents: |
     --volume /etc/systemd/system:/etc/systemd/system:z \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
-    set --retry-on-failure; \
+    set \
+    {{if eq .IPFamilies "IPv6" -}}
+    --prefer-ipv6 \
+    {{end -}}
+    --retry-on-failure; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
4.7 backport of #2478 