### PR TITLE
[release-4.9] Bug 2085413: configure-ovs.sh: Provide store hint for default route interface

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -453,6 +453,33 @@ contents:
       nmcli c mod "$conn" connection.autoconnect yes
     }
 
+    # Accepts parameters $iface_default_hint_file, $iface
+    # Writes content of $iface into $iface_default_hint_file
+    write_iface_default_hint() {
+      local iface_default_hint_file="$1"
+      local iface="$2"
+
+      echo "${iface}" >| "${iface_default_hint_file}"
+    }
+
+    # Accepts parameters $iface_default_hint_file
+    # Returns the stored interface default hint if the hint is non-empty,
+    # not br-ex, not br-ex1 and if the interface can be found in /sys/class/net
+    get_iface_default_hint() {
+      local iface_default_hint_file=$1
+      if [ -f "${iface_default_hint_file}" ]; then
+        local iface_default_hint=$(cat "${iface_default_hint_file}")
+        if [ "${iface_default_hint}" != "" ] &&
+           [ "${iface_default_hint}" != "br-ex" ] &&
+           [ "${iface_default_hint}" != "br-ex1" ] &&
+           [ -d "/sys/class/net/${iface_default_hint}" ]; then
+           echo "${iface_default_hint}"
+           return
+        fi
+      fi
+      echo ""
+    }
+
     # Accepts parameters $bridge_interface (e.g. ovs-port-phys0)
     # Returns the physical interface name if $bridge_interface exists, "" otherwise
     get_bridge_physical_interface() {
@@ -460,6 +487,87 @@ contents:
       local physical_interface=""
       physical_interface=$(nmcli -g connection.interface-name conn show "${bridge_interface}" 2>/dev/null || echo "")
       echo "${physical_interface}"
+    }
+
+    # Accepts parameters $iface, $iface_default_hint_file
+    # Finds the default interface. If the default interface is br-ex, use that and return.
+    # Never use the interface that is provided inside extra_bridge_file for br-ex1.
+    # Never use br-ex1.
+    # If the default interface is not br-ex:
+    # Check if there is a valid hint inside iface_default_hint_file. If so, use that hint.
+    # If there is no valid hint, use the default interface that we found during the step
+    # earlier. Write the default interface to the hint file.
+    get_default_interface() {
+      local iface=""
+      local counter=0
+      local iface_default_hint_file="$1"
+      local extra_bridge_file="$2"
+      local extra_bridge=""
+
+      if [ -f "${extra_bridge_file}" ]; then
+        extra_bridge=$(cat ${extra_bridge_file})
+      fi
+
+      # find default interface
+      # the default interface might be br-ex, so check this before looking at the hint
+      while [ ${counter} -lt 12 ]; do
+        # check ipv4
+        # never use the interface that's specified in extra_bridge_file
+        # never use br-ex1
+        if [ "${extra_bridge}" != "" ]; then
+          iface=$(ip route show default | grep -v "br-ex1" | grep -v "${extra_bridge}" | awk '{ if ($4 == "dev") { print $5; exit } }')
+        else
+          iface=$(ip route show default | grep -v "br-ex1" | awk '{ if ($4 == "dev") { print $5; exit } }')
+        fi
+        if [[ -n "${iface}" ]]; then
+          break
+        fi
+        # check ipv6
+        # never use the interface that's specified in extra_bridge_file
+        # never use br-ex1
+        if [ "${extra_bridge}" != "" ]; then
+          iface=$(ip -6 route show default | grep -v "br-ex1" | grep -v "${extra_bridge}" | awk '{ if ($4 == "dev") { print $5; exit } }')
+        else
+          iface=$(ip -6 route show default | grep -v "br-ex1" | awk '{ if ($4 == "dev") { print $5; exit } }')
+        fi
+        if [[ -n "${iface}" ]]; then
+          break
+        fi
+        counter=$((counter+1))
+        sleep 5
+      done
+
+      # if the default interface does not point out of br-ex or br-ex1
+      if [ "${iface}" != "br-ex" ] && [ "${iface}" != "br-ex1" ]; then
+        # determine if an interface default hint exists from a previous run
+        # and if the interface has a valid default route
+        iface_default_hint=$(get_iface_default_hint "${iface_default_hint_file}")
+        if [ "${iface_default_hint}" != "" ] &&
+           [ "${iface_default_hint}" != "${iface}" ]; then
+          # start wherever count left off in the previous loop
+          # allow this for one more iteration than the previous loop
+          while [ ${counter} -le 12 ]; do
+            # check ipv4
+            if [ "$(ip route show default dev "${iface_default_hint}")" != "" ]; then
+              iface="${iface_default_hint}"
+              break
+            fi
+            # check ipv6
+            if [ "$(ip -6 route show default dev "${iface_default_hint}")" != "" ]; then
+              iface="${iface_default_hint}"
+              break
+            fi
+            counter=$((counter+1))
+            sleep 5
+          done
+        fi
+        # store what was determined was the (new) default interface inside
+        # the default hint file for future reference
+        if [ "${iface}" != "" ]; then
+          write_iface_default_hint "${iface_default_hint_file}" "${iface}"
+        fi
+      fi
+      echo "${iface}"
     }
 
     # Used to print network state
@@ -526,28 +634,40 @@ contents:
         fi
       }
 
-      iface=""
-      counter=0
-      # find default interface
-      while [ $counter -lt 12 ]; do
-        # check ipv4
-        iface=$(ip route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
-        if [[ -n "$iface" ]]; then
-          echo "IPv4 Default gateway interface found: ${iface}"
-          break
-        fi
-        # check ipv6
-        iface=$(ip -6 route show default | awk '{ if ($4 == "dev") { print $5; exit } }')
-        if [[ -n "$iface" ]]; then
-          echo "IPv6 Default gateway interface found: ${iface}"
-          break
-        fi
-        counter=$((counter+1))
-        echo "No default route found on attempt: ${counter}"
-        sleep 5
-      done
+      ovnk_config_dir='/etc/ovnk'
+      ovnk_var_dir='/var/lib/ovnk'
+      extra_bridge_file="${ovnk_config_dir}/extra_bridge"
+      iface_default_hint_file="${ovnk_var_dir}/iface_default_hint"
 
-      extra_bridge_file='/etc/ovnk/extra_bridge'
+      # make sure to create ovnk_config_dir if it does not exist, yet
+      mkdir -p "${ovnk_config_dir}"
+      # make sure to create ovnk_var_dir if it does not exist, yet
+      mkdir -p "${ovnk_var_dir}"
+
+      # For upgrade scenarios, make sure that we stabilize what we already configured
+      # before. If we do not have a valid interface hint, find the physical interface
+      # that's attached to ovs-if-phys0.
+      # If we find such an interface, write it to the hint file.
+      iface_default_hint=$(get_iface_default_hint "${iface_default_hint_file}")
+      if [ "${iface_default_hint}" == "" ]; then
+        current_interface=$(get_bridge_physical_interface ovs-if-phys0)
+        if [ "${current_interface}" != "" ]; then
+          write_iface_default_hint "${iface_default_hint_file}" "${current_interface}"
+        fi
+      fi
+
+      # delete iface_default_hint_file if it has the same content as extra_bridge_file
+      # in that case, we must also force a reconfiguration of our network interfaces
+      # to make sure that we reconcile this conflict
+      if [ -f "${iface_default_hint_file}" ] &&
+         [ -f "${extra_bridge_file}" ] &&
+         [ "$(cat "${iface_default_hint_file}")" == "$(cat "${extra_bridge_file}")" ]; then
+        echo "${iface_default_hint_file} and ${extra_bridge_file} share the same content"
+        echo "Deleting file ${iface_default_hint_file} to choose a different interface"
+        rm -f "${iface_default_hint_file}"
+      fi
+
+      iface=$(get_default_interface "${iface_default_hint_file}" "$extra_bridge_file")
 
       if [ "$iface" != "br-ex" ]; then
         # Default gateway is not br-ex.


### PR DESCRIPTION
Provide a means to stabilize interface selection in scenarios with
multiple default route interfaces.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit a8754fa0d57682c6a5f251775950061e29fcb17a)
(cherry picked from commit bc566e892e8931fe069fecda8d76801d3a5b134d)

Conflicts:
  templates/common/_base/files/configure-ovs-network.yaml

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
