### PR TITLE
Bug 1973525: [on-prem] Drop runlevel from infra namespaces

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -24,7 +24,6 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-openstack-infra
-    openshift.io/run-level: "1"
 ---
 apiVersion: v1
 kind: Namespace
@@ -37,7 +36,6 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-kni-infra
-    openshift.io/run-level: "1"
 ---
 apiVersion: v1
 kind: Namespace
@@ -50,7 +48,6 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-ovirt-infra
-    openshift.io/run-level: "1"
 ---
 apiVersion: v1
 kind: Namespace
@@ -63,4 +60,3 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-vsphere-infra
-    openshift.io/run-level: "1"


### PR DESCRIPTION
This appears to have been copy-pasta from the MCO namespace, but we
don't need it for the on-prem services.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Dropped the runlevel specifier for the on-prem namespaces. It was not necessary and may have caused confusion about the services running in the namespace.
