### PR TITLE
[WIP] Testing Revert "controller: de-couple FIPS and realtime detection"

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -93,12 +93,17 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 		return nil, err
 	}
 
-	// Setting FIPS to true or kerneType to realtime in any MachineConfig takes priority in setting that field
+	// sets the KernelType if specified in any of the MachineConfig
+	// Setting kerneType to realtime in any of MachineConfig takes priority
+	// also if any of the config has FIPS enabled, it'll be set
 	for _, cfg := range configs {
 		if cfg.Spec.FIPS {
 			fips = true
 		}
 		if cfg.Spec.KernelType == KernelTypeRealtime {
+			kernelType = cfg.Spec.KernelType
+			break
+		} else if kernelType == KernelTypeDefault {
 			kernelType = cfg.Spec.KernelType
 		}
 	}

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -316,12 +316,12 @@ func TestMergeMachineConfigs(t *testing.T) {
 
 	// Now merge all of the above
 	inMachineConfigs = []*mcfgv1.MachineConfig{
+		machineConfigFIPS,
 		machineConfigOSImageURL,
 		machineConfigKernelArgs,
 		machineConfigKernelType,
 		machineConfigExtensions,
 		machineConfigIgn,
-		machineConfigFIPS,
 	}
 	mergedMachineConfig, err = MergeMachineConfigs(inMachineConfigs, osImageURL)
 	require.Nil(t, err)


### PR DESCRIPTION
[TRT-368](https://issues.redhat.com/browse/TRT-368) - Researching sudden increase in failures with FIPS Presubmits Failing On Sig-Node Tests & [sig-network][Feature:Router] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key 

This PR is just to see if the revert changes the failure rate in those tests

This reverts commit be5e5ff41fb10a69af9ba7331af4533c4a1be699.


