### PR TITLE
[OCPCLOUD-1209] Run KubeletConfig FeatureGate sync during bootstrap

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	containerruntimeconfig "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
+	kubeletconfig "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
 )
@@ -138,6 +139,14 @@ func (b *Bootstrap) Run(destDir string) error {
 		return err
 	}
 	configs = append(configs, rconfigs...)
+
+	if featureGate != nil {
+		kConfigs, err := kubeletconfig.RunFeatureGateBootstrap(b.templatesDir, featureGate, cconfig, pools)
+		if err != nil {
+			return err
+		}
+		configs = append(configs, kConfigs...)
+	}
 
 	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig)
 	if err != nil {

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -48,6 +48,7 @@ func New(templatesDir, manifestDir, pullSecretFile string) *Bootstrap {
 
 // Run runs boostrap for Machine Config Controller
 // It writes all the assets to destDir
+// nolint:gocyclo
 func (b *Bootstrap) Run(destDir string) error {
 	infos, err := ioutil.ReadDir(b.manifestDir)
 	if err != nil {

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -45,6 +45,19 @@ spec:
 			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
 		}},
 	}, {
+		name: "feature gate",
+		raw: `
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade
+`,
+		want: []manifest{{
+			Raw: []byte(`{"apiVersion":"config.openshift.io/v1","kind":"FeatureGate","metadata":{"name":"cluster"},"spec":{"featureSet":"TechPreviewNoUpgrade"}}`),
+		}},
+	}, {
 		name: "two-resources",
 		raw: `
 apiVersion: extensions/v1beta1

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -311,3 +311,13 @@ func newKubeletconfigJSONEncoder(targetVersion schema.GroupVersion) (runtime.Enc
 	}
 	return codecs.EncoderForVersion(info.Serializer, targetVersion), nil
 }
+
+// kubeletConfigToIgnFile converts a KubeletConfiguration to an Ignition File
+func kubeletConfigToIgnFile(cfg *kubeletconfigv1beta1.KubeletConfiguration) (*ign3types.File, error) {
+	cfgJSON, err := EncodeKubeletConfig(cfg, kubeletconfigv1beta1.SchemeGroupVersion)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode kubelet configuration: %v", err)
+	}
+	cfgIgn := createNewKubeletIgnition(cfgJSON)
+	return cfgIgn, nil
+}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -478,7 +478,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		err := fmt.Errorf("could not fetch FeatureGates: %v", err)
 		return ctrl.syncStatusOnly(cfg, err)
 	}
-	featureGates, err := generateFeatureMap(features)
+	featureGates, err := generateFeatureMap(features, openshiftOnlyFeatureGates...)
 	if err != nil {
 		err := fmt.Errorf("could not generate FeatureMap: %v", err)
 		glog.V(2).Infof("%v", err)

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -587,19 +587,12 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 			if err != nil {
 				return ctrl.syncStatusOnly(cfg, err, "could not merge original config and new config: %v", err)
 			}
-			// Encode the new config into raw JSON
-			cfgJSON, err := EncodeKubeletConfig(originalKubeConfig, kubeletconfigv1beta1.SchemeGroupVersion)
-			if err != nil {
-				return ctrl.syncStatusOnly(cfg, err, "could not encode JSON: %v", err)
-			}
-			kubeletIgnition = createNewKubeletIgnition(cfgJSON)
-		} else {
-			// Encode the new config into raw JSON
-			cfgJSON, err := EncodeKubeletConfig(originalKubeConfig, kubeletconfigv1beta1.SchemeGroupVersion)
-			if err != nil {
-				return ctrl.syncStatusOnly(cfg, err, "could not encode JSON: %v", err)
-			}
-			kubeletIgnition = createNewKubeletIgnition(cfgJSON)
+		}
+
+		// Encode the new config into an Ignition File
+		kubeletIgnition, err = kubeletConfigToIgnFile(originalKubeConfig)
+		if err != nil {
+			return ctrl.syncStatusOnly(cfg, err, "could not encode JSON: %v", err)
 		}
 
 		if isNotFound {

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -16,7 +16,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
-	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -221,12 +220,12 @@ func generateKubeConfigIgnFromFeatures(cc *mcfgv1.ControllerConfig, templatesDir
 	}
 
 	// Encode the new config into raw JSON
-	cfgJSON, err := EncodeKubeletConfig(originalKubeConfig, kubeletconfigv1beta1.SchemeGroupVersion)
+	cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)
 	if err != nil {
 		return nil, err
 	}
+
 	tempIgnConfig := ctrlcommon.NewIgnConfig()
-	cfgIgn := createNewKubeletIgnition(cfgJSON)
 	tempIgnConfig.Storage.Files = append(tempIgnConfig.Storage.Files, *cfgIgn)
 	rawCfgIgn, err := json.Marshal(tempIgnConfig)
 	if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -25,7 +25,7 @@ func TestFeatureGateDrift(t *testing.T) {
 			f.ccLister = append(f.ccLister, cc)
 
 			ctrl := f.newController()
-			kubeletConfig, err := generateOriginalKubeletConfig(cc, ctrl.templatesDir, "master", nil)
+			kubeletConfig, err := generateOriginalKubeletConfigIgn(cc, ctrl.templatesDir, "master", nil)
 			if err != nil {
 				t.Errorf("could not generate kubelet config from templates %v", err)
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -11,8 +11,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFeatureGateDrift(t *testing.T) {
@@ -128,6 +130,81 @@ func TestFeaturesCustomNoUpgrade(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
 			f.runFeature(getKeyFromFeatureGate(features, t))
+		})
+	}
+}
+
+func TestBootstrapFeaturesDefault(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcps := []*mcfgv1.MachineConfigPool{mcp, mcp2}
+
+			features := createNewDefaultFeatureGate()
+
+			mcs, err := RunFeatureGateBootstrap("../../../templates", features, cc, mcps)
+			if err != nil {
+				t.Errorf("could not run feature gate bootstrap: %v", err)
+			}
+			if len(mcs) > 0 {
+				t.Errorf("expected no machine config generated with the default feature gate, got %d configs", len(mcs))
+			}
+		})
+	}
+}
+
+func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcps := []*mcfgv1.MachineConfigPool{mcp, mcp2}
+
+			features := &osev1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ctrlcommon.ClusterFeatureInstanceName,
+				},
+				Spec: osev1.FeatureGateSpec{
+					FeatureGateSelection: osev1.FeatureGateSelection{
+						FeatureSet: osev1.CustomNoUpgrade,
+						CustomNoUpgrade: &osev1.CustomFeatureGates{
+							Enabled: []string{"CSIMigration"},
+						},
+					},
+				},
+			}
+
+			mcs, err := RunFeatureGateBootstrap("../../../templates", features, cc, mcps)
+			if err != nil {
+				t.Errorf("could not run feature gate bootstrap: %v", err)
+			}
+			if len(mcs) != 2 {
+				t.Errorf("expected 2 machine configs generated with the custom feature gate, got %d configs", len(mcs))
+			}
+
+			for _, mc := range mcs {
+				ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
+				regfile := ignCfg.Storage.Files[0]
+				conf, err := dataurl.DecodeString(*regfile.Contents.Source)
+				require.NoError(t, err)
+
+				originalKubeConfig, _ := decodeKubeletConfig(conf.Data)
+				defaultFeatureGates, err := generateFeatureMap(createNewDefaultFeatureGate())
+				if err != nil {
+					t.Errorf("could not generate defaultFeatureGates: %v", err)
+				}
+				if reflect.DeepEqual(originalKubeConfig.FeatureGates, *defaultFeatureGates) {
+					t.Errorf("template FeatureGates should not match default openshift/api FeatureGates: (default=%v)", defaultFeatureGates)
+				}
+				if !originalKubeConfig.FeatureGates["CSIMigration"] {
+					t.Errorf("template FeatureGates should contain CSIMigration: %v", originalKubeConfig.FeatureGates)
+				}
+			}
 		})
 	}
 }

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -23,7 +23,7 @@ func TestFeatureGateDrift(t *testing.T) {
 			f.ccLister = append(f.ccLister, cc)
 
 			ctrl := f.newController()
-			kubeletConfig, err := ctrl.generateOriginalKubeletConfig("master", nil)
+			kubeletConfig, err := generateOriginalKubeletConfig(cc, ctrl.templatesDir, "master", nil)
 			if err != nil {
 				t.Errorf("could not generate kubelet config from templates %v", err)
 			}

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -523,6 +523,6 @@ func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.Co
 }
 
 // RunBootstrap runs the tempate controller in boostrap mode.
-func RunBootstrap(templatesDir string, config *mcfgv1.ControllerConfig, pullSecretRaw []byte) ([]*mcfgv1.MachineConfig, error) {
-	return getMachineConfigsForControllerConfig(templatesDir, config, pullSecretRaw, nil)
+func RunBootstrap(templatesDir string, config *mcfgv1.ControllerConfig, pullSecretRaw []byte, featureGate *configv1.FeatureGate) ([]*mcfgv1.MachineConfig, error) {
+	return getMachineConfigsForControllerConfig(templatesDir, config, pullSecretRaw, featureGate)
 }


### PR DESCRIPTION
Note, the first two commits of this PR are currently the content of #2647, there would be conflicts if I tried to implement it individually so thought it was quicker to leave this based on that.

**- What I did**
I've extracted some of the logic in the kubeletconfig package to standalone functions rather than being part of the `Controller.` This is the first commit "Extract KubeConfig FeatureGate ignition to a standalone function"

Then I've copied the logic from the feature gate sync into a bootstrap ready `RunFeatureGateBootstrap` function, and then we run this if a `FeatureGate` is detected in the manifests directory.

**- How to verify it**

* `openshift-install create install-config`
* `openshift-install create manifests`
* Add a FeatureGate yaml resource to the manifests directory
```
apiVersion: config.openshift.io/v1
kind: FeatureGate
metadata:
  name: cluster
spec:
  featureSet: TechPreviewNoUpgrade
```
* `openshift-install create cluster`
* Observe that the cluster bootstraps correctly

Without this fix, there is a discrepancy in the `/etc/mcs-machine-config-content.json` on the master hosts and the initial rendered master, because the feature gate sync handler has not run before the initial bootstrap machine config is generated.

This has been manually tested by me locally by taking the resources of a cluster I bootstrapped, from the bootstrap node, and running this patch locally and observing the output of the rendered master config.

**- Description for the changelog**

Clusters bootstrapped with a FeatureGate will now successfully complete installation.
