### PR TITLE
Add control plane nodes CPU alerts

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -144,8 +144,8 @@ spec:
               kube-apiservers are also under-provisioned.
               To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
-            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
-          for: 5m
+            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 75 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+          for: 1h
           labels:
             namespace: openshift-machine-config-operator
             severity: warning

--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -103,3 +103,69 @@ spec:
             severity: warning
           annotations:
             message: "Memory usage of {{ $value | humanize }} on {{ $labels.node }} exceeds 90%. Master nodes starved of memory could result in degraded performance of the control plane."
+    - name: control-plane-cpu-utilization
+      rules:
+        - alert: HighOverallControlPlaneCPU
+          annotations:
+            summary: >-
+              CPU utilization across all three control plane nodes is higher than two control plane nodes can sustain; a single control plane node outage may
+              cause a cascading failure; increase available CPU.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            description: >-
+              Given three control plane nodes, the overall CPU utilization may only be about 2/3 of all available capacity.
+              This is because if a single control plane node fails, the remaining two must handle the load of the cluster in order to be highly available.
+              If the cluster is using more than 2/3 of all capacity, if one control plane node fails, the remaining two are likely to
+              fail when they take the load.
+              To fix this, increase the CPU and memory on your control plane nodes.
+          expr: |
+            sum(
+              100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100)
+              AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+            )
+            /
+            count(kube_node_role{role="master"})
+            > 60
+          for: 10m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+        - alert: ExtremelyHighIndividualControlPlaneCPU
+          annotations:
+            summary: >-
+              CPU utilization on a single control plane node is very high, more CPU pressure is likely to cause a failover; increase available CPU.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            description: >-
+              Extreme CPU pressure on instance {{ $labels.instance }}.
+              This can cause slow serialization and poor performance from the kube-apiserver and etcd.
+              When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
+              causing even more CPU pressure.
+              It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
+              If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
+              kube-apiservers are also under-provisioned.
+              To fix this, increase the CPU and memory on your control plane nodes.
+          expr: |
+            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+          for: 5m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+        - alert: ExtremelyHighIndividualControlPlaneCPU
+          annotations:
+            summary: >-
+              Sustained high CPU utilization on a single control plane node, more CPU pressure is likely to cause a failover; increase available CPU.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            description: >-
+              Extreme CPU pressure on instance {{ $labels.instance }}.
+              This can cause slow serialization and poor performance from the kube-apiserver and etcd.
+              When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
+              causing even more CPU pressure.
+              It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
+              If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
+              kube-apiservers are also under-provisioned.
+              To fix this, increase the CPU and memory on your control plane nodes.
+          expr: |
+            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+          for: 1h
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: critical


### PR DESCRIPTION
Control-plane CPU alerts were previously created by the 
cluster-kube-apiserver-operator whereas the memory-related ones were
created by the machine-config-operator. For consistency purposes, there
was an intent to have all the control-plane-related alerts in one place.

Since these alerts require some low-level machine knowledge and are 
about the whole control-plane and not just the kube-apiserver, it makes
more sense to have them in the machine-config-operator.

This change is pending on the following PRs:

- [ ] https://github.com/openshift/cluster-kube-apiserver-operator/pull/1334
- [ ] https://github.com/openshift/runbooks/pull/46

/cc @rphillips @wking 