### PR TITLE
Add Christoph as a baremetal owner

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,15 +4,16 @@ aliases:
   baremetal-approvers:
     - bfournie
     - celebdor
+    - creydr
     - cybertron
     - hardys
     - yboaron
   baremetal-reviewers:
     - bfournie
     - celebdor
+    - creydr
     - cybertron
     - hardys
-    - yboaron
   openstack-approvers:
     - EmilienM
     - mandre


### PR DESCRIPTION
He's been working on metal IPI for a while now so he should be in the
list. I also removed Yossi from the reviewer list since he recently
moved to a different team. I'm leaving him as an approver for now
since we might still want to pull him in on patches. We just don't
want to pester him with automatic review requests.
