### PR TITLE
[OCPNODE-553] Add CRD ImageDigestMirrorSet,ImageTagMirrorSet

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -146,6 +146,8 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 			ctx.ConfigInformerFactory.Config().V1().Images(),
+			ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
+			ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),
 			ctx.OperatorInformerFactory.Operator().V1alpha1().ImageContentSourcePolicies(),
 			ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 			ctx.ClientBuilder.KubeClientOrDie("container-runtime-config-controller"),

--- a/docs/MachineConfigDaemon.md
+++ b/docs/MachineConfigDaemon.md
@@ -168,8 +168,8 @@ The "Reload Crio" action performs the file write and runs a `systemctl reload cr
 
 1. Container signing GPG keys: these can be changed by pointing `/etc/containers/policy.json` to `/etc/machine-config-daemon/no-reboot/containers-gpg.pub` and storing keys in the latter file. Changes to either file trigger the "Reload Crio" action
 2. **Selected** `/etc/containers/registries.conf` changes: this file is generally changed via ICSP object changes. Only the following changes will avoid a drain:
-   - addition of a registry with `mirror-by-digest-only=true`
-   - addition of a mirror in a registry with `mirror-by-digest-only=true`
+   - addition of a registry with `pull-from-mirror=digest-only` for each mirror
+   - addition of a mirror with `pull-from-mirror=digest-only` in a registry
    - appending items in the `unqualified-search-registries` list
 
 ### With Drain

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/openshift/api v0.0.0-20221220162201-efeef9d83325
 	github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
 	github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865
-	github.com/openshift/runtime-utils v0.0.0-20220906151503-3beb0b584526
+	github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f
 	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1014,8 +1014,8 @@ github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q7
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
 github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865 h1:x7KWaYzkD2KQ3rha9u7OVAfjZpSFTmJRSHb4CHc+CwM=
 github.com/openshift/library-go v0.0.0-20220915130036-73d5a4a82865/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
-github.com/openshift/runtime-utils v0.0.0-20220906151503-3beb0b584526 h1:VZQXj1MoaqmmnP0lZvwNOK/c22I4+ZQufs0+dvYVUCg=
-github.com/openshift/runtime-utils v0.0.0-20220906151503-3beb0b584526/go.mod h1:Zc9dB7MrREj9MwD4znL6jSHLHyeOpG823a92IkLV3d4=
+github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f h1:ubRzazPtplWWNWWX07v4ww74S9QL+B2RAxHJ8O00m7o=
+github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
   resources: ["images", "clusterversions", "featuregates", "nodes", "nodes/status"]
   verbs: ["*"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["schedulers", "apiservers", "infrastructures"]
+  resources: ["schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["operator.openshift.io"]
   resources: ["imagecontentsourcepolicies"]

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -80,6 +80,8 @@ func (b *Bootstrap) Run(destDir string) error {
 	var configs []*mcfgv1.MachineConfig
 	var crconfigs []*mcfgv1.ContainerRuntimeConfig
 	var icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy
+	var idmsRules []*apicfgv1.ImageDigestMirrorSet
+	var itmsRules []*apicfgv1.ImageTagMirrorSet
 	var imgCfg *apicfgv1.Image
 	for _, info := range infos {
 		if info.IsDir() {
@@ -121,6 +123,10 @@ func (b *Bootstrap) Run(destDir string) error {
 				kconfigs = append(kconfigs, obj)
 			case *apioperatorsv1alpha1.ImageContentSourcePolicy:
 				icspRules = append(icspRules, obj)
+			case *apicfgv1.ImageDigestMirrorSet:
+				idmsRules = append(idmsRules, obj)
+			case *apicfgv1.ImageTagMirrorSet:
+				itmsRules = append(itmsRules, obj)
 			case *apicfgv1.Image:
 				imgCfg = obj
 			case *apicfgv1.FeatureGate:
@@ -146,7 +152,7 @@ func (b *Bootstrap) Run(destDir string) error {
 	}
 	configs = append(configs, iconfigs...)
 
-	rconfigs, err := containerruntimeconfig.RunImageBootstrap(b.templatesDir, cconfig, pools, icspRules, imgCfg)
+	rconfigs, err := containerruntimeconfig.RunImageBootstrap(b.templatesDir, cconfig, pools, icspRules, idmsRules, itmsRules, imgCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bootstrap/testdata/bootstrap/image-content-source-policy-0.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/image-content-source-policy-0.yaml
@@ -7,4 +7,4 @@ spec:
   repositoryDigestMirrors:
   - mirrors:
     - registry.mirror.example.com/ocp
-    source: registry.product.example.org/ocp/4.2-DATE-VERSION
+    source: registry.product.example.org/ocp/4.2-date-version

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -65,6 +65,8 @@ type fixture struct {
 	imgLister  []*apicfgv1.Image
 	cvLister   []*apicfgv1.ClusterVersion
 	icspLister []*apioperatorsv1alpha1.ImageContentSourcePolicy
+	idmsLister []*apicfgv1.ImageDigestMirrorSet
+	itmsLister []*apicfgv1.ImageTagMirrorSet
 
 	actions               []core.Action
 	skipActionsValidation bool
@@ -162,6 +164,26 @@ func newICSP(name string, mirrors []apioperatorsv1alpha1.RepositoryDigestMirrors
 	}
 }
 
+func newIDMS(name string, mirrors []apicfgv1.ImageDigestMirrors) *apicfgv1.ImageDigestMirrorSet {
+	return &apicfgv1.ImageDigestMirrorSet{
+		TypeMeta:   metav1.TypeMeta{APIVersion: apioperatorsv1alpha1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5)), Generation: 1},
+		Spec: apicfgv1.ImageDigestMirrorSetSpec{
+			ImageDigestMirrors: mirrors,
+		},
+	}
+}
+
+func newITMS(name string, mirrors []apicfgv1.ImageTagMirrors) *apicfgv1.ImageTagMirrorSet {
+	return &apicfgv1.ImageTagMirrorSet{
+		TypeMeta:   metav1.TypeMeta{APIVersion: apioperatorsv1alpha1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5)), Generation: 1},
+		Spec: apicfgv1.ImageTagMirrorSetSpec{
+			ImageTagMirrors: mirrors,
+		},
+	}
+}
+
 func newClusterVersionConfig(name, desiredImage string) *apicfgv1.ClusterVersion {
 	return &apicfgv1.ClusterVersion{
 		TypeMeta:   metav1.TypeMeta{APIVersion: apicfgv1.SchemeGroupVersion.String()},
@@ -187,6 +209,8 @@ func (f *fixture) newController() *Controller {
 		i.Machineconfiguration().V1().ControllerConfigs(),
 		i.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 		ci.Config().V1().Images(),
+		ci.Config().V1().ImageDigestMirrorSets(),
+		ci.Config().V1().ImageTagMirrorSets(),
 		oi.Operator().V1alpha1().ImageContentSourcePolicies(),
 		ci.Config().V1().ClusterVersions(),
 		k8sfake.NewSimpleClientset(), f.client, f.imgClient)
@@ -196,6 +220,8 @@ func (f *fixture) newController() *Controller {
 	c.ccListerSynced = alwaysReady
 	c.imgListerSynced = alwaysReady
 	c.icspListerSynced = alwaysReady
+	c.idmsListerSynced = alwaysReady
+	c.itmsListerSynced = alwaysReady
 	c.clusterVersionListerSynced = alwaysReady
 	c.eventRecorder = &record.FakeRecorder{}
 
@@ -225,6 +251,12 @@ func (f *fixture) newController() *Controller {
 	}
 	for _, c := range f.icspLister {
 		oi.Operator().V1alpha1().ImageContentSourcePolicies().Informer().GetIndexer().Add(c)
+	}
+	for _, c := range f.idmsLister {
+		ci.Config().V1().ImageDigestMirrorSets().Informer().GetIndexer().Add(c)
+	}
+	for _, c := range f.itmsLister {
+		ci.Config().V1().ImageTagMirrorSets().Informer().GetIndexer().Add(c)
 	}
 
 	return c
@@ -356,24 +388,32 @@ func (f *fixture) expectUpdateContainerRuntimeConfigRoot(config *mcfgv1.Containe
 	f.actions = append(f.actions, core.NewRootUpdateAction(schema.GroupVersionResource{Version: "v1", Group: "machineconfiguration.openshift.io", Resource: "containerruntimeconfigs"}, config))
 }
 
-func (f *fixture) verifyRegistriesConfigAndPolicyJSONContents(t *testing.T, mcName string, imgcfg *apicfgv1.Image, icsp *apioperatorsv1alpha1.ImageContentSourcePolicy, releaseImageReg string, verifyPolicyJSON, verifySearchRegsDropin bool) {
+func (f *fixture) verifyRegistriesConfigAndPolicyJSONContents(t *testing.T, mcName string, imgcfg *apicfgv1.Image, icsp *apioperatorsv1alpha1.ImageContentSourcePolicy, idms *apicfgv1.ImageDigestMirrorSet, itms *apicfgv1.ImageTagMirrorSet, releaseImageReg string, verifyPolicyJSON, verifySearchRegsDropin bool) {
 	icsps := []*apioperatorsv1alpha1.ImageContentSourcePolicy{}
 	if icsp != nil {
 		icsps = append(icsps, icsp)
 	}
+	idmss := []*apicfgv1.ImageDigestMirrorSet{}
+	if idms != nil {
+		idmss = append(idmss, idms)
+	}
+	itmss := []*apicfgv1.ImageTagMirrorSet{}
+	if itms != nil {
+		itmss = append(itmss, itms)
+	}
 	updatedMC, err := f.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mcName, metav1.GetOptions{})
 	require.NoError(t, err)
-	verifyRegistriesConfigAndPolicyJSONContents(t, updatedMC, mcName, imgcfg, icsps, releaseImageReg, verifyPolicyJSON, verifySearchRegsDropin)
+	verifyRegistriesConfigAndPolicyJSONContents(t, updatedMC, mcName, imgcfg, icsps, idmss, itmss, releaseImageReg, verifyPolicyJSON, verifySearchRegsDropin)
 }
 
-func verifyRegistriesConfigAndPolicyJSONContents(t *testing.T, mc *mcfgv1.MachineConfig, mcName string, imgcfg *apicfgv1.Image, icsps []*apioperatorsv1alpha1.ImageContentSourcePolicy, releaseImageReg string, verifyPolicyJSON, verifySearchRegsDropin bool) {
+func verifyRegistriesConfigAndPolicyJSONContents(t *testing.T, mc *mcfgv1.MachineConfig, mcName string, imgcfg *apicfgv1.Image, icsps []*apioperatorsv1alpha1.ImageContentSourcePolicy, idmss []*apicfgv1.ImageDigestMirrorSet, itmss []*apicfgv1.ImageTagMirrorSet, releaseImageReg string, verifyPolicyJSON, verifySearchRegsDropin bool) {
 	// This is not testing updateRegistriesConfig, which has its own tests; this verifies the created object contains the expected
 	// configuration file.
 	// First get the valid blocked registries to ensure we don't block the registry where the release image is from
-	registriesBlocked, policyBlocked, allowed, _ := getValidBlockedAndAllowedRegistries(releaseImageReg, &imgcfg.Spec, icsps)
+	registriesBlocked, policyBlocked, allowed, _ := getValidBlockedAndAllowedRegistries(releaseImageReg, &imgcfg.Spec, icsps, idmss)
 	expectedRegistriesConf, err := updateRegistriesConfig(templateRegistriesConfig,
 		imgcfg.Spec.RegistrySources.InsecureRegistries,
-		registriesBlocked, icsps)
+		registriesBlocked, icsps, idmss, itmss)
 	require.NoError(t, err)
 	assert.Equal(t, mcName, mc.ObjectMeta.Name)
 
@@ -585,7 +625,7 @@ func TestImageConfigCreate(t *testing.T) {
 			f.run("cluster")
 
 			for _, mcName := range []string{mcs1.Name, mcs2.Name} {
-				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, cc.Spec.ReleaseImage, true, true)
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, nil, nil, cc.Spec.ReleaseImage, true, true)
 			}
 		})
 	}
@@ -640,7 +680,7 @@ func TestImageConfigUpdate(t *testing.T) {
 			close(stopCh)
 
 			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
-				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, cc.Spec.ReleaseImage, true, true)
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, nil, nil, cc.Spec.ReleaseImage, true, true)
 			}
 
 			// Perform Update
@@ -681,7 +721,7 @@ func TestImageConfigUpdate(t *testing.T) {
 			close(stopCh)
 
 			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
-				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfgUpdate, nil, cc.Spec.ReleaseImage, true, true)
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfgUpdate, nil, nil, nil, cc.Spec.ReleaseImage, true, true)
 			}
 		})
 	}
@@ -741,7 +781,7 @@ func TestICSPUpdate(t *testing.T) {
 			close(stopCh)
 
 			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
-				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, icsp, cc.Spec.ReleaseImage, false, false)
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, icsp, nil, nil, cc.Spec.ReleaseImage, false, false)
 			}
 
 			// Perform Update
@@ -786,7 +826,213 @@ func TestICSPUpdate(t *testing.T) {
 			close(stopCh)
 
 			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
-				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, icspUpdate, cc.Spec.ReleaseImage, false, false)
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, icspUpdate, nil, nil, cc.Spec.ReleaseImage, false, false)
+			}
+		})
+	}
+}
+
+func TestIDMSUpdate(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			imgcfg1 := newImageConfig("cluster", &apicfgv1.RegistrySources{InsecureRegistries: []string{"blah.io"}})
+			cvcfg1 := newClusterVersionConfig("version", "test.io/myuser/myimage:test")
+			keyReg1, _ := getManagedKeyReg(mcp, nil)
+			keyReg2, _ := getManagedKeyReg(mcp2, nil)
+			mcs1 := helpers.NewMachineConfig(getManagedKeyRegDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
+			mcs2 := helpers.NewMachineConfig(getManagedKeyRegDeprecated(mcp2), map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
+			idms := newIDMS("built-in", []apicfgv1.ImageDigestMirrors{
+				{Source: "built-in-source.example.com", Mirrors: []apicfgv1.ImageMirror{"built-in-mirror.example.com"}},
+			})
+			mcs1Update := mcs1.DeepCopy()
+			mcs2Update := mcs2.DeepCopy()
+			mcs1Update.Name = keyReg1
+			mcs2Update.Name = keyReg2
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+			f.mcpLister = append(f.mcpLister, mcp2)
+			f.imgLister = append(f.imgLister, imgcfg1)
+			f.idmsLister = append(f.idmsLister, idms)
+			f.cvLister = append(f.cvLister, cvcfg1)
+			f.imgObjects = append(f.imgObjects, imgcfg1)
+			f.operatorObjects = append(f.operatorObjects, idms)
+
+			f.expectGetMachineConfigAction(mcs1Update)
+			f.expectGetMachineConfigAction(mcs1)
+			f.expectGetMachineConfigAction(mcs1)
+			f.expectCreateMachineConfigAction(mcs1)
+			f.expectGetMachineConfigAction(mcs2Update)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectCreateMachineConfigAction(mcs2)
+
+			c := f.newController()
+			stopCh := make(chan struct{})
+
+			err := c.syncImgHandler("cluster")
+			if err != nil {
+				t.Errorf("syncImgHandler returned %v", err)
+			}
+
+			f.validateActions()
+			close(stopCh)
+
+			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, idms, nil, cc.Spec.ReleaseImage, false, false)
+			}
+
+			// Perform Update
+			f = newFixture(t)
+
+			// Modify IDMS
+			idmsUpdate := idms.DeepCopy()
+			idmsUpdate.Spec.ImageDigestMirrors = append(idmsUpdate.Spec.ImageDigestMirrors, apicfgv1.ImageDigestMirrors{
+				Source: "built-in-source.example.com", Mirrors: []apicfgv1.ImageMirror{"local-mirror.local"},
+			})
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+			f.mcpLister = append(f.mcpLister, mcp2)
+			f.imgLister = append(f.imgLister, imgcfg1)
+			f.idmsLister = append(f.idmsLister, idmsUpdate)
+			f.cvLister = append(f.cvLister, cvcfg1)
+			f.objects = append(f.objects, mcs1Update, mcs2Update)
+			f.imgObjects = append(f.imgObjects, imgcfg1)
+			f.operatorObjects = append(f.operatorObjects, idmsUpdate)
+
+			c = f.newController()
+			stopCh = make(chan struct{})
+
+			glog.Info("Applying update")
+
+			// Apply update
+			err = c.syncImgHandler("")
+			if err != nil {
+				t.Errorf("syncImgHandler returned: %v", err)
+			}
+
+			f.expectGetMachineConfigAction(mcs1Update)
+			f.expectGetMachineConfigAction(mcs1Update)
+			f.expectUpdateMachineConfigAction(mcs1Update)
+			f.expectGetMachineConfigAction(mcs2Update)
+			f.expectGetMachineConfigAction(mcs2Update)
+			f.expectUpdateMachineConfigAction(mcs2Update)
+
+			f.validateActions()
+
+			close(stopCh)
+
+			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, idmsUpdate, nil, cc.Spec.ReleaseImage, false, false)
+			}
+		})
+	}
+}
+
+func TestITMSUpdate(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			imgcfg1 := newImageConfig("cluster", &apicfgv1.RegistrySources{InsecureRegistries: []string{"blah.io"}})
+			cvcfg1 := newClusterVersionConfig("version", "test.io/myuser/myimage:test")
+			keyReg1, _ := getManagedKeyReg(mcp, nil)
+			keyReg2, _ := getManagedKeyReg(mcp2, nil)
+			mcs1 := helpers.NewMachineConfig(getManagedKeyRegDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
+			mcs2 := helpers.NewMachineConfig(getManagedKeyRegDeprecated(mcp2), map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
+			itms := newITMS("built-in", []apicfgv1.ImageTagMirrors{
+				{Source: "built-in-source.example.com", Mirrors: []apicfgv1.ImageMirror{"built-in-mirror.example.com"}},
+			})
+			mcs1Update := mcs1.DeepCopy()
+			mcs2Update := mcs2.DeepCopy()
+			mcs1Update.Name = keyReg1
+			mcs2Update.Name = keyReg2
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+			f.mcpLister = append(f.mcpLister, mcp2)
+			f.imgLister = append(f.imgLister, imgcfg1)
+			f.itmsLister = append(f.itmsLister, itms)
+			f.cvLister = append(f.cvLister, cvcfg1)
+			f.imgObjects = append(f.imgObjects, imgcfg1)
+			f.operatorObjects = append(f.operatorObjects, itms)
+
+			f.expectGetMachineConfigAction(mcs1Update)
+			f.expectGetMachineConfigAction(mcs1)
+			f.expectGetMachineConfigAction(mcs1)
+			f.expectCreateMachineConfigAction(mcs1)
+			f.expectGetMachineConfigAction(mcs2Update)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2)
+			f.expectCreateMachineConfigAction(mcs2)
+
+			c := f.newController()
+			stopCh := make(chan struct{})
+
+			err := c.syncImgHandler("cluster")
+			if err != nil {
+				t.Errorf("syncImgHandler returned %v", err)
+			}
+
+			f.validateActions()
+			close(stopCh)
+
+			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, nil, itms, cc.Spec.ReleaseImage, false, false)
+			}
+
+			// Perform Update
+			f = newFixture(t)
+
+			// Modify ITMS
+			itmsUpdate := itms.DeepCopy()
+			itmsUpdate.Spec.ImageTagMirrors = append(itmsUpdate.Spec.ImageTagMirrors, apicfgv1.ImageTagMirrors{
+				Source: "built-in-source.example.com", Mirrors: []apicfgv1.ImageMirror{"local-mirror.local"},
+			})
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+			f.mcpLister = append(f.mcpLister, mcp2)
+			f.imgLister = append(f.imgLister, imgcfg1)
+			f.itmsLister = append(f.itmsLister, itmsUpdate)
+			f.cvLister = append(f.cvLister, cvcfg1)
+			f.objects = append(f.objects, mcs1Update, mcs2Update)
+			f.imgObjects = append(f.imgObjects, imgcfg1)
+			f.operatorObjects = append(f.operatorObjects, itmsUpdate)
+
+			c = f.newController()
+			stopCh = make(chan struct{})
+
+			glog.Info("Applying update")
+
+			// Apply update
+			err = c.syncImgHandler("")
+			if err != nil {
+				t.Errorf("syncImgHandler returned: %v", err)
+			}
+
+			f.expectGetMachineConfigAction(mcs1Update)
+			f.expectGetMachineConfigAction(mcs1Update)
+			f.expectUpdateMachineConfigAction(mcs1Update)
+			f.expectGetMachineConfigAction(mcs2Update)
+			f.expectGetMachineConfigAction(mcs2Update)
+			f.expectUpdateMachineConfigAction(mcs2Update)
+
+			f.validateActions()
+
+			close(stopCh)
+
+			for _, mcName := range []string{mcs1Update.Name, mcs2Update.Name} {
+				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, nil, itmsUpdate, cc.Spec.ReleaseImage, false, false)
 			}
 		})
 	}
@@ -794,31 +1040,53 @@ func TestICSPUpdate(t *testing.T) {
 
 func TestRunImageBootstrap(t *testing.T) {
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
-		t.Run(string(platform), func(t *testing.T) {
-			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
-			pools := []*mcfgv1.MachineConfigPool{
-				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
-				helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0"),
-			}
-			icspRules := []*apioperatorsv1alpha1.ImageContentSourcePolicy{
-				newICSP("built-in", []apioperatorsv1alpha1.RepositoryDigestMirrors{
-					{Source: "built-in-source.example.com", Mirrors: []string{"built-in-mirror.example.com"}},
-					{Source: "built-in-source.example.com", Mirrors: []string{"local-mirror.local"}},
-				}),
-			}
-			// Adding the release-image registry "release-reg.io" to the list of blocked registries to ensure that is it not added to
-			// both registries.conf and policy.json as blocked
-			imgCfg := newImageConfig("cluster", &apicfgv1.RegistrySources{InsecureRegistries: []string{"insecure-reg-1.io", "insecure-reg-2.io"}, BlockedRegistries: []string{"blocked-reg.io", "release-reg.io"}, ContainerRuntimeSearchRegistries: []string{"search-reg.io"}})
+		for _, tc := range []struct {
+			icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy
+			idmsRules []*apicfgv1.ImageDigestMirrorSet
+			itmsRules []*apicfgv1.ImageTagMirrorSet
+		}{
+			{
+				icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+					newICSP("built-in", []apioperatorsv1alpha1.RepositoryDigestMirrors{
+						{Source: "built-in-source.example.com", Mirrors: []string{"built-in-mirror.example.com"}},
+						{Source: "built-in-source.example.com", Mirrors: []string{"local-mirror.local"}},
+					}),
+				},
+			},
+			{
+				idmsRules: []*apicfgv1.ImageDigestMirrorSet{
+					newIDMS("idms-1", []apicfgv1.ImageDigestMirrors{
+						{Source: "source.example.com", Mirrors: []apicfgv1.ImageMirror{"mirror.example.com"}},
+					}),
+				},
+				itmsRules: []*apicfgv1.ImageTagMirrorSet{
+					newITMS("itms-1", []apicfgv1.ImageTagMirrors{
+						{Source: "source.example.com", Mirrors: []apicfgv1.ImageMirror{"local.mirrorexample"}},
+					}),
+				},
+			},
+		} {
 
-			mcs, err := RunImageBootstrap("../../../templates", cc, pools, icspRules, imgCfg)
-			require.NoError(t, err)
-			require.Len(t, mcs, len(pools))
+			t.Run(string(platform), func(t *testing.T) {
+				cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+				pools := []*mcfgv1.MachineConfigPool{
+					helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
+					helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0"),
+				}
+				// Adding the release-image registry "release-reg.io" to the list of blocked registries to ensure that is it not added to
+				// both registries.conf and policy.json as blocked
+				imgCfg := newImageConfig("cluster", &apicfgv1.RegistrySources{InsecureRegistries: []string{"insecure-reg-1.io", "insecure-reg-2.io"}, BlockedRegistries: []string{"blocked-reg.io", "release-reg.io"}, ContainerRuntimeSearchRegistries: []string{"search-reg.io"}})
 
-			for i := range pools {
-				keyReg, _ := getManagedKeyReg(pools[i], nil)
-				verifyRegistriesConfigAndPolicyJSONContents(t, mcs[i], keyReg, imgCfg, icspRules, cc.Spec.ReleaseImage, true, true)
-			}
-		})
+				mcs, err := RunImageBootstrap("../../../templates", cc, pools, tc.icspRules, tc.idmsRules, tc.itmsRules, imgCfg)
+				require.NoError(t, err)
+				require.Len(t, mcs, len(pools))
+
+				for i := range pools {
+					keyReg, _ := getManagedKeyReg(pools[i], nil)
+					verifyRegistriesConfigAndPolicyJSONContents(t, mcs[i], keyReg, imgCfg, tc.icspRules, tc.idmsRules, tc.itmsRules, cc.Spec.ReleaseImage, true, true)
+				}
+			})
+		}
 	}
 }
 
@@ -828,7 +1096,7 @@ func TestRegistriesValidation(t *testing.T) {
 	failureTests := []struct {
 		name      string
 		config    *apicfgv1.RegistrySources
-		icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy
+		idmsRules []*apicfgv1.ImageDigestMirrorSet
 	}{
 		{
 			name: "adding registry used by payload to blocked registries",
@@ -843,11 +1111,11 @@ func TestRegistriesValidation(t *testing.T) {
 				BlockedRegistries:  []string{"blah.io", "docker.io"},
 				InsecureRegistries: []string{"test.io"},
 			},
-			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+			idmsRules: []*apicfgv1.ImageDigestMirrorSet{
 				{
-					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
-						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{
-							{Source: "blah.io/myuser", Mirrors: []string{"mirror-1.io/myuser", "mirror-2.io/myuser"}},
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{Source: "blah.io/myuser", Mirrors: []apicfgv1.ImageMirror{"mirror-1.io/myuser", "mirror-2.io/myuser"}},
 						},
 					},
 				},
@@ -859,7 +1127,7 @@ func TestRegistriesValidation(t *testing.T) {
 		name                                                              string
 		expectedRegistriesBlocked, expectedPolicyBlocked, expectedAllowed []string
 		config                                                            *apicfgv1.RegistrySources
-		icspRules                                                         []*apioperatorsv1alpha1.ImageContentSourcePolicy
+		idmsRules                                                         []*apicfgv1.ImageDigestMirrorSet
 	}{
 		{
 			name: "adding registry used by payload to insecure registries",
@@ -876,11 +1144,11 @@ func TestRegistriesValidation(t *testing.T) {
 				BlockedRegistries:  []string{"blah.io", "docker.io"},
 				InsecureRegistries: []string{"test.io"},
 			},
-			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+			idmsRules: []*apicfgv1.ImageDigestMirrorSet{
 				{
-					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
-						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{
-							{Source: "blah.io/payload", Mirrors: []string{"mirror-1.io/payload", "mirror-2.io/payload"}},
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{Source: "blah.io/payload", Mirrors: []apicfgv1.ImageMirror{"mirror-1.io/payload", "mirror-2.io/payload"}},
 						},
 					},
 				},
@@ -895,11 +1163,11 @@ func TestRegistriesValidation(t *testing.T) {
 				BlockedRegistries:  []string{"blah.io/payload", "docker.io"},
 				InsecureRegistries: []string{"test.io"},
 			},
-			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+			idmsRules: []*apicfgv1.ImageDigestMirrorSet{
 				{
-					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
-						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{
-							{Source: "blah.io", Mirrors: []string{"mirror-1.io", "mirror-2.io"}},
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{
+							{Source: "blah.io", Mirrors: []apicfgv1.ImageMirror{"mirror-1.io", "mirror-2.io"}},
 						},
 					},
 				},
@@ -914,7 +1182,7 @@ func TestRegistriesValidation(t *testing.T) {
 	for _, test := range failureTests {
 		imgcfg := newImageConfig(test.name, test.config)
 		cvcfg := newClusterVersionConfig("version", "blah.io/payload/myimage@sha256:4207ba569ff014931f1b5d125fe3751936a768e119546683c899eb09f3cdceb0")
-		registriesBlocked, _, _, err := getValidBlockedAndAllowedRegistries(cvcfg.Status.Desired.Image, &imgcfg.Spec, test.icspRules)
+		registriesBlocked, _, _, err := getValidBlockedAndAllowedRegistries(cvcfg.Status.Desired.Image, &imgcfg.Spec, nil, test.idmsRules)
 		if err == nil {
 			t.Errorf("%s: failed", test.name)
 		}
@@ -929,7 +1197,7 @@ func TestRegistriesValidation(t *testing.T) {
 	for _, test := range successTests {
 		imgcfg := newImageConfig(test.name, test.config)
 		cvcfg := newClusterVersionConfig("version", "blah.io/payload/myimage@sha256:4207ba569ff014931f1b5d125fe3751936a768e119546683c899eb09f3cdceb0")
-		registriesBlocked, policyBlocked, allowed, err := getValidBlockedAndAllowedRegistries(cvcfg.Status.Desired.Image, &imgcfg.Spec, test.icspRules)
+		registriesBlocked, policyBlocked, allowed, err := getValidBlockedAndAllowedRegistries(cvcfg.Status.Desired.Image, &imgcfg.Spec, nil, test.idmsRules)
 		if err != nil {
 			t.Errorf("%s: failed", test.name)
 		}

--- a/pkg/daemon/drain_test.go
+++ b/pkg/daemon/drain_test.go
@@ -26,7 +26,6 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
   prefix = ""
   location = "example.com/repo/test-img"
-  mirror-by-digest-only = true
 
   [[registry.mirror]]
     location = "mirror.com/repo/test-img"
@@ -34,10 +33,10 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
   prefix = ""
   location = "example.com/repo1/test-img1"
-  mirror-by-digest-only = true
 
   [[registry.mirror]]
     location = "mirror.com/repo1/test-img1"
+	pull-from-mirror= "digest-only"				
 `))),
 				},
 			},
@@ -55,7 +54,6 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
 prefix = ""
 location = "example.com/repo/test-img"
-mirror-by-digest-only = true
 
 [[registry.mirror]]
 	location = "mirror.com/repo/test-img"
@@ -63,13 +61,14 @@ mirror-by-digest-only = true
 [[registry]]
 prefix = ""
 location = "example.com/repo1/test-img1"
-mirror-by-digest-only = true
 
 [[registry.mirror]]
 	location = "mirror.com/repo1/test-img1"
+	pull-from-mirror = "digest-only"
 
 [[registry.mirror]]
 	location = "mirror1.com/repo1/test-img1"
+	pull-from-mirror = "digest-only"
 `))),
 				},
 			},
@@ -87,7 +86,6 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
 	prefix = ""
 	location = "example.com/repo/test-img"
-	mirror-by-digest-only = true
 
 	[[registry.mirror]]
 	location = "mirror.com/repo/test-img"
@@ -108,10 +106,10 @@ unqualified-search-registries = ["example.com", "foo.com", "bar.com"]
 [[registry]]
 	prefix = ""
 	location = "example.com/repo/test-img"
-	mirror-by-digest-only = true
 
 	[[registry.mirror]]
 	location = "mirror.com/repo/test-img"
+	pull-from-mirror = "digest-only"
 `))),
 				},
 			},
@@ -129,10 +127,10 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
 	prefix = ""
 	location = "example.com/repo/test-img"
-	mirror-by-digest-only = true
 
 	[[registry.mirror]]
 	location = "mirror.com/repo/test-img"
+	pull-from-mirror = "digest-only"
 `))),
 				},
 			},
@@ -150,15 +148,14 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
 prefix = ""
 location = "example.com/repo/test-img"
-mirror-by-digest-only = true
 
 [[registry.mirror]]
 location = "mirror.com/repo/test-img"
+pull-from-mirror = "digest-only"
 
 [[registry]]
 prefix = ""
 location = "example.com/repo1/test-img1"
-mirror-by-digest-only = false
 `))),
 				},
 			},
@@ -176,15 +173,17 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
 prefix = ""
 location = "example.com/repo/test-img"
-mirror-by-digest-only = true
+
+[[registry.mirror]]
+location = "mirror.com/repo/test-img"
+pull-from-mirror= "digest-only"
 
 [[registry]]
 prefix = ""
 location = "example.com/repo1/test-img1"
-mirror-by-digest-only = false
 
 [[registry.mirror]]
-location = "mirror.com/repo/test-img"
+location = "mirror.com/repo1/test-img1"
 `))),
 				},
 			},
@@ -251,15 +250,86 @@ unqualified-search-registries = ["example.com", "foo.com"]
 [[registry]]
 prefix = ""
 location = "example.com/repo1/test-img"
-mirror-by-digest-only = true
 
 [[registry.mirror]]
 location = "mirror.com/repo1/test-img"
+pull-from-mirror= "digest-only"
 
 [[registry]]
 prefix = "bar.com"
 location = "example.com/repo/test-img"
 blocked = true
+`))),
+				},
+			},
+		}}),
+		"mc12": helpers.NewMachineConfig("12-test", nil, "dummy://", []ign3types.File{{
+			Node: ign3types.Node{
+				Path: "/etc/containers/registries.conf",
+			},
+			FileEmbedded1: ign3types.FileEmbedded1{
+				Contents: ign3types.Resource{
+					Source: helpers.StrToPtr(dataurl.EncodeBytes([]byte(`
+unqualified-search-registries = ["example.com", "foo.com"]
+
+[[registry]]
+prefix = ""
+location = "example.com/repo/test-img"
+mirror-by-digest-only = true
+
+[[registry.mirror]]
+location = "mirror.com/repo/test-img"
+`))),
+				},
+			},
+		}}),
+		"mc13": helpers.NewMachineConfig("13-test", nil, "dummy://", []ign3types.File{{
+			Node: ign3types.Node{
+				Path: "/etc/containers/registries.conf",
+			},
+			FileEmbedded1: ign3types.FileEmbedded1{
+				Contents: ign3types.Resource{
+					Source: helpers.StrToPtr(dataurl.EncodeBytes([]byte(`
+unqualified-search-registries = ["example.com", "foo.com"]
+
+[[registry]]
+prefix = ""
+location = "example.com/repo/test-img"
+mirror-by-digest-only = true
+
+[[registry.mirror]]
+location = "mirror.com/repo/test-img"
+[[registry.mirror]]
+location = "mirror.com/repo/test-img-13"
+`))),
+				},
+			},
+		}}),
+		"mc14": helpers.NewMachineConfig("14-test", nil, "dummy://", []ign3types.File{{
+			Node: ign3types.Node{
+				Path: "/etc/containers/registries.conf",
+			},
+			FileEmbedded1: ign3types.FileEmbedded1{
+				Contents: ign3types.Resource{
+					Source: helpers.StrToPtr(dataurl.EncodeBytes([]byte(`
+unqualified-search-registries = ["example.com", "foo.com"]
+
+[[registry]]
+prefix = ""
+location = "example.com/repo/test-img"
+mirror-by-digest-only = true
+
+[[registry.mirror]]
+location = "mirror.com/repo/test-img"
+
+[[registry]]
+prefix = ""
+location = "example.com/repo/test-img-14"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "mirror.com/repo/test-img-14"
+
 `))),
 				},
 			},
@@ -295,7 +365,7 @@ blocked = true
 			expectedAction: false,
 		},
 		{
-			// skip drain: only new registry added with mirror-by-digest-only set to true
+			// skip drain: only new registry added with pull-from-mirror=digest-only
 			actions:        []string{postConfigChangeActionReloadCrio},
 			oldConfig:      machineConfigs["mc3"],
 			newConfig:      machineConfigs["mc1"],
@@ -316,14 +386,14 @@ blocked = true
 			expectedAction: true,
 		},
 		{
-			// skip drain: only new mirrors got added to the registry with mirror-by-digest-only set to true for registry
+			// skip drain: only new mirrors got added to the registry with pull-from-mirror=digest-only
 			actions:        []string{postConfigChangeActionReloadCrio},
 			oldConfig:      machineConfigs["mc1"],
 			newConfig:      machineConfigs["mc2"],
 			expectedAction: false,
 		},
 		{
-			// skip drain: only new mirrors are added to registry with mirror-by-digest-only=true while existing registries with mirror-by-digest-only=false are unchanged
+			// skip drain: only new mirrors are added to registry with pull-from-mirror=digest-only while existing registries with mirror-by-digest-only=false are unchanged
 			actions:        []string{postConfigChangeActionReloadCrio},
 			oldConfig:      machineConfigs["mc9"],
 			newConfig:      machineConfigs["mc11"],
@@ -377,6 +447,13 @@ blocked = true
 			oldConfig:      machineConfigs["mc1"],
 			newConfig:      machineConfigs["mc6"],
 			expectedAction: true,
+		},
+		{
+			// skip drain: only new mirror added to registry with mirror-by-digest-only set to true
+			actions:        []string{postConfigChangeActionReloadCrio},
+			oldConfig:      machineConfigs["mc12"],
+			newConfig:      machineConfigs["mc13"],
+			expectedAction: false,
 		},
 	}
 

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -429,6 +429,8 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 			ctx.ConfigInformerFactory.Config().V1().Images(),
+			ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
+			ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),
 			ctx.OperatorInformerFactory.Operator().V1alpha1().ImageContentSourcePolicies(),
 			ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 			ctx.ClientBuilder.KubeClientOrDie("container-runtime-config-controller"),

--- a/vendor/github.com/openshift/runtime-utils/pkg/registries/registries.go
+++ b/vendor/github.com/openshift/runtime-utils/pkg/registries/registries.go
@@ -248,7 +248,6 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 			// So, if there is any mirror defined for a more specific sub-scope of mirrorSet.Source,
 			// it must already exist with non-empty reg.Mirrors.
 			if scope != mirroredScope && ScopeIsNestedInsideScope(scope, mirroredScope) && len(reg.Mirrors) == 0 {
-				reg.MirrorByDigestOnly = mirroredReg.MirrorByDigestOnly
 				updated, err := mirrorsAdjustedForNestedScope(mirroredScope, scope, mirroredReg.Mirrors)
 				if err != nil {
 					return err
@@ -277,4 +276,17 @@ func IsValidRegistriesConfScope(scope string) bool {
 		return true
 	}
 	return false
+}
+
+// RejectMultiUpdateMirrorSetObjs returns error if icsp objects exist with imagedigestmirrorset or imagetagmirrorset objects
+// to avoid existing mirror settings get updated by others
+func RejectMultiUpdateMirrorSetObjs(icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy,
+	idmsRules []*apicfgv1.ImageDigestMirrorSet, itmsRules []*apicfgv1.ImageTagMirrorSet) error {
+	if len(icspRules) > 0 && len(idmsRules) > 0 {
+		return fmt.Errorf("error: both imagecontentsourcepolicy and imagedigestmirrorset exist")
+	}
+	if len(icspRules) > 0 && len(itmsRules) > 0 {
+		return fmt.Errorf("error: both imagecontentsourcepolicy and imagetagmirrorset exist")
+	}
+	return nil
 }

--- a/vendor/github.com/openshift/runtime-utils/pkg/registries/registries.go
+++ b/vendor/github.com/openshift/runtime-utils/pkg/registries/registries.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
+	apicfgv1 "github.com/openshift/api/config/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 )
 
@@ -35,79 +36,157 @@ func ScopeIsNestedInsideScope(subScope, superScope string) bool {
 	return match
 }
 
-// rdmContainsARealMirror returns true if set.Mirrors contains at least one entry that is not set.Source.
-func rdmContainsARealMirror(set *apioperatorsv1alpha1.RepositoryDigestMirrors) bool {
-	for _, mirror := range set.Mirrors {
-		if mirror != set.Source {
+// mirrorsContainsARealMirror returns true if mirrors contains at least one entry that is not source.
+func mirrorsContainsARealMirror(source string, mirrors []apicfgv1.ImageMirror) bool {
+	for _, mirror := range mirrors {
+		if string(mirror) != source {
 			return true
 		}
 	}
 	return false
 }
 
-// mergedMirrorSets processes icspRules and returns a set of RepositoryDigestMirrors, one for each Source value,
-// ordered consistently with the preference order of the individual entries (if possible)
-// E.g. given mirror sets (B, C) and (A, B), it will combine them into a single (A, B, C) set.
-func mergedMirrorSets(icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy) ([]apioperatorsv1alpha1.RepositoryDigestMirrors, error) {
-	disjointSets := map[string]*[]*apioperatorsv1alpha1.RepositoryDigestMirrors{} // Key == Source
-	for _, icsp := range icspRules {
-		for i := range icsp.Spec.RepositoryDigestMirrors {
-			set := &icsp.Spec.RepositoryDigestMirrors[i]
-			if !rdmContainsARealMirror(set) {
-				continue // No mirrors (or mirrors that only repeat the authoritative source) is not really a mirror set.
-			}
-			ds, ok := disjointSets[set.Source]
-			if !ok {
-				ds = &[]*apioperatorsv1alpha1.RepositoryDigestMirrors{}
-				disjointSets[set.Source] = ds
-			}
-			*ds = append(*ds, set)
+// mirrorSet collects data from mirror setting CRDs (ImageDigestMirrorSet, ImageTagMirrorSet)
+type mirrorSets struct {
+	disjointSets      map[string]*[][]string // Key == Source
+	mirrorBlockSource map[string]bool        // key == Source
+}
+
+func newMirrorSets() *mirrorSets {
+	return &mirrorSets{
+		disjointSets:      map[string]*[][]string{},
+		mirrorBlockSource: map[string]bool{},
+	}
+}
+
+func (sets *mirrorSets) addMirrorSet(source string, mirrorSourcePolicy apicfgv1.MirrorSourcePolicy, mirrors []apicfgv1.ImageMirror) {
+	if !mirrorsContainsARealMirror(source, mirrors) {
+		return // No mirrors (or mirrors that only repeat the authoritative source) is not really a mirror set. Ignore mirrorSourcePolicy intentionally.
+	}
+	strMirrors := []string{}
+	for _, m := range mirrors {
+		strMirrors = append(strMirrors, (string(m)))
+	}
+	if mirrorSourcePolicy == apicfgv1.NeverContactSource {
+		sets.mirrorBlockSource[source] = true
+	}
+	ds, ok := sets.disjointSets[source]
+	if !ok {
+		ds = &[][]string{}
+		sets.disjointSets[source] = ds
+	}
+	*ds = append(*ds, strMirrors)
+}
+
+// mergedMirrors generates deterministic order of mirrors for a given source
+func (sets *mirrorSets) mergedMirrors(source string) ([]string, error) {
+	topoGraph := newTopoGraph()
+	for _, mirrors := range *sets.disjointSets[source] {
+		for i := 0; i+1 < len(mirrors); i++ {
+			topoGraph.AddEdge(mirrors[i], mirrors[i+1])
 		}
+		sourceInGraph := false
+		for _, m := range mirrors {
+			if m == source {
+				sourceInGraph = true
+				break
+			}
+		}
+		if !sourceInGraph {
+			// mirrorSets.addMirrorSet guarantees len(set.Mirrors) > 0.
+			topoGraph.AddEdge(mirrors[len(mirrors)-1], source)
+		}
+		// Every node in topoGraph, including source, is implicitly added by topoGraph.AddEdge (every mirror set contains at least one non-source mirror,
+		// so there are no unconnected nodes that we would have to add separately from the edges).
+	}
+	sortedRepos, err := topoGraph.Sorted()
+	if err != nil {
+		return nil, err
+	}
+	if sortedRepos[len(sortedRepos)-1] == source {
+		// We don't need to explicitly include source in the list, it will be automatically tried last per the semantics of sysregistriesv2. Mirrors.
+		sortedRepos = sortedRepos[:len(sortedRepos)-1]
 	}
 
+	if err != nil {
+		return nil, err
+	}
+	return sortedRepos, nil
+}
+
+type mergedMirrorSet struct {
+	source             string
+	mirrors            []string
+	mirrorSourcePolicy apicfgv1.MirrorSourcePolicy
+}
+
+// mergedMirrorSets converts the set of mirrors to slice of mergedMirrorSet
+func mergedMirrorSets(sets *mirrorSets) ([]mergedMirrorSet, error) {
 	// Sort the sets of mirrors by Source to ensure deterministic output
 	sources := []string{}
-	for key := range disjointSets {
+	for key := range sets.disjointSets {
 		sources = append(sources, key)
 	}
+	// collects the mirror sources and sorted in increasing order
 	sort.Strings(sources)
 	// Convert the sets of mirrors
-	res := []apioperatorsv1alpha1.RepositoryDigestMirrors{}
+	res := []mergedMirrorSet{}
 	for _, source := range sources {
-		ds := disjointSets[source]
-		topoGraph := newTopoGraph()
-		for _, set := range *ds {
-			for i := 0; i+1 < len(set.Mirrors); i++ {
-				topoGraph.AddEdge(set.Mirrors[i], set.Mirrors[i+1])
-			}
-			sourceInGraph := false
-			for _, m := range set.Mirrors {
-				if m == source {
-					sourceInGraph = true
-					break
-				}
-			}
-			if !sourceInGraph {
-				// The build of mirrorSets guarantees len(set.Mirrors) > 0.
-				topoGraph.AddEdge(set.Mirrors[len(set.Mirrors)-1], source)
-			}
-			// Every node in topoGraph, including source, is implicitly added by topoGraph.AddEdge (every mirror set contains at least one non-source mirror,
-			// so there are no unconnected nodes that we would have to add separately from the edges).
-		}
-		sortedRepos, err := topoGraph.Sorted()
+		mirrors, err := sets.mergedMirrors(source)
 		if err != nil {
 			return nil, err
 		}
-		if sortedRepos[len(sortedRepos)-1] == source {
-			// We don't need to explicitly include source in the list, it will be automatically tried last per the semantics of sysregistriesv2. Mirrors.
-			sortedRepos = sortedRepos[:len(sortedRepos)-1]
+		item := mergedMirrorSet{
+			source:  source,
+			mirrors: mirrors,
 		}
-		res = append(res, apioperatorsv1alpha1.RepositoryDigestMirrors{
-			Source:  source,
-			Mirrors: sortedRepos,
-		})
+		if sets.mirrorBlockSource[source] {
+			item.mirrorSourcePolicy = apicfgv1.NeverContactSource
+		}
+		res = append(res, item)
 	}
 	return res, nil
+}
+
+// mergedTagMirrorSets processes itmsRules and returns a set of mergedMirrorSet, one for each Source value,
+// ordered consistently with the preference order of the individual entries (if possible)
+// E.g. given mirror sets (B, C) and (A, B), it will combine them into a single (A, B, C) set.
+func mergedTagMirrorSets(itmsRules []*apicfgv1.ImageTagMirrorSet) ([]mergedMirrorSet, error) {
+	tagMirrorSets := newMirrorSets()
+	for _, itms := range itmsRules {
+		for _, set := range itms.Spec.ImageTagMirrors {
+			tagMirrorSets.addMirrorSet(set.Source, set.MirrorSourcePolicy, set.Mirrors)
+		}
+	}
+	return mergedMirrorSets(tagMirrorSets)
+}
+
+// mergedDigestMirrorSets processes idmsRules and returns a set of mergedMirrorSet, one for each Source value,
+// ordered consistently with the preference order of the individual entries (if possible)
+// E.g. given mirror sets (B, C) and (A, B), it will combine them into a single (A, B, C) set.
+func mergedDigestMirrorSets(idmsRules []*apicfgv1.ImageDigestMirrorSet) ([]mergedMirrorSet, error) {
+	digestMirrorSets := newMirrorSets()
+	for _, idms := range idmsRules {
+		for _, set := range idms.Spec.ImageDigestMirrors {
+			digestMirrorSets.addMirrorSet(set.Source, set.MirrorSourcePolicy, set.Mirrors)
+		}
+	}
+	return mergedMirrorSets(digestMirrorSets)
+}
+
+func mergedICSPMirrorSets(icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy) ([]mergedMirrorSet, error) {
+	repositoryMirrorSets := newMirrorSets()
+	for _, icsp := range icspRules {
+		for _, set := range icsp.Spec.RepositoryDigestMirrors {
+			imgMirrors := []apicfgv1.ImageMirror{}
+			for _, m := range set.Mirrors {
+				imgMirrors = append(imgMirrors, apicfgv1.ImageMirror(m))
+			}
+			// leave MirrorSourcePolicy blank, it will follow the default AllowContactingSource
+			repositoryMirrorSets.addMirrorSet(set.Source, "", imgMirrors)
+		}
+	}
+	return mergedMirrorSets(repositoryMirrorSets)
 }
 
 // mirrorsAdjustedForNestedScope returns mirrors from mirroredScope, updated
@@ -150,14 +229,19 @@ func registryScope(reg *sysregistriesv2.Registry) string {
 // - Mark scope entries in insecureScopes as insecure (TLS is not required, and TLS certificate verification is not required when TLS is used)
 // - Mark scope entries in blockedScopes as blocked (any attempts to access them fail)
 // - Implement ImageContentSourcePolicy rules in icspRules.
+// - Implement ImageDigestMirrorSet rules in idmsRules.
+// - Implement ImageTagMirrorSet rules in itmsRules.
 // "scopes" can be any of whole registries, which means that the configuration applies to everything on that registry, including any possible separately-configured
 // namespaces/repositories within that registry.
 // or can be wildcard entries, which means that we accept wildcards in the form of *.example.registry.com for insecure and blocked registries only. We do not
 // accept them for mirror configuration.
 // A valid scope is in the form of registry/namespace...[/repo] (can also refer to sysregistriesv2.Registry.Prefix)
 // NOTE: Validation of wildcard entries is done before EditRegistriesConfig is called in the MCO code.
-func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScopes, blockedScopes []string, icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy) error {
-
+func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScopes, blockedScopes []string, icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy,
+	idmsRules []*apicfgv1.ImageDigestMirrorSet, itmsRules []*apicfgv1.ImageTagMirrorSet) error {
+	if err := RejectMultiUpdateMirrorSetObjs(icspRules, idmsRules, itmsRules); err != nil {
+		return err
+	}
 	// addRegistryEntry creates a Registry object corresponding to scope.
 	// NOTE: The pointer is valid only until the next getRegistryEntry call.
 	addRegistryEntry := func(scope string) *sysregistriesv2.Registry {
@@ -187,17 +271,35 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 		return addRegistryEntry(scope)
 	}
 
-	mirrorSets, err := mergedMirrorSets(icspRules)
+	addMirrorsToRegistries := func(mergedMirrorSets []mergedMirrorSet, pullFromMirror string) {
+		for _, mirrorItem := range mergedMirrorSets {
+			reg := getRegistryEntry(mirrorItem.source)
+			if mirrorItem.mirrorSourcePolicy == apicfgv1.NeverContactSource {
+				reg.Blocked = true
+			}
+			for _, mirror := range mirrorItem.mirrors {
+				reg.Mirrors = append(reg.Mirrors, sysregistriesv2.Endpoint{Location: mirror, PullFromMirror: pullFromMirror})
+			}
+		}
+	}
+
+	digestMirrorSets, err := mergedDigestMirrorSets(idmsRules)
 	if err != nil {
 		return err
 	}
-	for _, mirrorSet := range mirrorSets {
-		reg := getRegistryEntry(mirrorSet.Source)
-		reg.MirrorByDigestOnly = true
-		for _, mirror := range mirrorSet.Mirrors {
-			reg.Mirrors = append(reg.Mirrors, sysregistriesv2.Endpoint{Location: mirror})
-		}
+	addMirrorsToRegistries(digestMirrorSets, sysregistriesv2.MirrorByDigestOnly)
+
+	icspMirrorSets, err := mergedICSPMirrorSets(icspRules)
+	if err != nil {
+		return err
 	}
+	addMirrorsToRegistries(icspMirrorSets, sysregistriesv2.MirrorByDigestOnly)
+
+	tagMirrorSets, err := mergedTagMirrorSets(itmsRules)
+	if err != nil {
+		return err
+	}
+	addMirrorsToRegistries(tagMirrorSets, sysregistriesv2.MirrorByTagOnly)
 
 	// Add the blocked registry entries to the registries list so that we can find sub-scopes of insecure registries and set both the
 	// blocked and insecure flags accordingly.
@@ -238,8 +340,10 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 			}
 		}
 	}
-	for _, mirrorSet := range mirrorSets {
-		mirroredReg := getRegistryEntry(mirrorSet.Source)
+
+	allMirrorSets := append(icspMirrorSets, append(digestMirrorSets, tagMirrorSets...)...)
+	for _, mirrorSet := range allMirrorSets {
+		mirroredReg := getRegistryEntry(mirrorSet.source)
 		mirroredScope := registryScope(mirroredReg)
 		for i := range config.Registries {
 			reg := &config.Registries[i]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -859,7 +859,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/v1helpers
-# github.com/openshift/runtime-utils v0.0.0-20220906151503-3beb0b584526
+# github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f
 ## explicit; go 1.18
 github.com/openshift/runtime-utils/pkg/registries
 # github.com/pelletier/go-toml v1.9.5


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Add support for ImageDigestMirrorSet,ImageDigestMirrorSet mirror configuration CRDs.
- Reject the update of one of current icsp and new idms.itms resources if both exist to avoid having both icsp and new CRs on the same cluster.

Close card: https://issues.redhat.com/browse/OCPNODE-553
Epic: https://issues.redhat.com/browse/OCPNODE-521 
Dependent PR: https://github.com/openshift/runtime-utils/pull/15

**- How to verify it**

Apply following CR, check the /etc/containers/registries.conf

```
apiVersion: config.openshift.io/v1
kind: ImageTagMirrorSet
metadata:
  name: tag-mirror
spec:
  imageTagMirrors:
  - mirrors:
    - example.io/example/ubi-minimal 
    source: registry.access.redhat.com/ubi8/ubi-minimal
  - mirrors:
    - example.io/example/ubi-minimal 
    source: registry.access.redhat.com/ubi8/ubi-minimal-1
    mirrorSourcePolicy: NeverContactSource
```
/etc/containers/registries.conf
```
unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
short-name-mode = ""

[[registry]]
  prefix = ""
  location = "registry.access.redhat.com/ubi8/ubi-minimal"

  [[registry.mirror]]
    location = "example.io/example/ubi-minimal"
    pull-from-mirror = "tag-only"

[[registry]]
  prefix = ""
  location = "registry.access.redhat.com/ubi8/ubi-minimal-1"
  blocked = true

  [[registry.mirror]]
    location = "example.io/example/ubi-minimal"
    pull-from-mirror = "tag-only"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for ImageDigestMirrorSet,ImageDigestMirrorSet CRDs
