### PR TITLE
Bug 1950112: properly return error in failed podman cp

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -270,6 +270,9 @@ func podmanCopy(imgURL, osImageContentDir string) (err error) {
 	cid := strings.TrimSpace(string(cidBuf))
 	args = []string{"cp", fmt.Sprintf("%s:/", cid), osImageContentDir}
 	_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
+	if err != nil {
+		return
+	}
 
 	// Set selinux context to var_run_t to avoid selinux denial
 	args = []string{"-R", "-t", "var_run_t", osImageContentDir}


### PR DESCRIPTION
Return the error if the podman cp fails during a failed OS update,
instead of continuing on and having the next chcon command error
being reported to the operator status.

For the linked bug, it is a bit odd because I think if the command did
fail, the MCD should have logged warnings. Regardless, we should
try to return the error if it occurs.