### PR TITLE
[on-prem] Bug 2045559: Increase keepalived API check fall value to 3

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -23,7 +23,7 @@ contents:
         interval 2
         weight 20
         rise 3
-        fall 2
+        fall 3
     }
 
     vrrp_script chk_ocp_both {
@@ -33,7 +33,7 @@ contents:
         # bootstrap to master by itself.
         weight 5
         rise 3
-        fall 2
+        fall 3
     }
 
     # TODO: Improve this check. The port is assumed to be alive.


### PR DESCRIPTION
We have reports that on rare occasions when a control plane node is
taken offline it causes a keepalived failover on a different node.
This should not happen because haproxy should stop sending traffic
to the offline node before keepalived runs two health checks.
HAProxy is configured to check every second, while keepalived is
configured to check every 2 seconds, and it requires two failures
before considering the node failed.

What I think might be happening is that the keepalived and haproxy
health checks overlap exactly and the two keepalived health checks
happen exactly the same two seconds apart that it takes for haproxy
to notice the outage.

To ensure this cannot happen, I'm changing the fall value of the
keepalived checks to 3 so it will take 6 seconds to notice an outage.
While this does slow down failure detection, that should be a fairly
rare situation so it's a worthwhile tradeoff to avoid unnecessary
failovers (and associated disconnections) during normal conditions.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
