### PR TITLE
Swap order of nodeip-configuration and ovs-configuration

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -3,9 +3,9 @@ enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{en
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
-  Wants=network-online.target crio-wipe.service
-  After=network-online.target ignition-firstboot-complete.service crio-wipe.service
-  Before=kubelet.service crio.service
+  Wants=NetworkManager-wait-online.service crio-wipe.service
+  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]
   # Need oneshot to delay kubelet

--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -7,8 +7,8 @@ contents: |
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
-  Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service openvswitch.service network.service
+  Wants=nodeip-configuration.service
+  After=openvswitch.service network.service nodeip-configuration.service
   Before=network-online.target kubelet.service crio.service node-valid-hostname.service
 
   [Service]

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -6,9 +6,9 @@ contents: |
   # This only applies to VIP managing environments where the kubelet and crio IP
   # address picking logic is flawed and may end up selecting an address from a
   # different subnet or a deprecated address
-  Wants=network-online.target crio-wipe.service
-  After=network-online.target ignition-firstboot-complete.service crio-wipe.service
-  Before=kubelet.service crio.service
+  Wants=NetworkManager-wait-online.service crio-wipe.service
+  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]
   # Need oneshot to delay kubelet


### PR DESCRIPTION
In order to ensure all services on a node are using the same IP, we
need to have nodeip-configuration run first and allow other services
to use the results to help them figure out which IP and interface
they should use.

Previously, ovs-configuration was a prereq for network-online and
nodeip-configuration waited for network-online. Additionally,
ovs-configuration waited for NetworkManager-wait-online to ensure
NetworkManager was fully up before it tried to do its configuration.
To change the order of these two services, I removed the
network-online dependency from nodeip-configuration and replaced it
with the NetworkManager-wait-online that was previously part of the
ovs-configuration deps. A dependency was also added between
ovs-configuration and nodeip-configuration to ensure that they run
in the correct order.

This way, at the end of ovs-configuration we are able to reach the
network-online target just as before, but now we've also run
nodeip-configuration at that point so we know all of the services
should have the correct IP. Essentially nodeip-configuration was
moved earlier in the boot process, but everything else has been
left alone.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
