### PR TITLE
Bug 2066964: add dependency on sysroot mount to ovsdb-server service

### DIFF
--- a/templates/common/_base/units/ovsdb-server.service.yaml
+++ b/templates/common/_base/units/ovsdb-server.service.yaml
@@ -3,5 +3,8 @@ enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else if eq .NetworkType "Op
 dropins:
   - name: 10-ovsdb-restart.conf
     contents: |
+      [Unit]
+      After=sysroot.mount
+
       [Service]
       Restart=always


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

Added dependency service `sysroot.mount` to ovsdb-sever so ovsdb won't start till sysroot is mounted to fix BZ 2066964
