### PR TITLE
mcd: Remove redundant MkdirAll call in update.go

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -311,11 +311,6 @@ func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 		return
 	}
 
-	if err = os.MkdirAll(osImageContentDir, 0755); err != nil {
-		err = fmt.Errorf("error creating directory %s: %v", osImageContentDir, err)
-		return
-	}
-
 	// Extract the image
 	args := []string{"image", "extract", "--path", "/:" + osImageContentDir}
 	args = append(args, registryConfig...)


### PR DESCRIPTION
The call to TempDir a few lines above already created this directory, so
this call to MkdirAll is completely unecessary