### PR TITLE
Bug 1958812: daemon: Display more non-JSON text from rpm-ostree status --json

### DIFF
--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -17,6 +17,16 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, truncate("", 10), "")
+	assert.Equal(t, truncate("", 1), "")
+	assert.Equal(t, truncate("a", 1), "a")
+	assert.Equal(t, truncate("abcde", 1), "a [4 more chars]")
+	assert.Equal(t, truncate("abcde", 4), "abcd [1 more chars]")
+	assert.Equal(t, truncate("abcde", 7), "abcde")
+	assert.Equal(t, truncate("abcde", 5), "abcde")
+}
+
 // TestUpdateOS verifies the return errors from attempting to update the OS follow expectations
 func TestUpdateOS(t *testing.T) {
 	// expectedError is the error we will use when expecting an error to return


### PR DESCRIPTION
If we get an error deserializing, let's log a bit of the actual output
so we can better figure out what's going on there.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1958812
