### PR TITLE
Bug 1971046: templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes: Stderr for curl errors

### DIFF
--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -27,7 +27,21 @@ contents:
     declare -A vips
 
     curler() {
-      curl --silent -L -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/${1}"
+      # if the curl succeeds, write the body to stdout for the caller
+      # to consume.
+      #
+      # if the curl fails, write the body to stderr so its in the
+      # logs, but do not write anything to stdout.  The loop that the
+      # curler call was feeding will bail with no results, and we'll
+      # come back in on the next loop and try again.
+      RESPONSE="$(curl --silent --show-error -L -H "Metadata-Flavor: Google" -w '\n%{response_code}' "http://metadata.google.internal/computeMetadata/v1/instance/${1}")" &&
+        RESPONSE_CODE="$(echo "${RESPONSE}" | tail -n 1)" &&
+        BODY="$(echo "${RESPONSE}" | head -n -1)" &&
+        if test 0 -eq "${RESPONSE_CODE}" -o 400 -le "${RESPONSE_CODE}"; then
+          printf "%s" "${BODY}" >&2
+        else
+          printf "%s" "${BODY}"
+        fi
     }
 
     CHAIN_NAME="gcp-vips"


### PR DESCRIPTION
Log curl errors, ~with `--fail-with-body`~ (edit: [no longer using `--fail-with-body` due to RHCOS's old `curl`](https://github.com/openshift/machine-config-operator/pull/2617#issuecomment-881700256)):

```console
$ man curl | grep -A6 '^ *--fail-with-body'
     --fail-with-body
            (HTTP)  Return an error on server errors where the HTTP response code is 400 or greater). In normal cases when an HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This
            flag will still allow curl to outputting and save that content but also to return error 22.

            This is an alternative option to -f, --fail which makes curl fail for the same circumstances but without saving the content.

            See also -f, --fail. Added in 7.76.0.
```

This should avoid sucking down bogus HTML and later trying to use it as a VIP:

```
Jun 11 10:49:35.103493 ci-op-f4dw836w-f23e1-hfvww-master-0 bash[1013]: Processing route for NIC 0/42:01:0a:00:00:05 for (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
Jun 11 10:49:35.103613 ci-op-f4dw836w-f23e1-hfvww-master-0 bash[1013]: Processing route for NIC 0/42:01:0a:00:00:05 for no-repeat;-webkit-background-size:100%
```

Instead, we'll pipe 4xx responses to stderr, the loop that the curler call was feeding will bail with no results, and we'll come back in on the next loop and try again.