### PR TITLE
Bug 1949664: [on-prem] Disable liveness probe until keepalived.conf exists

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -125,7 +125,7 @@ contents:
             - /bin/bash
             - -c
             - |
-              echo "State = FAULT" > /tmp/keepalived.data && kill -s SIGUSR1 "$(pgrep -o keepalived)" && for i in $(seq 5); do grep -q "State = FAULT" /tmp/keepalived.data && sleep 1 || exit 0; done && exit 1
+              [ ! -s "/etc/keepalived/keepalived.conf" ] || (echo "State = FAULT" > /tmp/keepalived.data && kill -s SIGUSR1 "$(pgrep -o keepalived)" && for i in $(seq 5); do grep -q "State = FAULT" /tmp/keepalived.data && sleep 1 || exit 0; done && exit 1)
           initialDelaySeconds: 20
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Keepalived doesn't necessarily start immediately when its container
is created. It waits until keepalived.conf exists. In some case,
it takes longer for the config file to be created than for the
liveness probe to time out, which triggers unnecessary restarts of
the container. Once the monitor populates keepalived.conf it will
send the reload command, which starts keepalived.

This change just adds a check for the keepalived.conf file to the
liveness probe. This way, the liveness probe will always succeed
until keepalived.conf is created.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
