### PR TITLE
crio: set minimum_mappable_uid/minimum_mappable_gid

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -32,6 +32,8 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    minimum_mappable_uid = 1000000000
+    minimum_mappable_gid = 1000000000
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -32,6 +32,8 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    minimum_mappable_uid = 1000000000
+    minimum_mappable_gid = 1000000000
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"


### PR DESCRIPTION
**- What I did**

Set minimum_mappable_uid/minimum_mappable_gid to 1000000000, the start of the ranges we assign to namespaces in the default configuration, for use with unprivileged builds.  Follow-on to https://github.com/openshift/machine-config-operator/pull/2805, part of https://issues.redhat.com/browse/OCPNODE-683.

**- How to verify it**

Builds should be able to specify "io.kubernetes.cri-o.userns-mode" annotations in their build pods, using "private:..." values that specify mapping host IDs at or above 1000000000 for the build pod's containers.

**- Description for the changelog**
crio: set minimum_mappable_uid and minimum_mappable_gid to 1000000000