### PR TITLE
Bug 1949387: Fix the typo in reserved calculation in auto sizing script

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -37,7 +37,7 @@ contents:
             recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 6.72 | awk '{print $1 + $2}')
             total_memory=$((total_memory-112))
         fi
-        if (($total_memory >= 128)); then # 2% of any memory above 128GB
+        if (($total_memory >= 0)); then # 2% of any memory above 128GB
             recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.02 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
         fi
         echo "SYSTEM_RESERVED_MEMORY=${recommended_systemreserved_memory}Gi">> ${NODE_SIZES_ENV}
@@ -46,15 +46,16 @@ contents:
         total_cpu=$(getconf _NPROCESSORS_ONLN)
         recommended_systemreserved_cpu=0
         if (($total_cpu <= 1)); then # 6% of the first core
-            recommended_systemreserved_cpu=$(echo $total_cpu 0.60 | awk '{print $1 * $2}')
+            recommended_systemreserved_cpu=$(echo $total_cpu 0.06 | awk '{print $1 * $2}')
             total_cpu=0
         else
             recommended_systemreserved_cpu=0.06
             total_cpu=$((total_cpu-1))
         fi
         if (($total_cpu <= 1)); then # 1% of the next core (up to 2 cores)
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.10 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_cpu=0 else
+            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+            total_cpu=0
+        else
             recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
             total_cpu=$((total_cpu-1))
         fi
@@ -65,7 +66,7 @@ contents:
             recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
             total_cpu=$((total_cpu-2))
         fi
-        if (($total_cpu >= 4)); then # 0.25% of any cores above 4 cores
+        if (($total_cpu >= 0)); then # 0.25% of any cores above 4 cores
             recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.0025 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
         fi
         echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}">> ${NODE_SIZES_ENV}


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Fixes : https://bugzilla.redhat.com/show_bug.cgi?id=1949387

**- What I did**
Fixed the typo in auto node sizing script

**- How to verify it**
Enable auto node sizing where `getconf _NPROCESSORS_ONLN` is 2, and the auto node sizing should not fail. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix the typo reserved cpu calculation in auto sizing script