### PR TITLE
[release-4.8] Bug 2059330: ovs-configuration: use lower than NM default ethernet route metric

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -115,6 +115,9 @@ contents:
     nmcli c show
 
     if [ "$1" == "OVNKubernetes" ]; then
+      # when creating the bridge, we use a value lower than NM's ethernet device default route metric
+      # (we pick 49 to be lower than anything that NM chooses by default)
+      BRIDGE_METRIC="49"
       # Configures NICs onto OVS bridge "br-ex"
       # Configuration is either auto-detected or provided through a config file written already in Network Manager
       # key files under /etc/NetworkManager/system-connections/
@@ -206,14 +209,14 @@ contents:
         extra_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
       fi
 
-      # create bridge; use NM's ethernet device default route metric (100)
+      # create bridge
       if ! nmcli connection show br-ex &> /dev/null; then
         nmcli c add type ovs-bridge \
             con-name br-ex \
             conn.interface br-ex \
             802-3-ethernet.mtu ${iface_mtu} \
-            ipv4.route-metric 100 \
-            ipv6.route-metric 100 \
+            ipv4.route-metric "$BRIDGE_METRIC" \
+            ipv6.route-metric "$BRIDGE_METRIC" \
             ${extra_brex_args}
       fi
 
@@ -358,7 +361,7 @@ contents:
         else
           nmcli c add type ovs-interface slave-type ovs-port conn.interface br-ex master ovs-port-br-ex con-name \
             ovs-if-br-ex 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
-            ipv4.route-metric 100 ipv6.route-metric 100
+            ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC"
         fi
       fi
 


### PR DESCRIPTION
Setting the default NM route metric for ovs-if-br-ex is problematic
in the presence of other Ethernet ports. In that case, ovs-if-br-ex
as well as the Ethernet ports will have the same route metric, and
the winner is undefined. Lower ovs-if-br-ex route metric to 49 to
avoid ambiguous situations.

Conflicts:
  templates/common/_base/files/configure-ovs-network.yaml

Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit e6a673db9a2931906cf00832684f5d132ca333ee)
(cherry picked from commit 3711b7ceac0d1e92f0496ea78bd9305d499fe35b)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
