### PR TITLE
Support `ssh-key-dir` on OKD/FCOS

### DIFF
--- a/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
+++ b/templates/common/_base/files/sshd-disable-ssh-key-dir.yaml
@@ -1,6 +1,0 @@
-mode: 0644
-path: "/etc/ssh/sshd_config.d/10-disable-ssh-key-dir.conf"
-contents:
-  inline: |
-    # disable key lookup from ~/.ssh/authorized_keys.d/ on FCOS
-    AuthorizedKeysCommand none


### PR DESCRIPTION
**- What I did**
In older versions of OKD, the SSH keys were written to
`/home/core/.ssh/authorized_keys`. Newer versions of OKD will
expect the keys at `/home/core/.ssh/authorized_keys.d/ignition`.
In the case of a newer version of OKD, the keys file is removed
from the legacy path in the updateSSHKeys function.
It will then be recreated at the new fragment path by the
atomicallyWriteSSHKey function that is called right after.

**- How to verify it**
CI

**- Description for the changelog**
Support ssh-key-dir on OKD/FCOS
