### PR TITLE
    apiserver-watcher: use a lockfile.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.9
+	github.com/nightlyone/lockfile v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openshift/api v0.0.0-20210629145910-15a1cae1fca8
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
+github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=

--- a/vendor/github.com/nightlyone/lockfile/.gitignore
+++ b/vendor/github.com/nightlyone/lockfile/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# popular temporaries
+.err
+.out
+.diff
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/nightlyone/lockfile/.gitmodules
+++ b/vendor/github.com/nightlyone/lockfile/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "git-hooks"]
+	path = git-hooks
+	url = https://github.com/nightlyone/git-hooks

--- a/vendor/github.com/nightlyone/lockfile/.travis.yml
+++ b/vendor/github.com/nightlyone/lockfile/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+go:
+  - 1.13
+  - 1.14
+  - tip
+
+# Only test commits to production branch and all pull requests
+branches:
+  only:
+    - master
+
+matrix:
+  allow_failures:
+  - go: tip

--- a/vendor/github.com/nightlyone/lockfile/LICENSE
+++ b/vendor/github.com/nightlyone/lockfile/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 Ingo Oeser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/nightlyone/lockfile/README.md
+++ b/vendor/github.com/nightlyone/lockfile/README.md
@@ -1,0 +1,52 @@
+lockfile
+=========
+Handle locking via pid files.
+
+[![Build Status Unix][1]][2]
+[![Build status Windows][3]][4]
+
+[1]: https://secure.travis-ci.org/nightlyone/lockfile.png
+[2]: https://travis-ci.org/nightlyone/lockfile
+[3]: https://ci.appveyor.com/api/projects/status/7mojkmauj81uvp8u/branch/master?svg=true
+[4]: https://ci.appveyor.com/project/nightlyone/lockfile/branch/master
+
+
+
+install
+-------
+Install [Go 1][5], either [from source][6] or [with a prepackaged binary][7].
+For Windows suport, Go 1.4 or newer is required.
+
+Then run
+
+	go get github.com/nightlyone/lockfile
+
+[5]: http://golang.org
+[6]: http://golang.org/doc/install/source
+[7]: http://golang.org/doc/install
+
+LICENSE
+-------
+MIT
+
+documentation
+-------------
+[package documentation at godoc.org](http://godoc.org/github.com/nightlyone/lockfile)
+
+install
+-------------------
+	go get github.com/nightlyone/lockfile
+
+
+contributing
+============
+
+Contributions are welcome. Please open an issue or send me a pull request for a dedicated branch.
+Make sure the git commit hooks show it works.
+
+git commit hooks
+-----------------------
+enable commit hooks via
+
+        cd .git ; rm -rf hooks; ln -s ../git-hooks hooks ; cd ..
+

--- a/vendor/github.com/nightlyone/lockfile/appveyor.yml
+++ b/vendor/github.com/nightlyone/lockfile/appveyor.yml
@@ -1,0 +1,12 @@
+clone_folder: c:\gopath\src\github.com\nightlyone\lockfile
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - go version
+  - go env
+  - go get -v -t ./...
+
+build_script:
+  - go test -v ./...

--- a/vendor/github.com/nightlyone/lockfile/go.mod
+++ b/vendor/github.com/nightlyone/lockfile/go.mod
@@ -1,0 +1,3 @@
+module github.com/nightlyone/lockfile
+
+go 1.11

--- a/vendor/github.com/nightlyone/lockfile/lockfile.go
+++ b/vendor/github.com/nightlyone/lockfile/lockfile.go
@@ -1,0 +1,222 @@
+// Package lockfile handles pid file based locking.
+// While a sync.Mutex helps against concurrency issues within a single process,
+// this package is designed to help against concurrency issues between cooperating processes
+// or serializing multiple invocations of the same process. You can also combine sync.Mutex
+// with Lockfile in order to serialize an action between different goroutines in a single program
+// and also multiple invocations of this program.
+package lockfile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Lockfile is a pid file which can be locked
+type Lockfile string
+
+// TemporaryError is a type of error where a retry after a random amount of sleep should help to mitigate it.
+type TemporaryError string
+
+func (t TemporaryError) Error() string { return string(t) }
+
+// Temporary returns always true.
+// It exists, so you can detect it via
+//	if te, ok := err.(interface{ Temporary() bool }); ok {
+//		fmt.Println("I am a temporary error situation, so wait and retry")
+//	}
+func (t TemporaryError) Temporary() bool { return true }
+
+// Various errors returned by this package
+var (
+	ErrBusy          = TemporaryError("Locked by other process")             // If you get this, retry after a short sleep might help
+	ErrNotExist      = TemporaryError("Lockfile created, but doesn't exist") // If you get this, retry after a short sleep might help
+	ErrNeedAbsPath   = errors.New("Lockfiles must be given as absolute path names")
+	ErrInvalidPid    = errors.New("Lockfile contains invalid pid for system")
+	ErrDeadOwner     = errors.New("Lockfile contains pid of process not existent on this system anymore")
+	ErrRogueDeletion = errors.New("Lockfile owned by me has been removed unexpectedly")
+)
+
+// New describes a new filename located at the given absolute path.
+func New(path string) (Lockfile, error) {
+	if !filepath.IsAbs(path) {
+		return Lockfile(""), ErrNeedAbsPath
+	}
+
+	return Lockfile(path), nil
+}
+
+// GetOwner returns who owns the lockfile.
+func (l Lockfile) GetOwner() (*os.Process, error) {
+	name := string(l)
+
+	// Ok, see, if we have a stale lockfile here
+	content, err := ioutil.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// try hard for pids. If no pid, the lockfile is junk anyway and we delete it.
+	pid, err := scanPidLine(content)
+	if err != nil {
+		return nil, err
+	}
+
+	running, err := isRunning(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	if running {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return nil, err
+		}
+
+		return proc, nil
+	}
+
+	return nil, ErrDeadOwner
+}
+
+// TryLock tries to own the lock.
+// It Returns nil, if successful and and error describing the reason, it didn't work out.
+// Please note, that existing lockfiles containing pids of dead processes
+// and lockfiles containing no pid at all are simply deleted.
+func (l Lockfile) TryLock() error {
+	name := string(l)
+
+	// This has been checked by New already. If we trigger here,
+	// the caller didn't use New and re-implemented it's functionality badly.
+	// So panic, that he might find this easily during testing.
+	if !filepath.IsAbs(name) {
+		panic(ErrNeedAbsPath)
+	}
+
+	tmplock, cleanup, err := makePidFile(name, os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	defer cleanup()
+
+	// EEXIST and similar error codes, caught by os.IsExist, are intentionally ignored,
+	// as it means that someone was faster creating this link
+	// and ignoring this kind of error is part of the algorithm.
+	// Then we will probably fail the pid owner check later, if this process is still alive.
+	// We cannot ignore ALL errors, since failure to support hard links, disk full
+	// as well as many other errors can happen to a filesystem operation
+	// and we really want to abort on those.
+	if err := os.Link(tmplock, name); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+
+	fiTmp, err := os.Lstat(tmplock)
+	if err != nil {
+		return err
+	}
+
+	fiLock, err := os.Lstat(name)
+	if err != nil {
+		// tell user that a retry would be a good idea
+		if os.IsNotExist(err) {
+			return ErrNotExist
+		}
+
+		return err
+	}
+
+	// Success
+	if os.SameFile(fiTmp, fiLock) {
+		return nil
+	}
+
+	proc, err := l.GetOwner()
+	switch err {
+	default:
+		// Other errors -> defensively fail and let caller handle this
+		return err
+	case nil:
+		if proc.Pid != os.Getpid() {
+			return ErrBusy
+		}
+	case ErrDeadOwner, ErrInvalidPid: // cases we can fix below
+	}
+
+	// clean stale/invalid lockfile
+	err = os.Remove(name)
+	if err != nil {
+		// If it doesn't exist, then it doesn't matter who removed it.
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	// now that the stale lockfile is gone, let's recurse
+	return l.TryLock()
+}
+
+// Unlock a lock again, if we owned it. Returns any error that happened during release of lock.
+func (l Lockfile) Unlock() error {
+	proc, err := l.GetOwner()
+	switch err {
+	case ErrInvalidPid, ErrDeadOwner:
+		return ErrRogueDeletion
+	case nil:
+		if proc.Pid == os.Getpid() {
+			// we really own it, so let's remove it.
+			return os.Remove(string(l))
+		}
+		// Not owned by me, so don't delete it.
+		return ErrRogueDeletion
+	default:
+		// This is an application error or system error.
+		// So give a better error for logging here.
+		if os.IsNotExist(err) {
+			return ErrRogueDeletion
+		}
+		// Other errors -> defensively fail and let caller handle this
+		return err
+	}
+}
+
+func scanPidLine(content []byte) (int, error) {
+	if len(content) == 0 {
+		return 0, ErrInvalidPid
+	}
+
+	var pid int
+	if _, err := fmt.Sscanln(string(content), &pid); err != nil {
+		return 0, ErrInvalidPid
+	}
+
+	if pid <= 0 {
+		return 0, ErrInvalidPid
+	}
+
+	return pid, nil
+}
+
+func makePidFile(name string, pid int) (tmpname string, cleanup func(), err error) {
+	tmplock, err := ioutil.TempFile(filepath.Dir(name), filepath.Base(name)+".")
+	if err != nil {
+		return "", nil, err
+	}
+
+	cleanup = func() {
+		_ = tmplock.Close()
+		_ = os.Remove(tmplock.Name())
+	}
+
+	if _, err := io.WriteString(tmplock, fmt.Sprintf("%d\n", pid)); err != nil {
+		cleanup() // Do cleanup here, so call doesn't have to.
+		return "", nil, err
+	}
+
+	return tmplock.Name(), cleanup, nil
+}

--- a/vendor/github.com/nightlyone/lockfile/lockfile_unix.go
+++ b/vendor/github.com/nightlyone/lockfile/lockfile_unix.go
@@ -1,0 +1,21 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris aix
+
+package lockfile
+
+import (
+	"os"
+	"syscall"
+)
+
+func isRunning(pid int) (bool, error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/nightlyone/lockfile/lockfile_windows.go
+++ b/vendor/github.com/nightlyone/lockfile/lockfile_windows.go
@@ -1,0 +1,30 @@
+package lockfile
+
+import (
+	"syscall"
+)
+
+//For some reason these consts don't exist in syscall.
+const (
+	error_invalid_parameter = 87
+	code_still_active       = 259
+)
+
+func isRunning(pid int) (bool, error) {
+	procHnd, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, true, uint32(pid))
+	if err != nil {
+		if scerr, ok := err.(syscall.Errno); ok {
+			if uintptr(scerr) == error_invalid_parameter {
+				return false, nil
+			}
+		}
+	}
+
+	var code uint32
+	err = syscall.GetExitCodeProcess(procHnd, &code)
+	if err != nil {
+		return false, err
+	}
+
+	return code == code_still_active, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -445,6 +445,9 @@ github.com/nbutton23/zxcvbn-go/match
 github.com/nbutton23/zxcvbn-go/matching
 github.com/nbutton23/zxcvbn-go/scoring
 github.com/nbutton23/zxcvbn-go/utils/math
+# github.com/nightlyone/lockfile v1.0.0
+## explicit
+github.com/nightlyone/lockfile
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit
 github.com/opencontainers/go-digest


### PR DESCRIPTION
We eventually want to rename this pod (since it's in the wrong namespace), but before we can do that, we have to handle multiple instances of the process. This is because the kubelet often handles static pod updates by creating the new one before deleting the old one.
    
So, write a lockfile. Fortunately, we're hostPID, so we can actually detect stale lockfiles. Whew.

/cc @aojea 
