### PR TITLE
daemon: Load current node FIPS state on firstboot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -573,6 +574,26 @@ func (dn *Daemon) RunOnceFrom(onceFrom string, skipReboot bool) error {
 	return errors.New("unsupported onceFrom type provided")
 }
 
+// synthesizeCurrentState creates a machineconfig object which describes
+// what we see on the node.
+func (dn *Daemon) synthesizeCurrentState() (*mcfgv1.MachineConfig, error) {
+	// Start with an empty config, then add our *booted* osImageURL to
+	// it, reflecting the current machine state.
+	config := canonicalizeEmptyMC(nil)
+	config.Spec.OSImageURL = dn.bootedOSImageURL
+	// Also inject the current fips state, which was handled before we run.
+	content, err := ioutil.ReadFile(fipsFile)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading FIPS file at %s: %w", fipsFile, err)
+	}
+	fips, err := strconv.ParseBool(strings.TrimSuffix(string(content), "\n"))
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing FIPS: %w", err)
+	}
+	config.Spec.FIPS = fips
+	return config, nil
+}
+
 // RunFirstbootCompleteMachineconfig is run via systemd on the first boot
 // to complete processing of the target MachineConfig.
 func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
@@ -586,10 +607,10 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 		return errors.Wrapf(err, "failed to parse MachineConfig")
 	}
 
-	// Start with an empty config, then add our *booted* osImageURL to
-	// it, reflecting the current machine state.
-	oldConfig := canonicalizeEmptyMC(nil)
-	oldConfig.Spec.OSImageURL = dn.bootedOSImageURL
+	oldConfig, err := dn.synthesizeCurrentState()
+	if err != nil {
+		return err
+	}
 	// Currently, we generally expect the bootimage to be older, but in the special
 	// case of having bootimage == machine-os-content, and no kernel arguments
 	// specified, then we don't need to do anything here.


### PR DESCRIPTION
On firstboot, we synthesize a machineConfig which represents
what we *actually see* on the node.  We just fill this in with
what rpm-ostree says is `osImageURL`.  However, FIPS is also
special in that it's handled by a special "FIPS boot" before what
we think of as firstboot.

It cleans up our later comparisons if we have the correct FIPS
state in here.

(In a layering future, I think what we'd do actually is just move
 `fips=1` into a kernel argument passed via MachineConfig, then
  this code wouldn't need to special case it; it'd just be another
  kernel argument)
