### PR TITLE
templates: Clean out filesystem properties

### DIFF
--- a/templates/common/_base/files/etc-mco-proxy.yaml
+++ b/templates/common/_base/files/etc-mco-proxy.yaml
@@ -1,4 +1,3 @@
-filesystem: "root"
 mode: 0644
 path: "/etc/mco/proxy.env"
 contents:

--- a/templates/common/_base/files/etc-systemd-system.conf.d-10-default-env-godebug.conf.yaml
+++ b/templates/common/_base/files/etc-systemd-system.conf.d-10-default-env-godebug.conf.yaml
@@ -1,4 +1,3 @@
-filesystem: "root"
 mode: 0644
 path: "/etc/systemd/system.conf.d/10-default-env-godebug.conf"
 contents:

--- a/templates/common/_base/files/vsphere-disable-vmxnet3v4-features.yaml
+++ b/templates/common/_base/files/vsphere-disable-vmxnet3v4-features.yaml
@@ -1,4 +1,3 @@
-filesystem: "root"
 mode: 0744
 path: "/etc/NetworkManager/dispatcher.d/99-vsphere-disable-tx-udp-tnl"
 contents:


### PR DESCRIPTION
The `filesystem: "root"` kv pair is a remnant of the past from when
the template format was based on the Container Linux Config spec.
Nowadays, it's based on the Butane config spec (formerly known as
Fedora CoreOS Config) where this property node does not exist, and is
thus ignored when transpiling templates to Ignition config.