### PR TITLE
Update postConfigChangeActionNone comment

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -46,8 +46,8 @@ const (
 	osImageContentBaseDir = "/run/mco-machine-os-content/"
 
 	// These are the actions for a node to take after applying config changes. (e.g. a new machineconfig is applied)
-	// "None" means no special action needs to be taken. A drain will still happen.
-	// This currently happens when ssh keys or pull secret (/var/lib/kubelet/config.json) is changed
+	// "None" means no special action needs to be taken
+	// This happens for example when ssh keys or the pull secret (/var/lib/kubelet/config.json) is changed
 	postConfigChangeActionNone = "none"
 	// Rebooting is still the default scenario for any other change
 	postConfigChangeActionReboot = "reboot"


### PR DESCRIPTION
A drain no longer occurs, and another case, kubelet-ca.crt, has been
added