### PR TITLE
bootstrap_test.go: remove unused constants

### DIFF
--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -42,11 +41,7 @@ const (
 	bootstrapTestName        = "BootstrapTest"
 	templatesDir             = "../../templates"
 	bootstrapTestDataDir     = "../../pkg/controller/bootstrap/testdata/bootstrap"
-	imagesFile               = "../../install/image-references"
 	openshiftConfigNamespace = "openshift-config"
-	componentNamespace       = "openshift-machine-config-operator"
-	pollInterval             = 200 * time.Millisecond
-	pollTimeout              = 30 * time.Second
 )
 
 var (


### PR DESCRIPTION
I came across these when working on https://github.com/openshift/machine-config-operator/pull/3020, and rather than replacing componentNamespace with the new constant, it looks like it's unused and should just be dropped. Couldn't find references to some of the other constants either