### PR TITLE
update.go: refactor calculatePostConfigChangeAction() 

### DIFF
--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -17,14 +17,25 @@ type OperatingSystem struct {
 	VersionID string
 }
 
+var FCOS = OperatingSystem{
+	ID:        "fedora",
+	VariantID: "coreos",
+}
+
+var RHCOS = OperatingSystem{
+	ID: "rhcos",
+	// per https://github.com/openshift/os/commit/31f295e3362a6622749a64a6ff610b727560bda1
+	// there's no VARIANT_ID and confirmed by looking at /etc/os-release
+}
+
 // IsRHCOS is true if the OS is RHEL CoreOS
 func (os OperatingSystem) IsRHCOS() bool {
-	return os.ID == "rhcos"
+	return os.ID == RHCOS.ID
 }
 
 // IsFCOS is true if the OS is RHEL CoreOS
 func (os OperatingSystem) IsFCOS() bool {
-	return os.ID == "fedora" && os.VariantID == "coreos"
+	return os.ID == FCOS.ID && os.VariantID == FCOS.VariantID
 }
 
 // IsCoreOSVariant is true if the OS is FCOS or a derivative (ostree+Ignition)


### PR DESCRIPTION
    Currently, post config change actions are calculated as follows:
    1) Reboot if there's a force file
    2) Reboot if any MachineConfig fields change except for passwd
    3) Calculate an action based on file changes
    
    Layered updates will need to calculate post config change actions solely
    based on files, as they will be diffing two images. 1) and 3) can be
    consolidated into a single function that is shared between layered and
    legacy updates. All MachineConfig changes (2) will result in file
    changes on disk, which will cause a reboot if actions are calculated as
    normal. This is correct for any change except for changes to passwd,
    which currently do not require any post config change action. In order
    to preserve this behavior, add a reboot file exception for ssh keys,
    which is the only field the MCO supports modifying using passwd.

    Add some test cases to check that changes to ssh keys result in
    postConfigChangeActionNone when appropriate