### PR TITLE
Bug 2003655: [IPI ON-PREM] move Keepalived default ingress script to separate file

### DIFF
--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingress.sh.tmpl"
+contents:
+  inline: |
+    #!/bin/bash
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q {{`{{.NonVirtualIP}}`}}

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -46,7 +46,7 @@ contents:
     }
 
     vrrp_script chk_default_ingress {
-        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        script "/usr/bin/timeout 4.9 /etc/keepalived/chk_default_ingress.sh"
         interval 5
         weight 50
         rise 3

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -19,7 +19,7 @@ contents:
     }
 
     vrrp_script chk_default_ingress {
-        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        script "/usr/bin/timeout 4.9 /etc/keepalived/chk_default_ingress.sh"
         interval 5
         weight 50
         rise 3


### PR DESCRIPTION
The Keepalived default ingress track script checks if a node running an instance of a default router pod.
We noticed that Keepalived failed to run this script as a command, this PR moves default ingress track script
to a separate file (like chk_ocp_lb and chk_ocp_both).

