### PR TITLE
Bug 2066605: [on-prem] make Corefile api matching stricter

### DIFF
--- a/manifests/on-prem/coredns-corefile.tmpl
+++ b/manifests/on-prem/coredns-corefile.tmpl
@@ -16,21 +16,21 @@
         fallthrough
     }
     template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
-        match api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        match ^api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ onPremPlatformAPIServerInternalIP .ControllerConfig }}"
         fallthrough
     }
     template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
-        match api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        match ^api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
     template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
-        match api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        match ^api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ onPremPlatformAPIServerInternalIP .ControllerConfig }}"
         fallthrough
     }
     template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
-        match api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        match ^api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
 }

--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -21,21 +21,21 @@ contents:
             fallthrough
         }
         template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api.{{ .DNS.Spec.BaseDomain }}
+            match ^api.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ onPremPlatformAPIServerInternalIP . }}"
             fallthrough
         }
         template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api.{{ .DNS.Spec.BaseDomain }}
+            match ^api.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
         template IN {{`{{ .Cluster.APIVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api-int.{{ .DNS.Spec.BaseDomain }}
+            match ^api-int.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ onPremPlatformAPIServerInternalIP . }}"
             fallthrough
         }
         template IN {{`{{ .Cluster.APIVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match api-int.{{ .DNS.Spec.BaseDomain }}
+            match ^api-int.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
         hosts {


### PR DESCRIPTION
Closes: #2066605

**- What I did**
Make coredns template block more strict to match only exact "api.\<basedomain\>" and resolve the API address.

**- How to verify it**
Resolve a host matching ".*api.\<basedomain\>" from inside a pod. Only an exact match should resolve the API address.
e.g.:
`nslookup api.mycluster.tld` should resolve the API address
`nslookup myapi.mycluster.tld` should be resolved upstream

**- Description for the changelog**
make Corefile api matching stricter
