### PR TITLE
Revert "operator/controller pods: faster leader elections"

### DIFF
--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// LeaseDuration is the default duration for the leader election lease.
-	LeaseDuration = 30 * time.Second
+	LeaseDuration = 90 * time.Second
 	// RenewDeadline is the default duration for the leader renewal.
-	RenewDeadline = 20 * time.Second
+	RenewDeadline = 60 * time.Second
 	// RetryPeriod is the default duration for the leader electrion retrial.
-	RetryPeriod = 10 * time.Second
+	RetryPeriod = 30 * time.Second
 )
 
 // CreateResourceLock returns an interface for the resource lock.


### PR DESCRIPTION
This reverts commit 84aac80b46297fd582572f3c5c73f5b830f9a8b4.

Until this is fully investigated, let's revert the PR. See https://github.com/openshift/machine-config-operator/pull/2603#issuecomment-856810647 .