### PR TITLE
Bug 2017756: Remove crio settings that overwrite /etc/containers/storage.conf

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -4,10 +4,6 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
-    storage_driver = "overlay"
-    storage_option = [
-        "overlay.override_kernel_check=1",
-    ]
     version_file_persist = "/var/lib/crio/version"
 
     [crio.api]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -4,10 +4,6 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
-    storage_driver = "overlay"
-    storage_option = [
-        "overlay.override_kernel_check=1",
-    ]
     version_file_persist = "/var/lib/crio/version"
 
     [crio.api]


### PR DESCRIPTION
This intends to fix https://bugzilla.redhat.com/show_bug.cgi?id=2017756

The way it does is:
- Removing crio options from `/etc/crio/crio.conf.d/00-default` that may overwrite changes in `/etc/containers/storage.conf` introduced by `ContainerRuntimeConfig` custom resources.
- Wiping default `/etc/crio/crio.conf`, as it also includes the offending settings and any other interesting default has already been moved to MCO-managed configuration `/etc/crio/crio.conf.d/00-default`.