### PR TITLE
Bug 1957015: [on-prem] Backport duplicate VIP fixes

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -90,7 +90,21 @@ contents:
             done
           }
 
+          remove_vip()
+          {
+            address=$1
+            interface=$(ip -o a | grep '\s${address}/' | awk '{print $2}')
+            cidr=$(ip -o a | grep '\s${address}/' | awk '{print $4}')
+            if [ -n "$interface" ]; then
+                ip a del $cidr dev $interface
+            fi
+          }
+
           set -ex
+          # Ensure that we don't have stale VIPs configured
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=1931505
+          remove_vip "{{ onPremPlatformAPIServerInternalIP . }}"
+          remove_vip "{{ onPremPlatformIngressIP . }}"
           declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
           export -f msg_handler
           export -f reload_keepalived

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -93,8 +93,8 @@ contents:
           remove_vip()
           {
             address=$1
-            interface=$(ip -o a | grep '\s${address}/' | awk '{print $2}')
-            cidr=$(ip -o a | grep '\s${address}/' | awk '{print $4}')
+            interface=$(ip -o a | awk "/\s${address}\// {print \$2}")
+            cidr=$(ip -o a | awk "/\s${address}\// {print \$4}")
             if [ -n "$interface" ]; then
                 ip a del $cidr dev $interface
             fi


### PR DESCRIPTION
**- What I did**
This is a combined backport of the fixes in #2511 and #2548 . It works around a bug in keepalived that could cause duplicate VIPs to be assigned to nodes.

**- How to verify it**
Deploy a cluster. When this bug occurs, operators like console and authentication fail to deploy because they can't talk to the ingress VIP correctly.

**- Description for the changelog**
Fix an intermittent issue with VIPs being duplicated across multiple nodes.
