### PR TITLE
[release-4.7] Bug 2069766: Improvements for configure-ovs script

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -322,9 +322,23 @@ contents:
           nmcli c load ${new_conn_file}
           echo "Loaded new $ovs_interface connection file: ${new_conn_file}"
         else
+          extra_if_brex_args=""
+          # check if interface had ipv4/ipv6 addresses assigned
+          ipv4_addr=$(nmcli --get-values ip4.address conn show ${old_conn})
+          if [ -n "$ipv4_addr" ]; then
+            extra_if_brex_args+="ipv4.may-fail no "
+          fi
+
+          # IPV6 should have at least a link local address. Check for more than 1 to see if there is an
+          # assigned address.
+          num_ip6_addrs=$(nmcli -m multiline --get-values ip6.address conn show ${old_conn} | wc -l)
+          if [ "$num_ip6_addrs" -gt 1 ]; then
+            extra_if_brex_args+="ipv6.may-fail no "
+          fi
+
           nmcli c add type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
             "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
-            ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC"
+            ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC" ${extra_if_brex_args}
         fi
       fi
 

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -25,35 +25,24 @@ contents:
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
     copy_nm_conn_files() {
-      local src_path="$NM_CONN_PATH"
       local dst_path="$1"
-      if [ "$src_path" = "$dst_path" ]; then
-        echo "No need to copy configuration files, source and destination are the same"
-        return
-      fi
-      if [ -d "$src_path" ]; then
-        echo "$src_path exists"
-        local files=("${MANAGED_NM_CONN_FILES[@]}")
-        shopt -s nullglob
-        files+=($src_path/*${MANAGED_NM_CONN_SUFFIX}.nmconnection $src_path/*${MANAGED_NM_CONN_SUFFIX})
-        shopt -u nullglob
-        for file in "${files[@]}"; do
-          file="$(basename $file)"
-          if [ -f "$src_path/$file" ]; then
-            if [ ! -f "$dst_path/$file" ]; then
-              echo "Copying configuration $file"
-              cp "$src_path/$file" "$dst_path/$file"
-            elif ! cmp --silent "$src_path/$file" "$dst_path/$file"; then
-              echo "Copying updated configuration $file"
-              cp -f "$src_path/$file" "$dst_path/$file"
-            else
-              echo "Skipping $file since it's equal at destination"
-            fi
+      for src in "${MANAGED_NM_CONN_FILES[@]}"; do
+        src_path=$(dirname "$src")
+        file=$(basename "$src")
+        if [ -f "$src_path/$file" ]; then
+          if [ ! -f "$dst_path/$file" ]; then
+            echo "Copying configuration $file"
+            cp "$src_path/$file" "$dst_path/$file"
+          elif ! cmp --silent "$src_path/$file" "$dst_path/$file"; then
+            echo "Copying updated configuration $file"
+            cp -f "$src_path/$file" "$dst_path/$file"
           else
-            echo "Skipping $file since it does not exist at source"
+            echo "Skipping $file since it's equal at destination"
           fi
-        done
-      fi
+        else
+          echo "Skipping $file since it does not exist at source"
+        fi
+      done
     }
 
     persist_nm_conn_files() {
@@ -67,27 +56,21 @@ contents:
       ovs_interface="ovs-if-${bridge_name}"
       default_port_name="ovs-port-${port_name}" # ovs-port-phys0
       bridge_interface_name="ovs-if-${port_name}" # ovs-if-phys0
-    # In RHEL7 files in /{etc,run}/NetworkManager/system-connections end without the suffix '.nmconnection', whereas in RHCOS they end with the suffix.
-      MANAGED_NM_CONN_FILES=($(echo {"$bridge_name","$ovs_interface","$ovs_port","$bridge_interface_name","$default_port_name"} {"$bridge_name","$ovs_interface","$ovs_port","$bridge_interface_name","$default_port_name"}.nmconnection))
+      # In RHEL7 files in /{etc,run}/NetworkManager/system-connections end without the suffix '.nmconnection', whereas in RHCOS they end with the suffix.
+      MANAGED_NM_CONN_FILES=($(echo "${NM_CONN_PATH}"/{"$bridge_name","$ovs_interface","$ovs_port","$bridge_interface_name","$default_port_name"}{,.nmconnection}))
+      shopt -s nullglob
+      MANAGED_NM_CONN_FILES+=(${NM_CONN_PATH}/*${MANAGED_NM_CONN_SUFFIX}.nmconnection ${NM_CONN_PATH}/*${MANAGED_NM_CONN_SUFFIX})
+      shopt -u nullglob
     }
 
     # Used to remove files managed by configure-ovs
     rm_nm_conn_files() {
-      local files=("${MANAGED_NM_CONN_FILES[@]}")
-      shopt -s nullglob
-      files+=(${NM_CONN_PATH}/*${MANAGED_NM_CONN_SUFFIX}.nmconnection ${NM_CONN_PATH}/*${MANAGED_NM_CONN_SUFFIX})
-      shopt -u nullglob
-      for file in "${files[@]}"; do
-        file="$(basename $file)"
-        # Also remove files in underlay
-        for path in "${NM_CONN_PATH}" "${NM_CONN_UNDERLAY}"; do
-          file_path="${path}/$file"
-          if [ -f "$file_path" ]; then
-            rm -f "$file_path"
-            echo "Removed nmconnection file $file_path"
-            nm_config_changed=1
-          fi
-        done
+      for file in "${MANAGED_NM_CONN_FILES[@]}"; do
+        if [ -f "$file" ]; then
+          rm -f "$file"
+          echo "Removed nmconnection file $file"
+          nm_config_changed=1
+        fi
       done
     }
 
@@ -109,7 +92,7 @@ contents:
     replace_connection_master() {
       local old="$1"
       local new="$2"
-      for conn_uuid in $(nmcli -g UUID connection show) ; do
+      for conn_uuid in $(nmcli -g UUID connection show --active) ; do
         if [ "$(nmcli -g connection.master connection show uuid "$conn_uuid")" != "$old" ]; then
           continue
         fi
@@ -178,21 +161,18 @@ contents:
       # create bridge
       if ! nmcli connection show "$bridge_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-br "$bridge_name"
-        nmcli c add type ovs-bridge \
-            con-name "$bridge_name" \
-            conn.interface "$bridge_name" \
-            802-3-ethernet.mtu ${iface_mtu}
+        add_nm_conn type ovs-bridge con-name "$bridge_name" conn.interface "$bridge_name" 802-3-ethernet.mtu ${iface_mtu}
       fi
 
       # find default port to add to bridge
       if ! nmcli connection show "$default_port_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" ${iface}
-        nmcli c add type ovs-port conn.interface ${iface} master "$bridge_name" con-name "$default_port_name"
+        add_nm_conn type ovs-port conn.interface ${iface} master "$bridge_name" con-name "$default_port_name"
       fi
 
       if ! nmcli connection show "$ovs_port" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" "$bridge_name"
-        nmcli c add type ovs-port conn.interface "$bridge_name" master "$bridge_name" con-name "$ovs_port"
+        add_nm_conn type ovs-port conn.interface "$bridge_name" master "$bridge_name" con-name "$ovs_port"
       fi
 
       extra_phys_args=()
@@ -232,8 +212,9 @@ contents:
       # use ${extra_phys_args[@]+"${extra_phys_args[@]}"} instead of ${extra_phys_args[@]} to be compatible with bash 4.2 in RHEL7.9
       if ! nmcli connection show "$bridge_interface_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists destroy interface ${iface}
-        nmcli c add type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
-        connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args[@]+"${extra_phys_args[@]}"}
+        add_nm_conn type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
+        connection.autoconnect-priority 100 connection.autoconnect-slaves 1 802-3-ethernet.mtu ${iface_mtu} \
+        ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 
       # Get the new connection uuid
@@ -282,6 +263,8 @@ contents:
           # modify file to work with OVS and have unique settings
           sed -i '/^\[connection\]$/,/^\[/ s/^uuid=.*$/uuid='"$br_iface_uuid"'/' ${new_conn_file}
           sed -i '/^multi-connect=.*$/d' ${new_conn_file}
+          sed -i '/^autoconnect=.*$/d' ${new_conn_file}
+          sed -i '/^\[connection\]$/a autoconnect=false' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^type=.*$/type=ovs-interface/' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^id=.*$/id='"$ovs_interface"'/' ${new_conn_file}
           sed -i '/^\[connection\]$/a slave-type=ovs-port' ${new_conn_file}
@@ -338,7 +321,7 @@ contents:
             extra_if_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
           fi
 
-          nmcli c add type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
+          add_nm_conn type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
             "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC" ${extra_if_brex_args}
         fi
@@ -373,65 +356,105 @@ contents:
       echo "OVS configuration successfully reverted"
     }
 
-    # Reloads NetworkManager if any configuration change was done
-    reload_nm() {
+    # Reloads NM NetworkManager profiles if any configuration change was done.
+    # Accepts a list of devices that should be re-connect after reload.
+    reload_profiles_nm() {
       if [ $nm_config_changed -eq 0 ]; then
         # no config was changed, no need to reload
         return
       fi
+
+      # reload profiles
+      nmcli connection reload
+
+      # precautionary sleep of 10s (default timeout of NM to bring down devices)
+      sleep 10
+    
+      # After reload, devices that were already connected should connect again
+      # if any profile is available. If no profile is available, a device can
+      # remain disconnected and we have to explicitly connect it so that a
+      # profile is generated. This can happen for physical devices but should
+      # not happen for software devices as those always require a profile.
+      for dev in $@; do
+        # Only attempt to connect a disconnected device
+        local connected_state=$(nmcli -g GENERAL.STATE device show "$dev" || echo "")
+        if [[ "$connected_state" =~ "disconnected" ]]; then
+          # keep track if a profile by the same name as the device existed 
+          # before we attempt activation
+          local named_profile_existed=$([ -f "${NM_CONN_PATH}/${dev}" ] || [ -f "${NM_CONN_PATH}/${dev}.nmconnection" ] && echo "yes")
+          
+          for i in {1..10}; do
+              echo "Attempt $i to connect device $dev"
+              nmcli device connect "$dev" && break
+              sleep 5
+          done
+
+          # if a profile did not exist before but does now, it was generated
+          # but we want it to be ephemeral, so move it back to /run
+          if [ ! "$named_profile_existed" = "yes" ]; then
+            local dst="/run/NetworkManager/system-connections/"
+            MANAGED_NM_CONN_FILES=("${NM_CONN_PATH}/${dev}" "${NM_CONN_PATH}/${dev}.nmconnection")
+            copy_nm_conn_files "${dst}"
+            rm_nm_conn_files
+            # reload profiles so that NM notices that some might have been moved
+            nmcli connection reload
+          fi
+        fi
+
+        echo "Waiting for interface $dev to activate..."
+        if ! timeout 60 bash -c "while ! nmcli -g DEVICE,STATE c | grep "'"'"$dev":activated'"'"; do sleep 5; done"; then
+          echo "Warning: $dev did not activate"
+        fi
+      done
+
       nm_config_changed=0
-      
-      echo "Reloading NetworkManager after configuration changes..."
-
-      # set network off, so that auto-connect priority is evaluated when turning
-      # it back on
-      nmcli network off
-      
-      # restart NetworkManager to reload profiles, including generating
-      # transient profiles for devices that don't have any
-      systemctl restart NetworkManager
-
-      # turn network back on triggering auto-connects 
-      nmcli network on
-
-      # Wait until all profiles auto-connect
-      if nm-online -s -t 60; then
-        echo "NetworkManager has activated all suitable profiles after reload"
-      else
-        echo "NetworkManager has not activated all suitable profiles after reload"
-      fi
-
-      # Check if we have any type of connectivity
-      if nm-online -t 0; then
-        echo "NetworkManager has connectivity after reload"
-      else
-        echo "NetworkManager does not have connectivity after reload"
-      fi
     }
 
     # Removes all configuration and reloads NM if necessary
     rollback_nm() {
+      phys0=$(get_bridge_physical_interface ovs-if-phys0)
+
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
       remove_all_ovn_bridges
       
-      # Reload NM if necessary
-      reload_nm
+      # reload profiles so that NM notices that some were removed
+      reload_profiles_nm "$phys0"
+    }
+
+    # Add a deactivated connection profile
+    add_nm_conn() {
+      nmcli c add "$@" connection.autoconnect no
     }
 
     # Activates a NM connection profile
     activate_nm_conn() {
       local conn="$1"
-      for i in {1..10}; do
-        echo "Attempt $i to bring up connection $conn"
-        nmcli conn up "$conn" && s=0 && break || s=$?
-        sleep 5
-      done
-      if [ $s -eq 0 ]; then
-        echo "Brought up connection $conn successfully"
+      local active_state="$(nmcli -g GENERAL.STATE conn show $conn)"
+      if [ "$active_state" != "activated" ]; then
+        for i in {1..10}; do
+          echo "Attempt $i to bring up connection $conn"
+          nmcli conn up "$conn" && s=0 && break || s=$?
+          sleep 5
+        done
+        if [ $s -eq 0 ]; then
+          echo "Brought up connection $conn successfully"
+        else
+          echo "ERROR: Cannot bring up connection $conn after $i attempts"
+          return $s
+        fi
       else
-        echo "ERROR: Cannot bring up connection $conn after $i attempts"
+        echo "Connection $conn already activated"
       fi
-      return $s
+      nmcli c mod "$conn" connection.autoconnect yes
+    }
+
+    # Accepts parameters $bridge_interface (e.g. ovs-port-phys0)
+    # Returns the physical interface name if $bridge_interface exists, "" otherwise
+    get_bridge_physical_interface() {
+      local bridge_interface="$1"
+      local physical_interface=""
+      physical_interface=$(nmcli -g connection.interface-name conn show "${bridge_interface}" 2>/dev/null || echo "")
+      echo "${physical_interface}"
     }
 
     # Used to print network state
@@ -528,11 +551,11 @@ contents:
 
       # Remove bridges created by openshift-sdn
       ovs-vsctl --timeout=30 --if-exists del-br br0
-      
-      # Recycle NM connections
-      reload_nm
 
       # Make sure everything is activated
+      for connection in $(nmcli -g NAME c | grep -- "$MANAGED_NM_CONN_SUFFIX"); do
+        activate_nm_conn "$connection"
+      done
       activate_nm_conn ovs-if-phys0
       activate_nm_conn ovs-if-br-ex
     elif [ "$1" == "OpenShiftSDN" ]; then

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -568,9 +568,11 @@ contents:
 
       # Make sure everything is activated
       connections=()
-      for connection in $(nmcli -g NAME c | grep -- "$MANAGED_NM_CONN_SUFFIX"); do
-        connections+=("$connection")
-      done
+      while IFS= read -r connection; do
+        if [[ $connection == *"$MANAGED_NM_CONN_SUFFIX" ]]; then
+          connections+=("$connection")
+        fi
+      done < <(nmcli -g NAME c)
       connections+=(ovs-if-phys0 ovs-if-br-ex)
       activate_nm_connections "${connections[@]}"
       persist_nm_conn_files

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -215,7 +215,7 @@ contents:
       if ! nmcli connection show "$bridge_interface_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists destroy interface ${iface}
         add_nm_conn type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
-        connection.autoconnect-priority 100 connection.autoconnect-slaves 1 802-3-ethernet.mtu ${iface_mtu} \
+        connection.autoconnect-priority 100 802-3-ethernet.cloned-mac-address "${iface_mac}" 802-3-ethernet.mtu ${iface_mtu}  \
         ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -324,15 +324,15 @@ contents:
         else
           extra_if_brex_args=""
           # check if interface had ipv4/ipv6 addresses assigned
-          ipv4_addr=$(nmcli --get-values ip4.address conn show ${old_conn})
-          if [ -n "$ipv4_addr" ]; then
+          num_ipv4_addrs=$(ip -j a show dev ${iface} | jq ".[0].addr_info | map(. | select(.family == \"inet\")) | length")
+          if [ "$num_ipv4_addrs" -gt 0 ]; then
             extra_if_brex_args+="ipv4.may-fail no "
           fi
 
           # IPV6 should have at least a link local address. Check for more than 1 to see if there is an
           # assigned address.
-          num_ip6_addrs=$(nmcli -m multiline --get-values ip6.address conn show ${old_conn} | wc -l)
-          if [ "$num_ip6_addrs" -gt 1 ]; then
+          num_ip6_addrs=$(ip -j a show dev ${iface} | jq ".[0].addr_info | map(. | select(.family == \"inet6\" and .scope != \"link\")) | length")
+          if [ "$num_ip6_addrs" -gt 0 ]; then
             extra_if_brex_args+="ipv6.may-fail no "
           fi
 

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -203,6 +203,11 @@ contents:
         extra_brex_args+="ipv6.dhcp-duid ${dhcp6_client_id} "
       fi
 
+      ipv6_addr_gen_mode=$(nmcli --get-values ipv6.addr-gen-mode conn show ${old_conn})
+      if [ -n "$ipv6_addr_gen_mode" ]; then
+        extra_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
+      fi
+
       # create bridge
       if ! nmcli connection show br-ex &> /dev/null; then
         nmcli c add type ovs-bridge \

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -511,8 +511,6 @@ contents:
         sleep 5
       done
 
-      extra_bridge_file='/etc/ovnk/extra_bridge'
-
       if [ "$iface" != "br-ex" ]; then
         # Default gateway is not br-ex.
         echo "Bridge br-ex is not active, restoring previous configuration before proceeding..."

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -421,26 +421,45 @@ contents:
       nmcli c add "$@" connection.autoconnect no
     }
 
-    # Activates a NM connection profile
-    activate_nm_conn() {
-      local conn="$1"
-      local active_state="$(nmcli -g GENERAL.STATE conn show $conn)"
-      if [ "$active_state" != "activated" ]; then
-        for i in {1..10}; do
-          echo "Attempt $i to bring up connection $conn"
-          nmcli conn up "$conn" && s=0 && break || s=$?
-          sleep 5
-        done
-        if [ $s -eq 0 ]; then
-          echo "Brought up connection $conn successfully"
-        else
-          echo "ERROR: Cannot bring up connection $conn after $i attempts"
-          return $s
+    # Activates an ordered set of NM connection profiles
+    activate_nm_connections() {
+      local connections=("$@")
+      
+      # make sure to set bond or team slaves autoconnect, otherwise as we
+      # activate one slave, the other slave might get implicitly re-activated
+      # with the old profile, activating the old master, interfering and
+      # causing the former activation to fail.
+      # we don't want to set autoconnect on all the other profiles just yet
+      # though as that would activate them which is what we want to do next.
+      # note that these slaves should already be activated with their original
+      # profiles and setting autoconnect won't implicitly activate them again.
+      for conn in "${connections[@]}"; do
+        local slave_type=$(nmcli -g connection.slave-type connection show "$conn")
+        if [ "$slave_type" = "team" ] || [ "$slave_type" = "bond" ]; then
+          nmcli c mod "$conn" connection.autoconnect yes
         fi
-      else
-        echo "Connection $conn already activated"
-      fi
-      nmcli c mod "$conn" connection.autoconnect yes
+      done
+
+      # Then activate all the connections
+      for conn in "${connections[@]}"; do
+        local active_state=$(nmcli -g GENERAL.STATE conn show "$conn")
+        if [ "$active_state" != "activated" ]; then
+          for i in {1..10}; do
+            echo "Attempt $i to bring up connection $conn"
+            nmcli conn up "$conn" && s=0 && break || s=$?
+            sleep 5
+          done
+          if [ $s -eq 0 ]; then
+            echo "Brought up connection $conn successfully"
+          else
+            echo "ERROR: Cannot bring up connection $conn after $i attempts"
+            return $s
+          fi
+        else
+          echo "Connection $conn already activated"
+        fi
+        nmcli c mod "$conn" connection.autoconnect yes
+      done
     }
 
     # Accepts parameters $bridge_interface (e.g. ovs-port-phys0)
@@ -548,11 +567,12 @@ contents:
       ovs-vsctl --timeout=30 --if-exists del-br br0
 
       # Make sure everything is activated
+      connections=()
       for connection in $(nmcli -g NAME c | grep -- "$MANAGED_NM_CONN_SUFFIX"); do
-        activate_nm_conn "$connection"
+        connections+=("$connection")
       done
-      activate_nm_conn ovs-if-phys0
-      activate_nm_conn ovs-if-br-ex
+      connections+=(ovs-if-phys0 ovs-if-br-ex)
+      activate_nm_connections "${connections[@]}"
       persist_nm_conn_files
     elif [ "$1" == "OpenShiftSDN" ]; then
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -17,7 +17,9 @@ contents:
       NM_CONN_PATH="$NM_CONN_UNDERLAY"
     fi
 
-    # In RHEL7 files in /{etc,run}/NetworkManager/system-connections end without the suffix '.nmconnection', whereas in RHCOS they end with the suffix.
+    # this flag tracks if any config change was made
+    nm_config_changed=0
+
     MANAGED_NM_CONN_SUFFIX="-slave-ovs-clone"
 
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
@@ -83,7 +85,7 @@ contents:
           if [ -f "$file_path" ]; then
             rm -f "$file_path"
             echo "Removed nmconnection file $file_path"
-            nm_conn_files_removed=1
+            nm_config_changed=1
           fi
         done
       done
@@ -143,6 +145,10 @@ contents:
         echo "Networking already configured and up for ${bridge-name}!"
         return
       fi
+
+      # flag to reload NM to account for all the configuration changes
+      # going forward
+      nm_config_changed=1
 
       if [ -z "$iface" ]; then
         echo "ERROR: Unable to find default gateway interface"
@@ -367,9 +373,15 @@ contents:
       echo "OVS configuration successfully reverted"
     }
 
-    # Reloads NetworkManager
+    # Reloads NetworkManager if any configuration change was done
     reload_nm() {
-      echo "Reloading NetworkManager..."
+      if [ $nm_config_changed -eq 0 ]; then
+        # no config was changed, no need to reload
+        return
+      fi
+      nm_config_changed=0
+      
+      echo "Reloading NetworkManager after configuration changes..."
 
       # set network off, so that auto-connect priority is evaluated when turning
       # it back on
@@ -399,17 +411,11 @@ contents:
 
     # Removes all configuration and reloads NM if necessary
     rollback_nm() {
-      # This will be set to 1 if remove_all_ovn_bridges actually changes anything
-      nm_conn_files_removed=0
-
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
       remove_all_ovn_bridges
       
-      # Reload only if we removed connection profiles
-      if [ $nm_conn_files_removed -eq 1 ]; then
-        echo "OVS configuration was cleaned up, will reload NetworkManager"
-        reload_nm
-      fi
+      # Reload NM if necessary
+      reload_nm
     }
 
     # Activates a NM connection profile

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -169,33 +169,13 @@ contents:
       # store old conn for later
       old_conn=$(nmcli --fields UUID,DEVICE conn show --active | awk "/\s${iface}\s*\$/ {print \$1}")
 
-      extra_brex_args=""
-      # check for dhcp client ids
-      dhcp_client_id=$(nmcli --get-values ipv4.dhcp-client-id conn show ${old_conn})
-      if [ -n "$dhcp_client_id" ]; then
-        extra_brex_args+="ipv4.dhcp-client-id ${dhcp_client_id} "
-      fi
-
-      dhcp6_client_id=$(nmcli --get-values ipv6.dhcp-duid conn show ${old_conn})
-      if [ -n "$dhcp6_client_id" ]; then
-        extra_brex_args+="ipv6.dhcp-duid ${dhcp6_client_id} "
-      fi
-
-      ipv6_addr_gen_mode=$(nmcli --get-values ipv6.addr-gen-mode conn show ${old_conn})
-      if [ -n "$ipv6_addr_gen_mode" ]; then
-        extra_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
-      fi
-
       # create bridge
       if ! nmcli connection show "$bridge_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-br "$bridge_name"
         nmcli c add type ovs-bridge \
             con-name "$bridge_name" \
             conn.interface "$bridge_name" \
-            802-3-ethernet.mtu ${iface_mtu} \
-            ipv4.route-metric "$BRIDGE_METRIC" \
-            ipv6.route-metric "$BRIDGE_METRIC" \
-            ${extra_brex_args}
+            802-3-ethernet.mtu ${iface_mtu}
       fi
 
       # find default port to add to bridge
@@ -334,6 +314,22 @@ contents:
           num_ip6_addrs=$(ip -j a show dev ${iface} | jq ".[0].addr_info | map(. | select(.family == \"inet6\" and .scope != \"link\")) | length")
           if [ "$num_ip6_addrs" -gt 0 ]; then
             extra_if_brex_args+="ipv6.may-fail no "
+          fi
+
+          # check for dhcp client ids
+          dhcp_client_id=$(nmcli --get-values ipv4.dhcp-client-id conn show ${old_conn})
+          if [ -n "$dhcp_client_id" ]; then
+            extra_if_brex_args+="ipv4.dhcp-client-id ${dhcp_client_id} "
+          fi
+
+          dhcp6_client_id=$(nmcli --get-values ipv6.dhcp-duid conn show ${old_conn})
+          if [ -n "$dhcp6_client_id" ]; then
+            extra_if_brex_args+="ipv6.dhcp-duid ${dhcp6_client_id} "
+          fi
+
+          ipv6_addr_gen_mode=$(nmcli --get-values ipv6.addr-gen-mode conn show ${old_conn})
+          if [ -n "$ipv6_addr_gen_mode" ]; then
+            extra_if_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
           fi
 
           nmcli c add type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -352,9 +352,6 @@ contents:
       bridge_name=${1}
       port_name=${2}
 
-      # Revert changes made by /usr/local/bin/configure-ovs.sh.
-      rm_nm_conn_files
-
       # Reload configuration, after reload the preferred connection profile
       # should be auto-activated
       update_nm_conn_files ${bridge_name} ${port_name}

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -251,7 +251,8 @@ contents:
         # check team config options
         team_config_opts=$(nmcli --get-values team.config -e no conn show ${old_conn})
         if [ -n "$team_config_opts" ]; then
-          extra_phys_args+=( team.config "${team_config_opts}" )
+          # team.config is json, remove spaces to avoid problems later on
+          extra_phys_args+=( team.config "${team_config_opts//[[:space:]]/}" )
         fi
       else
         iface_type=802-3-ethernet

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -104,6 +104,7 @@ contents:
 
         nmcli conn mod uuid $new_uuid connection.master "$new"
         nmcli conn mod $new_uuid connection.autoconnect-priority 100
+        nmcli conn mod $new_uuid connection.autoconnect no
         echo "Replaced master $old with $new for slave profile $new_uuid"
       done
     }
@@ -198,6 +199,11 @@ contents:
         bond_opts=$(nmcli --get-values bond.options conn show ${old_conn})
         if [ -n "$bond_opts" ]; then
           extra_phys_args+=( bond.options "${bond_opts}" )
+          MODE_REGEX="(^|,)mode=active-backup(,|$)"
+          MAC_REGEX="(^|,)fail_over_mac=(1|active|2|follow)(,|$)"
+          if [[ $bond_opts =~ $MODE_REGEX ]] && [[ $bond_opts =~ $MAC_REGEX ]]; then
+            clone_mac=0
+          fi
         fi
       elif [ $(nmcli --get-values connection.type conn show ${old_conn}) == "team" ]; then
         iface_type=team
@@ -206,17 +212,36 @@ contents:
         if [ -n "$team_config_opts" ]; then
           # team.config is json, remove spaces to avoid problems later on
           extra_phys_args+=( team.config "${team_config_opts//[[:space:]]/}" )
+          team_mode=$(echo "${team_config_opts}" | jq -r ".runner.name // empty")
+          team_mac_policy=$(echo "${team_config_opts}" | jq -r ".runner.hwaddr_policy // empty")
+          MAC_REGEX="(by_active|only_active)"
+          if [ "$team_mode" = "activebackup" ] && [[ "$team_mac_policy" =~ $MAC_REGEX ]]; then
+            clone_mac=0
+          fi
         fi
       else
         iface_type=802-3-ethernet
+      fi
+
+      if [ ! "${clone_mac:-}" = "0" ]; then
+        # In active-backup link aggregation, with fail_over_mac mode enabled,
+        # cloning the mac address is not supported. It is possible then that
+        # br-ex has a different mac address than the bond which might be
+        # troublesome on some platforms where the nic won't accept packets with
+        # a different destination mac. But nobody has complained so far so go on
+        # with what we got. 
+        
+        # Do set it though for other link aggregation configurations where the
+        # mac address would otherwise depend on enslave order for which we have
+        # no control going forward.
+        extra_phys_args+=( 802-3-ethernet.cloned-mac-address "${iface_mac}" )
       fi
 
       # use ${extra_phys_args[@]+"${extra_phys_args[@]}"} instead of ${extra_phys_args[@]} to be compatible with bash 4.2 in RHEL7.9
       if ! nmcli connection show "$bridge_interface_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists destroy interface ${iface}
         add_nm_conn type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
-        connection.autoconnect-priority 100 802-3-ethernet.cloned-mac-address "${iface_mac}" 802-3-ethernet.mtu ${iface_mtu}  \
-        ${extra_phys_args[@]+"${extra_phys_args[@]}"}
+        connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 
       # Get the new connection uuids

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -18,16 +18,15 @@ contents:
     fi
 
     # In RHEL7 files in /{etc,run}/NetworkManager/system-connections end without the suffix '.nmconnection', whereas in RHCOS they end with the suffix.
-    MANAGED_NM_CONN_FILES=($(echo {br-ex,ovs-if-br-ex,ovs-port-br-ex,ovs-if-phys0,ovs-port-phys0} {br-ex,ovs-if-br-ex,ovs-port-br-ex,ovs-if-phys0,ovs-port-phys0}.nmconnection))
     MANAGED_NM_CONN_SUFFIX="-slave-ovs-clone"
 
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
     copy_nm_conn_files() {
       local src_path="$NM_CONN_PATH"
-      local dst_path="$NM_CONN_UNDERLAY"
+      local dst_path="$1"
       if [ "$src_path" = "$dst_path" ]; then
-        echo "No need to persist configuration files"
+        echo "No need to copy configuration files, source and destination are the same"
         return
       fi
       if [ -d "$src_path" ]; then
@@ -40,17 +39,34 @@ contents:
           file="$(basename $file)"
           if [ -f "$src_path/$file" ]; then
             if [ ! -f "$dst_path/$file" ]; then
-              echo "Persisting new configuration $file"
+              echo "Copying configuration $file"
               cp "$src_path/$file" "$dst_path/$file"
             elif ! cmp --silent "$src_path/$file" "$dst_path/$file"; then
-              echo "Persisting updated configuration $file"
+              echo "Copying updated configuration $file"
               cp -f "$src_path/$file" "$dst_path/$file"
+            else
+              echo "Skipping $file since it's equal at destination"
             fi
           else
-            echo "Skipping $file since its status is current"
+            echo "Skipping $file since it does not exist at source"
           fi
         done
       fi
+    }
+
+    persist_nm_conn_files() {
+      copy_nm_conn_files "$NM_CONN_UNDERLAY"
+    }
+
+    update_nm_conn_files() {
+      bridge_name=${1}
+      port_name=${2}
+      ovs_port="ovs-port-${bridge_name}"
+      ovs_interface="ovs-if-${bridge_name}"
+      default_port_name="ovs-port-${port_name}" # ovs-port-phys0
+      bridge_interface_name="ovs-if-${port_name}" # ovs-if-phys0
+    # In RHEL7 files in /{etc,run}/NetworkManager/system-connections end without the suffix '.nmconnection', whereas in RHCOS they end with the suffix.
+      MANAGED_NM_CONN_FILES=($(echo {"$bridge_name","$ovs_interface","$ovs_port","$bridge_interface_name","$default_port_name"} {"$bridge_name","$ovs_interface","$ovs_port","$bridge_interface_name","$default_port_name"}.nmconnection))
     }
 
     # Used to remove files managed by configure-ovs
@@ -67,6 +83,7 @@ contents:
           if [ -f "$file_path" ]; then
             rm -f "$file_path"
             echo "Removed nmconnection file $file_path"
+            nm_conn_files_removed=1
           fi
         done
       done
@@ -104,72 +121,33 @@ contents:
         echo "Replaced master $old with $new for slave profile $new_uuid"
       done
     }
-    
-    if ! rpm -qa | grep -q openvswitch; then
-      echo "Warning: Openvswitch package is not installed!"
-      exit 1
-    fi
 
-    echo "Current routing and connection state:"
-    ip route show
-    nmcli c show
+    # when creating the bridge, we use a value lower than NM's ethernet device default route metric
+    # (we pick 49 to be lower than anything that NM chooses by default)
+    BRIDGE_METRIC="49"
+    # Given an interface, generates NM configuration to add to an OVS bridge
+    convert_to_bridge() {
+      iface=${1}
+      bridge_name=${2}
+      port_name=${3}
+      ovs_port="ovs-port-${bridge_name}"
+      ovs_interface="ovs-if-${bridge_name}"
+      default_port_name="ovs-port-${port_name}" # ovs-port-phys0
+      bridge_interface_name="ovs-if-${port_name}" # ovs-if-phys0
 
-    if [ "$1" == "OVNKubernetes" ]; then
-      # when creating the bridge, we use a value lower than NM's ethernet device default route metric
-      # (we pick 49 to be lower than anything that NM chooses by default)
-      BRIDGE_METRIC="49"
-      # Configures NICs onto OVS bridge "br-ex"
-      # Configuration is either auto-detected or provided through a config file written already in Network Manager
-      # key files under /etc/NetworkManager/system-connections/
-      # Managing key files is outside of the scope of this script
-
-      # if the interface is of type vmxnet3 add multicast capability for that driver
-      # REMOVEME: Once BZ:1854355 is fixed, this needs to get removed.
-      function configure_driver_options {
-        intf=$1
-        driver=$(cat "/sys/class/net/${intf}/device/uevent" | grep DRIVER | awk -F "=" '{print $2}')
-        echo "Driver name is" $driver
-        if [ "$driver" = "vmxnet3" ]; then
-          ifconfig "$intf" allmulti
-        fi
-      }
-      iface=""
-      counter=0
-      # find default interface
-      while [ $counter -lt 12 ]; do
-        # check ipv4
-        iface=$(ip route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
-        if [[ -n "$iface" ]]; then
-          echo "IPv4 Default gateway interface found: ${iface}"
-          break
-        fi
-        # check ipv6
-        iface=$(ip -6 route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
-        if [[ -n "$iface" ]]; then
-          echo "IPv6 Default gateway interface found: ${iface}"
-          break
-        fi
-        counter=$((counter+1))
-        echo "No default route found on attempt: ${counter}"
-        sleep 5
-      done
-
-      if [ "$iface" = "br-ex" ]; then
+      if [ "$iface" = "$bridge_name" ]; then
         # handle vlans and bonds etc if they have already been
         # configured via nm key files and br-ex is already up
         ifaces=$(ovs-vsctl list-ifaces ${iface})
         for intf in $ifaces; do configure_driver_options $intf; done
-        echo "Networking already configured and up for br-ex!"
-        # remove bridges created by openshift-sdn
-        ovs-vsctl --timeout=30 --if-exists del-br br0
-        exit 0
+        echo "Networking already configured and up for ${bridge-name}!"
+        return
       fi
 
       if [ -z "$iface" ]; then
         echo "ERROR: Unable to find default gateway interface"
         exit 1
       fi
-
       # find the MAC from OVS config or the default interface to use for OVS internal port
       # this prevents us from getting a different DHCP lease and dropping connection
       if ! iface_mac=$(<"/sys/class/net/${iface}/address"); then
@@ -209,10 +187,10 @@ contents:
       fi
 
       # create bridge
-      if ! nmcli connection show br-ex &> /dev/null; then
+      if ! nmcli connection show "$bridge_name" &> /dev/null; then
         nmcli c add type ovs-bridge \
-            con-name br-ex \
-            conn.interface br-ex \
+            con-name "$bridge_name" \
+            conn.interface "$bridge_name" \
             802-3-ethernet.mtu ${iface_mtu} \
             ipv4.route-metric "$BRIDGE_METRIC" \
             ipv6.route-metric "$BRIDGE_METRIC" \
@@ -220,12 +198,12 @@ contents:
       fi
 
       # find default port to add to bridge
-      if ! nmcli connection show ovs-port-phys0 &> /dev/null; then
-        nmcli c add type ovs-port conn.interface ${iface} master br-ex con-name ovs-port-phys0
+      if ! nmcli connection show "$default_port_name" &> /dev/null; then
+        nmcli c add type ovs-port conn.interface ${iface} master "$bridge_name" con-name "$default_port_name"
       fi
 
-      if ! nmcli connection show ovs-port-br-ex &> /dev/null; then
-        nmcli c add type ovs-port conn.interface br-ex master br-ex con-name ovs-port-br-ex
+      if ! nmcli connection show "$ovs_port" &> /dev/null; then
+        nmcli c add type ovs-port conn.interface "$bridge_name" master "$bridge_name" con-name "$ovs_port"
       fi
 
       extra_phys_args=()
@@ -263,38 +241,19 @@ contents:
       fi
 
       # use ${extra_phys_args[@]+"${extra_phys_args[@]}"} instead of ${extra_phys_args[@]} to be compatible with bash 4.2 in RHEL7.9
-      if ! nmcli connection show ovs-if-phys0 &> /dev/null; then
-        nmcli c add type ${iface_type} conn.interface ${iface} master ovs-port-phys0 con-name ovs-if-phys0 \
+      if ! nmcli connection show "$bridge_interface_name" &> /dev/null; then
+        nmcli c add type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
         connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 
       # Get the new connection uuid
-      new_conn=$(nmcli -g connection.uuid conn show ovs-if-phys0)
-
-      # Setup an exit trap to restore any modifications going further
-      handle_exit_error() {
-        e=$?
-        [ $e -eq 0 ] && exit 0
-        # if there was a problem network isn't coming up, revert for debugging
-        set +e
-        nmcli c show
-        # For some reason RHEL7 requires the interface connection to be brought down explicitly whereas RHCOS does not
-        nmcli conn down ovs-if-phys0
-        nmcli conn up $old_conn
-        exit $e
-      }
-      trap "handle_exit_error" EXIT
+      new_conn=$(nmcli -g connection.uuid conn show "$bridge_interface_name")
 
       # Update connections with master property set to use the new connection
       replace_connection_master $old_conn $new_conn
       replace_connection_master $iface $new_conn
 
-      # For some reason RHEL7 requires the ovs bridge to be brought up explicitly whereas RHCOS does not
-      nmcli conn up br-ex
-      # Bring up the new interface connection
-      nmcli conn up ovs-if-phys0
-
-      if ! nmcli connection show ovs-if-br-ex &> /dev/null; then
+      if ! nmcli connection show "$ovs_interface" &> /dev/null; then
         if nmcli --fields ipv4.method,ipv6.method conn show $old_conn | grep manual; then
           echo "Static IP addressing detected on default gateway connection: ${old_conn}"
           # find and copy the old connection to get the address settings
@@ -317,9 +276,9 @@ contents:
           fi
           echo "old connection file found at: ${old_conn_file}"
           old_basename=$(basename "${old_conn_file}" .nmconnection)
-          new_conn_file="${old_conn_file/${NM_CONN_PATH}\/$old_basename/${NM_CONN_PATH}/ovs-if-br-ex}"
+          new_conn_file="${old_conn_file/${NM_CONN_PATH}\/$old_basename/${NM_CONN_PATH}/$ovs_interface}"
           if [ -f "$new_conn_file" ]; then
-            echo "WARN: existing br-ex interface file found: $new_conn_file, which is not loaded in NetworkManager...overwriting"
+            echo "WARN: existing $bridge_name interface file found: $new_conn_file, which is not loaded in NetworkManager...overwriting"
           fi
           cp -f "${old_conn_file}" ${new_conn_file}
           restorecon ${new_conn_file}
@@ -327,19 +286,19 @@ contents:
             nmcli conn delete ${old_conn}-clone
             rm -f "${old_conn_file}"
           fi
-          ovs_port_conn=$(nmcli --fields connection.uuid conn show ovs-port-br-ex | awk '{print $2}')
+          ovs_port_conn=$(nmcli --fields connection.uuid conn show "$ovs_port" | awk '{print $2}')
           br_iface_uuid=$(cat /proc/sys/kernel/random/uuid)
           # modify file to work with OVS and have unique settings
           sed -i '/^\[connection\]$/,/^\[/ s/^uuid=.*$/uuid='"$br_iface_uuid"'/' ${new_conn_file}
           sed -i '/^multi-connect=.*$/d' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^type=.*$/type=ovs-interface/' ${new_conn_file}
-          sed -i '/^\[connection\]$/,/^\[/ s/^id=.*$/id=ovs-if-br-ex/' ${new_conn_file}
+          sed -i '/^\[connection\]$/,/^\[/ s/^id=.*$/id='"$ovs_interface"'/' ${new_conn_file}
           sed -i '/^\[connection\]$/a slave-type=ovs-port' ${new_conn_file}
           sed -i '/^\[connection\]$/a master='"$ovs_port_conn" ${new_conn_file}
           if grep 'interface-name=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[connection\]$/,/^\[/ s/^interface-name=.*$/interface-name=br-ex/' ${new_conn_file}
+            sed -i '/^\[connection\]$/,/^\[/ s/^interface-name=.*$/interface-name='"$bridge_name"'/' ${new_conn_file}
           else
-            sed -i '/^\[connection\]$/a interface-name=br-ex' ${new_conn_file}
+            sed -i '/^\[connection\]$/a interface-name='"$bridge_name" ${new_conn_file}
           fi
           if ! grep 'cloned-mac-address=' ${new_conn_file} &> /dev/null; then
             sed -i '/^\[ethernet\]$/a cloned-mac-address='"$iface_mac" ${new_conn_file}
@@ -356,79 +315,208 @@ contents:
     type=internal
     EOF
           nmcli c load ${new_conn_file}
-          echo "Loaded new ovs-if-br-ex connection file: ${new_conn_file}"
+          echo "Loaded new $ovs_interface connection file: ${new_conn_file}"
         else
-          nmcli c add type ovs-interface slave-type ovs-port conn.interface br-ex master ovs-port-br-ex con-name \
-            ovs-if-br-ex 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
+          nmcli c add type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
+            "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC"
         fi
       fi
 
-      # wait for DHCP to finish, verify connection is up
-      counter=0
-      while [ $counter -lt 5 ]; do
-        sleep 5
-        # check if connection is active
-        if nmcli --fields GENERAL.STATE conn show ovs-if-br-ex | grep -i "activated"; then
-          echo "OVS successfully configured"
-          copy_nm_conn_files
-          ip a show br-ex
-          ip route show
-          nmcli c show
-          configure_driver_options ${iface}
-          exit 0
-        fi
-        counter=$((counter+1))
-      done
+      configure_driver_options "${iface}"
+      update_nm_conn_files "$bridge_name" "$port_name"
+      persist_nm_conn_files
+    }
 
-      echo "WARN: OVS did not succesfully activate NM connection. Attempting to bring up connections"
-      counter=0
-      while [ $counter -lt 5 ]; do
-        if nmcli conn up ovs-if-br-ex; then
-          echo "OVS successfully configured"
-          copy_nm_conn_files
-          ip a show br-ex
-          ip route show
-          nmcli c show
-          configure_driver_options ${iface}
-          exit 0
-        fi
-        sleep 5
-        counter=$((counter+1))
-      done
-
-      echo "ERROR: Failed to activate ovs-if-br-ex NM connection"
-      exit 1
-    elif [ "$1" == "OpenShiftSDN" ]; then
-      iface=""
-      if nmcli connection show ovs-port-phys0 &> /dev/null; then
-        iface=$(nmcli --get-values connection.interface-name connection show ovs-port-phys0)
-      fi
+    # Used to remove a bridge
+    remove_ovn_bridges() {
+      bridge_name=${1}
+      port_name=${2}
 
       # Revert changes made by /usr/local/bin/configure-ovs.sh.
       rm_nm_conn_files
 
       # Reload configuration, after reload the preferred connection profile
       # should be auto-activated
-      nmcli c reload
-      sleep 5
+      update_nm_conn_files ${bridge_name} ${port_name}
+      rm_nm_conn_files
 
       # NetworkManager will not remove br-ex if it has the patch port created by ovn-kubernetes
       # so remove explicitly
-      ovs-vsctl --timeout=30 --if-exists del-br br-ex
+      ovs-vsctl --timeout=30 --if-exists del-br ${bridge_name}
+    }
 
-      # Remove bridges created by OVN-Kubernetes
-      ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local
+    # Removes any previous ovs configuration
+    remove_all_ovn_bridges() {
+      echo "Reverting any previous OVS configuration"
+      
+      remove_ovn_bridges br-ex phys0
+      
+      echo "OVS configuration successfully reverted"
+    }
 
-      # In some cases the preferred connection profile is not auto-activated
-      # (maybe due to differences in NM versions) so try to activate it
-      # explicitly.
-      if [ -n "$iface" ]; then
-        nmcli device connect $iface
+    # Reloads NetworkManager
+    reload_nm() {
+      echo "Reloading NetworkManager..."
+
+      # set network off, so that auto-connect priority is evaluated when turning
+      # it back on
+      nmcli network off
+      
+      # restart NetworkManager to reload profiles, including generating
+      # transient profiles for devices that don't have any
+      systemctl restart NetworkManager
+
+      # turn network back on triggering auto-connects 
+      nmcli network on
+
+      # Wait until all profiles auto-connect
+      if nm-online -s -t 60; then
+        echo "NetworkManager has activated all suitable profiles after reload"
+      else
+        echo "NetworkManager has not activated all suitable profiles after reload"
       fi
 
-      echo "OVS configuration successfully reverted"
-      nmcli c show
-      ovs-vsctl show
-      ip route
+      # Check if we have any type of connectivity
+      if nm-online -t 0; then
+        echo "NetworkManager has connectivity after reload"
+      else
+        echo "NetworkManager does not have connectivity after reload"
+      fi
+    }
+
+    # Activates a NM connection profile
+    activate_nm_conn() {
+      local conn="$1"
+      for i in {1..10}; do
+        echo "Attempt $i to bring up connection $conn"
+        nmcli conn up "$conn" && s=0 && break || s=$?
+        sleep 5
+      done
+      if [ $s -eq 0 ]; then
+        echo "Brought up connection $conn successfully"
+      else
+        echo "ERROR: Cannot bring up connection $conn after $i attempts"
+      fi
+      return $s
+    }
+
+    # Used to print network state
+    print_state() {
+      echo "Current connection, interface and routing state:"
+      nmcli -g all c show
+      ip -d address show
+      ip route show
+      ip -6 route show
+    }
+
+    # Setup an exit trap to rollback on error
+    handle_exit() {
+      e=$?
+      [ $e -eq 0 ] && print_state && exit 0
+
+      echo "ERROR: configure-ovs exited with error: $e"
+      print_state
+
+      # copy configuration to tmp
+      dir=$(mktemp -d -t "configure-ovs-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX")
+      update_nm_conn_files br-ex phys0
+      copy_nm_conn_files "$dir"
+      echo "Copied OVS configuration to $dir for troubleshooting"
+
+      # attempt to restore the previous network state
+      echo "Attempting to restore previous configuration..."
+      remove_all_ovn_bridges
+      reload_nm
+      print_state
+
+      exit $e
+    }
+    trap "handle_exit" EXIT
+
+    if ! rpm -qa | grep -q openvswitch; then
+      echo "Warning: Openvswitch package is not installed!"
+      exit 1
+    fi
+
+    # print initial state
+    print_state
+
+    if [ "$1" == "OVNKubernetes" ]; then
+      # Configures NICs onto OVS bridge "br-ex"
+      # Configuration is either auto-detected or provided through a config file written already in Network Manager
+      # key files under /etc/NetworkManager/system-connections/
+      # Managing key files is outside of the scope of this script
+
+      # if the interface is of type vmxnet3 add multicast capability for that driver
+      # REMOVEME: Once BZ:1854355 is fixed, this needs to get removed.
+      function configure_driver_options {
+        intf=$1
+        if [ ! -f "/sys/class/net/${intf}/device/uevent" ]; then
+          echo "Device file doesn't exist, skipping setting multicast mode"
+        else
+          driver=$(cat "/sys/class/net/${intf}/device/uevent" | grep DRIVER | awk -F "=" '{print $2}')
+          echo "Driver name is" $driver
+          if [ "$driver" = "vmxnet3" ]; then
+            ifconfig "$intf" allmulti
+          fi
+        fi
+      }
+
+      iface=""
+      counter=0
+      # find default interface
+      while [ $counter -lt 12 ]; do
+        # check ipv4
+        iface=$(ip route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
+        if [[ -n "$iface" ]]; then
+          echo "IPv4 Default gateway interface found: ${iface}"
+          break
+        fi
+        # check ipv6
+        iface=$(ip -6 route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
+        if [[ -n "$iface" ]]; then
+          echo "IPv6 Default gateway interface found: ${iface}"
+          break
+        fi
+        counter=$((counter+1))
+        echo "No default route found on attempt: ${counter}"
+        sleep 5
+      done
+
+      extra_bridge_file='/etc/ovnk/extra_bridge'
+
+      if [ "$iface" != "br-ex" ]; then
+        # Default gateway is not br-ex.
+        echo "Bridge br-ex is not active, restoring previous configuration before proceeding..."
+        rollback_nm
+        print_state
+      fi
+      
+      convert_to_bridge "$iface" "br-ex" "phys0"
+
+      # Remove bridges created by openshift-sdn
+      ovs-vsctl --timeout=30 --if-exists del-br br0
+      
+      # Recycle NM connections
+      reload_nm
+
+      # Make sure everything is activated
+      activate_nm_conn ovs-if-phys0
+      activate_nm_conn ovs-if-br-ex
+    elif [ "$1" == "OpenShiftSDN" ]; then
+      # This will be set to 1 if remove_all_ovn_bridges actually changes anything
+      nm_conn_files_removed=0
+
+      # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
+      remove_all_ovn_bridges
+      
+      # Reload only if we removed connection profiles
+      if [ $nm_conn_files_removed -eq 1 ]; then
+        echo "OVS configuration was cleaned up, will reload NetworkManager"
+        reload_nm
+      fi
+      
+      # Remove bridges created by ovn-kubernetes
+      ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local
     fi

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -243,33 +243,24 @@ contents:
             exit 1
           fi
           new_conn_file="${new_conn_files[0]}"
-          # modify file to work with OVS and have unique settings
+
+          # modify basic connection settings, some of which can't be modified through nmcli
           sed -i '/^multi-connect=.*$/d' ${new_conn_file}
           sed -i '/^autoconnect=.*$/d' ${new_conn_file}
           sed -i '/^\[connection\]$/a autoconnect=false' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^type=.*$/type=ovs-interface/' ${new_conn_file}
           sed -i '/^\[connection\]$/a slave-type=ovs-port' ${new_conn_file}
           sed -i '/^\[connection\]$/a master='"$ovs_port_conn" ${new_conn_file}
-          if grep 'interface-name=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[connection\]$/,/^\[/ s/^interface-name=.*$/interface-name='"$bridge_name"'/' ${new_conn_file}
-          else
-            sed -i '/^\[connection\]$/a interface-name='"$bridge_name" ${new_conn_file}
-          fi
-          if ! grep 'cloned-mac-address=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[ethernet\]$/a cloned-mac-address='"$iface_mac" ${new_conn_file}
-          else
-            sed -i '/^\[ethernet\]$/,/^\[/ s/^cloned-mac-address=.*$/cloned-mac-address='"$iface_mac"'/' ${new_conn_file}
-          fi
-          if grep 'mtu=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[ethernet\]$/,/^\[/ s/^mtu=.*$/mtu='"$iface_mtu"'/' ${new_conn_file}
-          else
-            sed -i '/^\[ethernet\]$/a mtu='"$iface_mtu" ${new_conn_file}
-          fi
           cat <<EOF >> ${new_conn_file}
     [ovs-interface]
     type=internal
     EOF
+
+          # reload the connection and modify some more settings through nmcli
           nmcli c load ${new_conn_file}
+          nmcli c mod "${ovs_interface}" conn.interface "$bridge_name" \
+            802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
+            ipv4.route-metric "${bridge_metric}" ipv6.route-metric "${bridge_metric}"
           echo "Loaded new $ovs_interface connection file: ${new_conn_file}"
         else
           extra_if_brex_args=""

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -46,6 +46,7 @@ contents:
     }
 
     persist_nm_conn_files() {
+      update_nm_conn_files br-ex phys0
       copy_nm_conn_files "$NM_CONN_UNDERLAY"
     }
 
@@ -328,8 +329,6 @@ contents:
       fi
 
       configure_driver_options "${iface}"
-      update_nm_conn_files "$bridge_name" "$port_name"
-      persist_nm_conn_files
     }
 
     # Used to remove a bridge
@@ -558,6 +557,7 @@ contents:
       done
       activate_nm_conn ovs-if-phys0
       activate_nm_conn ovs-if-br-ex
+      persist_nm_conn_files
     elif [ "$1" == "OpenShiftSDN" ]; then
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
       rollback_nm

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -218,8 +218,9 @@ contents:
         ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 
-      # Get the new connection uuid
+      # Get the new connection uuids
       new_conn=$(nmcli -g connection.uuid conn show "$bridge_interface_name")
+      ovs_port_conn=$(nmcli -g connection.uuid conn show "$ovs_port")
 
       # Update connections with master property set to use the new connection
       replace_connection_master $old_conn $new_conn
@@ -229,45 +230,23 @@ contents:
         ovs-vsctl --timeout=30 --if-exists destroy interface "$bridge_name"
         if nmcli --fields ipv4.method,ipv6.method conn show $old_conn | grep manual; then
           echo "Static IP addressing detected on default gateway connection: ${old_conn}"
-          # find and copy the old connection to get the address settings
-          if egrep -l "^uuid=$old_conn" ${NM_CONN_PATH}/*; then
-            old_conn_file=$(egrep -l "^uuid=$old_conn" ${NM_CONN_PATH}/*)
-            cloned=false
-          else
-            echo "WARN: unable to find NM configuration file for conn: ${old_conn}. Attempting to clone conn"
-            nmcli conn clone ${old_conn} ${old_conn}-clone
-            shopt -s nullglob
-            old_conn_files=(${NM_CONN_PATH}/"${old_conn}"-clone*)
-            shopt -u nullglob
-            if [ ${#old_conn_files[@]} -ne 1 ]; then
-              echo "ERROR: unable to locate cloned conn file for ${old_conn}-clone"
-              exit 1
-            fi
-            old_conn_file="${old_conn_files[0]}"
-            cloned=true
-            echo "Successfully cloned conn to ${old_conn_file}"
+          # clone the old connection to get the address settings
+          # clone is better than file copy since the resulting file will inherit proper
+          # NM selinux attributes vs using restorecon on systemConnectionsMerged
+          nmcli conn clone "${old_conn}" "${ovs_interface}"
+          shopt -s nullglob
+          new_conn_files=(${NM_CONN_PATH}/"${ovs_interface}"*)
+          shopt -u nullglob
+          if [ ${#new_conn_files[@]} -ne 1 ] || [ ! -f "${new_conn_files[0]}" ]; then
+            echo "ERROR: could not find ${ovs_interface} conn file after cloning from ${old_conn}"
+            exit 1
           fi
-          echo "old connection file found at: ${old_conn_file}"
-          old_basename=$(basename "${old_conn_file}" .nmconnection)
-          new_conn_file="${old_conn_file/${NM_CONN_PATH}\/$old_basename/${NM_CONN_PATH}/$ovs_interface}"
-          if [ -f "$new_conn_file" ]; then
-            echo "WARN: existing $bridge_name interface file found: $new_conn_file, which is not loaded in NetworkManager...overwriting"
-          fi
-          cp -f "${old_conn_file}" ${new_conn_file}
-          restorecon ${new_conn_file}
-          if $cloned; then
-            nmcli conn delete ${old_conn}-clone
-            rm -f "${old_conn_file}"
-          fi
-          ovs_port_conn=$(nmcli --fields connection.uuid conn show "$ovs_port" | awk '{print $2}')
-          br_iface_uuid=$(cat /proc/sys/kernel/random/uuid)
+          new_conn_file="${new_conn_files[0]}"
           # modify file to work with OVS and have unique settings
-          sed -i '/^\[connection\]$/,/^\[/ s/^uuid=.*$/uuid='"$br_iface_uuid"'/' ${new_conn_file}
           sed -i '/^multi-connect=.*$/d' ${new_conn_file}
           sed -i '/^autoconnect=.*$/d' ${new_conn_file}
           sed -i '/^\[connection\]$/a autoconnect=false' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^type=.*$/type=ovs-interface/' ${new_conn_file}
-          sed -i '/^\[connection\]$/,/^\[/ s/^id=.*$/id='"$ovs_interface"'/' ${new_conn_file}
           sed -i '/^\[connection\]$/a slave-type=ovs-port' ${new_conn_file}
           sed -i '/^\[connection\]$/a master='"$ovs_port_conn" ${new_conn_file}
           if grep 'interface-name=' ${new_conn_file} &> /dev/null; then
@@ -322,7 +301,7 @@ contents:
             extra_if_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
           fi
 
-          add_nm_conn type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
+          add_nm_conn type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port_conn" con-name \
             "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC" ${extra_if_brex_args}
         fi

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -113,13 +113,14 @@ contents:
     BRIDGE_METRIC="49"
     # Given an interface, generates NM configuration to add to an OVS bridge
     convert_to_bridge() {
-      iface=${1}
-      bridge_name=${2}
-      port_name=${3}
-      ovs_port="ovs-port-${bridge_name}"
-      ovs_interface="ovs-if-${bridge_name}"
-      default_port_name="ovs-port-${port_name}" # ovs-port-phys0
-      bridge_interface_name="ovs-if-${port_name}" # ovs-if-phys0
+      local iface=${1}
+      local bridge_name=${2}
+      local port_name=${3}
+      local bridge_metric=${4}
+      local ovs_port="ovs-port-${bridge_name}"
+      local ovs_interface="ovs-if-${bridge_name}"
+      local default_port_name="ovs-port-${port_name}" # ovs-port-phys0
+      local bridge_interface_name="ovs-if-${port_name}" # ovs-if-phys0
 
       if [ "$iface" = "$bridge_name" ]; then
         # handle vlans and bonds etc if they have already been
@@ -303,7 +304,7 @@ contents:
 
           add_nm_conn type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port_conn" con-name \
             "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
-            ipv4.route-metric "$BRIDGE_METRIC" ipv6.route-metric "$BRIDGE_METRIC" ${extra_if_brex_args}
+            ipv4.route-metric "${bridge_metric}" ipv6.route-metric "${bridge_metric}" ${extra_if_brex_args}
         fi
       fi
 
@@ -524,8 +525,8 @@ contents:
         rollback_nm
         print_state
       fi
-      
-      convert_to_bridge "$iface" "br-ex" "phys0"
+
+      convert_to_bridge "$iface" "br-ex" "phys0" "${BRIDGE_METRIC}"
 
       # Remove bridges created by openshift-sdn
       ovs-vsctl --timeout=30 --if-exists del-br br0

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -209,7 +209,6 @@ contents:
             con-name br-ex \
             conn.interface br-ex \
             802-3-ethernet.mtu ${iface_mtu} \
-            802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric "$BRIDGE_METRIC" \
             ipv6.route-metric "$BRIDGE_METRIC" \
             ${extra_brex_args}

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -188,6 +188,7 @@ contents:
 
       # create bridge
       if ! nmcli connection show "$bridge_name" &> /dev/null; then
+        ovs-vsctl --timeout=30 --if-exists del-br "$bridge_name"
         nmcli c add type ovs-bridge \
             con-name "$bridge_name" \
             conn.interface "$bridge_name" \
@@ -199,10 +200,12 @@ contents:
 
       # find default port to add to bridge
       if ! nmcli connection show "$default_port_name" &> /dev/null; then
+        ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" ${iface}
         nmcli c add type ovs-port conn.interface ${iface} master "$bridge_name" con-name "$default_port_name"
       fi
 
       if ! nmcli connection show "$ovs_port" &> /dev/null; then
+        ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" "$bridge_name"
         nmcli c add type ovs-port conn.interface "$bridge_name" master "$bridge_name" con-name "$ovs_port"
       fi
 
@@ -242,6 +245,7 @@ contents:
 
       # use ${extra_phys_args[@]+"${extra_phys_args[@]}"} instead of ${extra_phys_args[@]} to be compatible with bash 4.2 in RHEL7.9
       if ! nmcli connection show "$bridge_interface_name" &> /dev/null; then
+        ovs-vsctl --timeout=30 --if-exists destroy interface ${iface}
         nmcli c add type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
         connection.autoconnect-priority 100 802-3-ethernet.mtu ${iface_mtu} ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
@@ -254,6 +258,7 @@ contents:
       replace_connection_master $iface $new_conn
 
       if ! nmcli connection show "$ovs_interface" &> /dev/null; then
+        ovs-vsctl --timeout=30 --if-exists destroy interface "$bridge_name"
         if nmcli --fields ipv4.method,ipv6.method conn show $old_conn | grep manual; then
           echo "Static IP addressing detected on default gateway connection: ${old_conn}"
           # find and copy the old connection to get the address settings
@@ -385,6 +390,21 @@ contents:
       fi
     }
 
+    # Removes all configuration and reloads NM if necessary
+    rollback_nm() {
+      # This will be set to 1 if remove_all_ovn_bridges actually changes anything
+      nm_conn_files_removed=0
+
+      # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
+      remove_all_ovn_bridges
+      
+      # Reload only if we removed connection profiles
+      if [ $nm_conn_files_removed -eq 1 ]; then
+        echo "OVS configuration was cleaned up, will reload NetworkManager"
+        reload_nm
+      fi
+    }
+
     # Activates a NM connection profile
     activate_nm_conn() {
       local conn="$1"
@@ -403,8 +423,9 @@ contents:
 
     # Used to print network state
     print_state() {
-      echo "Current connection, interface and routing state:"
-      nmcli -g all c show
+      echo "Current device, connection, interface and routing state:"
+      nmcli -g all device | grep -v unmanaged
+      nmcli -g all connection
       ip -d address show
       ip route show
       ip -6 route show
@@ -426,8 +447,7 @@ contents:
 
       # attempt to restore the previous network state
       echo "Attempting to restore previous configuration..."
-      remove_all_ovn_bridges
-      reload_nm
+      rollback_nm
       print_state
 
       exit $e
@@ -505,17 +525,8 @@ contents:
       activate_nm_conn ovs-if-phys0
       activate_nm_conn ovs-if-br-ex
     elif [ "$1" == "OpenShiftSDN" ]; then
-      # This will be set to 1 if remove_all_ovn_bridges actually changes anything
-      nm_conn_files_removed=0
-
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
-      remove_all_ovn_bridges
-      
-      # Reload only if we removed connection profiles
-      if [ $nm_conn_files_removed -eq 1 ]; then
-        echo "OVS configuration was cleaned up, will reload NetworkManager"
-        reload_nm
-      fi
+      rollback_nm
       
       # Remove bridges created by ovn-kubernetes
       ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local


### PR DESCRIPTION
This PR cherry-picks a stream of fixes from 4.8 for configure-ovs which have been blocked for quite some time.

CARRY from 4.8 (things that were not picked from previous cherry picks):
* [configure-ovs: remove spaces from team config json](https://github.com/openshift/machine-config-operator/pull/3043/commits/079968d6531b0a386df021ff8d1279063c9402a0)
* [configure-ovs: don't clone mac address for br-ex ovs bridge](https://github.com/openshift/machine-config-operator/pull/3043/commits/dce098250a85e12a7593134cddcb0b4a0cb9f709)

CHERRY-PICKS from 4.8:
* [configure-ovs: Persist addr-gen-mode for ipv6 connections](https://github.com/openshift/machine-config-operator/pull/3043/commits/0a34865722705199ab3986c07dbec4a03a4ce615)
* [Improvements for configure-ovs script](https://github.com/openshift/machine-config-operator/pull/3043/commits/6efed3757e3a12948ef54a5d46a4d3686a8e5d2e)
* [configure-ovs: cleanup leftovers from previous run](https://github.com/openshift/machine-config-operator/pull/3043/commits/29cbcaa0a749c6401099dee597d5d3c7fb583899)
* [Configure-ovs: Ensure DHCP finishes for both address families](https://github.com/openshift/machine-config-operator/pull/3043/commits/4a38b402be9dc5d36f439269ff96e0a7c039cbe9)
* [Use ip command to check for ipv4/v6 addresses](https://github.com/openshift/machine-config-operator/pull/3043/commits/efaa77ef90900d1295507043d9306299f54abdc6)
* [Fix bad cherry-pick at](https://github.com/openshift/machine-config-operator/pull/3043/commits/d9023160ae21914fc55bd296b08b3d62a2e9ec97) https://github.com/jcaamano/machine-config-operator/commit/9f7a7eb9633840104eacdd835d81c268f109a74d
* [configure-ovs: move dhcp config from br-ex to ovs-if-br-ex](https://github.com/openshift/machine-config-operator/pull/3043/commits/96201c51e1600a4263a98838b039b07898a08577)
* [configure-ovs: remove unused extra_bridge_file](https://github.com/openshift/machine-config-operator/pull/3043/commits/242b13fd535f8ef1dbd338e99b55d475a555cc47)
* [configure-ovs: reload NM only when necessary](https://github.com/openshift/machine-config-operator/pull/3043/commits/6f1891c3663636f67c888cd0b7a9c838aca0b234)
* [configure-ovs: avoid restarting NetworkManager](https://github.com/openshift/machine-config-operator/pull/3043/commits/e4dfa68cc5ee230ba493443a8053bbfba5d2cff5)
* [configure-ovs: persist profiles after auto-connect has been set](https://github.com/openshift/machine-config-operator/pull/3043/commits/0f2246733de858f465858a47285f4a6037e206c9)
* [configure-ovs: clone connection to avoid selinux problems](https://github.com/openshift/machine-config-operator/pull/3043/commits/3be94396b491949d8080cba7a22dd1304c081e6f)
* [configure-ovs-network: Use lower metric for br-ex than for br-ex1](https://github.com/openshift/machine-config-operator/pull/3043/commits/049322febbdc99db144ba50e692681e2d54970f0)
* [configure-ovs: explicitly set ovs-if-phys mac](https://github.com/openshift/machine-config-operator/pull/3043/commits/6d52afc156efee50887f21de196932e154514d95)
* [configure-ovs: improve static ip configuration flow](https://github.com/openshift/machine-config-operator/pull/3043/commits/9597b418dde55c519768c9ec89a1d12fd94ac0d6)
* [configure-ovs: set mac only for non fail_over_mac bonds](https://github.com/openshift/machine-config-operator/pull/3043/commits/382b2a129b559c3ebed75501f25cd61660c99847)
* [configure-ovs: set autoconnect before activating](https://github.com/openshift/machine-config-operator/pull/3043/commits/67128eaad00deef8fd6cded0d99d25873db8b87a)
* [Fix problem with retaining data in string array in piped while loop](https://github.com/openshift/machine-config-operator/pull/3043/commits/db798babb707ce9a9b6f5be251c8d6beb255b12d)

While I could have just replaced the file entirely, I preferred to keep the tracking side of things as well. 
The review can be made by
- comparing the 4.8 version, they should be identical.
- verifying that commits that include functional changes make sense to have in 4.7
