### PR TITLE
RFE-2962: Set interface name from node-ip-configuration to configure-ovs

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -508,11 +508,19 @@ contents:
     # If there is no valid hint, use the default interface that we found during the step
     # earlier. Write the default interface to the hint file.
     get_default_interface() {
-      local iface=""
+      local iface=${NODE_IP_INTERFACE:-""}
       local counter=0
       local iface_default_hint_file="$1"
       local extra_bridge_file="$2"
       local extra_bridge=""
+
+      # if interface was set by external service, take it
+      # nodeip-configuration service will set NODE_IP_INTERFACE
+      # ovs should take it for bridge configuration
+      if [[ -n "${iface}" ]]; then
+        echo "${iface}"
+        return
+      fi
 
       if [ -f "${extra_bridge_file}" ]; then
         extra_bridge=$(cat ${extra_bridge_file})

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -5,7 +5,7 @@ contents: |
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=network-online.target crio-wipe.service
   After=network-online.target ignition-firstboot-complete.service crio-wipe.service
-  Before=kubelet.service crio.service
+  Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]
   # Need oneshot to delay kubelet

--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -18,5 +18,7 @@ contents: |
   StandardOutput=journal+console
   StandardError=journal+console
 
+  EnvironmentFile=-/run/nodeip-configuration/interface
+
   [Install]
   WantedBy=network-online.target


### PR DESCRIPTION
    node-ip-configuration will set env file for configure-ovs when it will
    set kubelet ip, this will allow to configure ovs with the bridge on the
    same interface that kubelet will use.
    Configure ovs should start after nodeip service and set bridge on the
    interface provided by nodeip

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
