### PR TITLE
Don't perform registries.conf checks on GPG change

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -71,4 +71,7 @@ const (
 	// coreUser is "core" and currently the only permissible user name
 	CoreUserName  = "core"
 	CoreGroupName = "core"
+
+	// changes to registries.conf will cause a crio reload and require extra logic about whether to drain
+	ContainerRegistryConfPath = "/etc/containers/registries.conf"
 )

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -10,8 +10,8 @@ import (
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/golang/glog"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/pkg/errors"
-	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubectl/pkg/drain"
@@ -182,40 +182,30 @@ func isDrainRequired(actions []string, oldIgnConfig, newIgnConfig ign3types.Conf
 // See https://bugzilla.redhat.com/show_bug.cgi?id=1943315
 //nolint:gocyclo
 func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Config) (bool, error) {
-	containerRegistryConfPath := "/etc/containers/registries.conf"
-	var oldContainerRegistryConf, newContainerRegistryConf ign3types.File
-
-	for _, f := range oldIgnConfig.Storage.Files {
-		if f.Path == containerRegistryConfPath {
-			oldContainerRegistryConf = f
-		}
-	}
-
-	for _, f := range newIgnConfig.Storage.Files {
-		if f.Path == containerRegistryConfPath {
-			newContainerRegistryConf = f
-		}
-	}
-
-	// /etc/containers/registries.conf contains config in toml format. Parse the file and compare the content
-	oldDataURL, err := dataurl.DecodeString(*oldContainerRegistryConf.Contents.Source)
+	// /etc/containers/registries.conf contains config in toml format. Parse the file
+	oldData, err := ctrlcommon.GetIgnitionFileDataByPath(&oldIgnConfig, constants.ContainerRegistryConfPath)
 	if err != nil {
 		return false, fmt.Errorf("Failed decoding Data URL scheme string: %v", err)
 	}
 
-	newDataURL, err := dataurl.DecodeString(*newContainerRegistryConf.Contents.Source)
+	newData, err := ctrlcommon.GetIgnitionFileDataByPath(&newIgnConfig, constants.ContainerRegistryConfPath)
 	if err != nil {
 		return false, fmt.Errorf("Failed decoding Data URL scheme string %v", err)
 	}
 
+	if oldData == nil && newData == nil {
+		// these ignition configs don't touch registries.conf, so any change is safe
+		return true, nil
+	}
+
 	tomlConfOldReg := sysregistriesv2.V2RegistriesConf{}
-	if _, err := toml.Decode(string(oldDataURL.Data), &tomlConfOldReg); err != nil {
-		return false, fmt.Errorf("Failed decoding TOML content from file %s: %v", oldContainerRegistryConf.Path, err)
+	if _, err := toml.Decode(string(oldData), &tomlConfOldReg); err != nil {
+		return false, fmt.Errorf("Failed decoding TOML content from file %s: %v", constants.ContainerRegistryConfPath, err)
 	}
 
 	tomlConfNewReg := sysregistriesv2.V2RegistriesConf{}
-	if _, err := toml.Decode(string(newDataURL.Data), &tomlConfNewReg); err != nil {
-		return false, fmt.Errorf("Failed decoding TOML content from file %s: %v", oldContainerRegistryConf.Path, err)
+	if _, err := toml.Decode(string(newData), &tomlConfNewReg); err != nil {
+		return false, fmt.Errorf("Failed decoding TOML content from file %s: %v", constants.ContainerRegistryConfPath, err)
 	}
 
 	// Ensure that any unqualified-search-registries has not been deleted
@@ -251,7 +241,7 @@ func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Con
 	for regLoc := range oldRegHashMap {
 		_, ok := newRegHashMap[regLoc]
 		if !ok {
-			glog.Infof("%s: registry %s has been removed", containerRegistryConfPath, regLoc)
+			glog.Infof("%s: registry %s has been removed", constants.ContainerRegistryConfPath, regLoc)
 			return false, nil
 		}
 	}
@@ -264,22 +254,22 @@ func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Con
 			// Check that changes made are safe or not.
 			if oldReg.Prefix != newReg.Prefix {
 				glog.Infof("%s: prefix value for registry %s has changed from %s to %s",
-					containerRegistryConfPath, regLoc, oldReg.Prefix, newReg.Prefix)
+					constants.ContainerRegistryConfPath, regLoc, oldReg.Prefix, newReg.Prefix)
 				return false, nil
 			}
 			if oldReg.Location != newReg.Location {
 				glog.Infof("%s: location value for registry %s has changed from %s to %s",
-					containerRegistryConfPath, regLoc, oldReg.Location, newReg.Location)
+					constants.ContainerRegistryConfPath, regLoc, oldReg.Location, newReg.Location)
 				return false, nil
 			}
 			if oldReg.Blocked != newReg.Blocked {
 				glog.Infof("%s: blocked value for registry %s has changed from %t to %t",
-					containerRegistryConfPath, regLoc, oldReg.Blocked, newReg.Blocked)
+					constants.ContainerRegistryConfPath, regLoc, oldReg.Blocked, newReg.Blocked)
 				return false, nil
 			}
 			if oldReg.Insecure != newReg.Insecure {
 				glog.Infof("%s: insecure value for registry %s has changed from %t to %t",
-					containerRegistryConfPath, regLoc, oldReg.Insecure, newReg.Insecure)
+					constants.ContainerRegistryConfPath, regLoc, oldReg.Insecure, newReg.Insecure)
 				return false, nil
 			}
 			if oldReg.MirrorByDigestOnly == newReg.MirrorByDigestOnly {
@@ -287,7 +277,7 @@ func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Con
 				for _, m := range oldReg.Mirrors {
 					if !searchRegistryMirror(m.Location, newReg.Mirrors) {
 						glog.Infof("%s: mirror %s has been removed in registry %s",
-							containerRegistryConfPath, m.Location, regLoc)
+							constants.ContainerRegistryConfPath, m.Location, regLoc)
 						return false, nil
 					}
 				}
@@ -295,24 +285,24 @@ func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Con
 				for _, m := range newReg.Mirrors {
 					if !searchRegistryMirror(m.Location, oldReg.Mirrors) && !newReg.MirrorByDigestOnly {
 						glog.Infof("%s: mirror %s has been added in registry %s that has mirror-by-digest-only set to %t ",
-							containerRegistryConfPath, m.Location, regLoc, newReg.MirrorByDigestOnly)
+							constants.ContainerRegistryConfPath, m.Location, regLoc, newReg.MirrorByDigestOnly)
 						return false, nil
 					}
 				}
 			} else {
 				glog.Infof("%s: mirror-by-digest-only value for registry %s has changed from %t to %t",
-					containerRegistryConfPath, regLoc, oldReg.MirrorByDigestOnly, newReg.MirrorByDigestOnly)
+					constants.ContainerRegistryConfPath, regLoc, oldReg.MirrorByDigestOnly, newReg.MirrorByDigestOnly)
 				return false, nil
 			}
 		} else if !newReg.MirrorByDigestOnly {
 			// New mirrors added into registry but mirror-by-digest-only has been set to false
 			glog.Infof("%s: registry %s has been added with mirror-by-digest-only set to %t",
-				containerRegistryConfPath, regLoc, newReg.MirrorByDigestOnly)
+				constants.ContainerRegistryConfPath, regLoc, newReg.MirrorByDigestOnly)
 			return false, nil
 		}
 	}
 
-	glog.Infof("%s: changes made are safe to skip drain", containerRegistryConfPath)
+	glog.Infof("%s: changes made are safe to skip drain", constants.ContainerRegistryConfPath)
 	return true, nil
 }
 

--- a/pkg/daemon/drain_test.go
+++ b/pkg/daemon/drain_test.go
@@ -358,7 +358,8 @@ location = "example.com/repo/test-img"
 			if err != nil {
 				t.Errorf("parsing new Ignition config failed: %v", err)
 			}
-			drain, err := isDrainRequired(test.actions, oldIgnConfig, newIgnConfig)
+			diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
+			drain, err := isDrainRequired(test.actions, diffFileSet, oldIgnConfig, newIgnConfig)
 			if !reflect.DeepEqual(test.expectedAction, drain) {
 				t.Errorf("Failed determining drain behavior: expected: %v but result is: %v. Error: %v", test.expectedAction, drain, err)
 			}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -51,11 +51,11 @@ const (
 	// "None" means no special action needs to be taken
 	// This happens for example when ssh keys or the pull secret (/var/lib/kubelet/config.json) is changed
 	postConfigChangeActionNone = "none"
+	// The "reload crio" action will run "systemctl reload crio"
+	postConfigChangeActionReloadCrio = "reload crio"
 	// Rebooting is still the default scenario for any other change
 	postConfigChangeActionReboot = "reboot"
-	// Crio reload will happen when /etc/containers/registries.conf is changed. This will cause
-	// a "systemctl reload crio"
-	postConfigChangeActionReloadCrio = "reload crio"
+
 	// GPGNoRebootPath is the path MCO expects will contain GPG key updates. MCO will attempt to only reload crio for
 	// changes to this path. Note that other files added to the parent directory will not be handled specially
 	GPGNoRebootPath = "/etc/machine-config-daemon/no-reboot/containers-gpg.pub"
@@ -434,60 +434,22 @@ func calculatePostConfigChangeActionFromFileDiffs(oldIgnConfig, newIgnConfig ign
 		"/var/lib/kubelet/config.json",
 	}
 	filesPostConfigChangeActionReloadCrio := []string{
+		constants.ContainerRegistryConfPath,
 		GPGNoRebootPath,
 		"/etc/containers/policy.json",
-		"/etc/containers/registries.conf",
 	}
 
-	oldFileSet := make(map[string]ign3types.File)
-	for _, f := range oldIgnConfig.Storage.Files {
-		oldFileSet[f.Path] = f
-	}
-	newFileSet := make(map[string]ign3types.File)
-	for _, f := range newIgnConfig.Storage.Files {
-		newFileSet[f.Path] = f
-	}
-	diffFileSet := []string{}
-
-	// First check if any files were removed
-	for path := range oldFileSet {
-		_, ok := newFileSet[path]
-		if !ok {
-			// debug: remove
-			glog.Infof("File diff: %v was deleted", path)
-			diffFileSet = append(diffFileSet, path)
-		}
-	}
-
-	// Now check if any files were added/changed
-	for path, newFile := range newFileSet {
-		oldFile, ok := oldFileSet[path]
-		if !ok {
-			// debug: remove
-			glog.Infof("File diff: %v was added", path)
-			diffFileSet = append(diffFileSet, path)
-		} else if !reflect.DeepEqual(oldFile, newFile) {
-			// debug: remove
-			glog.Infof("File diff: detected change to %v", newFile.Path)
-			diffFileSet = append(diffFileSet, path)
-		}
-	}
-
-	// Now calculate action
-	for _, k := range diffFileSet {
-		if ctrlcommon.InSlice(k, filesPostConfigChangeActionNone) {
+	diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
+	actions = []string{postConfigChangeActionNone}
+	for _, path := range diffFileSet {
+		if ctrlcommon.InSlice(path, filesPostConfigChangeActionNone) {
 			continue
-		} else if ctrlcommon.InSlice(k, filesPostConfigChangeActionReloadCrio) {
+		} else if ctrlcommon.InSlice(path, filesPostConfigChangeActionReloadCrio) {
 			actions = []string{postConfigChangeActionReloadCrio}
-			continue
 		} else {
 			actions = []string{postConfigChangeActionReboot}
-			break
+			return
 		}
-	}
-
-	if len(actions) == 0 {
-		actions = []string{postConfigChangeActionNone}
 	}
 	return
 }

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -693,7 +693,8 @@ func TestCalculatePostConfigChangeAction(t *testing.T) {
 			if err != nil {
 				t.Errorf("error creating machineConfigDiff: %v", err)
 			}
-			calculatedAction, err := calculatePostConfigChangeAction(mcDiff, oldIgnConfig, newIgnConfig)
+			diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
+			calculatedAction, err := calculatePostConfigChangeAction(mcDiff, diffFileSet)
 
 			if !reflect.DeepEqual(test.expectedAction, calculatedAction) {
 				t.Errorf("Failed calculating config change action: expected: %v but result is: %v. Error: %v", test.expectedAction, calculatedAction, err)


### PR DESCRIPTION
If a config change does not contain changes to registries.conf, don't
apply checks specific to registries.conf

Also start using helper functions added in
https://github.com/openshift/machine-config-operator/pull/2870