### PR TITLE
Bug 1931505: [On-prem] - fix vip filtering syntax for Keepalived remove-vips

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -100,8 +100,8 @@ contents:
           remove_vip()
           {
             address=$1
-            interface=$(ip -o a | grep '\s${address}/' | awk '{print $2}')
-            cidr=$(ip -o a | grep '\s${address}/' | awk '{print $4}')
+            interface=$(ip -o a | awk "/\s${address}\// {print \$2}")
+            cidr=$(ip -o a | awk "/\s${address}\// {print \$4}")
             if [ -n "$interface" ]; then
                 ip a del $cidr dev $interface
             fi


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1931505  reproduced in QE folks environments even with the latest version,
seems that changing vip filtering syntax solved the problem locally.