### PR TITLE
Make: Remove executable bits from generator scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,6 @@ go-deps:
 	go mod tidy
 	go mod vendor
 	go mod verify
-	# make scripts executable
-	chmod +x ./vendor/k8s.io/code-generator/generate-groups.sh
-	chmod +x ./vendor/k8s.io/code-generator/generate-internal-groups.sh
 
 install-tools:
 	GO111MODULE=on go build -o $(GOPATH)/bin/golangci-lint ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
@@ -70,15 +67,7 @@ verify: install-tools
 	# Remove once https://github.com/golangci/golangci-lint/issues/597 is
 	# addressed
 	gosec -severity high --confidence medium -exclude G204 -quiet ./...
-	# Remove the vendor/k8s.io/code-generator vendor hack
-	# once code-generator plays nice with go modules, see
-	# https://github.com/kubernetes/kubernetes/issues/82531 and
-	# https://github.com/kubernetes/kubernetes/pull/85559
-	pushd vendor/k8s.io/code-generator && cp go.mod go.mod.bak && go mod vendor && popd
 	hack/verify-codegen.sh
-	rm -f vendor/k8s.io/code-generator/go.mod
-	mv vendor/k8s.io/code-generator/go.mod.bak vendor/k8s.io/code-generator/go.mod
-	rm -rf vendor/k8s.io/code-generator/vendor
 
 # Template for defining build targets for binaries.
 define target_template =

--- a/tools.go
+++ b/tools.go
@@ -5,7 +5,7 @@ package tools
 
 import (
 	// Code generators built at runtime.
-	_ "k8s.io/code-generator" // TODO: Investigate why scripts in this directory are removed and not vendored by go mod.
+	_ "k8s.io/code-generator" // Imports non-go generator scripts for vendoring
 	_ "k8s.io/code-generator/cmd/client-gen"
 	_ "k8s.io/code-generator/cmd/conversion-gen"
 	_ "k8s.io/code-generator/cmd/deepcopy-gen"


### PR DESCRIPTION
Split out from https://github.com/openshift/machine-config-operator/pull/1986

The executable bit is not necessary as the `generate-groups.sh` script
is not invoked directly, but via a bash call in `hack/update-codegen.sh`.
The `generate-internal-groups.sh` script is not used in this repository
at all.

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
