### PR TITLE
Bug 2023657: Only write ssh keys if core user exists

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1716,6 +1716,16 @@ func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 		return nil
 	}
 
+	var uErr user.UnknownUserError
+	switch _, err := user.Lookup(constants.CoreUserName); {
+	case err == nil:
+	case errors.As(err, &uErr):
+		glog.Info("core user does not exist, and creating users is not supported, so ignoring configuration specified for core user")
+		return nil
+	default:
+		return fmt.Errorf("failed to check if user core exists: %w", err)
+	}
+
 	// we're also appending all keys for any user to core, so for now
 	// we pass this to atomicallyWriteSSHKeys to write.
 	// we know these users are "core" ones also cause this slice went through Reconcilable


### PR DESCRIPTION
Ignore ssh keys if core user does not exist, rather than failing and
degrading the node. Degrading is undesirable because ssh keys were
previously written as root, so machine configs with ssh keys could be
applied even if the core user did not exist