### PR TITLE
daemon: add log and event for uncordoning node

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1292,7 +1292,8 @@ func (dn *Daemon) completeUpdate(desiredConfigName string) error {
 		return err
 	}
 
-	dn.logSystem("completed update for config %s", desiredConfigName)
+	dn.logSystem("Update completed for config %s and node has been successfully uncordoned", desiredConfigName)
+	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Uncordon", fmt.Sprintf("Update completed for config %s and node has been uncordoned", desiredConfigName))
 
 	return nil
 }


### PR DESCRIPTION
For better debugging in future for bugs like
https://bugzilla.redhat.com/show_bug.cgi?id=1975907,
let's explicitly log and add event when a node has
been successfully uncordoned by MCO.