### PR TITLE
Remove all references to mdns

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -33,7 +33,6 @@ var (
 		keepalivedImage           string
 		kubeCAFile                string
 		mcoImage                  string
-		mdnsPublisherImage        string
 		oauthProxyImage           string
 		networkConfigFile         string
 		oscontentImage            string
@@ -70,7 +69,6 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.additionalTrustBundleFile, "additional-trust-bundle-config-file", "/assets/manifests/user-ca-bundle-config.yaml", "File containing the additional user provided CA bundle manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.keepalivedImage, "keepalived-image", "", "Image for Keepalived.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.corednsImage, "coredns-image", "", "Image for CoreDNS.")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mdnsPublisherImage, "mdns-publisher-image", "", "Image for mdns-publisher.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oauthProxyImage, "oauth-proxy-image", "", "Image for origin oauth proxy.")
@@ -98,7 +96,6 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 			InfraImage:          bootstrapOpts.infraImage,
 			Keepalived:          bootstrapOpts.keepalivedImage,
 			Coredns:             bootstrapOpts.corednsImage,
-			MdnsPublisher:       bootstrapOpts.mdnsPublisherImage,
 			Haproxy:             bootstrapOpts.haproxyImage,
 			BaremetalRuntimeCfg: bootstrapOpts.baremetalRuntimeCfgImage,
 		},

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -18,7 +18,6 @@ data:
       "clusterEtcdOperatorImage": "registry.svc.ci.openshift.org/openshift:cluster-etcd-operator",
       "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
       "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
-      "mdnsPublisherImage": "registry.svc.ci.openshift.org/openshift:mdns-publisher",
       "haproxyImage": "registry.svc.ci.openshift.org/openshift:haproxy-router",
       "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg",
       "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy"

--- a/install/image-references
+++ b/install/image-references
@@ -31,10 +31,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:coredns
-  - name: mdns-publisher
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:mdns-publisher
   - name: haproxy-router
     from:
       kind: DockerImage

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: {{ onPremPlatformShortName .ControllerConfig }}-infra-mdns
+    app: {{ onPremPlatformShortName .ControllerConfig }}-infra-coredns
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:

--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -15,7 +15,6 @@ spec:
     infraImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     keepalivedImage: ""
     kubeClientAgentImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-    mdnsPublisherImage: ""
   infra:
     apiVersion: config.openshift.io/v1
     kind: Infrastructure

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -16,9 +16,6 @@ const (
 	// CorednsKey is the key that references the coredns image in the controller
 	CorednsKey string = "corednsImage"
 
-	// MdnsPublisherKey is the key that references the mdns-publisher image in the controller
-	MdnsPublisherKey string = "mdnsPublisherImage"
-
 	// HaproxyKey is the key that references the haproxy-router image in the controller
 	HaproxyKey string = "haproxyImage"
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2043,7 +2043,7 @@ metadata:
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:
-    app: {{ onPremPlatformShortName .ControllerConfig }}-infra-mdns
+    app: {{ onPremPlatformShortName .ControllerConfig }}-infra-coredns
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -147,7 +147,6 @@ func RenderBootstrap(
 		templatectrl.InfraImageKey:          imgs.InfraImage,
 		templatectrl.KeepalivedKey:          imgs.Keepalived,
 		templatectrl.CorednsKey:             imgs.Coredns,
-		templatectrl.MdnsPublisherKey:       imgs.MdnsPublisher,
 		templatectrl.HaproxyKey:             imgs.Haproxy,
 		templatectrl.BaremetalRuntimeCfgKey: imgs.BaremetalRuntimeCfg,
 	}

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -34,7 +34,6 @@ type ControllerConfigImages struct {
 	ClusterEtcdOperator string `json:"clusterEtcdOperatorImage"`
 	Keepalived          string `json:"keepalivedImage"`
 	Coredns             string `json:"corednsImage"`
-	MdnsPublisher       string `json:"mdnsPublisherImage"`
 	Haproxy             string `json:"haproxyImage"`
 	BaremetalRuntimeCfg string `json:"baremetalRuntimeCfgImage"`
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -270,7 +270,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		templatectrl.InfraImageKey:          imgs.InfraImage,
 		templatectrl.KeepalivedKey:          imgs.Keepalived,
 		templatectrl.CorednsKey:             imgs.Coredns,
-		templatectrl.MdnsPublisherKey:       imgs.MdnsPublisher,
 		templatectrl.HaproxyKey:             imgs.Haproxy,
 		templatectrl.BaremetalRuntimeCfgKey: imgs.BaremetalRuntimeCfg,
 	}

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -10,7 +10,7 @@ contents:
       creationTimestamp:
       deletionGracePeriodSeconds: 65
       labels:
-        app: {{ onPremPlatformShortName . }}-infra-mdns
+        app: {{ onPremPlatformShortName . }}-infra-coredns
     spec:
       volumes:
       - name: resource-dir


### PR DESCRIPTION
mDNS functionality was removed in 4.8, but we left some of the code
in the interest of not risking issues on upgrade. Now that we're
multiple releases past the initial removal we should be able to get
rid of the last vestiges.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
