### PR TITLE
templates: Silence audit events from container infra by default

### DIFF
--- a/templates/common/_base/files/audit-quiet-containers.yaml
+++ b/templates/common/_base/files/audit-quiet-containers.yaml
@@ -1,0 +1,14 @@
+mode: 0644
+path: "/etc/audit/rules.d/mco-audit-quiet-containers.rules"
+contents:
+  inline: |
+    # This file is managed by machine-config-operator.
+    # Suppress audit rules which always trigger for container
+    # workloads, as they spam the audit log.  Workloads are expected
+    # to be dynamic, and the networking stack uses iptables.
+    -a exclude,always -F msgtype=NETFILTER_CFG
+    # The default bridged networking enables promiscuous on the veth
+    # device.  Ideally, we'd teach audit to ignore only veth devices,
+    # since one might legitimately care about promiscuous on real physical
+    # devices.  But we can't currently differentiate.
+    -a exclude,always -F msgtype=ANOM_PROMISCUOUS


### PR DESCRIPTION
I was going to go add a check for "system has an AVC denial"
but the problem today is that every time a container starts or
stops *and* most notably liveness probes end up generating
audit events.

This very quickly rotates out audit events that we *do* care
about.

Outside of Kubernetes, workloads can be much more "static"
and it makes sense for "iptables rules changed" to cause an
audit event.  For OpenShift, it doesn't make sense.

Silence that and the promiscuous device one so that we can
more easily read the audit logs captured from a CI run to
verify there were no AVC denials.

This will also be useful preparation for e.g. teaching
the MCO do watch for some types of audit event (such as
AVC) and bridge them to Prometheus metrics or so.
