### PR TITLE
Deprecate the use of pkg/errors

### DIFF
--- a/cmd/apiserver-watcher/run.go
+++ b/cmd/apiserver-watcher/run.go
@@ -59,7 +59,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 
 	uri, err := url.Parse(runOpts.healthCheckURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse health-check-url: %v", err)
+		return fmt.Errorf("failed to parse health-check-url: %w", err)
 	}
 	if !uri.IsAbs() {
 		return fmt.Errorf("invalid URI %q (no scheme)", uri)
@@ -82,7 +82,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		}},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create httpCheck: %v", err)
+		return fmt.Errorf("failed to create httpCheck: %w", err)
 	}
 	errCh := make(chan error)
 

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/cmd/common"
@@ -14,7 +15,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
 	"github.com/openshift/machine-config-operator/pkg/version"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/leaderelection"
@@ -52,7 +52,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	cb, err := clients.NewBuilder(startOpts.kubeconfig)
 	if err != nil {
-		ctrlcommon.WriteTerminationError(errors.Wrapf(err, "Creating clients"))
+		ctrlcommon.WriteTerminationError(fmt.Errorf("creating clients: %w", err))
 	}
 	run := func(ctx context.Context) {
 		ctrlctx := ctrlcommon.CreateControllerContext(cb, ctx.Done(), componentName)

--- a/cmd/machine-config-daemon/pivot.go
+++ b/cmd/machine-config-daemon/pivot.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/golang/glog"
 	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
-	errors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -50,9 +49,9 @@ func run(_ *cobra.Command, args []string) (retErr error) {
 		data, err := ioutil.ReadFile(etcPivotFile)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("No container specified")
+				return fmt.Errorf("no container specified")
 			}
-			return errors.Wrapf(err, "failed to read from %s", etcPivotFile)
+			return fmt.Errorf("failed to read from %s: %w", etcPivotFile, err)
 		}
 		container = strings.TrimSpace(string(data))
 	} else {
@@ -74,7 +73,7 @@ func run(_ *cobra.Command, args []string) (retErr error) {
 	if fromEtcPullSpec {
 		if err := os.Remove(etcPivotFile); err != nil {
 			if !os.IsNotExist(err) {
-				return errors.Wrapf(err, "failed to delete %s", etcPivotFile)
+				return fmt.Errorf("failed to delete %s: %w", etcPivotFile, err)
 			}
 		}
 	}

--- a/internal/kubeutils.go
+++ b/internal/kubeutils.go
@@ -41,14 +41,14 @@ func UpdateNodeRetry(client corev1client.NodeInterface, lister corev1lister.Node
 
 		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldNode, newNode, corev1.Node{})
 		if err != nil {
-			return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+			return fmt.Errorf("failed to create patch for node %q: %w", nodeName, err)
 		}
 
 		node, err = client.Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 		return err
 	}); err != nil {
 		// may be conflict if max retries were hit
-		return nil, fmt.Errorf("unable to update node %q: %v", node, err)
+		return nil, fmt.Errorf("unable to update node %q: %w", node, err)
 	}
 	return node, nil
 }

--- a/lib/resourceread/machineconfig.go
+++ b/lib/resourceread/machineconfig.go
@@ -28,7 +28,7 @@ func ReadMachineConfigV1(objBytes []byte) (*mcfgv1.MachineConfig, error) {
 
 	m, err := runtime.Decode(mcfgCodecs.UniversalDecoder(mcfgv1.SchemeGroupVersion), objBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode raw bytes to mcfgv1.SchemeGroupVersion: %v", err)
+		return nil, fmt.Errorf("failed to decode raw bytes to mcfgv1.SchemeGroupVersion: %w", err)
 	}
 	if m == nil {
 		return nil, fmt.Errorf("expected mcfgv1.SchemeGroupVersion but got nil")

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -87,13 +87,13 @@ func (b *Bootstrap) Run(destDir string) error {
 
 		file, err := os.Open(filepath.Join(b.manifestDir, info.Name()))
 		if err != nil {
-			return fmt.Errorf("error opening %s: %v", file.Name(), err)
+			return fmt.Errorf("error opening %s: %w", file.Name(), err)
 		}
 		defer file.Close()
 
 		manifests, err := parseManifests(file.Name(), file)
 		if err != nil {
-			return fmt.Errorf("error parsing manifests from %s: %v", file.Name(), err)
+			return fmt.Errorf("error parsing manifests from %s: %w", file.Name(), err)
 		}
 
 		for idx, m := range manifests {
@@ -104,7 +104,7 @@ func (b *Bootstrap) Run(destDir string) error {
 					glog.V(4).Infof("skipping path %q [%d] manifest because it is not part of expected api group: %v", file.Name(), idx+1, err)
 					continue
 				}
-				return fmt.Errorf("error parsing %q [%d] manifest: %v", file.Name(), idx+1, err)
+				return fmt.Errorf("error parsing %q [%d] manifest: %w", file.Name(), idx+1, err)
 			}
 
 			switch obj := obji.(type) {
@@ -268,7 +268,7 @@ func parseManifests(filename string, r io.Reader) ([]manifest, error) {
 			if err == io.EOF {
 				return manifests, nil
 			}
-			return manifests, fmt.Errorf("error parsing %q: %v", filename, err)
+			return manifests, fmt.Errorf("error parsing %q: %w", filename, err)
 		}
 		m.Raw = bytes.TrimSpace(m.Raw)
 		if len(m.Raw) == 0 || bytes.Equal(m.Raw, []byte("null")) {

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -36,7 +36,6 @@ import (
 	validate3 "github.com/coreos/ignition/v2/config/validate"
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/vincent-petithory/dataurl"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -210,17 +209,17 @@ func ConvertRawExtIgnitionToV3(inRawExtIgn *runtime.RawExtension) (runtime.RawEx
 	} else {
 		ignCfg, rpt, err := ign2.Parse(inRawExtIgn.Raw)
 		if err != nil || rpt.IsFatal() {
-			return runtime.RawExtension{}, errors.Errorf("parsing Ignition config spec v2.2 failed with error: %v\nReport: %v", err, rpt)
+			return runtime.RawExtension{}, fmt.Errorf("parsing Ignition config spec v2.2 failed with error: %w\nReport: %v", err, rpt)
 		}
 		converted3, err = convertIgnition2to3(ignCfg)
 		if err != nil {
-			return runtime.RawExtension{}, errors.Errorf("failed to convert config from spec v2.2 to v3.2: %v", err)
+			return runtime.RawExtension{}, fmt.Errorf("failed to convert config from spec v2.2 to v3.2: %w", err)
 		}
 	}
 
 	outIgnV3, err := json.Marshal(converted3)
 	if err != nil {
-		return runtime.RawExtension{}, errors.Errorf("failed to marshal converted config: %v", err)
+		return runtime.RawExtension{}, fmt.Errorf("failed to marshal converted config: %w", err)
 	}
 
 	outRawExt := runtime.RawExtension{}
@@ -239,7 +238,7 @@ func ConvertRawExtIgnitionToV3_1(inRawExtIgn *runtime.RawExtension) (runtime.Raw
 
 	ignCfgV3, rptV3, errV3 := ign3.Parse(rawExt.Raw)
 	if errV3 != nil || rptV3.IsFatal() {
-		return runtime.RawExtension{}, errors.Errorf("parsing Ignition config failed with error: %v\nReport: %v", errV3, rptV3)
+		return runtime.RawExtension{}, fmt.Errorf("parsing Ignition config failed with error: %w\nReport: %v", errV3, rptV3)
 	}
 
 	ignCfgV31, err := convertIgnition32to31(ignCfgV3)
@@ -249,7 +248,7 @@ func ConvertRawExtIgnitionToV3_1(inRawExtIgn *runtime.RawExtension) (runtime.Raw
 
 	outIgnV31, err := json.Marshal(ignCfgV31)
 	if err != nil {
-		return runtime.RawExtension{}, errors.Errorf("failed to marshal converted config: %v", err)
+		return runtime.RawExtension{}, fmt.Errorf("failed to marshal converted config: %w", err)
 	}
 
 	outRawExt := runtime.RawExtension{}
@@ -263,17 +262,17 @@ func ConvertRawExtIgnitionToV3_1(inRawExtIgn *runtime.RawExtension) (runtime.Raw
 func ConvertRawExtIgnitionToV2(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
 	ignCfg, rpt, err := ign3.Parse(inRawExtIgn.Raw)
 	if err != nil || rpt.IsFatal() {
-		return runtime.RawExtension{}, errors.Errorf("parsing Ignition config spec v3.2 failed with error: %v\nReport: %v", err, rpt)
+		return runtime.RawExtension{}, fmt.Errorf("parsing Ignition config spec v3.2 failed with error: %w\nReport: %v", err, rpt)
 	}
 
 	converted2, err := convertIgnition3to2(ignCfg)
 	if err != nil {
-		return runtime.RawExtension{}, errors.Errorf("failed to convert config from spec v3.2 to v2.2: %v", err)
+		return runtime.RawExtension{}, fmt.Errorf("failed to convert config from spec v3.2 to v2.2: %w", err)
 	}
 
 	outIgnV2, err := json.Marshal(converted2)
 	if err != nil {
-		return runtime.RawExtension{}, errors.Errorf("failed to marshal converted config: %v", err)
+		return runtime.RawExtension{}, fmt.Errorf("failed to marshal converted config: %w", err)
 	}
 
 	outRawExt := runtime.RawExtension{}
@@ -293,7 +292,7 @@ func convertIgnition2to3(ign2config ign2types.Config) (ign3types.Config, error) 
 	ign2_3config := ign2_3.Translate(ign2config)
 	ign3_0config, err := v23tov30.Translate(ign2_3config, fsMap)
 	if err != nil {
-		return ign3types.Config{}, errors.Errorf("unable to convert Ignition spec v2 config to v3: %v", err)
+		return ign3types.Config{}, fmt.Errorf("unable to convert Ignition spec v2 config to v3: %w", err)
 	}
 	// Workaround to get a v3.2 config as output
 	converted3 := translate3.Translate(translate3_1.Translate(ign3_0config))
@@ -306,7 +305,7 @@ func convertIgnition2to3(ign2config ign2types.Config) (ign3types.Config, error) 
 func convertIgnition3to2(ign3config ign3types.Config) (ign2types.Config, error) {
 	converted2, err := v32tov22.Translate(ign3config)
 	if err != nil {
-		return ign2types.Config{}, errors.Errorf("unable to convert Ignition spec v3 config to v2: %v", err)
+		return ign2types.Config{}, fmt.Errorf("unable to convert Ignition spec v3 config to v2: %w", err)
 	}
 	glog.V(4).Infof("Successfully translated Ignition spec v3 config to Ignition spec v2 config: %v", converted2)
 
@@ -317,7 +316,7 @@ func convertIgnition3to2(ign3config ign3types.Config) (ign2types.Config, error) 
 func convertIgnition32to31(ign3config ign3types.Config) (ign3_1types.Config, error) {
 	converted31, err := v32tov31.Translate(ign3config)
 	if err != nil {
-		return ign3_1types.Config{}, errors.Errorf("unable to convert Ignition spec v3_2 config to v3_1: %v", err)
+		return ign3_1types.Config{}, fmt.Errorf("unable to convert Ignition spec v3_2 config to v3_1: %w", err)
 	}
 	glog.V(4).Infof("Successfully translated Ignition spec v3_2 config to Ignition spec v3_1 config: %v", converted31)
 
@@ -336,7 +335,7 @@ func ValidateIgnition(ignconfig interface{}) error {
 			return nil
 		}
 		if report := validate2.ValidateWithoutSource(reflect.ValueOf(cfg)); report.IsFatal() {
-			return errors.Errorf("invalid ignition V2 config found: %v", report)
+			return fmt.Errorf("invalid ignition V2 config found: %v", report)
 		}
 		return validateIgn2FileModes(cfg)
 	case ign3types.Config:
@@ -344,11 +343,11 @@ func ValidateIgnition(ignconfig interface{}) error {
 			return nil
 		}
 		if report := validate3.ValidateWithContext(cfg, nil); report.IsFatal() {
-			return errors.Errorf("invalid ignition V3 config found: %v", report)
+			return fmt.Errorf("invalid ignition V3 config found: %v", report)
 		}
 		return validateIgn3FileModes(cfg)
 	default:
-		return errors.Errorf("unrecognized ignition type")
+		return fmt.Errorf("unrecognized ignition type")
 	}
 }
 
@@ -425,7 +424,7 @@ func InSlice(elem string, slice []string) bool {
 // ValidateMachineConfig validates that given MachineConfig Spec is valid.
 func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
 	if !(cfg.KernelType == "" || cfg.KernelType == KernelTypeDefault || cfg.KernelType == KernelTypeRealtime) {
-		return errors.Errorf("kernelType=%s is invalid", cfg.KernelType)
+		return fmt.Errorf("kernelType=%s is invalid", cfg.KernelType)
 	}
 
 	if cfg.Config.Raw != nil {
@@ -467,15 +466,15 @@ func IgnParseWrapper(rawIgn []byte) (interface{}, error) {
 
 				// If the error is still UnknownVersion it's not a 3.2/3.1/3.0 or 2.x config, thus unsupported
 				if errV2.Error() == ign2error.ErrUnknownVersion.Error() {
-					return ign3types.Config{}, errors.Errorf("parsing Ignition config failed: unknown version. Supported spec versions: 2.2, 3.0, 3.1, 3.2")
+					return ign3types.Config{}, fmt.Errorf("parsing Ignition config failed: unknown version. Supported spec versions: 2.2, 3.0, 3.1, 3.2")
 				}
-				return ign3types.Config{}, errors.Errorf("parsing Ignition spec v2 failed with error: %v\nReport: %v", errV2, rptV2)
+				return ign3types.Config{}, fmt.Errorf("parsing Ignition spec v2 failed with error: %w\nReport: %v", errV2, rptV2)
 			}
-			return ign3types.Config{}, errors.Errorf("parsing Ignition config spec v3.0 failed with error: %v\nReport: %v", errV3_0, rptV3_0)
+			return ign3types.Config{}, fmt.Errorf("parsing Ignition config spec v3.0 failed with error: %w\nReport: %v", errV3_0, rptV3_0)
 		}
-		return ign3types.Config{}, errors.Errorf("parsing Ignition config spec v3.1 failed with error: %v\nReport: %v", errV3_1, rptV3_1)
+		return ign3types.Config{}, fmt.Errorf("parsing Ignition config spec v3.1 failed with error: %w\nReport: %v", errV3_1, rptV3_1)
 	}
-	return ign3types.Config{}, errors.Errorf("parsing Ignition config spec v3.2 failed with error: %v\nReport: %v", errV3_2, rptV3_2)
+	return ign3types.Config{}, fmt.Errorf("parsing Ignition config spec v3.2 failed with error: %w\nReport: %v", errV3_2, rptV3_2)
 }
 
 // ParseAndConvertConfig parses rawIgn for both V2 and V3 ignition configs and returns
@@ -483,7 +482,7 @@ func IgnParseWrapper(rawIgn []byte) (interface{}, error) {
 func ParseAndConvertConfig(rawIgn []byte) (ign3types.Config, error) {
 	ignconfigi, err := IgnParseWrapper(rawIgn)
 	if err != nil {
-		return ign3types.Config{}, errors.Wrapf(err, "failed to parse Ignition config")
+		return ign3types.Config{}, fmt.Errorf("failed to parse Ignition config: %w", err)
 	}
 
 	switch typedConfig := ignconfigi.(type) {
@@ -496,11 +495,11 @@ func ParseAndConvertConfig(rawIgn []byte) (ign3types.Config, error) {
 		}
 		convertedIgnV3, err := convertIgnition2to3(ignconfv2)
 		if err != nil {
-			return ign3types.Config{}, errors.Wrapf(err, "failed to convert Ignition config spec v2 to v3")
+			return ign3types.Config{}, fmt.Errorf("failed to convert Ignition config spec v2 to v3: %w", err)
 		}
 		return convertedIgnV3, nil
 	default:
-		return ign3types.Config{}, errors.Errorf("unexpected type for ignition config: %v", typedConfig)
+		return ign3types.Config{}, fmt.Errorf("unexpected type for ignition config: %v", typedConfig)
 	}
 }
 
@@ -575,11 +574,11 @@ func removeIgnDuplicateFilesUnitsUsers(ignConfig ign2types.Config) (ign2types.Co
 	if len(users) > 0 {
 		outUser := users[len(users)-1]
 		if outUser.Name != "core" {
-			return ignConfig, errors.Errorf("unexpected user with name: %v. Only core user is supported.", outUser.Name)
+			return ignConfig, fmt.Errorf("unexpected user with name: %v. Only core user is supported", outUser.Name)
 		}
 		for i := len(users) - 2; i >= 0; i-- {
 			if users[i].Name != "core" {
-				return ignConfig, errors.Errorf("unexpected user with name: %v. Only core user is supported.", users[i].Name)
+				return ignConfig, fmt.Errorf("unexpected user with name: %v. Only core user is supported", users[i].Name)
 			}
 			for j := range users[i].SSHAuthorizedKeys {
 				outUser.SSHAuthorizedKeys = append(outUser.SSHAuthorizedKeys, users[i].SSHAuthorizedKeys[j])
@@ -605,7 +604,7 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign3types.Config, error
 	for _, contents := range files {
 		f := new(fcctbase.File)
 		if err := yaml.Unmarshal([]byte(contents), f); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal %q into struct: %v", contents, err)
+			return nil, fmt.Errorf("failed to unmarshal %q into struct: %w", contents, err)
 		}
 		f.Overwrite = &overwrite
 
@@ -614,7 +613,7 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign3types.Config, error
 		ctCfg.Storage.Files = append(ctCfg.Storage.Files, *f)
 		ign3_0config, tSet, err := ctCfg.ToIgn3_0()
 		if err != nil {
-			return nil, fmt.Errorf("failed to transpile config to Ignition config %s\nTranslation set: %v", err, tSet)
+			return nil, fmt.Errorf("failed to transpile config to Ignition config %w\nTranslation set: %v", err, tSet)
 		}
 		ign3_2config := translate3.Translate(translate3_1.Translate(ign3_0config))
 		outConfig = ign3.Merge(outConfig, ign3_2config)
@@ -623,7 +622,7 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign3types.Config, error
 	for _, contents := range units {
 		u := new(fcctbase.Unit)
 		if err := yaml.Unmarshal([]byte(contents), u); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal systemd unit into struct: %v", err)
+			return nil, fmt.Errorf("failed to unmarshal systemd unit into struct: %w", err)
 		}
 
 		// Add the unit to the config
@@ -631,7 +630,7 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign3types.Config, error
 		ctCfg.Systemd.Units = append(ctCfg.Systemd.Units, *u)
 		ign3_0config, tSet, err := ctCfg.ToIgn3_0()
 		if err != nil {
-			return nil, fmt.Errorf("failed to transpile config to Ignition config %s\nTranslation set: %v", err, tSet)
+			return nil, fmt.Errorf("failed to transpile config to Ignition config %w\nTranslation set: %v", err, tSet)
 		}
 		ign3_2config := translate3.Translate(translate3_1.Translate(ign3_0config))
 		outConfig = ign3.Merge(outConfig, ign3_2config)
@@ -644,7 +643,7 @@ func TranspileCoreOSConfigToIgn(files, units []string) (*ign3types.Config, error
 func MachineConfigFromIgnConfig(role, name string, ignCfg interface{}) (*mcfgv1.MachineConfig, error) {
 	rawIgnCfg, err := json.Marshal(ignCfg)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling Ignition config: %v", err)
+		return nil, fmt.Errorf("error marshalling Ignition config: %w", err)
 	}
 	return MachineConfigFromRawIgnConfig(role, name, rawIgnCfg)
 }
@@ -680,7 +679,7 @@ func GetManagedKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interfac
 	}
 	old, err := client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), deprecatedKey, metav1.GetOptions{})
 	if err != nil && !kerr.IsNotFound(err) {
-		return "", fmt.Errorf("could not get MachineConfig %q: %v", deprecatedKey, err)
+		return "", fmt.Errorf("could not get MachineConfig %q: %w", deprecatedKey, err)
 	}
 	// this means no previous CR config were here, so we can start fresh
 	if kerr.IsNotFound(err) {

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
@@ -22,7 +22,7 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 		// use selector since label matching part of a ContaineRuntimeConfig is not handled during the bootstrap
 		selector, err := metav1.LabelSelectorAsSelector(cfg.Spec.MachineConfigPoolSelector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid label selector: %v", err)
+			return nil, fmt.Errorf("invalid label selector: %w", err)
 		}
 		for _, pool := range mcpPools {
 			// If a pool with a nil or empty selector creeps in, it should match nothing, not everything.
@@ -34,7 +34,7 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 			// Generate the original ContainerRuntimeConfig
 			originalStorageIgn, _, _, err := generateOriginalContainerRuntimeConfigs(templateDir, controllerConfig, role)
 			if err != nil {
-				return nil, fmt.Errorf("could not generate origin ContainerRuntime Configs: %v", err)
+				return nil, fmt.Errorf("could not generate origin ContainerRuntime Configs: %w", err)
 			}
 
 			var configFileList []generatedConfigFile
@@ -55,15 +55,15 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 
 			ctrRuntimeConfigIgn := createNewIgnition(configFileList)
 			if err != nil {
-				return nil, fmt.Errorf("could not marshal container runtime ignition: %v", err)
+				return nil, fmt.Errorf("could not marshal container runtime ignition: %w", err)
 			}
 			managedKey, err := generateBootstrapManagedKeyContainerConfig(pool, managedKeyExist)
 			if err != nil {
-				return nil, fmt.Errorf("could not marshal container runtime ignition: %v", err)
+				return nil, fmt.Errorf("could not marshal container runtime ignition: %w", err)
 			}
 			mc, err := ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ctrRuntimeConfigIgn)
 			if err != nil {
-				return nil, fmt.Errorf("could not create MachineConfig from new Ignition config: %v", err)
+				return nil, fmt.Errorf("could not create MachineConfig from new Ignition config: %w", err)
 			}
 			mc.SetAnnotations(map[string]string{
 				ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -140,7 +140,7 @@ func createNewIgnition(configs []generatedConfigFile) ign3types.Config {
 func findStorageConfig(mc *mcfgv1.MachineConfig) (*ign3types.File, error) {
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Storage Ignition config failed with error: %v", err)
+		return nil, fmt.Errorf("parsing Storage Ignition config failed with error: %w", err)
 	}
 	for _, c := range ignCfg.Storage.Files {
 		if c.Path == storageConfigPath {
@@ -154,7 +154,7 @@ func findStorageConfig(mc *mcfgv1.MachineConfig) (*ign3types.File, error) {
 func findRegistriesConfig(mc *mcfgv1.MachineConfig) (*ign3types.File, error) {
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Registries Ignition config failed with error: %v", err)
+		return nil, fmt.Errorf("parsing Registries Ignition config failed with error: %w", err)
 	}
 	for _, c := range ignCfg.Storage.Files {
 		if c.Path == registriesConfigPath {
@@ -167,7 +167,7 @@ func findRegistriesConfig(mc *mcfgv1.MachineConfig) (*ign3types.File, error) {
 func findPolicyJSON(mc *mcfgv1.MachineConfig) (*ign3types.File, error) {
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Policy JSON Ignition config failed with error: %v", err)
+		return nil, fmt.Errorf("parsing Policy JSON Ignition config failed with error: %w", err)
 	}
 	for _, c := range ignCfg.Storage.Files {
 		if c.Path == policyConfigPath {
@@ -187,7 +187,7 @@ func getManagedKeyCtrCfg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.In
 	// Get all the ctrcfg CRs
 	ctrcfgListAll, err := client.MachineconfigurationV1().ContainerRuntimeConfigs().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return "", fmt.Errorf("error listing container runtime configs: %v", err)
+		return "", fmt.Errorf("error listing container runtime configs: %w", err)
 	}
 	// If there is no ctrcfg in the list, return the default MC name with no suffix
 	if ctrcfgListAll == nil || len(ctrcfgListAll.Items) == 0 {
@@ -198,7 +198,7 @@ func getManagedKeyCtrCfg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.In
 	for _, ctrcfg := range ctrcfgListAll.Items {
 		selector, err := metav1.LabelSelectorAsSelector(ctrcfg.Spec.MachineConfigPoolSelector)
 		if err != nil {
-			return "", fmt.Errorf("invalid label selector: %v", err)
+			return "", fmt.Errorf("invalid label selector: %w", err)
 		}
 		if selector.Empty() || !selector.Matches(labels.Set(pool.Labels)) {
 			continue
@@ -231,7 +231,7 @@ func getManagedKeyCtrCfg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.In
 			// Convert the suffix value to int so we can look through the list and grab the max suffix created so far
 			intVal, err := strconv.Atoi(val)
 			if err != nil {
-				return "", fmt.Errorf("error converting %s to int: %v", val, err)
+				return "", fmt.Errorf("error converting %s to int: %w", val, err)
 			}
 			if intVal > suffixNum {
 				suffixNum = intVal
@@ -288,7 +288,7 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.ContainerRunt
 func updateStorageConfig(data []byte, internal *mcfgv1.ContainerRuntimeConfiguration) ([]byte, error) {
 	tomlConf := new(tomlConfigStorage)
 	if _, err := toml.DecodeReader(bytes.NewBuffer(data), tomlConf); err != nil {
-		return nil, fmt.Errorf("error decoding crio config: %v", err)
+		return nil, fmt.Errorf("error decoding crio config: %w", err)
 	}
 
 	if internal.OverlaySize.Value() < 0 {
@@ -312,7 +312,7 @@ func addTOMLgeneratedConfigFile(configFileList []generatedConfigFile, path strin
 	var newData bytes.Buffer
 	encoder := toml.NewEncoder(&newData)
 	if err := encoder.Encode(tomlConf); err != nil {
-		return nil, fmt.Errorf("error encoding toml for CRIO drop-in files: %v", err)
+		return nil, fmt.Errorf("error encoding toml for CRIO drop-in files: %w", err)
 	}
 	configFileList = append(configFileList, generatedConfigFile{filePath: path, data: newData.Bytes()})
 	return configFileList, nil
@@ -374,7 +374,7 @@ func updateSearchRegistriesConfig(searchRegs []string) []generatedConfigFile {
 func updateRegistriesConfig(data []byte, internalInsecure, internalBlocked []string, icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy) ([]byte, error) {
 	tomlConf := sysregistriesv2.V2RegistriesConf{}
 	if _, err := toml.Decode(string(data), &tomlConf); err != nil {
-		return nil, fmt.Errorf("error unmarshalling registries config: %v", err)
+		return nil, fmt.Errorf("error unmarshalling registries config: %w", err)
 	}
 
 	if err := validateRegistriesConfScopes(internalInsecure, internalBlocked, []string{}, icspRules); err != nil {
@@ -417,7 +417,7 @@ func updatePolicyJSON(data []byte, internalBlocked, internalAllowed []string) ([
 	decoder := json.NewDecoder(bytes.NewBuffer(data))
 	err := decoder.Decode(policyObj)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding policy json: %v", err)
+		return nil, fmt.Errorf("error decoding policy json: %w", err)
 	}
 	transportScopes := make(signature.PolicyTransportScopes)
 	if len(internalAllowed) > 0 {

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -27,7 +27,7 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 		// use selector since label matching part of a KubeletConfig is not handled during the bootstrap
 		selector, err := metav1.LabelSelectorAsSelector(kubeletConfig.Spec.MachineConfigPoolSelector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid label selector: %v", err)
+			return nil, fmt.Errorf("invalid label selector: %w", err)
 		}
 
 		for _, pool := range mcpPools {
@@ -76,7 +76,7 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			ignConfig := ctrlcommon.NewIgnConfig()
 			mc, err := ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
 			if err != nil {
-				return nil, fmt.Errorf("could not create MachineConfig from new Ignition config: %v", err)
+				return nil, fmt.Errorf("could not create MachineConfig from new Ignition config: %w", err)
 			}
 			mc.Spec.Config.Raw = rawIgn
 			mc.SetAnnotations(map[string]string{

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -70,7 +70,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
-		return fmt.Errorf("could not get ControllerConfig %v", err)
+		return fmt.Errorf("could not get ControllerConfig: %w", err)
 	}
 
 	// Find all MachineConfigPools
@@ -122,7 +122,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 			}
 			return err
 		}); err != nil {
-			return fmt.Errorf("Could not Create/Update MachineConfig: %v", err)
+			return fmt.Errorf("Could not Create/Update MachineConfig: %w", err)
 		}
 		glog.Infof("Applied FeatureSet %v on MachineConfigPool %v", key, pool.Name)
 	}
@@ -133,7 +133,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 func (ctrl *Controller) enqueueFeature(feat *osev1.FeatureGate) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(feat)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", feat, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %w", feat, err))
 		return
 	}
 	ctrl.featureQueue.Add(key)

--- a/pkg/controller/render/hash.go
+++ b/pkg/controller/render/hash.go
@@ -44,10 +44,10 @@ func hashData(data []byte) ([]byte, error) {
 	//nolint:gosec
 	hasher := md5.New()
 	if _, err := hasher.Write(salt); err != nil {
-		return nil, fmt.Errorf("error computing hash: %v", err)
+		return nil, fmt.Errorf("error computing hash: %w", err)
 	}
 	if _, err := hasher.Write(data); err != nil {
-		return nil, fmt.Errorf("error computing hash: %v", err)
+		return nil, fmt.Errorf("error computing hash: %w", err)
 	}
 	return hasher.Sum(nil), nil
 }

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -294,7 +294,7 @@ func (ctrl *Controller) getPoolsForMachineConfig(config *mcfgv1.MachineConfig) (
 	for _, p := range pList {
 		selector, err := metav1.LabelSelectorAsSelector(p.Spec.MachineConfigSelector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid label selector: %v", err)
+			return nil, fmt.Errorf("invalid label selector: %w", err)
 		}
 
 		// If a pool with a nil or empty selector creeps in, it should match nothing, not everything.
@@ -314,7 +314,7 @@ func (ctrl *Controller) getPoolsForMachineConfig(config *mcfgv1.MachineConfig) (
 func (ctrl *Controller) enqueue(pool *mcfgv1.MachineConfigPool) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pool)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", pool, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %w", pool, err))
 		return
 	}
 
@@ -324,7 +324,7 @@ func (ctrl *Controller) enqueue(pool *mcfgv1.MachineConfigPool) {
 func (ctrl *Controller) enqueueRateLimited(pool *mcfgv1.MachineConfigPool) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pool)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", pool, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %w", pool, err))
 		return
 	}
 
@@ -335,7 +335,7 @@ func (ctrl *Controller) enqueueRateLimited(pool *mcfgv1.MachineConfigPool) {
 func (ctrl *Controller) enqueueAfter(pool *mcfgv1.MachineConfigPool, after time.Duration) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pool)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", pool, err))
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %w", pool, err))
 		return
 	}
 
@@ -611,7 +611,7 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 func getMachineConfigsForPool(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) ([]*mcfgv1.MachineConfig, error) {
 	selector, err := metav1.LabelSelectorAsSelector(pool.Spec.MachineConfigSelector)
 	if err != nil {
-		return nil, fmt.Errorf("invalid label selector: %v", err)
+		return nil, fmt.Errorf("invalid label selector: %w", err)
 	}
 
 	var out []*mcfgv1.MachineConfig

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -57,7 +57,7 @@ const (
 func generateTemplateMachineConfigs(config *RenderConfig, templateDir string) ([]*mcfgv1.MachineConfig, error) {
 	infos, err := ioutil.ReadDir(templateDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read dir %q: %v", templateDir, err)
+		return nil, fmt.Errorf("failed to read dir %q: %w", templateDir, err)
 	}
 
 	cfgs := []*mcfgv1.MachineConfig{}
@@ -74,7 +74,7 @@ func generateTemplateMachineConfigs(config *RenderConfig, templateDir string) ([
 
 		roleConfigs, err := GenerateMachineConfigsForRole(config, role, templateDir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create MachineConfig for role %s: %v", role, err)
+			return nil, fmt.Errorf("failed to create MachineConfig for role %s: %w", role, err)
 		}
 		cfgs = append(cfgs, roleConfigs...)
 	}
@@ -103,7 +103,7 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 	path := filepath.Join(templateDir, rolePath)
 	infos, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read dir %q: %v", path, err)
+		return nil, fmt.Errorf("failed to read dir %q: %w", path, err)
 	}
 
 	cfgs := []*mcfgv1.MachineConfig{}
@@ -176,7 +176,7 @@ func filterTemplates(toFilter map[string]string, path string, config *RenderConf
 
 		filedata, err := ioutil.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("failed to read file %q: %v", path, err)
+			return fmt.Errorf("failed to read file %q: %w", path, err)
 		}
 
 		// Render the template file
@@ -287,11 +287,11 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 
 	ignCfg, err := ctrlcommon.TranspileCoreOSConfigToIgn(keySortVals(files), keySortVals(units))
 	if err != nil {
-		return nil, fmt.Errorf("error transpiling CoreOS config to Ignition config: %v", err)
+		return nil, fmt.Errorf("error transpiling CoreOS config to Ignition config: %w", err)
 	}
 	mcfg, err := ctrlcommon.MachineConfigFromIgnConfig(role, name, ignCfg)
 	if err != nil {
-		return nil, fmt.Errorf("error creating MachineConfig from Ignition config: %v", err)
+		return nil, fmt.Errorf("error creating MachineConfig from Ignition config: %w", err)
 	}
 	// And inject the osimageurl here
 	mcfg.Spec.OSImageURL = config.OSImageURL
@@ -314,7 +314,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["urlPort"] = urlPort
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse template %s: %v", path, err)
+		return nil, fmt.Errorf("failed to parse template %s: %w", path, err)
 	}
 
 	if config.Constants == nil {
@@ -323,7 +323,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 
 	buf := new(bytes.Buffer)
 	if err := tmpl.Execute(buf, config); err != nil {
-		return nil, fmt.Errorf("failed to execute template: %v", err)
+		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 
 	return buf.Bytes(), nil
@@ -505,7 +505,7 @@ func existsDir(path string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to open dir %q: %v", path, err)
+		return false, fmt.Errorf("failed to open dir %q: %w", path, err)
 	}
 	if !info.IsDir() {
 		return false, fmt.Errorf("expected template directory, %q is not a directory", path)

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -453,7 +453,7 @@ func controllerConfigFromFile(path string) (*mcfgv1.ControllerConfig, error) {
 	}
 	cci, _, err := scheme.Codecs.UniversalDecoder().Decode(data, nil, &mcfgv1.ControllerConfig{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode ControllerConfig manifest: %v", err)
+		return nil, fmt.Errorf("unable to decode ControllerConfig manifest: %w", err)
 	}
 	cc, ok := cci.(*mcfgv1.ControllerConfig)
 	if !ok {
@@ -489,7 +489,7 @@ func verifyIgn(actual [][]byte, dir string, t *testing.T) {
 		}
 		if info.IsDir() {
 			if path != dir {
-				return fmt.Errorf("unexpected dir: %v", err)
+				return fmt.Errorf("unexpected dir: %w", err)
 			}
 			return nil
 		}

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -161,12 +161,12 @@ func (ctrl *Controller) deleteSecret(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		secret, ok = tombstone.Obj.(*corev1.Secret)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Secret %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Secret %#v", obj))
 			return
 		}
 	}
@@ -174,7 +174,7 @@ func (ctrl *Controller) deleteSecret(obj interface{}) {
 	if secret.Name == "pull-secret" {
 		cfg, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get ControllerConfig on secret callback %#v", err))
+			utilruntime.HandleError(fmt.Errorf("couldn't get ControllerConfig on secret callback %#w", err))
 			return
 		}
 		glog.V(4).Infof("Re-syncing ControllerConfig %s due to secret deletion", cfg.Name)
@@ -186,7 +186,7 @@ func (ctrl *Controller) deleteSecret(obj interface{}) {
 func (ctrl *Controller) enqueueController() {
 	cfg, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get ControllerConfig on dependency callback %#v", err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get ControllerConfig on dependency callback %#w", err))
 		return
 	}
 	glog.V(4).Infof("Re-syncing ControllerConfig %s due to dependency change", cfg.Name)
@@ -213,12 +213,12 @@ func (ctrl *Controller) deleteFeature(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		features, ok = tombstone.Obj.(*osev1.FeatureGate)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a FeatureGate %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a FeatureGate %#v", obj))
 			return
 		}
 	}
@@ -263,12 +263,12 @@ func (ctrl *Controller) deleteControllerConfig(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		cfg, ok = tombstone.Obj.(*mcfgv1.ControllerConfig)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ControllerConfig %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ControllerConfig %#v", obj))
 			return
 		}
 	}
@@ -318,12 +318,12 @@ func (ctrl *Controller) deleteMachineConfig(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		mc, ok = tombstone.Obj.(*mcfgv1.MachineConfig)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a MachineConfig %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a MachineConfig %#v", obj))
 			return
 		}
 	}
@@ -363,7 +363,7 @@ func (ctrl *Controller) resolveControllerRef(controllerRef *metav1.OwnerReferenc
 func (ctrl *Controller) enqueue(config *mcfgv1.ControllerConfig) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(config)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", config, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", config, err))
 		return
 	}
 
@@ -373,7 +373,7 @@ func (ctrl *Controller) enqueue(config *mcfgv1.ControllerConfig) {
 func (ctrl *Controller) enqueueRateLimited(controllerconfig *mcfgv1.ControllerConfig) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(controllerconfig)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", controllerconfig, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", controllerconfig, err))
 		return
 	}
 
@@ -384,7 +384,7 @@ func (ctrl *Controller) enqueueRateLimited(controllerconfig *mcfgv1.ControllerCo
 func (ctrl *Controller) enqueueAfter(controllerconfig *mcfgv1.ControllerConfig, after time.Duration) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(controllerconfig)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", controllerconfig, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", controllerconfig, err))
 		return
 	}
 
@@ -476,7 +476,7 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 
 	fg, err := ctrl.featLister.Get(ctrlcommon.ClusterFeatureInstanceName)
 	if err != nil && !errors.IsNotFound(err) {
-		err := fmt.Errorf("could not fetch FeatureGate: %v", err)
+		err := fmt.Errorf("could not fetch FeatureGate: %w", err)
 		glog.V(2).Infof("%v", err)
 		return ctrl.syncFailingStatus(cfg, err)
 	}
@@ -501,7 +501,7 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.ControllerConfig, pullSecretRaw []byte, featureGate *configv1.FeatureGate) ([]*mcfgv1.MachineConfig, error) {
 	buf := &bytes.Buffer{}
 	if err := json.Compact(buf, pullSecretRaw); err != nil {
-		return nil, fmt.Errorf("couldn't compact pullsecret %q: %v", string(pullSecretRaw), err)
+		return nil, fmt.Errorf("couldn't compact pullsecret %q: %w", string(pullSecretRaw), err)
 	}
 	rc := &RenderConfig{
 		ControllerConfigSpec: &config.Spec,

--- a/pkg/daemon/config_drift_monitor.go
+++ b/pkg/daemon/config_drift_monitor.go
@@ -17,13 +17,19 @@ import (
 )
 
 // Outermost error type for config drift errors
-type configDriftErr error
+type configDriftErr struct {
+	error
+}
 
 // Error type for file config drifts
-type fileConfigDriftErr error
+type fileConfigDriftErr struct {
+	error
+}
 
 // Error type for systemd unit config drifts
-type unitConfigDriftErr error
+type unitConfigDriftErr struct {
+	error
+}
 
 type ConfigDriftMonitor interface {
 	Start(ConfigDriftMonitorOpts) error
@@ -258,7 +264,7 @@ func (c *configDriftWatcher) handleFileEvent(event fsnotify.Event) error {
 		return nil
 	}
 
-	var cdErr configDriftErr
+	var cdErr *configDriftErr
 	if errors.As(err, &cdErr) {
 		c.OnDrift(cdErr)
 		// Don't bubble this error up further since it's handled by OnDrift.
@@ -276,7 +282,7 @@ func (c *configDriftWatcher) checkMachineConfigForEvent(event fsnotify.Event) er
 	}
 
 	if err := validateOnDiskState(c.MachineConfig, c.SystemdPath); err != nil {
-		return configDriftErr(err)
+		return &configDriftErr{err}
 	}
 
 	return nil

--- a/pkg/daemon/config_drift_monitor_test.go
+++ b/pkg/daemon/config_drift_monitor_test.go
@@ -23,8 +23,8 @@ func TestConfigDriftMonitor(t *testing.T) {
 	// Our errors. Their contents don't matter because we're not basing our
 	// assertions off of their contents. Instead, we're more concerned about
 	// their types.
-	fileErr := configDriftErr(fileConfigDriftErr(fmt.Errorf("file error")))
-	unitErr := configDriftErr(unitConfigDriftErr(fmt.Errorf("unit error")))
+	fileErr := &configDriftErr{&fileConfigDriftErr{fmt.Errorf("file error")}}
+	unitErr := &configDriftErr{&unitConfigDriftErr{fmt.Errorf("unit error")}}
 
 	// Filesystem Mutators
 	// These are closures to avoid namespace collisions and pollution since
@@ -446,17 +446,17 @@ func (tc configDriftMonitorTestCase) onDriftFunc(t *testing.T, err error) {
 
 	// Make sure that we get specific error types based upon the expected
 	// values
-	var cdErr configDriftErr
+	var cdErr *configDriftErr
 	assert.ErrorAs(t, err, &cdErr)
 
 	// If the testcase asks for a fileConfigDriftErr, be sure we got one.
-	var fErr fileConfigDriftErr
+	var fErr *fileConfigDriftErr
 	if errors.As(tc.expectedErr, &fErr) {
 		assert.ErrorAs(t, err, &fErr)
 	}
 
 	// If the testcase asks for a unitConfigDriftErr, be sure we got one.
-	var uErr unitConfigDriftErr
+	var uErr *unitConfigDriftErr
 	if errors.As(tc.expectedErr, &uErr) {
 		assert.ErrorAs(t, err, &uErr)
 	}

--- a/pkg/daemon/controlplane.go
+++ b/pkg/daemon/controlplane.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // setRootDeviceSchedulerBFQ switches to the `bfq` I/O scheduler
@@ -69,7 +68,7 @@ func setRootDeviceSchedulerBFQ() error {
 // latency spikes for etcd; see https://github.com/ostreedev/ostree/pull/2152
 func updateOstreeObjectSync() error {
 	if err := exec.Command("ostree", "--repo=/sysroot/ostree/repo", "config", "set", "core.per-object-fsync", "true").Run(); err != nil {
-		return errors.Wrapf(err, "Failed to set per-object-fsync for ostree")
+		return fmt.Errorf("failed to set per-object-fsync for ostree: %w", err)
 	}
 	return nil
 }

--- a/pkg/daemon/coreos.go
+++ b/pkg/daemon/coreos.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // alephPath contains information on the original bootimage; for more
@@ -44,12 +43,12 @@ func byLabel(label string) string {
 func getParentDeviceSysfs(device string) (string, error) {
 	target, err := os.Readlink(device)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading %s", device)
+		return "", fmt.Errorf("reading %s: %w", device, err)
 	}
 	sysfsDevLink := fmt.Sprintf("/sys/class/block/%s", filepath.Base(target))
 	sysfsDev, err := filepath.EvalSymlinks(sysfsDevLink)
 	if err != nil {
-		return "", errors.Wrapf(err, "parsing %s", sysfsDevLink)
+		return "", fmt.Errorf("parsing %s: %w", sysfsDevLink, err)
 	}
 	if _, err := os.Stat(filepath.Join(sysfsDev, "partition")); err == nil {
 		sysfsDev = filepath.Dir(sysfsDev)
@@ -71,7 +70,7 @@ func getRootBlockDeviceSysfs() (string, error) {
 	if _, err := os.Stat(root); err == nil {
 		return getParentDeviceSysfs(root)
 	}
-	return "", fmt.Errorf("Failed to find %s", root)
+	return "", fmt.Errorf("failed to find %s", root)
 }
 
 func logAlephInformation() error {

--- a/pkg/daemon/image-inspect.go
+++ b/pkg/daemon/image-inspect.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -67,14 +66,14 @@ func imageInspect(imageName string) (*types.ImageInspectInfo, error) {
 		src, err = newDockerImageSource(ctx, sys, imageName)
 		return err
 	}); err != nil {
-		return nil, errors.Wrapf(err, "Error parsing image name %q", imageName)
+		return nil, fmt.Errorf("error parsing image name %q: %w", imageName, err)
 	}
 
 	defer src.Close()
 
 	img, err := image.FromUnparsedImage(ctx, sys, image.UnparsedInstance(src, nil))
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing manifest for image: %v", err)
+		return nil, fmt.Errorf("error parsing manifest for image: %w", err)
 	}
 
 	if err := retryIfNecessary(ctx, func() error {

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/pkg/daemon/pivot/types"
-	errors "github.com/pkg/errors"
 )
 
 const (
@@ -39,7 +38,7 @@ var tuneableFCOSArgsAllowlist = map[string]bool{
 func isArgTunable(arg string) (bool, error) {
 	os, err := GetHostRunningOS()
 	if err != nil {
-		return false, errors.Errorf("failed to get OS for determining whether kernel arg is tuneable: %v", err)
+		return false, fmt.Errorf("failed to get OS for determining whether kernel arg is tuneable: %w", err)
 	}
 
 	if os.IsRHCOS() {
@@ -84,7 +83,7 @@ func parseTuningFile(tuningFilePath, cmdLinePath string) ([]types.TuneArgument, 
 			// It's ok if the file doesn't exist
 			return addArguments, deleteArguments, nil
 		}
-		return addArguments, deleteArguments, errors.Wrapf(err, "reading %s", tuningFilePath)
+		return addArguments, deleteArguments, fmt.Errorf("reading %s: %w", tuningFilePath, err)
 	}
 	// Clean up
 	defer file.Close()

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -25,7 +25,7 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 
 	d, err := ioutil.ReadFile(constants.InitialNodeAnnotationsFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed to read initial annotations from %q: %v", constants.InitialNodeAnnotationsFilePath, err)
+		return nil, fmt.Errorf("failed to read initial annotations from %q: %w", constants.InitialNodeAnnotationsFilePath, err)
 	}
 	if os.IsNotExist(err) {
 		// try currentConfig if, for whatever reason we lost annotations? this is super best effort.
@@ -39,13 +39,13 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 
 	var initial map[string]string
 	if err := json.Unmarshal(d, &initial); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal initial annotations: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal initial annotations: %w", err)
 	}
 
 	glog.Infof("Setting initial node config: %s", initial[constants.CurrentMachineConfigAnnotationKey])
 	n, err := setNodeAnnotations(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, node.Name, initial)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set initial annotations: %v", err)
+		return nil, fmt.Errorf("failed to set initial annotations: %w", err)
 	}
 	return n, nil
 }

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/opencontainers/go-digest"
 	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -94,7 +93,7 @@ func (r *RpmOstreeClient) loadStatus() (*rpmOstreeState, error) {
 	}
 
 	if err := json.Unmarshal(output, &rosState); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse `rpm-ostree status --json` output (%s)", truncate(string(output), 30))
+		return nil, fmt.Errorf("failed to parse `rpm-ostree status --json` output (%s): %w", truncate(string(output), 30), err)
 	}
 
 	return &rosState, nil
@@ -207,7 +206,7 @@ func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
 	var imagedataArray []imageInspection
 	err = json.Unmarshal(output, &imagedataArray)
 	if err != nil {
-		err = errors.Wrapf(err, "unmarshaling podman inspect")
+		err = fmt.Errorf("unmarshaling podman inspect: %w", err)
 		return
 	}
 	imgdata = &imagedataArray[0]
@@ -283,11 +282,11 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 			}
 			ostreeCsum = strings.TrimSpace(string(ostreeCsumBytes))
 		} else if len(refs) > 1 {
-			err = errors.New("multiple refs found in repo")
+			err = fmt.Errorf("multiple refs found in repo")
 			return
 		} else {
 			// XXX: in the future, possibly scan the repo to find a unique .commit object
-			err = errors.New("No refs found in repo")
+			err = fmt.Errorf("no refs found in repo")
 			return
 		}
 	}

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -120,7 +120,7 @@ func RenderBootstrap(
 	if infra.Spec.CloudConfig.Name != "" {
 		cloudConf, err := loadBootstrapCloudProviderConfig(infra, cloudConfigFile)
 		if err != nil {
-			return fmt.Errorf("failed to load the cloud provider config: %v", err)
+			return fmt.Errorf("failed to load the cloud provider config: %w", err)
 		}
 		spec.CloudProviderConfig = cloudConf
 	}

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -50,7 +50,7 @@ func newAssetRenderer(path string) *assetRenderer {
 func (a *assetRenderer) read() error {
 	objBytes, err := manifests.ReadFile(a.Path)
 	if err != nil {
-		return fmt.Errorf("error getting asset %s: %v", a.Path, err)
+		return fmt.Errorf("error getting asset %s: %w", a.Path, err)
 	}
 	a.templateData = string(objBytes)
 	return nil
@@ -70,12 +70,12 @@ func (a *assetRenderer) addTemplateFuncs() {
 func (a *assetRenderer) render(config interface{}) ([]byte, error) {
 	tmpl, err := a.tmpl.Parse(a.templateData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse asset %s: %v", a.Path, err)
+		return nil, fmt.Errorf("failed to parse asset %s: %w", a.Path, err)
 	}
 
 	buf := new(bytes.Buffer)
 	if err := tmpl.Execute(buf, config); err != nil {
-		return nil, fmt.Errorf("failed to execute template: %v", err)
+		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -391,7 +391,7 @@ func (optr *Operator) isKubeletSkewSupported(pools []*v1.MachineConfigPool) (ske
 	)
 	nodes, err := optr.GetAllManagedNodes(pools)
 	if err != nil {
-		err = fmt.Errorf("getting all managed nodes failed: %v", err)
+		err = fmt.Errorf("getting all managed nodes failed: %w", err)
 		coStatus.Reason = skewUnchecked
 		coStatus.Message = fmt.Sprintf("An error occurred when getting all the managed nodes: %v", err.Error())
 	}
@@ -441,7 +441,7 @@ func (optr *Operator) GetAllManagedNodes(pools []*v1.MachineConfigPool) ([]*core
 		}
 		poolNodes, err := optr.nodeLister.List(selector)
 		if err != nil {
-			return nil, fmt.Errorf("could not list nodes for pool %v with error %v", pool.Name, err)
+			return nil, fmt.Errorf("could not list nodes for pool %v with error %w", pool.Name, err)
 		}
 		nodes = append(nodes, poolNodes...)
 	}

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/clarketm/json"
 	"github.com/coreos/go-semver/semver"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -253,7 +252,7 @@ func parseAcceptHeader(input string) ([]acceptHeaderValue, error) {
 	}
 
 	if len(header) == 0 {
-		return nil, errors.New("no valid accept header detected")
+		return nil, fmt.Errorf("no valid accept header detected")
 	}
 
 	// Sort headers by descending q factor value.
@@ -294,7 +293,7 @@ func detectSpecVersionFromAcceptHeader(acceptHeader string) (*semver.Version, er
 			} else if !header.SemVer.LessThan(*v2_2) && header.SemVer.LessThan(*semver.New("3.0.0")) {
 				return v2_2, nil
 			}
-			ignVersionError = errors.Errorf("unsupported Ignition version in Accept header: %s", acceptHeader)
+			ignVersionError = fmt.Errorf("unsupported Ignition version in Accept header: %s", acceptHeader)
 		}
 	}
 	// return error if version of Ignition MIME subtype is not supported

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -70,13 +70,13 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("server: could not read file %s, err: %v", fileName, err)
+		return nil, fmt.Errorf("server: could not read file %s, err: %w", fileName, err)
 	}
 
 	mp := new(mcfgv1.MachineConfigPool)
 	err = yaml.Unmarshal(data, mp)
 	if err != nil {
-		return nil, fmt.Errorf("server: could not unmarshal file %s, err: %v", fileName, err)
+		return nil, fmt.Errorf("server: could not unmarshal file %s, err: %w", fileName, err)
 	}
 
 	currConf := mp.Status.Configuration.Name
@@ -90,17 +90,17 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("server: could not read file %s, err: %v", fileName, err)
+		return nil, fmt.Errorf("server: could not read file %s, err: %w", fileName, err)
 	}
 
 	mc := new(mcfgv1.MachineConfig)
 	err = yaml.Unmarshal(data, mc)
 	if err != nil {
-		return nil, fmt.Errorf("server: could not unmarshal file %s, err: %v", fileName, err)
+		return nil, fmt.Errorf("server: could not unmarshal file %s, err: %w", fileName, err)
 	}
 	ignConf, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Ignition config failed with error: %v", err)
+		return nil, fmt.Errorf("parsing Ignition config failed with error: %w", err)
 	}
 
 	appenders := getAppenders(currConf, nil, bsc.kubeconfigFunc)
@@ -120,7 +120,7 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 func kubeconfigFromFile(path string) ([]byte, []byte, error) {
 	kcData, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting kubeconfig from disk: %v", err)
+		return nil, nil, fmt.Errorf("error getting kubeconfig from disk: %w", err)
 	}
 
 	kc := clientcmd.Config{}

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -49,7 +49,7 @@ type clusterServer struct {
 func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 	restConfig, err := getClientConfig(kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create Kubernetes rest client: %v", err)
+		return nil, fmt.Errorf("failed to create Kubernetes rest client: %w", err)
 	}
 
 	mc := v1.NewForConfigOrDie(restConfig)
@@ -64,7 +64,7 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error) {
 	mp, err := cs.machineClient.MachineConfigPools().Get(context.TODO(), cr.machineConfigPool, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch pool. err: %v", err)
+		return nil, fmt.Errorf("could not fetch pool. err: %w", err)
 	}
 
 	// For new nodes, we roll out the latest if at least one node has successfully updated.
@@ -80,11 +80,11 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 
 	mc, err := cs.machineClient.MachineConfigs().Get(context.TODO(), currConf, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch config %s, err: %v", currConf, err)
+		return nil, fmt.Errorf("could not fetch config %s, err: %w", currConf, err)
 	}
 	ignConf, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Ignition config failed with error: %v", err)
+		return nil, fmt.Errorf("parsing Ignition config failed with error: %w", err)
 	}
 
 	appenders := getAppenders(currConf, cr.version, cs.kubeconfigFunc)
@@ -118,11 +118,11 @@ func kubeconfigFromSecret(secretDir, apiserverURL string) ([]byte, []byte, error
 	tokenFile := filepath.Join(secretDir, corev1.ServiceAccountTokenKey)
 	caData, err := ioutil.ReadFile(caFile)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to read %s: %v", caFile, err)
+		return nil, nil, fmt.Errorf("failed to read %s: %w", caFile, err)
 	}
 	token, err := ioutil.ReadFile(tokenFile)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to read %s: %v", tokenFile, err)
+		return nil, nil, fmt.Errorf("failed to read %s: %w", tokenFile, err)
 	}
 
 	kubeconfig := clientcmdv1.Config{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -78,7 +78,7 @@ func appendEncapsulated(conf *igntypes.Config, mc *mcfgv1.MachineConfig, version
 		tmpIgnCfg := ctrlcommon.NewIgnConfig()
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {
-			return fmt.Errorf("error marshalling Ignition config: %v", err)
+			return fmt.Errorf("error marshalling Ignition config: %w", err)
 		}
 	} else {
 		tmpIgnCfg := ign2types.Config{
@@ -88,7 +88,7 @@ func appendEncapsulated(conf *igntypes.Config, mc *mcfgv1.MachineConfig, version
 		}
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {
-			return fmt.Errorf("error marshalling Ignition config: %v", err)
+			return fmt.Errorf("error marshalling Ignition config: %w", err)
 		}
 	}
 
@@ -96,11 +96,11 @@ func appendEncapsulated(conf *igntypes.Config, mc *mcfgv1.MachineConfig, version
 	tmpcfg.Spec.Config.Raw = rawTmpIgnCfg
 	serialized, err := json.Marshal(tmpcfg)
 	if err != nil {
-		return fmt.Errorf("error marshalling MachineConfig: %v", err)
+		return fmt.Errorf("error marshalling MachineConfig: %w", err)
 	}
 	err = appendFileToIgnition(conf, daemonconsts.MachineConfigEncapsulatedPath, string(serialized))
 	if err != nil {
-		return fmt.Errorf("error appending file to raw Ignition config: %v", err)
+		return fmt.Errorf("error appending file to raw Ignition config: %w", err)
 	}
 	return nil
 }
@@ -150,7 +150,7 @@ func getNodeAnnotation(conf string) (string, error) {
 	}
 	contents, err := json.Marshal(nodeAnnotations)
 	if err != nil {
-		return "", fmt.Errorf("could not marshal node annotations, err: %v", err)
+		return "", fmt.Errorf("could not marshal node annotations, err: %w", err)
 	}
 	return string(contents), nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -386,12 +386,12 @@ func getTestMachineConfigPool() (*mcfgv1.MachineConfigPool, error) {
 	mpPath := path.Join(testDir, "machine-pools", testPool+".yaml")
 	mpData, err := ioutil.ReadFile(mpPath)
 	if err != nil {
-		return nil, fmt.Errorf("unexpected error while reading machine-pool: %s, err: %v", mpPath, err)
+		return nil, fmt.Errorf("unexpected error while reading machine-pool: %s, err: %w", mpPath, err)
 	}
 	mp := new(mcfgv1.MachineConfigPool)
 	err = yaml.Unmarshal(mpData, mp)
 	if err != nil {
-		return nil, fmt.Errorf("unexpected error while unmarshaling machine-pool: %s, err: %v", mpPath, err)
+		return nil, fmt.Errorf("unexpected error while unmarshaling machine-pool: %s, err: %w", mpPath, err)
 	}
 	return mp, nil
 }

--- a/test/e2e/ctrcfg_test.go
+++ b/test/e2e/ctrcfg_test.go
@@ -14,7 +14,6 @@ import (
 	ctrcfg "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,7 +146,7 @@ func runTestWithCtrcfg(t *testing.T, testName, regexKey, expectedConfVal1, expec
 	arr := strings.Split(ctrcfg.CRIODropInFilePathLogLevel, "/")
 	overrideFileName := arr[len(arr)-1]
 	if fileExists(t, cs, node, overrideFileName) {
-		err := errors.New("override file still exists in crio.conf.d")
+		err := fmt.Errorf("override file still exists in crio.conf.d")
 		require.Nil(t, err)
 	}
 }
@@ -204,7 +203,7 @@ func getMCFromCtrcfg(t *testing.T, cs *framework.ClientSet, ctrcfgName string) (
 		}
 		return false, nil
 	}); err != nil {
-		return "", errors.Wrapf(err, "can't find machine config created by ctrcfg %s", ctrcfgName)
+		return "", fmt.Errorf("can't find machine config created by ctrcfg %s: %w", ctrcfgName, err)
 	}
 	return mcName, nil
 }

--- a/test/e2e/kubeletcfg_test.go
+++ b/test/e2e/kubeletcfg_test.go
@@ -13,7 +13,6 @@ import (
 	kcfg "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -214,7 +213,7 @@ func getMCFromKubeletCfg(t *testing.T, cs *framework.ClientSet, kcName string) (
 		}
 		return false, nil
 	}); err != nil {
-		return "", errors.Wrapf(err, "can't find machine config created by kubelet config %s", kcName)
+		return "", fmt.Errorf("can't find machine config created by kubelet config %s: %w", kcName, err)
 	}
 	return mcName, nil
 }


### PR DESCRIPTION
Deprecate the use of pkg/errors in MCO to use built-in Golang error-wrapping

Signed-off-by: Raisaat Rashid <rarashid@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Changed all the code instances in machine-config-operator using pkg/errors to use built-in Golang error-wrapping instead.

**- How to verify it**

Make sure all the e2e and unit tests run properly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Deprecate the use of pkg/errors in machine-config-operator to use built-in Golang error-wrapping

