### PR TITLE
Bug 2013726: [on-prem] Update NetworkManager-resolv-prepender.yaml

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -50,7 +50,18 @@ contents:
             show \
             "{{ onPremPlatformAPIServerInternalIP . }}" \
             "{{ onPremPlatformIngressIP . }}")
-        DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
+            
+        # Ignore white space while creating /etc/resolv.conf between search and search domain names if the NM variables are empty.  
+        
+        if   [[ -z "$IP4_DOMAINS" && -z "$IP6_DOMAINS" ]] ; then 
+             DOMAINS="{{.DNS.Spec.BaseDomain}}" 
+        elif [[ -n "$IP4_DOMAINS" && -z "$IP6_DOMAINS" ]] ; then
+             DOMAINS="${IP4_DOMAINS} {{.DNS.Spec.BaseDomain}}" 
+        elif [[ -z "$IP4_DOMAINS" && -n "$IP6_DOMAINS" ]] ; then
+             DOMAINS="${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}" ; else 
+             DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
+        fi    
+        
         if [[ -n "$NAMESERVER_IP" ]]; then
             if systemctl -q is-enabled systemd-resolved; then
                 >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -62,6 +62,12 @@ contents:
              DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
         fi    
         
+        # If the connection is DHCP, the search list is provided in option 119 
+        
+        if [[ "$STATUS" == dhcp* ]]; then
+            DOMAINS="${DHCP4_DOMAIN_SEARCH} {{.DNS.Spec.BaseDomain}}"
+        fi 
+        
         if [[ -n "$NAMESERVER_IP" ]]; then
             if systemctl -q is-enabled systemd-resolved; then
                 >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"


### PR DESCRIPTION
Fixies # Don't add white namespace while generating /etc/resolv.conf on nodes if variables are empty. 
Empty NetworkManager variables cause generating whitespace in /etc/resolv.conf between search and search domains.
This patch checks if the variables are empty. If empty, don't add it to Variable $DOMAINS 

i.e 
 
$ cat <sosreport>/etc/resolv.conf 
# Generated by KNI resolv prepender NM dispatcher script
search   abc.com ## **three whitespace added here between search and abc.com** 
nameserver xx.xx.xx.xx
nameserver xx.xx.xx.xx
nameserver xx.xx.xx.xx

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Validate if variables are set to empty. 

**- How to verify it**
Don't pass search domain via dhcp service. 

**- Description for the changelog**
Validate the NetworkManager variables before using them in the dispatcher script. 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Validate the NetworkManager variables before using them in the dispatcher script. 
