### PR TITLE
Bug 2009404: ovs-configuration: work around NM connection dependency issue

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -254,8 +254,13 @@ contents:
 
       # For some reason RHEL7 requires the ovs bridge to be brought up explicitly whereas RHCOS does not
       nmcli conn up "$bridge_name"
-      # Bring up the new interface connection
-      nmcli conn up "$bridge_interface_name"
+      # Bring up the new interface connection; retry a few times to work around an NM dependency failure issue
+      for i in {0..3}; do
+        if nmcli conn up "$bridge_interface_name"; then
+          break
+        fi
+        sleep 2
+      done
 
       if ! nmcli connection show "$ovs_interface" &> /dev/null; then
         if nmcli --fields ipv4.method,ipv6.method conn show $old_conn | grep manual; then


### PR DESCRIPTION
Every now and again NM fails to bring up the phys0 connection.
Try a couple times.

```
configure-ovs.sh[1280]: ++ nmcli -g connection.master connection show uuid 3739be42-f3bc-4ac0-8c69-7a4de7d9e464
configure-ovs.sh[1280]: + '[' c5abc0d7-e93c-4a2d-ac6b-71cb1ead98bf '!=' ens5 ']'
configure-ovs.sh[1280]: + continue
configure-ovs.sh[1280]: + nmcli conn up br-ex
configure-ovs.sh[1280]: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/5)
configure-ovs.sh[1280]: + nmcli conn up ovs-if-phys0
configure-ovs.sh[1280]: Error: Connection activation failed: A dependency of the connection failed
configure-ovs.sh[1280]: Hint: use 'journalctl -xe NM_CONNECTION=3739be42-f3bc-4ac0-8c69-7a4de7d9e464 + NM_DEVICE=ens5' to get more details.
configure-ovs.sh[1280]: + handle_exit_error
configure-ovs.sh[1280]: + e=4
configure-ovs.sh[1280]: + '[' 4 -eq 0 ']'
configure-ovs.sh[1280]: + set +e
configure-ovs.sh[1280]: + nmcli c show
configure-ovs.sh[1280]: NAME                UUID                                  TYPE        DEVICE
configure-ovs.sh[1280]: Wired connection 1  06f63e11-cc3b-3d8e-9a3c-e685b2a11f24  ethernet    ens5
configure-ovs.sh[1280]: br-ex               6b41000c-f7f5-4bc7-9a52-e4388ce360e3  ovs-bridge  br-ex
configure-ovs.sh[1280]: ovs-port-br-ex      e9041443-4386-4547-9747-49202456d736  ovs-port    br-ex
configure-ovs.sh[1280]: ovs-port-phys0      c5abc0d7-e93c-4a2d-ac6b-71cb1ead98bf  ovs-port    ens5
configure-ovs.sh[1280]: ovs-if-phys0        3739be42-f3bc-4ac0-8c69-7a4de7d9e464  ethernet    --
configure-ovs.sh[1280]: + nmcli conn down ovs-if-phys0
configure-ovs.sh[1280]: Error: 'ovs-if-phys0' is not an active connection.
configure-ovs.sh[1280]: Error: no active connection provided.
configure-ovs.sh[1280]: + nmcli conn up 06f63e11-cc3b-3d8e-9a3c-e685b2a11f24
configure-ovs.sh[1280]: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/10)
configure-ovs.sh[1280]: + exit 4
```

@rook @trozet @mohit-sheth 