### PR TITLE
Bug 2044808: mcd pull service: use `cp` instead of `cat` to copy MCD on host

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -18,8 +18,8 @@ contents: |
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/bin/sh -c "/usr/bin/podman run --rm --quiet --net=host --entrypoint=cat '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon > /run/bin/machine-config-daemon.tmp"
-  ExecStart=/bin/sh -c '/usr/bin/chmod a+x /run/bin/machine-config-daemon.tmp && mv /run/bin/machine-config-daemon.tmp /run/bin/machine-config-daemon'
+  ExecStart=/usr/bin/podman run --rm --quiet --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
+  ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}


### PR DESCRIPTION
Recent podman in F35 is hanging during `cat`. Not sure why, but since its not being regularly tested, we should fall back to `cp` and `chcon` instead.

This doesn't affect OCP (at least yet), but critical for OKD, see https://github.com/openshift/installer/pull/5567