### PR TITLE
rbac: allow build/image manipulation and retrieval

### DIFF
--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -37,3 +37,9 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups: ["build.openshift.io"]
+  resources: ["buildconfigs","buildconfigs/instantiate"]
+  verbs: ["*"]
+- apiGroups: ["image.openshift.io"]
+  resources: ["imagestreams","images"]
+  verbs: ["*"]

--- a/manifests/machineconfigcontroller/registry-rolebinding.yaml
+++ b/manifests/machineconfigcontroller/registry-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-push-images-to-internal-registry
+  namespace: {{.TargetNamespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: registry-editor
+subjects:
+- kind: ServiceAccount
+  name: machine-config-controller
+  namespace: {{.TargetNamespace}}

--- a/manifests/machineconfigdaemon/registry-rolebinding.yaml
+++ b/manifests/machineconfigdaemon/registry-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-pull-images-from-internal-registry
+  namespace: {{.TargetNamespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: registry-viewer
+subjects:
+- kind: ServiceAccount
+  name: machine-config-daemon
+  namespace: {{.TargetNamespace}}

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -70,6 +70,7 @@ const (
 	mccEventsRoleBindingDefaultManifestPath = "manifests/machineconfigcontroller/events-rolebinding-default.yaml"
 	mccEventsRoleBindingTargetManifestPath  = "manifests/machineconfigcontroller/events-rolebinding-target.yaml"
 	mccClusterRoleBindingManifestPath       = "manifests/machineconfigcontroller/clusterrolebinding.yaml"
+	mccRegistryRoleBindingManifestPath      = "manifests/machineconfigcontroller/registry-rolebinding.yaml"
 	mccServiceAccountManifestPath           = "manifests/machineconfigcontroller/sa.yaml"
 
 	// Machine Config Daemon manifest paths
@@ -80,6 +81,7 @@ const (
 	mcdClusterRoleBindingManifestPath       = "manifests/machineconfigdaemon/clusterrolebinding.yaml"
 	mcdServiceAccountManifestPath           = "manifests/machineconfigdaemon/sa.yaml"
 	mcdDaemonsetManifestPath                = "manifests/machineconfigdaemon/daemonset.yaml"
+	mcdRegistryRoleBindingManifestPath      = "manifests/machineconfigcontroller/registry-rolebinding.yaml"
 
 	// Machine Config Server manifest paths
 	mcsClusterRoleManifestPath                    = "manifests/machineconfigserver/clusterrole.yaml"
@@ -535,6 +537,7 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig) error {
 		roleBindings: []string{
 			mccEventsRoleBindingDefaultManifestPath,
 			mccEventsRoleBindingTargetManifestPath,
+			mccRegistryRoleBindingManifestPath,
 		},
 		clusterRoleBindings: []string{
 			mccClusterRoleBindingManifestPath,
@@ -594,6 +597,7 @@ func (optr *Operator) syncMachineConfigDaemon(config *renderConfig) error {
 		roleBindings: []string{
 			mcdEventsRoleBindingDefaultManifestPath,
 			mcdEventsRoleBindingTargetManifestPath,
+			mcdRegistryRoleBindingManifestPath,
 		},
 		clusterRoleBindings: []string{
 			mcdClusterRoleBindingManifestPath,


### PR DESCRIPTION
&lt;walters&gt; *note*: This drops https://github.com/openshift/machine-config-operator/commit/04df6242acc9526e3898a0cdfe8f877e73b3c2dd#diff-879656d2f0921beeb4e9f00c109ade9a4fe9920cd742b43fa407144e6bbbd555R43 since I don't understand why it was there and it needs more motivation.

Splitting this out from the layering branch since it's one of the changes that currently conflicts on master.  Prep for merging layering.

---


This give rbac permissions to the machine-config-controller service
account to manipulate Builds/BuildRequests and Imagestreams in the
machine-config-operator namespace, as well as push images into the internal registry.

This gives rbac permissions to the machine-config-daemon serviceaccount
to retrieve images from the internal registry.

This also updates the operator's sync so that these new registry role files will be
generated and deployed properly with the mco.

