### PR TITLE
Add CRI-O metrics collectors configuration

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -45,3 +45,19 @@ contents:
     [crio.metrics]
     enable_metrics = true
     metrics_port = 9537
+    metrics_collectors = [
+      "operations",
+      "operations_latency_microseconds_total",
+      "operations_latency_microseconds",
+      "operations_errors",
+      "image_pulls_layer_size",
+      "containers_oom_total",
+      "containers_oom",
+      # Drop metrics with excessive label cardinality.
+      # "image_pulls_by_digest",
+      # "image_pulls_by_name",
+      # "image_pulls_by_name_skipped",
+      # "image_pulls_failures",
+      # "image_pulls_successes",
+      # "image_layer_reuse",
+    ]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -45,3 +45,19 @@ contents:
     [crio.metrics]
     enable_metrics = true
     metrics_port = 9537
+    metrics_collectors = [
+      "operations",
+      "operations_latency_microseconds_total",
+      "operations_latency_microseconds",
+      "operations_errors",
+      "image_pulls_layer_size",
+      "containers_oom_total",
+      "containers_oom",
+      # Drop metrics with excessive label cardinality.
+      # "image_pulls_by_digest",
+      # "image_pulls_by_name",
+      # "image_pulls_by_name_skipped",
+      # "image_pulls_failures",
+      # "image_pulls_successes",
+      # "image_layer_reuse",
+    ]


### PR DESCRIPTION



**- What I did**
We now can configure metrics by referencing the collector since
https://github.com/cri-o/cri-o/pull/5061 has been merged.

This patch adds the default CRI-O metrics collectors and reflects the
previously overwritten state from the Cluster Monitoring Operator (CMO).

**- How to verify it**
Verify that the configured metrics are being served.

**- Description for the changelog**
Added CRI-O `metrics_collectors` configuration.
