### PR TITLE
Bug 1943539: templates: order service files that use podman around crio-wipe

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -8,8 +8,7 @@ contents: |
   # Removal of this file signals firstboot completion
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
   After=machine-config-daemon-pull.service
-  Before=crio.service crio-wipe.service
-  Before=kubelet.service
+  Before=crio.service kubelet.service
 
   [Service]
   Type=oneshot

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -8,8 +8,9 @@ contents: |
   # This "stamp file" is unlinked when we complete
   # machine-config-daemon-firstboot.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
-  Wants=network-online.target
-  After=network-online.target
+  # Run after crio-wipe so the pulled MCD image is protected against a corrupted storage from a forced shutdown
+  Wants=network-online.target crio-wipe.service
+  After=network-online.target crio-wipe.service
 
   [Service]
   Type=oneshot

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -3,8 +3,8 @@ enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{en
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
-  Wants=network-online.target
-  After=network-online.target ignition-firstboot-complete.service
+  Wants=network-online.target crio-wipe.service
+  After=network-online.target ignition-firstboot-complete.service crio-wipe.service
   Before=kubelet.service crio.service
 
   [Service]

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -6,8 +6,8 @@ contents: |
   # This only applies to VIP managing environments where the kubelet and crio IP
   # address picking logic is flawed and may end up selecting an address from a
   # different subnet or a deprecated address
-  Wants=network-online.target
-  After=network-online.target ignition-firstboot-complete.service
+  Wants=network-online.target crio-wipe.service
+  After=network-online.target ignition-firstboot-complete.service crio-wipe.service
   Before=kubelet.service crio.service
 
   [Service]


### PR DESCRIPTION
or else they may race against each other, causing issues with crio-wipe running on a forced shutdown

both machine-config-daemon-pull.service and nodeip-configuration.service must run after crio wipe runs, to protect against a corrupted image storage from a forced reboot


Signed-off-by: Peter Hunt <pehunt@redhat.com>
