### PR TITLE
ovs-vswitchd.service: delete transient ports

### DIFF
--- a/templates/common/_base/units/ovs-vswitchd.service.yaml
+++ b/templates/common/_base/units/ovs-vswitchd.service.yaml
@@ -7,5 +7,6 @@ dropins:
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /var/lib/openvswitch'
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /etc/openvswitch'
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /run/openvswitch'
+      ExecStartPre=-/usr/bin/ovs-ctl delete-transient-ports
       ExecStartPost=-/usr/bin/ovs-appctl vlog/set syslog:info
       ExecReload=-/usr/bin/ovs-appctl vlog/set syslog:info


### PR DESCRIPTION
## What I did

Added StartPost for service to delete OVS ports marked as transient.

## How to verify it

Restart service or reboot system and verify that the following commands were executed in the
logs:

Ref: https://github.com/openvswitch/ovs/blob/20a4f546f7db197a9652a79c4e8edac972a16084/utilities/ovs-ctl.in#L112-L116
```
del_transient_ports () {
    for port in `ovs-vsctl --bare -- --columns=name find port other_config:transient=true`; do
        ovs_vsctl -- del-port "$port"
    done
}
```

Check logs:

* run `oc adm must-gather -- gather_network_logs` and see log file from host_service_logs/<node_name>/ovs-vswitchs_service.log

* Make sure transient ports were deleted upon service start

## Description for the changelog

delete transient ports upon reboot or restarting the ovs-vswitchd service
