### PR TITLE
start.go: rm orphaned err check

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -216,9 +216,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		startOpts.kubeletHealthzEnabled,
 		startOpts.kubeletHealthzEndpoint,
 	)
-	if err != nil {
-		glog.Fatalf("Failed to initialize daemon: %v", err)
-	}
 
 	ctx.KubeInformerFactory.Start(stopCh)
 	ctx.InformerFactory.Start(stopCh)


### PR DESCRIPTION
Looks like this err check got orphaned in
https://github.com/openshift/machine-config-operator/commit/ccde275df88add21aee41ca91bdd5ee1407e9cb6
@cgwalters 