### PR TITLE
Bug 1971899: match tlsSecurityProfile  doc with kubelet.conf file

### DIFF
--- a/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
@@ -94,12 +94,10 @@ spec:
                   intermediate:
                     description: "intermediate is a TLS security profile based on: \n
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-                      \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256
-                      \    - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256
-                      \    - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256
-                      \    - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384
-                      \    - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305
-                      \    - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384
+                      \n and looks like this (yaml): \n   ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                      \    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 
+                      \    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                      \    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
                       \  minTLSVersion: TLSv1.2"
                     nullable: true
                     type: object
@@ -112,19 +110,16 @@ spec:
                     type: object
                   old:
                     description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-                      \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256
-                      \    - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256
-                      \    - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256
-                      \    - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384
-                      \    - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305
-                      \    - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384
-                      \    - DHE-RSA-CHACHA20-POLY1305     - ECDHE-ECDSA-AES128-SHA256
-                      \    - ECDHE-RSA-AES128-SHA256     - ECDHE-ECDSA-AES128-SHA     -
-                      ECDHE-RSA-AES128-SHA     - ECDHE-ECDSA-AES256-SHA384     - ECDHE-RSA-AES256-SHA384
-                      \    - ECDHE-ECDSA-AES256-SHA     - ECDHE-RSA-AES256-SHA     -
-                      DHE-RSA-AES128-SHA256     - DHE-RSA-AES256-SHA256     - AES128-GCM-SHA256
-                      \    - AES256-GCM-SHA384     - AES128-SHA256     - AES256-SHA256
-                      \    - AES128-SHA     - AES256-SHA     - DES-CBC3-SHA   minTLSVersion:
+                      \n and looks like this (yaml): \n   ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                      \    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                      \    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                      \    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+                      \    - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+                      \    - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+                      \    - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_AES_128_GCM_SHA256
+                      \    - TLS_RSA_WITH_AES_256_GCM_SHA384     - TLS_RSA_WITH_AES_128_CBC_SHA256
+                      \    - TLS_RSA_WITH_AES_128_CBC_SHA     - TLS_RSA_WITH_AES_256_CBC_SHA
+                      \    - TLS_RSA_WITH_3DES_EDE_CBC_SHA   minTLSVersion:
                       TLSv1.0"
                     nullable: true
                     type: object


### PR DESCRIPTION
Bug 1971899: match tlsSecurityProfile oc explain doc with the output of kubelet.conf file.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
