### PR TITLE
Bug 1978581: remove run-level info from operators namespaces

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -10,7 +10,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-machine-config-operator
-    openshift.io/run-level: "1"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/manifests/machineconfigdaemon/clusterrole.yaml
+++ b/manifests/machineconfigdaemon/clusterrole.yaml
@@ -22,6 +22,10 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs"]
   verbs: ["*"]
+- apiGroups: ["security.openshift.io"]
+  resourceNames: ["privileged"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["use"]
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -7,3 +7,7 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: ["security.openshift.io"]
+  resourceNames: ["hostnetwork"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["use"]

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1391,6 +1391,10 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs"]
   verbs: ["*"]
+- apiGroups: ["security.openshift.io"]
+  resourceNames: ["privileged"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["use"]
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -1722,6 +1726,10 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
   verbs: ["*"]
+- apiGroups: ["security.openshift.io"]
+  resourceNames: ["hostnetwork"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["use"]
 `)
 
 func manifestsMachineconfigserverClusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
