### PR TITLE
initializeControlPlane not return error on non-CoreOS systems

### DIFF
--- a/pkg/daemon/controlplane.go
+++ b/pkg/daemon/controlplane.go
@@ -78,7 +78,7 @@ func updateOstreeObjectSync() error {
 // scheduler too but we now only do that late in the process when
 // we go to start an OS update.
 func (dn *Daemon) initializeControlPlane() error {
-	if err := updateOstreeObjectSync(); err != nil {
+	if err := updateOstreeObjectSync(); err != nil && dn.os.IsCoreOSVariant() {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Not return error on non-CoreOS systems

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Avoid reporting errors in control plane non-coreos systems.
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
updateOstreeObjectSync enables "per-object-fsync" which helps avoid
latency spikes for etcd,but ostree command does not exist in non-coreos systems.