### PR TITLE
Add support for `authorized_keys.d/ignition` in OKD 

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1725,8 +1725,8 @@ func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
 	// Keys should only be written to "/home/core/.ssh"
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
 	glog.Infof("Writing SSHKeys at %q", authKeyPath)
-
-	if err := writeFileAtomicallyWithDefaults(authKeyPath, []byte(keys)); err != nil {
+	// write the file and ensure it's owned by the core user (uid: 1000, gid: 1000)
+	if err := writeFileAtomically(authKeyPath, []byte(keys), defaultDirectoryPermissions, defaultFilePermissions, 1000, 1000); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1185,6 +1185,11 @@ func (dn *Daemon) updateFiles(oldConfig, newConfig *mcfgv1.MachineConfig) error 
 	if err := dn.writeUnits(newIgnConfig.Systemd.Units); err != nil {
 		return err
 	}
+	// In OKD /var/home/core/.ssh/authorized_keys is not created during ignition.  Create
+	// from /var/home/core/.ssh/authorized_keys.d/ignition if missing
+	if err := dn.writeMissingAuthorizedKeys(); err != nil {
+		return err
+	}
 	if err := dn.deleteStaleData(&oldIgnConfig, &newIgnConfig); err != nil {
 		return err
 	}
@@ -1448,6 +1453,39 @@ func (dn *Daemon) presetUnit(unit ign3types.Unit) error {
 		return fmt.Errorf("error running preset on unit: %s", stdouterr)
 	}
 	glog.Infof("Preset systemd unit %s", unit.Name)
+	return nil
+}
+
+// writeMissingAuthorizedKeys: In OKD /var/home/core/.ssh/authorized_keys is not created during ignition.  Create
+// from /var/home/core/.ssh/authorized_keys.d/ignition if missing
+func (dn *Daemon) writeMissingAuthorizedKeys() error {
+	authKeyPath := filepath.Join(coreUserSSHPath, "authorized_keys")
+	authKeyFragPath := filepath.Join(coreUserSSHPath, "authorized_keys.d", "ignition")
+
+	// if authKeyFragPath doesn't exist return as the rest is unneeded
+	if _, err := os.Stat(authKeyFragPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	if _, err := os.Stat(authKeyPath); err != nil {
+		if os.IsNotExist(err) {
+			glog.Infof("Creating missing %s", authKeyPath)
+			key, err := ioutil.ReadFile(authKeyFragPath)
+			if err != nil {
+				glog.Infof("Unable to read %s", authKeyFragPath)
+				return err
+			}
+			if err := dn.atomicallyWriteSSHKey(string(key)); err != nil {
+				glog.Infof("Unable to create %s", authKeyPath)
+				return err
+			}
+		} else {
+			glog.Infof("exists, keys already written")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
See also #2778 

**- What I did**
```
commit 22f0fb8e8c38e6da8f3a930ffb2e6f6fcddb3a86
Author: John Fortin <fortinj66@gmail.com>
Date:   Mon Feb 8 17:08:23 2021 -0500

    daemon: Create missing /home/core/.ssh/authorized_keys file on OKD
    
    Ignition on OKD may create dropins in authorized_keys.d instead of a single authorized_keys file, so in order
    to properly manage this file MCO should convert it into a single authorized_keys entry

commit 91c8881805142f21c8a28d60d4b7940b71d1b5a0
Author: Christian Glombek <cglombek@redhat.com>
Date:   Thu Jun 17 14:05:43 2021 +0200

    daemon: Make SSH keys owned by core user
    
    In OKD, the file does not exist and is therefore newly written
    via the atomicallyWriteSSHKey function.
    This change ensures the ownership is explicitly set to the core user
    and group (uid 1000/gid 1000) as it'll otherwise default to root.
    
    Fixes: https://github.com/openshift/okd/issues/655

```

**- How to verify it**

OKD e2e

**- Description for the changelog**
daemon: Create missing /home/core/.ssh/authorized_keys file on OKD
daemon: Make SSH keys owned by core user

cc @fortinj66 @bgilbert 