### PR TITLE
GRPA-3788: Machine-config-daemon: support RHEL 8 OS versions

### DIFF
--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -44,6 +44,15 @@ func (os OperatingSystem) IsLikeTraditionalRHEL7() bool {
 	return os.VersionID == "7"
 }
 
+// IsLikeTraditionalRHEL8 is true if the OS is traditional RHEL8 or CentOS8:
+func (os OperatingSystem) IsLikeTraditionalRHEL8() bool {
+
+	if len(os.VersionID) > 2 {
+		return strings.HasPrefix(os.VersionID, "8.")
+	}
+	return os.VersionID == "8"
+}
+
 // ToPrometheusLabel returns a value we historically fed to Prometheus
 func (os OperatingSystem) ToPrometheusLabel() string {
 	// We historically upper cased this

--- a/pkg/daemon/osrelease_test.go
+++ b/pkg/daemon/osrelease_test.go
@@ -16,3 +16,15 @@ func TestIsLikeTraditionalRHEL7(t *testing.T) {
 	testOS.VersionID = "6.8"
 	assert.False(t, testOS.IsLikeTraditionalRHEL7())
 }
+
+func TestIsLikeTraditionalRHEL8(t *testing.T) {
+	var testOS OperatingSystem
+	testOS.VersionID = "8"
+	assert.True(t, testOS.IsLikeTraditionalRHEL8())
+	testOS.VersionID = "8.5"
+	assert.True(t, testOS.IsLikeTraditionalRHEL8())
+	testOS.VersionID = "7"
+	assert.False(t, testOS.IsLikeTraditionalRHEL8())
+	testOS.VersionID = "6.8"
+	assert.False(t, testOS.IsLikeTraditionalRHEL8())
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -260,4 +261,9 @@ func mcdForNode(cs *framework.ClientSet, node *corev1.Node) (*corev1.Pod, error)
 		return nil, fmt.Errorf("too many (%d) MCDs for node %s", len(mcdList.Items), node.Name)
 	}
 	return &mcdList.Items[0], nil
+}
+
+// IsCoreOSNode determines if the node is a CoreOS variant
+func IsCoreOSNode(n *corev1.Node) bool {
+	return strings.Contains(n.Status.NodeInfo.OSImage, "CoreOS")
 }


### PR DESCRIPTION
This PR: 

- Gives the MCD the ability to tell if a node is a RHEL8 node 
- Adds a simple unit test to make sure the version is being recognized properly 
- Modifies the e2e tests such that RHEL7/8 unsupported features no longer result in e2e test failures

JIRA ticket link: https://issues.redhat.com/browse/GRPA-3788

The places where we were explicitly checking for RHEL7 were places where RHEL7 was "broken" compared to everything else, and that was due to older versions of software (systemd, logger). RHEL8 is newer (and closer to RHCOS than 7 was), it doesn't suffer from any of the current RHEL7 issues, and as a result we don't yet have a need to explicitly check for it anywhere right now.

There are still places in the code where we check to see if the OS is a CoreOS variant so we can determine whether the OS supports a feature or not, but those checks will still mark RHEL8 as "non-CoreOS", just like they did RHEL7. so our existing decision-making there does not need to change for RHEL8. 

The e2e tests were failing against RHEL7/8 nodes because they were checking for the results of functionality that was explicitly not supported by non-CoreOS nodes (KernelArguments, Kernel, Extensions) and  I have modified the tests to take those unsupported items into account so the RHEL nodes can now be e2e tested. 
