### PR TITLE
Clean up keepalived log messages

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -5,6 +5,7 @@ contents:
     global_defs {
         enable_script_security
         script_user root
+        max_auto_priority -1
     }
 
     # These are separate checks to provide the following behavior:

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -2,6 +2,12 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
 contents:
   inline: |
+    global_defs {
+        enable_script_security
+        script_user root
+        max_auto_priority -1
+    }
+
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {


### PR DESCRIPTION
The new version of keepalived recommends setting a config value of
max_auto_priority. Since we are not having performance issues with
keepalived to my knowledge, I'm just setting it to -1 to suppress
the message.

In addition, the worker config was missing a couple of settings
related to running check scripts. Those were already present in the
master config so I've added them for workers too.
