### PR TITLE
Bug 1975626: Fix KubeletConfig nil error

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -92,7 +92,7 @@ func getManagedKubeletConfigKeyDeprecated(pool *mcfgv1.MachineConfigPool) string
 
 // validates a KubeletConfig and returns an error if invalid
 func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
-	if cfg.Spec.KubeletConfig.Raw == nil {
+	if cfg.Spec.KubeletConfig == nil || cfg.Spec.KubeletConfig.Raw == nil {
 		return nil
 	}
 	kcDecoded, err := decodeKubeletConfig(cfg.Spec.KubeletConfig.Raw)


### PR DESCRIPTION
Add nil check for KubeletConfig to fix the nil pointer panic.

Signed-off-by: Qi Wang <qiwan@redhat.com>
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1975626
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
