### PR TITLE
remove redundant kargs assertions

### DIFF
--- a/test/e2e-shared-tests/helpers.go
+++ b/test/e2e-shared-tests/helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kubeErrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -20,22 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func assertKernelArgsEqual(t *testing.T, cs *framework.ClientSet, target corev1.Node, startKargs string, expectedKargs []string) {
-	t.Helper()
-
-	kargs := getKernelArgs(t, cs, target)
-
-	for _, karg := range expectedKargs {
-		assert.Contains(t, kargs, karg, "Missing karg %s", karg)
-	}
-
-	assert.Equal(t, kargs, startKargs)
-}
-
-func getKernelArgs(t *testing.T, cs *framework.ClientSet, target corev1.Node) string {
-	return helpers.ExecCmdOnNode(t, cs, target, "cat", "/proc/cmdline")
-}
 
 func waitForConfigDriftMonitorStart(t *testing.T, cs *framework.ClientSet, node corev1.Node) {
 	t.Helper()

--- a/test/e2e-shared-tests/mcd_config_drift.go
+++ b/test/e2e-shared-tests/mcd_config_drift.go
@@ -151,7 +151,7 @@ func (c configDriftTest) getMachineConfig(t *testing.T) *mcfgv1.MachineConfig {
 		[]ign3types.SSHAuthorizedKey{},
 		[]string{},
 		false,
-		[]string{"foo=bar", "foo=baz"},
+		[]string{},
 		"",
 		"",
 	)
@@ -164,12 +164,6 @@ func (c configDriftTest) Teardown(t *testing.T) {
 
 // Runs the Config Drift Test
 func (c configDriftTest) Run(t *testing.T) {
-	// Get our kernel args for future verification
-	kargs := getKernelArgs(t, c.ClientSet, c.node)
-
-	// Check that we have our kernel args pre-test
-	assertKernelArgsEqual(t, c.ClientSet, c.node, kargs, c.mc.Spec.KernelArguments)
-
 	testCases := []struct {
 		name           string
 		rebootExpected bool
@@ -237,9 +231,6 @@ func (c configDriftTest) Run(t *testing.T) {
 			waitForConfigDriftMonitorStart(t, c.ClientSet, c.node)
 
 			testCase.testFunc(t)
-
-			// Ensure that we have our kernel args post-test
-			assertKernelArgsEqual(t, c.ClientSet, c.node, kargs, c.mc.Spec.KernelArguments)
 
 			// Verify our reboot expectations
 			if testCase.rebootExpected {


### PR DESCRIPTION
**- What I did**

The Config Drift Monitor has no interaction with kernel args. This
particular case is better covered by the TestKernelArguments test.

**- How to verify it**

Run the TestKernelArguments test

**- Description for the changelog**

Removed redundant kargs test
