### PR TITLE
[OCPCLOUD-1209] Add feature gate to bootstrap mode manifests

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	apicfgv1 "github.com/openshift/api/config/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	containerruntimeconfig "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
@@ -46,6 +47,7 @@ func New(templatesDir, manifestDir, pullSecretFile string) *Bootstrap {
 
 // Run runs boostrap for Machine Config Controller
 // It writes all the assets to destDir
+// nolint: gocyclo
 func (b *Bootstrap) Run(destDir string) error {
 	infos, err := ioutil.ReadDir(b.manifestDir)
 	if err != nil {
@@ -70,6 +72,7 @@ func (b *Bootstrap) Run(destDir string) error {
 	decoder := codecFactory.UniversalDecoder(mcfgv1.GroupVersion, apioperatorsv1alpha1.GroupVersion, apicfgv1.GroupVersion)
 
 	var cconfig *mcfgv1.ControllerConfig
+	var featureGate *apicfgv1.FeatureGate
 	var pools []*mcfgv1.MachineConfigPool
 	var configs []*mcfgv1.MachineConfig
 	var icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy
@@ -112,6 +115,10 @@ func (b *Bootstrap) Run(destDir string) error {
 				icspRules = append(icspRules, obj)
 			case *apicfgv1.Image:
 				imgCfg = obj
+			case *apicfgv1.FeatureGate:
+				if obj.GetName() == ctrlcommon.ClusterFeatureInstanceName {
+					featureGate = obj
+				}
 			default:
 				glog.Infof("skipping %q [%d] manifest because of unhandled %T", file.Name(), idx+1, obji)
 			}
@@ -121,7 +128,7 @@ func (b *Bootstrap) Run(destDir string) error {
 	if cconfig == nil {
 		return fmt.Errorf("error: no controllerconfig found in dir: %q", destDir)
 	}
-	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig, psraw)
+	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig, psraw, featureGate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -45,6 +45,19 @@ spec:
 			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
 		}},
 	}, {
+		name: "feature gate",
+		raw: `
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade
+`,
+		want: []manifest{{
+			Raw: []byte(`{"apiVersion":"config.openshift.io/v1","kind":"FeatureGate","metadata":{"name":"cluster"},"spec":{"featureSet":"TechPreviewNoUpgrade"}}`),
+		}},
+	}, {
 		name: "two-resources",
 		raw: `
 apiVersion: extensions/v1beta1

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -478,7 +478,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		err := fmt.Errorf("could not fetch FeatureGates: %v", err)
 		return ctrl.syncStatusOnly(cfg, err)
 	}
-	featureGates, err := generateFeatureMap(features)
+	featureGates, err := generateFeatureMap(features, openshiftOnlyFeatureGates...)
 	if err != nil {
 		err := fmt.Errorf("could not generate FeatureMap: %v", err)
 		glog.V(2).Infof("%v", err)

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -523,6 +523,6 @@ func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.Co
 }
 
 // RunBootstrap runs the tempate controller in boostrap mode.
-func RunBootstrap(templatesDir string, config *mcfgv1.ControllerConfig, pullSecretRaw []byte) ([]*mcfgv1.MachineConfig, error) {
-	return getMachineConfigsForControllerConfig(templatesDir, config, pullSecretRaw, nil)
+func RunBootstrap(templatesDir string, config *mcfgv1.ControllerConfig, pullSecretRaw []byte, featureGate *configv1.FeatureGate) ([]*mcfgv1.MachineConfig, error) {
+	return getMachineConfigsForControllerConfig(templatesDir, config, pullSecretRaw, featureGate)
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added feature gate into list of supported manifests to render during install time. Additionally makes sure openshift only feature gates are excluded from Kubelet config list too, so it won't be confusing when the feature gate is present in Kubelet config, but Kubelet is not running it.

**- How to verify it**

1. openshift-install create manifests
2. Put featureGate to manifests folder
3. run openshift-install create cluster.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
