### PR TITLE
on-prem: render-config-coredns from /var/run/NetworkManager/resolv.conf

### DIFF
--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -39,6 +39,8 @@ contents:
         - "/config"
         - "--out-dir"
         - "/etc/coredns"
+        - "--resolvconf-path"
+        - "/var/run/NetworkManager/resolv.conf"
         resources: {}
         volumeMounts:
         - name: kubeconfig
@@ -47,6 +49,8 @@ contents:
           mountPath: "/config"
         - name: conf-dir
           mountPath: "/etc/coredns"
+        - name: nm-resolv
+          mountPath: "/var/run/NetworkManager"
         imagePullPolicy: IfNotPresent
       containers:
       - name: coredns


### PR DESCRIPTION
coredns sometimes gets stuck in a CrashLoopBackoff (and thus node stays
at NotReadfy) because render-config-coredns fails to render when there
are no nameservers in /etc/resolv.conf. Currently this happens because
kubelet might start before resolv-prepender has had a chance to write
/etc/resolv.conf and when it does render-config-coredns does not see the
update.

Make render-config-coredns use /var/run/NetworkManager/resolv.conf which
is actually what coredns-monitor is using as well.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
