### PR TITLE
Bug 2031049: Fix panic when PlatformStatus VSphere is nil

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -353,8 +353,12 @@ func getIgnitionHost(infraStatus *configv1.InfrastructureStatus) (string, error)
 		case configv1.OvirtPlatformType:
 			ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.Ovirt.APIServerInternalIP, securePortStr)
 		case configv1.VSpherePlatformType:
-			if infraStatus.PlatformStatus.VSphere.APIServerInternalIP != "" {
-				ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIP, securePortStr)
+			if infraStatus.PlatformStatus.VSphere != nil {
+				if infraStatus.PlatformStatus.VSphere.APIServerInternalIP != "" {
+					ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIP, securePortStr)
+				}
+			} else {
+				glog.Warning("Warning: PlatformStatus.VSphere should not be nil")
 			}
 		}
 	}


### PR DESCRIPTION
This PR is to resolve a panic when
`PlatformStatus.VSphere` is nil.

