### PR TITLE
Bug 1966602: Don't explicitly set the IPv6DualStack feature gate

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -26,9 +26,6 @@ contents:
       ephemeral-storage: 1Gi
     featureGates:
       APIPriorityAndFairness: true
-{{- if eq .IPFamilies "DualStack"}}
-      IPv6DualStack: true
-{{- end}}
       LegacyNodeRoleBehavior: false
       NodeDisruptionExclusion: true
       RotateKubeletServerCertificate: true

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -26,9 +26,6 @@ contents:
       ephemeral-storage: 1Gi
     featureGates:
       APIPriorityAndFairness: true
-{{- if eq .IPFamilies "DualStack"}}
-      IPv6DualStack: true
-{{- end}}
       LegacyNodeRoleBehavior: false
       NodeDisruptionExclusion: true
       RotateKubeletServerCertificate: true


### PR DESCRIPTION
It's on by default now, and setting it explicitly may result in an initial kubelet config that doesn't match the post-bootstrap one.

I think we're not hitting this in CI because we're still explicitly setting the feature gate there...
