### PR TITLE
Bug 2074613: templates: Don't use `:z` with podman on system directories

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -18,7 +18,8 @@ contents: |
     /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
     --net=host \
-    --volume /etc/systemd/system:/etc/systemd/system:z \
+    --security-opt label=disable \
+    --volume /etc/systemd/system:/etc/systemd/system \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set \

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -21,7 +21,8 @@ contents: |
     /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
     --net=host \
-    --volume /etc/systemd/system:/etc/systemd/system:z \
+    --security-opt label=disable \
+    --volume /etc/systemd/system:/etc/systemd/system \
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set --retry-on-failure \


### PR DESCRIPTION
SELinux and containers and host paths is a huge, common trap for us
because Fedora derivatives use SELinux, but e.g. Ubuntu does not.
And SELinux breaks simple uses of `-v` (bind mounts) with containers.

The `:z` and `:Z` flags are really also traps - one rarely wants
them.  In this case, we absolutely do not want to relabel the files
in `/etc`.

Instead, since this is effectively a privileged container, disable
SELinux labeling for it.

xref https://bugzilla.redhat.com/show_bug.cgi?id=2074090
