### PR TITLE
Add Dockerfile for proxy test image

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,0 +1,4 @@
+FROM registry.redhat.io/rhel7:latest
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY docs/openshift-proxy-pull-test.md .
+LABEL io.openshift.release.operator true

--- a/docs/openshift-proxy-pull-test.md
+++ b/docs/openshift-proxy-pull-test.md
@@ -1,0 +1,1 @@
+The Dockerfile.proxy builds the openshift-proxy-pull-test image.  If the http proxy is set by controller config,  [MCO](https://github.com/openshift/machine-config-operator) will validate the proxy by pulling this image through the proxy.  The proxy is valid if the image can be successfully pulled.


### PR DESCRIPTION
This image will be added into the ocp-build-data(https://github.com/openshift/ocp-build-data)
repository. So product MCO(https://github.com/openshift/machine-config-operator) can
pull the image through a proxy that the customer configured to validate the proxy.

Ticket for the image build request: https://issues.redhat.com/browse/ART-2961

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
