### PR TITLE
templates: add apiserver-url.env file for Azure workers

### DIFF
--- a/templates/worker/00-worker/azure/files/apiserver-url-env.yaml
+++ b/templates/worker/00-worker/azure/files/apiserver-url-env.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "{{.Constants.APIServerURLFile}}"
+# used by the cluster network operator to learn the URL to the internal apiserver load balancer
+contents:
+ inline: |
+   KUBERNETES_SERVICE_HOST='{{urlHost .Infra.Status.APIServerInternalURL}}'
+   KUBERNETES_SERVICE_PORT='{{urlPort .Infra.Status.APIServerInternalURL}}'


### PR DESCRIPTION
Azure node controller needs to know the URL of the internal apiserver load balancer.

To do it, this commit creates an environment file with required env variables, that can be consumed by the controller.

This approach is similar to what we do on master nodes:
https://github.com/openshift/machine-config-operator/pull/2232
