### PR TITLE
Render Nutanix cloud provider as blank.

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -350,7 +350,7 @@ func cloudProvider(cfg RenderConfig) (interface{}, error) {
 		}
 
 		switch cfg.Infra.Status.PlatformStatus.Type {
-		case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType, configv1.NutanixPlatformType:
+		case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
 			return strings.ToLower(string(cfg.Infra.Status.PlatformStatus.Type)), nil
 		case configv1.GCPPlatformType:
 			return "gce", nil

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -65,7 +65,7 @@ func TestCloudProvider(t *testing.T) {
 	}, {
 		platform:    configv1.NutanixPlatformType,
 		featureGate: newFeatures("cluster", "CustomNoUpgrade", nil, []string{cloudprovider.ExternalCloudProviderFeature}),
-		res:         "nutanix",
+		res:         "",
 	}, {
 		platform: configv1.AWSPlatformType,
 		res:      "aws",
@@ -95,7 +95,7 @@ func TestCloudProvider(t *testing.T) {
 		res:      "external",
 	}, {
 		platform: configv1.NutanixPlatformType,
-		res:      "nutanix",
+		res:      "",
 	}}
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)


### PR DESCRIPTION
Nutanix `cloudProvider` field needs to be rendered as blank.
