### PR TITLE
Bug 1886572: [on-prem] set keepalived ingress priority to variable

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -77,7 +77,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority 40
+        priority {{`{{ .IngressConfig.Priority }}`}}
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -16,7 +16,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority 40
+        priority {{`{{ .IngressConfig.Priority }}`}}
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}


### PR DESCRIPTION
Ingress VIP should be set only on a node that runs an instance of
the default ingress controller pod.
In current code, in case extra ingress-controllers are created the
ingress VIP might be wrongly set on a node that doesn't run an instance of
the default ingress controller.

This PR sets keepalived ingress priority to a variable, the variable should be calculated and set by 
baremetal-runtimecfg based on the presence of the router pod in the node.

This PR should be merged after  - https://github.com/openshift/baremetal-runtimecfg/pull/141

