### PR TITLE
build-sys: Default to `make binaries`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ export GOLANGCI_LINT_CACHE=$(shell echo $${GOLANGCI_LINT_CACHE:-$$GOPATH/cache})
 
 GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 
+all: binaries
+
 .PHONY: clean test test-unit test-e2e verify update install-tools
 # Remove build artifaces
 # Example:


### PR DESCRIPTION
Today, typing `make` does nothing, which is not very useful.  By listing this rule first,
`make` will default to `make binaries`.
