### PR TITLE
Bug 1982766: [on-prem] Make ingress VIP more tolerant to failures

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -41,12 +41,16 @@ contents:
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 20
+        rise 3
+        fall 2
     }
 
     vrrp_script chk_default_ingress {
         script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
         interval 5
         weight 50
+        rise 3
+        fall 2
     }
 
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -14,12 +14,16 @@ contents:
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
         weight 20
+        rise 3
+        fall 2
     }
 
     vrrp_script chk_default_ingress {
         script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
         interval 5
         weight 50
+        rise 3
+        fall 2
     }
 
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}


### PR DESCRIPTION
We've noticed that the ingress VIP could be flapping in some
environments where the keepalived check fails due to timeout. We should
make the ingress check more resilient to errors and start using `fall`
and `raise` to mitigate flapping as we did for the API checks.