### PR TITLE
Bug 2063324: Ensure directories are created with usable permission bits

### DIFF
--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -197,7 +197,7 @@ func RenderBootstrap(
 
 		path := filepath.Join(destinationDir, m.filename)
 		dirname := filepath.Dir(path)
-		if err := os.MkdirAll(dirname, 0655); err != nil {
+		if err := os.MkdirAll(dirname, 0755); err != nil {
 			return err
 		}
 		// Disable gosec here to avoid throwing


### PR DESCRIPTION
Before this commit, the MCO template rendering code created a template output
parent directory with mode `0655`, which caused subsequent subdirectory creation
and file writes to fail when running MCO in some unprivileged contexts that rely
on linux file permissions (as both `wx` are required for owner writes).

This commit adjusts the directory mode to `0755` on creation to ensure
compatibility in those unprivileged contexts.

### What I did

While integrating with HyperShift which executes MCO binaries in unprivileged containers, I discovered the MCO template execution is creating a parent output directory with mode 0655, which causes rendering to fail because subdirectories and files can't be created within that parent due to the missing executable bit for the owner.

### How to verify it

Run `machine-config-operator bootstrap ... --dest-dir=/output`.

##### Actual results:

Resulting destination directory has mode `drw-r-xr-x`.

##### Expected results:

Destination directory should have mode `drwxr-xr-x`.


**- Description for the changelog**
Ensure MCO bootstrap directories are created with usable permission bits
