### PR TITLE
Set "node.kubernetes.io/exclude-from-external-load-balancers" label at reboot and unset it at startup

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -128,6 +128,10 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 // finalizeBeforeReboot is the last step in an update() and then we take appropriate postConfigChangeAction.
 // It can also be called as a special case for the "bootstrap pivot".
 func (dn *Daemon) finalizeBeforeReboot(newConfig *mcfgv1.MachineConfig) (retErr error) {
+	if err := dn.addOrRemoveExcludeFromLoadBalancerLabel(true); err != nil {
+		glog.Warningf("Unable to add label %s to node : %s", excludeFromLoadBalancerLabel, err)
+	}
+
 	if out, err := dn.storePendingState(newConfig, 1); err != nil {
 		return fmt.Errorf("failed to log pending config: %s: %w", string(out), err)
 	}


### PR DESCRIPTION
Add label `node.kubernetes.io/exclude-from-external-load-balancers` on nodes that are going for a reboot and remove it at startup. This label is used by the cloud service controller in order to know which nodes to exclude from backend pools of cloud load balancers.

By adding this label at very start of the reboot process, instead of just waiting for the node to become NotReady, we give the cloud service controller more time to update backend pools on cloud load balancers.

This is part of the solution for BZ #2040715