### PR TITLE
Bug 2028025: [Release 4.8] daemon: make cordon/uncordon more robust and better logging

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1286,7 +1286,8 @@ func (dn *Daemon) completeUpdate(desiredConfigName string) error {
 		return err
 	}
 
-	dn.logSystem("completed update for config %s", desiredConfigName)
+	dn.logSystem("Update completed for config %s and node has been successfully uncordoned", desiredConfigName)
+	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Uncordon", fmt.Sprintf("Update completed for config %s and node has been uncordoned", desiredConfigName))
 
 	return nil
 }

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -40,12 +40,31 @@ func (dn *Daemon) cordonOrUncordonNode(desired bool) error {
 	}
 	var lastErr error
 	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		// Log has been added to ensure that MCO is correctly performing cordon/uncordon.
+		// This should help us with debugging bugs like https://bugzilla.redhat.com/show_bug.cgi?id=2022387
+		glog.Infof("Initiating %s on node (currently schedulable: %t)", verb, !dn.node.Spec.Unschedulable)
 		err := drain.RunCordonOrUncordon(dn.drainer, dn.node, desired)
 		if err != nil {
 			lastErr = err
 			glog.Infof("%s failed with: %v, retrying", verb, err)
 			return false, nil
 		}
+
+		// Re-fetch node so that we are not using cached information
+		var node *corev1.Node
+		if node, err = dn.nodeLister.Get(dn.node.GetName()); err != nil {
+			lastErr = err
+			glog.Errorf("Failed to fetch node %v, retrying", err)
+			return false, nil
+		}
+
+		if node.Spec.Unschedulable != desired {
+			// See https://bugzilla.redhat.com/show_bug.cgi?id=2022387
+			glog.Infof("RunCordonOrUncordon() succeeded but node is still not in %s state, retrying", verb)
+			return false, nil
+		}
+
+		glog.Infof("%s succeeded on node (currently schedulable: %t)", verb, !node.Spec.Unschedulable)
 		return true, nil
 	}); err != nil {
 		if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
Manual backport of https://github.com/openshift/machine-config-operator/pull/2829
Also, requires https://github.com/openshift/machine-config-operator/pull/2659 to get #2829 work properly
Back-porting https://github.com/openshift/machine-config-operator/pull/2657 as well for completeness in event and logging that we have for node cordon/uncordon