### PR TITLE
[release-4.10] Bug 2060954: Explicitly set keyfile as the default plugin

### DIFF
--- a/templates/common/_base/files/NetworkManager-keyfiles.yaml
+++ b/templates/common/_base/files/NetworkManager-keyfiles.yaml
@@ -2,5 +2,7 @@ mode: 0644
 path: "/etc/NetworkManager/conf.d/20-keyfiles.conf"
 contents:
   inline: |
+    [main]
+    plugins=keyfile,ifcfg-rh
     [keyfile]
     path=/etc/NetworkManager/system-connections


### PR DESCRIPTION
Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit 342f20bf2e6efe43e2735d426aae2d49674df3fb)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
