### PR TITLE
updateKernelArgs: pass kargs instead of MCs

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -408,7 +408,7 @@ func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newC
 
 	// Apply kargs
 	if mcDiff.kargs {
-		if err := dn.updateKernelArguments(oldConfig, newConfig); err != nil {
+		if err := dn.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {
 			return err
 		}
 	}
@@ -923,9 +923,9 @@ func parseKernelArguments(kargs []string) []string {
 // Note what we really should be doing though is also looking at the *current*
 // kernel arguments in case there was drift.  But doing that requires us knowing
 // what the "base" arguments are. See https://github.com/ostreedev/ostree/issues/479
-func generateKargs(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
-	oldKargs := parseKernelArguments(oldConfig.Spec.KernelArguments)
-	newKargs := parseKernelArguments(newConfig.Spec.KernelArguments)
+func generateKargs(oldKernelArguments, newKernelArguments []string) []string {
+	oldKargs := parseKernelArguments(oldKernelArguments)
+	newKargs := parseKernelArguments(newKernelArguments)
 	cmdArgs := []string{}
 
 	// To keep kernel argument processing simpler and bug free, we first delete all
@@ -942,8 +942,8 @@ func generateKargs(oldConfig, newConfig *mcfgv1.MachineConfig) []string {
 }
 
 // updateKernelArguments adjusts the kernel args
-func (dn *CoreOSDaemon) updateKernelArguments(oldConfig, newConfig *mcfgv1.MachineConfig) error {
-	kargs := generateKargs(oldConfig, newConfig)
+func (dn *CoreOSDaemon) updateKernelArguments(oldKernelArguments, newKernelArguments []string) error {
+	kargs := generateKargs(oldKernelArguments, newKernelArguments)
 	if len(kargs) == 0 {
 		return nil
 	}

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -313,15 +313,7 @@ func TestKernelAguments(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
-			oldIgnCfg := ctrlcommon.NewIgnConfig()
-			oldMcfg := helpers.CreateMachineConfigFromIgnition(oldIgnCfg)
-			oldMcfg.Spec.KernelArguments = test.oldKargs
-
-			newIgnCfg := ctrlcommon.NewIgnConfig()
-			newMcfg := helpers.CreateMachineConfigFromIgnition(newIgnCfg)
-			newMcfg.Spec.KernelArguments = test.newKargs
-
-			res := generateKargs(oldMcfg, newMcfg)
+			res := generateKargs(test.oldKargs, test.newKargs)
 
 			if !reflect.DeepEqual(test.out, res) {
 				t.Errorf("Failed kernel arguments processing: expected: %v but result is: %v", test.out, res)


### PR DESCRIPTION
This is a refactor to allow reusing updateKernelArgs() for layering. It
is a minor improvement for master since it better protects
MachineConfigs from unintended modification by updateKernelArgs(), and
it simplifies test code which doesn't have to create dummy
MachineConfigs