### PR TITLE
manifests: Lower daemon RBAC permissions on machineconfig objects

### DIFF
--- a/manifests/machineconfigdaemon/clusterrole.yaml
+++ b/manifests/machineconfigdaemon/clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   verbs: ["create"]
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs"]
-  verbs: ["*"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["security.openshift.io"]
   resourceNames: ["privileged"]
   resources: ["securitycontextconstraints"]


### PR DESCRIPTION
There is no reason for the daemonset to mutate machineconfigs.

Part of https://github.com/openshift/machine-config-operator/pull/3135
