### PR TITLE
Bug 1949827: Add KUBELET_NODEIP_HINT to nodeip-configuration

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -25,7 +25,8 @@ contents: |
     {{if eq .IPFamilies "IPv6" -}}
     --prefer-ipv6 \
     {{end -}}
-    --retry-on-failure; \
+    --retry-on-failure \
+    $KUBELET_NODEIP_HINT; \
     do \
     sleep 5; \
     done"
@@ -34,6 +35,7 @@ contents: |
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
+  EnvironmentFile=-/etc/default/nodeip-configuration
 
   [Install]
   RequiredBy=kubelet.service


### PR DESCRIPTION
When we added the nodeip-configuration service for None platform
deployments, we broke some existing users who were relying on the
(largely undefined) previous behavior Kubelet used to select its
node ip. While it is possible to work around this by overriding the
node ip selection logic, that's very cumbersome and not an acceptable
user experience.

This change adds a KUBELET_NODEIP_HINT env variable that can be used
to override the default behavior of runtimecfg when selecting a node
ip. When the variable is unset, the old behavior of selecting an
address on the interface of the default route will take effect. When
the variable is set, its value will be passed to runtimecfg like a
VIP for the IPI platforms. This will cause runtimecfg to prefer an
address in the same subnet as the one provided in
KUBELET_NODEIP_HINT. If no such address is found, it will fall back
to the default route logic as before.

KUBELET_NODEIP_HINT can be set using a systemd environment file.
The file must be named /etc/default/nodeip-configuration
with contents such as (replacing the IP as appropriate):

KUBELET_NODEIP_HINT=192.0.2.1

This file should be created using a machine-config manifest that is
passed to the installer so it will take effect on initial deployment.
The node ip cannot be changed after the node registers initially so
this cannot be done as a day 2 operation.

Note that the IP specified in the hint does not necessarily need to
exist in the environment, it just needs to be in the correct subnet.
No traffic will be sent to this address.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added a mechanism for deployers to override the default node ip selection logic in None platform deployments.
