### PR TITLE
WIP: Set proper InvolvedObject when using library-go EventRecorder

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -153,8 +153,13 @@ func New(
 		apiExtClient:  apiExtClient,
 		configClient:  configClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigoperator"}),
-		libgoRecorder: events.NewRecorder(kubeClient.CoreV1().Events("openshift-machine-config-operator"), "machine-config-operator", &corev1.ObjectReference{}),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
+		libgoRecorder: events.NewRecorder(kubeClient.CoreV1().Events("openshift-machine-config-operator"), "machine-config-operator", &corev1.ObjectReference{
+			Kind:       "Deployment",
+			Name:       "machine-config-operator",
+			Namespace:  "openshift-machine-config-operator",
+			APIVersion: "apps/v1",
+		}),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
 	}
 
 	for _, i := range []cache.SharedIndexInformer{


### PR DESCRIPTION
You'll need to set a proper `InvolvedObject` such that you won't too many events like:
```
W1222 00:46:00.935946       1 recorder.go:190] Error creating event &Event{ObjectMeta:{.16c2ed25cd8773b4      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []},InvolvedObject:ObjectReference{Kind:,Namespace:,Name:,UID:,APIVersion:,ResourceVersion:,FieldPath:,},Reason:ClusterRoleUpdated,Message:Updated ClusterRole.rbac.authorization.k8s.io/machine-config-controller-events -n openshift-machine-config-operator because it changed,Source:EventSource{Component:machine-config-operator,Host:,},FirstTimestamp:2021-12-22 00:46:00.93406098 +0000 UTC m=+8307.807549581,LastTimestamp:2021-12-22 00:46:00.93406098 +0000 UTC m=+8307.807549581,Count:1,Type:Normal,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:,ReportingInstance:,}: Event ".16c2ed25cd8773b4" is invalid: involvedObject.namespace: Invalid value: "": does not match event.namespace
```
as you can observe for example in https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_kubernetes/1087/pull-ci-openshift-kubernetes-master-k8s-e2e-gcp-serial/1473408603632177152/artifacts/k8s-e2e-gcp-serial/gather-extra/artifacts/pods/openshift-machine-config-operator_machine-config-controller-789f46f7dc-mwsn2_machine-config-controller.log
/assign @kikisdeliveryservice @sinnykumari 