### PR TITLE
Bug 2033953: Afterburn to try config-drive before Nova metadata

### DIFF
--- a/templates/common/openstack/units/afterburn-hostname.service.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.service.yaml
@@ -11,7 +11,7 @@ contents: |
   Before=node-valid-hostname.service
 
   [Service]
-  ExecStart=/usr/bin/afterburn --provider openstack-metadata --hostname=/etc/hostname
+  ExecStart=/usr/bin/afterburn --provider openstack --hostname=/etc/hostname
   Type=oneshot
 
   [Install]


### PR DESCRIPTION
With this change, the afterburn-hostname service uses the 'openstack'
provider, which fetches userdata from the config drive, and only uses
the Nova metadata service as a fallback. This is especially useful in
network topologies where Nova-metadata is not guaranteed to be reachable
(e.g. when using baremetal (Ironic) instances).