### PR TITLE
daemon: Have nodeWriter maintain ref to lister and node name

### DIFF
--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -32,6 +32,11 @@ func resyncPeriod() func() time.Duration {
 	}
 }
 
+// DefaultResyncPeriod returns a function which generates a random resync period
+func DefaultResyncPeriod() func() time.Duration {
+	return resyncPeriod()
+}
+
 // ControllerContext stores all the informers for a variety of kubernetes objects.
 type ControllerContext struct {
 	ClientBuilder *clients.Builder

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -477,7 +477,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig) (retErr err
 			return err
 		}
 		if state != constants.MachineConfigDaemonStateDegraded && state != constants.MachineConfigDaemonStateUnreconcilable {
-			if err := dn.nodeWriter.SetWorking(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name); err != nil {
+			if err := dn.nodeWriter.SetWorking(); err != nil {
 				return fmt.Errorf("error setting node's state to Working: %w", err)
 			}
 		}


### PR DESCRIPTION
This is just the first two commits from https://github.com/openshift/machine-config-operator/pull/3141

I think we can safely land this now.

--

daemon: Have nodeWriter maintain ref to lister and node name

The NodeWriter is an instance of the "actor" pattern effectively;
it processes messages to update its internal state.

However, it's a bit redundant to have every update take the node
lister and node name - we only use this on the daemon side,
where there is exactly one node we will be updating.

Have the clusterNodeWriter instance of this interface cache
references to that data and avoid passing it on every message.

Prep for reworking the NodeWriter to have its own clientset.

---

controller: Export default resync period function

So I can use this from the daemon code.

---

