### PR TITLE
Bug 1952358: vSphere platform none vmxnet3v4 fix

### DIFF
--- a/templates/common/none/OWNERS
+++ b/templates/common/none/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers
+reviewers:
+  - vsphere-reviewers

--- a/templates/common/none/files/vsphere-disable-vmxnet3v4-features.yaml
+++ b/templates/common/none/files/vsphere-disable-vmxnet3v4-features.yaml
@@ -1,0 +1,17 @@
+filesystem: "root"
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/99-vsphere-disable-tx-udp-tnl"
+contents:
+    inline: |
+      #!/bin/bash
+      # Workaround:
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1941714
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+
+      driver=$(nmcli -t -m tabular -f general.driver dev show "${DEVICE_IFACE}")
+
+      if [[ "$2" == "up" && "${driver}" == "vmxnet3" ]]; then
+        logger -s "99-vsphere-disable-tx-udp-tnl triggered by ${2} on device ${DEVICE_IFACE}."
+        ethtool -K ${DEVICE_IFACE} tx-udp_tnl-segmentation off
+        ethtool -K ${DEVICE_IFACE} tx-udp_tnl-csum-segmentation off
+      fi


### PR DESCRIPTION
This adds `templates/common/none` directory
with the fix `platform: vsphere` for vmxnet3 v4.
