### PR TITLE
Remove sysctl-inotify.conf.yaml

### DIFF
--- a/templates/common/_base/files/sysctl-inotify.conf.yaml
+++ b/templates/common/_base/files/sysctl-inotify.conf.yaml
@@ -1,7 +1,0 @@
-mode: 0644
-path: "/etc/sysctl.d/inotify.conf"
-contents:
-  inline: |
- 
-    fs.inotify.max_user_watches = 65536
-    fs.inotify.max_user_instances = 8192


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed `sysctl-inotify.conf.yaml`

**- How to verify it**
Install a functional OCP cluster.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Sysctls (and other node-level tuning) on OpenShift clusters is handled
by the Node Tuning Operator (NTO).  Changing sysctls via NTO has the
added benefit of not needing to reboot the node and settings rollback.

Both the OS-level (e.g. RHEL) and containerized TuneD shipped by NTO
does not override sysctls set via /etc/sysctl{.conf,.d}.  Cluster
administrators trying to change sysctls already set in
/etc/sysctl{.conf,.d} are easily confused why are their settings not
applied by NTO.

I believe only system-critical sysctls for enabling OpenShift
functionality should be managed by MCO.  NTO delivers both

    fs.inotify.max_user_watches = 65536
    fs.inotify.max_user_instances = 8192

for OCP worker nodes by default.

Additional details:
rhbz#2039701
rhbz#1825322

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>
