### PR TITLE
Bug 1955300: tighten operator availability conditions

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -100,15 +100,13 @@ func (optr *Operator) syncAvailableStatus() error {
 		return nil
 	}
 
-	optrVersion, _ := optr.vStore.Get("operator")
 	degraded := cov1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded)
-	message := fmt.Sprintf("Cluster has deployed %s", optrVersion)
+	message := fmt.Sprintf("Cluster has deployed %s", co.Status.Versions)
 
 	available := configv1.ConditionTrue
 
 	if degraded {
 		available = configv1.ConditionFalse
-		message = fmt.Sprintf("Cluster not available for %s", optrVersion)
 		mcoObjectRef := &corev1.ObjectReference{
 			Kind:      co.Kind,
 			Name:      co.Name,
@@ -117,6 +115,7 @@ func (optr *Operator) syncAvailableStatus() error {
 		}
 
 		optr.eventRecorder.Eventf(mcoObjectRef, corev1.EventTypeWarning, "OperatorNotAvailable", message)
+		message = fmt.Sprintf("Cluster not available for %s", co.Status.Versions)
 	}
 
 	coStatus := configv1.ClusterOperatorStatusCondition{

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -84,7 +84,7 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		return fmt.Errorf("error syncing degraded status: %v", err)
 	}
 
-	if err := optr.syncAvailableStatus(); err != nil {
+	if err := optr.syncAvailableStatus(syncErr); err != nil {
 		return fmt.Errorf("error syncing available status: %v", err)
 	}
 


### PR DESCRIPTION
The MCO available status should only be set to False when we believe that the operator/operands have problems/aren't working correctly.  An Operator can be degraded (such as in the case of a degraded master pool) but that does not mean that the operator itself is Unavailable and not functioning properly.

We are setting Available = False when we have Degraded = True across the board and by far this is being set when we have a problem with syncRequiredPools. Pool issues do not mean that the operator itself has a problem (if it did it wouldve failed the other syncs first). Instead, let syncAvailable() look at the results of the syncs itself and only set Available = False when the syncing of operands, etc.. fails (which occurs much less often). When those other syncs fail, we have good reason to believe something is fundamentally wrong with the MCO thus setting Available = False

Also fix Available message version. We are using the incoming version as Available at before the version is fully rolled out to the MCO. Instead we should be looking at the clusteroperator version and using that instead.