### PR TITLE
Bug 2046683: Ensure correct providerID format for Alibaba nodes

### DIFF
--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -39,7 +39,7 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
-        --provider-id=${KUBELET_NODE_NAME} \
+        --provider-id=alicloud://${KUBELET_NODE_NAME} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
         --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -39,7 +39,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
-        --provider-id=${KUBELET_NODE_NAME} \
+        --provider-id=alicloud://${KUBELET_NODE_NAME} \
         --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This adds the `alicloud://` prefix to the provider ID that we set on the alibaba kubelet service.

This ensures that the provider ID on the nodes includes the expected prefix and matches the provider ID format used in other places (eg Machine API).

I've manually tested this and check with @gujingit that this is supported by the Alibaba CCM

**- How to verify it**

Boot a cluster on Alibaba and check the `node.spec.providerID` has the `alicloud://` prefix

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix Alibaba providerID to include `alicloud` prefix
