### PR TITLE
Bug 2099664: daemon: initialize nodewriter before login monitor

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -293,8 +293,6 @@ func (dn *Daemon) ClusterConnect(
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(updateDelay), 1)},
 		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, maxUpdateBackoff)), "machineconfigdaemon")
 
-	go dn.runLoginMonitor(dn.stopCh, dn.exitCh)
-
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    dn.handleNodeEvent,
 		UpdateFunc: func(oldObj, newObj interface{}) { dn.handleNodeEvent(newObj) },
@@ -316,6 +314,8 @@ func (dn *Daemon) ClusterConnect(
 
 	dn.kubeletHealthzEnabled = kubeletHealthzEnabled
 	dn.kubeletHealthzEndpoint = kubeletHealthzEndpoint
+
+	go dn.runLoginMonitor(dn.stopCh, dn.exitCh)
 
 	return nil
 }


### PR DESCRIPTION
As part of https://github.com/openshift/machine-config-operator/pull/3143
we re-ordered the clusterconnect operations. This meant that the login
monitor started before the nodewriter object was initialized, which
caused a race where the monitor could try to write the ssh accessed
annotation before the nodewriter was initialized, causing a panic.

This is good to get fixed, but also note that:
1. this is relatively rare since most users should not be ssh'ing
2. the general ssh accessed annotation is broken such that its not
   always applied, but we definitely should not panic here.