### PR TITLE
Bug 1934176: ensure SSH key uniqueness

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -479,7 +479,8 @@ func removeIgnDuplicateFilesUnitsUsers(ignConfig ign2types.Config) (ign2types.Co
 				outUser.SSHAuthorizedKeys = append(outUser.SSHAuthorizedKeys, users[i].SSHAuthorizedKeys[j])
 			}
 		}
-		ignConfig.Passwd.Users = []ign2types.PasswdUser{outUser}
+		// Ensure SSH key uniqueness
+		ignConfig.Passwd.Users = []ign2types.PasswdUser{dedupePasswdUserSSHKeys(outUser)}
 	}
 
 	// outFiles and outUnits should now have all duplication removed
@@ -590,4 +591,31 @@ func GetManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interfac
 	}
 	err = client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), deprecatedKey, metav1.DeleteOptions{})
 	return managedKey, err
+}
+
+// Ensures SSH keys are unique for a given Ign 2 PasswdUser
+// See: https://bugzilla.redhat.com/show_bug.cgi?id=1934176
+func dedupePasswdUserSSHKeys(passwdUser ign2types.PasswdUser) ign2types.PasswdUser {
+	// Map for checking for duplicates.
+	knownSSHKeys := map[ign2types.SSHAuthorizedKey]bool{}
+
+	// Preserve ordering of SSH keys.
+	dedupedSSHKeys := []ign2types.SSHAuthorizedKey{}
+
+	for _, sshKey := range passwdUser.SSHAuthorizedKeys {
+		if _, isKnown := knownSSHKeys[sshKey]; isKnown {
+			// We've seen this key before warn and move on.
+			glog.Warningf("duplicate SSH public key found: %s", sshKey)
+			continue
+		}
+
+		// We haven't seen this key before, add it.
+		dedupedSSHKeys = append(dedupedSSHKeys, sshKey)
+		knownSSHKeys[sshKey] = true
+	}
+
+	// Overwrite the keys with the deduped list.
+	passwdUser.SSHAuthorizedKeys = dedupedSSHKeys
+
+	return passwdUser
 }

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -61,6 +61,7 @@ func TestValidateIgnition(t *testing.T) {
 func TestConvertIgnition2to3(t *testing.T) {
 	// Make a new Ign spec v2 config
 	testIgn2Config := ign2types.Config{}
+
 	tempUser := ign2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ign2types.SSHAuthorizedKey{"5678", "abc"}}
 	testIgn2Config.Passwd.Users = []ign2types.PasswdUser{tempUser}
 	testIgn2Config.Ignition.Version = "2.2.0"
@@ -99,7 +100,12 @@ func TestParseAndConvert(t *testing.T) {
 
 	// Make a Ign2 comp config
 	testIgn2Config := ign2types.Config{}
-	tempUser2 := ign2types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ign2types.SSHAuthorizedKey{"5678", "abc"}}
+	tempUser2SSHKeys := []ign2types.SSHAuthorizedKey{
+		"5678",
+		"5678", // Purposely duplicated.
+		"abc",
+	}
+	tempUser2 := ign2types.PasswdUser{Name: "core", SSHAuthorizedKeys: tempUser2SSHKeys}
 	testIgn2Config.Passwd.Users = []ign2types.PasswdUser{tempUser2}
 	testIgn2Config.Ignition.Version = "2.2.0"
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1934176

**- What I did**
I added some code to `pkg/controller/common/helpers.go` to ensure that when Ignition 2 configs are converted to Ignition 3, all `PasswdUser` objects contain per-user-unique `AuthorizedSSHKey`. Not ensuring the SSH keys are unique results in a degraded state for the MCO.

**- How to verify it**

**- Description for the changelog**
Ensures SSH keys are unique for translation from Ignition 2 to Ignition 3.