### PR TITLE
configure-ovs: reload NM only when necessary

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -9,6 +9,9 @@ contents:
     touch /var/run/ovs-config-executed
     NM_CONN_PATH="/etc/NetworkManager/system-connections"
 
+    # this flag tracks if any config change was made
+    nm_config_changed=0
+
     MANAGED_NM_CONN_SUFFIX="-slave-ovs-clone"
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
@@ -67,7 +70,7 @@ contents:
         if [ -f "$file_path" ]; then
           rm -f "$file_path"
           echo "Removed nmconnection file $file_path"
-          nm_conn_files_removed=1
+          nm_config_changed=1
         fi
       done
     }
@@ -127,6 +130,10 @@ contents:
         echo "Networking already configured and up for ${bridge-name}!"
         return
       fi
+
+      # flag to reload NM to account for all the configuration changes
+      # going forward
+      nm_config_changed=1
 
       if [ -z "$iface" ]; then
         echo "ERROR: Unable to find default gateway interface"
@@ -357,9 +364,15 @@ contents:
       echo "OVS configuration successfully reverted"
     }
 
-    # Reloads NetworkManager
+    # Reloads NetworkManager if any configuration change was done
     reload_nm() {
-      echo "Reloading NetworkManager..."
+      if [ $nm_config_changed -eq 0 ]; then
+        # no config was changed, no need to reload
+        return
+      fi
+      nm_config_changed=0
+      
+      echo "Reloading NetworkManager after configuration changes..."
 
       # set network off, so that auto-connect priority is evaluated when turning
       # it back on
@@ -389,17 +402,11 @@ contents:
 
     # Removes all configuration and reloads NM if necessary
     rollback_nm() {
-      # This will be set to 1 if remove_all_ovn_bridges actually changes anything
-      nm_conn_files_removed=0
-
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
       remove_all_ovn_bridges
       
-      # Reload only if we removed connection profiles
-      if [ $nm_conn_files_removed -eq 1 ]; then
-        echo "OVS configuration was cleaned up, will reload NetworkManager"
-        reload_nm
-      fi
+      # Reload NM if necessary
+      reload_nm
     }
 
     # Activates a NM connection profile


### PR DESCRIPTION
Makes configure-ovs reload NM only when it has actually made any
configuration change.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
