### PR TITLE
add ibmcloud platform to render

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -147,7 +147,7 @@ func platformStringFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (st
 		return "", fmt.Errorf("cannot generate MachineConfigs when no platformStatus.type is set")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case configv1.AWSPlatformType, configv1.AlibabaCloudPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.KubevirtPlatformType, configv1.PowerVSPlatformType, configv1.NonePlatformType:
+	case configv1.AWSPlatformType, configv1.AlibabaCloudPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.IBMCloudPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.KubevirtPlatformType, configv1.PowerVSPlatformType, configv1.NonePlatformType:
 		return strings.ToLower(string(ic.Infra.Status.PlatformStatus.Type)), nil
 	default:
 		// platformNone is used for a non-empty, but currently unsupported platform.

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -88,6 +88,9 @@ func TestCloudProvider(t *testing.T) {
 	}, {
 		platform: configv1.AlibabaCloudPlatformType,
 		res:      "external",
+	}, {
+		platform: configv1.IBMCloudPlatformType,
+		res:      "external",
 	}}
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)
@@ -292,6 +295,7 @@ var (
 		"aws":       "./test_data/controller_config_aws.yaml",
 		"baremetal": "./test_data/controller_config_baremetal.yaml",
 		"gcp":       "./test_data/controller_config_gcp.yaml",
+		"ibmcloud":  "./test_data/controller_config_ibmcloud.yaml",
 		"openstack": "./test_data/controller_config_openstack.yaml",
 		"libvirt":   "./test_data/controller_config_libvirt.yaml",
 		"none":      "./test_data/controller_config_none.yaml",

--- a/pkg/controller/template/test_data/controller_config_ibmcloud.yaml
+++ b/pkg/controller/template/test_data/controller_config_ibmcloud.yaml
@@ -1,0 +1,25 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 3
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      platformStatus:
+        type: "IBMCloud"


### PR DESCRIPTION
This change adds the ibm cloud platform to the platform detection logic
in the render process. It also adds a test for the cloud provider string
and a controller config test data file for the render.

**- What I did**

* add IBMCloud provider type to the case statement for `platformStringFromControllerConfigSpec`
* add a test case in `TestCloudProvider`
* add a rendered test data file for `TestGeneratedMachineConfigs`

**- How to verify it**

`make test-unit` should verify the functionality locally.

**- Description for the changelog**

IBM Cloud added as a recognized platform for MachineConfig rendering.