### PR TITLE
Bug 1957374: install: Automatically fill in the pod for MCDDrainError

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -29,7 +29,7 @@ spec:
             severity: warning
           for: 15m
           annotations:
-            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details:  oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon"
+            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon"
     - name: mcd-pivot-error
       rules:
         - alert: MCDPivotError


### PR DESCRIPTION
Instead of asking folks to look up the pod using the node name, use the pod label that the Prometheus scraper adds automatically when scraping metrics off the daemon pod.  While I'm touching this, I'm pivoting to the automatic label for the namespace as well, even though that is very unlikely to change.  The container being scraped is `oauth-proxy`, so I'm leaving the target container hard-coded to `machine-config-daemon`, since that's where the interesting logs are.