### PR TITLE
Bug 2103786: drain controller: don't skip the MCC pod drain

### DIFF
--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -22,11 +22,6 @@ spec:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"
         - "--v=2"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
In 4.11 we moved the drain operation to a centralized controller.
This drain controller doesn't drain the MCC today.

In theory this means the pod can finish and then gracefully terminate.
In practice this is problematic since the pod never gets scheduled
off the node, meaning it thinks its still running (according to the API)
when the master node shuts down, and won't be reachable until the master
node reboots.

For some metal setups the reboot could take up to 30 minutes, this means
that we won't have a MCC for 30 minutes, which would be very problematic
as other pools waiting for drains/updates are stalled as well. We should
instead just drain the controller pod. The next one will immediately
pick up where this one left off, so there shouldn't be any conflicts.
The pod when drained will restart existing operations in ~10 seconds
from testing, which would be much faster.
