### PR TITLE
Bug 2102004: pkg/controller/common/helpers: Explicitly set mode 0644

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -777,11 +777,13 @@ func NewIgnFile(path, contents string) ign3types.File {
 
 // NewIgnFileBytes is like NewIgnFile, but accepts binary data
 func NewIgnFileBytes(path string, contents []byte) ign3types.File {
+	mode := 0644
 	return ign3types.File{
 		Node: ign3types.Node{
 			Path: path,
 		},
 		FileEmbedded1: ign3types.FileEmbedded1{
+			Mode: &mode,
 			Contents: ign3types.Resource{
 				Source:      strToPtr(dataurl.EncodeBytes(contents)),
 				Compression: strToPtr(""),
@@ -792,6 +794,7 @@ func NewIgnFileBytes(path string, contents []byte) ign3types.File {
 
 // NewIgnFileBytesOverwriting is like NewIgnFileBytes, but overwrites existing files by default
 func NewIgnFileBytesOverwriting(path string, contents []byte) ign3types.File {
+	mode := 0644
 	overwrite := true
 	return ign3types.File{
 		Node: ign3types.Node{
@@ -799,6 +802,7 @@ func NewIgnFileBytesOverwriting(path string, contents []byte) ign3types.File {
 			Overwrite: &overwrite,
 		},
 		FileEmbedded1: ign3types.FileEmbedded1{
+			Mode: &mode,
 			Contents: ign3types.Resource{
 				Source:      strToPtr(dataurl.EncodeBytes(contents)),
 				Compression: strToPtr(""), // See https://github.com/coreos/butane/issues/332


### PR DESCRIPTION
When da5184f304 (#3128) created the `NewIgnFileBytes*` helpers, the call-sites which had previously explicitly set file modes
began leaving them unset.  Updating from 4.10 to 4.11 and picking up da5184f304, clusters which include ContainerRuntimeConfig (or possibly KubeletConfig) which flow through the NewIgnFileBytes* helpers would have rendered MachineConfig entries with null/unset mode values.

While this is not a problem for Ignition v3 clients, where there is an explicit 0644 default:

```console
$ git clone --depth 1 --branch main https://github.com/coreos/ignition.git
$ cd ignition
$ git --no-pager log --oneline -1
7652b83 (grafted, HEAD -> main, origin/main, origin/HEAD) Merge pull request #1409 from bgilbert/notes
$ git --no-pager grep '_mode_.*file' docs
docs/configuration-v3_0.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents.source` is unspecified, and a file already exists at the path.
docs/configuration-v3_1.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents.source` is unspecified, and a file already exists at the path.
docs/configuration-v3_2.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents.source` is unspecified, and a file already exists at the path.
docs/configuration-v3_3.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). Setuid/setgid/sticky bits are not supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents.source` is unspecified, and a file already exists at the path.
docs/configuration-v3_4_experimental.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). Setuid/setgid/sticky bits are supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents.source` is unspecified, and a file already exists at the path.
```

it is a problem for Ignition v2 clients, where there is no such default:

```console
$ git clone --depth 1 --branch spec2x https://github.com/coreos/ignition.git
$ cd ignition
$ git --no-pager log --oneline -1
4db553d (grafted, HEAD -> spec2x, origin/spec2x) Merge pull request #1067 from bgilbert/spec2y
$ git --no-pager grep '_mode_.*file' doc
doc/configuration-v2_0.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
doc/configuration-v2_1.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
doc/configuration-v2_2.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
doc/configuration-v2_3.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
doc/configuration-v2_4.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
doc/configuration-v2_5-experimental.md:    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
```

There is also no in-cluster component responsible for updating boot image configuration, or even complaining about stale boot image configuration, in Machines or MachineSets.  This causes problems when 4.10 clusters with older boot images ([at least older than 4.6][1], I haven't pinned down a specific version):

1. Cluster updates to 4.11.
2. Incoming machine-config operator renders fresh MachineConfig from any ContainerRuntimeConfig or KubeletConfig.
3. Those rendered MachineConfig contain null/unset modes.
4. A new Machine is created with the old Ignition v2 boot image.
5. The boot image Ignition lays down a file with mode 0, because Ignition v2 does not define a default mode.
6. The boot image pivots into the modern machine-os-content image.
7. The incoming (modern) machine-config daemon notices the mode 0 file, compares it with its Ignition-v3-like 0644 default mode, and complains [with][2]:

        unexpected on-disk state validating against rendered-worker-44f2c74623e4d3bbe9557a9e82102c01: mode mismatch for file: "/etc/crio/crio.conf.d/01-ctrcfg-pidsLimit"; expected: -rw-r--r--/420/0644; received: ----------/0/0

Folks should probably update to more modern boot images, but this commit restores the explicit mode to avoid breaking on this mode-mismatch issue for folks who are still running Ignition v2 boot images.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2102004#c28
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2102004#c0