### PR TITLE
On-prem: add default ingress track script to Keepalived

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -134,6 +134,8 @@ contents:
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         livenessProbe:
           exec:
             command:

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -40,6 +40,12 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
+        weight 20
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        interval 5
         weight 50
     }
 
@@ -78,7 +84,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority {{`{{ .IngressConfig.Priority }}`}}
+        priority 20
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
@@ -99,5 +105,6 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_default_ingress
         }
     }

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -13,6 +13,12 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
+        weight 20
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        interval 5
         weight 50
     }
 
@@ -22,7 +28,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority {{`{{ .IngressConfig.Priority }}`}}
+        priority 20
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
@@ -43,5 +49,6 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_default_ingress
         }
     }


### PR DESCRIPTION
Ingress VIP should be set only on a node that runs an instance of the default
ingress controller pod.

In the current code, the keepalived-monitor container calculates the priority for keepalived ingress
VIP depending on the presence of the router pod in the node by monitoring the content of
router-internal-default endpoints resource.

This PR moves the ingress dynamic priority setting to Keepalived track_script which makes it easier
to debug and eliminates the need for keepalived container reload in case of priority change.

