### PR TITLE
Bug 1995785: crio: complete crio default config

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -4,12 +4,18 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
+    storage_driver = "overlay"
+    storage_option = [
+        "overlay.override_kernel_check=1",
+    ]
 
     [crio.api]
     stream_address = ""
     stream_port = "10010"
 
     [crio.runtime]
+    selinux = true
+    conmon = ""
     conmon_cgroup = "pod"
     default_env = [
         "NSS_SDB_USE_CACHE=no",

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -4,12 +4,18 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
+    storage_driver = "overlay"
+    storage_option = [
+        "overlay.override_kernel_check=1",
+    ]
 
     [crio.api]
     stream_address = ""
     stream_port = "10010"
 
     [crio.runtime]
+    selinux = true
+    conmon = ""
     conmon_cgroup = "pod"
     default_env = [
         "NSS_SDB_USE_CACHE=no",


### PR DESCRIPTION
Instead of relying on /etc/crio/crio.conf (shipped in the cri-o rpm) for fields, we should import all relevant fields into MCO.
This will allow us to eventaully use MCO to remove /etc/crio/crio.conf (and have the rpm stop shipping it).

We do this because there exists a feature where rpm-ostree pins a file if it was ever managed by an RPM, and doesn't update it.
however, we want to be able to change crio configuration post-installation, and having a pinned crio config could interfere with that.

Finally, even though conmon path ("conmon" option) is set to the default, we include it here, to work around the aforementioned bug manifesting
in CRI-O failing to come up.


Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
