### PR TITLE
[release-4.6] Bug 1989403: daemon: add check before updating kernelArgs

### DIFF
--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -272,7 +272,7 @@ func TestKernelAguments(t *testing.T) {
 			newMcfg := helpers.CreateMachineConfigFromIgnition(newIgnCfg)
 			newMcfg.Spec.KernelArguments = test.newKargs
 
-			res := generateKargsCommand(oldMcfg, newMcfg)
+			res := generateKargs(oldMcfg, newMcfg)
 
 			if !reflect.DeepEqual(test.out, res) {
 				t.Errorf("Failed kernel arguments processing: expected: %v but result is: %v", test.out, res)


### PR DESCRIPTION
Also, make kargs variable and function name logical to
avoid confusion.

Manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/2349