### PR TITLE
Bug 2060133: Explicitly set keyfile as the default plugin

### DIFF
--- a/templates/common/_base/files/NetworkManager-keyfiles.yaml
+++ b/templates/common/_base/files/NetworkManager-keyfiles.yaml
@@ -2,5 +2,7 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/20-keyfiles.conf"
 contents:
   inline: |
+    [main]
+    plugins=keyfile,ifcfg-rh
     [keyfile]
     path=/etc/NetworkManager/system-connections


### PR DESCRIPTION
This was originally set as such in 4.9. But it was removed what it seems inadvertently in 4.10 at the same time systemConnectionsMerged overlay was removed. We still want keyfile to be the default plugin, which it already is for RHCOS but not for RHEL. Set it back.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
