### PR TITLE
Factor out functionality from update() that will be needed for layering

### DIFF
--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -176,6 +176,20 @@ func isDrainRequired(actions, diffFileSet []string, readOldFile, readNewFile Rea
 	return true, nil
 }
 
+func (dn *Daemon) drainIfRequired(actions, diffFileSet []string, readOldFile, readNewFile ReadFileFunc) error {
+	drain, err := isDrainRequired(actions, diffFileSet, readOldFile, readNewFile)
+	if err != nil {
+		return err
+	}
+
+	if drain {
+		return dn.performDrain()
+	}
+
+	glog.Info("Changes do not require drain, skipping.")
+	return nil
+}
+
 // isSafeContainerRegistryConfChanges looks inside old and new versions of registries.conf file.
 // It compares the content and determines whether changes made are safe or not. This will
 // help MCD to decide whether we can skip node drain for applied changes into container

--- a/pkg/daemon/drain_test.go
+++ b/pkg/daemon/drain_test.go
@@ -359,7 +359,7 @@ location = "example.com/repo/test-img"
 				t.Errorf("parsing new Ignition config failed: %v", err)
 			}
 			diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
-			drain, err := isDrainRequired(test.actions, diffFileSet, oldIgnConfig, newIgnConfig)
+			drain, err := isDrainRequired(test.actions, diffFileSet, getIgnitionFileDataReadFunc(&oldIgnConfig), getIgnitionFileDataReadFunc(&newIgnConfig))
 			if !reflect.DeepEqual(test.expectedAction, drain) {
 				t.Errorf("Failed determining drain behavior: expected: %v but result is: %v. Error: %v", test.expectedAction, drain, err)
 			}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -499,6 +499,13 @@ func (dn *Daemon) setWorking() error {
 	return nil
 }
 
+// this should probably become part of the implementation of an Updater interface
+func getIgnitionFileDataReadFunc(ignConfig *ign3types.Config) ReadFileFunc {
+	return func(path string) ([]byte, error) {
+		return ctrlcommon.GetIgnitionFileDataByPath(ignConfig, path)
+	}
+}
+
 // update the node to the provided node configuration.
 func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
 	if err := dn.setWorking(); err != nil {
@@ -552,7 +559,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 	}
 
 	// Check and perform node drain if required
-	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig)
+	drain, err := isDrainRequired(actions, diffFileSet, getIgnitionFileDataReadFunc(&oldIgnConfig), getIgnitionFileDataReadFunc(&newIgnConfig))
 	if err != nil {
 		return err
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -116,9 +116,6 @@ func reloadService(name string) error {
 }
 
 // performPostConfigChangeAction takes action based on what postConfigChangeAction has been asked.
-// For non-reboot action, it applies configuration, updates node's config and state.
-// In the end uncordon node to schedule workload.
-// If at any point an error occurs, we reboot the node so that node has correct configuration.
 func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string, configName string) error {
 	if ctrlcommon.InSlice(postConfigChangeActionReboot, postConfigChangeActions) {
 		dn.logSystem("Rebooting node")
@@ -147,10 +144,10 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 		}
 		dn.logSystem("%s config reloaded successfully! Desired config %s has been applied, skipping reboot", serviceName, configName)
 	}
+	return nil
+}
 
-	// We are here, which means reboot was not needed to apply the configuration.
-
-	// Get current state of node, in case of an error reboot
+func (dn *Daemon) getAndUpdateConfigAndState(configName string) error {
 	state, err := dn.getStateAndConfigs(configName)
 	if err != nil {
 		return fmt.Errorf("Could not apply update: error processing state and configs. Error: %v", err)
@@ -630,7 +627,16 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 		return err
 	}
 
-	return dn.performPostConfigChangeAction(actions, newConfig.GetName())
+	if err := dn.performPostConfigChangeAction(actions, newConfig.GetName()); err != nil {
+		return err
+	}
+
+	// if dn.skipReboot, a reboot might be performed manually after update(), in which case we don't want to update state
+	// else reboot was not needed to apply the configuration, and we need to update state
+	if !dn.skipReboot {
+		return dn.getAndUpdateConfigAndState(newConfig.GetName())
+	}
+	return nil
 }
 
 // machineConfigDiff represents an ad-hoc difference between two MachineConfig objects.

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -559,16 +559,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 	}
 
 	// Check and perform node drain if required
-	drain, err := isDrainRequired(actions, diffFileSet, getIgnitionFileDataReadFunc(&oldIgnConfig), getIgnitionFileDataReadFunc(&newIgnConfig))
-	if err != nil {
+	if err := dn.drainIfRequired(actions, diffFileSet, getIgnitionFileDataReadFunc(&oldIgnConfig), getIgnitionFileDataReadFunc(&newIgnConfig)); err != nil {
 		return err
-	}
-	if drain {
-		if err := dn.performDrain(); err != nil {
-			return err
-		}
-	} else {
-		glog.Info("Changes do not require drain, skipping.")
 	}
 
 	// update files on disk that need updating


### PR DESCRIPTION
Various refactors that will be helpful for sharing functionality between a legacy and layering update flow. Opening this against `master` per discussion in https://github.com/openshift/machine-config-operator/pull/2982#issuecomment-1059193703. I would like to get a CI run because I'm having trouble launching a cluster with code we're trying to get into `layering`