### PR TITLE
Bug 2009785: crio: specifically enable version_file_persist

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -8,6 +8,7 @@ contents:
     storage_option = [
         "overlay.override_kernel_check=1",
     ]
+    version_file_persist = "/var/lib/crio/version"
 
     [crio.api]
     stream_address = ""

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -8,6 +8,7 @@ contents:
     storage_option = [
         "overlay.override_kernel_check=1",
     ]
+    version_file_persist = "/var/lib/crio/version"
 
     [crio.api]
     stream_address = ""


### PR DESCRIPTION
instead of relying on the default config.

(a step in fixing https://github.com/cri-o/cri-o/issues/5352)

Signed-off-by: Peter Hunt <pehunt@redhat.com>