### PR TITLE
Bug 2038827: add /etc/sub{u,g}id files

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/etc-subgid.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/etc-subgid.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/subgid"
+contents:
+  inline: |
+    containers:100000:16000000

--- a/templates/master/01-master-container-runtime/_base/files/etc-subuid.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/etc-subuid.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/subuid"
+contents:
+  inline: |
+    containers:100000:16000000

--- a/templates/worker/01-worker-container-runtime/_base/files/etc-subgid.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/etc-subgid.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/subgid"
+contents:
+  inline: |
+    containers:100000:16000000

--- a/templates/worker/01-worker-container-runtime/_base/files/etc-subuid.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/etc-subuid.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/subuid"
+contents:
+  inline: |
+    containers:100000:16000000


### PR DESCRIPTION
to give the container managers access to user namespace ranges OOTB

Signed-off-by: Peter Hunt <pehunt@redhat.com>

