### PR TITLE
[release-4.6] Bug 1975626: KubeletConfig validation warning in CRD and Docs

### DIFF
--- a/docs/KubeletConfigDesign.md
+++ b/docs/KubeletConfigDesign.md
@@ -61,6 +61,12 @@ KubeletConfig
   [KubeletConfigurationSpec](https://github.com/kubernetes/kubernetes/blob/release-1.11/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go#L45)
 ```
 
+## VALIDATION
+
+It's important to note that, since the fields of the kubelet configuration are directly fetched from upstream the validation
+of those values is handled directly by the kubelet. Please refer to the upstream version of the relevant kubernetes for the
+valid values of these fields. Invalid values of the kubelet configuration fields may render cluster nodes unusable.
+
 ## Example
 This is what an example `kubelet config` CR looks like. Note: you must make sure to add a label under `matchLabels` in the KubeletConfig CR:
 

--- a/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_kubeletconfig.crd.yaml
@@ -43,6 +43,15 @@ spec:
           type: object
           properties:
             kubeletConfig:
+              description: The fields of the kubelet configuration are defined in
+                kubernetes upstream. Please refer to the types defined in the
+                version/commit used by OpenShift of the upstream kubernetes.
+                It's important to note that, since the fields of the kubelet
+                configuration are directly fetched from upstream the validation
+                of those values is handled directly by the kubelet. Please refer
+                to the upstream version of the relevant kubernetes for the
+                valid values of these fields. Invalid values of the kubelet
+                configuration fields may render cluster nodes unusable.
               type: object
               x-kubernetes-preserve-unknown-fields: true
             machineConfigPoolSelector:


### PR DESCRIPTION


<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Close https://bugzilla.redhat.com/show_bug.cgi?id=1975626
**- What I did**
Backport of https://github.com/openshift/machine-config-operator/pull/2358 since the cherrypick robot failed. https://github.com/openshift/machine-config-operator/pull/2358#issuecomment-768780813
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
