### PR TITLE
Bug 2002121: Periodically send gratuitous ARPs

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -6,6 +6,7 @@ contents:
         enable_script_security
         script_user root
         max_auto_priority -1
+        vrrp_garp_master_refresh 60
     }
 
     # These are separate checks to provide the following behavior:

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -6,6 +6,7 @@ contents:
         enable_script_security
         script_user root
         max_auto_priority -1
+        vrrp_garp_master_refresh 60
     }
 
     # TODO: Improve this check. The port is assumed to be alive.


### PR DESCRIPTION
Under some circumstances, the network infrastructure might miss the
GARPs sent when a VIP fails over. This causes the VIP to become
inaccessible because the network doesn't know where it is. Worse, in
some cases the network might not realize it doesn't have the correct
information because it has previously cached the old VIP location.

To get around this, configure keepalived to periodically send GARPs.
This will ensure that even if the failover is missed, the network
will eventually catch up.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
