### PR TITLE
Bug 1969681: maxUnavailable of ds/machine-config-daemon isn't changed even after Bug 1899535 was fixed 

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -36,5 +36,10 @@ func EnsureDaemonSet(modified *bool, existing *appsv1.DaemonSet, required appsv1
 		existing.Spec.Selector = required.Spec.Selector
 	}
 
+	if !equality.Semantic.DeepEqual(existing.Spec.UpdateStrategy, required.Spec.UpdateStrategy) {
+		*modified = true
+		existing.Spec.UpdateStrategy = required.Spec.UpdateStrategy
+	}
+
 	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
 }

--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -1,0 +1,147 @@
+package resourcemerge
+
+import (
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestMergeDaemonSetUpdateStrategy(t *testing.T) {
+	// The merge functions set "modified" to true if pointer fields
+	// are nil. Since this test doesn't "zero" all possible pointer
+	// fields, modified will be true, so this test expects this
+	// behavior
+	daemonset_update_strategy_tests := []struct {
+		existing appsv1.DaemonSet
+		input    appsv1.DaemonSet
+
+		expectedModified bool
+		expected         appsv1.DaemonSet
+	}{
+
+		{
+			existing: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+						},
+					},
+				},
+			},
+			input: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+						},
+					},
+				},
+			},
+			// this "true" is expected true because of the nil pointers elsewhere in the DaemonSet struct
+			// it always takes new struct and sets modified to "true" in event of nil
+			expectedModified: true,
+			expected: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+						},
+					},
+				},
+			},
+		}, {
+			existing: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "OnDelete",
+					},
+				},
+			},
+			input: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+						},
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+						},
+					},
+				},
+			},
+		},
+		{
+			existing: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 1, StrVal: ""},
+						},
+					},
+				},
+			},
+			input: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 2, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 3, StrVal: ""},
+						},
+					},
+				},
+			},
+			expectedModified: true,
+			expected: appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{Type: 0, IntVal: 2, StrVal: ""},
+							MaxSurge:       &intstr.IntOrString{Type: 0, IntVal: 3, StrVal: ""},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for idx, test := range daemonset_update_strategy_tests {
+		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
+			modified := BoolPtr(false)
+			EnsureDaemonSet(modified, &test.existing, test.input)
+
+			if *modified != test.expectedModified {
+				t.Fatalf("mismatch updatestrategy got: %v want: %v", *modified, test.expectedModified)
+			}
+
+			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
+				t.Fatalf("mismatch updatestrategy got: %v want: %v", test.existing, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The configuration change fix from Bug #1899535 ( set maxUnavaiable to "10%" instead of "1") worked only against newly installed clusters because the EnsureDaemonSet function in resourcemerge doesn't merge the UpdateStrategy part of the DaemonSet structure. 

This PR makes EnsureDaemonSet additionally merge the UpdateStrategy part of the structure so it also works for cluster upgrades. 

- Fixes #1959258

**- What I did**
- Added code to merge the UpdateStrategy portion of the DaemonSet as part of a resource merge if it has been updated
- Added unit test just to make sure the UpdateStrategy structure gets merged as part of EnsureDaemonSet (if UpdateStrategy has been updated)

**- How to verify it**
- Verified that this works by upgrading 4.5 -> 4.6 -> 4.7 -> this commit (4.8) and verifying that maxUnavailable changed from "1" to "10%", and it did. 

**- Description for the changelog**

Merge UpdateStrategy as part of DaemonSet resource merge. 