### PR TITLE
Add PowerVS platform

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -51,3 +51,11 @@ aliases:
     - kwoodson
     - fabianofranz
     - rvanderp3
+  powervs-approvers:
+    - Prashanth684
+    - clnperez
+    - mkumatag
+  powervs-reviewers:
+    - Prashanth684
+    - clnperez
+    - mkumatag

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -278,6 +278,10 @@ spec:
                             description: Ovirt contains settings specific to the oVirt
                               infrastructure provider.
                             type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              IBM Power Systems Virtual Servers infrastructure provider.
+                            type: object
                           type:
                             description: type is the underlying infrastructure provider
                               for the cluster. This value controls whether infrastructure
@@ -286,8 +290,8 @@ spec:
                               integrations are enabled. If None, no infrastructure
                               automation is enabled. Allowed values are "AlibabaCloud", "AWS",
                               "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere",
-                              "oVirt", "KubeVirt", "EquinixMetal", and "None". Individual
-                              components may not support all platforms, and must handle
+                              "oVirt", "KubeVirt", "EquinixMetal", "PowerVS" and "None".
+                              Individual components may not support all platforms, and must handle
                               unrecognized platforms as None if they do not support
                               that platform.
                             enum:
@@ -305,6 +309,7 @@ spec:
                             - IBMCloud
                             - KubeVirt
                             - EquinixMetal
+                            - PowerVS
                             type: string
                           vsphere:
                             description: VSphere contains settings specific to the
@@ -392,6 +397,7 @@ spec:
                         - IBMCloud
                         - KubeVirt
                         - EquinixMetal
+                        - PowerVS
                         type: string
                       platformStatus:
                         description: platformStatus holds status information specific
@@ -703,6 +709,52 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              region:
+                                description: region holds the default Power VS region
+                                  for new Power VS resources created by the cluster.
+                                type: string
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                              zone:
+                                description: 'zone holds the default zone for the
+                                  new Power VS resources created by the cluster. Note:
+                                  Currently only single-zone OCP clusters are supported'
+                                type: string
+                            type: object
                           type:
                             description: "type is the underlying infrastructure provider
                               for the cluster. This value controls whether infrastructure
@@ -711,8 +763,8 @@ spec:
                               integrations are enabled. If None, no infrastructure
                               automation is enabled. Allowed values are \"AlibabaCloud\",
                               \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\",
-                              \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", and
-                              \"None\". Individual components may not support all platforms,
+                              \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\"
+                              and \"None\". Individual components may not support all platforms,
                               and must handle unrecognized platforms as None if they
                               do not support that platform. \n This value will be
                               synced with to the `status.platform` and `status.platformStatus.type`.
@@ -732,6 +784,7 @@ spec:
                             - IBMCloud
                             - KubeVirt
                             - EquinixMetal
+                            - PowerVS
                             type: string
                           vsphere:
                             description: VSphere contains settings specific to the

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -147,7 +147,7 @@ func platformStringFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (st
 		return "", fmt.Errorf("cannot generate MachineConfigs when no platformStatus.type is set")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case configv1.AWSPlatformType, configv1.AlibabaCloudPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.KubevirtPlatformType, configv1.NonePlatformType:
+	case configv1.AWSPlatformType, configv1.AlibabaCloudPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.KubevirtPlatformType, configv1.PowerVSPlatformType, configv1.NonePlatformType:
 		return strings.ToLower(string(ic.Infra.Status.PlatformStatus.Type)), nil
 	default:
 		// platformNone is used for a non-empty, but currently unsupported platform.

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -80,6 +80,9 @@ func TestCloudProvider(t *testing.T) {
 		platform: configv1.NonePlatformType,
 		res:      "",
 	}, {
+		platform: configv1.PowerVSPlatformType,
+		res:      "",
+	}, {
 		platform: configv1.VSpherePlatformType,
 		res:      "vsphere",
 	}, {
@@ -294,6 +297,7 @@ var (
 		"none":      "./test_data/controller_config_none.yaml",
 		"vsphere":   "./test_data/controller_config_vsphere.yaml",
 		"kubevirt":  "./test_data/controller_config_kubevirt.yaml",
+		"powervs":   "./test_data/controller_config_powervs.yaml",
 	}
 )
 

--- a/pkg/controller/template/test_data/controller_config_powervs.yaml
+++ b/pkg/controller/template/test_data/controller_config_powervs.yaml
@@ -1,0 +1,25 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 3
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      platformStatus:
+        type: "PowerVS"

--- a/templates/common/powervs/OWNERS
+++ b/templates/common/powervs/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - powervs-approvers
+reviewers:
+  - powervs-reviewers

--- a/templates/common/powervs/units/afterburn-hostname.service.yaml
+++ b/templates/common/powervs/units/afterburn-hostname.service.yaml
@@ -1,0 +1,18 @@
+name: afterburn-hostname.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Afterburn Hostname
+  # Block services relying on Networking being up.
+  Before=network-online.target
+  # Wait for NetworkManager to report its online
+  After=NetworkManager-wait-online.service
+  # Run before hostname checks
+  Before=node-valid-hostname.service
+
+  [Service]
+  ExecStart=/usr/bin/afterburn --provider powervs --hostname=/etc/hostname
+  Type=oneshot
+
+  [Install]
+  WantedBy=network-online.target


### PR DESCRIPTION
Enable Power VS(Virtual Servers) as a platform. PowerVS is an extension of IBMCloud which supports deploying ppc64le VMs.
Details here: https://github.com/openshift/enhancements/pull/736

The hostname for the VMs are set through afterburn which reads the metadata provided through the config drive which is the primary mechanism through which ignition and hostname are provided.
(https://github.com/coreos/afterburn/pull/592)

Cross referencing some other PRs for completeness:
https://github.com/openshift/installer/pull/5270
https://github.com/openshift/installer/pull/5224 (closed, WIP to split into multiple PRs)

ova images for PowerVS are already generated today:
https://github.com/coreos/coreos-assembler/pull/2200
https://github.com/coreos/coreos-assembler/pull/2361