### PR TITLE
Shorten prepender wait time to 30 seconds

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -27,7 +27,7 @@ contents:
         >&2 echo "NM resolv-prepender triggered by ${1} ${2}."
 
         # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
-        timeout 45s /bin/bash <<EOF
+        timeout 30s /bin/bash <<EOF
             if [[ "$STATUS" == dhcp* ]]; then
                 >&2 echo  "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
                 while ! grep nameserver /var/run/NetworkManager/resolv.conf; do


### PR DESCRIPTION
Due to a bug in NetworkManager[0], the prepender script is frequently
failing due to resolv.conf not being populated. In dual stack
environments, this happens twice per interface activation because
we wait for both DHCP versions. Waiting 90 seconds for an interface
to activate is causing us to hit other timeouts and making CI jobs
fail. Let's shorten the timeout to 30 seconds, which should still
be plenty long for resolv.conf to be populated under normal
circumstances but will hopefully unblock dual stack deployments until
we get the NM fix.

0: https://bugzilla.redhat.com/show_bug.cgi?id=2100456

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
