### PR TITLE
OpenStack: set transient hostname in afterburn-hostname

### DIFF
--- a/templates/common/openstack/files/usr-local-bin-openstack-afterburn-hostname.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-afterburn-hostname.yaml
@@ -1,0 +1,10 @@
+mode: 0755
+path: "/usr/local/bin/openstack-afterburn-hostname"
+contents:
+  inline: |
+    #!/bin/bash
+    set -euo pipefail
+
+    # Fetch hostname from OpenStack. Set both transient and static hostnames to
+    # ensure node-valid-hostname sees the new hostname immediately.
+    /usr/bin/afterburn --provider openstack --hostname=/dev/stdout | xargs hostnamectl set-hostname

--- a/templates/common/openstack/units/afterburn-hostname.service.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.service.yaml
@@ -11,7 +11,7 @@ contents: |
   Before=node-valid-hostname.service
 
   [Service]
-  ExecStart=/usr/bin/afterburn --provider openstack --hostname=/etc/hostname
+  ExecStart=/usr/local/bin/openstack-afterburn-hostname
   Type=oneshot
 
   [Install]


### PR DESCRIPTION
afterburn-hostname was setting the static hostname but not the transient
hostname. This was causing a 5 minute timeout on first boot while
node-valid-hostname waited for hostname to be changed to something other
than localhost.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
