### PR TITLE
daemon/update: use `--delete-if-present` to delete old kargs

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -979,7 +979,11 @@ func generateKargs(oldKernelArguments, newKernelArguments []string) []string {
 	// kernel arguments present in the new rendered MachineConfig.
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1866546#c10.
 	for _, arg := range oldKargs {
-		cmdArgs = append(cmdArgs, "--delete="+arg)
+		// Use `--delete-if-present` instead of `--delete` so we gracefully
+		// deal with any possible drift that could have happened, e.g.
+		// sysadmins directly editing kargs instead of using the MCO.
+		// https://bugzilla.redhat.com/show_bug.cgi?id=2075126
+		cmdArgs = append(cmdArgs, "--delete-if-present="+arg)
 	}
 	for _, arg := range newKargs {
 		cmdArgs = append(cmdArgs, "--append="+arg)


### PR DESCRIPTION
Let's make the MCO more resilient to the old state not being what it
expects it to be. In an ideal world, that shouldn't happen but there's
nothing preventing sysadmins from fiddling around with kargs for testing
things and that would throw us off.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2075126