### PR TITLE
[release-4.8] Bug 2062655: Fix bad cherry-pick at 9f7a7eb96

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -352,9 +352,6 @@ contents:
       bridge_name=${1}
       port_name=${2}
 
-      # Revert changes made by /usr/local/bin/configure-ovs.sh.
-      rm_nm_conn_files
-
       # Reload configuration, after reload the preferred connection profile
       # should be auto-activated
       update_nm_conn_files ${bridge_name} ${port_name}


### PR DESCRIPTION
Fix a bad cherry-pick done on https://github.com/openshift/machine-config-operator/pull/3065 9f7a7eb96

It failed on RHEL on a manual verification:
```
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + remove_all_ovn_bridges
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + echo 'Reverting any previous OVS configuration'
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: Reverting any previous OVS configuration
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + remove_ovn_bridges br-ex phys0
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + bridge_name=br-ex
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + port_name=phys0
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + rm_nm_conn_files
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: + files=("${MANAGED_NM_CONN_FILES[@]}")
Apr 06 01:43:55 ip-10-0-49-218.us-east-2.compute.internal configure-ovs.sh[1278]: /usr/local/bin/configure-ovs.sh: line 70: MANAGED_NM_CONN_FILES[@]: unbound variable
```
but did not fail at the time of the original PR on CI with RHCOS:
```
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + remove_all_ovn_bridges
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + echo 'Reverting any previous OVS configuration'
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: Reverting any previous OVS configuration
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + remove_ovn_bridges br-ex phys0
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + bridge_name=br-ex
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + port_name=phys0
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + rm_nm_conn_files
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + files=("${MANAGED_NM_CONN_FILES[@]}")
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + local files
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + shopt -s nullglob
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + files+=(${NM_CONN_PATH}/*${MANAGED_NM_CONN_SUFFIX}.nmconnection ${NM_CONN_PATH}/*${MANAGED_NM_CONN_SUFFIX})
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + shopt -u nullglob
Mar 14 09:53:47.282534 ip-10-0-142-30 configure-ovs.sh[1213]: + update_nm_conn_files br-ex phys0
```

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
