### PR TITLE
RFE-2703: add prometheus rules for master memory usage

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -93,13 +93,63 @@ spec:
             severity: warning
           annotations:
             message: "System memory usage of {{ $value | humanize }} on {{ $labels.node }} exceeds 95% of the reservation. Reserved memory ensures system processes can function even when the node is fully allocated and protects against workload out of memory events impacting the proper functioning of the node. The default reservation is expected to be sufficient for most configurations and should be increased (https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-managing.html) when running nodes with high numbers of pods (either due to rate of change or at steady state)."
-    - name: master-nodes-high-memory-usage
+    - name: high-overall-control-plane-memory
       rules:
-        - alert: MasterNodesHighMemoryUsage
+        - alert: HighOverallControlPlaneMemory
           expr: |
-            ((sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) - sum(node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" ))) / sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) * 100) > 90
-          for: 15m
+            (
+              1
+              -
+              sum (
+                node_memory_MemFree_bytes
+                + node_memory_Buffers_bytes
+                + node_memory_Cached_bytes
+                AND on (instance)
+                label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+              ) / sum (
+                node_memory_MemTotal_bytes
+                AND on (instance)
+                label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+              )
+            ) * 100 > 60
+          for: 1h
           labels:
             severity: warning
           annotations:
-            message: "Memory usage of {{ $value | humanize }} on {{ $labels.node }} exceeds 90%. Master nodes starved of memory could result in degraded performance of the control plane."
+            summary: >-
+              Memory utilization across all control plane nodes is high, and could impact responsiveness and stability.
+            description: >-
+              Given three control plane nodes, the overall memory utilization may only be about 2/3 of all available capacity.
+              This is because if a single control plane node fails, the kube-apiserver and etcd my be slow to respond.
+              To fix this, increase memory of the control plane nodes.
+    - name: extremely-high-individual-control-plane-memory
+      rules:
+        - alert: ExtremelyHighIndividualControlPlaneMemory
+          expr: |
+            (
+              1
+              -
+              sum by (instance) (
+                node_memory_MemFree_bytes
+                + node_memory_Buffers_bytes
+                + node_memory_Cached_bytes
+                AND on (instance)
+                label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+              ) / sum by (instance) (
+                node_memory_MemTotal_bytes
+                AND on (instance)
+                label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+              )
+            ) * 100 > 90
+          for: 45m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Extreme memory utilization per node within control plane nodes is extremely high, and could impact responsiveness and stability.
+            description: >-
+              The memory utilization per instance within control plane nodes influence the stability, and responsiveness of the cluster.
+              This can lead to cluster instability and slow responses from kube-apiserver or failing requests specially on etcd.
+              Moreover, OOM kill is expected which negatively influences the pod scheduling.
+              If this happens on container level, the descheduler will not be able to detect it, as it works on the pod level.
+              To fix this, increase memory of the affected node of control plane nodes.


### PR DESCRIPTION
This PR add two prometheus rules for master node memory usage.

The docs recommend limiting control plane memory consumption to <=60% [1].  
This commit adds `HighOverallControlPlaneMemory` to give warning-level alerting when the control plane as a whole passes that level.  Scaling the control plane instances currently requires draining and rebooting nodes, so we don't want to wait for higher resource consumption before scaling up.  `60m` is the default for warning alerts [2], and we have no reason to diverge from that default here.

Also replace the old, full-control-plane `MasterNodesHighMemoryUsage` with `ExtremelyHighIndividualControlPlaneMemory` at the >90% level, and raise severity to critical.  The new name aligns with the established CPU-alerting pattern.  The new severity is compatible with the alerting policy [3], because manual pod-rescheduling or node-scale-ups would be required to preserve etcd throughput and control-plane functionality in such a low-free/cache/buffer situation.  `45m` diverges from the default `for: 5m` for critical alerts [3], because  individual control plane nodes could have memory spikes during normal operations and need time to go back to normal, so `5m` is very low to raise an alert.

1.https://docs.openshift.com/container-platform/4.10/scalability_and_performance/recommended-host-practices.html#master-node-sizing_recommended-host-practices

2.https://github.com/openshift/enhancements/blob/34ba81cd125d788062172ca4c630bd228d1609bf/enhancements/monitoring/alerting-consistency.md#warning-alerts

3.https://github.com/openshift/enhancements/blob/34ba81cd125d788062172ca4c630bd228d1609bf/enhancements/monitoring/alerting-consistency.md#critical-alerts
