### PR TITLE
Add a loop while running nmcli connection up

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -243,7 +243,9 @@ contents:
         nmcli c show
         # For some reason RHEL7 requires the interface connection to be brought down explicitly whereas RHCOS does not
         nmcli conn down "$bridge_interface_name"
-        nmcli conn up $old_conn
+        for connection in ${old_conn}; do
+          nmcli conn up $connection
+        done
         exit $e
       }
       trap "handle_exit_error" EXIT


### PR DESCRIPTION
ovs-configuration.service service failing with below error while migrating from OpenShiftSDN to OVNKubernetes. This is occurring as there is no loop[1] when we run 'nmcli conn up $old_conn' command and nmcli does not allow passing multiple UUID at once.

[1] - https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml#L246

~~~
[root@lltwa046xsdi012 ~]# systemctl status ovs-configuration.service
● ovs-configuration.service - Configures OVS with proper host networking configuration
   Loaded: loaded (/etc/systemd/system/ovs-configuration.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Thu 2021-10-14 21:17:40 UTC; 17h ago
 Main PID: 3364 (code=exited, status=1/FAILURE)
      CPU: 951ms

Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com configure-ovs.sh[3364]: Error: no active connection provided.
Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com configure-ovs.sh[3364]: + nmcli conn down ovs-if-phys0
Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com configure-ovs.sh[3364]: Connection 'ovs-if-phys0' successfully deactivated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/11)
Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com configure-ovs.sh[3364]: + nmcli conn up a6be43ca-2c48-4ee1-af40-786872bea27d 1f0041d2-aacc-4ea4-ab10-db243eaa817c
Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com configure-ovs.sh[3364]: Error: invalid extra argument '1f0041d2-aacc-4ea4-ab10-db243eaa817c'.
Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com configure-ovs.sh[3364]: + exit 1
Oct 14 21:17:40 lltwa046xsdi012.sdi.corp.bankofamerica.com systemd[1]: ovs-configuration.service: Main process exited, code=exited, status=1/FAILURE
~~~

**- What I did**
- Added a for loop to bring up all connections as part of handle_exit_error() function. nmcli does not allow us to mention multiple connection UUID at once while running "nmcli conn up <UUID>". Hence a for loop will prevent any error due to multiple connection stored in old_conn variable in line[1].

[1] - https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml#L155

**- Description for the changelog**
Added a for loop so that we can bring up all connections one by one.