### PR TITLE
Kubelet: apply default podPidsLimit

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -18,6 +18,7 @@ contents:
     maxPods: 250
     kubeAPIQPS: 50
     kubeAPIBurst: 100
+    podPidsLimit: 4096
     rotateCertificates: true
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -18,6 +18,7 @@ contents:
     maxPods: 250
     kubeAPIQPS: 50
     kubeAPIBurst: 100
+    podPidsLimit: 4096
     rotateCertificates: true
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests


### PR DESCRIPTION
there is an effort in CRI-O to deprecate config values that are duplicated with ones in the kubelet (see https://issues.redhat.com/browse/OCPNODE-878)

To begin this process, we intend on setting the default in cri-o to unlimited. Before doing so, there should be a kubelet config in place to replace it.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Set kubelet's config field `podPidsLimit` by default so the CRI-O version of the field can be deprecated.
