### PR TITLE
Bug 2012780: Avoid dynamically allocated port range for haproxy

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -20,7 +20,7 @@ contents:
       bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters
     listen health_check_http_url
-      bind :::50936 v4v6
+      bind :::30936 v4v6
       mode http
       monitor-uri /haproxy_ready
       option dontlognull

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -117,7 +117,7 @@ contents:
           initialDelaySeconds: 50
           httpGet:
             path: /haproxy_ready
-            port: 50936
+            port: 30936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: haproxy-monitor


### PR DESCRIPTION
The haproxy stats and health endpoints were configured with high
port numbers (50000 and 50936) that conflict with the range used for
dynamic allocation of ports:

$ cat /proc/sys/net/ipv4/ip_local_port_range
32768   60999

This can occasionally cause haproxy to fail if the kernel happens to
pick one of those ports for a client connection.

To avoid this, we should use ports outside the range shown above.
This patch changes the health endpoint to 30936, while the stats
port is controlled by runtimecfg and will be fixed in a separate
commit there.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Moved the haproxy health check port to avoid conflicts with dynamically allocated client ports.
