### PR TITLE
Remove `onPremPlatformKeepalivedEnableUnicast` function

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -309,7 +309,6 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["onPremPlatformAPIServerInternalIP"] = onPremPlatformAPIServerInternalIP
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
-	funcs["onPremPlatformKeepalivedEnableUnicast"] = onPremPlatformKeepalivedEnableUnicast
 	funcs["urlHost"] = urlHost
 	funcs["urlPort"] = urlPort
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
@@ -421,19 +420,6 @@ func onPremPlatformShortName(cfg RenderConfig) interface{} {
 		}
 	} else {
 		return ""
-	}
-}
-
-func onPremPlatformKeepalivedEnableUnicast(cfg RenderConfig) (interface{}, error) {
-	if cfg.Infra.Status.PlatformStatus != nil {
-		switch cfg.Infra.Status.PlatformStatus.Type {
-		case configv1.BareMetalPlatformType:
-			return "yes", nil
-		default:
-			return "no", nil
-		}
-	} else {
-		return "no", nil
 	}
 }
 

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -62,7 +62,6 @@ func (a *assetRenderer) addTemplateFuncs() {
 	funcs["onPremPlatformAPIServerInternalIP"] = onPremPlatformAPIServerInternalIP
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
-	funcs["onPremPlatformKeepalivedEnableUnicast"] = onPremPlatformKeepalivedEnableUnicast
 
 	a.tmpl = a.tmpl.Funcs(funcs)
 }
@@ -239,19 +238,6 @@ func onPremPlatformShortName(cfg mcfgv1.ControllerConfigSpec) interface{} {
 		}
 	} else {
 		return ""
-	}
-}
-
-func onPremPlatformKeepalivedEnableUnicast(cfg mcfgv1.ControllerConfigSpec) (interface{}, error) {
-	if cfg.Infra.Status.PlatformStatus != nil {
-		switch cfg.Infra.Status.PlatformStatus.Type {
-		case configv1.BareMetalPlatformType:
-			return "yes", nil
-		default:
-			return "no", nil
-		}
-	} else {
-		return "no", nil
 	}
 }
 


### PR DESCRIPTION
This isn't used anymore since we enabled Unicast for all on-prem
platforms which use Keepalived, via #3016.
