### PR TITLE
Split methods into ImageUpdater and MCUpdater

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -471,7 +471,7 @@ func (dn *Daemon) syncNode(key string) error {
 		}
 		if coreOSDaemon != nil {
 			// experimentalUpdateLayeredConfig is idempotent
-			return coreOSDaemon.experimentalUpdateLayeredConfig()
+			return (&ImageUpdater{coreOSDaemon}).experimentalUpdateLayeredConfig()
 		}
 		if err := dn.checkStateOnFirstRun(); err != nil {
 			return err
@@ -618,7 +618,7 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	}
 
 	dn.skipReboot = true
-	err = dn.update(nil, &mc)
+	err = (&MCUpdater{dn}).update(nil, &mc)
 	if err != nil {
 		return err
 	}
@@ -1333,7 +1333,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 	}
 	if contentFrom == onceFromLocalConfig {
 		// Execute update without hitting the cluster
-		return dn.update(nil, &machineConfig)
+		return (&MCUpdater{dn}).update(nil, &machineConfig)
 	}
 	// Otherwise return an error as the input format is unsupported
 	return fmt.Errorf("%v is not a path nor url; can not run once", contentFrom)
@@ -1521,11 +1521,11 @@ func (dn *Daemon) triggerUpdateWithMachineConfig(currentConfig, desiredConfig *m
 		return err
 	}
 	if coreOSDaemon != nil {
-		return coreOSDaemon.experimentalUpdateLayeredConfig()
+		return (&ImageUpdater{coreOSDaemon}).experimentalUpdateLayeredConfig()
 	}
 
 	// run the update process. this function doesn't currently return.
-	return dn.update(currentConfig, desiredConfig)
+	return (&MCUpdater{dn}).update(currentConfig, desiredConfig)
 }
 
 // validateOnDiskState compares the on-disk state against what a configuration

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -25,7 +25,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
-func newMockDaemon() Daemon {
+func newMockDaemon() MCUpdater {
 	// testClient is the NodeUpdaterClient mock instance that will front
 	// calls to update the host.
 	testClient := RpmOstreeClientMock{
@@ -33,14 +33,15 @@ func newMockDaemon() Daemon {
 	}
 
 	// Create a Daemon instance with mocked clients
-	return Daemon{
-		mock:              true,
-		name:              "nodeName",
-		os:                OperatingSystem{},
-		NodeUpdaterClient: testClient,
-		kubeClient:        k8sfake.NewSimpleClientset(),
-		bootedOSImageURL:  "test",
-	}
+	return MCUpdater{
+		Daemon: &Daemon{
+			mock:              true,
+			name:              "nodeName",
+			os:                OperatingSystem{},
+			NodeUpdaterClient: testClient,
+			kubeClient:        k8sfake.NewSimpleClientset(),
+			bootedOSImageURL:  "test",
+		}}
 }
 
 func setupTempDirWithEtc(t *testing.T) (string, func()) {
@@ -725,7 +726,7 @@ func TestCalculatePostConfigChangeAction(t *testing.T) {
 			dn := Daemon{
 				os: test.os,
 			}
-			calculatedAction, err := dn.calculatePostConfigChangeActionWithMCDiff(mcDiff, diffFileSet)
+			calculatedAction, err := (&MCUpdater{&dn}).calculatePostConfigChangeActionWithMCDiff(mcDiff, diffFileSet)
 
 			if !reflect.DeepEqual(test.expectedAction, calculatedAction) {
 				t.Errorf("Failed calculating config change action: expected: %v but result is: %v. Error: %v", test.expectedAction, calculatedAction, err)


### PR DESCRIPTION
Protecting these methods with wrapper structs ensures a more clear
separation of Image vs MC updates.

I don't think the double embedding of struct pointers is beautiful, but
I can't come up with a better way to ensure type checking.

The structs embed a pointer to a Daemon since the update methods need
access to fields of Daemon. We don't know whether or not an update is an
image or MC update until the time of the update, so we can't
construct an Updater where Daemon is currently created in
daemon.go:New()

Closes https://issues.redhat.com/browse/MCO-224