### PR TITLE
Bug 2045866: Set proper InvolvedObject when using library-go EventRecorder

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -153,8 +153,13 @@ func New(
 		apiExtClient:  apiExtClient,
 		configClient:  configClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigoperator"}),
-		libgoRecorder: events.NewRecorder(kubeClient.CoreV1().Events("openshift-machine-config-operator"), "machine-config-operator", &corev1.ObjectReference{}),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
+		libgoRecorder: events.NewRecorder(kubeClient.CoreV1().Events("openshift-machine-config-operator"), "machine-config-operator", &corev1.ObjectReference{
+			Kind:       "Deployment",
+			Name:       "machine-config-operator",
+			Namespace:  "openshift-machine-config-operator",
+			APIVersion: "apps/v1",
+		}),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigoperator"),
 	}
 
 	for _, i := range []cache.SharedIndexInformer{


### PR DESCRIPTION
Currently we're getting the error:
Error creating event &Event...
Event ".16c2ed25cd8773b4" is invalid: involvedObject.namespace: Invalid value: "": does not match event.namespace

Related to Bug 2034364, overlooked in
https://github.com/openshift/machine-config-operator/pull/2833

Replaces https://github.com/openshift/machine-config-operator/pull/2891