### PR TITLE
Bug 1956372: gcp-routes should wait until network is stopped

### DIFF
--- a/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
+++ b/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
@@ -5,8 +5,7 @@ contents: |
   Description=Update GCP routes for forwarded IPs.
   ConditionKernelCommandLine=|ignition.platform.id=gce
   ConditionKernelCommandLine=|ignition.platform.id=gcp
-  Wants=network-online.target
-  After=network-online.target
+  Before=network-online.target
 
   [Service]
   Type=simple
@@ -18,3 +17,5 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
+  # Ensure that network-online.target will not complete until the node has working external LBs.
+  RequiredBy=network-online.target


### PR DESCRIPTION
The gcp-routes script handles the traffic from external LB
directed to the node, hence, it should start before the network
is up, and it should exit after the network goes down.