### PR TITLE
[on-prem] Test - change keepalived VIP filtering syntax

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -100,8 +100,8 @@ contents:
           remove_vip()
           {
             address=$1
-            interface=$(ip -o a | grep '\s${address}/' | awk '{print $2}')
-            cidr=$(ip -o a | grep '\s${address}/' | awk '{print $4}')
+            interface=$(ip -o a | grep "\s${address}/" | awk '{print $2}')
+            cidr=$(ip -o a | grep "\s${address}/" | awk '{print $4}')
             if [ -n "$interface" ]; then
                 ip a del $cidr dev $interface
             fi
@@ -117,7 +117,7 @@ contents:
           export -f reload_keepalived
           export -f sigterm_handler
 
-          trap sigterm_handler SIGTERM
+          #trap sigterm_handler SIGTERM
           if [ -s "/etc/keepalived/keepalived.conf" ]; then
               /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
           fi


### PR DESCRIPTION
Keepalived - Check CI gates when filtering VIP using grep with " instead of ' 