### PR TITLE
Bug 2089687: Update alert message for drain failure

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -64,7 +64,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon"
+            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
     - name: mcd-pivot-error
       rules:
         - alert: MCDPivotError


### PR DESCRIPTION
Update message to point to MCC and not MCD pod, since MCC now does
the actual draining.

For now we are doing this to preserve old alerts, but we should
potentially consider alerting via MCC and deprecating the old alert.


