### PR TITLE
Bug 1965992: Gracefully shutdown taking around 6-7 mins (libvirt provider) 

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -535,9 +535,9 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 
 	dn.catchIgnoreSIGTERM()
 	defer func() {
-		if retErr != nil {
-			dn.cancelSIGTERM()
-		}
+		// now that we do rebootless updates, we need to turn off our SIGTERM protection
+		// regardless of how we leave the "update loop"
+		dn.cancelSIGTERM()
 	}()
 
 	oldConfigName := oldConfig.GetName()
@@ -1893,6 +1893,7 @@ func (dn *Daemon) catchIgnoreSIGTERM() {
 	if dn.updateActive {
 		return
 	}
+	glog.Info("Adding SIGTERM protection")
 	dn.updateActive = true
 }
 
@@ -1900,6 +1901,7 @@ func (dn *Daemon) cancelSIGTERM() {
 	dn.updateActiveLock.Lock()
 	defer dn.updateActiveLock.Unlock()
 	if dn.updateActive {
+		glog.Info("Removing SIGTERM protection")
 		dn.updateActive = false
 	}
 }


### PR DESCRIPTION
The machine config daemon's SIGTERM protection was not being removed on 
rebootless updates.The existing logic made sense before rebootless updates
 were a thing, but now if an update happens and we don't reboot, the MCD 
protects itself from SIGTERM forever.

Also, the sequence of functions triggerUpdateWithmachineConfig->
update->performPostConfigChangeAction is recursive, so if we put the
work from https://github.com/openshift/machine-config-operator/pull/2395 back in to solve this, or try to use the mutex "properly" we'll
 potentially deadlock on ourselves under the right conditions. 

- This PR removes an if condition so the SIGTERM protection is removed
on a successful rebootless update and also adds some logging messages to make 
it more apparent when the protection is being added/removed. 

- Long term we should figure out the desired behavior and "proper" way to
organize this (maybe flatten it into a loop and get rid of the recursion, maybe
decide to just stop after one update round without recursing, etc), but for right 
now we at least need to fix the SIGTERM handler because we're negatively 
impacting upgrades and rebootless changes. 

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1965992
Fixes some cases of: https://bugzilla.redhat.com/show_bug.cgi?id=1927041



