### PR TITLE
adds zacks hack scripts

### DIFF
--- a/hack/get-mcd-nodes.py
+++ b/hack/get-mcd-nodes.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# This is a simple script that grabs all the cluster nodes and associates them
+# with a given MCD pod and outputs their roles. There is probably an easier way
+# to do this that I am too naïve to be aware of :). Running this script yields
+# the following output:
+#
+# Current MCD Pods:
+# machine-config-daemon-9px26     ip-10-0-161-151.ec2.internal    worker
+# machine-config-daemon-cpt8q     ip-10-0-130-41.ec2.internal     master
+# machine-config-daemon-jnjx4     ip-10-0-137-167.ec2.internal    worker
+# machine-config-daemon-klclf     ip-10-0-152-65.ec2.internal     master
+# machine-config-daemon-kml9h     ip-10-0-171-232.ec2.internal    master
+# machine-config-daemon-t6v5j     ip-10-0-155-187.ec2.internal    worker
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+def run_oc_cmd_json(oc_cmd):
+    """Runs an arbitrary oc command and returns a dictionary with JSON from the
+    output.
+    """
+    oc_cmd = oc_cmd.split(" ")
+    oc_cmd.append("--output=json")
+    cmd = subprocess.run(oc_cmd, capture_output=True)
+    return json.loads(cmd.stdout)
+
+def get_max_len(in_string, max_len):
+    """Gets current length of string and returns it if it exceeds the provided
+    max_len. Otherwise, returns the provided max_len.
+    """
+    curr_len = len(in_string)
+    if curr_len > max_len:
+        return curr_len
+    return max_len
+
+def can_run():
+    kubeconfig = os.environ.get("KUBECONFIG")
+    if not kubeconfig:
+        print("ERROR: Expected to find $KUBECONFIG")
+        return False
+
+    if not os.path.exists(kubeconfig):
+        print("ERROR: No kubeconfig found at", kubeconfig)
+        return False
+
+    if not shutil.which("oc"):
+        print("ERROR: 'oc' command missing from your $PATH")
+
+    return True
+
+def main():
+    if not can_run():
+        sys.exit(1)
+
+    # Get all the MCD pods
+    mcd_pods = run_oc_cmd_json("oc get pods -n openshift-machine-config-operator -l k8s-app=machine-config-daemon")
+
+    # Get our nodes and group by node name
+    nodes_by_name = {node["metadata"]["name"]: node
+                    for node in run_oc_cmd_json("oc get nodes")["items"]}
+
+    out = []
+    node_name_max_len = 0
+    pod_name_max_len = 0
+
+    for pod in mcd_pods["items"]:
+        pod_name = pod["metadata"]["name"]
+        node_name = pod["spec"]["nodeName"]
+        # Get the node the MCD pod is running on
+        node = nodes_by_name[node_name]
+
+        # Get max pod name length; used to format output
+        pod_name_max_len = get_max_len(pod_name, pod_name_max_len)
+
+        # Get max node name length; used to format output
+        node_name_max_len = get_max_len(node_name, node_name_max_len)
+
+        # Lazily get node roles
+        roles = (label.split("/")[1]
+                for label in node["metadata"]["labels"].keys()
+                if "node-role.kubernetes.io" in label)
+
+        # Insert our results into an output list
+        out.append((pod_name, node_name, ','.join(roles)))
+
+    # Output format template
+    tmpl = "{: <%s}\t{: <%s}\t{: <6}" % (pod_name_max_len, node_name_max_len)
+
+    # Print our output
+    for item in out:
+        print(tmpl.format(*item))
+
+if __name__ == "__main__":
+    main()

--- a/hack/lib
+++ b/hack/lib
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export MCO_NAMESPACE="openshift-machine-config-operator"
+export MCD_DAEMONSET="daemonset/machine-config-daemon"
+export MCD_CONTAINER_NAME="machine-config-daemon"
+export ROOTFS_MCD_PATH="/rootfs/usr/local/bin/machine-config-daemon"
+
+can_run() {
+  # Check if we have an oc binary in our path
+  if [ ! "$(which oc)" ]; then
+    echo "oc not in path"
+    exit 1
+  fi
+
+  # Check if KUBECONFIG is set
+  if [ -z "$KUBECONFIG" ]; then
+    echo "KUBECONFIG is not set"
+    exit 1
+  fi
+
+  # Check if KUBECONFIG actually points to something
+  if [ ! -f "$KUBECONFIG" ]; then
+    echo "$KUBECONFIG does not exist"
+    exit 1
+  fi
+
+  if [ ! "$(oc get nodes)" ]; then
+    echo "Stale kubeconfig, cannot authenticate"
+    exit 1
+  fi
+}

--- a/hack/prep-cluster-for-mcd-push.sh
+++ b/hack/prep-cluster-for-mcd-push.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib"
+
+copy_mcd_to_disk() {
+  pod="$1"
+
+  oc debug \
+    -n "$MCO_NAMESPACE" \
+    -c "$MCD_CONTAINER_NAME" \
+    --one-container=true \
+    "pod/$pod" -- cp -v /usr/bin/machine-config-daemon "$ROOTFS_MCD_PATH"
+}
+
+main() {
+  # Disable the cluster version operator
+  # --replicas 1 out-of-the-box
+  oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator
+
+  # Disable the MCO
+  # --replicas 1 out-of-the-box
+  oc scale --replicas 0 -n "$MCO_NAMESPACE" deployments/machine-config-operator
+
+  # Copy the MCD from the container to rootfs first to avoid startup issues
+  echo "Copy MCD from container to /rootfs"
+  mcd_pods="$(oc get pods -n "$MCO_NAMESPACE" -l 'k8s-app=machine-config-daemon' -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"
+  for pod in $mcd_pods; do
+    copy_mcd_to_disk "$pod" &
+  done
+
+  echo "Waiting for copies to finish..."
+  wait
+  echo "Done"
+
+  # Now we modify the MCD daemonset to copy the MCD binary from rootfs and run it
+  # Note: This was originally done with a read, however read exits with code 1.
+  patch="$(/bin/cat <<- EOM
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+          - -c
+          - "sha256sum $ROOTFS_MCD_PATH && cp $ROOTFS_MCD_PATH /usr/local/bin/machine-config-daemon && /usr/local/bin/machine-config-daemon start -v 4"
+        command: ["/bin/bash"]
+        name: machine-config-daemon
+EOM
+)"
+
+  echo "Modifying the MCD daemonset"
+
+  # Apply the modifications
+  oc patch \
+    daemonset/machine-config-daemon \
+    -n "$MCO_NAMESPACE" \
+    --patch="$patch"
+
+  # Wait for the updated daemonset to roll out
+  oc rollout status -n "$MCO_NAMESPACE" -w "$MCD_DAEMONSET"
+}
+
+can_run && main

--- a/hack/push-to-mcd-pods.sh
+++ b/hack/push-to-mcd-pods.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+target_mcd_pod="$1"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib"
+
+copy_binary() {
+  local -r pod="$1"
+  local -r bin_path="$2"
+
+  echo "Copying to $pod..."
+  oc cp -n "$MCO_NAMESPACE" -c "$MCD_CONTAINER_NAME" "$bin_path" "$pod:$ROOTFS_MCD_PATH"
+}
+
+push_binary_to_pod() {
+  local -r pod="$1"
+  local -r bin_path="$2"
+
+  local -r local_bin_sha256sum="$(sha256sum "$bin_path" | awk '{print $1;}')"
+
+  # Check if we have the file on the pod in question
+  oc rsh -n "$MCO_NAMESPACE" -c "$MCD_CONTAINER_NAME" "pod/$pod" sha256sum "$ROOTFS_MCD_PATH"
+  local -r has_file_retval="$?"
+
+  # We don't have the file, so lets copy it
+  if [ "$has_file_retval" -ne 0 ]; then
+    echo "Binary not found on $pod"
+    copy_binary "$pod" "$bin_path"
+    return
+  fi
+
+  local -r remote_bin_sha256sum="$(oc rsh -n "$MCO_NAMESPACE" -c "$MCD_CONTAINER_NAME" "pod/$pod" sha256sum "$ROOTFS_MCD_PATH" | awk '{print $1;}')"
+
+  if [[ "$local_bin_sha256sum" == "$remote_bin_sha256sum" ]]; then
+    echo "Skipping copy to $pod, binary $ROOTFS_MCD_PATH with equal checksum found: $local_bin_sha256sum"
+    return
+  fi
+
+  echo "Local: $local_bin_sha256sum, Remote ($pod): $remote_bin_sha256sum"
+  copy_binary "$pod" "$bin_path" "$ROOTFS_MCD_PATH"
+}
+
+push_binary_to_all_pods() {
+  local -r bin_path="$1"
+
+  # Get our target MCD pods
+  echo "Getting MCD pods"
+  mcd_pods="$(oc get pods -n "$MCO_NAMESPACE" -l 'k8s-app=machine-config-daemon' -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"
+
+  # Concurrently copy the built binary to all MCD pods for speed.
+  for pod in $mcd_pods; do
+    push_binary_to_pod "$pod" "$bin_path" &
+  done
+
+  # Wait for all the copy jobs to complete since we don't block for each one.
+  wait
+
+  # Restart the MCD pods
+  oc rollout restart -n "$MCO_NAMESPACE" "$MCD_DAEMONSET"
+}
+
+main() {
+  # Heterogeneous clusters are targeted for OCP 4.11, so this will need to change eventually.
+  #
+  # Ideas:
+  # - Get all individual arches and build for each of those concurrently.
+  # - Get a list of MCD pods on nodes and get the arch for each of the nodes just before copying.
+
+  # Gets the architecture and operating system of the first node in the list, e.g., amd64\tlinux
+  local -r node_info="$(oc get nodes -o go-template='{{(index .items 0).status.nodeInfo.architecture}}{{"\t"}}{{(index .items 0).status.nodeInfo.operatingSystem}}')"
+  local -r cluster_arch="$(echo "$node_info" | cut -f1)"
+
+  # Not really needed, but lets not make assumptions :)
+  local -r cluster_os="$(echo "$node_info" | cut -f2)"
+
+  echo "Detected cluster arch / OS: $cluster_arch/$cluster_os"
+
+  echo "Building MCD binary..."
+  # Need to set both GOOS / GOARCH on Mac otherwise the built binaries will be
+  # compiled for a Darwin target instead.
+  #
+  # Set WHAT to only build the MCD since that's the only component we're
+  # interested in at this time.
+  GOOS="$cluster_os" GOARCH="$cluster_arch" WHAT=machine-config-daemon "$SCRIPT_DIR/build-go.sh"
+  compile_retval="$?"
+  if [ $compile_retval -ne 0 ]; then
+    echo "Compilation failed!"
+    return $compile_retval
+  fi
+
+  local -r bin_path="./_output/$cluster_os/$cluster_arch/machine-config-daemon"
+
+  # Get the hash of our MCD binary; useful to compare to the startup value in the MCD pod logs
+  sha256sum "$bin_path"
+
+  if [ -z "$target_mcd_pod" ]; then
+    # We're not targeting a specific pod, so push the binary to all MCD pods
+    echo "Will copy to all MCD pods..."
+    push_binary_to_all_pods "$bin_path"
+  else
+    # We're targeting a specific pod, so only push the binary to that pod
+    echo "Pod $target_mcd_pod specified, will only copy to this pod..."
+    push_binary_to_pod "$target_mcd_pod" "$bin_path"
+
+    # Delete the pod to force pod re-creation so the new binary will be used.
+    oc delete -n "$MCO_NAMESPACE" "pod/$target_mcd_pod"
+  fi
+
+  # Wait for the MCD to finish restarting (not strictly required, but doesn't hurt)
+  echo "Waiting for MCD daemonsets to restart"
+  oc rollout status -w -n "$MCO_NAMESPACE" "$MCD_DAEMONSET"
+
+  echo "Current MCD Pods:"
+  "$SCRIPT_DIR/get-mcd-nodes.py"
+}
+
+can_run && main


### PR DESCRIPTION
**- What I did**
These are some small hack scripts I wrote to make it quicker to work on the MCD between build / run / test cycles.

**- How to verify it**

1. Provision an OpenShift cluster.
2. Store your kubeconfig in a file.
3. `export KUBECONFIG=/path/to/kubeconfig`.
4. Run `$ ./hack/prep-cluster-for-mcd-push.sh`.
5. Make a change to the MCD.
6. Run `$ ./hack/push-to-mcd-pods.sh`.

**- Description for the changelog**
MCO developer tool enhancements