### PR TITLE
nodecontroller: 3 logging patches

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -1034,7 +1034,7 @@ func (ctrl *Controller) updateCandidateMachines(pool *mcfgv1.MachineConfigPool, 
 		candidate := candidates[0]
 		ctrl.eventRecorder.Eventf(pool, corev1.EventTypeNormal, "SetDesiredConfig", "Targeted node %s to config %s", candidate.Name, targetConfig)
 	} else {
-		ctrl.eventRecorder.Eventf(pool, corev1.EventTypeNormal, "SetDesiredConfig", "Set target for %d nodes to config %s", targetConfig)
+		ctrl.eventRecorder.Eventf(pool, corev1.EventTypeNormal, "SetDesiredConfig", "Set target for %d nodes to config %s", len(candidates), targetConfig)
 	}
 	return nil
 }

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -460,6 +460,12 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 	}
 	glog.V(4).Infof("Node %s updated", curNode.Name)
 
+	// Let's be verbose when a node changes pool
+	oldPool, err := ctrl.getPrimaryPoolForNode(oldNode)
+	if err == nil && oldPool.Name != pool.Name {
+		ctrl.logPoolNode(pool, curNode, "changed from pool %s", oldPool.Name)
+	}
+
 	var changed bool
 	oldReadyErr := checkNodeReady(oldNode)
 	newReadyErr := checkNodeReady(curNode)


### PR DESCRIPTION
nodecontroller: Log when a node changes pool

A customer is implementing "control upgrade of group of nodes"
by changing pools.  I think zone ordering is the right fix to this,
but let's be verbose and explicit when a node changes pool so it's
easier to debug things.

---

nodecontroller: Add missing format argument

I saw this in logs from a customer:
```
2022-04-11T20:05:02.493178928Z I0411 20:05:02.493135       1 event.go:282] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"", Name:"x", UID:"0c0508c0-c827-4d46-9b2c-2b7f8f0bcd9a", APIVersion:"machineconfiguration.o
penshift.io/v1", ResourceVersion:"378320503", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for %!d(string=rendered-x-d78cb2662dd777c789f033d3611e71e8) nodes to config %!s(MISSING)
```

---

nodecontroller: Log zones too

Given that zones are an input into our upgrade ordering now, add some
logging for them.

---

