### PR TITLE
Bug 2090436: It takes 30min-60min to update the machine count in custom MachineConfigPools (MCPs) when a node is removed from the pool

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -472,6 +472,8 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 	oldPool, err := ctrl.getPrimaryPoolForNode(oldNode)
 	if err == nil && oldPool.Name != pool.Name {
 		ctrl.logPoolNode(pool, curNode, "changed from pool %s", oldPool.Name)
+		// Let's also make sure the old pool node counts/status get updated
+		ctrl.enqueueMachineConfigPool(oldPool)
 	}
 
 	var changed bool


### PR DESCRIPTION
This explicitly requeues the "old" pool when a node between pools so the "old" pool can update its counts immediately rather than having to wait until the pool gets re-queued by something else (which can take minutes). 

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2090436
