### PR TITLE
crio: add openshift builder workload

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -37,6 +37,13 @@ contents:
     ]
     drop_infra_ctr = true
 
+    [crio.runtime.workloads.openshift-builder]
+    activation_annotation = "io.openshift.builder"
+    allowed_annotations = [
+      "io.kubernetes.cri-o.userns-mode",
+      "io.kubernetes.cri-o.Devices"
+    ]
+
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"
     pause_image = "{{.Images.infraImageKey}}"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -37,6 +37,13 @@ contents:
     ]
     drop_infra_ctr = true
 
+    [crio.runtime.workloads.openshift-builder]
+    activation_annotation = "io.openshift.builder"
+    allowed_annotations = [
+      "io.kubernetes.cri-o.userns-mode",
+      "io.kubernetes.cri-o.Devices"
+    ]
+
     [crio.image]
     global_auth_file = "/var/lib/kubelet/config.json"
     pause_image = "{{.Images.infraImageKey}}"


### PR DESCRIPTION
this workload will be allowed to mount devices (like /dev/fuse) and configure user namespaces
to allow for unprivileged builds

completes https://issues.redhat.com/browse/OCPNODE-683

Signed-off-by: Peter Hunt <pehunt@redhat.com>