### PR TITLE
Provide cluster name and base domain to keepalived/runtimecfg rendering

### DIFF
--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -471,3 +471,54 @@ func verifyIgn(actual [][]byte, dir string, t *testing.T) {
 		t.Errorf("can't find expected file:\n%v", key)
 	}
 }
+
+func Test_clusterNameFromAPIServerHostname(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiHostname string
+		baseDomain  string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "Should return cluster name",
+			apiHostname: "api-int.my-clustername.ocp.redhat.com",
+			baseDomain:  "ocp.redhat.com",
+			want:        "my-clustername",
+			wantErr:     false,
+		},
+		{
+			name:        "Should be able to handle dots ('.') in cluster name",
+			apiHostname: "api-int.sub.sub.my-clustername.ocp.redhat.com",
+			baseDomain:  "ocp.redhat.com",
+			want:        "sub.sub.my-clustername",
+			wantErr:     false,
+		},
+		{
+			name:        "Should return error if clustername could not be found",
+			apiHostname: "api-int.ocp.redhat.com",
+			baseDomain:  "ocp.redhat.com",
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:        "Should return error if base domain is not part of api hostname",
+			apiHostname: "api-int.my-cluster.ocp.redhat.com",
+			baseDomain:  "console.redhat.com",
+			want:        "",
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := clusterNameFromAPIServerHostname(tt.apiHostname, tt.baseDomain)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("clusterNameFromAPIServerHostname() error = \"%v\", wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("clusterNameFromAPIServerHostname() = \"%v\", want \"%v\"", got, tt.want)
+			}
+		})
+	}
+}

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -47,6 +47,11 @@ contents:
         - "/config"
         - "--out-dir"
         - "/etc/keepalived"
+        env:
+        - name: CLUSTER_NAME
+          value: "{{ clusterName . }}"
+        - name: CLUSTER_BASE_DOMAIN
+          value: "{{ clusterBaseDomain . }}"
         resources: {}
         volumeMounts:
         - name: kubeconfig
@@ -156,6 +161,10 @@ contents:
             value: "{{ onPremPlatformKeepalivedEnableUnicast . }}"
           - name: IS_BOOTSTRAP
             value: "no"
+          - name: CLUSTER_NAME
+            value: "{{ clusterName . }}"
+          - name: CLUSTER_BASE_DOMAIN
+            value: "{{ clusterBaseDomain . }}"
         command:
         - dynkeepalived
         - "/var/lib/kubelet/kubeconfig"


### PR DESCRIPTION
**- What I did**
In [openshift/baremetal-runtimecfg/pkg/config/node.go#L124](https://github.com/openshift/baremetal-runtimecfg/blob/92ec13e1d0daf6eb644cfe25271f341e1fce78ff/pkg/config/node.go#L124) we are getting the cluster name and cluster domain by splitting the api server url from the kubeconfig by dots (`.`). As [BZ 1971709](https://bugzilla.redhat.com/show_bug.cgi?id=1971709) shows this can lead to problems, if the cluster name itself contains a dot. So we need MCO to provide the cluster name and cluster base domain to runtimecfg so it is able to render the manifests for keepalived correctly (e.g. for api server VIP assignment).

**- How to verify it**
I wrote a unit test to verify the "split logic". 

**- Description for the changelog**
None
