### PR TITLE
daemon: Drop tuneableFCOSArgsAllowlist

### DIFF
--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -28,12 +28,6 @@ var tuneableRHCOSArgsAllowlist = map[string]bool{
 	"nosmt": true,
 }
 
-// tuneableFCOSArgsAllowlist contains allowed keys for tunable kernel arguments on FCOS
-var tuneableFCOSArgsAllowlist = map[string]bool{
-	"systemd.unified_cgroup_hierarchy=0": true,
-	"mitigations=auto,nosmt":             true,
-}
-
 // isArgTuneable returns if the argument provided is allowed to be modified
 func isArgTunable(arg string) (bool, error) {
 	os, err := GetHostRunningOS()
@@ -44,7 +38,7 @@ func isArgTunable(arg string) (bool, error) {
 	if os.IsRHCOS() {
 		return tuneableRHCOSArgsAllowlist[arg], nil
 	} else if os.IsFCOS() {
-		return tuneableFCOSArgsAllowlist[arg], nil
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
**- What I did**

daemon: Drop tuneableFCOSArgsAllowlist

In OKD/FCOS, there is no reason from a supportability standpoint to
enforce an allowlist for kernel arguments that the MCD can tune.
Currently, its existence is actually rather a hindrance, as in OKD this
API is used to set kargs during cluster bootstrapping via manifests,
the flexibility of which is therefore limited.

**- How to verify it**

Verify this doesn't break CI

/cc @vrutkovs 