### PR TITLE
WIP: MCBS hack week

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -231,3 +231,19 @@ Enabling FIPS mode is a Day 1 operation, set at install time.  You cannot enable
 
 You should not attempt to set this field; it is controlled by the operator and injected directly into the final `rendered-` config.
 For more information, see [OSUpgrades.md](OSUpgrades.md).
+
+### Override Image
+
+Allows you to specify an arbitrary container image with corresponding install/override rpms to apply to system.
+
+Example usage:
+```
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker"
+  name: 99-mcbs-override-image
+spec:
+  overrideImage: quay.io/skumari/rhcos-custom-content:latest
+```

--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -335,6 +335,10 @@ spec:
                 description: Contains which kernel we want to be running like default
                   (traditional), realtime
                 type: string
+              overrideImage:
+                description: OverrideImage specifies an image location with rpms/files
+                  to overlay via rpm-ostree
+                type: string
               osImageURL:
                 description: OSImageURL specifies the remote location that will be used
                   to fetch the OS to fetch the OS.

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -63,6 +63,10 @@ func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec,
 		*modified = true
 		(*existing).Extensions = required.Extensions
 	}
+	if !equality.Semantic.DeepEqual(existing.OverrideImage, required.OverrideImage) {
+		*modified = true
+		(*existing).OverrideImage = required.OverrideImage
+	}
 }
 
 func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfigSpec, required mcfgv1.ControllerConfigSpec) {

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -188,8 +188,9 @@ type MachineConfigSpec struct {
 	KernelArguments []string `json:"kernelArguments"`
 	Extensions      []string `json:"extensions"`
 
-	FIPS       bool   `json:"fips"`
-	KernelType string `json:"kernelType"`
+	FIPS          bool   `json:"fips"`
+	KernelType    string `json:"kernelType"`
+	OverrideImage string `json:"overrideImage"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -95,6 +95,15 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 		}
 	}
 
+	// for OverrideImage, take the latest one
+	overrideImage := ""
+	for i := len(configs) - 1; i >= 0; i-- {
+		if configs[i].Spec.OverrideImage != "" {
+			overrideImage = configs[i].Spec.OverrideImage
+			break
+		}
+	}
+
 	// If no MC sets kerneType, then set it to 'default' since that's what it is using
 	if kernelType == "" {
 		kernelType = KernelTypeDefault
@@ -124,9 +133,10 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 			Config: runtime.RawExtension{
 				Raw: rawOutIgn,
 			},
-			FIPS:       fips,
-			KernelType: kernelType,
-			Extensions: extensions,
+			FIPS:          fips,
+			KernelType:    kernelType,
+			Extensions:    extensions,
+			OverrideImage: overrideImage,
 		},
 	}, nil
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -374,6 +374,7 @@ func (dn *Daemon) applyOSChanges(oldConfig, newConfig *mcfgv1.MachineConfig) (re
 
 	// apply Override Image
 	if mcDiff.overrideImage {
+		glog.Infof("Found override image with location %s, applying...", newConfig.Spec.OverrideImage)
 		if err := dn.applyOverrideImage(newConfig.Spec.OverrideImage); err != nil {
 			return err
 		}
@@ -1766,6 +1767,7 @@ func (dn *Daemon) applyOverrideImage(overrideImage string) error {
 	}
 	defer os.RemoveAll(overrideImageContentDir)
 
+	glog.Infof("Copying the image at %s to %s", overrideImage, overrideImageContentDir)
 	if err = podmanCopy(overrideImage, overrideImageContentDir); err != nil {
 		return fmt.Errorf("Cannot extract custom override image at location %s: %v", overrideImage, err)
 	}
@@ -1779,6 +1781,8 @@ func (dn *Daemon) applyOverrideImage(overrideImage string) error {
 	for _, f := range installFileInfo {
 		installFiles = append(installFiles, f.Name())
 	}
+	glog.Infof("Found rpms to install: %v", installFiles)
+
 	overrideFileInfo, err := ioutil.ReadDir(filepath.Join(overrideImageContentDir, "rpms", "overrides"))
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Cannot parse rpms to override: %v", err)
@@ -1786,6 +1790,7 @@ func (dn *Daemon) applyOverrideImage(overrideImage string) error {
 	for _, f := range overrideFileInfo {
 		overrideFiles = append(overrideFiles, f.Name())
 	}
+	glog.Infof("Found rpms to override: %v", overrideFiles)
 
 	client := NewNodeUpdaterClient()
 	// clean out existing override/overlay
@@ -1804,6 +1809,7 @@ func (dn *Daemon) applyOverrideImage(overrideImage string) error {
 	}
 
 	// good to go
+	glog.Infof("Successfully applied override image!")
 	return nil
 }
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1774,7 +1774,7 @@ func (dn *Daemon) applyOverrideImage(overrideImage string) error {
 
 	var installFiles, overrideFiles []string
 	// Create list of packages to Install and Override
-	installFileInfo, err := ioutil.ReadDir(filepath.Join(overrideImageContentDir, "rpms", "overlay"))
+	installFileInfo, err := ioutil.ReadDir(filepath.Join(overrideImageContentDir, "rpms", "install"))
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Cannot parse rpms to overlay: %v", err)
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1774,21 +1774,23 @@ func (dn *Daemon) applyOverrideImage(overrideImage string) error {
 
 	var installFiles, overrideFiles []string
 	// Create list of packages to Install and Override
-	installFileInfo, err := ioutil.ReadDir(filepath.Join(overrideImageContentDir, "rpms", "install"))
+	installDir := filepath.Join(overrideImageContentDir, "rpms", "install")
+	installFileInfo, err := ioutil.ReadDir(installDir)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Cannot parse rpms to overlay: %v", err)
 	}
 	for _, f := range installFileInfo {
-		installFiles = append(installFiles, f.Name())
+		installFiles = append(installFiles, filepath.Join(installDir, f.Name()))
 	}
 	glog.Infof("Found rpms to install: %v", installFiles)
 
-	overrideFileInfo, err := ioutil.ReadDir(filepath.Join(overrideImageContentDir, "rpms", "overrides"))
+	overrideDir := filepath.Join(overrideImageContentDir, "rpms", "overrides")
+	overrideFileInfo, err := ioutil.ReadDir(overrideDir)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Cannot parse rpms to override: %v", err)
 	}
 	for _, f := range overrideFileInfo {
-		overrideFiles = append(overrideFiles, f.Name())
+		overrideFiles = append(overrideFiles, filepath.Join(overrideDir, f.Name()))
 	}
 	glog.Infof("Found rpms to override: %v", overrideFiles)
 


### PR DESCRIPTION
A base working start that will allow you to apply an overlay image built from https://github.com/coreos/mcbs-hackweek

Does not yet handle deletions, or multiple images, etc.

Example MC included in docs below. Example result:

```
# rpm-ostree status
State: idle
Deployments:
* pivot://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0b444d325e550b72deee243567b85108cafbeaecf6aebeb88ec114027145f350
              CustomOrigin: Managed by machine-config-operator
                   Version: 49.84.202109041651-0 (2021-09-04T16:54:50Z)
      ReplacedBasePackages: kernel-modules-extra kernel kernel-core kernel-modules 4.18.0-305.12.1.el8_4 -> 4.18.0-340.el8
             LocalPackages: libqb-1.0.3-12.el8.x86_64 protobuf-3.5.0-13.el8.x86_64 usbguard-1.0.0-2.el8.x86_64

  pivot://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0b444d325e550b72deee243567b85108cafbeaecf6aebeb88ec114027145f350
              CustomOrigin: Managed by machine-config-operator
                   Version: 49.84.202109041651-0 (2021-09-04T16:54:50Z)
```

If you build this locally with hack scripts, you have to manually apply the new CRD definition.