### PR TITLE
templates: Change default container-runtime config to enable all CRI-O metrics

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -58,18 +58,29 @@ contents:
     enable_metrics = true
     metrics_port = 9537
     metrics_collectors = [
-      "operations",
-      "operations_latency_microseconds_total",
-      "operations_latency_microseconds",
-      "operations_errors",
+      "operations", # DEPRECATED: in favour of "operations_total"
+      "operations_latency_microseconds_total", # DEPRECATED: in favour of "operations_latency_seconds_total"
+      "operations_latency_microseconds", # DEPRECATED: in favour of "operations_latency_seconds"
+      "operations_errors", # DEPRECATED: in favour of "operations_errors_total"
       "image_pulls_layer_size",
-      "containers_oom_total",
+      "containers_oom_total", # DEPRECATED: in favour of "containers_oom_count_total"
       "containers_oom",
       # Drop metrics with excessive label cardinality.
-      # "image_pulls_by_digest",
-      # "image_pulls_by_name",
-      # "image_pulls_by_name_skipped",
-      # "image_pulls_failures",
-      # "image_pulls_successes",
-      # "image_layer_reuse",
+      # "image_pulls_by_digest", # DEPRECATED: in favour of "image_pulls_bytes_total"
+      # "image_pulls_by_name", # DEPRECATED: in favour of "image_pulls_bytes_total"
+      # "image_pulls_by_name_skipped", # DEPRECATED: in favour of "image_pulls_skipped_bytes_total"
+      # "image_pulls_failures", # DEPRECATED: in favour of "image_pulls_failure_total"
+      # "image_pulls_successes", # DEPRECATED: in favour of "image_pulls_success_total"
+      # "image_layer_reuse", # DEPRECATED: in favour of "image_layer_reuse_total"
+      "operations_total",
+      "operations_latency_seconds_total",
+      "operations_latency_seconds",
+      "operations_errors_total",
+      "image_pulls_bytes_total",
+      "image_pulls_skipped_bytes_total",
+      "image_pulls_success_total",
+      "image_pulls_failure_total",
+      "image_layer_reuse_total",
+      "containers_oom_count_total",
+      "processes_defunct"
     ]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -58,18 +58,29 @@ contents:
     enable_metrics = true
     metrics_port = 9537
     metrics_collectors = [
-      "operations",
-      "operations_latency_microseconds_total",
-      "operations_latency_microseconds",
-      "operations_errors",
+      "operations", # DEPRECATED: in favour of "operations_total"
+      "operations_latency_microseconds_total", # DEPRECATED: in favour of "operations_latency_seconds_total"
+      "operations_latency_microseconds", # DEPRECATED: in favour of "operations_latency_seconds"
+      "operations_errors", # DEPRECATED: in favour of "operations_errors_total"
       "image_pulls_layer_size",
-      "containers_oom_total",
+      "containers_oom_total", # DEPRECATED: in favour of "containers_oom_count_total"
       "containers_oom",
       # Drop metrics with excessive label cardinality.
-      # "image_pulls_by_digest",
-      # "image_pulls_by_name",
-      # "image_pulls_by_name_skipped",
-      # "image_pulls_failures",
-      # "image_pulls_successes",
-      # "image_layer_reuse",
+      # "image_pulls_by_digest", # DEPRECATED: in favour of "image_pulls_bytes_total"
+      # "image_pulls_by_name", # DEPRECATED: in favour of "image_pulls_bytes_total"
+      # "image_pulls_by_name_skipped", # DEPRECATED: in favour of "image_pulls_skipped_bytes_total"
+      # "image_pulls_failures", # DEPRECATED: in favour of "image_pulls_failure_total"
+      # "image_pulls_successes", # DEPRECATED: in favour of "image_pulls_success_total"
+      # "image_layer_reuse", # DEPRECATED: in favour of "image_layer_reuse_total"
+      "operations_total",
+      "operations_latency_seconds_total",
+      "operations_latency_seconds",
+      "operations_errors_total",
+      "image_pulls_bytes_total",
+      "image_pulls_skipped_bytes_total",
+      "image_pulls_success_total",
+      "image_pulls_failure_total",
+      "image_layer_reuse_total",
+      "containers_oom_count_total",
+      "processes_defunct"
     ]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did** Changed metrics that are enabled by default for CRI-O set by default worker and master machine config templates
* metrics that have high cardinality labels are disabled as previous
* metrics that do not follow prometheus naming best practices are enabled for now but in deprecated stage and will be removed in a future release
* enabled metrics that CRI-O provide and which are not marked as deprecated
  * `"operations_total", "operations_latency_seconds_total", "operations_latency_seconds", "operations_errors_total", "image_pulls_layer_size", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_success_total", "image_pulls_failure_total", "image_layer_reuse_total", "containers_oom_total", "containers_oom_count_total", "processes_defunct"`

**- How to verify it** The new metrics are exported by Prometheus exporter of CRI-O, it should also be accessible from metrics available through OpenShift Console. However, MCO when launched sets the default CRI-O conf for master and worker contaner-runtimes which is updated in this PR to reflect new metrics in [crio/crio#5487](https://github.com/cri-o/cri-o/pull/5487).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
All CRI-O metrics are enabled by default using master, worker container-runtime machine configs. The following CRI-O metrics will be enabled: `"operations_total", "operations_latency_seconds_total", "operations_latency_seconds", "operations_errors_total", "image_pulls_layer_size", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_success_total", "image_pulls_failure_total", "image_layer_reuse_total", "containers_oom_total", "containers_oom_count_total", "processes_defunct"`