### PR TITLE
Bug 1817075: MCC & MCO don't free leader leases during shut down -> 10 minutes of leader election timeouts

### DIFF
--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/golang/glog"
 	"github.com/openshift/machine-config-operator/internal/clients"
@@ -68,4 +70,24 @@ func GetLeaderElectionConfig(restcfg *rest.Config) configv1.LeaderElection {
 	}
 
 	return defaultLeaderElection
+}
+
+// SignalHandler catches SIGINT/SIGTERM signals and makes sure the passed context gets cancelled when those signals happen. This allows us to use a
+// context to shut down our operations cleanly when we are signalled to shutdown.
+func SignalHandler(runCancel context.CancelFunc) {
+
+	// make a signal handling channel for os signals
+	ch := make(chan os.Signal, 1)
+	// stop listening for signals when we leave this function
+	defer func() { signal.Stop(ch) }()
+	// catch SIGINT and SIGTERM
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	sig := <-ch
+	glog.Infof("Shutting down due to: %s", sig)
+	// if we're shutting down, cancel the context so everything else will stop
+	runCancel()
+	glog.Infof("Context cancelled")
+	sig = <-ch
+	glog.Fatalf("Received shutdown signal twice, exiting: %s", sig)
+
 }

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/tools/leaderelection"
 )
 

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -62,7 +62,12 @@ func StartMetricsListener(addr string, stopCh <-chan struct{}) {
 		}
 	}()
 	<-stopCh
-	if err := s.Shutdown(context.Background()); err != http.ErrServerClosed {
-		glog.Errorf("error stopping metrics listener: %v", err)
+	if err := s.Shutdown(context.Background()); err != nil {
+		if err != http.ErrServerClosed {
+			glog.Errorf("error stopping metrics listener: %v", err)
+		}
+	} else {
+		glog.Infof("Metrics listener successfully stopped")
 	}
+
 }


### PR DESCRIPTION
**TL;DR**: SIGTERM/SIGINT --> cancel `runContext` --> shutdown -->   cancel `leaderContext` --> release leader lease --> terminate 

**- What I did**
- added two contexts:
   - a `runContext` (for cencelling our running state)  and 
   - a `leaderContext` (for cancelling our leader lease) 
 to both the controller and the operator run functions
- added a signal handler that catches SIGINT/SIGTERM to controller and operator
- updated run functions such that: 
   - signal handler cancels `runContext` when SIGTERM/SIGINT is received
   - operator/controller shuts down when `runContext` is cancelled, and then sequentially cancels `leaderContext`
- updated leaderElection config in controller and operator to release leader lease when `leaderContext` is cancelled 
- shutdown metrics listener properly 

**- How to verify it**
- delete a controller or an operator pod 
- observe logging that shows it shutting down/releasing the lease 
- observe that the pod that replaces it has short ( < 1 minute) leader election wait 

**- Description for the changelog**
Controller and operator shutdown cleanly on normal termination and release their leader lease cleanly, resulting in faster leader election times, since we don't have to wait for the previous lease to time out anymore. 

Fixes: [BZ1817075](https://bugzilla.redhat.com/show_bug.cgi?id=1817075)