### PR TITLE
[MCC][MCD]: Introduce in progress taint

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,5 +1,12 @@
 package constants
 
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
 // constants defines some file paths that are shared outside of the
 // MCO package; and thus consumed by other users
 
@@ -9,7 +16,21 @@ const (
 	APIServerURLFile = "/etc/kubernetes/apiserver-url.env"
 )
 
-// ConstantsByName is a map of constants for ease of templating
-var ConstantsByName = map[string]string{
-	"APIServerURLFile": APIServerURLFile,
-}
+var (
+	// NodeUpdateBackoff is the backoff time before asking APIServer to update node
+	// object again.
+	NodeUpdateBackoff = wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Jitter:   1.0,
+	}
+	// NodeUpdateInProgressTaint is a taint applied by MCC when the update of node starts.
+	NodeUpdateInProgressTaint = &corev1.Taint{
+		Key:    "UpdateInProgress",
+		Effect: corev1.TaintEffectPreferNoSchedule,
+	}
+	// ConstantsByName is a map of constants for ease of templating
+	ConstantsByName = map[string]string{
+		"APIServerURLFile": APIServerURLFile,
+	}
+)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -27,7 +27,10 @@ import (
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,12 +39,14 @@ import (
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	clientretry "k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubectl/pkg/drain"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-config-operator/lib/resourceread"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	commonconstants "github.com/openshift/machine-config-operator/pkg/constants"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	mcfginformersv1 "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions/machineconfiguration.openshift.io/v1"
@@ -1290,10 +1295,57 @@ func (dn *Daemon) completeUpdate(desiredConfigName string) error {
 		return err
 	}
 
+	ctx := context.TODO()
+	if err := dn.removeUpdateInProgressTaint(ctx); err != nil {
+		return err
+	}
+
 	dn.logSystem("Update completed for config %s and node has been successfully uncordoned", desiredConfigName)
 	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Uncordon", fmt.Sprintf("Update completed for config %s and node has been uncordoned", desiredConfigName))
 
 	return nil
+}
+
+func (dn *Daemon) removeUpdateInProgressTaint(ctx context.Context) error {
+	return clientretry.RetryOnConflict(commonconstants.NodeUpdateBackoff, func() error {
+		oldNode, err := dn.kubeClient.CoreV1().Nodes().Get(ctx, dn.name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		oldData, err := json.Marshal(oldNode)
+		if err != nil {
+			return err
+		}
+
+		newNode := oldNode.DeepCopy()
+
+		// New taints to be copied.
+		var taintsAfterUpgrade []corev1.Taint
+		for _, taint := range newNode.Spec.Taints {
+			if taint.MatchTaint(commonconstants.NodeUpdateInProgressTaint) {
+				continue
+			} else {
+				taintsAfterUpgrade = append(taintsAfterUpgrade, taint)
+			}
+		}
+		// updateInProgress taint is not there, so no need to patch the node object, return immediately
+		if len(taintsAfterUpgrade) == len(newNode.Spec.Taints) {
+			return nil
+		}
+		// Remove the NodeUpdateInProgressTaint.
+		newNode.Spec.Taints = taintsAfterUpgrade
+		newData, err := json.Marshal(newNode)
+		if err != nil {
+			return err
+		}
+
+		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, corev1.Node{})
+		if err != nil {
+			return fmt.Errorf("failed to create patch for node %q: %v", dn.name, err)
+		}
+		_, err = dn.kubeClient.CoreV1().Nodes().Patch(ctx, dn.name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+		return err
+	})
 }
 
 // triggerUpdateWithMachineConfig starts the update. It queries the cluster for


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
All the upgrade candidate nodes in a mcp would be applied
`UpdateInProgress: PreferNoSchedule` taint.
The taint will be removed MCD once the upgrade is complete.
Since kubernetes/kubernetes#104251 landed,
the nodes not having PreferNoSchedule taint will have higher score.
Before the upgrade starts, MCC will taint all the nodes in the
cluster that are supposed to be upgraded. Once the upgrade is
complete since MCD will remove the taint, none of the nodes will
have `UpdateInProgress: PreferNoSchedule` taint. This ensures
the score of the nodes will be equal again.

Why is this needed?
This reduces the pod churn when the cluster upgrade is in progress.
When the non-upgraded nodes in the cluster have `UpdateInProgress:
PreferNoSchedule` taint, they would get lesser score and the pods
would prefer to land onto untainted(upgraded) nodes there by
reducing the chances of landing onto an unupgraded node which
can cause one more reschedule
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
