### PR TITLE
Hard-code 127.0.0.1 to unicast_peer list in keepalived

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -300,6 +300,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
 	funcs["onPremPlatformKeepalivedEnableUnicast"] = onPremPlatformKeepalivedEnableUnicast
+	funcs["onPremPlatformLocalhostIP"] = onPremPlatformLocalhostIP
 	funcs["urlHost"] = urlHost
 	funcs["urlPort"] = urlPort
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
@@ -463,6 +464,18 @@ func onPremPlatformAPIServerInternalIP(cfg RenderConfig) (interface{}, error) {
 	} else {
 		return nil, fmt.Errorf("")
 	}
+}
+
+// Provide an IP for localhost that matches the IP version of the API VIP
+func onPremPlatformLocalhostIP(cfg RenderConfig) (interface{}, error) {
+	apiIP, err := onPremPlatformAPIServerInternalIP(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Index(apiIP.(string), ":") != -1 {
+		return "::1", nil
+	}
+	return "127.0.0.1", nil
 }
 
 // existsDir returns true if path exists and is a directory, false if the path

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -53,6 +53,11 @@ contents:
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
         unicast_peer {
+            # Hard-code localhost so we never have an empty unicast peer list,
+            # even if there are no peers. An empty peer list causes keepalived
+            # to fall back to multicast and ignore unicast messages, which can
+            # cause problems during bootstrapping.
+            {{ onPremPlatformLocalhostIP . }}
             {{`{{- range .LBConfig.Backends -}}
             {{- if ne $nonVirtualIP .Address}}
             {{.Address}}


### PR DESCRIPTION
In the latest version of keepalived we have (2.1.5), the behavior
of unicast_peers changed so that if the list is empty it reverts to
multicast and ignores messages from other unicast nodes. This is a
problem during bootstrapping because it can cause a master to
incorrectly take the VIP and ignore attempts by the bootstrap node
to take it back.

Note that we filter the node's own IP out of the peer list because if
we don't it triggers warnings in the keepalived logs. 127.0.0.1 does
not trigger the same warnings, so it should be safe to use.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
