### PR TITLE
Start of centralizing node writes via nodeWriter

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -234,7 +234,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	ctx := ctrlcommon.CreateControllerContext(cb, stopCh, componentName)
 	// create the daemon instance. this also initializes kube client items
 	// which need to come from the container and not the chroot.
-	dn.ClusterConnect(
+	err = dn.ClusterConnect(
 		startOpts.nodeName,
 		kubeClient,
 		ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
@@ -242,6 +242,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		startOpts.kubeletHealthzEnabled,
 		startOpts.kubeletHealthzEndpoint,
 	)
+	if err != nil {
+		glog.Fatalf("Failed to initialize: %v", err)
+	}
 
 	ctx.KubeInformerFactory.Start(stopCh)
 	ctx.InformerFactory.Start(stopCh)

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -207,12 +207,15 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	if startOpts.hypershiftDesiredConfigMap != "" {
 		// This is a hypershift-mode daemon
 		ctx := ctrlcommon.CreateControllerContext(cb, stopCh, componentName)
-		dn.HypershiftConnect(
+		err := dn.HypershiftConnect(
 			startOpts.nodeName,
 			kubeClient,
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			startOpts.hypershiftDesiredConfigMap,
 		)
+		if err != nil {
+			ctrlcommon.WriteTerminationError(err)
+		}
 
 		ctx.KubeInformerFactory.Start(stopCh)
 		close(ctx.InformersStarted)

--- a/manifests/machineconfigdaemon/clusterrole.yaml
+++ b/manifests/machineconfigdaemon/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["*"]

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -32,6 +32,11 @@ func resyncPeriod() func() time.Duration {
 	}
 }
 
+// DefaultResyncPeriod returns a function which generates a random resync period
+func DefaultResyncPeriod() func() time.Duration {
+	return resyncPeriod()
+}
+
 // ControllerContext stores all the informers for a variety of kubernetes objects.
 type ControllerContext struct {
 	ClientBuilder *clients.Builder

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -451,7 +451,7 @@ func (dn *Daemon) updateErrorStateHypershift(err error) {
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateDegraded,
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
-	if annoErr := dn.nodeWriter.SetAnnotations(annos); annoErr != nil {
+	if _, annoErr := dn.nodeWriter.SetAnnotations(annos); annoErr != nil {
 		glog.Fatalf("Error setting degraded annotation %v, original error %v", annoErr, err)
 	}
 }
@@ -772,7 +772,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 			constants.CurrentMachineConfigAnnotationKey:      targetHash,
 			constants.DesiredDrainerAnnotationKey:            fmt.Sprintf("%s-%s", constants.DrainerStateUncordon, targetHash),
 		}
-		if err := dn.nodeWriter.SetAnnotations(annos); err != nil {
+		if _, err := dn.nodeWriter.SetAnnotations(annos); err != nil {
 			return fmt.Errorf("failed to set Done annotation on node: %w", err)
 		}
 		glog.Infof("The pod has completed update. Awaiting removal.")
@@ -794,7 +794,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 			constants.MachineConfigDaemonReasonAnnotationKey: "",
 			constants.DesiredDrainerAnnotationKey:            targetDrainValue,
 		}
-		if err := dn.nodeWriter.SetAnnotations(annos); err != nil {
+		if _, err := dn.nodeWriter.SetAnnotations(annos); err != nil {
 			return fmt.Errorf("failed to set Done annotation on node: %w", err)
 		}
 		// Wait for a future sync to perform post-drain actions

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -22,7 +22,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -159,7 +158,6 @@ func (f *fixture) newController() *Daemon {
 
 	d.mcListerSynced = alwaysReady
 	d.nodeListerSynced = alwaysReady
-	d.recorder = &record.FakeRecorder{}
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -110,7 +110,7 @@ func (dn *Daemon) drain() error {
 	case <-time.After(1 * time.Hour):
 		done <- true
 		failMsg := fmt.Sprintf("failed to drain node : %s after 1 hour", dn.node.Name)
-		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeWarning, "FailedToDrain", failMsg)
+		dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedToDrain", failMsg)
 		MCDDrainErr.Set(1)
 		return fmt.Errorf(failMsg)
 	case <-drainer():
@@ -128,11 +128,11 @@ func (dn *Daemon) performDrain() error {
 		return err
 	}
 	dn.logSystem("Node has been successfully cordoned")
-	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Cordon", "Cordoned node to apply update")
+	dn.nodeWriter.Eventf(corev1.EventTypeNormal, "Cordon", "Cordoned node to apply update")
 
 	if !dn.drainRequired() {
 		dn.logSystem("Drain not required, skipping")
-		dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Drain", "Drain not required, skipping")
+		dn.nodeWriter.Eventf(corev1.EventTypeNormal, "Drain", "Drain not required, skipping")
 		return nil
 	}
 
@@ -140,7 +140,7 @@ func (dn *Daemon) performDrain() error {
 	dn.logSystem("Update prepared; beginning drain")
 	startTime := time.Now()
 
-	dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "Drain", "Draining node to update config.")
+	dn.nodeWriter.Eventf(corev1.EventTypeNormal, "Drain", "Draining node to update config.")
 
 	if err := dn.drain(); err != nil {
 		return err

--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -32,7 +32,7 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 		currentOnDisk, err := dn.getCurrentConfigOnDisk()
 		if err == nil {
 			glog.Infof("Setting initial node config based on current configuration on disk: %s", currentOnDisk.GetName())
-			return setNodeAnnotations(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, node.Name, map[string]string{constants.CurrentMachineConfigAnnotationKey: currentOnDisk.GetName()})
+			return dn.nodeWriter.SetAnnotations(map[string]string{constants.CurrentMachineConfigAnnotationKey: currentOnDisk.GetName()})
 		}
 		return nil, err
 	}
@@ -43,11 +43,11 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 	}
 
 	glog.Infof("Setting initial node config: %s", initial[constants.CurrentMachineConfigAnnotationKey])
-	n, err := setNodeAnnotations(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, node.Name, initial)
+	node, err = dn.nodeWriter.SetAnnotations(initial)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set initial annotations: %w", err)
 	}
-	return n, nil
+	return node, nil
 }
 
 // getNodeAnnotation gets the node annotation, unsurprisingly

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -477,7 +477,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 			return err
 		}
 		if state != constants.MachineConfigDaemonStateDegraded && state != constants.MachineConfigDaemonStateUnreconcilable {
-			if err := dn.nodeWriter.SetWorking(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name); err != nil {
+			if err := dn.nodeWriter.SetWorking(); err != nil {
 				return fmt.Errorf("error setting node's state to Working: %w", err)
 			}
 		}

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -43,6 +43,7 @@ type NodeWriter interface {
 	SetUnreconcilable(err error) error
 	SetDegraded(err error) error
 	SetSSHAccessed() error
+	SetAnnotations(annos map[string]string) error
 }
 
 // newNodeWriter Create a new NodeWriter
@@ -159,6 +160,16 @@ func (nw *clusterNodeWriter) SetSSHAccessed() error {
 		responseChannel: respChan,
 	}
 	return <-respChan
+}
+
+func (nw *clusterNodeWriter) SetAnnotations(annos map[string]string) error {
+	respChan := make(chan error, 1)
+	nw.writer <- message{
+		annos:           annos,
+		responseChannel: respChan,
+	}
+	err := <-respChan
+	return err
 }
 
 func setNodeAnnotations(client corev1client.NodeInterface, lister corev1lister.NodeLister, nodeName string, m map[string]string) (*corev1.Node, error) {


### PR DESCRIPTION
Part of https://github.com/openshift/machine-config-operator/pull/3135

---

daemon: Have nodeWriter maintain ref to lister and node name

The NodeWriter is an instance of the "actor" pattern effectively;
it processes messages to update its internal state.

However, it's a bit redundant to have every update take the node
lister and node name - we only use this on the daemon side,
where there is exactly one node we will be updating.

Have the clusterNodeWriter instance of this interface cache
references to that data and avoid passing it on every message.

Prep for reworking the NodeWriter to have its own clientset.

---

controller: Export default resync period function

So I can use this from the daemon code.

---

daemon: Have nodewriter use kubelet credentials

---

daemon: Change hypershift path to use nodewriter

Ensure that this code path is using kubelet credentials.

---

