### PR TITLE
podsecurity: enforce privileged for openshift-machine-config-operator namespace

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -12,6 +12,9 @@ metadata:
     name: openshift-machine-config-operator
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-machine-config-operator` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 
