### PR TITLE
Bug 1948533: Add nodeip-configuration.service for oVirt

### DIFF
--- a/templates/common/ovirt/units/nodeip-configuration.service.yaml
+++ b/templates/common/ovirt/units/nodeip-configuration.service.yaml
@@ -1,0 +1,78 @@
+name: nodeip-configuration.service
+enabled: {{if .Infra -}}
+         {{if .Infra.Status -}}
+         {{if .Infra.Status.PlatformStatus -}}
+         {{if .Infra.Status.PlatformStatus.Ovirt -}}
+         {{if .Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP -}}
+         true
+         {{- else -}}
+         false
+         {{- end -}}
+         {{- else -}}
+         false
+         {{- end -}}
+         {{- else -}}
+         false
+         {{- end -}}
+         {{- else -}}
+         false
+         {{- end -}}
+         {{- else -}}
+         false
+         {{- end }}
+contents: |
+  [Unit]
+  Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
+  # This only applies to VIP managing environments where the kubelet and crio IP
+  # address picking logic is flawed and may end up selecting an address from a
+  # different subnet or a deprecated address
+  Wants=network-online.target
+  After=network-online.target ignition-firstboot-complete.service
+  Before=kubelet.service crio.service
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  {{ if .Infra -}}
+  {{ if .Infra.Status -}}
+  {{ if .Infra.Status.PlatformStatus -}}
+  {{ if .Infra.Status.PlatformStatus.Ovirt -}}
+  {{ if .Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP -}}
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
+    --authfile /var/lib/kubelet/config.json \
+    --volume /etc/systemd/system:/etc/systemd/system:z \
+    --net=host \
+    {{ .Images.baremetalRuntimeCfgImage }} \
+    node-ip \
+    set --retry-on-failure \
+    {{.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIP }}; \
+    do \
+    sleep 5; \
+    done"
+  {{ end -}}
+  {{ end -}}
+  {{ end -}}
+  {{ end -}}
+  {{ end -}}
+  ExecStart=/bin/systemctl daemon-reload
+
+  {{if .Proxy -}}
+  {{if .Proxy.HTTPProxy -}}
+  Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+  {{end -}}
+  {{if .Proxy.HTTPSProxy -}}
+  Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+  {{end -}}
+  {{if .Proxy.NoProxy -}}
+  Environment=NO_PROXY={{.Proxy.NoProxy}}
+  {{end -}}
+  {{end -}}
+
+  [Install]
+  WantedBy=multi-user.target
+


### PR DESCRIPTION
**- What I did**

This change adds the nodeip-configuration.service to the oVirt platform.
On 4.7 due to the unification of the unit files of each on prem platform to the "on-prem" directory oVirt got the "nodeip-configuration.service" file but on 4.6 release we are missing it which can cause hard to debug problems to customers.

This change also adds fixes for BZ#1940939 https://github.com/openshift/machine-config-operator/pull/2470

** I was not able to reproduce the issue on BZ#1948533 but this change seems relevant and according to the comments on BZ#1948533 will fix the issues

**- How to verify it**
Install a 4.6 ovirt cluster

**- Description for the changelog**
<!--
Add nodeip-configuration.service for oVirt platform
-->