### PR TITLE
Bug 2022144: cleanup sbdb and nbdb pid file when node is reloaded

### DIFF
--- a/templates/common/_base/files/cleanup-cni-conf.yaml
+++ b/templates/common/_base/files/cleanup-cni-conf.yaml
@@ -6,3 +6,5 @@ contents:
     r /etc/kubernetes/cni/net.d/10-ovn-kubernetes.conf
     d /run/multus/cni/net.d/ 0755 root root - -
     D /var/lib/cni/networks/openshift-sdn/ 0755 root root - -
+    r /var/run/ovn/ovnsb_db.pid
+    r /var/run/ovn/ovnnb_db.pid


### PR DESCRIPTION
it was noticed in the above Bug that sbdb and nbdb stayed around after node reboot causing `run_sb_ovsdb` to do early return leading to ovnkube-master POD stuck in crashloop