### PR TITLE
[release-4.7] Bug 2008692: Don't write empty static pod manifests

### DIFF
--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -1,8 +1,7 @@
 mode: 0644
-path: "/etc/kubernetes/manifests/coredns.yaml"
+path: {{ if (onPremPlatformAPIServerInternalIP .) -}} "/etc/kubernetes/manifests/coredns.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/coredns.yaml" {{ end }}
 contents:
   inline: |
-    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -107,4 +106,3 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
-    {{ end -}}

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -1,8 +1,7 @@
 mode: 0644
-path: "/etc/kubernetes/manifests/keepalived.yaml"
+path: {{ if (onPremPlatformAPIServerInternalIP .) }} "/etc/kubernetes/manifests/keepalived.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/keepalived.yaml" {{ end }}
 contents:
   inline: |
-    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -176,4 +175,3 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
-    {{ end -}}

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -1,8 +1,7 @@
 mode: 0644
-path: "/etc/kubernetes/manifests/haproxy.yaml"
+path: {{ if (onPremPlatformAPIServerInternalIP .) -}} "/etc/kubernetes/manifests/haproxy.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/haproxy.yaml" {{ end }}
 contents:
   inline: |
-    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     kind: Pod
     apiVersion: v1
     metadata:
@@ -145,4 +144,3 @@ contents:
       - operator: Exists
       priorityClassName: system-node-critical
     status: {}
-    {{ end -}}


### PR DESCRIPTION
Kubelet complains about empty files in the manifests directory because
it can't parse them. While this doesn't cause any harm, it has caused
bugs to be mis-routed because people see the error messages while
debugging and think something is wrong.

Instead of conditionalizing the content of the files, we can
conditionalize the path and just write them to a disabled location
so they won't be deployed and they also won't be processed by kubelet.
Note that I tried just using /dev/null to avoid writing the files
entirely, but I was not able to get that to work.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
