### PR TITLE
Bug 1960035: Use host's iptables binary in keepalived container

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -133,6 +133,8 @@ contents:
           mountPath: "/etc/keepalived"
         - name: run-dir
           mountPath: "/var/run/keepalived"
+        - name: chroot-host
+          mountPath: "/host"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Mount the host filesystem as /host in the keepalived container so that
the host's iptables binary can be called in the keepalived setup script

This PR works in combination with openshift/images#89
