### PR TITLE
Bug 1958812: daemon: Change runGetOut to not intermix stdout/stderr

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -253,13 +253,28 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 	return
 }
 
+func truncate(input string, length int) string {
+	asRunes := []rune(input)
+
+	if length > len(asRunes) {
+		length = len(asRunes)
+	}
+
+	return string(asRunes[:length])
+}
+
 // runGetOut executes a command, logging it, and return the stdout output.
 func runGetOut(command string, args ...string) ([]byte, error) {
 	glog.Infof("Running captured: %s %s", command, strings.Join(args, " "))
 	cmd := exec.Command(command, args...)
-	rawOut, err := cmd.CombinedOutput()
+	rawOut, err := cmd.Output()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error running %s %s: %s", command, strings.Join(args, " "), string(rawOut))
+		errtext := ""
+		if e, ok := err.(*exec.ExitError); ok {
+			// Trim to max of 256 characters
+			errtext = fmt.Sprintf("\n%s", truncate(string(e.Stderr), 256))
+		}
+		return nil, fmt.Errorf("error running %s %s: %s%s", command, strings.Join(args, " "), err, errtext)
 	}
 	return rawOut, nil
 }

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -647,3 +647,25 @@ func checkIrreconcilableResults(t *testing.T, key string, reconcilableError erro
 		t.Errorf("Different %s values should not be reconcilable.", key)
 	}
 }
+
+func TestRunGetOut(t *testing.T) {
+	o, err := runGetOut("true")
+	assert.Nil(t, err)
+	assert.Equal(t, len(o), 0)
+
+	o, err = runGetOut("false")
+	assert.NotNil(t, err)
+
+	o, err = runGetOut("echo", "hello")
+	assert.Nil(t, err)
+	assert.Equal(t, string(o), "hello\n")
+
+	// base64 encode "oops" so we can't match on the command arguments
+	o, err = runGetOut("/bin/sh", "-c", "echo hello; echo b29wcwo= | base64 -d 1>&2; exit 1")
+	assert.Error(t, err)
+	errtext := err.Error()
+	assert.Contains(t, errtext, "exit status 1\noops\n")
+
+	o, err = runGetOut("/usr/bin/test-failure-to-exec-this-should-not-exist", "arg")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Using `CombinedOutput()` here is wrong since e.g. for invoking
things like `rpm-ostree status --json` we don't want to try to
ever parse stderr text.

Instead, propagate the stderr text into the error, so it
will be reported up into the daemon logs where we can see the
actual error text.
