### PR TITLE
Bug 1978041: templates: split unit dropins into separate files

### DIFF
--- a/templates/common/_base/units/crio.service-proxy.yaml
+++ b/templates/common/_base/units/crio.service-proxy.yaml
@@ -1,0 +1,17 @@
+name: crio.service
+dropins:
+  - name: 10-mco-default-env.conf
+    contents: |
+      [Unit]
+      {{if .Proxy -}}
+      [Service]
+      {{if .Proxy.HTTPProxy -}}
+      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+      {{end -}}
+      {{if .Proxy.HTTPSProxy -}}
+      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      {{end -}}
+      {{if .Proxy.NoProxy -}}
+      Environment=NO_PROXY={{.Proxy.NoProxy}}
+      {{end -}}
+      {{end -}}

--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -1,20 +1,5 @@
 name: crio.service
 dropins:
-  - name: 10-mco-default-env.conf
-    contents: |
-      [Unit]
-      {{if .Proxy -}}
-      [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
-      {{end -}}
   - name: 10-mco-default-madv.conf
     contents: |
       [Service]

--- a/templates/common/_base/units/kubelet.service-proxy.yaml
+++ b/templates/common/_base/units/kubelet.service-proxy.yaml
@@ -1,0 +1,17 @@
+name: kubelet.service
+dropins:
+  - name: 10-mco-default-env.conf
+    contents: |
+      [Unit]
+      {{if .Proxy -}}
+      [Service]
+      {{if .Proxy.HTTPProxy -}}
+      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
+      {{end -}}
+      {{if .Proxy.HTTPSProxy -}}
+      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
+      {{end -}}
+      {{if .Proxy.NoProxy -}}
+      Environment=NO_PROXY={{.Proxy.NoProxy}}
+      {{end -}}
+      {{end -}}

--- a/templates/common/_base/units/kubelet.service.yaml
+++ b/templates/common/_base/units/kubelet.service.yaml
@@ -1,20 +1,5 @@
 name: kubelet.service
 dropins:
-  - name: 10-mco-default-env.conf
-    contents: |
-      [Unit]
-      {{if .Proxy -}}
-      [Service]
-      {{if .Proxy.HTTPProxy -}}
-      Environment=HTTP_PROXY={{.Proxy.HTTPProxy}}
-      {{end -}}
-      {{if .Proxy.HTTPSProxy -}}
-      Environment=HTTPS_PROXY={{.Proxy.HTTPSProxy}}
-      {{end -}}
-      {{if .Proxy.NoProxy -}}
-      Environment=NO_PROXY={{.Proxy.NoProxy}}
-      {{end -}}
-      {{end -}}
   - name: 10-mco-default-madv.conf
     contents: |
       [Service]


### PR DESCRIPTION
The template rendering has broken merge logic, which causes us
to lose some templates. This was originally fixed for 4.7
(see https://github.com/openshift/machine-config-operator/pull/2378/)
but previous cherry-pick failures + a recent backport of another
bug broke this for 4.6.

Split the crio/kubelet dropins such that we don't break the proxy.

