### PR TITLE
Bug 2084450: Add unit/file for AWS to compute instance provider-id and pass it to the kubelet

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-providerid.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-providerid.yaml
@@ -1,0 +1,26 @@
+mode: 0755
+path: "/usr/local/bin/aws-kubelet-providerid"
+contents:
+  inline: |
+    #!/bin/bash
+    set -e -o pipefail
+
+    NODECONF=/etc/systemd/system/kubelet.service.d/20-aws-providerid.conf
+
+    if [ -e "${NODECONF}" ]; then
+        echo "Not replacing existing ${NODECONF}"
+        exit 0
+    fi
+
+    # Due to a potential mismatch between Hostname and PrivateDNSName with clusters that use custom DHCP Option Sets
+    # which can cause issues in cloud controller manager node syncing
+    # (see: https://github.com/kubernetes/cloud-provider-aws/issues/384),
+    # set KUBELET_PROVIDERID to be a fully qualified AWS instace provider id.
+    # This new variable is later used to populate the kubelet's `provider-id` flag, later set on the Node .spec
+    # and used by the cloud controller manager's node controller to retrieve the Node's backing instance.
+    # This is obtained by using afterburn service variables, in turn obtained from metadata retrival.
+    # See respective systemd unit metadata related afterburn doc: https://coreos.github.io/afterburn/usage/attributes/
+    cat > "${NODECONF}" <<EOF
+    [Service]
+    Environment="KUBELET_PROVIDERID=aws://${AFTERBURN_AWS_AVAILABILITY_ZONE}/${AFTERBURN_AWS_INSTANCE_ID}"
+    EOF

--- a/templates/common/aws/units/aws-kubelet-providerid.service.yaml
+++ b/templates/common/aws/units/aws-kubelet-providerid.service.yaml
@@ -1,0 +1,23 @@
+name: aws-kubelet-providerid.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Fetch kubelet provider id from AWS Metadata
+
+  # Run afterburn service for collect info from metadata server
+  # see: https://coreos.github.io/afterburn/usage/attributes/
+  Requires=afterburn.service
+  After=afterburn.service
+
+  # Wait for NetworkManager to report it's online
+  After=NetworkManager-wait-online.service
+  # Run before kubelet
+  Before=kubelet.service
+
+  [Service]
+  EnvironmentFile=/run/metadata/afterburn
+  ExecStart=/usr/local/bin/aws-kubelet-providerid
+  Type=oneshot
+
+  [Install]
+  WantedBy=network-online.target

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -40,6 +40,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
+        --provider-id=${KUBELET_PROVIDERID} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
         --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -40,6 +40,7 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
+        --provider-id=${KUBELET_PROVIDERID} \
         --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}


### PR DESCRIPTION
**- What I did**
I Added AWS specific systemd unit (`aws-kubelet-providerid.service`) and file (`/usr/local/bin/aws-kubelet-providerid`) for generating the AWS instance provider-id (then stored in the `KUBELET_PROVIDERID` env var), in order to pass it as the `--provider-id` argument to the kubelet service binary.

We needed to add such flag, and make it non-empty only on AWS, to make the node syncing (specifically backing instance detection) work via provider-id detection, to cover cases where the node hostname doesn't match the expected `private-dns-name` (e.g. when a custom DHCP Option Set with empty `domain-name` is used).

Should fix: https://bugzilla.redhat.com/show_bug.cgi?id=2084450
Reference to an upstream issue with context: https://github.com/kubernetes/cloud-provider-aws/issues/384

**- How to verify it**
Try the reproduction steps available at: https://bugzilla.redhat.com/show_bug.cgi?id=2084450#c0 while launching a cluster with this MCO PR included.
Verify that the issue is not reproducible anymore.

**- Description for the changelog**
Add systemd units/files for AWS specific kubelet service


---
I tested this manually and here's what I got:
```
Every 2.0s: oc -n openshift-machine-api get machine.machine.openshift.io,nodes -o wide                                                                                                                                                        Damianos-MacBook-Pro: Wed May 25 17:53:47 2022

NAME                                                                            PHASE     TYPE         REGION         ZONE            AGE   NODE                                            PROVIDERID                                 STATE
machine.machine.openshift.io/ddonati-test111-tlq5x-master-0                     Running   m6i.xlarge   eu-central-1   eu-central-1a   68m   ip-10-0-138-106.eu-central-1.compute.internal   aws:///eu-central-1a/i-065897aad3875d4cd   running
machine.machine.openshift.io/ddonati-test111-tlq5x-master-1                     Running   m6i.xlarge   eu-central-1   eu-central-1b   68m   ip-10-0-180-99.eu-central-1.compute.internal    aws:///eu-central-1b/i-006f4c08cfbf1bf29   running
machine.machine.openshift.io/ddonati-test111-tlq5x-master-2                     Running   m6i.xlarge   eu-central-1   eu-central-1c   68m   ip-10-0-218-116.eu-central-1.compute.internal   aws:///eu-central-1c/i-08e52d41b18dac1c2   running
machine.machine.openshift.io/ddonati-test111-tlq5x-worker-eu-central-1a-xsg4h   Running   m6i.xlarge   eu-central-1   eu-central-1a   62m   ip-10-0-149-5.eu-central-1.compute.internal     aws:///eu-central-1a/i-0cd1a4e5a7bb7f7f9   running
machine.machine.openshift.io/ddonati-test111-tlq5x-worker-eu-central-1b-fwssv   Running   m6i.xlarge   eu-central-1   eu-central-1b   62m   ip-10-0-172-133.eu-central-1.compute.internal   aws:///eu-central-1b/i-0944ed2824e6dba03   running
machine.machine.openshift.io/ddonati-test111-tlq5x-worker-eu-central-1c-tln2r   Running   m6i.xlarge   eu-central-1   eu-central-1c   40m   ip-10-0-219-246                                 aws:///eu-central-1c/i-0df46c39b1323c47b   running  <--- NEW

NAME                                                 STATUS   ROLES    AGE   VERSION           INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                        KERNEL-VERSION                 CONTAINER-RUNTIME
node/ip-10-0-138-106.eu-central-1.compute.internal   Ready    master   67m   v1.23.3+ad897c4   10.0.138.106   <none>        Red Hat Enterprise Linux CoreOS 411.85.202205192031-0 (Ootpa)   4.18.0-348.23.1.el8_5.x86_64   cri-o://1.24.0-45.rhaos4.11.gitccef160.el8
node/ip-10-0-149-5.eu-central-1.compute.internal     Ready    worker   54m   v1.23.3+ad897c4   10.0.149.5     <none>        Red Hat Enterprise Linux CoreOS 411.85.202205192031-0 (Ootpa)   4.18.0-348.23.1.el8_5.x86_64   cri-o://1.24.0-45.rhaos4.11.gitccef160.el8
node/ip-10-0-172-133.eu-central-1.compute.internal   Ready    worker   58m   v1.23.3+ad897c4   10.0.172.133   <none>        Red Hat Enterprise Linux CoreOS 411.85.202205192031-0 (Ootpa)   4.18.0-348.23.1.el8_5.x86_64   cri-o://1.24.0-45.rhaos4.11.gitccef160.el8
node/ip-10-0-180-99.eu-central-1.compute.internal    Ready    master   68m   v1.23.3+ad897c4   10.0.180.99    <none>        Red Hat Enterprise Linux CoreOS 411.85.202205192031-0 (Ootpa)   4.18.0-348.23.1.el8_5.x86_64   cri-o://1.24.0-45.rhaos4.11.gitccef160.el8
node/ip-10-0-218-116.eu-central-1.compute.internal   Ready    master   68m   v1.23.3+ad897c4   10.0.218.116   <none>        Red Hat Enterprise Linux CoreOS 411.85.202205192031-0 (Ootpa)   4.18.0-348.23.1.el8_5.x86_64   cri-o://1.24.0-45.rhaos4.11.gitccef160.el8
node/ip-10-0-219-246                                 Ready    worker   34m   v1.23.3+ad897c4   10.0.219.246   <none>        Red Hat Enterprise Linux CoreOS 411.85.202205192031-0 (Ootpa)   4.18.0-348.23.1.el8_5.x86_64   cri-o://1.24.0-45.rhaos4.11.gitccef160.el8 <--- NEW
```

```
$ oc -n openshift-controller-manager logs -f aws-cloud-controller-manager-86778cf86b-gwttj
I0525 15:19:49.855913       1 node_controller.go:391] Initializing node ip-10-0-219-246 with cloud provider
I0525 15:19:50.045112       1 node_controller.go:493] Adding node label from cloud provider: beta.kubernetes.io/instance-type=m6i.xlarge
I0525 15:19:50.045456       1 node_controller.go:494] Adding node label from cloud provider: node.kubernetes.io/instance-type=m6i.xlarge
I0525 15:19:50.045606       1 node_controller.go:505] Adding node label from cloud provider: failure-domain.beta.kubernetes.io/zone=eu-central-1c
I0525 15:19:50.045634       1 node_controller.go:506] Adding node label from cloud provider: topology.kubernetes.io/zone=eu-central-1c
I0525 15:19:50.045688       1 node_controller.go:516] Adding node label from cloud provider: failure-domain.beta.kubernetes.io/region=eu-central-1
I0525 15:19:50.045708       1 node_controller.go:517] Adding node label from cloud provider: topology.kubernetes.io/region=eu-central-1
I0525 15:19:50.066905       1 node_controller.go:455] Successfully initialized node ip-10-0-219-246 with cloud provider
I0525 15:19:50.067622       1 event.go:294] "Event occurred" object="ip-10-0-219-246" kind="Node" apiVersion="v1" type="Normal" reason="Synced" message="Node synced successfully"
I0525 15:20:40.349078       1 controller.go:265] Node changes detected, triggering a full node sync on all loadbalancer services
I0525 15:20:40.349210       1 controller.go:741] Syncing backends for all LB services.
I0525 15:20:40.349292       1 controller.go:804] Updating backends for load balancer openshift-ingress/router-default with node set: map[ip-10-0-138-106.eu-central-1.compute.internal:{} ip-10-0-149-5.eu-central-1.compute.internal:{} ip-10-0-172-133.eu-central-1.compute.internal:{} ip-10-0-180-99.eu-central-1.compute.internal:{} ip-10-0-218-116.eu-central-1.compute.internal:{} ip-10-0-219-246:{}]
I0525 15:20:40.522259       1 aws_loadbalancer.go:1462] Instances added to load-balancer a781e5af36d8f4550baf5e3776505e3c
I0525 15:20:40.705767       1 controller.go:748] Successfully updated 1 out of 1 load balancers to direct traffic to the updated set of nodes
I0525 15:20:40.705790       1 event.go:294] "Event occurred" object="openshift-ingress/router-default" kind="Service" apiVersion="v1" type="Normal" reason="UpdatedLoadBalancer" message="Updated load balancer with new hosts"
```

- The new machine `machine.machine.openshift.io/ddonati-test111-tlq5x-worker-eu-central-1c-tln2r` is correctly Provisioned and goes into Running state
- A new node `node/ip-10-0-219-246` is created for the machine, which is then synced up and linked correctly
    