### PR TITLE
daemon.go/update.go: various cleanup surrounding OS updates

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1368,16 +1368,6 @@ func (dn *Daemon) validateOnDiskState(currentConfig *mcfgv1.MachineConfig) error
 	}
 }
 
-// compareOSImageURL checks whether the current and desired
-// URL are the same.  This used to do more, but now the
-// only special casing is to support an empty desired URL
-// as meaning "keep current OS" which we probably don't need
-// anymore either.
-func compareOSImageURL(current, desired string) bool {
-	// A desired "" is special cased
-	return desired == "" || current == desired
-}
-
 // checkOS determines whether the booted system matches the target
 // osImageURL and if not whether we need to take action.  This function
 // returns `true` if no action is required, which is the case if we're
@@ -1391,7 +1381,7 @@ func (dn *Daemon) checkOS(osImageURL string) bool {
 		return true
 	}
 
-	return compareOSImageURL(dn.bootedOSImageURL, osImageURL)
+	return dn.bootedOSImageURL == osImageURL
 }
 
 // checkUnits validates the contents of all the units in the

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -124,6 +124,11 @@ type Daemon struct {
 	drainer *drain.Helper
 }
 
+// CoreOSDaemon protects the methods that should only be called on CoreOS variants
+type CoreOSDaemon struct {
+	*Daemon
+}
+
 const (
 	// pathSystemd is the path systemd modifiable units, services, etc.. reside
 	pathSystemd = "/etc/systemd/system"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1040,7 +1040,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 			if err != nil {
 				return err
 			}
-			if err := dn.updateOS(state.currentConfig, osImageContentDir); err != nil {
+			if err := updateOS(state.currentConfig, osImageContentDir); err != nil {
 				return err
 			}
 			if err := os.RemoveAll(osImageContentDir); err != nil {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -11,7 +11,6 @@ import (
 
 	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
@@ -108,26 +107,6 @@ func TestValidateFiles(t *testing.T) {
 	if err := checkV2Files(filesV2); err != nil {
 		t.Errorf("Validating an overwritten file failed: %v", err)
 	}
-}
-
-func TestCompareOSImageURL(t *testing.T) {
-	refA := "registry.example.com/foo/bar@sha256:0743a3cc3bcf3b4aabb814500c2739f84cb085ff4e7ec7996aef7977c4c19c7f"
-	refB := "registry.example.com/foo/baz@sha256:0743a3cc3bcf3b4aabb814500c2739f84cb085ff4e7ec7996aef7977c4c19c7f"
-	refC := "registry.example.com/foo/bar@sha256:2a76681fd15bfc06fa4aa0ff6913ba17527e075417fc92ea29f6bcc2afca24ff"
-	m := compareOSImageURL(refA, refA)
-	if !m {
-		t.Fatalf("Expected refA ident")
-	}
-	m = compareOSImageURL(refA, refB)
-	if m {
-		t.Fatalf("Expected refA != refB")
-	}
-	m = compareOSImageURL(refA, refC)
-	if m {
-		t.Fatalf("Expected refA != refC")
-	}
-	m = compareOSImageURL("", refA)
-	assert.False(t, m)
 }
 
 type fixture struct {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -336,6 +336,10 @@ func removePendingDeployment() error {
 }
 
 func (dn *Daemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
+	if dn.os.IsCoreOSVariant() {
+		glog.Info("updating the OS on non-CoreOS nodes is not supported")
+		return nil
+	}
 	// Extract image and add coreos-extensions repo if we have either OS update or package layering to perform
 
 	if dn.recorder != nil {
@@ -369,12 +373,10 @@ func (dn *Daemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig 
 		// Delete extracted OS image once we are done.
 		defer os.RemoveAll(osImageContentDir)
 
-		if dn.os.IsCoreOSVariant() {
-			if err := addExtensionsRepo(osImageContentDir); err != nil {
-				return err
-			}
-			defer os.Remove(extensionsRepo)
+		if err := addExtensionsRepo(osImageContentDir); err != nil {
+			return err
 		}
+		defer os.Remove(extensionsRepo)
 	}
 
 	// Update OS
@@ -969,11 +971,6 @@ func generateKargs(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
 
 // updateKernelArguments adjusts the kernel args
 func (dn *Daemon) updateKernelArguments(oldConfig, newConfig *mcfgv1.MachineConfig) error {
-	if !dn.os.IsCoreOSVariant() {
-		glog.Info("updating kargs on non-CoreOS nodes is not supported")
-		return nil
-	}
-
 	kargs := generateKargs(oldConfig, newConfig)
 	if len(kargs) == 0 {
 		return nil
@@ -1074,12 +1071,6 @@ func validateExtensions(exts []string) error {
 }
 
 func (dn *Daemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConfig) error {
-	// Right now, we support extensions only on CoreOS nodes
-	if !dn.os.IsCoreOSVariant() {
-		glog.Info("applying extensions on non-CoreOS nodes is not supported")
-		return nil
-	}
-
 	extensionsEmpty := len(oldConfig.Spec.Extensions) == 0 && len(newConfig.Spec.Extensions) == 0
 	if (extensionsEmpty) ||
 		(reflect.DeepEqual(oldConfig.Spec.Extensions, newConfig.Spec.Extensions) && oldConfig.Spec.OSImageURL == newConfig.Spec.OSImageURL) {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -378,13 +378,15 @@ func (dn *Daemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig 
 	}
 
 	// Update OS
-	if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
-		nodeName := ""
-		if dn.node != nil {
-			nodeName = dn.node.Name
+	if mcDiff.osUpdate {
+		if err := updateOS(newConfig, osImageContentDir); err != nil {
+			nodeName := ""
+			if dn.node != nil {
+				nodeName = dn.node.Name
+			}
+			MCDPivotErr.WithLabelValues(nodeName, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
+			return err
 		}
-		MCDPivotErr.WithLabelValues(nodeName, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
-		return err
 	}
 
 	defer func() {
@@ -718,7 +720,7 @@ func newMachineConfigDiff(oldConfig, newConfig *mcfgv1.MachineConfig) (*machineC
 	extensionsEmpty := len(oldConfig.Spec.Extensions) == 0 && len(newConfig.Spec.Extensions) == 0
 
 	return &machineConfigDiff{
-		osUpdate:   oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL,
+		osUpdate:   !compareOSImageURL(oldConfig.Spec.OSImageURL, newConfig.Spec.OSImageURL),
 		kargs:      !(kargsEmpty || reflect.DeepEqual(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments)),
 		fips:       oldConfig.Spec.FIPS != newConfig.Spec.FIPS,
 		passwd:     !reflect.DeepEqual(oldIgn.Passwd, newIgn.Passwd),
@@ -1840,17 +1842,8 @@ func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 }
 
 // updateOS updates the system OS to the one specified in newConfig
-func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
-	if !dn.os.IsCoreOSVariant() {
-		glog.Info("Updating of non-CoreOS nodes are not supported")
-		return nil
-	}
-
+func updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
 	newURL := config.Spec.OSImageURL
-	if compareOSImageURL(dn.bootedOSImageURL, newURL) {
-		return nil
-	}
-
 	glog.Infof("Updating OS to %s", newURL)
 	client := NewNodeUpdaterClient()
 	if _, err := client.Rebase(newURL, osImageContentDir); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -722,7 +722,7 @@ func newMachineConfigDiff(oldConfig, newConfig *mcfgv1.MachineConfig) (*machineC
 	extensionsEmpty := len(oldConfig.Spec.Extensions) == 0 && len(newConfig.Spec.Extensions) == 0
 
 	return &machineConfigDiff{
-		osUpdate:   !compareOSImageURL(oldConfig.Spec.OSImageURL, newConfig.Spec.OSImageURL),
+		osUpdate:   oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL,
 		kargs:      !(kargsEmpty || reflect.DeepEqual(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments)),
 		fips:       oldConfig.Spec.FIPS != newConfig.Spec.FIPS,
 		passwd:     !reflect.DeepEqual(oldIgn.Passwd, newIgn.Passwd),

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -91,10 +91,6 @@ func TestUpdateOS(t *testing.T) {
 	// expectedError is the error we will use when expecting an error to return
 	expectedError := fmt.Errorf("broken")
 
-	d := newMockDaemon()
-
-	// Set up machineconfigs to pass to updateOS.
-	mcfg := &mcfgv1.MachineConfig{}
 	// differentMcfg has a different OSImageURL so it will force Daemon.UpdateOS
 	// to trigger an update of the operatingsystem (as fronted by our testClient)
 	differentMcfg := &mcfgv1.MachineConfig{
@@ -103,12 +99,8 @@ func TestUpdateOS(t *testing.T) {
 		},
 	}
 
-	// This should be a no-op
-	if err := d.updateOS(mcfg, ""); err != nil {
-		t.Errorf("Expected no error. Got %s.", err)
-	}
-	// Second call should return an error
-	if err := d.updateOS(differentMcfg, ""); err == expectedError {
+	// should return an error
+	if err := updateOS(differentMcfg, ""); err == expectedError {
 		t.Error("Expected an error. Got none.")
 	}
 }


### PR DESCRIPTION
I'm going to have to do some refactoring of OS update code for https://issues.redhat.com/browse/MCO-126, which is to use the new format for OS images. Currently there are 3 separate code paths that perform OS updates (`applyOSChanges()`, `checkStateOnFirstRun()`, and pivot.go), and it will likely make sense to refactor those code paths so that I don't have to make additions for the new format in all three places. While reading over what we have currently, I ran into a few things that make it hard to understand the differences between what's going on in `applyOSChanges()` and `checkStateOnFirstRun()`, so I cleaned those up anticipating that it will make later refactoring easier.

I kept things separate into 4 commits (and I'm not completely sure the last one is good style), so if any of it is just unnecessary refactoring I can drop it.