### PR TITLE
Bug 1921937: crio: reject /etc/hostname mount if absent

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -25,6 +25,9 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
+    absent_mount_sources_to_reject = [
+        "/etc/hostname",
+    ]
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -25,6 +25,9 @@ contents:
         "/run/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
+    absent_mount_sources_to_reject = [
+        "/etc/hostname",
+    ]
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION
otherwise, we create /etc/hostname as a directory, which causes issues on reboot
Signed-off-by: Peter Hunt <pehunt@redhat.com>