### PR TITLE
Bug 1950974: change system-connections-merged directory to systemConnectionsMerged

### DIFF
--- a/templates/common/_base/files/NetworkManager-keyfiles.yaml
+++ b/templates/common/_base/files/NetworkManager-keyfiles.yaml
@@ -3,5 +3,5 @@ path: "/etc/NetworkManager/conf.d/99-keyfiles.conf"
 contents:
   inline: |
     [keyfile]
-    path=/etc/NetworkManager/system-connections-merged
+    path=/etc/NetworkManager/systemConnectionsMerged
 

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -12,7 +12,7 @@ contents:
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
     copy_nm_conn_files() {
-      src_path="/etc/NetworkManager/system-connections-merged"
+      src_path="/etc/NetworkManager/systemConnectionsMerged"
       dst_path="/etc/NetworkManager/system-connections"
       if [ -d $src_path ]; then
         echo "$src_path exists"
@@ -48,8 +48,8 @@ contents:
           ifconfig "$intf" allmulti
         fi
       }
-      if [ -d "/etc/NetworkManager/system-connections-merged" ]; then
-        NM_CONN_PATH="/etc/NetworkManager/system-connections-merged"
+      if [ -d "/etc/NetworkManager/systemConnectionsMerged" ]; then
+        NM_CONN_PATH="/etc/NetworkManager/systemConnectionsMerged"
       else
         NM_CONN_PATH="/etc/NetworkManager/system-connections"
       fi

--- a/templates/common/_base/files/nm-tmpfiles.yaml
+++ b/templates/common/_base/files/nm-tmpfiles.yaml
@@ -4,5 +4,5 @@ contents:
   inline: |
     D /run/nm-system-connections 0755 root root - -
     D /run/nm-system-connections-work 0755 root root - -
-    d /etc/NetworkManager/system-connections-merged 0755 root root - -
+    d /etc/NetworkManager/systemConnectionsMerged 0755 root root - -
 

--- a/templates/common/_base/units/nm-system-connections-mount.yaml
+++ b/templates/common/_base/units/nm-system-connections-mount.yaml
@@ -1,11 +1,11 @@
-name: etc-NetworkManager-system\x2dconnections\x2dmerged.mount
+name: etc-NetworkManager-systemConnectionsMerged.mount
 enabled: true
 contents: |
   [Unit]
   Before=NetworkManager.service
   After=systemd-tmpfiles-setup.service
   [Mount]
-  Where=/etc/NetworkManager/system-connections-merged
+  Where=/etc/NetworkManager/systemConnectionsMerged
   What=overlay
   Type=overlay
   Options=lowerdir=/etc/NetworkManager/system-connections,upperdir=/run/nm-system-connections,workdir=/run/nm-system-connections-work

--- a/templates/common/baremetal/files/NetworkManager-static-dhcp.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcp.yaml
@@ -63,7 +63,7 @@ contents:
     nmcli con up "$STATIC_INT_NAME"
 
     # Copy it from the OverlayFS mount to the persistent lowerdir
-    cp "/etc/NetworkManager/system-connections-merged/${STATIC_INT_NAME}.nmconnection" /etc/NetworkManager/system-connections
+    cp "/etc/NetworkManager/systemConnectionsMerged/${STATIC_INT_NAME}.nmconnection" /etc/NetworkManager/system-connections
 
     if [ -n "${DHCP4_HOST_NAME:-}" ]
     then


### PR DESCRIPTION
Looks like there is a bug in 8.4 systemd which causes the system-connections-merged mount unit to not be enabled. On further investigation looks like systemd does not like the `\x2d` character when enabling presets. While this issue needs to be investigated by the systemd folks, changing the name here so that UPI baremetal deploys can succeed.