### PR TITLE
Bug 2101157: configure-ovs: fix handling of connection names with spaces and checking the connection name suffix

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -719,8 +719,10 @@ contents:
 
       # Make sure everything is activated
       connections=()
-      for connection in $(nmcli -g NAME c | grep -- "$MANAGED_NM_CONN_SUFFIX"); do
-        connections+=("$connection")
+      nmcli -g NAME c | while IFS= read -r connection; do
+        if [[ $connection == *"$MANAGED_NM_CONN_SUFFIX" ]]; then
+          connections+=("$connection")
+        fi
       done
       connections+=(ovs-if-phys0 ovs-if-br-ex)
       if [ -f "$extra_bridge_file" ]; then


### PR DESCRIPTION
For OVN-K based clusters, each connection is activated if  it contains the suffix "-slave-ovs-clone". The iteration doesn't work if the connection name has spaces in it. It will also incorrectly activate a connection if the name contains the string "-slave-ovs-clone" but not as a suffix.

Added the correct handling of connection names with spaces. Also added the check to activate connections which has the string "-slave-ovs-clone" as suffix only.

Signed-off-by: Arkadeep Sen <arsen@redhat.com>

**- What I did**

**- How to verify it**

**- Description for the changelog**
