### PR TITLE
render: Hack in symlink for `ignition-apply`

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -831,7 +831,7 @@ func (ctrl *Controller) experimentalAddBuildConfigs(pool *mcfgv1.MachineConfigPo
 
 	# Apply the config to the host 
 	ENV container=1
-	RUN ignition-liveapply /etc/machine-config-ignition.json
+	RUN exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition /etc/machine-config-ignition.json
 
 	# Rebuild origin.d (I included an /etc/yum.repos.d/ file in my machineconfig so it could find the RPMS, that's why this works)
 	RUN rpm-ostree ex rebuild && rm -rf /var/cache /etc/rpm-ostree/origin.d


### PR DESCRIPTION
xref https://github.com/coreos/coreos-layering-examples/pull/10/files#diff-cd7826bbd09913ac02ac88625deb775fa25e3feeee90522f12601665e2a59031R9

Basically we're not certain on the CoreOS side where/how to ship
this actually, so just hack it in here for now.
