### PR TITLE
Bug 2089775: Revert "Fix regexp in keepalived script chk_default_ingress.sh"

### DIFF
--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingre
 contents:
   inline: |
     #!/bin/bash
-    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep -q 'ip: {{`{{.NonVirtualIP}}`}}$'
+    /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep 'ip:' | grep -q {{`{{.NonVirtualIP}}`}}


### PR DESCRIPTION
Reverts openshift/machine-config-operator#3156

Since this landed, IPv6 metal looks broken. Example https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6/1534859841690931200

All workers appear unable to reach mcs:

```
[   14.574859] ignition[903]: GET https://[fd2e:6f44:5dd8:c956::5]:22623/config/worker: attempt #6
[   14.577568] ignition[903]: GET result: Internal Server Error
[  *** ] A start job is running for Ignition (fetch) (15s / no limit)[   19.575682] ignition[903]: GET https://[fd2e:6f44:5dd8:c956::5]:22623/config/worker: attempt #7
[   19.577556] ignition[903]: GET result: Internal Server Error
```

chk_default_ingress is erroring the logs:

```
./control-plane/fd2e:6f44:5dd8:c956::15/containers/keepalived-ced7cabf353227bcaa2637f5d16aa655865d3d387e63962fb0f29d9a7b85b212.log:Thu Jun  9 12:03:13 2022: Script `chk_default_ingress` now returning 1
./control-plane/fd2e:6f44:5dd8:c956::15/containers/keepalived-ced7cabf353227bcaa2637f5d16aa655865d3d387e63962fb0f29d9a7b85b212.log:Thu Jun  9 12:03:13 2022: VRRP_Script(chk_default_ingress) failed (exited with status 1)
./control-plane/fd2e:6f44:5dd8:c956::15/containers/keepalived-monitor-bafe76488efe1263370bd878e9311392535475e8c4de2b46e5bd1ef3abaafa80.log:time="2022-06-09T12:03:13Z" level=info msg="vrrp_script chk_default_ingress {"
./control-plane/fd2e:6f44:5dd8:c956::15/containers/keepalived-monitor-bafe76488efe1263370bd878e9311392535475e8c4de2b46e5bd1ef3abaafa80.log:time="2022-06-09T12:03:13Z" level=info msg="    script \"/usr/bin/timeout 4.9 /etc/keepalived/chk_default_ingress.sh\""
./control-plane/fd2e:6f44:5dd8:c956::15/containers/keepalived-monitor-bafe76488efe1263370bd878e9311392535475e8c4de2b46e5bd1ef3abaafa80.log:time="2022-06-09T12:03:13Z" level=info msg="        chk_default_ingress"
./control-plane/fd2e:6f44:5dd8:c956::15/containers/render-config-keepalived-6c241cadad3349349362496e80c552abd16d122599baf4f2e3d30d2036636887.log:time="2022-06-09T12:01:11Z" level=info msg="Runtimecfg rendering template" path=/etc/keepalived/chk_default_ingress.sh
./control-plane/fd2e:6f44:5dd8:c956::16/containers/keepalived-6b794bd233a57ca1738cf463ae0ff1a8b1aa07437f856b1710f9364af0da4bbe.log:Thu Jun  9 12:03:18 2022: Script `chk_default_ingress` now returning 1
```

I see the ingress script rendered like this:

```
time="2022-06-09T12:02:26Z" level=info msg="#!/bin/bash"
time="2022-06-09T12:02:26Z" level=info msg="/host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get ep -n openshift-ingress router-internal-default -o yaml | grep -q 'ip: fd2e:6f44:5dd8:c956::16$'"
```

I can't see router-internal-default in a must-gather so I don't know what it looks like, but I'm wondering if combining the greps is excluding a bracketed IPv6 address now?

