### PR TITLE
Bug 1916890: Stop setting nopreempt on bootstrap keepalived.conf

### DIFF
--- a/manifests/on-prem/keepalived.conf.tmpl
+++ b/manifests/on-prem/keepalived.conf.tmpl
@@ -10,7 +10,6 @@
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 70
     advert_int 1
-    nopreempt
     {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1797,7 +1797,6 @@ var _manifestsOnPremKeepalivedConfTmpl = []byte(`# Configuration template for Ke
     virtual_router_id {{.Cluster.APIVirtualRouterID }}
     priority 70
     advert_int 1
-    nopreempt
     {{ if .EnableUnicast }}
     unicast_src_ip {{.NonVirtualIP}}
     unicast_peer {


### PR DESCRIPTION
The nopreempt option has the opposite effect to what we want on the
bootstrap. In our current LB architecture, we want the VIP to be on
the bootstrap any time the bootstrap api is running. nopreempt
breaks this by not allowing the VIP to move back to the bootstrap
if there happens to be a blip in the bootstrap apiserver that causes
keepalived to stop temporarily while one of the masters is running.

The following sequence of events is the problematic one:
1) A master keepalived instance comes up
2) There is a temporary outage of the bootstrap apiserver.
3) Bootstrap keepalived-monitor notices the outage and stops the
   bootstrap keepalived.
4) The master keepalived takes the VIP
5) The bootstrap apiserver comes back up.
6) Bootstrap keepalived-monitor notices that the api is back and
   restarts keepalived
7) nopreempt stops bootstrap keepalived from taking the API VIP
   back, which wedges the deployment because the VIP remains
   pointing at a node without an api available.

Note that the bootstrap priority is always higher than the master
priority, so any time the bootstrap is active it should hold the VIP.

Dropping nopreempt allows the VIP to move back to the bootstrap node
in this scenario which allows the deployment to continue.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Fixed a bug with VIP handling during bootstrap that could prevent a deployment from completing.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
