### PR TITLE
configure-ovs: Add extra delay

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -548,6 +548,8 @@ contents:
         activate_nm_conn ovs-if-phys1
         activate_nm_conn ovs-if-br-ex1
       fi
+
+      sleep 5
     elif [ "$1" == "OpenShiftSDN" ]; then
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
       rollback_nm


### PR DESCRIPTION
Add back an extra delay that was removed by
9cc7ac42a69474566a6930f80f72190769319f30, which appears to have broken
the baremetal dual-stack job by causing the nodeip-configuration.service
to start before we have an IPv6 address from DHCP6.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
