### PR TITLE
Bug 1956739: Change owner and group of authorized_keys to core

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -67,4 +67,8 @@ const (
 	// "currentConfig" state.  Create this file (empty contents is fine) if you wish the MCD
 	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.
 	MachineConfigDaemonForceFile = "/run/machine-config-daemon-force"
+
+	// coreUser is "core" and currently the only permissible user name
+	CoreUserName  = "core"
+	CoreGroupName = "core"
 )

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -400,6 +400,9 @@ func TestNoReboot(t *testing.T) {
 	}
 	t.Logf("Node %s has SSH key", infraNode.Name)
 
+	usernameAndGroup := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "stat", "--format=%U %G", "/home/core/.ssh/authorized_keys"), "\n"), " ")
+	assert.Equal(t, usernameAndGroup, []string{constants.CoreUserName, constants.CoreGroupName})
+
 	output = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
 	newTime := strings.Split(output, " ")[0]
 


### PR DESCRIPTION
Previously updating ssh keys would change their owner and group to root

Closes https://bugzilla.redhat.com/show_bug.cgi?id=1956739