### PR TITLE
templates: Add /usr/share/containers/oci/hooks.d to the "hooks_dir" array of crio.conf

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,7 @@ contents:
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
         "/run/containers/oci/hooks.d",
+        "/usr/share/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
     absent_mount_sources_to_reject = [

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -28,6 +28,7 @@ contents:
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
         "/run/containers/oci/hooks.d",
+        "/usr/share/containers/oci/hooks.d",
     ]
     manage_ns_lifecycle = true
     absent_mount_sources_to_reject = [


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Having this directory by default enables the use of the
oci-seccomp-bpf-hook which in turn enables recording of syscalls either
manually or via e.g. the Security Profiles Operator.

oci-seccomp-bpf-hook is being requested as an extension of RHCOS at the
moment:
    https://github.com/openshift/os/pull/596


**- How to verify it**
The easy way is to verify that the file contents contain /usr/share/containers/oci/hooks.d

A more involved way includes actually installing the oci-seccomp-bpf-hook
which is not trivial on RHCOS, but see e.g. https://issues.redhat.com/browse/CMP-927
or ping me for instructions.

**- Description for the changelog**
(Not sure if this change warrants a changelog entry?)

The CRI-O configuration files enables the use of OCI plugins whose
JSON manifests are stored at /usr/share/containers/oci/hooks.d.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->