### PR TITLE
Bug 2068613: ClusterRoleUpdated/ClusterRoleBindingUpdated Spamming Event Logs

### DIFF
--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-config-controller
-  namespace: {{.TargetNamespace}}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]

--- a/manifests/machineconfigcontroller/clusterrolebinding.yaml
+++ b/manifests/machineconfigcontroller/clusterrolebinding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-config-controller
-  namespace: {{.TargetNamespace}}
 roleRef:
   kind: ClusterRole
   name: machine-config-controller

--- a/manifests/machineconfigcontroller/events-clusterrole.yaml
+++ b/manifests/machineconfigcontroller/events-clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-config-controller-events
-  namespace: {{.TargetNamespace}}
 rules:
 - apiGroups: [""]
   resources: ["events"]

--- a/manifests/machineconfigdaemon/clusterrole.yaml
+++ b/manifests/machineconfigdaemon/clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-config-daemon
-  namespace: {{.TargetNamespace}}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]

--- a/manifests/machineconfigdaemon/clusterrolebinding.yaml
+++ b/manifests/machineconfigdaemon/clusterrolebinding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-config-daemon
-  namespace: {{.TargetNamespace}}
 roleRef:
   kind: ClusterRole
   name: machine-config-daemon
@@ -16,7 +15,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-config-daemon
-  namespace: {{.TargetNamespace}}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/machineconfigdaemon/events-clusterrole.yaml
+++ b/manifests/machineconfigdaemon/events-clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-config-daemon-events
-  namespace: {{.TargetNamespace}}
 rules:
 - apiGroups: [""]
   resources: ["events"]

--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-config-server
-  namespace: {{.TargetNamespace}}
 rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]

--- a/manifests/machineconfigserver/clusterrolebinding.yaml
+++ b/manifests/machineconfigserver/clusterrolebinding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-config-server
-  namespace: {{.TargetNamespace}}
 roleRef:
   kind: ClusterRole
   name: machine-config-server


### PR DESCRIPTION
### The Problem: 

We recently switched some of our calls to use library-go, and around the same time we started filling up events and logs with update notifications for ClusterRoles and ClusterRoleBindings: 
```
42s         42s          1         machine-config-operator.16e0bbc5b7e9ffbb                      Deployment                                                Normal    ClusterRoleUpdated                machine-config-operator                             Updated ClusterRole.rbac.authorization.k8s.io/machine-config-daemon -n openshift-machine-config-operator because it changed
42s         42s          1         machine-config-operator.16e0bbc5baa68337                      Deployment                                                Normal    ClusterRoleBindingUpdated         machine-config-operator                             Updated ClusterRoleBinding.rbac.authorization.k8s.io/machine-config-daemon -n openshift-machine-config-operator because it changed
41s         41s          1         machine-config-operator.16e0bbc5f909b03e                      Deployment                                                Normal    ClusterRoleUpdated                machine-config-operator                             Updated ClusterRole.rbac.authorization.k8s.io/machine-config-controller -n openshift-machine-config-operator because it changed
41s         41s          1         machine-config-operator.16e0bbc5ff3273bc                      Deployment                                                Normal    ClusterRoleBindingUpdated         machine-config-operator                             Updated ClusterRoleBinding.rbac.authorization.k8s.io/machine-config-controller -n openshift-machine-config-operator because it changed
41s         41s          1         machine-config-operator.16e0bbc5fa574510                      Deployment                                                Normal    ClusterRoleUpdated                machine-config-operator                             Updated ClusterRole.rbac.authorization.k8s.io/machine-config-controller-events -n openshift-machine-config-operator because it changed
39s         39s          1         machine-config-operator.16e0bbc67af94630                      Deployment                                                Normal    ClusterRoleUpdated                machine-config-operator                             Updated ClusterRole.rbac.authorization.k8s.io/machine-config-server -n openshift-machine-config-operator because it changed
39s         39s          1         machine-config-operator.16e0bbc67c0b4380                      Deployment                                                Normal    ClusterRoleBindingUpdated         machine-config-operator                             Updated ClusterRoleBinding.rbac.authorization.k8s.io/machine-config-server -n openshift-machine-config-operator because it changed
```
For a very long time we have been including a `namespace` metadata field in our manifests for cluster-scoped resources, resources which are not namespaced and will silently ignore any namespace given. 

Since the namespace was silently ignored for these resource types, the machine-config-operator (via library-go) thought these resources needed to be updated every sync because the `namespace` was empty ( vs the value specified in the manifest ) and emitted logs and an event every time. Our old fork of the library either didn't care or didn't log that it was always updating. 

### The Fix: 

This PR removes the namespaces from our ClusterRoles and ClusterRoleBindings as they are cluster scoped resources and the api silently ignores the namespace field even if you supply it. 

Removing them stops the log spam and the change event spam as they are no longer perceived as "changing" every sync. 

Fixes: [BZ2068613](https://bugzilla.redhat.com/show_bug.cgi?id=2068613)