### PR TITLE
Bug 1946584: Check suffix annotation is a number

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -579,8 +580,11 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 			// If the MC name suffix annotation does not exist and the managed key value returned has a suffix, then add the MC name
 			// suffix annotation and suffix value to the ctrcfg object
 			if len(arr) > 4 && !ok {
-				if err := ctrl.addAnnotation(cfg, ctrlcommon.MCNameSuffixAnnotationKey, arr[len(arr)-1]); err != nil {
-					return ctrl.syncStatusOnly(cfg, err, "could not update annotation for containerRuntimeConfig")
+				_, err := strconv.Atoi(arr[len(arr)-1])
+				if err == nil {
+					if err := ctrl.addAnnotation(cfg, ctrlcommon.MCNameSuffixAnnotationKey, arr[len(arr)-1]); err != nil {
+						return ctrl.syncStatusOnly(cfg, err, "could not update annotation for containerRuntimeConfig")
+					}
 				}
 			}
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -597,8 +598,11 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 			// If the MC name suffix annotation does not exist and the managed key value returned has a suffix, then add the MC name
 			// suffix annotation and suffix value to the kubelet config object
 			if len(arr) > 4 && !ok {
-				if err := ctrl.addAnnotation(cfg, ctrlcommon.MCNameSuffixAnnotationKey, arr[len(arr)-1]); err != nil {
-					return ctrl.syncStatusOnly(cfg, err, "could not update annotation for kubeletConfig")
+				_, err := strconv.Atoi(arr[len(arr)-1])
+				if err == nil {
+					if err := ctrl.addAnnotation(cfg, ctrlcommon.MCNameSuffixAnnotationKey, arr[len(arr)-1]); err != nil {
+						return ctrl.syncStatusOnly(cfg, err, "could not update annotation for kubeletConfig")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix: Bug 1946584 https://bugzilla.redhat.com/show_bug.cgi?id=1946584
When checking whether managedKey has MC name suffix annotation, add validation to confirm it is a number type as we added.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
