### PR TITLE
kcfg controller remove cleanupmc

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -630,35 +630,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		}
 		glog.Infof("Applied KubeletConfig %v on MachineConfigPool %v", key, pool.Name)
 	}
-	if err := ctrl.cleanUpDuplicatedMC(); err != nil {
-		return err
-	}
-
 	return ctrl.syncStatusOnly(cfg, nil)
-}
-
-// cleanUpDuplicatedMC removes the MC of uncorrected version if format of its name contains 'generated-xxx'.
-// BZ 1955517: upgrade when there are more than one configs, these generated MC will be duplicated
-// by upgraded MC with number suffixed name (func getManagedKubeletConfigKey()) and fails the upgrade.
-func (ctrl *Controller) cleanUpDuplicatedMC() error {
-	generatedKubeletCfg := "generated-kubelet"
-	// Get all machine configs
-	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("error listing kubelet machine configs: %w", err)
-	}
-	for _, mc := range mcList.Items {
-		if !strings.Contains(mc.Name, generatedKubeletCfg) {
-			continue
-		}
-		// delete the mc if its degraded
-		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
-			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil {
-				return fmt.Errorf("error deleting degraded kubelet machine config %s: %w", mc.Name, err)
-			}
-		}
-	}
-	return nil
 }
 
 func (ctrl *Controller) popFinalizerFromKubeletConfig(kc *mcfgv1.KubeletConfig) error {


### PR DESCRIPTION
Remove `cleanUpDuplicatedMC()` from pkg/controller/kubelet-config/kubelet_config_controller_test.go
`cleanUpDuplicatedMC()` was a symptomatic fix for https://bugzilla.redhat.com/show_bug.cgi?id=1955517.
The root cause is getManagedKubeletConfigKey(). After https://github.com/openshift/machine-config-operator/commit/b0139eaf9c1f2c4c225e6019e0b14e70ea6f199f  and https://github.com/openshift/machine-config-operator/commit/6b5bdaf1f4fae0eee6630dbb6ca3b6c01f287c52
bz 1955517 should be fixed. `cleanUpDuplicatedMC()` is nolonger needed.

I confirmed bz 1955517 is not reproducible without cleanUpDuplicatedMC():
1.Launch a cluster
2.Apply 2 kubeletconfigs: one for master pool, one for worker pool.
3.Upgrade the cluster to a release-payload built from this patch
4.Should not see degraded 99-xxx-generated-kubelet

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
