### PR TITLE
Bug 2050466: Not allow empty string in icsp&image CR

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -522,18 +522,27 @@ func getValidBlockedRegistries(releaseImage string, imgSpec *apicfgv1.ImageSpec)
 
 func validateRegistriesConfScopes(insecure, blocked, allowed []string, icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy) error {
 	for _, scope := range insecure {
+		if scope == "" {
+			return fmt.Errorf("invaid empty entry for insecure registries")
+		}
 		if !registries.IsValidRegistriesConfScope(scope) {
 			return fmt.Errorf("invalid entry for insecure registries %q", scope)
 		}
 	}
 
 	for _, scope := range blocked {
+		if scope == "" {
+			return fmt.Errorf("invalid empty entry for blocked registries")
+		}
 		if !registries.IsValidRegistriesConfScope(scope) {
 			return fmt.Errorf("invalid entry for blocked registries %q", scope)
 		}
 	}
 
 	for _, scope := range allowed {
+		if scope == "" {
+			return fmt.Errorf("invalid empty entry for allowed registries")
+		}
 		if !registries.IsValidRegistriesConfScope(scope) {
 			return fmt.Errorf("invalid entry for allowed registries %q", scope)
 		}
@@ -541,10 +550,16 @@ func validateRegistriesConfScopes(insecure, blocked, allowed []string, icspRules
 
 	for _, icsp := range icspRules {
 		for _, mirrorSet := range icsp.Spec.RepositoryDigestMirrors {
+			if mirrorSet.Source == "" {
+				return fmt.Errorf("invalid empty entry for source configuration")
+			}
 			if strings.Contains(mirrorSet.Source, "*") {
 				return fmt.Errorf("wildcard entries are not supported with mirror configuration %q", mirrorSet.Source)
 			}
 			for _, mirror := range mirrorSet.Mirrors {
+				if mirror == "" {
+					return fmt.Errorf("invalid empty entry for mirror configuration")
+				}
 				if strings.Contains(mirror, "*") {
 					return fmt.Errorf("wildcard entries are not supported with mirror configuration %q", mirror)
 				}


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2050466
Add validation for image and icsp CR to not allow the empty string ("") in the CRD.
Empty string regsitries configurations will fail the machine config daemon operations
of pulling images and the nodes will stopped in NotReady state when node rebooting after node drain.

```
2022-02-03T23:16:02.952318066Z I0203 23:16:02.952259    2590 run.go:18] Running: podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6d4ff6bb5494c55c24f9a322b1a5faffb8a92ea0f572f1078db55f3f1abaa588
2022-02-03T23:16:03.033231339Z Error: error loading registries configuration "/etc/containers/registries.conf": invalid condition: mirror location is unset
```



Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

Apply the following icsp to the cluster:
it should logs error about the icsp is invalid and do not update the registries.conf.
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  generation: 1
  name: sonatyperepo
spec:
  repositoryDigestMirrors:
  - mirrors:
    - sonatyperepo.test.com
    source: docker.io
  - mirrors:
    - ""
    source: sonatyperepo.test.com:18594

```



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
