### PR TITLE
Add node ip retry to resolv-prepender

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -42,12 +42,13 @@ contents:
         fi
 
 
-        NAMESERVER_IP=$(/usr/bin/podman run --rm \
+        NAMESERVER_IP=$(timeout 30s /usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \
             --net=host \
             {{ .Images.baremetalRuntimeCfgImage }} \
             node-ip \
             show \
+            --retry-on-failure \
             "{{ onPremPlatformAPIServerInternalIP . }}" \
             "{{ onPremPlatformIngressIP . }}")
         DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"


### PR DESCRIPTION
Since https://github.com/openshift/baremetal-runtimecfg/commit/564911767501d8a2b31161b509bec4fe39733e60
the possibility exists that the node-ip show command will fail due
to a transient situation. If this happens in resolv-prepender, it
can result in an empty resolv.conf because the script will exit and
may not be run again until the DHCP lease times out.

We have a --retry-on-failure option in runtimecfg that is designed
to handle exactly this situation. This patch adds that to the
command so we won't fail the script anymore.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
