### PR TITLE
apiserver-watcher: move to klog

### DIFF
--- a/cmd/apiserver-watcher/log.go
+++ b/cmd/apiserver-watcher/log.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	log "github.com/InVisionApp/go-logger"
+	"k8s.io/klog/v2"
+)
+
+type logger struct {
+	keysAndValues []interface{}
+}
+
+func (k *logger) Debug(msg ...interface{}) {
+	klog.V(4).InfoSDepth(1, fmt.Sprint(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Info(msg ...interface{}) {
+	klog.V(0).InfoSDepth(1, fmt.Sprint(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Warn(msg ...interface{}) {
+	klog.V(1).InfoSDepth(1, fmt.Sprint(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Error(msg ...interface{}) {
+	klog.ErrorSDepth(1, nil, fmt.Sprint(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Debugln(msg ...interface{}) {
+	klog.V(4).InfoSDepth(1, fmt.Sprintln(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Infoln(msg ...interface{}) {
+	klog.V(0).InfoSDepth(1, fmt.Sprintln(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Warnln(msg ...interface{}) {
+	klog.V(1).InfoSDepth(1, fmt.Sprintln(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Errorln(msg ...interface{}) {
+	klog.ErrorSDepth(1, nil, fmt.Sprintln(msg...), k.keysAndValues...)
+}
+
+func (k *logger) Debugf(format string, args ...interface{}) {
+	klog.V(4).InfoSDepth(1, fmt.Sprintf(format, args...), k.keysAndValues...)
+}
+
+func (k *logger) Infof(format string, args ...interface{}) {
+	klog.V(0).InfoSDepth(1, fmt.Sprintf(format, args...), k.keysAndValues...)
+}
+
+func (k *logger) Warnf(format string, args ...interface{}) {
+	klog.V(1).InfoSDepth(1, fmt.Sprintf(format, args...), k.keysAndValues...)
+}
+
+func (k *logger) Errorf(format string, args ...interface{}) {
+	klog.ErrorSDepth(1, nil, fmt.Sprintf(format, args...), k.keysAndValues...)
+}
+
+func (k *logger) WithFields(fields log.Fields) log.Logger {
+	l := &logger{}
+	for k, v := range fields {
+		l.keysAndValues = append(l.keysAndValues, k, v)
+	}
+	return l
+}

--- a/cmd/apiserver-watcher/main.go
+++ b/cmd/apiserver-watcher/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/component-base/cli"
 )
 
 const (
@@ -26,7 +26,5 @@ func init() {
 }
 
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing %s: %v", componentName, err)
-	}
+	_ = cli.Run(rootCmd)
 }


### PR DESCRIPTION
The apiserver-watcher tool is still using the deprecated `glog` logging package.

This PR migrates to `klog/v2` and provides an adapter for one of the 3rd party dependency's logger, resulting in log output consistent with other tools.