### PR TITLE
Bug 1970129: Set ovs syslog level to info

### DIFF
--- a/templates/common/_base/units/ovs-vswitchd.service.yaml
+++ b/templates/common/_base/units/ovs-vswitchd.service.yaml
@@ -7,3 +7,5 @@ dropins:
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /var/lib/openvswitch'
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /etc/openvswitch'
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /run/openvswitch'
+      ExecStartPost=-/usr/bin/ovs-appctl vlog/set syslog:info
+      ExecReload=-/usr/bin/ovs-appctl vlog/set syslog:info


### PR DESCRIPTION
This bug was previously fixed in a different way: https://github.com/openshift/cluster-network-operator/pull/1142
And then reverted: https://github.com/openshift/cluster-network-operator/pull/1163

**- What I did**
Set ovs syslog level to info (default is err), to collect info level logs with must-gather since it uses systemd journal.
ovs-vswitchd service runs `ovs-ctl` to start and reload service (https://github.com/openvswitch/ovs/blob/master/rhel/usr_lib_systemd_system_ovs-vswitchd.service.in#L23).
`ovs-ctl` doesn't let you set log level on start (https://github.com/openvswitch/ovs/blob/master/utilities/ovs-ctl.in#L214)
So, I added `ExecStartPost` to the service which sets right log level on start and restart.
There is also `reload` operation defined for the service (https://github.com/openvswitch/ovs/blob/master/rhel/usr_lib_systemd_system_ovs-vswitchd.service.in#L28), but `ExecStartPost` is not executed on reload, so I added `ExecReload` command which is executed after the main service `ExecReload`, therefore ovs has right log settings after reload also.

**- How to verify it**
Check logs and ovs log level on a cluster, then create new MachineConfig object that will update all your nodes, then check logs and log level again.

Check logs: 
- run `oc adm must-gather -- gather_network_logs` and see log file from `host_service_logs/<node_name>/ovs-vswitchs_service.log`, find (or check there are None at the beginning) INFO level logs there
- get access to node binaries:  run `oc debug --image fedora:31 node/<node name>` then `chroot /host` 
- check log levels on host: after previous step run `ovs-appctl vlog/list`, check syslog column is set to ERR at the beginning and at the end is set to INFO

Create new MachineConfig object (from https://github.com/openshift/machine-config-operator#applying-configuration-changes-to-the-cluster):
Create MachineConfig (two copies for worker and master, change `machineconfiguration.openshift.io/role` accordingly):
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 50-change-ovs-loglevel
spec:
  config:
    ignition:
      version: 3.2.0
    systemd:
      units:
      - dropins:
        - contents: |
            [Service]
            Restart=always
            ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /var/lib/openvswitch'
            ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /etc/openvswitch'
            ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /run/openvswitch'
            ExecStartPost=-/usr/bin/ovs-appctl vlog/set syslog:info
            ExecReload=-/usr/bin/ovs-appctl vlog/set syslog:info
          name: 10-ovs-vswitchd-restart.conf
        name: ovs-vswitchd.service
```
Then run `oc create -f <machine config file name>` for both files to create MachineConfig that corresponds presented changes.
Then use `oc describe machineconfigpool/worker(master)` to watch the progress of the rollout. You should see that new config successfully generated, then the nodes will get updated, e.g.
```
  Normal  RenderedConfigGenerated  62m   machineconfigcontroller-rendercontroller  rendered-worker-eac6cd3e114c5c3d1be4db3005827d08 successfully generated
  Normal  SetDesiredConfig         62m   machineconfigcontroller-nodecontroller    Targeted node ci-ln-7xlpli2-f76d1-gwkvq-worker-a-r4864 to config rendered-worker-eac6cd3e114c5c3d1be4db3005827d08
```
After all nodes are updated, check the logs once again the same way as it the beginning (it should now collect more log messages including WARN and INFO levels), also check `ovs-appctl vlog/list`

Now you can access host binaries as described in Check logs section above and check that log levels are stable after service restart/reload. Run 
- `systemctl restart ovs-vswitchd` and then 'ovs-appctl vlog/list'
- `systemctl reload ovs-vswitchd` and then 'ovs-appctl vlog/list'

**- Description for the changelog**
Set ovs syslog level to info

