### PR TITLE
Bug 2072040: Avoid NM managing patch port between br-int and br-ex

### DIFF
--- a/templates/common/_base/files/nm-ignore-sdn.yaml
+++ b/templates/common/_base/files/nm-ignore-sdn.yaml
@@ -4,5 +4,5 @@ contents:
   inline: |
     # ignore known SDN-managed devices
     [device]
-    match-device=interface-name:br-int;interface-name:br-local;interface-name:br-nexthop,interface-name:ovn-k8s-*,interface-name:k8s-*;interface-name:tun0;interface-name:br0;driver:veth
+    match-device=interface-name:br-int;interface-name:br-local;interface-name:br-nexthop;interface-name:ovn-k8s-*;interface-name:k8s-*;interface-name:tun0;interface-name:br0;interface-name:patch-br-*;interface-name:br-ext;interface-name:ext-vxlan;interface-name:ext;interface-name:int;interface-name:vxlan_sys_*;interface-name:genev_sys_*;driver:veth
     managed=0


### PR DESCRIPTION
Causes delays on boot waiting for the patch port to become unmanaged.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

