### PR TITLE
Bug 1973006: daemon: cordon the node before performing drain

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1149,7 +1149,7 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 			// Great, we've successfully rebooted for the desired config,
 			// let's mark it done!
 			glog.Infof("Completing pending config %s", state.pendingConfig.GetName())
-			if err := dn.completeUpdate(dn.node, state.pendingConfig.GetName()); err != nil {
+			if err := dn.completeUpdate(state.pendingConfig.GetName()); err != nil {
 				MCDUpdateState.WithLabelValues("", err.Error()).SetToCurrentTime()
 				return inDesiredConfig, err
 			}
@@ -1281,8 +1281,8 @@ func (dn *Daemon) prepUpdateFromCluster() (*mcfgv1.MachineConfig, *mcfgv1.Machin
 // completeUpdate marks the node as schedulable again, then deletes the
 // "transient state" file, which signifies that all of those prior steps have
 // been completed.
-func (dn *Daemon) completeUpdate(node *corev1.Node, desiredConfigName string) error {
-	if err := drain.RunCordonOrUncordon(dn.drainer, node, false); err != nil {
+func (dn *Daemon) completeUpdate(desiredConfigName string) error {
+	if err := dn.cordonOrUncordonNode(false); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubectl/pkg/drain"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -184,11 +185,41 @@ func (dn *Daemon) finalizeBeforeReboot(newConfig *mcfgv1.MachineConfig) (retErr 
 	return nil
 }
 
+func (dn *Daemon) cordonOrUncordonNode(desired bool) error {
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 10 * time.Second,
+		Factor:   2,
+	}
+	var lastErr error
+	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := drain.RunCordonOrUncordon(dn.drainer, dn.node, desired)
+		if err != nil {
+			lastErr = err
+			glog.Infof("cordon/uncordon failed with: %v, retrying", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		if err == wait.ErrWaitTimeout {
+			return errors.Wrapf(lastErr, "failed to cordon/uncordon node (%d tries): %v", backoff.Steps, err)
+		}
+		return errors.Wrap(err, "failed to cordon/uncordon node")
+	}
+	return nil
+}
+
 func (dn *Daemon) drain() error {
 	// Skip draining of the node when we're not cluster driven
 	if dn.kubeClient == nil {
 		return nil
 	}
+
+	if err := dn.cordonOrUncordonNode(true); err != nil {
+		return err
+	}
+	dn.logSystem("Node has been successfully cordoned")
+	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Cordon", "Cordoned node to apply update")
 
 	dn.logSystem("Update prepared; beginning drain")
 	failedDrains := 0


### PR DESCRIPTION
Also, add log and event for successful node cordon.    

cordoning the node accidentally got removed in https://github.com/openshift/machine-config-operator/pull/2605.

