### PR TITLE
Bug 1980658: ON-PREM] HAProxy - Verify that NM prepender script was applied using initcontainer

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -27,6 +27,22 @@ contents:
       - name: chroot-host
         hostPath:
           path: "/"
+      initContainers:
+      - name: verify-api-int-resolvable
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get nodes
+        resources: {}
+        volumeMounts:
+        - name: chroot-host
+          mountPath: "/host"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
+        imagePullPolicy: IfNotPresent
       containers:
       - name: haproxy
         image: {{.Images.haproxyImage}}
@@ -109,11 +125,12 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-          - "/bin/bash"
-          - "-c"
-          - |            
-            cp /host/etc/resolv.conf /etc/resolv.conf
-            monitor /var/lib/kubelet/kubeconfig  /config/haproxy.cfg.tmpl  /etc/haproxy/haproxy.cfg  --api-vip {{ onPremPlatformAPIServerInternalIP . }}
+        - monitor
+        - "/var/lib/kubelet/kubeconfig"
+        - "/config/haproxy.cfg.tmpl"
+        - "/etc/haproxy/haproxy.cfg"
+        - "--api-vip"
+        - "{{ onPremPlatformAPIServerInternalIP . }}"
         resources:
           requests:
             cpu: 100m
@@ -129,14 +146,6 @@ contents:
           mountPath: "/host"
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
-        livenessProbe:
-          initialDelaySeconds: 10
-          exec:
-            command:
-              - /bin/bash
-              - -c
-              - |
-                cmp /host/etc/resolv.conf /etc/resolv.conf
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true


### PR DESCRIPTION

The HAProxy-monitor container should start running only after applying the NM prepender script
(to be able to communicate with api-int: kube-api).

We noticed that in the current implementation (Liveness probe) we may break the API traffic for a
few seconds even because of changes in host's resolv.conf that aren't relevant to the HAProxy monitor.

This PR replaces the Liveness probe that compares resolv.conf and host's resolv.conf
with an init container.
