### PR TITLE
Bug 2080267: [vsphere] remove warning encountered on vSphere UPI cluster without API VIP

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -359,8 +359,6 @@ func getIgnitionHost(infraStatus *configv1.InfrastructureStatus) (string, error)
 				if infraStatus.PlatformStatus.VSphere.APIServerInternalIP != "" {
 					ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIP, securePortStr)
 				}
-			} else {
-				glog.Warning("Warning: PlatformStatus.VSphere should not be nil")
 			}
 		}
 	}


### PR DESCRIPTION
**- What I did**
Removed logged warning when PlatformStatus.VSphere is nil.  

**- How to verify it**
Check machine-config-operator logs for the presence of `Warning: PlatformStatus.VSphere should not be nil` on conclusion of e2e-vsphere-upi e2e test.  Log message should not be present.

**- Description for the changelog**
remove `PlatformStatus.VSphere should not be nil` warning encountered on vSphere UPI clusters.
