### PR TITLE
Alibaba Cloud Provider: use --provider-id kubelet parameter

### DIFF
--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -1,0 +1,52 @@
+name: kubelet.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service network-online.target
+  Requires=crio.service kubelet-auto-node-size.service
+  After=network-online.target crio.service kubelet-auto-node-size.service
+  After=ostree-finalize-staged.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- end}}
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+  EnvironmentFile=/etc/node-sizing.env
+
+  ExecStart=/usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
+        --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+{{- if eq .IPFamilies "DualStack"}}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
+        --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
+        --minimum-container-ttl-duration=6m0s \
+        --cloud-provider={{cloudProvider .}} \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        {{cloudConfigFlag . }} \
+        --provider-id=${KUBELET_NODE_NAME} \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
+        --v=${KUBELET_LOG_LEVEL}
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -1,0 +1,51 @@
+name: kubelet.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service network-online.target
+  Requires=crio.service kubelet-auto-node-size.service
+  After=network-online.target crio.service kubelet-auto-node-size.service
+  After=ostree-finalize-staged.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- end}}
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+  EnvironmentFile=/etc/node-sizing.env
+
+  ExecStart=/usr/bin/hyperkube \
+      kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+{{- if eq .IPFamilies "DualStack"}}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
+        --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
+        --minimum-container-ttl-duration=6m0s \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --cloud-provider={{cloudProvider .}} \
+        {{cloudConfigFlag . }} \
+        --provider-id=${KUBELET_NODE_NAME} \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
+        --v=${KUBELET_LOG_LEVEL}
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
**- What I did**
Alibaba Cloud provider requires the `--provider-id` kubelet parameter instead of `--hostname-override`. 

I added custom kubelet.service files for `alibabacloud`.

**- How to verify it**
Install a cluster on Alibaba and verify that the control plane nodes have the proper settings in `/cat /etc/systemd/system/kubelet.service`.

**- Description for the changelog**
AlibabaCloud provider-id kubelet flag
