### PR TITLE
MCD: Add support for RHCOS9 and SCOS9

### DIFF
--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -35,7 +35,7 @@ func isArgTunable(arg string) (bool, error) {
 		return false, fmt.Errorf("failed to get OS for determining whether kernel arg is tuneable: %w", err)
 	}
 
-	if os.IsRHCOS() {
+	if os.IsEL() {
 		return tuneableRHCOSArgsAllowlist[arg], nil
 	} else if os.IsFCOS() {
 		return true, nil

--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -17,21 +17,27 @@ type OperatingSystem struct {
 	VersionID string
 }
 
-// IsRHCOS is true if the OS is RHEL CoreOS
-func (os OperatingSystem) IsRHCOS() bool {
-	return os.ID == "rhcos"
+// IsEL is true if the OS is an Enterprise Linux variant,
+// i.e. RHEL CoreOS (RHCOS) or CentOS Stream CoreOS (SCOS)
+func (os OperatingSystem) IsEL() bool {
+	return os.ID == "rhcos" || os.ID == "scos"
 }
 
-// IsFCOS is true if the OS is RHEL CoreOS
+// IsEL9 is true if the OS is RHCOS 9 or SCOS 9
+func (os OperatingSystem) IsEL9() bool {
+	return os.IsEL() && os.VersionID == "9"
+}
+
+// IsFCOS is true if the OS is Fedora CoreOS
 func (os OperatingSystem) IsFCOS() bool {
 	return os.ID == "fedora" && os.VariantID == "coreos"
 }
 
 // IsCoreOSVariant is true if the OS is FCOS or a derivative (ostree+Ignition)
-// which includes RHCOS.
+// which includes SCOS and RHCOS.
 func (os OperatingSystem) IsCoreOSVariant() bool {
-	// We should probably add VARIANT_ID=coreos to RHCOS too and key off that
-	return os.IsFCOS() || os.IsRHCOS()
+	// In RHCOS8 the variant id is not specified. SCOS (future RHCOS9) and FCOS have VARIANT_ID=coreos.
+	return os.VariantID == "coreos" || os.IsEL()
 }
 
 // IsLikeTraditionalRHEL7 is true if the OS is traditional RHEL7 or CentOS7:

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1087,7 +1087,7 @@ func (dn *Daemon) generateExtensionsArgs(oldConfig, newConfig *mcfgv1.MachineCon
 
 	extArgs := []string{"update"}
 
-	if dn.os.IsRHCOS() {
+	if dn.os.IsEL() {
 		extensions := getSupportedExtensions()
 		for _, ext := range added {
 			for _, pkg := range extensions[ext] {
@@ -1156,7 +1156,7 @@ func (dn *CoreOSDaemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConf
 	}
 
 	// Validate extensions allowlist on RHCOS nodes
-	if err := validateExtensions(newConfig.Spec.Extensions); err != nil && dn.os.IsRHCOS() {
+	if err := validateExtensions(newConfig.Spec.Extensions); err != nil && dn.os.IsEL() {
 		return err
 	}
 
@@ -1168,8 +1168,8 @@ func (dn *CoreOSDaemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConf
 // switchKernel updates kernel on host with the kernelType specified in MachineConfig.
 // Right now it supports default (traditional) and realtime kernel
 func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig) error {
-	// We support Kernel update only on RHCOS nodes
-	if !dn.os.IsRHCOS() {
+	// We support Kernel update only on RHCOS and SCOS nodes
+	if !dn.os.IsEL() {
 		glog.Info("updating kernel on non-RHCOS nodes is not supported")
 		return nil
 	}
@@ -1786,7 +1786,9 @@ func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
 	}
 
 	var authKeyPath string
-	if dn.os.IsFCOS() {
+	if dn.os.IsEL9() || dn.os.IsFCOS() {
+		// In FCOS and EL9, ignition writes the SSH key to ~/.ssh/authorized_keys.d/ignition,
+		// and the ssh-key-dir sshd AuthorizedKeysCommand binary reads it from there.
 		authKeyPath = filepath.Join(coreUserSSHPath, "authorized_keys.d", "ignition")
 	} else {
 		authKeyPath = filepath.Join(coreUserSSHPath, "authorized_keys")


### PR DESCRIPTION
**- What I did**

This adds MCD support for `ID="scos"` in `/usr/lib/os-release` and
`/etc/os-release`.

Done:
- [x] discuss removal of kernel-arg allowlist for OKD and split out into separate PR: https://github.com/openshift/machine-config-operator/pull/3248

Requires: ~~https://github.com/openshift/os/pull/773 and possibly https://issues.redhat.com/browse/MCO-126~~ we can defer both

/cc @cheesesashimi 
/cc @travier 

**- How to verify it**

**- Description for the changelog**
MCD: Add support for RHCOS9 and SCOS9
