### PR TITLE
crio: Remove drop_infra_ctr

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -33,7 +33,6 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
-    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -33,7 +33,6 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
-    drop_infra_ctr = true
 
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"


### PR DESCRIPTION
We see some failures in metal that may be related

https://bugzilla.redhat.com/show_bug.cgi?id=1998643

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



**- Description for the changelog**
Revert the drop_infra_ctr change