### PR TITLE
[on-prem] Bug 2089775: Fix regexp in keepalived script chk_default_ingress.sh

### DIFF
--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingre
 contents:
   inline: |
     #!/bin/bash
-    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q '{{`{{.NonVirtualIP}}`}}$'
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o json | jq -e '.subsets[].addresses | map( select (.ip == "{{`{{.NonVirtualIP}}`}}") )[0]' >/dev/null

--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingre
 contents:
   inline: |
     #!/bin/bash
-    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o json | jq -e '.subsets[].addresses | map( select (.ip == "{{`{{.NonVirtualIP}}`}}") )[0]' >/dev/null
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep -q 'ip: {{`{{.NonVirtualIP}}`}}$'

--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingre
 contents:
   inline: |
     #!/bin/bash
-    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q {{`{{.NonVirtualIP}}`}}
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q '{{`{{.NonVirtualIP}}`}}$'


### PR DESCRIPTION
Fixes: #3155

**- What I did**
Changed regexp in template. Really I didn't even try to build MCO, just created machineconfig override to test if it works :-)

**- How to verify it**
Apply fix on cluster and see if destination file contains correct grep command, and keepalived keeps ingress VIP on same node that runs ingress pod.
Ideally one can check it on cluster that has nodes with IP as described in issue #3155.

**- Description for the changelog**
Fixed keepalived check for ingress VIP
