### PR TITLE
Fix description typo in osImageURL CRD parameter

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -337,5 +337,5 @@ spec:
                 type: string
               osImageURL:
                 description: OSImageURL specifies the remote location that will be used
-                  to fetch the OS to fetch the OS.
+                  to fetch the OS
                 type: string


### PR DESCRIPTION
Fix a typo in the description of osImageURL field of CRD