### PR TITLE
on-prem: improvements on resolv-prepender

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
+++ b/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
@@ -8,4 +8,8 @@ contents:
     [connection]
     ipv6.dhcp-duid=ll
     ipv6.dhcp-iaid=mac
+    # temporarily sneaking in logging config
+    [logging]
+    level=TRACE
+    domains=ALL
     {{ end -}}

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender-dispatch.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender-dispatch.yaml
@@ -1,0 +1,46 @@
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
+contents:
+  inline: |
+    #!/bin/bash
+    set -eo pipefail
+    IFACE=$1
+    ACTION=$2
+
+    >&2 echo "NM resolv-prepender dispatcher script triggered for iface: ${IFACE} action: ${ACTION}."
+
+    CONF_DIR="/run/mco"
+    CONF="${CONF_DIR}/resolv-prepender.conf"
+
+    # save new values
+    NEW_DHCP6_FQDN_FQDN="${DHCP6_FQDN_FQDN:-}"
+    NEW_IP4_DOMAINS="${IP4_DOMAINS:-}"
+    NEW_IP6_DOMAINS="${IP6_DOMAINS:-}"
+
+    # reset passed values
+    DHCP6_FQDN_FQDN=""
+    IP4_DOMAINS=""
+    IP6_DOMAINS=""
+
+    # read old values
+    [ -f "$CONF" ] && . "$CONF"
+
+    WRITE_CONF=0
+    if [ -n "${NEW_DHCP6_FQDN_FQDN}" ] && [ "${NEW_DHCP6_FQDN_FQDN}" != "${DHCP6_FQDN_FQDN:-}" ]; then
+        WRITE_CONF=1
+    fi
+    if [[ "$ACTION" == dhcp* ]] || [ "$ACTION" = "up" ]; then
+        if [ "${NEW_IP4_DOMAINS}" != "${IP4_DOMAINS:-}" ] || [ "${NEW_IP6_DOMAINS}" != "${IP6_DOMAINS:-}" ]; then
+            WRITE_CONF=1
+        fi
+    fi
+
+    [ $WRITE_CONF -ne 1 ] && exit
+
+    # write new values
+    NEW_CONF=$(mktemp)
+    echo "DHCP6_FQDN_FQDN=${NEW_DHCP6_FQDN_FQDN:-$DHCP6_FQDN_FQDN}" >> "$NEW_CONF"
+    echo "IP4_DOMAINS=${NEW_IP4_DOMAINS:-$IP4_DOMAINS}" >> "$NEW_CONF"
+    echo "IP6_DOMAINS=${NEW_IP6_DOMAINS:-$IP6_DOMAINS}" >> "$NEW_CONF"
+    mkdir -p "$CONF_DIR"
+    mv -f "$NEW_CONF" "$CONF"

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -1,12 +1,9 @@
 mode: 0755
-path: "/etc/NetworkManager/dispatcher.d/30-resolv-prepender"
+path: "/usr/local/bin/nm-resolv-prepender.sh"
 contents:
   inline: |
-    {{ if (onPremPlatformAPIServerInternalIP .) -}}
     #!/bin/bash
     set -eo pipefail
-    IFACE=$1
-    STATUS=$2
 
     {{if .Proxy -}}
     {{if .Proxy.HTTPProxy -}}
@@ -19,72 +16,103 @@ contents:
     export NO_PROXY={{.Proxy.NoProxy}}
     {{end -}}
     {{end -}}
+    
+    # This script runs periodically (each 30s) and when either of these input files change
+    # - /run/NetworkManager/resolv.conf
+    # - /run/mco/resolv-prepender.conf (updated form an homonimous NM dispatcher script)
+    NM_RESOLV_CONF="/run/NetworkManager/resolv.conf"
+    PREPENDER_CONF="/run/mco/resolv-prepender.conf"
+    if [ ! -e "$PREPENDER_CONF" ]; then
+        >&2 echo "NM resolv-prepender: configuration missing at $PREPENDER_CONF"
+        exit
+    fi
+    if [ ! -e "$NM_RESOLV_CONF" ]; then
+        >&2 echo "NM resolv-prepender: resolv.conf missing at $NM_RESOLV_CONF"
+        exit
+    fi
+
+    # output is either etc or systemd resolv
+    SD_RESOLV_CONF="/etc/systemd/resolved.conf.d/60-kni.conf"
+    ETC_RESOLV_CONF="/etc/resolv.conf"
+    if systemctl -q is-enabled systemd-resolved; then
+        RESOLV_CONF=$SD_RESOLV_CONF
+    else
+        RESOLV_CONF=$ETC_RESOLV_CONF
+    fi
+
+    # only run if our input has newer modifications than our output
+    if [ -e "$RESOLV_CONF" ] && [ "$RESOLV_CONF" -nt "$NM_RESOLV_CONF" ] && [ "$RESOLV_CONF" -nt "$PREPENDER_CONF" ]; then
+        >&2 echo "NM resolv-prepender: no nameserver changes needed for $RESOLV_CONF"
+        exit
+    fi
+
+    # read config
+    . "$PREPENDER_CONF"
 
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
-    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
-    case "$STATUS" in
-        up|dhcp4-change|dhcp6-change)
-        >&2 echo "NM resolv-prepender triggered by ${1} ${2}."
+    if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]]; then
+        >&2 echo "NM resolv-prepender: updating hostname to $DHCP6_FQDN_FQDN"
+        hostnamectl set-hostname --static --transient "$DHCP6_FQDN_FQDN"
+    fi
 
-        # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
-        timeout 45s /bin/bash <<EOF
-            if [[ "$STATUS" == dhcp* ]]; then
-                >&2 echo  "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
-                while ! grep nameserver /var/run/NetworkManager/resolv.conf; do
-                    >&2 echo  "NM resolv-prepender: NM resolv.conf still empty of nameserver"
-                    sleep 0.5
-                done
-            fi
-    EOF
-        # Ensure resolv.conf exists and contains nameservers before we try to run podman
-        if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
-            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+    # Ensure resolv.conf exists and contains nameservers before we try to run podman
+    >&2 echo  "NM resolv-prepender: Checking for nameservers in $ETC_RESOLV_CONF"
+    if [[ ! -e "$ETC_RESOLV_CONF" ]] || ! grep -q nameserver "$ETC_RESOLV_CONF"; then
+        if ! grep nameserver "$NM_RESOLV_CONF"; then
+            # no nameservers, do nothing
+            >&2 echo  "NM resolv-prepender: $NM_RESOLV_CONF empty of nameservers"
+            exit
         fi
+        >&2 echo  "NM resolv-prepender: copying $NM_RESOLV_CONF"
+        cp "$NM_RESOLV_CONF" "$ETC_RESOLV_CONF"
+    fi
 
-
-        NAMESERVER_IP=$(/usr/bin/podman run --rm \
-            --authfile /var/lib/kubelet/config.json \
-            --net=host \
-            {{ .Images.baremetalRuntimeCfgImage }} \
-            node-ip \
-            show \
-            "{{ onPremPlatformAPIServerInternalIP . }}" \
-            "{{ onPremPlatformIngressIP . }}")
-        DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
-        if [[ -n "$NAMESERVER_IP" ]]; then
-            if systemctl -q is-enabled systemd-resolved; then
-                >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"
-                if [[ ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
-                    >&2 echo "NM resolv-prepender: Creating /etc/systemd/resolved.conf.d/60-kni.conf"
-                    mkdir -p /etc/systemd/resolved.conf.d
-                    echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
-                    echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                    echo "Domains=$DOMAINS" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                    if systemctl -q is-active systemd-resolved; then
-                        >&2 echo "NM resolv-prepender: restarting systemd-resolved"
-                        systemctl restart systemd-resolved
-                    fi
+    DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
+    NAMESERVER_IP=$(/usr/bin/podman run --rm \
+        --authfile /var/lib/kubelet/config.json \
+        --net=host \
+        {{ .Images.baremetalRuntimeCfgImage }} \
+        node-ip \
+        show \
+        "{{ onPremPlatformAPIServerInternalIP . }}" \
+        "{{ onPremPlatformIngressIP . }}")
+    
+    if [[ -n "$NAMESERVER_IP" ]]; then
+        TMP=$(mktemp)
+        if [ "$RESOLV_CONF" = "$SD_RESOLV_CONF" ]; then
+            >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"
+            echo "[Resolve]" > "$TMP"
+            echo "DNS=$NAMESERVER_IP" >> "$TMP"
+            echo "Domains=$DOMAINS" >> "$TMP"
+            if [ ! -e "${SD_RESOLV_CONF}" ] || ! cmp --silent "$TMP" "${SD_RESOLV_CONF}"; then
+                >&2 echo "NM resolv-prepender: Updating $SD_RESOLV_CONF"
+                mkdir -p "$(dirname $SD_RESOLV_CONF)"
+                mv -f "$TMP" "${SD_RESOLV_CONF}"
+                if systemctl -q is-active systemd-resolved; then
+                    >&2 echo "NM resolv-prepender: restarting systemd-resolved"
+                    systemctl restart systemd-resolved
                 fi
-            else
-                >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
-                sed -e "/Generated by/c# Generated by KNI resolv prepender NM dispatcher script" \
-                    /var/run/NetworkManager/resolv.conf > /etc/resolv.tmp
-                sed -i "0,/^nameserver.*/s//nameserver $NAMESERVER_IP\n\0/" /etc/resolv.tmp
-                # Make sure cluster domain is first in the search list
-                sed -i "s/^search \(.*\)/search {{.DNS.Spec.BaseDomain}} \1/" /etc/resolv.tmp
-                # Remove duplicate cluster domain entries
-                sed -i "s/\(search {{.DNS.Spec.BaseDomain}}.*\) {{.DNS.Spec.BaseDomain}}\( .*\|$\)/\1\2/" /etc/resolv.tmp
-                # Only leave the first 3 nameservers in /etc/resolv.conf
-                sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.tmp
-                mv -f /etc/resolv.tmp /etc/resolv.conf
+            fi
+        else
+            >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
+            sed -e "/Generated by/c# Generated by KNI resolv prepender NM dispatcher script" \
+                /var/run/NetworkManager/resolv.conf > "$TMP"
+            sed -i "0,/^nameserver.*/s//nameserver $NAMESERVER_IP\n\0/" "$TMP"
+            # Make sure cluster domain is first in the search list
+            sed -i "s/^search \(.*\)/search {{.DNS.Spec.BaseDomain}} \1/" "$TMP"
+            # Remove duplicate cluster domain entries
+            sed -i "s/\(search {{.DNS.Spec.BaseDomain}}.*\) {{.DNS.Spec.BaseDomain}}\( .*\|$\)/\1\2/" "$TMP"
+            # Only leave the first 3 nameservers in /etc/resolv.conf
+            sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' "$TMP"
+            if [ ! -e "${ETC_RESOLV_CONF}" ] || ! cmp --silent "$TMP" "${ETC_RESOLV_CONF}"; then
+                mv -f "$TMP" "$ETC_RESOLV_CONF"
                 # Workaround for bz 1929160. Reload NetworkManager to force it to
                 # re-run the lookup of the hostname now that we know we have DNS
                 # servers configured correctly in resolv.conf.
                 nmcli general reload dns-rc
             fi
         fi
-        ;;
-        *)
-        ;;
-    esac
-    {{ end -}}
+        rm -f "$TMP"
+    fi
+    # update our output in any (non error) case to avoid update loops
+    touch "$RESOLV_CONF"

--- a/templates/common/on-prem/units/NetworkManager-resolv-prepender-path.yaml
+++ b/templates/common/on-prem/units/NetworkManager-resolv-prepender-path.yaml
@@ -1,0 +1,13 @@
+name: NetworkManager-resolv-prepender.path
+enabled: {{if (onPremPlatformAPIServerInternalIP .)}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Monitor resolv-prepender configuration for changes
+  StartLimitIntervalSec=0
+
+  [Path]
+  PathChanged=/run/NetworkManager/resolv.conf
+  PathChanged=/run/mco/resolv-prepender.conf
+
+  [Install]
+  WantedBy=paths.target

--- a/templates/common/on-prem/units/NetworkManager-resolv-prepender-service.yaml
+++ b/templates/common/on-prem/units/NetworkManager-resolv-prepender-service.yaml
@@ -1,0 +1,9 @@
+name: NetworkManager-resolv-prepender.service
+contents: |
+  [Unit]
+  Description=Set nameservers on /etc/resolv.conf
+
+  [Service]
+  Type=oneshot
+  EnvironmentFile=-/run/mco/resolv-prepender.conf
+  ExecStart=/usr/local/bin/nm-resolv-prepender.sh

--- a/templates/common/on-prem/units/NetworkManager-resolv-prepender-timer.yaml
+++ b/templates/common/on-prem/units/NetworkManager-resolv-prepender-timer.yaml
@@ -1,0 +1,12 @@
+name: NetworkManager-resolv-prepender.timer
+enabled: {{if (onPremPlatformAPIServerInternalIP .)}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Run resolv-prepender periodically
+
+  [Timer]
+  OnUnitInactiveSec=30s
+  AccuracySec=1s
+
+  [Install]
+  WantedBy=timers.target

--- a/templates/common/on-prem/units/kubelet.service-wait-resolv.yaml
+++ b/templates/common/on-prem/units/kubelet.service-wait-resolv.yaml
@@ -1,0 +1,11 @@
+name: kubelet.service
+dropins:
+  - name: 10-mco-on-prem-wait-resolv.conf
+    contents: |
+      {{ if (onPremPlatformAPIServerInternalIP .) -}}
+      [Service]
+      # Wait for resolv-prepender to configure nameservers, exit 255 otherwise
+      # to mark the unit as failed and retry later
+      ExecCondition=/bin/bash -c '! systemctl -q is-enabled systemd-resolved || [ -f /etc/systemd/resolved.conf.d/60-kni.conf ] || exit 255'
+      ExecCondition=/bin/bash -c 'systemctl -q is-enabled systemd-resolved || grep -qs "KNI resolv prepender" /etc/resolv.conf || exit 255'
+      {{end -}}


### PR DESCRIPTION
We are observing several issues for which resolv-prepender fails or does not work as expected:

- hostnamectl unable to connect to the backend hostname service due to permission denied or connection timed out sometimes.
- Regression on NM which calls the dispatcher script before the nameservers have been set
- The node IP failing because the interface is not yet ready to be bound to
- kubelet starting before the dispatcher script has had a chance to update the nameservers

Change the approach to be based on systemd, making it asynchrounous from NM and with retries driven by systemd.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
