### PR TITLE
Bug 1948551: apiserver-watcher should run in a privileged namespace 

### DIFF
--- a/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -6,7 +6,7 @@ contents:
     kind: Pod
     metadata:
       name: apiserver-watcher
-      namespace: kube-system
+      namespace: openshift-kube-apiserver
     spec:
       containers:
       - name: apiserver-watcher

--- a/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -6,7 +6,7 @@ contents:
     kind: Pod
     metadata:
       name: apiserver-watcher
-      namespace: kube-system
+      namespace: openshift-kube-apiserver
     spec:
       containers:
       - name: apiserver-watcher

--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -6,7 +6,7 @@ contents:
     kind: Pod
     metadata:
       name: apiserver-watcher
-      namespace: kube-system
+      namespace: openshift-kube-apiserver
     spec:
       containers:
       - name: apiserver-watcher


### PR DESCRIPTION
Move the `apiserver-watcher` static pods from the `kube-system` namespace to the `openshift-kube-apiserver` namespace.