### PR TITLE
Bug 2012969: emit kube events for skipped and upgraded OSes

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -379,6 +379,14 @@ func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newC
 			MCDPivotErr.WithLabelValues(nodeName, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
 			return err
 		}
+		if dn.nodeWriter != nil {
+			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "OSUpgradeApplied", "OS upgrade applied; new MachineConfig (%s) has new OS image (%s)", newConfig.Name, newConfig.Spec.OSImageURL)
+		}
+	} else { //nolint:gocritic // The nil check for dn.nodeWriter has nothing to do with an OS update being unavailable.
+		// An OS upgrade is not available
+		if dn.nodeWriter != nil {
+			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "OSUpgradeSkipped", "OS upgrade skipped; new MachineConfig (%s) has same OS image (%s) as old MachineConfig (%s)", newConfig.Name, newConfig.Spec.OSImageURL, oldConfig.Name)
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
To provide better information to what the MCD is doing, the MCD should emit an event whenever a MachineConfig specifies that a new OS will be installed as well as whenever it does not.

**- What I did**

I added two events, `OSUpgradeApplied` and `OSUpgradeSkipped` which are emitted whenever the MCD determines an OS upgrade is required or not.

**- How to verify it**

1. Spin up a test cluster.
2. Watch the logs for a given node, e.g.: `$ oc logs -n openshift-machine-config-operator -c machine-config-daemon -f pod/machine-config-daemon-8hqvd`.
3. Create and apply a new MachineConfig.
4. Watch for the following events in the log (may need to start the MCD with the `-v4`) flag:

```console
I0518 19:51:24.703522    2623 event.go:285] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"ip-10-0-130-248.ec2.internal", UID:"cdac4d45-1c5f-4e31-b106-b9d76583d624", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NoOSUpgradeAvailable' New MachineConfig (rendered-infra-d4288fbd661c4a61fbc31a4614a9271f) has same OS (quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e42eb8c6aa523511d928b3dde3a5e0251e6baaba0b60ed00b431e17698556777) as old MachineConfig (rendered-infra-f02bc763e0574470ff44e34981d34e12); skipping OS upgrade
```

For the upgrade cases:

1. Create a new MachineConfig with a new `.spec.osImageURL` value.
2. Watch the logs for a given node, e.g.: `$ oc logs -n openshift-machine-config-operator -c machine-config-daemon -f pod/machine-config-daemon-8hqvd`.
3. Apply the new MachineConfig.
4. Watch for the upgrade event to be emitted in the MCD log.

**- Description for the changelog**
Emit a Kube event when an OS upgrade is applied or skipped