### PR TITLE
update Dockerfile.rhel7 name to Dockerfile.rhel

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,16 @@
+# THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+# FIXME once we can depend on a new enough host that supports globs for COPY,
+# just use that.  For now we work around this by copying a tarball.
+RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
+
+FROM registry.ci.openshift.org/ocp/4.10:base
+COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
+RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY install /manifests
+RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
+COPY templates /etc/mcc/templates
+ENTRYPOINT ["/usr/bin/machine-config-operator"]
+LABEL io.openshift.release.operator true

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ install: binaries
 	  install -D -m 0755 _output/linux/$(GOARCH)/$${component} $(DESTDIR)$(PREFIX)/bin/$${component}; \
 	done
 
-Dockerfile.rhel7: Dockerfile Makefile
+Dockerfile.rhel: Dockerfile Makefile
 	(echo '# THIS FILE IS GENERATED FROM '$<' DO NOT EDIT' && \
 	 sed -e s,org/openshift/release,org/ocp/builder, -e s,/openshift/origin-v4.0:base,/ocp/4.0:base, < $<) > $@.tmp && mv $@.tmp $@
 


### PR DESCRIPTION
Rhel7 was deprecated in 4.10+ this file name is now stale. 

Need to ratchet in the change since there is a dependency here: https://github.com/openshift/ocp-build-data/blob/79fa14aac4fe70e2d6b85876bf225f546a8e73a7/images/ose-machine-config-operator.yml 

And also need to update some stuff with ART

Then I can come back and remove Dockerfile.rhel7 from MCO repo.

Since this is used by the above and that file is automatically updated for correct rhel version, making this file name rhel version neutral so we aren't stale again. Went with .rhel bc I copied another [repo](https://github.com/openshift/ocp-build-data/blob/79fa14aac4fe70e2d6b85876bf225f546a8e73a7/images/ose-cluster-update-keys.yml) that sagely didn't bind itself to a version.

