### PR TITLE
Bug 2101157: configure-ovs: fix handling of connection names with spaces and checking the connection name suffix

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -729,11 +729,11 @@ contents:
 
       # Make sure everything is activated
       connections=()
-      nmcli -g NAME c | while IFS= read -r connection; do
+      while IFS= read -r connection; do
         if [[ $connection == *"$MANAGED_NM_CONN_SUFFIX" ]]; then
           connections+=("$connection")
         fi
-      done
+      done < <(nmcli -g NAME c)
       connections+=(ovs-if-phys0 ovs-if-br-ex)
       if [ -f "$extra_bridge_file" ]; then
         connections+=(ovs-if-phys1 ovs-if-br-ex1)


### PR DESCRIPTION
The previous fix that was merged in #3214 had issues of data not being retained in string array in piped while loop.

Data added to string array in piped while loop is not retained after the loop. Process substitution (http://mywiki.wooledge.org/ProcessSubstitution) fixes the problem.

Signed-off-by: Arkadeep Sen <arsen@redhat.com>

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
