### PR TITLE
Bug 1944605: Use recommended retry intervals

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -341,7 +341,7 @@ func (ctrl *Controller) generateOriginalKubeletConfig(role string) (*ign3types.F
 }
 
 func (ctrl *Controller) syncStatusOnly(cfg *mcfgv1.KubeletConfig, err error, args ...interface{}) error {
-	statusUpdateError := retry.RetryOnConflict(updateBackoff, func() error {
+	statusUpdateError := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		newcfg, getErr := ctrl.mckLister.Get(cfg.Name)
 		if getErr != nil {
 			return getErr


### PR DESCRIPTION
Fix bug 1944605. The nodes get stuck after applying the kubeletconfig,
the log has timeout error requesting data from the node.
use recommended retry intervals for possible timeout errors. I am not sure
if this will fix the bug since there's no way to reproduce.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
