### PR TITLE
Bug 2078945: Ensure only one apiserver-watcher process is active on a node. 

### DIFF
--- a/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -11,7 +11,13 @@ contents:
       containers:
       - name: apiserver-watcher
         image: "{{.Images.apiServerWatcherKey}}"
-        command: ["apiserver-watcher"]
+        command:
+          - flock
+          - --verbose
+          - --exclusive
+          - --timeout=300
+          - /rootfs/run/cloud-routes/apiserver-watcher.lock
+          - apiserver-watcher
         args:
         - "run"
         - "--health-check-url={{.Infra.Status.APIServerInternalURL}}/readyz"

--- a/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -11,7 +11,13 @@ contents:
       containers:
       - name: apiserver-watcher
         image: "{{.Images.apiServerWatcherKey}}"
-        command: ["apiserver-watcher"]
+        command:
+          - flock
+          - --verbose
+          - --exclusive
+          - --timeout=300
+          - /rootfs/run/cloud-routes/apiserver-watcher.lock
+          - apiserver-watcher
         args:
         - "run"
         - "--health-check-url={{.Infra.Status.APIServerInternalURL}}/readyz"

--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -11,7 +11,13 @@ contents:
       containers:
       - name: apiserver-watcher
         image: "{{.Images.apiServerWatcherKey}}"
-        command: ["apiserver-watcher"]
+        command:
+          - flock
+          - --verbose
+          - --exclusive
+          - --timeout=300
+          - /rootfs/run/cloud-routes/apiserver-watcher.lock
+          - apiserver-watcher
         args:
         - "run"
         - "--health-check-url={{.Infra.Status.APIServerInternalURL}}/readyz"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

An alternative of https://github.com/openshift/machine-config-operator/pull/2674, using `flock`.
<!--
**- How to verify it**
-->
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
wrap `apiserver-watcher` call with `flock`.