### PR TITLE
Bug 1987108: vSpehere: disable vmxnet3 tx csum offload

### DIFF
--- a/templates/common/_base/files/vsphere-disable-vmxnet3v4-features.yaml
+++ b/templates/common/_base/files/vsphere-disable-vmxnet3v4-features.yaml
@@ -7,6 +7,7 @@ contents:
       # Workaround:
       # https://bugzilla.redhat.com/show_bug.cgi?id=1941714
       # https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 
       driver=$(nmcli -t -m tabular -f general.driver dev show "${DEVICE_IFACE}")
 
@@ -14,4 +15,5 @@ contents:
         logger -s "99-vsphere-disable-tx-udp-tnl triggered by ${2} on device ${DEVICE_IFACE}."
         ethtool -K ${DEVICE_IFACE} tx-udp_tnl-segmentation off
         ethtool -K ${DEVICE_IFACE} tx-udp_tnl-csum-segmentation off
+        ethtool -K ${DEVICE_IFACE} tx-checksum-ip-generic off
       fi


### PR DESCRIPTION
**- What I did**
Disable tx checksum offload of vmxnet3 interfaces.

**- How to verify it**
On VSphere openshift cluster HW >= 14, verify cluster up with normal operation and check ` tx-checksum-ip-generic` is off with `ethtool -k <vmxnet3 dev>` on cluster nodes.

**- Description for the changelog**
Disable tx checksum offload of vmxnet3 interfaces.

Closes: #1987108
Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
