### PR TITLE
Bug 2090794: drain controller: continue retry after 1h timeout

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -529,6 +529,15 @@ func (dn *Daemon) syncNode(key string) error {
 		return nil
 	}
 
+	// Check if a previous drain caused us to degrade. If the drain
+	// has yet to complete and we are in a degrade state, continue
+	// to stay in this state
+	if dn.node.Annotations[constants.DesiredDrainerAnnotationKey] != "" &&
+		dn.node.Annotations[constants.DesiredDrainerAnnotationKey] != dn.node.Annotations[constants.LastAppliedDrainerAnnotationKey] {
+		glog.Infof("A previously requested drain has not yet completed. Waiting for machine-config-controller to finish draining node.")
+		return nil
+	}
+
 	// Pass to the shared update prep method
 	current, desired, err := dn.prepUpdateFromCluster()
 	if err != nil {


### PR DESCRIPTION
Change drain controller to continue retrying after 1h timeout,
to match old daemon behaviour. If the drain is eventually successful
or if a user intervenes and deletes the problematic pod, the controller
will now continue instead of being stuck on the failure.

Also modify daemon logic to properly report degrade instead of
unnecessarily retrying.

**- How to verify it**

Using the steps in the BZ https://bugzilla.redhat.com/show_bug.cgi?id=2090794, wait for timeout to ensure the pool is degraded with the corresponding message, then delete the pod. The MCC/MCD will continue and undegrade.

Manually tested with above (after dropping timeouts to 6 min)
