### PR TITLE
Bug 1958391: configure kubelet with apiserver TLSSecurityProfile

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -109,6 +109,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
 			ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
+			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ClientBuilder.KubeClientOrDie("kubelet-config-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("kubelet-config-controller"),
 		),

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -17,7 +17,7 @@ rules:
   resources: ["images", "clusterversions", "featuregates"]
   verbs: ["*"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["schedulers"]
+  resources: ["schedulers", "apiservers"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -356,9 +356,9 @@ type KubeletConfigSpec struct {
 	MachineConfigPoolSelector *metav1.LabelSelector `json:"machineConfigPoolSelector,omitempty"`
 	KubeletConfig             *runtime.RawExtension `json:"kubeletConfig,omitempty"`
 
-	// If unset, a default (which may change between releases) is chosen. Note that only Old and
-	// Intermediate profiles are currently supported, and the maximum available MinTLSVersions
-	// is VersionTLS12.
+	// If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
+	// Note that only Old and Intermediate profiles are currently supported, and
+	// the maximum available MinTLSVersions is VersionTLS12.
 	// +optional
 	TLSSecurityProfile *configv1.TLSSecurityProfile `json:"tlsSecurityProfile,omitempty"`
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -718,7 +718,7 @@ rules:
   resources: ["images", "clusterversions", "featuregates"]
   verbs: ["*"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["schedulers"]
+  resources: ["schedulers", "apiservers"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]


### PR DESCRIPTION
**- What I did**
Mixin the default `apiserver.v1.config.openshift.io` config singleton to configure the KubeletConfig's TLSSecurityProfile. The KubeletConfig can override the global setting, but the global setting takes precedence. 

**- How to verify it**
Unit+Integration Tests

**- Description for the changelog**
