### PR TITLE
Add support for bind-address flag

### DIFF
--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -43,8 +43,8 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	}
 
 	apiHandler := server.NewServerAPIHandler(bs)
-	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
-	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
+	secureServer := server.NewAPIServer(apiHandler, rootOpts.BindAddr, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
+	insecureServer := server.NewAPIServer(apiHandler, rootOpts.BindAddr, rootOpts.isport, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()

--- a/cmd/machine-config-server/main.go
+++ b/cmd/machine-config-server/main.go
@@ -20,15 +20,17 @@ var (
 	}
 
 	rootOpts struct {
-		sport  int
-		isport int
-		cert   string
-		key    string
+		BindAddr string
+		sport    int
+		isport   int
+		cert     string
+		key      string
 	}
 )
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	rootCmd.PersistentFlags().StringVar(&rootOpts.BindAddr, "bind-address", server.BindAddr, "the bind address for the server to run")
 	rootCmd.PersistentFlags().IntVar(&rootOpts.sport, "secure-port", server.SecurePort, "secure port to serve ignition configs")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.cert, "cert", "/etc/ssl/mcs/tls.crt", "cert file for TLS")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.key, "key", "/etc/ssl/mcs/tls.key", "key file for TLS")

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -47,8 +47,8 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 
 	apiHandler := server.NewServerAPIHandler(cs)
-	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
-	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "")
+	secureServer := server.NewAPIServer(apiHandler, rootOpts.BindAddr, rootOpts.sport, false, rootOpts.cert, rootOpts.key)
+	insecureServer := server.NewAPIServer(apiHandler, rootOpts.BindAddr, rootOpts.isport, true, "", "")
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -554,7 +554,7 @@ func TestAPIServer(t *testing.T) {
 			ms := &mockServer{
 				GetConfigFn: scenario.serverFunc,
 			}
-			server := NewAPIServer(NewServerAPIHandler(ms), 0, false, "", "")
+			server := NewAPIServer(NewServerAPIHandler(ms), "0.0.0.0", 0, false, "", "")
 			server.handler.ServeHTTP(w, scenario.request)
 
 			resp := w.Result()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**

Currently the MCS bind itself to 0.0.0.0, this keeps current behaviour by default while letting a consumer to specify a different binding address e.g 127.0.0.1.

