### PR TITLE
Bug 1947066: Allow wildcard in noProxy field

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
           {{end}}
           {{if .ControllerConfig.Proxy.NoProxy}}
           - name: NO_PROXY
-            value: {{.ControllerConfig.Proxy.NoProxy}}
+            value: "{{.ControllerConfig.Proxy.NoProxy}}"
           {{end}}
           {{end}}
       - name: oauth-proxy

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1141,7 +1141,7 @@ spec:
           {{end}}
           {{if .ControllerConfig.Proxy.NoProxy}}
           - name: NO_PROXY
-            value: {{.ControllerConfig.Proxy.NoProxy}}
+            value: "{{.ControllerConfig.Proxy.NoProxy}}"
           {{end}}
           {{end}}
       - name: oauth-proxy


### PR DESCRIPTION
If a wildcard (*) is used in the `noProxy` field, it is not properly quoted before being rendered into YAML, causing `resourceread.ReadDaemonSetV1OrDie()` to fail because the rendered YAML was `noProxy: *` instead of `noProxy: "*"`.

The reason for the read failure is because an unquoted asterisk has special meaning in YAML, typically used to repeat other sections (which we're not doing here).

Fixes: #1947066

**- What I did**
I added quotes to the `manifests/machineconfigdaemon/daemonset.yaml` file around the optional `noProxy` field.

**- How to verify it**
I've updated the unit test suite `pkg/operator/render_test.go` to read the rendered templates using the appropriate `resourceread` function.

**- Description for the changelog**
Allow wildcard (*) in noProxy field