### PR TITLE
Bug 2069740: Avoid kubernetes node port range

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -20,7 +20,7 @@ contents:
       bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters
     listen health_check_http_url
-      bind :::30936 v4v6
+      bind :::9444 v4v6
       mode http
       monitor-uri /haproxy_ready
       option dontlognull

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -117,7 +117,7 @@ contents:
           initialDelaySeconds: 50
           httpGet:
             path: /haproxy_ready
-            port: 30936
+            port: 9444
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: haproxy-monitor


### PR DESCRIPTION
Per [0], the range 30000-32767 is used for kubernetes node ports.
We should not have haproxy listening in that range to avoid possible
conflicts.

0: https://github.com/openshift/openshift-docs/blob/main/modules/installation-network-user-infra.adoc

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Move the haproxy listening port out of the kubernetes node port range to avoid conflicts.
