### PR TITLE
Bug 2096413: configure-ovs: improve handling of static ip and mac address configuration

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -229,35 +229,24 @@ contents:
             exit 1
           fi
           new_conn_file="${new_conn_files[0]}"
-          # modify file to work with OVS and have unique settings
+
+          # modify basic connection settings, some of which can't be modified through nmcli
           sed -i '/^multi-connect=.*$/d' ${new_conn_file}
           sed -i '/^autoconnect=.*$/d' ${new_conn_file}
           sed -i '/^\[connection\]$/a autoconnect=false' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^type=.*$/type=ovs-interface/' ${new_conn_file}
           sed -i '/^\[connection\]$/a slave-type=ovs-port' ${new_conn_file}
           sed -i '/^\[connection\]$/a master='"$ovs_port_conn" ${new_conn_file}
-          if grep 'interface-name=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[connection\]$/,/^\[/ s/^interface-name=.*$/interface-name='"$bridge_name"'/' ${new_conn_file}
-          else
-            sed -i '/^\[connection\]$/a interface-name='"$bridge_name" ${new_conn_file}
-          fi
-          if ! grep 'cloned-mac-address=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[ethernet\]$/a cloned-mac-address='"$iface_mac" ${new_conn_file}
-          else
-            sed -i '/^\[ethernet\]$/,/^\[/ s/^cloned-mac-address=.*$/cloned-mac-address='"$iface_mac"'/' ${new_conn_file}
-          fi
-          if grep 'mtu=' ${new_conn_file} &> /dev/null; then
-            sed -i '/^\[ethernet\]$/,/^\[/ s/^mtu=.*$/mtu='"$iface_mtu"'/' ${new_conn_file}
-          else
-            sed -i '/^\[ethernet\]$/a mtu='"$iface_mtu" ${new_conn_file}
-          fi
           cat <<EOF >> ${new_conn_file}
     [ovs-interface]
     type=internal
     EOF
+
+          # reload the connection and modify some more settings through nmcli
           nmcli c load ${new_conn_file}
-          # Set interface metric in the static route case. For the DHCP route case, see below.
-          nmcli c mod "${ovs_interface}" ipv4.route-metric "${bridge_metric}" ipv6.route-metric "${bridge_metric}"
+          nmcli c mod "${ovs_interface}" conn.interface "$bridge_name" \
+            802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
+            ipv4.route-metric "${bridge_metric}" ipv6.route-metric "${bridge_metric}"
           echo "Loaded new $ovs_interface connection file: ${new_conn_file}"
         else
           extra_if_brex_args=""

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -202,7 +202,7 @@ contents:
       if ! nmcli connection show "$bridge_interface_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists destroy interface ${iface}
         add_nm_conn type ${iface_type} conn.interface ${iface} master "$default_port_name" con-name "$bridge_interface_name" \
-        connection.autoconnect-priority 100 connection.autoconnect-slaves 1 802-3-ethernet.mtu ${iface_mtu} \
+        connection.autoconnect-priority 100 802-3-ethernet.cloned-mac-address "${iface_mac}" 802-3-ethernet.mtu ${iface_mtu}  \
         ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -206,8 +206,9 @@ contents:
         ${extra_phys_args[@]+"${extra_phys_args[@]}"}
       fi
 
-      # Get the new connection uuid
+      # Get the new connection uuids
       new_conn=$(nmcli -g connection.uuid conn show "$bridge_interface_name")
+      ovs_port_conn=$(nmcli -g connection.uuid conn show "$ovs_port")
 
       # Update connections with master property set to use the new connection
       replace_connection_master $old_conn $new_conn
@@ -217,45 +218,22 @@ contents:
         ovs-vsctl --timeout=30 --if-exists destroy interface "$bridge_name"
         if nmcli --fields ipv4.method,ipv6.method conn show $old_conn | grep manual; then
           echo "Static IP addressing detected on default gateway connection: ${old_conn}"
-          # find and copy the old connection to get the address settings
-          if egrep -l "^uuid=$old_conn" ${NM_CONN_PATH}/*; then
-            old_conn_file=$(egrep -l "^uuid=$old_conn" ${NM_CONN_PATH}/*)
-            cloned=false
-          else
-            echo "WARN: unable to find NM configuration file for conn: ${old_conn}. Attempting to clone conn"
-            nmcli conn clone ${old_conn} ${old_conn}-clone
-            shopt -s nullglob
-            old_conn_files=(${NM_CONN_PATH}/"${old_conn}"-clone*)
-            shopt -u nullglob
-            if [ ${#old_conn_files[@]} -ne 1 ]; then
-              echo "ERROR: unable to locate cloned conn file for ${old_conn}-clone"
-              exit 1
-            fi
-            old_conn_file="${old_conn_files[0]}"
-            cloned=true
-            echo "Successfully cloned conn to ${old_conn_file}"
+          # clone the old connection to get the address settings
+          # prefer cloning vs copying the connection file to avoid problems with selinux
+          nmcli conn clone "${old_conn}" "${ovs_interface}"
+          shopt -s nullglob
+          new_conn_files=(${NM_CONN_PATH}/"${ovs_interface}"*)
+          shopt -u nullglob
+          if [ ${#new_conn_files[@]} -ne 1 ] || [ ! -f "${new_conn_files[0]}" ]; then
+            echo "ERROR: could not find ${ovs_interface} conn file after cloning from ${old_conn}"
+            exit 1
           fi
-          echo "old connection file found at: ${old_conn_file}"
-          old_basename=$(basename "${old_conn_file}" .nmconnection)
-          new_conn_file="${old_conn_file/${NM_CONN_PATH}\/$old_basename/${NM_CONN_PATH}/$ovs_interface}"
-          if [ -f "$new_conn_file" ]; then
-            echo "WARN: existing $bridge_name interface file found: $new_conn_file, which is not loaded in NetworkManager...overwriting"
-          fi
-          cp -f "${old_conn_file}" ${new_conn_file}
-          restorecon ${new_conn_file}
-          if $cloned; then
-            nmcli conn delete ${old_conn}-clone
-            rm -f "${old_conn_file}"
-          fi
-          ovs_port_conn=$(nmcli --fields connection.uuid conn show "$ovs_port" | awk '{print $2}')
-          br_iface_uuid=$(cat /proc/sys/kernel/random/uuid)
+          new_conn_file="${new_conn_files[0]}"
           # modify file to work with OVS and have unique settings
-          sed -i '/^\[connection\]$/,/^\[/ s/^uuid=.*$/uuid='"$br_iface_uuid"'/' ${new_conn_file}
           sed -i '/^multi-connect=.*$/d' ${new_conn_file}
           sed -i '/^autoconnect=.*$/d' ${new_conn_file}
           sed -i '/^\[connection\]$/a autoconnect=false' ${new_conn_file}
           sed -i '/^\[connection\]$/,/^\[/ s/^type=.*$/type=ovs-interface/' ${new_conn_file}
-          sed -i '/^\[connection\]$/,/^\[/ s/^id=.*$/id='"$ovs_interface"'/' ${new_conn_file}
           sed -i '/^\[connection\]$/a slave-type=ovs-port' ${new_conn_file}
           sed -i '/^\[connection\]$/a master='"$ovs_port_conn" ${new_conn_file}
           if grep 'interface-name=' ${new_conn_file} &> /dev/null; then
@@ -312,7 +290,7 @@ contents:
             extra_if_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
           fi
 
-          add_nm_conn type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port" con-name \
+          add_nm_conn type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port_conn" con-name \
             "$ovs_interface" 802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.route-metric "${bridge_metric}" ipv6.route-metric "${bridge_metric}" ${extra_if_brex_args}
         fi


### PR DESCRIPTION
* clone connection to avoid selinux problems

  /etc/NetworkManager/systemConnectionsMerged is not correctly registered
  in selinux as a location for NM to manage its connection profiles so
  attempting to update a profile through NM after manually copying and
  doing a restorecon from that location fails. So instead of copying files
  there and restorecon manually, rely on `nmcli clone` to copy a connection
  and let that handle selinux attributes.
  
  While we don't use /etc/NetworkManager/systemConnectionsMerged since
  4.9 and this only really applies to that and earlier releases, bring in
  these changes anyway as it should still be ok and common code eases
  backports.
  
* explicitly set ovs-if-phys mac

  ovs-if-br-ex and ovs-if-phys need to be configured with the same mac
  address. While ovs-if-br-ex mac address is being explicitly set,
  ovs-if-phys is not as it is assumed it does not change.
  
  But there are circumstances where it can change. For example, link
  aggregation devices take the mac from the first enslaved device. While
  we are accustomed for this to follow a lexicographical order, it is not
  specified. Further more, unforeseen administrative action or internal NM
  temporary errors upon network activation might influence this order and
  the resulting mac address of the link aggregation device.
  
  Just explicitly set the mac address in ovs-if-phys as well to avoid such
  issues.
  
  Incidentally, configuring a bond with autoconnect-slaves set, was
  causing a race condition when activating a slave that would activate the
  bond which would activate the other slave at the same time, making the
  first slave activation to fail on the first attempt, succeeding after a
  retry, but changing the enslaving order and thus the mac address of the
  bond.
  
  Remove autoconnect-slaves since it is now unnecessary as we explicitly
  activate the slaves.
  
  Note that our configuration did not and does not properly support
  active-backup bonding with fail_over_mac set to active, as in such a
  case the bond mac address changes dynamically.

* improve static ip configuration flow

  When configuring static ip connections, settings were attempted to be
  set with sed looking up an ethernet section. This section might not be
  present in the cloned configuration file and these settings might not be
  set correctly.
  
  Change the approach and only set with sed basic settings that cannot be
  set with nmcli or that we need them to be there before loading the
  connection. Set the remaining settings with nmcli.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
