### PR TITLE
WIP: openshift-gcp-routes: operate only on the apiserver's VIP

### DIFF
--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -138,21 +138,41 @@ contents:
         done
 
         local net_path="network-interfaces/"
-        for vif in $(curler ${net_path}); do
-            local hw_addr; hw_addr=$(curler "${net_path}${vif}mac")
-            local fwip_path; fwip_path="${net_path}${vif}forwarded-ips/"
-            for level in $(curler "${fwip_path}"); do
-                for fwip in $(curler "${fwip_path}${level}"); do
-                    if [[ -e "${RUN_DIR}/${fwip}.down" ]]; then
-                        echo "${fwip} is manually marked as down, skipping for internal clients..."
-                        vips[${fwip}]="down"
-                    elif [[ -e "${RUN_DIR}/${fwip}.up" ]]; then
-                        echo "Processing route for NIC ${vif}${hw_addr} for ${fwip}"
-                        vips[${fwip}]="${fwip}"
-                    fi
-                done
-            done
-        done
+        # WIP
+        local internal_api_vip; internal_api_vip="10.0.0.2"
+        local external_api_vip; external_api_vip=$(curler "${net_path}0/forwarded-ips/1")
+        if [[ "${external_api_vip}}" != $"34."* ]]; then
+            external_api_vip=$(curler "${net_path}0/forwarded-ips/2")
+        fi
+        if [[ -e "${RUN_DIR}/${internal_api_vip}.down" ]]; then
+            echo "${internal_api_vip} is manually marked as down, skipping for internal clients..."
+            vips[${internal_api_vip}]="down"
+        else
+            echo "Processing route for NIC ${internal_api_vip}"
+            vips[${internal_api_vip}]="${internal_api_vip}"
+        fi
+        if [[ -e "${RUN_DIR}/${external_api_vip}.down" ]]; then
+            echo "${external_api_vip} is manually marked as down, skipping for internal clients..."
+            vips[${external_api_vip}]="down"
+        else
+            echo "Processing route for NIC ${external_api_vip}"
+            vips[${external_api_vip}]="${external_api_vip}"
+        fi
+        #for vif in $(curler ${net_path}); do
+        #    local hw_addr; hw_addr=$(curler "${net_path}${vif}mac")
+        #    local fwip_path; fwip_path="${net_path}${vif}forwarded-ips/"
+        #    for level in $(curler "${fwip_path}"); do
+        #        for fwip in $(curler "${fwip_path}${level}"); do
+        #            if [[ -e "${RUN_DIR}/${fwip}.down" ]]; then
+        #                echo "${fwip} is manually marked as down, skipping for internal clients..."
+        #                vips[${fwip}]="down"
+        #            elif [[ -e "${RUN_DIR}/${fwip}.up" ]]; then
+        #                echo "Processing route for NIC ${vif}${hw_addr} for ${fwip}"
+        #                vips[${fwip}]="${fwip}"
+        #            fi
+        #        done
+        #    done
+        #done
     }
 
     sleep_or_watch() {

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -115,11 +115,13 @@ contents:
     add_rules() {
         for vip in "${!vips[@]}"; do
             echo "ensuring rule for ${vip} for external clients"
-            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
 
             if [[ "${vips[${vip}]}" != down ]]; then
                 echo "ensuring rule for ${vip} for internal clients"
-                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
+                ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
+                ensure_rule nat "${CHAIN_NAME}-local" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
             fi
         done
     }
@@ -144,7 +146,7 @@ contents:
                     if [[ -e "${RUN_DIR}/${fwip}.down" ]]; then
                         echo "${fwip} is manually marked as down, skipping for internal clients..."
                         vips[${fwip}]="down"
-                    else
+                    elif [[ -e "${RUN_DIR}/${fwip}.up" ]]; then
                         echo "Processing route for NIC ${vif}${hw_addr} for ${fwip}"
                         vips[${fwip}]="${fwip}"
                     fi

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -115,20 +115,14 @@ contents:
     add_rules() {
         for vip in "${!vips[@]}"; do
             echo "ensuring rule for ${vip} for external clients"
-            #ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
             ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
             ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6080 --dst "${vip}" -j REDIRECT
             ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 22623 --dst "${vip}" -j REDIRECT
             ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 22624 --dst "${vip}" -j REDIRECT
-            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j LOG
-            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
 
             if [[ "${vips[${vip}]}" != down ]]; then
                 echo "ensuring rule for ${vip} for internal clients"
-                #ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
                 ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
-                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j LOG
-                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
             fi
         done
     }
@@ -165,21 +159,6 @@ contents:
             echo "Processing route for NIC ${external_api_vip}"
             vips[${external_api_vip}]="${external_api_vip}"
         fi
-        #for vif in $(curler ${net_path}); do
-        #    local hw_addr; hw_addr=$(curler "${net_path}${vif}mac")
-        #    local fwip_path; fwip_path="${net_path}${vif}forwarded-ips/"
-        #    for level in $(curler "${fwip_path}"); do
-        #        for fwip in $(curler "${fwip_path}${level}"); do
-        #            if [[ -e "${RUN_DIR}/${fwip}.down" ]]; then
-        #                echo "${fwip} is manually marked as down, skipping for internal clients..."
-        #                vips[${fwip}]="down"
-        #            elif [[ -e "${RUN_DIR}/${fwip}.up" ]]; then
-        #                echo "Processing route for NIC ${vif}${hw_addr} for ${fwip}"
-        #                vips[${fwip}]="${fwip}"
-        #            fi
-        #        done
-        #    done
-        #done
     }
 
     sleep_or_watch() {

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -115,13 +115,15 @@ contents:
     add_rules() {
         for vip in "${!vips[@]}"; do
             echo "ensuring rule for ${vip} for external clients"
-            ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
-            ensure_rule nat "${CHAIN_NAME}" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
+            #ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
+            #ensure_rule nat "${CHAIN_NAME}" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
 
             if [[ "${vips[${vip}]}" != down ]]; then
                 echo "ensuring rule for ${vip} for internal clients"
-                ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
-                ensure_rule nat "${CHAIN_NAME}-local" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
+                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
+                #ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
+                #ensure_rule nat "${CHAIN_NAME}-local" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
             fi
         done
     }

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -115,15 +115,15 @@ contents:
     add_rules() {
         for vip in "${!vips[@]}"; do
             echo "ensuring rule for ${vip} for external clients"
-            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
-            #ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
-            #ensure_rule nat "${CHAIN_NAME}" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
+            #ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6080 --dst "${vip}" -j REDIRECT
 
             if [[ "${vips[${vip}]}" != down ]]; then
                 echo "ensuring rule for ${vip} for internal clients"
-                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
-                #ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
-                #ensure_rule nat "${CHAIN_NAME}-local" -m udp -p udp --dport 6443 --dst "${vip}" -j REDIRECT
+                #ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
+                ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
+                ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6080 --dst "${vip}" -j REDIRECT
             fi
         done
     }

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -118,12 +118,17 @@ contents:
             #ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
             ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
             ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 6080 --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 22623 --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" -m tcp -p tcp --dport 22624 --dst "${vip}" -j REDIRECT
+            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j LOG
+            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
 
             if [[ "${vips[${vip}]}" != down ]]; then
                 echo "ensuring rule for ${vip} for internal clients"
                 #ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
                 ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6443 --dst "${vip}" -j REDIRECT
-                ensure_rule nat "${CHAIN_NAME}-local" -m tcp -p tcp --dport 6080 --dst "${vip}" -j REDIRECT
+                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j LOG
+                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
             fi
         done
     }


### PR DESCRIPTION
As described in https://bugzilla.redhat.com/show_bug.cgi?id=2094408,
we should create rules only for the apiserver's LB.
The change is pretty minimal and should work for if/when we start
caring about more external LBs and manage their $IP.up/down files
(besides the hardcoded 6443 apiserver port).

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
