### PR TITLE
Bug 2089775: [on-prem] Make ingress check grep more specific

### DIFF
--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingre
 contents:
   inline: |
     #!/bin/bash
-    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q {{`{{.NonVirtualIP}}`}}
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep -q 'ip: {{`{{.NonVirtualIP}}`}}$'


### PR DESCRIPTION
Currently the grep for the ingress check is too broad - for example,
grepping for 1.1.1.1 will match any of 1.1.1.1, 1.1.1.11, 1.1.1.100,
etc. We need to ensure that we match only the exact IP we're looking
for. This patch accomplishes that by adding the 'ip: ' to the address
grep and ensuring that the address is the end of the line. This should
prevent accidental substring matches.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Fixed an overly broad grep in the ingress check script that would incorrectly match multiple addresses.
