### PR TITLE
Bug 1993922: fixes 1 to 1 kubelet config mapping

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -174,7 +174,7 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		}
 		val, ok := kc.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
 		// If we find a matching kubelet config and it is the only one in the list, then return the default MC name with no suffix
-		// add check len(kcList.Items) < 2, mc name should not suffixed if cfg is the first kubelet config to be updated/created
+		// add check len(kcList) < 2, mc name should not suffixed if cfg is the first kubelet config to be updated/created
 		if !ok && len(kcList) < 2 {
 			return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -56,7 +56,8 @@ type fixture struct {
 	featLister      []*osev1.FeatureGate
 	apiserverLister []*osev1.APIServer
 
-	actions []core.Action
+	actions               []core.Action
+	skipActionsValidation bool
 
 	objects    []runtime.Object
 	oseobjects []runtime.Object
@@ -78,7 +79,23 @@ func newFixture(t *testing.T) *fixture {
 }
 
 func (f *fixture) validateActions() {
+	if f.skipActionsValidation {
+		f.t.Log("Skipping actions validation")
+		return
+	}
 	actions := filterInformerActions(f.client.Actions())
+	if len(f.actions) != len(actions) {
+		f.t.Log("Expected Actions:")
+		for i := range f.actions {
+			f.t.Logf("\t%v %#v", f.actions[i].GetVerb(), f.actions[i])
+		}
+		f.t.Log("Seen Actions:")
+		for i := range actions {
+			f.t.Logf("\t%v %#v", actions[i].GetVerb(), actions[i])
+		}
+		f.t.Errorf("number of seen actions do not match expected actions count")
+		return
+	}
 	for i, action := range actions {
 		glog.Infof("  Action: %v", action)
 
@@ -88,7 +105,7 @@ func (f *fixture) validateActions() {
 		}
 
 		expectedAction := f.actions[i]
-		checkAction(expectedAction, action, f.t)
+		checkAction(expectedAction, action, f.t, i)
 	}
 
 	if len(f.actions) > len(actions) {
@@ -287,9 +304,14 @@ func filterOSEActions(actions []core.Action) []core.Action {
 
 // checkAction verifies that expected and actual actions are equal and both have
 // same attached resources
-func checkAction(expected, actual core.Action, t *testing.T) {
+func checkAction(expected, actual core.Action, t *testing.T, index int) {
 	if !(expected.Matches(actual.GetVerb(), actual.GetResource().Resource) && actual.GetSubresource() == expected.GetSubresource()) {
-		t.Errorf("Expected\n\t%#v\ngot\n\t%#v", expected, actual)
+		if actual.GetVerb() == "patch" {
+			actual := actual.(core.PatchAction)
+			t.Errorf("Expected(index=%v)\n\t%#v\ngot\n\t%#v\npatch\t%#v", index, expected, actual, string(actual.GetPatch()))
+		} else {
+			t.Errorf("Expected(index=%v)\n\t%#v\ngot\n\t%#v", index, expected, actual)
+		}
 		return
 	}
 
@@ -348,6 +370,15 @@ func (f *fixture) expectPatchKubeletConfig(config *mcfgv1.KubeletConfig, patch [
 
 func (f *fixture) expectUpdateKubeletConfig(config *mcfgv1.KubeletConfig) {
 	f.actions = append(f.actions, core.NewRootUpdateSubresourceAction(schema.GroupVersionResource{Version: "v1", Group: "machineconfiguration.openshift.io", Resource: "kubeletconfigs"}, "status", config))
+}
+
+func (f *fixture) expectUpdateKubeletConfigRoot(config *mcfgv1.KubeletConfig) {
+	f.actions = append(f.actions, core.NewRootUpdateAction(schema.GroupVersionResource{Version: "v1", Group: "machineconfiguration.openshift.io", Resource: "kubeletconfigs"}, config))
+}
+
+func (f *fixture) resetActions() {
+	f.actions = []core.Action{}
+	f.client.ClearActions()
 }
 
 func TestKubeletConfigCreate(t *testing.T) {

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -383,6 +383,54 @@ func TestKubeletConfigCreate(t *testing.T) {
 	}
 }
 
+func TestKubeletConfigMultiCreate(t *testing.T) {
+	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.newController()
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			f.ccLister = append(f.ccLister, cc)
+
+			kcCount := 30
+			for i := 0; i < kcCount; i++ {
+				f.resetActions()
+
+				poolName := fmt.Sprintf("subpool%v", i)
+				poolLabelName := fmt.Sprintf("pools.operator.machineconfiguration.openshift.io/%s", poolName)
+				labelSelector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, poolLabelName, "")
+
+				mcp := helpers.NewMachineConfigPool(poolName, nil, labelSelector, "v0")
+				mcp.ObjectMeta.Labels[poolLabelName] = ""
+
+				kc := newKubeletConfig(poolName, &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, labelSelector)
+
+				f.mcpLister = append(f.mcpLister, mcp)
+				f.mckLister = append(f.mckLister, kc)
+				f.objects = append(f.objects, kc)
+
+				mcs := helpers.NewMachineConfig(generateManagedKey(kc, 1), labelSelector.MatchLabels, "dummy://", []ign3types.File{{}})
+				mcsDeprecated := mcs.DeepCopy()
+				mcsDeprecated.Name = getManagedKubeletConfigKeyDeprecated(mcp)
+
+				expectedPatch := fmt.Sprintf("{\"metadata\":{\"finalizers\":[\"99-%v-generated-kubelet-1\"]}}", poolName)
+
+				f.expectGetMachineConfigAction(mcs)
+				f.expectGetMachineConfigAction(mcsDeprecated)
+				f.expectGetMachineConfigAction(mcs)
+				f.expectCreateMachineConfigAction(mcs)
+				f.expectPatchKubeletConfig(kc, []byte(expectedPatch))
+				f.expectUpdateKubeletConfig(kc)
+				f.run(poolName)
+			}
+		})
+	}
+}
+
+func generateManagedKey(kcfg *mcfgv1.KubeletConfig, generation uint64) string {
+	return fmt.Sprintf("99-%s-generated-kubelet-%v", kcfg.Name, generation)
+}
+
 func TestKubeletConfigAutoSizingReserved(t *testing.T) {
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
 		t.Run(string(platform), func(t *testing.T) {


### PR DESCRIPTION
**- What I did**
The bug reported a problem with the 1-to-1 mapping to MCPs and Kubelet Configs. I figured out the `getManageKubeletConfigKey` function did not include a LabelSelector to filter out the KubeletConfig for the Pool, thus including all the KubeletConfigs in the system for the limit validation.

**- How to verify it**
The patch adds a test to validate multiple pools and their 1:1 relationship with KubeletConfigs.

**- Description for the changelog**
```
Fix KubeletConfig 1-to-1 relationship to Pools.
```
