### PR TITLE
Bug 2099945: configure-ovs: clone inactive autoconnect slaves

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -79,8 +79,18 @@ contents:
     replace_connection_master() {
       local old="$1"
       local new="$2"
-      for conn_uuid in $(nmcli -g UUID connection show --active) ; do
+      for conn_uuid in $(nmcli -g UUID connection show) ; do
         if [ "$(nmcli -g connection.master connection show uuid "$conn_uuid")" != "$old" ]; then
+          continue
+        fi
+
+        local active_state=$(nmcli -g GENERAL.STATE connection show "$conn_uuid")
+        local autoconnect=$(nmcli -g connection.autoconnect connection show "$conn_uuid")
+        if [ "$active_state" != "activated" ] && [ "$autoconnect" != "yes" ]; then
+          # Assume that slave profiles intended to be used are those that are:
+          # - active
+          # - or inactive (which might be due to link being down) but to be autoconnected.
+          # Otherwise, ignore them.
           continue
         fi
 


### PR DESCRIPTION
We assumed that only active slave profiles were valid. But if a node
boots with one of the slave links down, and thus the corresponding
profile inactive, it would be ignored, and then if the link went up we
would have no cloned profile for it.

So not only clone active slave profiles, but those that have autoconnect
set as well.

We can't just clone all profiles because we don't know if there is a
profile sitting around not intended to be used.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
