### PR TITLE
daemon: allow tuning any kernel arg on FCOS

### DIFF
--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -23,16 +23,10 @@ const (
 	CmdLineFile = "/proc/cmdline"
 )
 
-// TODO: fill out the allowlists
+// TODO: fill out the allowlist
 // tuneableRHCOSArgsAllowlist contains allowed keys for tunable kernel arguments on RHCOS
 var tuneableRHCOSArgsAllowlist = map[string]bool{
 	"nosmt": true,
-}
-
-// tuneableFCOSArgsAllowlist contains allowed keys for tunable kernel arguments on FCOS
-var tuneableFCOSArgsAllowlist = map[string]bool{
-	"systemd.unified_cgroup_hierarchy=0": true,
-	"mitigations=auto,nosmt":             true,
 }
 
 // isArgTuneable returns if the argument provided is allowed to be modified
@@ -45,7 +39,7 @@ func isArgTunable(arg string) (bool, error) {
 	if os.IsRHCOS() {
 		return tuneableRHCOSArgsAllowlist[arg], nil
 	} else if os.IsFCOS() {
-		return tuneableFCOSArgsAllowlist[arg], nil
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
OKD can be a bit more flexible so any karg param is allowed to be tweaked for FCOS nodes

This restriction is not needed on OKD clusters. This change does not affect OCP in any way.