### PR TITLE
Bug 1988102: [release-4.7] On-prem: add default ingress track script to Keepalived

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -123,6 +123,10 @@ contents:
           mountPath: "/etc/keepalived"
         - name: run-dir
           mountPath: "/var/run/keepalived"
+        - name: chroot-host
+          mountPath: "/host"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         livenessProbe:
           exec:
             command:

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -39,6 +39,12 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
+        weight 20
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        interval 5
         weight 50
     }
 
@@ -75,7 +81,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority 40
+        priority 20
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
@@ -94,5 +100,6 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_default_ingress
         }
     }

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -7,6 +7,12 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
+        weight 20
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        interval 5
         weight 50
     }
 
@@ -16,7 +22,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority 40
+        priority 20
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
@@ -35,5 +41,6 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_default_ingress
         }
     }


### PR DESCRIPTION
Ingress VIP should be set only on a node that runs an instance of
the default ingress controller pod.
In current code, in case extra ingress-controllers are created the
ingress VIP might be wrongly set on a node that doesn't run an instance of
the default ingress controller.

This PR adds a Keepalived track_script that should update the priority based on the 
existence of a default ingress pod on the node.