### PR TITLE
Use openshift-on-prem-infra namespace for all on-prem platforms

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -16,7 +16,7 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-openstack-infra
+  name: openshift-on-prem-infra
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -24,43 +24,4 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-openstack-infra
-    openshift.io/run-level: "1"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-kni-infra
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    openshift.io/node-selector: ""
-    workload.openshift.io/allowed: "management"
-  labels:
-    name: openshift-kni-infra
-    openshift.io/run-level: "1"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-ovirt-infra
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    openshift.io/node-selector: ""
-    workload.openshift.io/allowed: "management"
-  labels:
-    name: openshift-ovirt-infra
-    openshift.io/run-level: "1"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-vsphere-infra
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    openshift.io/node-selector: ""
-    workload.openshift.io/allowed: "management"
-  labels:
-    name: openshift-vsphere-infra
     openshift.io/run-level: "1"

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -381,20 +381,7 @@ func cloudConfigFlag(cfg RenderConfig) interface{} {
 
 func onPremPlatformShortName(cfg RenderConfig) interface{} {
 	if cfg.Infra.Status.PlatformStatus != nil {
-		switch cfg.Infra.Status.PlatformStatus.Type {
-		case configv1.BareMetalPlatformType:
-			return "kni"
-		case configv1.OvirtPlatformType:
-			return "ovirt"
-		case configv1.OpenStackPlatformType:
-			return "openstack"
-		case configv1.VSpherePlatformType:
-			return "vsphere"
-		case configv1.KubevirtPlatformType:
-			return "kubevirt"
-		default:
-			return ""
-		}
+		return "on-prem"
 	} else {
 		return ""
 	}

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -183,20 +183,7 @@ func (rc renderConfig) GenerateProxyCookieSecret() string {
 
 func onPremPlatformShortName(cfg mcfgv1.ControllerConfigSpec) interface{} {
 	if cfg.Infra.Status.PlatformStatus != nil {
-		switch cfg.Infra.Status.PlatformStatus.Type {
-		case configv1.BareMetalPlatformType:
-			return "kni"
-		case configv1.OvirtPlatformType:
-			return "ovirt"
-		case configv1.OpenStackPlatformType:
-			return "openstack"
-		case configv1.VSpherePlatformType:
-			return "vsphere"
-		case configv1.KubevirtPlatformType:
-			return "kubevirt"
-		default:
-			return ""
-		}
+		return "on-prem"
 	} else {
 		return ""
 	}


### PR DESCRIPTION
While this alone won't solve the problem of unnecessary namespaces
being deployed in clusters that don't need them, at least there will
only be one.

This is a mitigation of https://bugzilla.redhat.com/show_bug.cgi?id=1920199

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
