### PR TITLE
adds e2e-layering test package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ test-e2e:
 test-e2e-single-node:
 	go test -tags=$(GOTAGS) -failfast -timeout 90m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/
 
+test-e2e-layering:
+	go test -tags=$(GOTAGS) -failfast -timeout 90m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-layering/
+
 bootstrap-e2e:
 	./hack/bootstrap-e2e-test.sh
 

--- a/test/e2e-layering/README.md
+++ b/test/e2e-layering/README.md
@@ -1,0 +1,3 @@
+# e2e-layering
+
+This package contains end-to-end (e2e) tests which are useful for testing portions of the MCO which implement the new layering update strategy.

--- a/test/e2e-layering/layering_test.go
+++ b/test/e2e-layering/layering_test.go
@@ -1,0 +1,7 @@
+package e2e_layering_test
+
+import "testing"
+
+func TestHelloWorld(t *testing.T) {
+	t.Log("Hello world")
+}


### PR DESCRIPTION
**- What I did**

I've added an empty e2e-layering test package which is intended to house future tests related to the OpenShift CoreOS Layering effort as well as an additional Makefile target.

**- How to verify it**

1. Clone this PR.
2. `$ make test-e2e-layering`

**- Description for the changelog**
Enables e2e layering tests
