### PR TITLE
[4.11] Bug 2102633: NS manifest: Set empty openshift.io/run-level

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -27,6 +27,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-openstack-infra
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
 ---
 apiVersion: v1
 kind: Namespace
@@ -39,6 +40,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-kni-infra
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
 ---
 apiVersion: v1
 kind: Namespace
@@ -51,6 +53,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-ovirt-infra
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
 ---
 apiVersion: v1
 kind: Namespace
@@ -63,6 +66,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-vsphere-infra
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
 ---
 apiVersion: v1
 kind: Namespace
@@ -75,4 +79,5 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-nutanix-infra
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
 


### PR DESCRIPTION
We dropped the run-level label from this namespace back in 4.5
but because of how the cluster-version operator reconciles manifest
labels, dropping a label from the manifest does not remove it from the
in-cluster resource when old clusters are updated into the new
manifest. This commit uses the approach the cluster-version
operator used to drop its run-level, by setting the value to an
empty string, which the run-level-consuming code treats identically to
an unset label.

This avoids errors about:

...container has runAsNonRoot and image will run as root...

when updating to 4.11 in case the operator deployment manifest
specifically requests `runAsNonRoot: true`.
