### PR TITLE
Bug 2047445: Filter out empty lines and link-local addrs from nmcli output

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -313,10 +313,10 @@ contents:
             extra_if_brex_args+="ipv4.may-fail no "
           fi
 
-          # IPV6 should have at least a link local address. Check for more than 1 to see if there is an
-          # assigned address.
-          num_ip6_addrs=$(nmcli -m multiline --get-values ip6.address conn show ${old_conn} | wc -l)
-          if [ "$num_ip6_addrs" -gt 1 ]; then
+          # Check for IPv6 addresses on the connection. Ignore blank lines and
+          # link-local addresses.
+          num_ip6_addrs=$(nmcli -m multiline --get-values ip6.address conn show ${old_conn} | grep -v ^$ | grep -v "IP6.ADDRESS\[.*\]:fe80::" | wc -l)
+          if [ "$num_ip6_addrs" -gt 0 ]; then
             extra_if_brex_args+="ipv6.may-fail no "
           fi
 


### PR DESCRIPTION
For some reason the nmcli call to determine the number of ipv6
addresses on an interface is sometimes returning a blank line as
part of the output. This causes a single address to look like 2
because we're just checking the line count and makes us incorrectly
set "ipv6.may-fail no" on the interface. This causes the connection
to fail and prevents ovs-configuration from completing.

Here's some example output from an affected system:

[root@master-0-0 core]# nmcli -m multiline --get-values ip6.address conn show 84a523ff-ee8a-4a29-94ca-47590eb0cb76
IP6.ADDRESS[1]:fe80::5054:ff:fe6e:6923/64

[root@master-0-0 core]#

Additionally, we have seen another case where the link-local address
from both the baremetal and provisioning networks shows up in the
output of this command. That will also fail because we're just
looking for line count > 1.

This change alters the logic to filter out blank lines and any
link-local addresses, then sees if anything is left. This should be
less prone to false positive results.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
