### PR TITLE
Bug 2096496: controller: de-couple FIPS and realtime detection

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -93,17 +93,12 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 		return nil, err
 	}
 
-	// sets the KernelType if specified in any of the MachineConfig
-	// Setting kerneType to realtime in any of MachineConfig takes priority
-	// also if any of the config has FIPS enabled, it'll be set
+	// Setting FIPS to true or kerneType to realtime in any MachineConfig takes priority in setting that field
 	for _, cfg := range configs {
 		if cfg.Spec.FIPS {
 			fips = true
 		}
 		if cfg.Spec.KernelType == KernelTypeRealtime {
-			kernelType = cfg.Spec.KernelType
-			break
-		} else if kernelType == KernelTypeDefault {
 			kernelType = cfg.Spec.KernelType
 		}
 	}

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -316,12 +316,12 @@ func TestMergeMachineConfigs(t *testing.T) {
 
 	// Now merge all of the above
 	inMachineConfigs = []*mcfgv1.MachineConfig{
-		machineConfigFIPS,
 		machineConfigOSImageURL,
 		machineConfigKernelArgs,
 		machineConfigKernelType,
 		machineConfigExtensions,
 		machineConfigIgn,
+		machineConfigFIPS,
 	}
 	mergedMachineConfig, err = MergeMachineConfigs(inMachineConfigs, osImageURL)
 	require.Nil(t, err)


### PR DESCRIPTION
Our current logic looks for FIPS and kerneltype in the same loop,
breaking if any of them sets type=realtime. This means that if both
are enabled, and the FIPS MachineConfig is higher alphanumerically
compared to kerneltype (which is generally the case: installer
generates FIPS as 99 and NTO generates realtime as 50), the FIPS gets
lost when merging, causing the cluster to break.

Modify the logic a bit so this can't happen. Also re-order the test
to ensure this case is fixed.

