### PR TITLE
Bug 2081119: drop doc overlaysize default

### DIFF
--- a/install/0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_containerruntimeconfig.crd.yaml
@@ -75,7 +75,7 @@ spec:
                   overlaySize:
                     description: 'overlaySize specifies the maximum size of a container
                       image. This flag can be used to set quota on the size of container
-                      images. (default: 10GB)'
+                      images.'
                     type: string
                   pidsLimit:
                     description: pidsLimit specifies the maximum number of processes

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -474,7 +474,7 @@ type ContainerRuntimeConfiguration struct {
 	LogSizeMax resource.Quantity `json:"logSizeMax,omitempty"`
 
 	// overlaySize specifies the maximum size of a container image.
-	// This flag can be used to set quota on the size of container images. (default: 10GB)
+	// This flag can be used to set quota on the size of container images.
 	OverlaySize resource.Quantity `json:"overlaySize,omitempty"`
 }
 


### PR DESCRIPTION

The outdated doc confused the customer with default overlaySize. The description should be updated since the default was removed.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
