### PR TITLE
hack scripts: Set VERSION_OVERRIDE to sane defaults

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -20,12 +20,13 @@ fi
 # Go to the root of the repo
 cdup="$(git rev-parse --show-cdup)" && test -n "$cdup" && cd "$cdup"
 
-if [ -z ${VERSION_OVERRIDE+a} ]; then
-	echo "Using version from git..."
-	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
-fi
-
 HASH=${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}
+
+if [ -z ${VERSION_OVERRIDE+a} ]; then
+	echo "Generating version name from git..."
+	BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+	VERSION_OVERRIDE="${BRANCH_NAME}-${HASH}"
+fi
 
 GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE} -X ${REPO}/pkg/version.Hash=${HASH}"
 


### PR DESCRIPTION
VERSION_OVERRIDE would set the value of version.Raw to the last tag's
name. MCO is no longer using tag names, so use the branch name and
commit hash as sane defaults.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
