### PR TITLE
templates: [on-prem] NM prepender: ensure /etc/systemd/resolved.conf.d dir exists

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -56,6 +56,7 @@ contents:
                 >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"
                 if [[ ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
                     >&2 echo "NM resolv-prepender: Creating /etc/systemd/resolved.conf.d/60-kni.conf"
+                    mkdir -p /etc/systemd/resolved.conf.d
                     echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
                     echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
                     echo "Domains=$DOMAINS" >> /etc/systemd/resolved.conf.d/60-kni.conf


### PR DESCRIPTION
Fixes: https://github.com/openshift/okd/issues/690
See also: #2778 

**- How to verify it**
OKD e2e

**- Description for the changelog**
templates: NM prepender: ensure /etc/systemd/resolved.conf.d dir exists