### PR TITLE
Bug 1982052: Handle team/bond interfaces with a more clear message

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -74,10 +74,14 @@ contents:
       # REMOVEME: Once BZ:1854355 is fixed, this needs to get removed.
       function configure_driver_options {
         intf=$1
-        driver=$(cat "/sys/class/net/${intf}/device/uevent" | grep DRIVER | awk -F "=" '{print $2}')
-        echo "Driver name is" $driver
-        if [ "$driver" = "vmxnet3" ]; then
-          ifconfig "$intf" allmulti
+        if [ ! -f "/sys/class/net/${intf}/device/uevent" ]; then
+          echo "Device file doesn't exist, skipping setting multicast mode"
+        else
+          driver=$(cat "/sys/class/net/${intf}/device/uevent" | grep DRIVER | awk -F "=" '{print $2}')
+          echo "Driver name is" $driver
+          if [ "$driver" = "vmxnet3" ]; then
+            ifconfig "$intf" allmulti
+          fi
         fi
       }
 


### PR DESCRIPTION
When teamed/bonded interfaces are presented to the ovs-configure
script, the uevent file doesn't exist under the device dir because
there is no actual net-device corresponding to the bond. This
commit adds a more clear error message for handling team/bonded
interfaces.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>