### PR TITLE
Bug 1986757: Set timeoutSeconds for keepalived liveness probe

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -144,6 +144,7 @@ contents:
             - |
               [ ! -s "/etc/keepalived/keepalived.conf" ] || (echo "State = FAULT" > /tmp/keepalived.data && kill -s SIGUSR1 "$(pgrep -o keepalived)" && for i in $(seq 5); do grep -q "State = FAULT" /tmp/keepalived.data && sleep 1 || exit 0; done && exit 1)
           initialDelaySeconds: 20
+          timeoutSeconds: 5
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: keepalived-monitor


### PR DESCRIPTION
timeoutSeconds defaults to 1 second, but our liveness probe attempts
to wait for 5 seconds. This seems to be causing frequent liveness
probe timeouts in some environments which triggers unnecessary
restarts.

This patch sets timeoutSeconds to 5 to match the expectations of
the probe.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
Fixed an issue with the keepalived liveness probe that could cause spurious timeouts.