### PR TITLE
Revert "Remove sysctl-inotify.conf.yaml"

### DIFF
--- a/templates/common/_base/files/sysctl-inotify.conf.yaml
+++ b/templates/common/_base/files/sysctl-inotify.conf.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "/etc/sysctl.d/inotify.conf"
+contents:
+  inline: |
+ 
+    fs.inotify.max_user_watches = 65536
+    fs.inotify.max_user_instances = 8192


### PR DESCRIPTION
Reverts openshift/machine-config-operator#2909

This is leading to open file exhaustion, with messages like `too many open files` sinking [dev-branch update CI][1]:

![Screenshot 2022-02-03 22 14 11](https://user-images.githubusercontent.com/209920/152482927-a10436e7-c6ad-45a0-a202-7f660af9bec4.png)

I'm not entirely clear why update jobs appear particularly vulnerable.  Hunting for a bracket, I focused just on [`master` origin update presubmits][2], to exclude confounders like differences in job definition between different repositories:

![Screenshot 2022-02-03 22 19 54](https://user-images.githubusercontent.com/209920/152483033-42a5ac8c-3c76-49e9-ba59-0a289820d0c9.png)

The success on the extreme left is [this run][3].  The first failure with this mode is [this run][4].  Diffing the two payloads to find suspects:

```console
$ REF_A=https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/26806/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1489144429657722880/artifacts/release/artifacts/release-payload-latest/image-references
$ REF_B=https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/26798/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1489171608252715008/artifacts/release/artifacts/release-payload-latest/image-references
$ JQ='[.spec.tags[] | .name + " " + .annotations["io.openshift.build.source-location"] + "/commit/" + .annotations["io.openshift.build.commit.id"]] | sort[]'
$ diff -U0 <(curl -s "${REF_A}" | jq -r "${JQ}") <(curl -s "${REF_B}" | jq -r "${JQ}")
...
-machine-config-operator https://github.com/openshift/machine-config-operator/commit/4b65d7851e0ac9fc53b9d20214887e24d854bb8d
+machine-config-operator https://github.com/openshift/machine-config-operator/commit/d3010b34d344e38c98c329f6d69aa6be4b40cfbd
...nothing else that sounded like it could cause 'too many open files' across so many platforms...
```

And the only change between those two commits is the one I'm reverting here:

```console
$ git --no-pager log --first-parent --oneline 4b65d7851e0a..d3010b34d344
d3010b34 (HEAD -> master, origin/master, origin/HEAD) Merge pull request #2909 from jmencak/sysctl-inotify-rm
```

I haven't looked into the contents of the pull request to say exactly how it leads to the `too many open files` errors, but inotify certainly sounds suspicious for "something that involves open files", so here's a revert, and if we land it, and things don't get better quickly, we can revert the revert ;).

[1]: https://search.ci.openshift.org/chart?maxAge=24h&type=build-log&name=pull-ci.*master.*upgrade&search=too+many+open+files
[2]: https://search.ci.openshift.org/chart?maxAge=24h&type=build-log&name=pull-ci-openshift-origin.*master.*upgrade&search=too+many+open+files
[3]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26806/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1489144429657722880
[4]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26798/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1489171608252715008
