### PR TITLE
Fix podman CP for OS extract

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -242,6 +242,13 @@ func podmanCopy(imgURL, osImageContentDir string) (err error) {
 	// make sure that osImageContentDir doesn't exist
 	os.RemoveAll(osImageContentDir)
 
+	// recreate the folder to prevent podman to copy the files into the parent directory
+	// https://github.com/containers/podman/pull/9630/commits/31b11b5cd62093d86891d32e0912661814d6b78b
+	if err = os.MkdirAll(osImageContentDir, 0755); err != nil {
+		err = fmt.Errorf("error creating directory %s: %v", osImageContentDir, err)
+		return
+	}
+
 	// Pull the container image
 	var authArgs []string
 	if _, err := os.Stat(kubeletAuthFile); err == nil {


### PR DESCRIPTION
This commit fix the the fallback podman extract OS by

logs

```
I0429 14:53:05.046167  752470 run.go:18] Running: nice -- ionice -c 3 oc image extract --path /:/run/mco-machine-os-content/os-content-215884633 --registry-config /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:826588080c4a98587f2cb45be94d9f162df2cfb3e988dd1de2e4d49de7a96aa3
error: unable to connect to image repository quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:826588080c4a98587f2cb45be94d9f162df2cfb3e988dd1de2e4d49de7a96aa3: Get "https://quay.io/v2/": dial tcp 34.224.196.162:443: connect: network is unreachable
W0429 14:53:05.101961  752470 run.go:44] nice failed: running nice -- ionice -c 3 oc image extract --path /:/run/mco-machine-os-content/os-content-215884633 --registry-config /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:826588080c4a98587f2cb45be94d9f162df2cfb3e988dd1de2e4d49de7a96aa3 failed: error: unable to connect to image repository quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:826588080c4a98587f2cb45be94d9f162df2cfb3e988dd1de2e4d49de7a96aa3: Get "https://quay.io/v2/": dial tcp 34.224.196.162:443: connect: network is unreachable
: exit status 1; retrying...
I0429 14:53:05.101990  752470 update.go:314] Falling back to using podman cp to fetch OS image content
I0429 14:53:05.102021  752470 run.go:18] Running: nice -- ionice -c 3 podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:826588080c4a98587f2cb45be94d9f162df2cfb3e988dd1de2e4d49de7a96aa3
d341d1cabe18c3ca6b1295549c2b81a09afa0bbddaeb5bde42ee72605760d77a
I0429 14:53:05.330641  752470 rpm-ostree.go:258] Running captured: podman create --net=none --annotation=org.openshift.machineconfigoperator.pivot=true --name ostree-container-pivot-77405bf3-4e66-44b3-a93f-e6bc70dd8cc1 quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:826588080c4a98587f2cb45be94d9f162df2cfb3e988dd1de2e4d49de7a96aa3
I0429 14:53:05.496648  752470 run.go:18] Running: nice -- ionice -c 3 podman cp 770bc9d09df714fc17edb14ad108ab932855346abd01240161567b33dfa548b1:/ /run/mco-machine-os-content/os-content-215884633
I0429 14:53:10.086698  752470 rpm-ostree.go:258] Running captured: chcon -R -t var_run_t /run/mco-machine-os-content/os-content-215884633
I0429 14:53:10.087770  752470 update.go:278] Error changing selinux context on path /run/mco-machine-os-content/os-content-215884633  error running chcon -R -t var_run_t /run/mco-machine-os-content/os-content-215884633: chcon: cannot access '/run/mco-machine-os-content/os-content-215884633': No such file or directory
: exit status 1

```

related to https://github.com/containers/podman/commit/31b11b5cd62093d86891d32e0912661814d6b78b

podman version

```
Version:      3.0.2-dev
API Version:  3.0.0
Go Version:   go1.15.7
Built:        Tue Mar  2 15:10:06 2021
OS/Arch:      linux/amd64
```

```
ls -la /tmp/os/
total 0
drwxr-xr-x. 2 root root  40 Apr 29 16:06 .
drwxrwxrwt. 9 root root 200 Apr 29 16:07 ..

podman cp 33db16462dd1e99962991c4b05d7d2927bdd30939933ffbf69996785c5266529:/ /tmp/os/os-content-176563952

ls -la /tmp/os/
total 20
drwxr-xr-x. 19 root root   480 Apr 29 16:08 .
drwxrwxrwt.  9 root root   200 Apr 29 16:08 ..
lrwxrwxrwx.  1 root root     7 Apr 23  2020 bin -> usr/bin
dr-xr-xr-x.  2 root root    40 Apr 23  2020 boot
drwxr-xr-x.  2 root root    40 Mar 30 18:28 dev
drwxr-xr-x. 46 root root  2360 Mar 30 18:30 etc
drwxr-xr-x.  3 root root   580 Apr 17 13:50 extensions
drwxr-xr-x.  2 root root    40 Apr 23  2020 home
lrwxrwxrwx.  1 root root     7 Apr 23  2020 lib -> usr/lib
lrwxrwxrwx.  1 root root     9 Apr 23  2020 lib64 -> usr/lib64
drwx------.  2 root root    40 Mar 30 18:28 lost+found
drwxr-xr-x.  2 root root    40 Apr 23  2020 media
drwxr-xr-x.  2 root root    40 Apr 23  2020 mnt
drwxr-xr-x.  2 root root    40 Apr 23  2020 opt
-rw-r--r--.  1 root root 18405 Apr 17 13:50 pkglist.txt
drwxr-xr-x.  2 root root    40 Mar 30 18:28 proc
dr-xr-x---.  3 root root   240 Mar 30 18:30 root
drwxr-xr-x.  4 root root    80 Mar 30 18:30 run
lrwxrwxrwx.  1 root root     8 Apr 23  2020 sbin -> usr/sbin
drwxr-xr-x.  3 root root    60 Apr 17 13:50 srv
drwxr-xr-x.  2 root root    40 Mar 30 18:28 sys
drwxrwxrwt.  2 root root    60 Mar 30 18:30 tmp
drwxr-xr-x. 12 root root   260 Mar 30 18:28 usr
drwxr-xr-x. 19 root root   440 Mar 30 18:29 var

```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

