### PR TITLE
Bug 2072621: [OCPNODE-869] Create a drop-in file for cri-o's seccomp use default config

### DIFF
--- a/cmd/machine-config-controller/main.go
+++ b/cmd/machine-config-controller/main.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	componentName = "machine-config-controller"
+	componentName      = "machine-config-controller"
+	componentNamespace = "openshift-machine-config-operator"
 )
 
 var (

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -118,6 +118,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 		),
 		containerruntimeconfig.New(
 			rootOpts.templates,
+			componentNamespace,
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -148,6 +148,12 @@ func (b *Bootstrap) Run(destDir string) error {
 
 	configs = append(configs, rconfigs...)
 
+	seccompUseconfigs, err := containerruntimeconfig.RunSeccompUseDefaultBootstrap(pools)
+	if err != nil {
+		return err
+	}
+	configs = append(configs, seccompUseconfigs...)
+
 	if len(crconfigs) > 0 {
 		containerRuntimeConfigs, err := containerruntimeconfig.RunContainerRuntimeBootstrap(b.templatesDir, crconfigs, cconfig, pools)
 		if err != nil {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
 
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,6 +61,7 @@ type fixture struct {
 	client         *fake.Clientset
 	imgClient      *fakeconfigv1client.Clientset
 	operatorClient *fakeoperatorclient.Clientset
+	kubeClient     *k8sfake.Clientset
 
 	ccLister   []*mcfgv1.ControllerConfig
 	mcpLister  []*mcfgv1.MachineConfigPool
@@ -74,6 +76,7 @@ type fixture struct {
 	objects         []runtime.Object
 	imgObjects      []runtime.Object
 	operatorObjects []runtime.Object
+	k8sObjects      []runtime.Object
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -144,6 +147,15 @@ func newContainerRuntimeConfig(name string, ctrconf *mcfgv1.ContainerRuntimeConf
 	}
 }
 
+func newConfigMap(name string) *k8sv1.ConfigMap {
+	return &k8sv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-machine-config-operator",
+		},
+	}
+}
+
 func newImageConfig(name string, regconf *apicfgv1.RegistrySources) *apicfgv1.Image {
 	return &apicfgv1.Image{
 		TypeMeta:   metav1.TypeMeta{APIVersion: apicfgv1.SchemeGroupVersion.String()},
@@ -180,18 +192,19 @@ func (f *fixture) newController() *Controller {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	f.imgClient = fakeconfigv1client.NewSimpleClientset(f.imgObjects...)
 	f.operatorClient = fakeoperatorclient.NewSimpleClientset(f.operatorObjects...)
+	f.kubeClient = k8sfake.NewSimpleClientset(f.k8sObjects...)
 
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.imgClient, noResyncPeriodFunc())
 	oi := operatorinformer.NewSharedInformerFactory(f.operatorClient, noResyncPeriodFunc())
-	c := New(templateDir,
+	c := New(templateDir, "openshift-machine-config-operator",
 		i.Machineconfiguration().V1().MachineConfigPools(),
 		i.Machineconfiguration().V1().ControllerConfigs(),
 		i.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 		ci.Config().V1().Images(),
 		oi.Operator().V1alpha1().ImageContentSourcePolicies(),
 		ci.Config().V1().ClusterVersions(),
-		k8sfake.NewSimpleClientset(), f.client, f.imgClient)
+		f.kubeClient, f.client, f.imgClient)
 
 	c.mcpListerSynced = alwaysReady
 	c.mccrListerSynced = alwaysReady
@@ -444,12 +457,14 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			mcs1 := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcs2 := mcs1.DeepCopy()
 			mcs2.Name = ctrCfgKey
+			cm := newConfigMap("crio-seccomp-use-default-when-empty")
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrcfg1)
 			f.objects = append(f.objects, ctrcfg1)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectGetMachineConfigAction(mcs1)
@@ -480,12 +495,14 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			mcs := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcsUpdate := mcs.DeepCopy()
 			mcsUpdate.Name = keyCtrCfg
+			cm := newConfigMap("crio-seccomp-use-default-when-empty")
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrcfg1)
 			f.objects = append(f.objects, ctrcfg1)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectGetMachineConfigAction(mcs)
@@ -518,6 +535,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrcfgUpdate)
 			f.objects = append(f.objects, mcsUpdate, ctrcfgUpdate)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			c = f.newController()
 			stopCh = make(chan struct{})
@@ -577,7 +595,15 @@ func TestImageConfigCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
 
-			f.run("cluster")
+			c := f.newController()
+			stopCh := make(chan struct{})
+			err := c.syncImgHandler("cluster")
+			if err != nil {
+				t.Errorf("syncImgHandler returned %v", err)
+			}
+
+			f.validateActions()
+			close(stopCh)
 
 			for _, mcName := range []string{mcs1.Name, mcs2.Name} {
 				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, cc.Spec.ReleaseImage, true, true)
@@ -1042,6 +1068,8 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
 
+			cm := newConfigMap("crio-seccomp-use-default-when-empty")
+			f.k8sObjects = []runtime.Object{cm}
 			ctrcfgCount := 30
 			for i := 0; i < ctrcfgCount; i++ {
 				f.resetActions()
@@ -1058,6 +1086,7 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 				f.mcpLister = append(f.mcpLister, mcp)
 				f.mccrLister = append(f.mccrLister, ccr)
 				f.objects = append(f.objects, ccr)
+				f.k8sObjects = []runtime.Object{cm}
 
 				mcs := helpers.NewMachineConfig(generateManagedKey(ccr, 1), labelSelector.MatchLabels, "dummy://", []ign3types.File{{}})
 				mcsDeprecated := mcs.DeepCopy()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Epic: https://issues.redhat.com/browse/OCPNODE-887
issue: https://issues.redhat.com/browse/OCPNODE-869

**- What I did**
Create a MCO drop-in to explicitly set `seccomp_use_default_when_empty = false` in 4.10.z

crio will change the default value of `seccomp_use_default_when_empty` from false to true in 4.11(crio1.24) and later versions.  In order to not break current clusters, in 4.10.z we create a machine-config to have drop-in crio.conf file with `seccomp_use_default_when_empty = false` and make it a mandatory upgrade edge(OTA team). So `seccomp_use_default_when_empty = true` change be an opt-in for upgraded users, users will have the option to delete the MC associated with this file when they are ready to
consume this change for their workload

**- How to verify it**
1. Fresh cluster installation, machine configs exit on the cluster:
`99-worker-generated-crio-seccomp-use-default`
`99-master-generated-crio-seccomp-use-default`
2. Upgrade to version with this patch 
   - with ctrcfg CR on one pool
   - with ctrcfg CR on all the pools
   - with no ctrcfg CR
3. After upgrade tried the following
   - if no ctrcfg CR was created prior to upgrade, create one
   - if ctrcfg CR was created prior to upgrade, delete it 
   - delete one or both of the capabilities MCs
   - restart the MCC
   - restart the MCO
   - reboot nodes (make sure that the delete capabilities MCs are not created again) 
   - check that the configmap `crio-seccomp-use-default-when-empty` exists in the openshift-machine-config-operator namespace 
4. Upgrade to next version 4.11.0-0.ci-2022-04-01-023231
   - upgrade with generated-crio-seccomp-use-default  MC existing
   - upgrade with no generated-crio-seccomp-use-default  MC 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
