### PR TITLE
daemon: add desiredConfigMap mode for Hypershift

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -14,6 +14,14 @@ const (
 	DesiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
 	// MachineConfigDaemonStateAnnotationKey is used to fetch the state of the daemon on the machine.
 	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
+	// DesiredDrainerAnnotationKey is set by the MCD to indicate drain/uncordon requests
+	DesiredDrainerAnnotationKey = "machineconfiguration.openshift.io/desiredDrain"
+	// LastAppliedDrainerAnnotationKey is set by the controller to indicate the last request applied
+	LastAppliedDrainerAnnotationKey = "machineconfiguration.openshift.io/lastAppliedDrain"
+	// DrainerStateDrain is used for drainer annotation as a value to indicate needing a drain
+	DrainerStateDrain = "drain"
+	// DrainerStateUncordon is used for drainer annotation as a value to indicate needing an uncordon
+	DrainerStateUncordon = "uncordon"
 	// ClusterControlPlaneTopologyAnnotationKey is set by the node controller by reading value from
 	// controllerConfig. MCD uses the annotation value to decide drain action on the node.
 	ClusterControlPlaneTopologyAnnotationKey = "machineconfiguration.openshift.io/controlPlaneTopology"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -788,7 +788,6 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 		annos := map[string]string{
 			constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateWorking,
 			constants.MachineConfigDaemonReasonAnnotationKey: "",
-			constants.CurrentMachineConfigAnnotationKey:      targetHash,
 			constants.DesiredDrainerAnnotationKey:            targetDrainValue,
 		}
 		if err := dn.HypershiftSetAnnotation(annos); err != nil {


### PR DESCRIPTION
Add new flag to indicate an update that looks for a desired config
in a ConfigMap, which will be used exclusively for Hypershift
hosted cluster nodes that do not have MachineConfig API.

This mode initializes a simplified daemon that watches for various
state changes, including requests to drain which the Hypershift
nodepool controller will perform instead. This pod should be
ephemeral and only created when an update is required.

There are some duplicated code, which was done to ensure the regular
in-cluster daemonset variant is not affected.

TODOs:
1. switch to using kubelet kubeconfig (can be done on the controller
   side by setting startOpts.kubeconfig + adding the necessary
   ConfigMap to the pod volumes)
2. add disruptionless update logic
3. move to using the same current/desiredconfig annotation logic to
   reduce API calls
4. eventing/variables/duplication comments inline
