### PR TITLE
[low priority] kubelet controller: rm unused userDefinedSystemReserved

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -340,12 +340,13 @@ func kubeletConfigToIgnFile(cfg *kubeletconfigv1beta1.KubeletConfiguration) (*ig
 }
 
 // generateKubeletIgnFiles generates the Ignition files from the kubelet config
-func generateKubeletIgnFiles(kubeletConfig *mcfgv1.KubeletConfig, originalKubeConfig *kubeletconfigv1beta1.KubeletConfiguration, userDefinedSystemReserved map[string]string) (*ign3types.File, *ign3types.File, *ign3types.File, error) {
+func generateKubeletIgnFiles(kubeletConfig *mcfgv1.KubeletConfig, originalKubeConfig *kubeletconfigv1beta1.KubeletConfiguration) (*ign3types.File, *ign3types.File, *ign3types.File, error) {
 	var (
 		kubeletIgnition            *ign3types.File
 		logLevelIgnition           *ign3types.File
 		autoSizingReservedIgnition *ign3types.File
 	)
+	userDefinedSystemReserved := make(map[string]string)
 
 	if kubeletConfig.Spec.KubeletConfig != nil && kubeletConfig.Spec.KubeletConfig.Raw != nil {
 		specKubeletConfig, err := decodeKubeletConfig(kubeletConfig.Spec.KubeletConfig.Raw)

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -16,7 +16,6 @@ import (
 func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletConfig, controllerConfig *mcfgv1.ControllerConfig, features *configv1.FeatureGate, mcpPools []*mcfgv1.MachineConfigPool) ([]*mcfgv1.MachineConfig, error) {
 	var res []*mcfgv1.MachineConfig
 	managedKeyExist := make(map[string]bool)
-	userDefinedSystemReserved := make(map[string]string)
 	// Validate the KubeletConfig CR if exists
 	for _, kubeletConfig := range kubeletConfigs {
 		if err := validateUserKubeletConfig(kubeletConfig); err != nil {
@@ -50,7 +49,7 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 				originalKubeConfig.TLSCipherSuites = observedCipherSuites
 			}
 
-			kubeletIgnition, logLevelIgnition, autoSizingReservedIgnition, err := generateKubeletIgnFiles(kubeletConfig, originalKubeConfig, userDefinedSystemReserved)
+			kubeletIgnition, logLevelIgnition, autoSizingReservedIgnition, err := generateKubeletIgnFiles(kubeletConfig, originalKubeConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -528,8 +528,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		}
 		isNotFound := macherrors.IsNotFound(err)
 
-		userDefinedSystemReserved := make(map[string]string, 2)
-
 		// Generate the original KubeletConfig
 		cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 		if err != nil {
@@ -558,7 +556,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		originalKubeConfig.TLSMinVersion = observedMinTLSVersion
 		originalKubeConfig.TLSCipherSuites = observedCipherSuites
 
-		kubeletIgnition, logLevelIgnition, autoSizingReservedIgnition, err := generateKubeletIgnFiles(cfg, originalKubeConfig, userDefinedSystemReserved)
+		kubeletIgnition, logLevelIgnition, autoSizingReservedIgnition, err := generateKubeletIgnFiles(cfg, originalKubeConfig)
 		if err != nil {
 			return ctrl.syncStatusOnly(cfg, err)
 		}


### PR DESCRIPTION
I was debugging https://bugzilla.redhat.com/show_bug.cgi?id=2070285 and reading through some kubelet controller code, and I figured I'd use the compiler to check my understanding of what's going on and make this change

Looks like a282006d2d3b245c2f5cdf444a4dea45d1b27585 factored out code
into generateKubeletIgnFiles and should have moved
userDefinedSystemReserved as well, but it got missed.
No caller of generateKubeletIgnFiles puts anything in
userDefinedSystemReserved, so it can be dropped as a parameter. Although
the capacity of the map is set by callers, only the length of the map is
checked in generateKubeletIgnFiles

@QiWang19 is there any reason you didn't move it?