### PR TITLE
Bug 1986453: Check for API server and node versions skew

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -75,6 +75,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			ctrlctx.ClientBuilder.APIExtClientOrDie(componentName),
 			ctrlctx.ClientBuilder.ConfigClientOrDie(componentName),
 			ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
+			ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
 		)
 
 		ctrlctx.NamespacedInformerFactory.Start(ctrlctx.Stop)


### PR DESCRIPTION

ref: https://issues.redhat.com/browse/OCPNODE-595
replace https://github.com/openshift/machine-config-operator/pull/2552

**- What I did**

Check for API server and node versions skew.
Update with the message the Kube API version is skew too far, but do not force
`Upgradeable=False` according to enhancement https://github.com/openshift/enhancements/pull/762/files

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
