### PR TITLE
[release-4.6] Bug 1927555: [vsphere] set hostname with --static to provide consistent node name for CSR approval

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -4,7 +4,8 @@ contents:
   inline: |
     #!/usr/bin/env bash
     set -e
-
+    # only run if the hostname is not set
+    test -f /etc/hostname && exit 0 || :
     if vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
-        /usr/bin/hostnamectl --transient set-hostname ${vm_name}
+        /usr/bin/hostnamectl set-hostname --static ${vm_name}
     fi

--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -3,7 +3,12 @@ enabled: true
 contents: |
   [Unit]
   Description=vSphere hostname
+  Requires=vmtoolsd.service
   After=vmtoolsd.service
+
+  ConditionPathExists=!/etc/hostname
+  ConditionVirtualization=vmware
+
   Before=kubelet.service
   Before=node-valid-hostname.service
   Before=NetworkManager.service
@@ -15,4 +20,3 @@ contents: |
 
   [Install]
   WantedBy=multi-user.target
-


### PR DESCRIPTION
Fixes: BZ1927555 - when creating a new machine, the node will get an unexpected hostname

Note: This pull-request is a replacement for PR 2404.  A problem was found in release-4.7 which required a change to PR 2404.

- What I did
Added the --static flag to hostnamectl to prevent DHCP from overriding the hostname sourced from guestinfo. 

- How to verify it

Configure DHCP to assign a hostname as part of the lease
Scale a new node
The node should automatically join the cluster with a node name like <cluster>-<clusterid>-worker-<name>
- Description for the changelog
Resolves issue where the hostname provided by the DHCP overrides the guestinfo hostname thus preventing the machine-api-controller from reconciling new nodes which receive a hostname from DHCP.