### PR TITLE
Bug 2041889: Explicitly configure NetworkManager keyfile

### DIFF
--- a/templates/common/_base/files/NetworkManager-keyfiles.yaml
+++ b/templates/common/_base/files/NetworkManager-keyfiles.yaml
@@ -1,0 +1,6 @@
+mode: 0644
+path: "/etc/NetworkManager/conf.d/20-keyfiles.conf"
+contents:
+  inline: |
+    [keyfile]
+    path=/etc/NetworkManager/system-connections


### PR DESCRIPTION
This commit explicitly sets NetworkManager to look for its keyfiles in
the default directory (`/etc/NetworkManager/system-connections`) instead
of relying on the defaults.

This change is driven by the bug introduced by the Assisted Installer in
pre-4.10 installations using IPv6 where the NM configuration has been
changed to use `/etc/NetworkManager/system-connections-merged` without
ensuring that the directory exists and contains a correct configuration.
The issue has been exposed by openshift#2742 when removal of the
`99-keyfiles.conf` made the file created by the AI the one taking
precedence. Back then the solution implemented in the AI was a
workaround for another issue which since 4.7+ is no longer present.

As a consequence, any OCP cluster installed initially by the Assisted
Installer and using IPv6 in its networking configuration is blocked from
a successful upgrade to the OCP 4.10

Closes: #2041889
Relates-to: #2030289
Relates-to: openshift/assisted-service#3199
Relates-to: openshift#2742