### PR TITLE
Bug 2040671: configure-ovs: restart NetworkManager-wait-online

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -555,3 +555,6 @@ contents:
       # Remove bridges created by ovn-kubernetes
       ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local
     fi
+
+    # Ensure network is online again before network-online.target is reached
+    systemctl restart NetworkManager-wait-online.service


### PR DESCRIPTION
After restarting NetworkManager and bringing up interfaces, also restart
NetworkManager-wait-online so that systemd does not declare
network-online.target complete at a point where the interfaces are not
yet completely online again after the restart (e.g. they are still
waiting for addresses from DHCP).

Prior to 9cc7ac42a69474566a6930f80f72190769319f30 there was an
unconditional 5s sleep that resulted in the interfaces usually being up
by the time configure-ovs finished, but that was not necessarily robust
in the real world. Tests began failing when the sleep was removed,
because nodeip-configuration.service runs immediately after
network-online.target completes.