### PR TITLE
ovs-delete-transient-ports: Enable for ovn or sdn type

### DIFF
--- a/templates/common/_base/units/ovs-delete-transient-ports.service.yaml
+++ b/templates/common/_base/units/ovs-delete-transient-ports.service.yaml
@@ -1,0 +1,2 @@
+name: "ovs-delete-transient-ports.service"
+enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else if eq .NetworkType "OpenShiftSDN"}}true{{else}}false{{end}}


### PR DESCRIPTION
Ensure transient ports are removed via this service, to scale node
start of OVS based systems. Even when this service is started, it
will only remove transient OVS ports.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Co-Authored-By: Andrew Stoycos <astoycos@redhat.com>

**- What I did**
Added ovs-delete-transient-ports.service.yaml file, with logic to
enable this service.

**- How to verify it**
Ensure that service started before ovs-vswitchd service.

**- Description for the changelog**
Enable service that removes transient OVS ports for ovn-k8 and sdn CNI