### PR TITLE
[OCPCLOUD-1436] Use afterburn to collect instance metadata in order to populate nodename

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
@@ -14,10 +14,9 @@ contents:
 
     # For compatibility with the AWS in-tree provider
     # Set node name to be instance name instead of the default FQDN hostname
-    #
-    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-    name=$(curl -s http://169.254.169.254/2016-09-02/meta-data/local-hostname)
+    # afterburn service is using for metadata retrival, see respective systemd unit
+    # metadata related afterburn doc: https://coreos.github.io/afterburn/usage/attributes/
     cat > "${NODECONF}" <<EOF
     [Service]
-    Environment="KUBELET_NODE_NAME=${name}"
+    Environment="KUBELET_NODE_NAME=${AFTERBURN_AWS_HOSTNAME}"
     EOF

--- a/templates/common/aws/units/aws-kubelet-nodename.service.yaml
+++ b/templates/common/aws/units/aws-kubelet-nodename.service.yaml
@@ -3,12 +3,19 @@ enabled: true
 contents: |
   [Unit]
   Description=Fetch kubelet node name from AWS Metadata
+
+  # Run afterburn service for collect info from metadata server
+  # see: https://coreos.github.io/afterburn/usage/attributes/
+  Requires=afterburn.service
+  After=afterburn.service
+
   # Wait for NetworkManager to report it's online
   After=NetworkManager-wait-online.service
   # Run before kubelet
   Before=kubelet.service
 
   [Service]
+  EnvironmentFile=/run/metadata/afterburn
   ExecStart=/usr/local/bin/aws-kubelet-nodename
   Type=oneshot
 


### PR DESCRIPTION
In order to support IMDSv2 on AWS platform curling metadata server is not enough.
Here is an attempt to use afterburn for obtaining information from IMDS

Tested manually with custom built release - works well, migration to techpreview also works

IMDSv2 doc: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html