### PR TITLE
Bug 2076975: OVN Kubernetes configure-ovs-network set static if conversion metric 

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -293,6 +293,8 @@ contents:
     type=internal
     EOF
           nmcli c load ${new_conn_file}
+          # Set interface metric in the static route case. For the DHCP route case, see below.
+          nmcli c mod "${ovs_interface}" ipv4.route-metric "${bridge_metric}" ipv6.route-metric "${bridge_metric}"
           echo "Loaded new $ovs_interface connection file: ${new_conn_file}"
         else
           extra_if_brex_args=""


### PR DESCRIPTION
When converting a static interface to br-ex, we must set the correct
metric as well.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
