### PR TITLE
[release-4.7] Bug 1961341: rbac: update remaining apis to v1

### DIFF
--- a/install/0000_80_machine-config-operator_03_rbac.yaml
+++ b/install/0000_80_machine-config-operator_03_rbac.yaml
@@ -1,6 +1,6 @@
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-account-openshift-machine-config-operator
   annotations:


### PR DESCRIPTION
Partial cherry-pick of #2572 to update CRB to v1, as we'd like to drop RBAC v1beta1 support in 4.7 CVO