### PR TITLE
configure-ovs-network: `systemctl reload`, not `restart` NetworkManager

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -387,8 +387,8 @@ contents:
       nmcli connection reload
       nmcli network on
       
-      # restart NetworkManager so that we can wait on `nm-online -s`
-      systemctl restart NetworkManager
+      # Ensure that new state is loaded
+      systemctl reload NetworkManager
 
       # Wait until all profiles auto-connect
       echo "Waiting for profiles to activate..."


### PR DESCRIPTION
A full process restart today can trigger bugs; xref
https://bugzilla.redhat.com/show_bug.cgi?id=2077605

NM is also managing the underlying host network state such as DHCP
leases, so blindly restarting it is problematic right now.

Let's try doing a reload instead.

/assign @jcaamano