### PR TITLE
Bug 2035326: ovs-configuration - use lower than NM default ethernet route metric

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -119,6 +119,10 @@ contents:
       done
     }
 
+
+    # when creating the bridge, we use a value lower than NM's ethernet device default route metric
+    # (we pick 49 to be lower than anything that NM chooses by default)
+    BRIDGE_METRIC="49"
     # Given an interface, generates NM configuration to add to an OVS bridge
     convert_to_bridge() {
       iface=${1}
@@ -180,14 +184,14 @@ contents:
         extra_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
       fi
 
-      # create bridge; use NM's ethernet device default route metric (100)
+      # create bridge
       if ! nmcli connection show "$bridge_name" &> /dev/null; then
         nmcli c add type ovs-bridge \
             con-name "$bridge_name" \
             conn.interface "$bridge_name" \
             802-3-ethernet.mtu ${iface_mtu} \
-            ipv4.route-metric 100 \
-            ipv6.route-metric 100 \
+            ipv4.route-metric "$BRIDGE_METRIC" \
+            ipv6.route-metric "$BRIDGE_METRIC" \
             ${extra_brex_args}
       fi
 
@@ -313,7 +317,7 @@ contents:
         else
           nmcli c add type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
             "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
-            ipv4.route-metric 100 ipv6.route-metric 100
+            ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC"
         fi
       fi
 


### PR DESCRIPTION
Setting the default NM route metric for ovs-if-br-ex is problematic
in the presence of other Ethernet ports. In that case, ovs-if-br-ex
as well as the Ethernet ports will have the same route metric, and
the winner is undefined. Lower ovs-if-br-ex route metric to 49 to
avoid ambiguous situations.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Cause: 
When more than one ethernet interface has the default route on startup, then NMs default behavior will assign metrics 100, 101, 102.. 
and so forth to the Ethernet interfaces to avoid ambiguity. NM will make sure that interfaces of the same type will not
have the same metric: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/managing-the-default-gateway-setting_configuring-and-managing-networking 

When ovs-configure.sh OVNKubernetes is run, it sets a metric of 100 to OVS port ovs-if-br-ex (which normally would have metric 800). 
The port is no longer an Ethernet type port and the remaining Ethernet interfaces will receive new metrics, assigned in ascending order, starting with 100. This will lead to 2 default routes having metric 100, one of the Ethernet interfaces, and ovs-if-br-ex. It is no longer guaranteed that br-ex will be used as the default interface.

Consequence: 
Cluster traffic will not function on clusters with multiple default route ethernet interfaces, such as OpenStack clusters with additional networks.

Fix: 
Enforce that the metric configured on the OVN-Kubernetes interface (br-ex and ovs-if-br-ex) is set to 50.

Result: 
The default route via br-ex should always be the one with the highest priority (= lowest metric).

**- How to verify it**
After deployment, routes via br-ex should have metric 50, e.g.:
~~~
# ip r
default via 192.168.20.1 dev br-ex proto dhcp metric 50 
default via 192.168.21.1 dev eth1 proto dhcp metric 100 
169.254.169.254 via 192.168.20.2 dev br-ex proto dhcp metric 50 
169.254.169.254 via 192.168.21.2 dev eth1 proto dhcp metric 100 
192.168.20.0/24 dev br-ex proto kernel scope link src 192.168.20.80 metric 50 
192.168.21.0/24 dev eth1 proto kernel scope link src 192.168.21.167 metric 100 
~~~

**- Description for the changelog**
Setting the default NM route metric for ovs-if-br-ex is problematic
in the presence of other Ethernet ports. In that case, ovs-if-br-ex
as well as the Ethernet ports will have the same route metric, and
the winner is undefined. Lower ovs-if-br-ex route metric to 50 to
avoid ambiguous situations.
