### PR TITLE
daemon: bootimage and ignition logging

### DIFF
--- a/pkg/daemon/coreos.go
+++ b/pkg/daemon/coreos.go
@@ -4,12 +4,35 @@ package daemon
 // including deriviatives like RHEL CoreOS.
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
+
+// alephPath contains information on the original bootimage; for more
+// information see e.g. https://github.com/coreos/fedora-coreos-tracker/blob/main/internals%2FREADME-internals.md#aleph-version
+const alephPath = "/sysroot/.coreos-aleph-version.json"
+
+type coreosAleph struct {
+	Build string `json:"build"`
+	Imgid string `json:"imgid"`
+}
+
+// ignitionProvisioningPath is written by Ignition, see
+// https://github.com/coreos/ignition/commit/556bc9404cfff08ea63c2a865bd3586ece7e8e44
+const ignitionProvisioningPath = "/etc/.ignition-result.json"
+
+// ignitionReport is JSON data written by (newer versions of) Ignition.
+// See https://github.com/coreos/ignition/blob/9a7533ccf57156725e03ec239e5568de2d36f117/internal/exec/stages/files/filesystemEntries.go#L173
+// We only really care about the provisioning date right now.
+type ignitionReport struct {
+	ProvisioningDate string `json:"provisioningDate"`
+}
 
 // byLabel returns the udev generated symlink to the block device with the given label
 func byLabel(label string) string {
@@ -49,4 +72,53 @@ func getRootBlockDeviceSysfs() (string, error) {
 		return getParentDeviceSysfs(root)
 	}
 	return "", fmt.Errorf("Failed to find %s", root)
+}
+
+func logAlephInformation() error {
+	f, err := os.Open(alephPath)
+	if err != nil {
+		// We assume this one should exist on CoreOS systems; if it somehow doesn't we'll just
+		// log the error but continue anyways.
+		return err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	contents, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	var alephData coreosAleph
+	if err := json.Unmarshal(contents, &alephData); err != nil {
+		return err
+	}
+	glog.Infof("CoreOS aleph version: mtime=%v build=%v imgid=%v\n", stat.ModTime().UTC(), alephData.Build, alephData.Imgid)
+	return nil
+}
+
+func logInitionProvisioning() error {
+	contents, err := ioutil.ReadFile(ignitionProvisioningPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("No %s found", ignitionProvisioningPath)
+			return nil
+		}
+		return err
+	}
+	var ignProvisioning ignitionReport
+	if err := json.Unmarshal(contents, &ignProvisioning); err != nil {
+		return err
+	}
+	glog.Infof("Ignition provisioning: time=%v\n", ignProvisioning.ProvisioningDate)
+	return nil
+}
+
+func logProvisioningInformation() {
+	if err := logAlephInformation(); err != nil {
+		glog.Warningf("Failed to get aleph information: %v", err)
+	}
+	if err := logInitionProvisioning(); err != nil {
+		glog.Warningf("Failed to get Ignition provisioning information: %v", err)
+	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -960,6 +960,8 @@ func (dn *Daemon) LogSystemData() {
 			glog.Fatalf("unable to get rpm-ostree status: %s", err)
 		}
 		glog.Info(status)
+
+		logProvisioningInformation()
 	}
 
 	boots, err := runGetOut("journalctl", "--list-boots")


### PR DESCRIPTION
daemon: Log data from `/sysroot/.coreos-aleph-version.json`

My immediate motivation is to gather more information in the MCD
logs; same reason we log the boots.  For coreos layering work,
we will be sensitive to the initial bootimage more and may need
to update it.

Another angle for this is that we could actually plumb this information
up into the node object, and from there into the operator/controller
and feed it into prometheus and into telemetry, so we start
to gather information on e.g. how many clusters have old bootimages.

---

daemon: Also log Ignition provisioning information

More data is good here; this builds on the previous information
for the bootimage generation time.

---

