### PR TITLE
Bug 2014999: Tweak nmcli command to remove field heading(UUID)

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -152,7 +152,7 @@ contents:
       fi
 
       # store old conn for later
-      old_conn=$(nmcli --fields UUID,DEVICE conn show --active | awk "/\s${iface}\s*\$/ {print \$1}")
+      old_conn=$(nmcli --fields UUID conn show --active | awk "/\s${iface}\s*\$/ {print \$1}" | tail -n +2)
 
       extra_brex_args=""
       # check for dhcp client ids


### PR DESCRIPTION
Migration from OpenShiftSDN to OVNKubernetes might fail or show some unwanted results due to field headings present in old_conn variable.

https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml#L155

I have tried to run subsequent nmcli commands where this variable is being used and those were failing due to field headings.

~~~
[root@worker-0 ~]# nmcli conn show
NAME                UUID                                  TYPE           DEVICE 
ovs-if-br-ex        8b9b8806-01d6-41b6-b39d-6e9bb93488b1  ovs-interface  br-ex  
br-ex               1b8db8f6-5beb-44c3-bd49-2e645e89adbe  ovs-bridge     br-ex  
ovs-if-phys0        de6af9a3-d81a-4537-9783-ec08a58f1600  ethernet       ens3   
ovs-port-br-ex      b18cf7d2-9c40-4198-8f43-8771b1400e5a  ovs-port       br-ex  
ovs-port-phys0      7af697d6-b561-4147-ac86-2ee20701cc9f  ovs-port       ens3   
Wired connection 1  fce22e85-a71a-3e63-a1da-33ac9f819852  ethernet       --     
[root@worker-0 ~]# old_conn=$(nmcli --fields UUID,DEVICE conn show --active | awk "/\s${iface}\s*\$/ {print \$1}")
[root@worker-0 ~]# echo $old_conn
UUID 8b9b8806-01d6-41b6-b39d-6e9bb93488b1 1b8db8f6-5beb-44c3-bd49-2e645e89adbe de6af9a3-d81a-4537-9783-ec08a58f1600 b18cf7d2-9c40-4198-8f43-8771b1400e5a 7af697d6-b561-4147-ac86-2ee20701cc9f

### Running command in https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml#L196

[root@worker-0 ~]# nmcli --get-values connection.type conn show ${old_conn}
Error: UUID - no such connection profile.
~~~
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2014999

Using "UUID,DEVICE" with --fields flag in nmcli command does not print both UUID and Device. It only prints UUID of any connection. Removed Device from --fields flag to minimize confusion.


**- What I did**
Modified line[1] and did following changes.
- Removed DEVICE from --fields flag
- Removed field heading using 'tail'.

[1] - https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml#L155
**- How to verify it**

**- Description for the changelog**

- Removed DEVICE from --fields flag
- Removed field heading using 'tail'.

