### PR TITLE
Remove runtime request timeout restriction

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -263,9 +263,6 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 	if len(kcDecoded.FeatureGates) > 0 {
 		return fmt.Errorf("KubeletConfiguration: featureGates is not allowed to be set, but contains: %v", kcDecoded.FeatureGates)
 	}
-	if kcDecoded.RuntimeRequestTimeout.Duration != 0 {
-		return fmt.Errorf("KubeletConfiguration: runtimeRequestTimeout is not allowed to be set, but contains: %s", kcDecoded.RuntimeRequestTimeout.Duration)
-	}
 	if kcDecoded.StaticPodPath != "" {
 		return fmt.Errorf("KubeletConfiguration: staticPodPath is not allowed to be set, but contains: %s", kcDecoded.StaticPodPath)
 	}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/golang/glog"
@@ -656,12 +655,6 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			name: "test banned clusterdomain",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				ClusterDomain: "some_value",
-			},
-		},
-		{
-			name: "test banned runtimerequesttimeout",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				RuntimeRequestTimeout: metav1.Duration{Duration: 1 * time.Minute},
 			},
 		},
 		{


### PR DESCRIPTION
Remove the restriction on the runtime-request-timeout
option in the kubeletconfig.

Epic for this https://issues.redhat.com/browse/OCPNODE-896

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Remove the restriction on the runtime-request-timeout option.

**- How to verify it**
Create a kubletconfig CR and modify the runtime-request-timeout option. Apply the kubeletconfig to the cluster and check the kubeletconfig file on the node to verify that the runtime-request-timeout was set to the value from the CR.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
