### PR TITLE
e2e: Use `/proc/cmdline` instead of `rpm-ostree kargs`

### DIFF
--- a/test/e2e-shared-tests/helpers.go
+++ b/test/e2e-shared-tests/helpers.go
@@ -34,7 +34,7 @@ func assertKernelArgsEqual(t *testing.T, cs *framework.ClientSet, target corev1.
 }
 
 func getKernelArgs(t *testing.T, cs *framework.ClientSet, target corev1.Node) string {
-	return helpers.ExecCmdOnNode(t, cs, target, "chroot", "/rootfs", "/usr/bin/rpm-ostree", "kargs")
+	return helpers.ExecCmdOnNode(t, cs, target, "cat", "/proc/cmdline")
 }
 
 func waitForConfigDriftMonitorStart(t *testing.T, cs *framework.ClientSet, node corev1.Node) {


### PR DESCRIPTION
The main motivation here is to work around
https://github.com/coreos/rpm-ostree/pull/3523
(Which is itself a workaround for a RHEL8 systemd bug)

Basically this e2e is invoking `rpm-ostree kargs` in a pretty
tight loop which triggers that bug.

To read the kernel command line, we can just read `/proc/cmdline`
instead.  (Now, this is the *actual* cmdline instead of just rpm-ostree's
view of it, but it should be fine)
