### PR TITLE
Move Ignition file generation to controller/common, fix Compression

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -959,8 +959,8 @@ func TestAlertOnPausedKubeletCA(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v1")
 
 	mcfiles := []ign3types.File{
-		helpers.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", TestKubeletCABundle),
-		helpers.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", "newcertificates"),
+		ctrlcommon.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", TestKubeletCABundle),
+		ctrlcommon.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", "newcertificates"),
 	}
 
 	mcs := []*mcfgv1.MachineConfig{

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -571,18 +571,18 @@ func TestDropinCheck(t *testing.T) {
 // i.e. whether we need to reboot and what actions need to be taken if no reboot is needed
 func TestCalculatePostConfigChangeAction(t *testing.T) {
 	files := map[string]ign3types.File{
-		"pullsecret1":     helpers.NewIgnFile("/var/lib/kubelet/config.json", "kubelet conf 1\n"),
-		"pullsecret2":     helpers.NewIgnFile("/var/lib/kubelet/config.json", "kubelet conf 2\n"),
-		"registries1":     helpers.NewIgnFile("/etc/containers/registries.conf", "registries content 1\n"),
-		"registries2":     helpers.NewIgnFile("/etc/containers/registries.conf", "registries content 2\n"),
-		"randomfile1":     helpers.NewIgnFile("/etc/random-reboot-file", "test\n"),
-		"randomfile2":     helpers.NewIgnFile("/etc/random-reboot-file", "test 2\n"),
-		"kubeletCA1":      helpers.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", "kubeletCA1\n"),
-		"kubeletCA2":      helpers.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", "kubeletCA2\n"),
-		"policy1":         helpers.NewIgnFile("/etc/containers/policy.json", "policy1"),
-		"policy2":         helpers.NewIgnFile("/etc/containers/policy.json", "policy2"),
-		"containers-gpg1": helpers.NewIgnFile("/etc/machine-config-daemon/no-reboot/containers-gpg.pub", "containers-gpg1"),
-		"containers-gpg2": helpers.NewIgnFile("/etc/machine-config-daemon/no-reboot/containers-gpg.pub", "containers-gpg2"),
+		"pullsecret1":     ctrlcommon.NewIgnFile("/var/lib/kubelet/config.json", "kubelet conf 1\n"),
+		"pullsecret2":     ctrlcommon.NewIgnFile("/var/lib/kubelet/config.json", "kubelet conf 2\n"),
+		"registries1":     ctrlcommon.NewIgnFile("/etc/containers/registries.conf", "registries content 1\n"),
+		"registries2":     ctrlcommon.NewIgnFile("/etc/containers/registries.conf", "registries content 2\n"),
+		"randomfile1":     ctrlcommon.NewIgnFile("/etc/random-reboot-file", "test\n"),
+		"randomfile2":     ctrlcommon.NewIgnFile("/etc/random-reboot-file", "test 2\n"),
+		"kubeletCA1":      ctrlcommon.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", "kubeletCA1\n"),
+		"kubeletCA2":      ctrlcommon.NewIgnFile("/etc/kubernetes/kubelet-ca.crt", "kubeletCA2\n"),
+		"policy1":         ctrlcommon.NewIgnFile("/etc/containers/policy.json", "policy1"),
+		"policy2":         ctrlcommon.NewIgnFile("/etc/containers/policy.json", "policy2"),
+		"containers-gpg1": ctrlcommon.NewIgnFile("/etc/machine-config-daemon/no-reboot/containers-gpg.pub", "containers-gpg1"),
+		"containers-gpg2": ctrlcommon.NewIgnFile("/etc/machine-config-daemon/no-reboot/containers-gpg.pub", "containers-gpg2"),
 	}
 
 	tests := []struct {

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/clarketm/json"
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
-	"github.com/vincent-petithory/dataurl"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,19 +146,6 @@ func NewMachineConfigPool(name string, mcSelector, nodeSelector *metav1.LabelSel
 					Message:            "",
 				},
 			},
-		},
-	}
-}
-
-// NewIgnFile returns a simple ignition3 file from just path and file contents
-func NewIgnFile(path, contents string) ign3types.File {
-	return ign3types.File{
-		Node: ign3types.Node{
-			Path: path,
-		},
-		FileEmbedded1: ign3types.FileEmbedded1{
-			Contents: ign3types.Resource{
-				Source: StrToPtr(dataurl.EncodeBytes([]byte(contents)))},
 		},
 	}
 }


### PR DESCRIPTION
See https://github.com/coreos/butane/issues/332#issuecomment-1113670664

Basically, everywhere we make a "raw" Ignition file type, we need
to be explicitly setting the compression field.  This is prep
for updating butane and using it for some of our templates, which
will start compressing files automatically.

The problem is Ignition config merging is a bit broken with respect
to an unset compression field.  We need to make it the explicit
empty string.

Now, when I was digging into this I noticed that we'd ended up with
our API to make Ignition files in the `test/helpers`.  We shouldn't
have *core* code importing APIs from `test/`.

This moves the APIs into `controller/common`.

Port the kubelet config and container runtime config bits to this -
notice how much the code shrinks!
