### PR TITLE
Bug 2076355: fix MCNameSuffix when kcfg ctrrcfg after bootstrap config

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
@@ -61,6 +61,11 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 			if err != nil {
 				return nil, fmt.Errorf("could not marshal container runtime ignition: %w", err)
 			}
+			// the first managed key value 99-poolname-generated-containerruntime does not have a suffix
+			// set "" as suffix annotation to the containerruntime config object
+			cfg.SetAnnotations(map[string]string{
+				ctrlcommon.MCNameSuffixAnnotationKey: "",
+			})
 			mc, err := ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ctrRuntimeConfigIgn)
 			if err != nil {
 				return nil, fmt.Errorf("could not create MachineConfig from new Ignition config: %w", err)

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -1,0 +1,57 @@
+package containerruntimeconfig
+
+import (
+	"testing"
+
+	apicfgv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.newController()
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			pools := []*mcfgv1.MachineConfigPool{
+				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
+			}
+			// ctrcfg for bootstrap mode
+			ctrcfg := newContainerRuntimeConfig("log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, pools[0])
+			f.mccrLister = append(f.mccrLister, ctrcfg)
+			f.objects = append(f.objects, ctrcfg)
+
+			mcs, err := RunContainerRuntimeBootstrap("../../../templates", []*mcfgv1.ContainerRuntimeConfig{ctrcfg}, cc, pools)
+			require.NoError(t, err)
+			require.Len(t, mcs, 1)
+
+			// add ctrcfg1 after bootstrap
+			ctrcfg1 := newContainerRuntimeConfig("log-level-master", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
+
+			f.mccrLister = append(f.mccrLister, ctrcfg1)
+			f.objects = append(f.objects, ctrcfg1)
+			c := f.newController()
+			err = c.syncHandler(getKey(ctrcfg1, t))
+			if err != nil {
+				t.Errorf("syncHandler returned: %v", err)
+			}
+
+			// resync ctrcfg and check the managedKey
+			c = f.newController()
+			err = c.syncHandler(getKey(ctrcfg, t))
+			if err != nil {
+				t.Errorf("syncHandler returned: %v", err)
+			}
+			val := ctrcfg.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
+			require.Equal(t, "", val)
+		})
+	}
+}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -579,6 +579,13 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 			}
 			_, ok := cfg.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
 			arr := strings.Split(managedKey, "-")
+			// the first managed key value 99-poolname-generated-containerruntime does not have a suffix
+			// set "" as suffix annotation to the containerruntime config object
+			if _, err := strconv.Atoi(arr[len(arr)-1]); err != nil && !ok {
+				if err := ctrl.addAnnotation(cfg, ctrlcommon.MCNameSuffixAnnotationKey, ""); err != nil {
+					return ctrl.syncStatusOnly(cfg, err, "could not update annotation for containerruntimeConfig")
+				}
+			}
 			// If the MC name suffix annotation does not exist and the managed key value returned has a suffix, then add the MC name
 			// suffix annotation and suffix value to the ctrcfg object
 			if len(arr) > 4 && !ok {

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -194,23 +194,28 @@ func getManagedKeyCtrCfg(pool *mcfgv1.MachineConfigPool, client mcfgclientset.In
 			continue
 		}
 		val, ok := ctrcfg.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
-		// If we find a matching ctrcfg and it is the only one in the list, then return the default MC name with no suffix
-		if !ok && len(ctrcfgList) < 2 {
-			return ctrlcommon.GetManagedKey(pool, client, "99", "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
+		if !ok {
+			break
 		}
-		// Otherwise if an MC name suffix exists, append it to the default MC name and return that as this ctrcfg exists and
+		// if an MC name suffix exists, append it to the default MC name and return that as this containerruntime config exists and
 		// we are probably doing an update action on it
 		if val != "" {
 			return fmt.Sprintf("99-%s-generated-containerruntime-%s", pool.Name, val), nil
 		}
+		// if the suffix val is "", mc name should not suffixed the cfg to be updated is the first containerruntime config has been created
+		return ctrlcommon.GetManagedKey(pool, client, "99", "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
 	}
 
-	// If we are here, this means that a new ctrcfg was created, so we have to calculate the suffix value for its MC name
+	// If we are here, this means that a new containerruntime config was created, so we have to calculate the suffix value for its MC name
+	// if the containerruntime config is the only one in the list, mc name should not suffixed since cfg is the first containerruntime config to be created
+	if len(ctrcfgList) == 1 {
+		return ctrlcommon.GetManagedKey(pool, client, "99", "containerruntime", getManagedKeyCtrCfgDeprecated(pool))
+	}
 	suffixNum := 0
 	// Go through the list of ctrcfg objects created and get the max suffix value currently created
 	for _, item := range ctrcfgList {
 		val, ok := item.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
-		if ok {
+		if ok && val != "" {
 			// Convert the suffix value to int so we can look through the list and grab the max suffix created so far
 			intVal, err := strconv.Atoi(val)
 			if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -80,6 +80,11 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			if err != nil {
 				return nil, err
 			}
+			// the first managed key value 99-poolname-generated-kubelet does not have a suffix
+			// set "" as suffix annotation to the kubelet config object
+			kubeletConfig.SetAnnotations(map[string]string{
+				ctrlcommon.MCNameSuffixAnnotationKey: "",
+			})
 			ignConfig := ctrlcommon.NewIgnConfig()
 			mc, err := ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
 			if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
@@ -193,3 +193,48 @@ func TestGenerateDefaultManagedKeyKubelet(t *testing.T) {
 		require.Equal(t, tc.expectedManagedKey, res)
 	}
 }
+
+func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.newController()
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			pools := []*mcfgv1.MachineConfigPool{
+				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
+			}
+			// kc for bootstrap mode
+			kc := newKubeletConfig("kcfg-master", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, pools[0])
+			f.mckLister = append(f.mckLister, kc)
+			f.objects = append(f.objects, kc)
+
+			mcs, err := RunKubeletBootstrap("../../../templates", []*mcfgv1.KubeletConfig{kc}, cc, nil, nil, pools)
+			require.NoError(t, err)
+			require.Len(t, mcs, 1)
+
+			// add kc1 after bootstrap
+			kc1 := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
+
+			f.mckLister = append(f.mckLister, kc1)
+			f.objects = append(f.objects, kc1)
+			c := f.newController()
+			err = c.syncHandler(getKey(kc1, t))
+			if err != nil {
+				t.Errorf("syncHandler returned: %v", err)
+			}
+
+			// resync kc and check the managedKey
+			c = f.newController()
+			err = c.syncHandler(getKey(kc, t))
+			if err != nil {
+				t.Errorf("syncHandler returned: %v", err)
+			}
+			val := kc.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
+			require.Equal(t, "", val)
+		})
+	}
+}


### PR DESCRIPTION
fix: https://bugzilla.redhat.com/show_bug.cgi?id=2076355 for kubeletconfig and containerruntimeconfig.
This PR applies the changes made in https://github.com/openshift/machine-config-operator/pull/2936 to kubeletoconfig and containerruntimeconfig bootstrap.





Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Set MCNameSuffixAnnotationKey for bootstrap kubeletconfig/containerruntimeconfig to avoid
regeneration of suffixed machineconfig names.
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
