### PR TITLE
Add `--templates` flag to MCC `bootstrap` command

### DIFF
--- a/cmd/machine-config-controller/main.go
+++ b/cmd/machine-config-controller/main.go
@@ -26,7 +26,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-	startCmd.PersistentFlags().StringVar(&rootOpts.templates, "templates", "/etc/mcc/templates", "Path to the template files used for creating MachineConfig objects")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.templates, "templates", "/etc/mcc/templates", "Path to the template files used for creating MachineConfig objects")
 }
 
 func main() {


### PR DESCRIPTION
Before this commit, the `--templates` flag to `machine-config-controller` was
associated only with the `start` subcommand even though the `bootstrap`
subcommand also uses the value. As a result, users could not override the
default `--templates` value when using the `bootstrap` command.

This commit associates the persistent flag with the root command so that both
the `start` and `bootstrap` subcommands expose the `--templates` flag to users.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2062007

**- Description for the changelog**
Add `--templates` flag to the `machine-config-controller bootstrap` command
