### PR TITLE
Bug 1979297: Revert "Subtract hugepages from memory capacity and allocatables"

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -51,7 +51,7 @@ spec:
       rules:
         - alert: SystemMemoryExceedsReservation
           expr: |
-            sum by (node) (container_memory_rss{id="/system.slice"}) > ((sum by (node) (kube_node_status_capacity{resource="memory"}) - sum by (node) (kube_node_status_capacity{resource="hugepages_1Gi"}) - sum by (node) (kube_node_status_capacity{resource="hugepages_2Mi"}) - sum by (node) (kube_node_status_allocatable{resource="memory"}) - sum by (node)  (kube_node_status_allocatable{resource="hugepages_1Gi"}) - sum by (node)  (kube_node_status_allocatable{resource="hugepages_2Mi"})) * 0.9)
+            sum by (node) (container_memory_rss{id="/system.slice"}) > ((sum by (node) (kube_node_status_capacity{resource="memory"} - kube_node_status_allocatable{resource="memory"})) * 0.9)
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
This reverts commit faa05e7e87bd03cfd9d05fca3576f1dcf14130dc.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1979297

**- What I did**
It seems like we incorrectly modified a prometheus alert `SystemMemoryExceedsReservation`

**- How to verify it**
On a system with hugepages configured the alert should not fire without memory stress. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
