### PR TITLE
DROP: experiment with lowering the Azure MTU

### DIFF
--- a/templates/common/azure/files/override-mtu.yaml
+++ b/templates/common/azure/files/override-mtu.yaml
@@ -1,0 +1,13 @@
+path: "/etc/NetworkManager/dispatcher.d/30-override-azure-mtu"
+mode: 0755
+contents:
+  inline: |
+    #!/bin/sh
+
+    IFACE="$1"
+    STATUS="$2"
+
+    if [ "${IFACE}" = "eth0" -a "${STATUS}" = "up" ]; then
+        echo "Overriding default MTU on ${IFACE}"
+        ip link set "${IFACE}" mtu 1400
+    fi


### PR DESCRIPTION
This may fix networking problems observed in e2e-azure runs.

[Azure's documentation](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-tcpip-performance-tuning#azure-and-vm-mtu) says:

> The default MTU for Azure VMs is 1,500 bytes. The Azure Virtual Network stack will attempt to fragment a packet at 1,400 bytes.

which has always struck us as weird ("what part of 'Maximum Transmission Unit' didn't you understand?"), but things do seem to _mostly_ work. We have previously had MTU-related problems on Azure with SDN traffic and introduced a hacky workaround for that (https://github.com/openshift/cluster-network-operator/pull/1059). It appears that we may also have problems with host-network packets that we just hadn't noticed before (https://bugzilla.redhat.com/show_bug.cgi?id=2011939#c1). So this adds an NM dispatcher script to "correct" the eth0 MTU to 1400 to see if that helps things.

(@deads2k recommended we test this by changing the default Azure install in master rather than by adding a MachineConfig to the install manifests for the e2e-azure runs because Azure takes a really long time to roll out a new machine config, and so doing it the MachineConfig way would probably just cause CI runs to time out.)

**This change will break upgrades from 4.9 (on Azure) and must be reverted before 4.10.** (A more complicated solution will be needed if this turns out to fix problems.) Assuming we do agree to merge this PR, I'll file a 4.10 blocker bug tracking the fact that we need to revert it (though presumably we'll figure out if it's helping or not fairly quickly so it won't actually stick around that long).

/hold
for testing