### PR TITLE
Bug 1942506: [4.6] Use new --prefer-ipv6 flag to "runtimecfg node-ip" as appropriate

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -21,7 +21,11 @@ contents: |
     --volume /etc/systemd/system:/etc/systemd/system:z \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
-    set --retry-on-failure; \
+    set \
+    {{if .KubeletIPv6 -}}
+    --prefer-ipv6 \
+    {{end -}}
+    --retry-on-failure; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
Backport of #2478 / #2525 to 4.6, to make nodeip-configuration work for single-stack IPv6 on nodes with stray IPv4 addresses.
(baremetal-runtimecfg PR has already merged)
