### PR TITLE
Send WARN message to stderr

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -85,7 +85,7 @@ contents:
       old_name="$(nmcli -g connection.id connection show uuid "$uuid")"
       local new_name="${old_name}${MANAGED_NM_CONN_SUFFIX}"
       if nmcli connection show id "${new_name}" &> /dev/null; then
-        echo "WARN: existing ovs slave ${new_name} connection profile file found, overwriting..."
+        echo "WARN: existing ovs slave ${new_name} connection profile file found, overwriting..." >&2
         nmcli connection delete id "${new_name}" &> /dev/null
       fi
       nmcli connection clone $uuid "${new_name}" &> /dev/null


### PR DESCRIPTION
Warning message sent by `clone_slave_connection` function ends up in a `new_uuid` variable breaking following command:
```bash
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ clone_slave_connection 87546f2c-6f14-37d9-902b-75b2d99f9606
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ local uuid=87546f2c-6f14-37d9-902b-75b2d99f9606
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ local old_name
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: +++ nmcli -g connection.id connection show uuid 87546f2c-6f14-37d9-902b-75b2d99f9606
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ old_name=enp0s4
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ local new_name=enp0s4-slave-ovs-clone
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ nmcli connection show id enp0s4-slave-ovs-clone
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ echo 'WARN: existing ovs slave enp0s4-slave-ovs-clone connection profile file found, overwriting...'
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ nmcli connection delete id enp0s4-slave-ovs-clone
Sep 23 20:26:06 master-0-0 configure-ovs.sh[147099]: ++ nmcli connection clone 87546f2c-6f14-37d9-902b-75b2d99f9606 enp0s4-slave-ovs-clone
Sep 23 20:26:07 master-0-0 configure-ovs.sh[147099]: ++ nmcli -g connection.uuid connection show enp0s4-slave-ovs-clone
Sep 23 20:26:07 master-0-0 configure-ovs.sh[147099]: + new_uuid='WARN: existing ovs slave enp0s4-slave-ovs-clone connection profile file found, overwriting...
Sep 23 20:26:07 master-0-0 configure-ovs.sh[147099]: 03acfda9-6d08-4fd7-a511-efb13e9068e4'
Sep 23 20:26:07 master-0-0 configure-ovs.sh[147099]: + nmcli conn mod uuid WARN: existing ovs slave enp0s4-slave-ovs-clone connection profile file found, overwriting... 03acfda9-6d08-4fd7-a511-efb13e9068e4 connection.master 92f0309a-ebe4-4995-959c-2984f21226ed
Sep 23 20:26:07 master-0-0 configure-ovs.sh[147099]: Error: unknown connection 'WARN:'.
```