### PR TITLE
[mcbs] Validate rpm-ostree version is new enough

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -873,6 +873,10 @@ func (dn *Daemon) LogSystemData() {
 	} else {
 		glog.Info("systemd service state: OK")
 	}
+
+	if err := checkNodeRpmOstreeVersion(); err != nil {
+		glog.Errorf("Failed to check rpm-ostree version: %v", err)
+	}
 }
 
 const (


### PR DESCRIPTION
This is *mainly* to validate that
https://github.com/openshift/release/pull/24225
worked.

But, this code may be useful as a sanity check going forward.

See also https://github.com/coreos/rpm-ostree/pull/3251

(I also may try to expose e.g. `ex-container` as a feature flag
 that we can query instead of version-parsing)
