### PR TITLE
[release-4.9] Bug 2089763: configure-ovs: persist profiles after auto-connect has been set

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -44,7 +44,12 @@ contents:
     }
 
     persist_nm_conn_files() {
+      update_nm_conn_files br-ex phys0
       copy_nm_conn_files "$NM_CONN_UNDERLAY"
+      if [ -f "$extra_bridge_file" ]; then
+        update_nm_conn_files br-ex1 phys1
+        copy_nm_conn_files "$NM_CONN_UNDERLAY"
+      fi
     }
 
     update_nm_conn_files() {
@@ -326,8 +331,6 @@ contents:
       fi
 
       configure_driver_options "${iface}"
-      update_nm_conn_files "$bridge_name" "$port_name"
-      persist_nm_conn_files
     }
 
     # Used to remove a bridge
@@ -587,6 +590,7 @@ contents:
         activate_nm_conn ovs-if-phys1
         activate_nm_conn ovs-if-br-ex1
       fi
+      persist_nm_conn_files
     elif [ "$1" == "OpenShiftSDN" ]; then
       # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
       rollback_nm


### PR DESCRIPTION
After backporting 715393a in #3160, auto-connect was being set after keyfiles were persisted from the overlay `systemConnectionsMerged` to the underlay `system-connections` and thus the setting was lost after reboot. So persist profiles at the very end.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
