### PR TITLE
[release-4.7] Bug 1977432: crio: enable internal_wipe option

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -2,6 +2,9 @@ mode: 0644
 path: "/etc/crio/crio.conf.d/00-default"
 contents:
   inline: |
+    [crio]
+    internal_wipe = true
+
     [crio.api]
     stream_address = ""
     stream_port = "10010"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -2,6 +2,9 @@ mode: 0644
 path: "/etc/crio/crio.conf.d/00-default"
 contents:
   inline: |
+    [crio]
+    internal_wipe = true
+
     [crio.api]
     stream_address = ""
     stream_port = "10010"


### PR DESCRIPTION
to make sure we're calling CNI del on a node reboot

Signed-off-by: Peter Hunt <pehunt@redhat.com>
