### PR TITLE
 daemon: Dump systemctl status rpm-ostreed on load failure

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -201,9 +201,9 @@ func New(
 		err        error
 	)
 
-	os := OperatingSystem{}
+	hostos := OperatingSystem{}
 	if !mock {
-		os, err = GetHostRunningOS()
+		hostos, err = GetHostRunningOS()
 		if err != nil {
 			HostOS.WithLabelValues("unsupported", "").Set(1)
 			return nil, errors.Wrapf(err, "checking operating system")
@@ -211,7 +211,7 @@ func New(
 	}
 
 	// Only pull the osImageURL from OSTree when we are on RHCOS or FCOS
-	if os.IsCoreOSVariant() {
+	if hostos.IsCoreOSVariant() {
 		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %v", err)
@@ -230,7 +230,7 @@ func New(
 	// RHEL 7.6/Centos 7 logger (util-linux) doesn't have the --journald flag
 	loggerSupportsJournal := true
 	if !mock {
-		if os.IsLikeTraditionalRHEL7() {
+		if hostos.IsLikeTraditionalRHEL7() {
 			loggerOutput, err := exec.Command("logger", "--help").CombinedOutput()
 			if err != nil {
 				return nil, errors.Wrapf(err, "running logger --help")
@@ -240,12 +240,12 @@ func New(
 	}
 
 	// report OS & version (if RHCOS or FCOS) to prometheus
-	HostOS.WithLabelValues(os.ToPrometheusLabel(), osVersion).Set(1)
+	HostOS.WithLabelValues(hostos.ToPrometheusLabel(), osVersion).Set(1)
 
 	return &Daemon{
 		mock:                  mock,
 		booting:               true,
-		os:                    os,
+		os:                    hostos,
 		NodeUpdaterClient:     nodeUpdaterClient,
 		bootedOSImageURL:      osImageURL,
 		bootID:                bootID,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -214,6 +214,12 @@ func New(
 	if hostos.IsCoreOSVariant() {
 		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
+			// If this fails for some reason, let's dump the unit status
+			// into our logs to aid future debugging.
+			cmd := exec.Command("systemctl", "status", "rpm-ostreed")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %v", err)
 		}
 		glog.Infof("Booted osImageURL: %s (%s)", osImageURL, osVersion)


### PR DESCRIPTION
daemon: Rename `os` variable to `hostos`

Prep for a future patch; `os` conflicts with the standard Go package.

---

daemon: Dump systemctl status rpm-ostreed on load failure

This is yet another patch which should help debugging
https://bugzilla.redhat.com/show_bug.cgi?id=1958812
like situations in the future.

I also have https://github.com/coreos/rpm-ostree/pull/2932
cooking but it's going to take a while to cycle down.

---

