### PR TITLE
Remove direct call to gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - gofmt
     - goimports
     - golint
-    #- gosec
+    - gosec
     - govet
     - ineffassign
     #- interfacer
@@ -107,3 +107,8 @@ linters-settings:
       #- importShadow
       - paramTypeCombine
       #- unnamedResult
+  gosec:
+    severity: high
+    confidence: medium
+    excludes:
+      - G204

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,6 @@ install-tools:
 #    make verify
 verify: install-tools
 	golangci-lint run --build-tags=$(GOTAGS)
-	# Remove once https://github.com/golangci/golangci-lint/issues/597 is
-	# addressed
-	gosec -severity high --confidence medium -exclude G204 -quiet ./...
 	# Remove the vendor/k8s.io/code-generator vendor hack
 	# once code-generator plays nice with go modules, see
 	# https://github.com/kubernetes/kubernetes/issues/82531 and


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/issues/597 has been closed
and golangci-lint has been using upstream gosec since
https://github.com/golangci/golangci-lint/pull/694