### PR TITLE
OCPNODE-542: Add CPU and memory alerts for the master nodes

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -57,3 +57,24 @@ spec:
             severity: warning
           annotations:
             message: "System memory usage of {{ $value | humanize }} on {{ $labels.node }} exceeds 90% of the reservation. Reserved memory ensures system processes can function even when the node is fully allocated and protects against workload out of memory events impacting the proper functioning of the node. The default reservation is expected to be sufficient for most configurations and should be increased (https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-managing.html) when running nodes with high numbers of pods (either due to rate of change or at steady state)."
+    - name: master-nodes-high-memory-usage
+      rules:
+        - alert: MasterNodesHighMemoryUsage
+          expr: |
+            ((sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) - sum(node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" ))) / sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) * 100) > 90
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Memory usage of {{ $value | humanize }} on {{ $labels.node }} exceeds by 90%. Master nodes starved of memory could result in degraded performance of the control plane."
+    - name: master-nodes-high-cpu-usage
+      rules:
+        - alert: MasterNodesHighCPUUsage
+          expr: |
+            sum(node_load1 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) > (count(node_load1 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) * 3)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "Cumulative load of {{ $value | humanize }} on {{ $labels.node }} is very high. Master nodes starved of cpu could result in degraded performance of the control pane."
+


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add the CPU and Memory alerts for the master nodes - https://issues.redhat.com/browse/OCPNODE-542

**- How to verify it**
If the CPU or the Memory consumption goes beyond the specified limit in the alert then it should fire. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add CPU and memory alerts for the master nodes
