### PR TITLE
Bug 2056442: Bug fix for node drain caused by ICSP objects

### DIFF
--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -248,50 +248,53 @@ func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Con
 	// Check for modified registry
 	for regLoc, newReg := range newRegHashMap {
 		oldReg, ok := oldRegHashMap[regLoc]
-		if ok && !reflect.DeepEqual(oldReg, newReg) {
-			// Registry is available in both old and new config and some changes has been found.
-			// Check that changes made are safe or not.
-			if oldReg.Prefix != newReg.Prefix {
-				glog.Infof("%s: prefix value for registry %s has changed from %s to %s",
-					constants.ContainerRegistryConfPath, regLoc, oldReg.Prefix, newReg.Prefix)
-				return false, nil
-			}
-			if oldReg.Location != newReg.Location {
-				glog.Infof("%s: location value for registry %s has changed from %s to %s",
-					constants.ContainerRegistryConfPath, regLoc, oldReg.Location, newReg.Location)
-				return false, nil
-			}
-			if oldReg.Blocked != newReg.Blocked {
-				glog.Infof("%s: blocked value for registry %s has changed from %t to %t",
-					constants.ContainerRegistryConfPath, regLoc, oldReg.Blocked, newReg.Blocked)
-				return false, nil
-			}
-			if oldReg.Insecure != newReg.Insecure {
-				glog.Infof("%s: insecure value for registry %s has changed from %t to %t",
-					constants.ContainerRegistryConfPath, regLoc, oldReg.Insecure, newReg.Insecure)
-				return false, nil
-			}
-			if oldReg.MirrorByDigestOnly == newReg.MirrorByDigestOnly {
-				// Ensure that all the old mirrors are present
-				for _, m := range oldReg.Mirrors {
-					if !searchRegistryMirror(m.Location, newReg.Mirrors) {
-						glog.Infof("%s: mirror %s has been removed in registry %s",
-							constants.ContainerRegistryConfPath, m.Location, regLoc)
-						return false, nil
-					}
+		if ok {
+			// Registry is available in both old and new config.
+			if !reflect.DeepEqual(oldReg, newReg) {
+				// Registry has been changed in the new config.
+				// Check that changes made are safe or not.
+				if oldReg.Prefix != newReg.Prefix {
+					glog.Infof("%s: prefix value for registry %s has changed from %s to %s",
+						constants.ContainerRegistryConfPath, regLoc, oldReg.Prefix, newReg.Prefix)
+					return false, nil
 				}
-				// Ensure that any added mirror has mirror-by-digest-only set to true
-				for _, m := range newReg.Mirrors {
-					if !searchRegistryMirror(m.Location, oldReg.Mirrors) && !newReg.MirrorByDigestOnly {
-						glog.Infof("%s: mirror %s has been added in registry %s that has mirror-by-digest-only set to %t ",
-							constants.ContainerRegistryConfPath, m.Location, regLoc, newReg.MirrorByDigestOnly)
-						return false, nil
-					}
+				if oldReg.Location != newReg.Location {
+					glog.Infof("%s: location value for registry %s has changed from %s to %s",
+						constants.ContainerRegistryConfPath, regLoc, oldReg.Location, newReg.Location)
+					return false, nil
 				}
-			} else {
-				glog.Infof("%s: mirror-by-digest-only value for registry %s has changed from %t to %t",
-					constants.ContainerRegistryConfPath, regLoc, oldReg.MirrorByDigestOnly, newReg.MirrorByDigestOnly)
-				return false, nil
+				if oldReg.Blocked != newReg.Blocked {
+					glog.Infof("%s: blocked value for registry %s has changed from %t to %t",
+						constants.ContainerRegistryConfPath, regLoc, oldReg.Blocked, newReg.Blocked)
+					return false, nil
+				}
+				if oldReg.Insecure != newReg.Insecure {
+					glog.Infof("%s: insecure value for registry %s has changed from %t to %t",
+						constants.ContainerRegistryConfPath, regLoc, oldReg.Insecure, newReg.Insecure)
+					return false, nil
+				}
+				if oldReg.MirrorByDigestOnly == newReg.MirrorByDigestOnly {
+					// Ensure that all the old mirrors are present
+					for _, m := range oldReg.Mirrors {
+						if !searchRegistryMirror(m.Location, newReg.Mirrors) {
+							glog.Infof("%s: mirror %s has been removed in registry %s",
+								constants.ContainerRegistryConfPath, m.Location, regLoc)
+							return false, nil
+						}
+					}
+					// Ensure that any added mirror has mirror-by-digest-only set to true
+					for _, m := range newReg.Mirrors {
+						if !searchRegistryMirror(m.Location, oldReg.Mirrors) && !newReg.MirrorByDigestOnly {
+							glog.Infof("%s: mirror %s has been added in registry %s that has mirror-by-digest-only set to %t ",
+								constants.ContainerRegistryConfPath, m.Location, regLoc, newReg.MirrorByDigestOnly)
+							return false, nil
+						}
+					}
+				} else {
+					glog.Infof("%s: mirror-by-digest-only value for registry %s has changed from %t to %t",
+						constants.ContainerRegistryConfPath, regLoc, oldReg.MirrorByDigestOnly, newReg.MirrorByDigestOnly)
+					return false, nil
+				}
 			}
 		} else if !newReg.MirrorByDigestOnly {
 			// New mirrors added into registry but mirror-by-digest-only has been set to false


### PR DESCRIPTION
Signed-off-by: Raisaat Rashid <rarashid@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2056442

**- What I did**

Changed the logic of how the MCD handles node drains in order to prevent node drains from happening when mirrors are only added to registries with `mirror-by-digest-only=true` and no changes are made to existing registries with `mirror-by-digest-only=false`. Added a unit test case for the change.

**- How to verify it**

Change registry configurations according to the steps described [here](https://docs.openshift.com/container-platform/4.9/openshift_images/image-configuration.html#images-configuration-file_image-configuration). Make sure to have a blocked/insecure registry or a registry with the `mirror-by-digest-only` field unset. This change should cause node drains. Add a mirror to a registry with `mirror-by-digest-only=true` via an ICSP object as outlined [here](https://docs.openshift.com/container-platform/4.9/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration), with no changes made to existing registries with `mirror-by-digest-only=false`. This change should not cause any node drain.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changes the if-else logic of how the MCD handles node drains.