### PR TITLE
daemon: Only remove rollback when going to do an update

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1400,10 +1400,6 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return fmt.Errorf("error detecting previous SSH accesses: %w", err)
 	}
 
-	if err := dn.removeRollback(); err != nil {
-		return fmt.Errorf("Failed to remove rollback: %w", err)
-	}
-
 	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -43,6 +43,10 @@ func (r RpmOstreeClientMock) GetStatus() (string, error) {
 	return "rpm-ostree mock: blah blah some status here", nil
 }
 
+func (r RpmOstreeClientMock) CleanupRollback() error {
+	return nil
+}
+
 func (r RpmOstreeClientMock) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	return &RpmOstreeDeployment{}, nil
 }


### PR DESCRIPTION
A while ago, I did a patch to remove the rollback deployment
from the basis of complying with security scanners - the idea
was that previous deployments may have vulnerabilities and by
removing the ability to boot them, we ensure that any fixed
vulnerabilities can't be accessed accidentally or deliberately.

More recently, we applied that patch again to try to reclaim
disk space in `/boot`.

However, for the latter issue we don't need to remove the rollback
on boot, but only when the MCD goes to apply an OS update.

It's more conservative to do things this way, and in particular
doing so will avoid triggering a different bug in rpm-ostree/systemd;
see https://bugzilla.redhat.com/show_bug.cgi?id=2108320
