### PR TITLE
Bug 2005694: Removing proxy object takes up to 10 minutes for the changes to propagate to the MCO 

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -712,6 +712,10 @@ func (optr *Operator) syncRequiredMachineConfigPools(_ *renderConfig) error {
 				if syncerr != nil {
 					glog.Errorf("Error syncingUpgradeableStatus: %q", syncerr)
 				}
+				// If we don't account for pause here, we will spin in this loop until we hit the 10 minute timeout because paused pools can't sync.
+				if pool.Spec.Paused {
+					return false, fmt.Errorf("Required MachineConfigPool '%s' is paused and can not sync until it is unpaused", pool.Name)
+				}
 				return false, nil
 			}
 		}


### PR DESCRIPTION
This adjusts our behavior around how machine-config-operator reacts to config changes while the master pool has been paused. 

Old behavior on a config change with a paused master was: 
- `syncRequiredMachineConfigPools` spins for 10 minutes and times out with an error (which holds up other syncs such as RenderConfig) 
- Operator degrades after sync timeout error

New behavior is: 
- `syncRequiredMachineConfigPools` returns error immediately if pool is paused 
- Operator degrades after paused error

So we save the 10 minute timeout/wait that was useless anyway because we *knew* it would never succeed 

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2005694
