### PR TITLE
Bug 1934443: Fix team config JSON format for nmcli command

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -205,10 +205,9 @@ contents:
       fi
 
       # use ${extra_phys_args[@]+"${extra_phys_args[@]}"} instead of ${extra_phys_args[@]} to be compatible with bash 4.2 in RHEL7.9
-      extra_args=${extra_phys_args[@]+"${extra_phys_args[@]}"}
       if ! nmcli connection show ovs-if-phys0 &> /dev/null; then
         nmcli c add type ${iface_type} conn.interface ${iface} master ovs-port-phys0 con-name ovs-if-phys0 \
-          connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_args}
+        connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 
       # Get the new connection uuid


### PR DESCRIPTION
The configure-ovs.sh script does not provide the correct team interface configuration format in nmcli command. It fails with:
```
Error: failed to modify team.config: team configuration must be a JSON object.
```

**- What I did**
Corrected team interface configuration format.

**- How to verify it**
Install OpenShift with OVNKubernetes using team interface.

**- Description for the changelog**
Modify the script to correct the team interface configuration format.
