### PR TITLE
[release-4.11] Bug 2104386: Fix problem with retaining data in string array in piped while loop

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -719,9 +719,11 @@ contents:
 
       # Make sure everything is activated
       connections=()
-      for connection in $(nmcli -g NAME c | grep -- "$MANAGED_NM_CONN_SUFFIX"); do
-        connections+=("$connection")
-      done
+      while IFS= read -r connection; do
+        if [[ $connection == *"$MANAGED_NM_CONN_SUFFIX" ]]; then
+          connections+=("$connection")
+        fi
+      done < <(nmcli -g NAME c)
       connections+=(ovs-if-phys0 ovs-if-br-ex)
       if [ -f "$extra_bridge_file" ]; then
         connections+=(ovs-if-phys1 ovs-if-br-ex1)


### PR DESCRIPTION
Manual cherry-pick of #3242 to release-4.11.

Data added to string array in piped while loop is not retained after the loop. Process substitution (http://mywiki.wooledge.org/ProcessSubstitution) fixes the problem.

Signed-off-by: Arkadeep Sen <arsen@redhat.com>
(cherry picked from commit 7617323936a521c03217338b2b358571e4b9a6fe)

**- What I did**

**- How to verify it**

**- Description for the changelog**
