### PR TITLE
daemon: completeUpdate -> uncordonAndUntaintNode 

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1997,7 +1997,7 @@ func (dn *Daemon) experimentalUpdateLayeredConfig() error {
 		glog.Infof("Node is on proper image %s", desiredImage)
 
 		glog.Infof("Completing pending config %s", currentImage)
-		if err := dn.completeUpdate(currentImage); err != nil {
+		if err := dn.uncordonAndUntaintNode(); err != nil {
 			MCDUpdateState.WithLabelValues("", err.Error()).SetToCurrentTime()
 
 		}


### PR DESCRIPTION
Based on the comment about state file which appears to be deprecated,
the purpose of this function has changed slightly, and it would be more
clear if the function name/comments/log messages were updated, since
"completeUpdate" is vague and doesn't actually explain what the function
does

At the same time, layered updates will use this function and the
deprecated language does not make sense for layered updates. Since
pending config only makes sense for a legacy update, pending config name
was removed from the function signature, which required dropping logging
the pending config name, but that log statement was redundant as the
pending config name is already logged immediately before this function
is called