### PR TITLE
Add `rhel-coreos` image in configmap and `oscontainer` in controllerconfig

### DIFF
--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,6 +9,10 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
-  # The OS payload, managed by the daemon + pivot + rpm-ostree
-  # https://github.com/openshift/machine-config-operator/issues/183
+  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
+  # progresses towards the default.
+  baseOperatingSystemContainer: "registry.ci.openshift.org/openshift:rhel-coreos"
+  # The OS payload used for 4.10 and below; more information in
+  # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
+  # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )
   osImageURL: "registry.svc.ci.openshift.org/openshift:machine-os-content"

--- a/install/image-references
+++ b/install/image-references
@@ -23,6 +23,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:machine-os-content
+  - name: rhel-coreos
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:rhel-coreos
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -887,6 +887,10 @@ spec:
                   contains the OS update payload. Its value is taken from the data.osImageURL
                   field on the machine-config-osimageurl ConfigMap.
                 type: string
+              baseOperatingSystemContainer:
+                description: baseOperatingSystemContainer is the new format operating system update image.
+                  See https://github.com/openshift/enhancements/pull/1032
+                type: string
               platform:
                 description: platform is deprecated, use Infra.Status.PlatformStatus.Type
                   instead
@@ -961,6 +965,7 @@ spec:
             - ipFamilies
             - kubeAPIServerServingCAData
             - osImageURL
+            - baseOperatingSystemContainer
             - proxy
             - releaseImage
             - rootCAData

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -69,8 +69,10 @@ type ControllerConfigSpec struct {
 	// images is map of images that are used by the controller to render templates under ./templates/
 	Images map[string]string `json:"images"`
 
-	// osImageURL is the location of the container image that contains the OS update payload.
-	// Its value is taken from the data.osImageURL field on the machine-config-osimageurl ConfigMap.
+	// BaseOperatingSystemContainer is the new-format container image for operating system updates.
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+
+	// OSImageURL is the old-format container image that contains the OS update payload.
 	OSImageURL string `json:"osImageURL"`
 
 	// releaseImage is the image used when installing the cluster

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -545,6 +545,12 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		return nil, fmt.Errorf("Ignoring controller config generated without %s annotation (my version: %s)", daemonconsts.GeneratedByVersionAnnotationKey, version.Raw)
 	}
 
+	if cconfig.Spec.BaseOperatingSystemContainer == "" {
+		glog.Warningf("No BaseOperatingSystemContainer set")
+	} else {
+		glog.Infof("BaseOperatingSystemContainer=%s", cconfig.Spec.BaseOperatingSystemContainer)
+	}
+
 	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid
 	for _, config := range configs {
 		if err := ctrlcommon.ValidateMachineConfig(config.Spec); err != nil {

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -139,6 +139,7 @@ func RenderBootstrap(
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
+	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -17,6 +17,8 @@ type Images struct {
 type RenderConfigImages struct {
 	MachineConfigOperator string `json:"machineConfigOperator"`
 	MachineOSContent      string `json:"machineOSContent"`
+	// The new format image
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
 	// These have to be named differently from the ones in ControllerConfigImages
 	// or we get errors about ambiguous selectors because both structs are
 	// combined in the Images struct.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -255,11 +255,12 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 
 	// sync up os image url
 	// TODO: this should probably be part of the imgs
-	osimageurl, err := optr.getOsImageURL(optr.namespace)
+	oscontainer, osimageurl, err := optr.getOsImageURLs(optr.namespace)
 	if err != nil {
 		return err
 	}
 	imgs.MachineOSContent = osimageurl
+	imgs.BaseOperatingSystemContainer = oscontainer
 
 	// sync up the ControllerConfigSpec
 	infra, network, proxy, dns, err := optr.getGlobalConfig()
@@ -308,6 +309,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	spec.RootCAData = bundle
 	spec.PullSecret = &corev1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}
 	spec.OSImageURL = imgs.MachineOSContent
+	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,
 
@@ -688,7 +690,7 @@ func (optr *Operator) syncRequiredMachineConfigPools(_ *renderConfig) error {
 			_, hasRequiredPoolLabel := pool.Labels[requiredForUpgradeMachineConfigPoolLabelKey]
 
 			if hasRequiredPoolLabel {
-				opURL, err := optr.getOsImageURL(optr.namespace)
+				_, opURL, err := optr.getOsImageURLs(optr.namespace)
 				if err != nil {
 					glog.Errorf("Error getting configmap osImageURL: %q", err)
 					return false, nil
@@ -850,17 +852,26 @@ func (optr *Operator) waitForControllerConfigToBeCompleted(resource *mcfgv1.Cont
 	return nil
 }
 
-func (optr *Operator) getOsImageURL(namespace string) (string, error) {
+// getOsImageURLs returns (new type, old type) for operating system update images.
+func (optr *Operator) getOsImageURLs(namespace string) (string, string, error) {
 	cm, err := optr.mcoCmLister.ConfigMaps(namespace).Get(osImageConfigMapName)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	releaseVersion := cm.Data["releaseVersion"]
 	optrVersion, _ := optr.vStore.Get("operator")
 	if releaseVersion != optrVersion {
-		return "", fmt.Errorf("refusing to read osImageURL version %q, operator version %q", releaseVersion, optrVersion)
+		return "", "", fmt.Errorf("refusing to read osImageURL version %q, operator version %q", releaseVersion, optrVersion)
 	}
-	return cm.Data["osImageURL"], nil
+	newformat, ok := cm.Data["baseOperatingSystemContainer"]
+	if !ok {
+		return "", "", fmt.Errorf("Missing baseOperatingSystemContainer from configmap")
+	}
+	oldformat := cm.Data["osImageURL"]
+	if !ok {
+		return "", "", fmt.Errorf("Missing osImageURL from configmap")
+	}
+	return newformat, oldformat, nil
 }
 
 func (optr *Operator) getCAsFromConfigMap(namespace, name, key string) ([]byte, error) {


### PR DESCRIPTION

Part of https://github.com/openshift/enhancements/pull/1032

We'll add the new-format image into the payload alongside the old
one until we can complete the transition.

(There may actually be a separate `rhel-coreos-extensions` image
 e.g. too, so this is just the start)
