### PR TITLE
[ layering ] Fix ignition-apply args in dockerfile

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -831,7 +831,7 @@ func (ctrl *Controller) experimentalAddBuildConfigs(pool *mcfgv1.MachineConfigPo
 
 	# Apply the config to the host 
 	ENV container=1
-	RUN exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition /etc/machine-config-ignition.json
+	RUN exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported /etc/machine-config-ignition.json
 
 	# Rebuild origin.d (I included an /etc/yum.repos.d/ file in my machineconfig so it could find the RPMS, that's why this works)
 	RUN rpm-ostree ex rebuild && rm -rf /var/cache /etc/rpm-ostree/origin.d


### PR DESCRIPTION
Right now all the image builds fail because of ignition-apply errors during the docker build. 

https://github.com/openshift/machine-config-operator/pull/3087 would have worked, but the ignition binary I packed in my hacky image was older and seemed to care less. The newest ignition-apply is picky about passwd sections (I noticed this for the buildcontroller code and then promptly forgot to mention it). 

```
[2/2] STEP 5/13: RUN exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition /etc/machine-config-ignition.json
INFO     : Ignition 2.13.0
CRITICAL : failed to apply: running stage 'files': cannot apply passwd live
```

This just makes it skip past the parts it can't implement and continue so builds will work again, and we can talk about the ramifications (if any) later. 