### PR TITLE
Bug 1860774: Force Node IP configuration service on for all vSphere platforms

### DIFF
--- a/templates/common/vsphere/units/nodeip-configuration.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration.service.yaml
@@ -1,0 +1,46 @@
+name: nodeip-configuration.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
+  # This is more effective in VIP managing environments where the kubelet and crio IP
+  # address picking logic is flawed and may end up selecting an address from a
+  # different subnet or a deprecated address
+  Wants=network-online.target crio-wipe.service
+  After=network-online.target ignition-firstboot-complete.service crio-wipe.service
+  Before=kubelet.service crio.service
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/bin/podman run --rm \
+    --authfile /var/lib/kubelet/config.json \
+    --net=host \
+    --volume /etc/systemd/system:/etc/systemd/system:z \
+    {{ .Images.baremetalRuntimeCfgImage }} \
+    node-ip \
+    set --retry-on-failure \
+    {{if eq .IPFamilies "IPv6" -}}
+    --prefer-ipv6 \
+    {{end -}}
+    {{if (onPremPlatformAPIServerInternalIP .) -}}
+    {{ onPremPlatformAPIServerInternalIP . }}; \
+    {{- else -}}
+    ; \
+    {{end -}}
+    do \
+    sleep 5; \
+    done"
+  ExecStart=/bin/systemctl daemon-reload
+
+  {{if .Proxy -}}
+  EnvironmentFile=/etc/mco/proxy.env
+  {{end -}}
+
+  [Install]
+  RequiredBy=kubelet.service


### PR DESCRIPTION
**- What I did**
This copies the NodeIP configuration service from the base and on-prem templates, but removes the conditions for enabling it. This will now be enabled on all vSphere environments (where it wasn't on UPI before - in particular, those without an API server VIP).

This should resolve an issue where Egress IPs are being added to CSRs created by Kubelets on vSphere. Today, when a new egress IP is added to a UPI cluster, an Egress IP is picked up as a new IP by the kubelet and it regenerates its serving certificates. We have no easy way to verify that these additional IP addresses are valid and therefore cannot automatically approve the CSRs.
On IPI clusters today, because the NodeIP is fixed by the NodeIP configuration before any egress IPs are assigned (this is done before kubelet first starts, hence no CNI yet), this IP is used throughout the lifetime of the Node and this egress IP in CSR bug is not present.
Hence the motivation to make this the default for all vSphere clusters.

@lobziik Had some concerns about the potential fragility of this fix. For example, do we support users creating multiple networks on vSphere clusters, such that the first IP picked up by the node IP configuration service could be incorrect (not routable by the API server?). 
Reading through the [UPI setup docs](https://docs.openshift.com/container-platform/4.9/installing/installing_vsphere/installing-vsphere.html#installation-network-user-infra_installing-vsphere) I found this snippet:

>  The Kubernetes API server must be able to resolve the node names of the cluster machines. If the API servers and worker nodes are in different zones, you can configure a default DNS search zone to allow the API server to resolve the node names. Another supported approach is to always refer to hosts by their fully-qualified domain names in both the node objects and all DNS requests.

Which implies to me that the above scenario would not be supported and therefore this is a safe patch to apply (users must have the primary network routable from the API server is my interpretation of that snippet, could be wrong though).

As @danwinship introduced this originally, I would appreciate his review and assessment of the risk of adding this to all vSphere clusters. If the network team are happy with the risks associated with adding this unit to all vSphere platforms, then this is strictly a better fix for the issue we are trying to resolve than the alternative patch to the cluster machine approver.

**- How to verify it**
This was already on via the on-prem files for IPI, so best to check this with UPI and verify that vSphere nodes still join the cluster correctly with an appropriate IP address

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Force NodeIP configuration service to be enabled on vSphere environments
