### PR TITLE
Bug 1916169: storeCurrentConfigOnDisk after os changes

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -575,18 +575,6 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		}
 	}()
 
-	if err := dn.storeCurrentConfigOnDisk(newConfig); err != nil {
-		return err
-	}
-	defer func() {
-		if retErr != nil {
-			if err := dn.storeCurrentConfigOnDisk(oldConfig); err != nil {
-				retErr = errors.Wrapf(retErr, "error rolling back current config on disk %v", err)
-				return
-			}
-		}
-	}()
-
 	if err := dn.applyOSChanges(*diff, oldConfig, newConfig); err != nil {
 		return err
 	}
@@ -609,6 +597,18 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 	if tuningChanged {
 		glog.Info("Updated kernel tuning arguments")
 	}
+
+	if err := dn.storeCurrentConfigOnDisk(newConfig); err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			if err := dn.storeCurrentConfigOnDisk(oldConfig); err != nil {
+				retErr = errors.Wrapf(retErr, "error rolling back current config on disk %v", err)
+				return
+			}
+		}
+	}()
 
 	if err := dn.finalizeBeforeReboot(newConfig); err != nil {
 		return err


### PR DESCRIPTION
Currently the MachineConfig being applied is saved to disk before OS
changes are applied. If the node loses power while OS changes are being
applied, the MCO incorrectly concludes from the config stored on disk
that the update has been applied. Instead, wait until the OS changes
have been made to write the config to disk.

I manually verified that this shouldn't break anything:
getCurrentConfigOnDisk is the only function that accesses the config on
disk, and it is only called in the following code paths:
syncNode->runPreflightConfigDriftCheck
syncNode->startConfigDriftMonitor
performPostConfigChangeAction->startConfigDriftMonitor
checkStateOnFirstRun
syncNode->prepUpdateFromCluster
runOnceFromMachineConfig->prepUpdateFromCluster

None of those functions are called between where the config is currently
stored to disk and where I'm moving it to, so this change should be
safe.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1916169

**- How to verify it**
Run the reproducer script from https://bugzilla.redhat.com/show_bug.cgi?id=1916169 before and after the change. Without the change, the node does not end up with a realtime kernel, but with the change, the switch to realtime kernel is correctly performed