### PR TITLE
[release-4.8] Bug 2021073: [ipi onprem] cherry pick Keepalived default ingress scripts fixes

### DIFF
--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingress.sh.tmpl"
+contents:
+  inline: |
+    #!/bin/bash
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q {{`{{.NonVirtualIP}}`}}

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -134,6 +134,8 @@ contents:
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
         livenessProbe:
           exec:
             command:

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -39,6 +39,12 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
+        weight 20
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        interval 5
         weight 50
     }
 
@@ -77,7 +83,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority {{`{{ .IngressConfig.Priority }}`}}
+        priority 20
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
@@ -98,5 +104,6 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_default_ingress
         }
     }

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -43,7 +43,7 @@ contents:
     }
 
     vrrp_script chk_default_ingress {
-        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        script "/usr/bin/timeout 4.9 /etc/keepalived/chk_default_ingress.sh"
         interval 5
         weight 50
     }

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -7,6 +7,12 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
+        weight 20
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        interval 5
         weight 50
     }
 
@@ -16,7 +22,7 @@ contents:
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
-        priority {{`{{ .IngressConfig.Priority }}`}}
+        priority 20
         advert_int 1
         {{`{{if .EnableUnicast}}`}}
         unicast_src_ip {{`{{.NonVirtualIP}}`}}
@@ -37,5 +43,6 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_default_ingress
         }
     }

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -11,7 +11,7 @@ contents:
     }
 
     vrrp_script chk_default_ingress {
-        script "/usr/bin/timeout 4.9 /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml  | grep 'ip:' | grep {{`{{.NonVirtualIP}}`}} "
+        script "/usr/bin/timeout 4.9 /etc/keepalived/chk_default_ingress.sh"
         interval 5
         weight 50
     }


### PR DESCRIPTION
Manual cherry-pick:
 - https://github.com/openshift/machine-config-operator/pull/2637
 - https://github.com/openshift/machine-config-operator/pull/2798
