### PR TITLE
Rename workload annotations

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-app: machine-config-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-operator

--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: bootstrap-machine-config-operator
   namespace: {{.TargetNamespace}}
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   initContainers:
   - name: machine-config-controller

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         k8s-app: machine-config-controller
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-controller

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         k8s-app: machine-config-daemon
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-daemon

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         k8s-app: machine-config-server
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-server

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-mdns
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-vrrp
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -91,7 +91,7 @@ metadata:
   name: bootstrap-machine-config-operator
   namespace: {{.TargetNamespace}}
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   initContainers:
   - name: machine-config-controller
@@ -811,7 +811,7 @@ spec:
       labels:
         k8s-app: machine-config-controller
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-controller
@@ -1107,7 +1107,7 @@ spec:
       labels:
         k8s-app: machine-config-daemon
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-daemon
@@ -1446,7 +1446,7 @@ spec:
       labels:
         k8s-app: machine-config-server
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: machine-config-server
@@ -1691,7 +1691,7 @@ metadata:
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-mdns
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir
@@ -1836,7 +1836,7 @@ metadata:
   labels:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-vrrp
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
   - name: resource-dir


### PR DESCRIPTION
**- What I did**

As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

**- How to verify it**

As before, this will be verified via a an e2e test in CI still under development.

**- Description for the changelog**

None (fix to previous change)

/hold
Hold until after openshift/kubernetes#632 is merged please