### PR TITLE
operator/bootstrap: Accept new --image-references argument

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/images.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/images.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	imagesScheme = runtime.NewScheme()
+	imagesCodecs = serializer.NewCodecFactory(imagesScheme)
+)
+
+func init() {
+	if err := imagev1.AddToScheme(imagesScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadImageStreamV1OrDie(objBytes []byte) *imagev1.ImageStream {
+	requiredObj, err := runtime.Decode(imagesCodecs.UniversalDecoder(imagev1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*imagev1.ImageStream)
+}


### PR DESCRIPTION
operator/bootstrap: Accept new `--image-references` argument

The MCO orchestrates the management/setup of a big pile of different
containers today, from `machine-os-content` to `haproxy` and
configuring cri-o to use the correct `pause`/`pod` container.

These images get set up at both "bootstrap" time and cluster time.
In bootstrap today we manually scrape each image out of the CVO in
shell script, and then pass them as CLI arguments inside `bootkube.sh`.

This means adding new images requires a tedious "ratcheting" process
where the CLI argument is added to the MCO, then we patch the installer
to pass it in.

Instead, add a new CLI argument which accepts a serialized imagestream
object, which is exactly what the CVO carries.

Prep for adding a new `rhel-coreos` image into the payload, so I can
avoid that ratcheting process.

---

