### PR TITLE
Bug 1955517: Add cleanUpDuplicatedMC

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -616,8 +616,36 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		}
 		glog.Infof("Applied ContainerRuntimeConfig %v on MachineConfigPool %v", key, pool.Name)
 	}
+	if err := ctrl.cleanUpDuplicatedMC(); err != nil {
+		return err
+	}
 
 	return ctrl.syncStatusOnly(cfg, nil)
+}
+
+// cleanUpDuplicatedMC removes the MC of uncorrected version if format of its name contains 'generated-xxx'.
+// BZ 1955517: upgrade when there are more than one configs, these generated MC will be duplicated
+// by upgraded MC with number suffixed name (func getManagedKeyCtrCfg()) and fails the upgrade.
+func (ctrl *Controller) cleanUpDuplicatedMC() error {
+	generatedCtrCfg := "generated-containerruntime"
+	// Get all machine configs
+	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing containerruntime machine configs: %v", err)
+	}
+	for _, mc := range mcList.Items {
+		if !strings.Contains(mc.Name, generatedCtrCfg) {
+			continue
+		}
+		// delete the containerruntime mc if its degraded
+		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil {
+				return fmt.Errorf("error deleting degraded containerruntime machine config %s: %v", mc.Name, err)
+			}
+
+		}
+	}
+	return nil
 }
 
 // mergeConfigChanges retrieves the original/default config data from the templates, decodes it and merges in the changes given by the Custom Resource.

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -37,6 +37,7 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
@@ -955,4 +956,59 @@ func getKey(config *mcfgv1.ContainerRuntimeConfig, t *testing.T) string {
 		return ""
 	}
 	return key
+}
+
+// TestCleanUpDuplicatedMC test the function removes the MC from the MC list
+// if the MC is of old version.
+func TestCleanUpDuplicatedMC(t *testing.T) {
+	v := version.Hash
+	version.Hash = "3.2.0"
+	versionDegrade := "3.1.0"
+	defer func() {
+		version.Hash = v
+	}()
+	f := newFixture(t)
+	ctrl := f.newController()
+	// wrong version needs to be removed
+	machineConfigDegrade := mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "generated-containerruntime", UID: types.UID(utilrand.String(5))},
+	}
+	machineConfigDegrade.Annotations = make(map[string]string)
+	machineConfigDegrade.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+	ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigDegrade, metav1.CreateOptions{})
+
+	// not generated machine config should stay
+	machineConfigDegradeNotGen := mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-containerruntime", UID: types.UID(utilrand.String(5))},
+	}
+	machineConfigDegradeNotGen.Annotations = make(map[string]string)
+	machineConfigDegradeNotGen.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+	ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigDegradeNotGen, metav1.CreateOptions{})
+
+	// upgraded MC
+	machineConfigUpgrade := mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "generated-containerruntime-1", UID: types.UID(utilrand.String(5))},
+	}
+	machineConfigUpgrade.Annotations = make(map[string]string)
+	machineConfigUpgrade.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = version.Hash
+	ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigUpgrade, metav1.CreateOptions{})
+
+	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, mcList.Items, 3)
+
+	ctrl.cleanUpDuplicatedMC()
+	// successful test: ony custom and upgraded MCs stay
+	mcList, err = ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, mcList.Items, 2)
+	actual := make(map[string]mcfgv1.MachineConfig)
+	for _, mc := range mcList.Items {
+		require.GreaterOrEqual(t, len(mc.Annotations), 1)
+		actual[mc.Name] = mc
+	}
+	_, ok := actual[machineConfigDegradeNotGen.Name]
+	require.True(t, ok, "expect custom-containerruntime in the list, but got false")
+	_, ok = actual[machineConfigUpgrade.Name]
+	require.True(t, ok, "expect generated-containerruntime-1 in the list, but got false")
 }

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -159,6 +159,7 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		}
 		val, ok := kc.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
 		// If we find a matching kubelet config and it is the only one in the list, then return the default MC name with no suffix
+		// add check len(kcList.Items) < 2, mc name should not suffixed if cfg is the first kubelet config to be updated/created
 		if !ok && len(kcList.Items) < 2 {
 			return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -1,6 +1,7 @@
 package kubeletconfig
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	oseconfigfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	oseinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +32,7 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
@@ -742,4 +745,59 @@ func TestCleanUpStatusConditions(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestCleanUpDuplicatedMC test the function removes the MC from the MC list
+// if the MC is of old version.
+func TestCleanUpDuplicatedMC(t *testing.T) {
+	v := version.Hash
+	version.Hash = "3.2.0"
+	versionDegrade := "3.1.0"
+	defer func() {
+		version.Hash = v
+	}()
+	f := newFixture(t)
+	ctrl := f.newController()
+	// wrong version needs to be removed
+	machineConfigDegrade := mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "generated-kubelet", UID: types.UID(utilrand.String(5))},
+	}
+	machineConfigDegrade.Annotations = make(map[string]string)
+	machineConfigDegrade.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+	ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigDegrade, metav1.CreateOptions{})
+
+	// not generated machine config should stay
+	machineConfigDegradeNotGen := mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-kubelet", UID: types.UID(utilrand.String(5))},
+	}
+	machineConfigDegradeNotGen.Annotations = make(map[string]string)
+	machineConfigDegradeNotGen.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+	ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigDegradeNotGen, metav1.CreateOptions{})
+
+	// upgraded MC
+	machineConfigUpgrade := mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "generated-kubelet-1", UID: types.UID(utilrand.String(5))},
+	}
+	machineConfigUpgrade.Annotations = make(map[string]string)
+	machineConfigUpgrade.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = version.Hash
+	ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigUpgrade, metav1.CreateOptions{})
+
+	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, mcList.Items, 3)
+
+	ctrl.cleanUpDuplicatedMC()
+	// successful test: ony custom and upgraded MCs stay
+	mcList, err = ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, mcList.Items, 2)
+	actual := make(map[string]mcfgv1.MachineConfig)
+	for _, mc := range mcList.Items {
+		require.GreaterOrEqual(t, len(mc.Annotations), 1)
+		actual[mc.Name] = mc
+	}
+	_, ok := actual[machineConfigDegradeNotGen.Name]
+	require.True(t, ok, "expect custom-kubelet in the list, but got false")
+	_, ok = actual[machineConfigUpgrade.Name]
+	require.True(t, ok, "expect generated-kubelet-1 in the list, but got false")
 }


### PR DESCRIPTION
Fix BZ 1955517: upgrade when there are more than one configs,
these generated MC will be duplicated by upgraded MC with
number suffixed name (func getManagedKubeletConfigKey()) and fails the upgrade.
Remove the mc if its generated and degraded.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
