### PR TITLE
Bug 2050466: Not allow empty string in icsp&image CR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/api v0.0.0-20220209124712-b632c5fc10c0
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 	github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492
-	github.com/openshift/runtime-utils v0.0.0-20210722191527-8b8348d80d1d
+	github.com/openshift/runtime-utils v0.0.0-20220225175100-8dec0d84fb39
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1063,6 +1063,8 @@ github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492 h1:oj/rSQqVWV
 github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
 github.com/openshift/runtime-utils v0.0.0-20210722191527-8b8348d80d1d h1:lmhB56wFIB/CBhjiZTd1IinQz9OFoNet8OYBQF59Z0I=
 github.com/openshift/runtime-utils v0.0.0-20210722191527-8b8348d80d1d/go.mod h1:H2kQ7bM4oYJk8G+N9ybDDlTg45V10G/+h2xL8zmjjHU=
+github.com/openshift/runtime-utils v0.0.0-20220225175100-8dec0d84fb39 h1:5woAtivjIZDVaRdMRDstmSBd0hHLsdYcdumLCMs0dwk=
+github.com/openshift/runtime-utils v0.0.0-20220225175100-8dec0d84fb39/go.mod h1:H2kQ7bM4oYJk8G+N9ybDDlTg45V10G/+h2xL8zmjjHU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -541,10 +541,16 @@ func validateRegistriesConfScopes(insecure, blocked, allowed []string, icspRules
 
 	for _, icsp := range icspRules {
 		for _, mirrorSet := range icsp.Spec.RepositoryDigestMirrors {
+			if mirrorSet.Source == "" {
+				return fmt.Errorf("invalid empty entry for source configuration")
+			}
 			if strings.Contains(mirrorSet.Source, "*") {
 				return fmt.Errorf("wildcard entries are not supported with mirror configuration %q", mirrorSet.Source)
 			}
 			for _, mirror := range mirrorSet.Mirrors {
+				if mirror == "" {
+					return fmt.Errorf("invalid empty entry for mirror configuration")
+				}
 				if strings.Contains(mirror, "*") {
 					return fmt.Errorf("wildcard entries are not supported with mirror configuration %q", mirror)
 				}

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -214,7 +214,7 @@ func TestUpdatePolicyJSON(t *testing.T) {
 		Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
 		Transports: map[string]signature.PolicyTransportScopes{
 			"docker-daemon": map[string]signature.PolicyRequirements{
-				"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+				"": {signature.NewPRInsecureAcceptAnything()},
 			},
 		},
 	}
@@ -239,15 +239,15 @@ func TestUpdatePolicyJSON(t *testing.T) {
 				Default: signature.PolicyRequirements{signature.NewPRReject()},
 				Transports: map[string]signature.PolicyTransportScopes{
 					"atomic": map[string]signature.PolicyRequirements{
-						"allow.io":              signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
-						"*.allowed-example.com": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+						"allow.io":              {signature.NewPRInsecureAcceptAnything()},
+						"*.allowed-example.com": {signature.NewPRInsecureAcceptAnything()},
 					},
 					"docker": map[string]signature.PolicyRequirements{
-						"allow.io":              signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
-						"*.allowed-example.com": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+						"allow.io":              {signature.NewPRInsecureAcceptAnything()},
+						"*.allowed-example.com": {signature.NewPRInsecureAcceptAnything()},
 					},
 					"docker-daemon": map[string]signature.PolicyRequirements{
-						"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+						"": {signature.NewPRInsecureAcceptAnything()},
 					},
 				},
 			},
@@ -259,15 +259,15 @@ func TestUpdatePolicyJSON(t *testing.T) {
 				Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
 				Transports: map[string]signature.PolicyTransportScopes{
 					"atomic": map[string]signature.PolicyRequirements{
-						"block.com":             signature.PolicyRequirements{signature.NewPRReject()},
-						"*.blocked-example.com": signature.PolicyRequirements{signature.NewPRReject()},
+						"block.com":             {signature.NewPRReject()},
+						"*.blocked-example.com": {signature.NewPRReject()},
 					},
 					"docker": map[string]signature.PolicyRequirements{
-						"block.com":             signature.PolicyRequirements{signature.NewPRReject()},
-						"*.blocked-example.com": signature.PolicyRequirements{signature.NewPRReject()},
+						"block.com":             {signature.NewPRReject()},
+						"*.blocked-example.com": {signature.NewPRReject()},
 					},
 					"docker-daemon": map[string]signature.PolicyRequirements{
-						"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+						"": {signature.NewPRInsecureAcceptAnything()},
 					},
 				},
 			},

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -3,6 +3,7 @@ package containerruntimeconfig
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -291,5 +292,117 @@ func TestUpdatePolicyJSON(t *testing.T) {
 			_, err = signature.NewPolicyFromBytes(got)
 			require.NoError(t, err)
 		})
+	}
+}
+
+func TestValidateRegistriesConfScopes(t *testing.T) {
+	tests := []struct {
+		insecure    []string
+		blocked     []string
+		allowed     []string
+		icspRules   []*apioperatorsv1alpha1.ImageContentSourcePolicy
+		expectedErr error
+	}{
+		{
+			insecure: []string{""},
+			blocked:  []string{"*.block.com"},
+			allowed:  []string{"*.allowed.com"},
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{ // other.com is neither insecure nor blocked
+							{Source: "insecure.com/ns-i1", Mirrors: []string{"blocked.com/ns-b1", "other.com/ns-o1"}},
+							{Source: "blocked.com/ns-b/ns2-b", Mirrors: []string{"other.com/ns-o2", "insecure.com/ns-i2"}},
+							{Source: "other.com/ns-o3", Mirrors: []string{"insecure.com/ns-i2", "blocked.com/ns-b/ns3-b", "foo.insecure-example.com/bar"}},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(`invalid entry for insecure registries ""`),
+		},
+		{
+			insecure: []string{"*.insecure.com"},
+			blocked:  []string{""},
+			allowed:  []string{"*.allowed.com"},
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{ // other.com is neither insecure nor blocked
+							{Source: "insecure.com/ns-i1", Mirrors: []string{"blocked.com/ns-b1", "other.com/ns-o1"}},
+							{Source: "blocked.com/ns-b/ns2-b", Mirrors: []string{"other.com/ns-o2", "insecure.com/ns-i2"}},
+							{Source: "other.com/ns-o3", Mirrors: []string{"insecure.com/ns-i2", "blocked.com/ns-b/ns3-b", "foo.insecure-example.com/bar"}},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(`invalid entry for blocked registries ""`),
+		},
+		{
+			insecure: []string{"*.insecure.com"},
+			blocked:  []string{"*.block.com"},
+			allowed:  []string{""},
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{ // other.com is neither insecure nor blocked
+							{Source: "insecure.com/ns-i1", Mirrors: []string{"blocked.com/ns-b1", "other.com/ns-o1"}},
+							{Source: "blocked.com/ns-b/ns2-b", Mirrors: []string{"other.com/ns-o2", "insecure.com/ns-i2"}},
+							{Source: "other.com/ns-o3", Mirrors: []string{"insecure.com/ns-i2", "blocked.com/ns-b/ns3-b", "foo.insecure-example.com/bar"}},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(`invalid entry for allowed registries ""`),
+		},
+		{
+			insecure: []string{"*.insecure.com"},
+			blocked:  []string{"*.block.com"},
+			allowed:  []string{"*.allowed.com"},
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{ // other.com is neither insecure nor blocked
+							{Source: "", Mirrors: []string{"blocked.com/ns-b1", "other.com/ns-o1"}},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("invalid empty entry for source configuration"),
+		},
+		{
+			insecure: []string{"*.insecure.com"},
+			blocked:  []string{"*.block.com"},
+			allowed:  []string{"*.allowed.com"},
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{ // other.com is neither insecure nor blocked
+							{Source: "insecure.com/ns-i1", Mirrors: []string{"", "other.com/ns-o1"}},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("invalid empty entry for mirror configuration"),
+		},
+		{
+			insecure: []string{"*.insecure.com"},
+			blocked:  []string{"*.block.com"},
+			allowed:  []string{"*.allowed.com"},
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{
+							{Source: "insecure.com/ns-i1", Mirrors: []string{"other.com/ns-o1"}},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		res := validateRegistriesConfScopes(tc.insecure, tc.blocked, tc.allowed, tc.icspRules)
+		require.Equal(t, tc.expectedErr, res)
 	}
 }

--- a/vendor/github.com/openshift/runtime-utils/pkg/registries/registries.go
+++ b/vendor/github.com/openshift/runtime-utils/pkg/registries/registries.go
@@ -8,9 +8,9 @@ import (
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 )
 
-// scopeIsNestedInsideScope returns true if a subScope value (as in sysregistriesv2.Registry.Prefix / sysregistriesv2.Endpoint.Location)
+// ScopeIsNestedInsideScope returns true if a subScope value (as in sysregistriesv2.Registry.Prefix / sysregistriesv2.Endpoint.Location)
 // is a sub-scope of superScope.
-func scopeIsNestedInsideScope(subScope, superScope string) bool {
+func ScopeIsNestedInsideScope(subScope, superScope string) bool {
 	match := false
 	if superScope == subScope {
 		return true
@@ -188,12 +188,12 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 			if reg.Prefix != "" {
 				scope = reg.Prefix
 			}
-			if scopeIsNestedInsideScope(scope, insecureScope) {
+			if ScopeIsNestedInsideScope(scope, insecureScope) {
 				reg.Insecure = true
 			}
 			for j := range reg.Mirrors {
 				mirror := &reg.Mirrors[j]
-				if scopeIsNestedInsideScope(mirror.Location, insecureScope) {
+				if ScopeIsNestedInsideScope(mirror.Location, insecureScope) {
 					mirror.Insecure = true
 				}
 			}
@@ -209,7 +209,7 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 			if reg.Prefix != "" {
 				scope = reg.Prefix
 			}
-			if scopeIsNestedInsideScope(scope, blockedScope) {
+			if ScopeIsNestedInsideScope(scope, blockedScope) {
 				reg.Blocked = true
 			}
 		}
@@ -221,6 +221,9 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 // This function can be used to validate the registries entries prior to calling EditRegistriesConfig
 // in the MCO or builds code
 func IsValidRegistriesConfScope(scope string) bool {
+	if scope == "" {
+		return false
+	}
 	// If scope does not contain the wildcard character, we will assume it is a regular registry entry, which is valid
 	if !strings.Contains(scope, "*") {
 		return true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -842,7 +842,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/v1helpers
-# github.com/openshift/runtime-utils v0.0.0-20210722191527-8b8348d80d1d
+# github.com/openshift/runtime-utils v0.0.0-20220225175100-8dec0d84fb39
 ## explicit; go 1.13
 github.com/openshift/runtime-utils/pkg/registries
 # github.com/pelletier/go-toml v1.9.3


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2050466
- vendor in https://github.com/openshift/runtime-utils/pull/14
- Add validation for image and icsp CR to not allow the empty string ("") in the CRD.
Empty string regsitries configurations will fail the machine config daemon operations
of pulling images and the nodes will stopped in NotReady state when node rebooting after node drain.

```
2022-02-03T23:16:02.952318066Z I0203 23:16:02.952259    2590 run.go:18] Running: podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6d4ff6bb5494c55c24f9a322b1a5faffb8a92ea0f572f1078db55f3f1abaa588
2022-02-03T23:16:03.033231339Z Error: error loading registries configuration "/etc/containers/registries.conf": invalid condition: mirror location is unset
```



Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

Apply the following icsp to the cluster:
it should logs error about the icsp is invalid and do not update the registries.conf.
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  generation: 1
  name: sonatyperepo
spec:
  repositoryDigestMirrors:
  - mirrors:
    - sonatyperepo.test.com
    source: docker.io
  - mirrors:
    - ""
    source: sonatyperepo.test.com:18594

```



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
