### PR TITLE
[low priority] test/helpers: fix typo hardcoded pool

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -314,7 +314,7 @@ func LabelRandomNodeFromPool(t *testing.T, cs *framework.ClientSet, pool, label 
 		_, err = cs.Nodes().Update(context.TODO(), infraNode, metav1.UpdateOptions{})
 		return err
 	})
-	require.Nil(t, err, "unable to label worker node %s with infra: %s", infraNode.Name, err)
+	require.Nil(t, err, "unable to label %s node %s with infra: %s", pool, infraNode.Name, err)
 
 	return func() {
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {


### PR DESCRIPTION
We always call LabelRandomNodeFromPool with worker as the pool argument,
but it could be some other pool