### PR TITLE
Bug 2057544: daemon: Explicitly start rpm-ostreed, restart if we detect active txn

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -212,6 +212,10 @@ func New(
 
 	// Only pull the osImageURL from OSTree when we are on RHCOS or FCOS
 	if os.IsCoreOSVariant() {
+		err := nodeUpdaterClient.Initialize()
+		if err != nil {
+			return nil, fmt.Errorf("error initializing rpm-ostree: %v", err)
+		}
 		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %v", err)

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -20,6 +20,10 @@ type RpmOstreeClientMock struct {
 	GetBootedOSImageURLReturns []GetBootedOSImageURLReturn
 }
 
+func (r RpmOstreeClientMock) Initialize() error {
+	return nil
+}
+
 // GetBootedOSImageURL implements a test version of RpmOStreeClients GetBootedOSImageURL.
 // It returns an OsImageURL, Version, and Error as defined in GetBootedOSImageURLReturns in order.
 func (r RpmOstreeClientMock) GetBootedOSImageURL() (string, string, error) {


### PR DESCRIPTION
Cherry-picked from https://github.com/openshift/machine-config-operator/pull/2677

This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1982389
which is already fixed in rpm-ostree in
https://github.com/coreos/rpm-ostree/pull/2995
because it will take a fair while until we can ship the fixed
rpm-ostreed in RHEL and then OpenShift stable versions.
(Yes, this is a sad recurring pattern)

The updater client gains an explicit `Initialize` method, where
we also explicitly `systemctl start rpm-ostreed` which
then effectively rolls in the change from
https://github.com/coreos/rpm-ostree/pull/2945
too.
