### PR TITLE
storage.conf: remove obsolete option override_kernel_check

### DIFF
--- a/templates/common/_base/files/container-storage.yaml
+++ b/templates/common/_base/files/container-storage.yaml
@@ -31,9 +31,6 @@ contents:
     # certain container storage drivers.
     size = ""
 
-    # OverrideKernelCheck tells the driver to ignore kernel checks based on kernel version
-    override_kernel_check = "true"
-
     # Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
     # a container, to UIDs/GIDs as they should appear outside of the container, and
     # the length of the range of UIDs/GIDs.  Additional mapped sets can be listed


### PR DESCRIPTION
The `storage.conf(5)` `override_kernel_check` option was removed from the
containers/storage library in early 2019:

  https://github.com/containers/storage/commit/bd6cac944a0f808561eb3ab41ff0db73fc2596cb

With recent version of CRI-O present in OCP >= 4.9, the presence of
this field causes sandbox creation failure when using user namespaces:

    Warning  FailedCreatePodSandBox  SSs (xN over MMm)  kubelet
    (combined from similar events): Failed to create pod sandbox: rpc
    error: code = Unknown desc = error creating pod sandbox with name
    "{NAME}": error creating an ID-mapped copy of layer "{HASH}":
    time="{TIMESTAMP}" level=warning msg="Failed to decode the keys
    [\"storage.options.override_kernel_check\"] from
    \"/etc/containers/storage.conf\"."

Remove the `override_kernel_check` option.