### PR TITLE
Bug 1981090: [ON-PREM] HAProxy - enable listening sockets retrieval from old processes

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -2,6 +2,8 @@ mode: 0644
 path: "/etc/kubernetes/static-pod-resources/haproxy/haproxy.cfg.tmpl"
 contents:
   inline: |
+    global
+      stats socket /var/lib/haproxy/run/haproxy.sock  mode 600 level admin expose-fd listeners
     defaults
       maxconn 20000
       mode    tcp


### PR DESCRIPTION
To use the -x option [1] in HAProxy the socket must be enabled using "expose-fd listeners" in haproxy configuration.

[1] https://github.com/haproxy/haproxy/blob/c3fe968f221e2f7c63b7eb24f557223c4bbbe75f/doc/management.txt#L325

