### PR TITLE
DO NOT MERGE: Should openshift-gcp-routes.service be tied as network?

### DIFF
--- a/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
+++ b/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
@@ -7,6 +7,7 @@ contents: |
   ConditionKernelCommandLine=|ignition.platform.id=gcp
   Wants=network-online.target
   After=network-online.target
+  PartOf=network.target
 
   [Service]
   Type=simple


### PR DESCRIPTION
Testing theory that openshift-gcp-routes needs to be shutdown after
all pods are stopped (which includes apiserver), currently it is
shutdown at the same time.


<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->