### PR TITLE
Bug 1990625: configure-ovs: Persist addr-gen-mode for ipv6 connections

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -166,6 +166,11 @@ contents:
         extra_brex_args+="ipv6.dhcp-duid ${dhcp6_client_id} "
       fi
 
+      ipv6_addr_gen_mode=$(nmcli --get-values ipv6.addr-gen-mode conn show ${old_conn})
+      if [ -n "$ipv6_addr_gen_mode" ]; then
+        extra_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
+      fi
+
       # create bridge; use NM's ethernet device default route metric (100)
       if ! nmcli connection show "$bridge_name" &> /dev/null; then
         nmcli c add type ovs-bridge \


### PR DESCRIPTION
Currently br-ex defaults to the mode stable-privacy because that's
the default for new nmcli connections. However, the host interface
is actually configured for eui64, which causes inconsistency from
initial boot to bridge configuration.

To fix this we can just persist the addr-gen-mode like we do with
the DHCP parameters.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Persist addr-gen-mode for ipv6 connection when creating br-ex.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
