### PR TITLE
Bug 1817075: operator/controller pods: faster leader elections

### DIFF
--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// LeaseDuration is the default duration for the leader election lease.
-	LeaseDuration = 90 * time.Second
+	LeaseDuration = 30 * time.Second
 	// RenewDeadline is the default duration for the leader renewal.
-	RenewDeadline = 60 * time.Second
+	RenewDeadline = 20 * time.Second
 	// RetryPeriod is the default duration for the leader electrion retrial.
-	RetryPeriod = 30 * time.Second
+	RetryPeriod = 10 * time.Second
 )
 
 // CreateResourceLock returns an interface for the resource lock.


### PR DESCRIPTION
As a temporary solution in lieu of graceful shutdowns, have the
operator and controller pods use faster defaults for lease/renew/
retry, which shouldn't otherwise notably affect operation other
than the new pod acquiring a new lease faster during upgrades,
saving some waiting time.

Example in CVO: https://github.com/openshift/cluster-version-operator/blob/706a0062cade643767e95da2e6142823e8399986/pkg/start/start.go#L51