### PR TITLE
Bug 1948551: apiserver-watcher: change namespace to openshift-machine-config-operator

### DIFF
--- a/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -6,7 +6,7 @@ contents:
     kind: Pod
     metadata:
       name: apiserver-watcher
-      namespace: kube-system
+      namespace: openshift-machine-config-operator
     spec:
       containers:
       - name: apiserver-watcher

--- a/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -6,7 +6,7 @@ contents:
     kind: Pod
     metadata:
       name: apiserver-watcher
-      namespace: kube-system
+      namespace: openshift-machine-config-operator
     spec:
       containers:
       - name: apiserver-watcher

--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -6,7 +6,7 @@ contents:
     kind: Pod
     metadata:
       name: apiserver-watcher
-      namespace: kube-system
+      namespace: openshift-machine-config-operator
     spec:
       containers:
       - name: apiserver-watcher


### PR DESCRIPTION
It was a mistake that this pod was in kube-system. Now that we have a lockfile, we can change the namespace.

Fixes: 1948551