### PR TITLE
[WIP] Teach MCO to use the new-format image by default 

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -23,29 +23,31 @@ var (
 	}
 
 	bootstrapOpts struct {
-		baremetalRuntimeCfgImage  string
-		cloudConfigFile           string
-		configFile                string
-		cloudProviderCAFile       string
-		corednsImage              string
-		destinationDir            string
-		haproxyImage              string
-		imagesConfigMapFile       string
-		infraConfigFile           string
-		infraImage                string
-		releaseImage              string
-		keepalivedImage           string
-		kubeCAFile                string
-		mcoImage                  string
-		oauthProxyImage           string
-		networkConfigFile         string
-		oscontentImage            string
-		pullSecretFile            string
-		rootCAFile                string
-		proxyConfigFile           string
-		additionalTrustBundleFile string
-		dnsConfigFile             string
-		imageReferences           string
+		baremetalRuntimeCfgImage               string
+		cloudConfigFile                        string
+		configFile                             string
+		cloudProviderCAFile                    string
+		corednsImage                           string
+		destinationDir                         string
+		haproxyImage                           string
+		imagesConfigMapFile                    string
+		infraConfigFile                        string
+		infraImage                             string
+		releaseImage                           string
+		keepalivedImage                        string
+		kubeCAFile                             string
+		mcoImage                               string
+		oauthProxyImage                        string
+		networkConfigFile                      string
+		oscontentImage                         string
+		pullSecretFile                         string
+		rootCAFile                             string
+		proxyConfigFile                        string
+		additionalTrustBundleFile              string
+		dnsConfigFile                          string
+		imageReferences                        string
+		baseOperatingSystemContainer           string
+		baseOperatingSystemExtensionsContainer string
 	}
 )
 
@@ -127,16 +129,26 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.oauthProxyImage = findImageOrDie(imgstream, "oauth-proxy")
 		bootstrapOpts.infraImage = findImageOrDie(imgstream, "pod")
 		bootstrapOpts.haproxyImage = findImageOrDie(imgstream, "haproxy-router")
+		bootstrapOpts.baseOperatingSystemContainer, err = findImage(imgstream, "rhel-coreos-8")
+		if err != nil {
+			glog.Warningf("Base OS container not found: %s", err)
+		}
+		bootstrapOpts.baseOperatingSystemExtensionsContainer, err = findImage(imgstream, "rhel-coreos-8-extensions")
+		if err != nil {
+			glog.Warningf("Base OS extensions container not found: %s", err)
+		}
 	}
 
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{
-			MachineConfigOperator:        bootstrapOpts.mcoImage,
-			MachineOSContent:             bootstrapOpts.oscontentImage,
-			KeepalivedBootstrap:          bootstrapOpts.keepalivedImage,
-			CorednsBootstrap:             bootstrapOpts.corednsImage,
-			BaremetalRuntimeCfgBootstrap: bootstrapOpts.baremetalRuntimeCfgImage,
-			OauthProxy:                   bootstrapOpts.oauthProxyImage,
+			MachineConfigOperator:                  bootstrapOpts.mcoImage,
+			MachineOSContent:                       bootstrapOpts.oscontentImage,
+			KeepalivedBootstrap:                    bootstrapOpts.keepalivedImage,
+			CorednsBootstrap:                       bootstrapOpts.corednsImage,
+			BaremetalRuntimeCfgBootstrap:           bootstrapOpts.baremetalRuntimeCfgImage,
+			OauthProxy:                             bootstrapOpts.oauthProxyImage,
+			BaseOperatingSystemContainer:           bootstrapOpts.baseOperatingSystemContainer,
+			BaseOperatingSystemExtensionsContainer: bootstrapOpts.baseOperatingSystemExtensionsContainer,
 		},
 		ControllerConfigImages: operator.ControllerConfigImages{
 			InfraImage:          bootstrapOpts.infraImage,

--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -339,3 +339,11 @@ spec:
                 description: OSImageURL specifies the remote location that will be used
                   to fetch the OS
                 type: string
+              baseOperatingSystemContainer:
+                description: baseOperatingSystemContainer specifies the remote location that will be used
+                  to fetch the new-format OS image
+                type: string
+              baseOperatingSystemExtensionsContainer:
+                description: baseOperatingSystemExtensionContainer specifies the remote location that will be used
+                  to fetch the extensions container matching the new-format OS image
+                type: string

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -11,11 +11,11 @@ data:
   images.json: >
     {
       "releaseVersion": "0.0.1-snapshot",
-      "machineConfigOperator": "registry.svc.ci.openshift.org/openshift:machine-config-operator",
-      "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
-      "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
-      "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
-      "haproxyImage": "registry.svc.ci.openshift.org/openshift:haproxy-router",
-      "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg",
-      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy"
+      "machineConfigOperator": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator",
+      "infraImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:pod",
+      "keepalivedImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:keepalived-ipfailover",
+      "corednsImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:coredns",
+      "haproxyImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router",
+      "baremetalRuntimeCfgImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:baremetal-runtimecfg",
+      "oauthProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy"
     }

--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: machine-config-operator
-        image: registry.svc.ci.openshift.org/openshift:machine-config-operator
+        image: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
         args:
         - "start"
         - "--images-json=/etc/mco/images/images.json"

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,6 +9,10 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
+  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
+  # progresses towards the default.
+  baseOperatingSystemContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
+  baseOperatingSystemExtensionsContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,6 +9,10 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
-  # The OS payload, managed by the daemon + pivot + rpm-ostree
-  # https://github.com/openshift/machine-config-operator/issues/183
+  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
+  # progresses towards the default.
+  baseOperatingSystemContainer: "registry.ci.openshift.org/openshift:rhel-coreos"
+  # The OS payload used for 4.10 and below; more information in
+  # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
+  # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )
   osImageURL: "registry.svc.ci.openshift.org/openshift:machine-os-content"

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,9 +9,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
-  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
-  # progresses towards the default.
-  baseOperatingSystemContainer: "registry.ci.openshift.org/openshift:rhel-coreos"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -12,4 +12,4 @@ data:
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )
-  osImageURL: "registry.svc.ci.openshift.org/openshift:machine-os-content"
+  osImageURL: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content"

--- a/install/image-references
+++ b/install/image-references
@@ -7,35 +7,35 @@ spec:
   - name: machine-config-operator
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:machine-config-operator
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
   - name: pod
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:pod
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:pod
   - name: oauth-proxy
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:oauth-proxy
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy
   # This one is special, it's the OS payload
   # https://github.com/openshift/machine-config-operator/issues/183
   # See the machine-config-osimageurl configmap.
   - name: machine-os-content
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:machine-os-content
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content
   - name: keepalived-ipfailover
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:keepalived-ipfailover
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:keepalived-ipfailover
   - name: coredns
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:coredns
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:coredns
   - name: haproxy-router
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:haproxy-router
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router
   - name: baremetal-runtimecfg
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:baremetal-runtimecfg

--- a/install/image-references
+++ b/install/image-references
@@ -23,6 +23,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:machine-os-content
+  - name: rhel-coreos
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:rhel-coreos
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/install/image-references
+++ b/install/image-references
@@ -23,6 +23,14 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content
+  - name: rhel-coreos-8
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8
+  - name: rhel-coreos-8-extensions
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/install/image-references
+++ b/install/image-references
@@ -23,10 +23,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:machine-os-content
-  - name: rhel-coreos
-    from:
-      kind: DockerImage
-      name: registry.ci.openshift.org/openshift:rhel-coreos
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -47,6 +47,8 @@ func EnsureMachineConfigPool(modified *bool, existing *mcfgv1.MachineConfigPool,
 func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec, required mcfgv1.MachineConfigSpec) {
 	resourcemerge.SetStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
 	resourcemerge.SetStringIfSet(modified, &existing.KernelType, required.KernelType)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemContainer, required.BaseOperatingSystemContainer)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemExtensionsContainer, required.BaseOperatingSystemExtensionsContainer)
 
 	if !equality.Semantic.DeepEqual(existing.KernelArguments, required.KernelArguments) {
 		*modified = true
@@ -72,6 +74,8 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	resourcemerge.SetStringIfSet(modified, &existing.Platform, required.Platform)
 	resourcemerge.SetStringIfSet(modified, &existing.EtcdDiscoveryDomain, required.EtcdDiscoveryDomain)
 	resourcemerge.SetStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemContainer, required.BaseOperatingSystemContainer)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemExtensionsContainer, required.BaseOperatingSystemExtensionsContainer)
 	resourcemerge.SetStringIfSet(modified, &existing.NetworkType, required.NetworkType)
 
 	setBytesIfSet(modified, &existing.AdditionalTrustBundle, required.AdditionalTrustBundle)

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -918,6 +918,10 @@ spec:
                   contains the OS update payload. Its value is taken from the data.osImageURL
                   field on the machine-config-osimageurl ConfigMap.
                 type: string
+              baseOperatingSystemContainer:
+                description: baseOperatingSystemContainer is the new format operating system update image.
+                  See https://github.com/openshift/enhancements/pull/1032
+                type: string
               platform:
                 description: platform is deprecated, use Infra.Status.PlatformStatus.Type
                   instead
@@ -992,6 +996,7 @@ spec:
             - ipFamilies
             - kubeAPIServerServingCAData
             - osImageURL
+            - baseOperatingSystemContainer
             - proxy
             - releaseImage
             - rootCAData

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -922,6 +922,10 @@ spec:
                 description: baseOperatingSystemContainer is the new format operating system update image.
                   See https://github.com/openshift/enhancements/pull/1032
                 type: string
+              baseOperatingSystemExtensionsContainer:
+                description: baseOperatingSystemExtensionsContainer is the extensions container matching new format operating system update image.
+                  See https://github.com/openshift/enhancements/pull/1032
+                type: string
               platform:
                 description: platform is deprecated, use Infra.Status.PlatformStatus.Type
                   instead

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -72,8 +72,10 @@ type ControllerConfigSpec struct {
 	// images is map of images that are used by the controller to render templates under ./templates/
 	Images map[string]string `json:"images"`
 
-	// osImageURL is the location of the container image that contains the OS update payload.
-	// Its value is taken from the data.osImageURL field on the machine-config-osimageurl ConfigMap.
+	// BaseOperatingSystemContainer is the new-format container image for operating system updates.
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+
+	// OSImageURL is the old-format container image that contains the OS update payload.
 	OSImageURL string `json:"osImageURL"`
 
 	// releaseImage is the image used when installing the cluster

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -75,6 +75,9 @@ type ControllerConfigSpec struct {
 	// BaseOperatingSystemContainer is the new-format container image for operating system updates.
 	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
 
+	// BaseOperatingSystemExtensionsContainer is the matching extensions container for the new-format container
+	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
+
 	// OSImageURL is the old-format container image that contains the OS update payload.
 	OSImageURL string `json:"osImageURL"`
 
@@ -197,6 +200,14 @@ type MachineConfigSpec struct {
 	// OSImageURL specifies the remote location that will be used to
 	// fetch the OS.
 	OSImageURL string `json:"osImageURL"`
+
+	// BaseOperatingSystemContainer specifies the remote location that will be used
+	// to fetch the new-format OS image
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+	// BaseOperatingSystemExtensionContainer specifies the remote location that will be used
+	// to fetch the extensions container matching the new-format OS image
+	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
+
 	// Config is a Ignition Config object.
 	Config runtime.RawExtension `json:"config"`
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -55,7 +55,7 @@ func strToPtr(s string) *string {
 // It uses the Ignition config from first object as base and appends all the rest.
 // Kernel arguments are concatenated.
 // It uses only the OSImageURL provided by the CVO and ignores any MC provided OSImageURL.
-func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*mcfgv1.MachineConfig, error) {
+func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig) (*mcfgv1.MachineConfig, error) {
 	if len(configs) == 0 {
 		return nil, nil
 	}
@@ -127,7 +127,11 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, osImageURL string) (*m
 
 	return &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL:      osImageURL,
+			// TODO(jkyros): for the cconfig fields, sure seems to me like this is just a hacky way to attach these to the pool
+			OSImageURL:                             cconfig.Spec.OSImageURL,
+			BaseOperatingSystemContainer:           cconfig.Spec.BaseOperatingSystemContainer,
+			BaseOperatingSystemExtensionsContainer: cconfig.Spec.BaseOperatingSystemExtensionsContainer,
+
 			KernelArguments: kargs,
 			Config: runtime.RawExtension{
 				Raw: rawOutIgn,

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -233,7 +233,8 @@ func TestParseAndConvert(t *testing.T) {
 
 func TestMergeMachineConfigs(t *testing.T) {
 	// variable setup
-	osImageURL := "testURL"
+	cconfig := &mcfgv1.ControllerConfig{}
+	cconfig.Spec.OSImageURL = "testURL"
 	fips := true
 	kargs := []string{"testKarg"}
 	extensions := []string{"testExtensions"}
@@ -245,7 +246,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 		},
 	}
 	inMachineConfigs := []*mcfgv1.MachineConfig{machineConfigFIPS}
-	mergedMachineConfig, err := MergeMachineConfigs(inMachineConfigs, osImageURL)
+	mergedMachineConfig, err := MergeMachineConfigs(inMachineConfigs, cconfig)
 	require.Nil(t, err)
 
 	// check that the outgoing config does have the version string set,
@@ -259,7 +260,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 	require.Nil(t, err)
 	expectedMachineConfig := &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL:      osImageURL,
+			OSImageURL:      cconfig.Spec.OSImageURL,
 			KernelArguments: []string{},
 			Config: runtime.RawExtension{
 				Raw: rawOutIgn,
@@ -323,12 +324,12 @@ func TestMergeMachineConfigs(t *testing.T) {
 		machineConfigIgn,
 		machineConfigFIPS,
 	}
-	mergedMachineConfig, err = MergeMachineConfigs(inMachineConfigs, osImageURL)
+	mergedMachineConfig, err = MergeMachineConfigs(inMachineConfigs, cconfig)
 	require.Nil(t, err)
 
 	expectedMachineConfig = &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL:      osImageURL,
+			OSImageURL:      cconfig.Spec.OSImageURL,
 			KernelArguments: kargs,
 			Config: runtime.RawExtension{
 				Raw: rawOutIgn,

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -558,7 +558,7 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		}
 	}
 
-	merged, err := ctrlcommon.MergeMachineConfigs(configs, cconfig.Spec.OSImageURL)
+	merged, err := ctrlcommon.MergeMachineConfigs(configs, cconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -545,6 +545,12 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		return nil, fmt.Errorf("Ignoring controller config generated without %s annotation (my version: %s)", daemonconsts.GeneratedByVersionAnnotationKey, version.Raw)
 	}
 
+	if cconfig.Spec.BaseOperatingSystemContainer == "" {
+		glog.Warningf("No BaseOperatingSystemContainer set")
+	} else {
+		glog.Infof("BaseOperatingSystemContainer=%s", cconfig.Spec.BaseOperatingSystemContainer)
+	}
+
 	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid
 	for _, config := range configs {
 		if err := ctrlcommon.ValidateMachineConfig(config.Spec); err != nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1792,10 +1792,19 @@ func (dn *CoreOSDaemon) validateKernelArguments(currentConfig *mcfgv1.MachineCon
 // is stomping on our files, we want to highlight that and mark the system
 // degraded.
 func (dn *Daemon) validateOnDiskState(currentConfig *mcfgv1.MachineConfig) error {
+
 	// Be sure we're booted into the OS we expect
-	osMatch := dn.checkOS(currentConfig.Spec.OSImageURL)
-	if !osMatch {
-		return fmt.Errorf("expected target osImageURL %q, have %q", currentConfig.Spec.OSImageURL, dn.bootedOSImageURL)
+	if currentConfig.Spec.BaseOperatingSystemContainer != "" {
+		osMatch := dn.checkOS(currentConfig.Spec.BaseOperatingSystemContainer)
+		if !osMatch {
+			return fmt.Errorf("expected target BaseOperatingSystemContainer %q, have %q", currentConfig.Spec.OSImageURL, dn.bootedOSImageURL)
+		}
+	} else {
+
+		osMatch := dn.checkOS(currentConfig.Spec.OSImageURL)
+		if !osMatch {
+			return fmt.Errorf("expected target osImageURL %q, have %q", currentConfig.Spec.OSImageURL, dn.bootedOSImageURL)
+		}
 	}
 
 	if dn.os.IsCoreOSVariant() {

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -46,3 +46,15 @@ func (r RpmOstreeClientMock) GetStatus() (string, error) {
 func (r RpmOstreeClientMock) GetBootedDeployment() (*RpmOstreeDeployment, error) {
 	return &RpmOstreeDeployment{}, nil
 }
+
+func (r RpmOstreeClientMock) GetBootedAndStagedDeployment() (booted, staged *RpmOstreeDeployment, err error) {
+	return nil, nil, nil
+}
+
+func (r RpmOstreeClientMock) IsBootableImage(string) (bool, error) {
+	return false, nil
+}
+
+func (r RpmOstreeClientMock) RebaseLayered(string) error {
+	return nil
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1889,6 +1889,18 @@ func updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
 	return nil
 }
 
+// updateBootableOS updates the system OS to the one specified in newConfig
+func updateBootableOS(config *mcfgv1.MachineConfig) error {
+	newURL := config.Spec.BaseOperatingSystemContainer
+	glog.Infof("Updating OS to layered image %s", newURL)
+	client := NewNodeUpdaterClient()
+	if err := client.RebaseLayered(newURL); err != nil {
+		return fmt.Errorf("failed to update OS to %s : %w", newURL, err)
+	}
+
+	return nil
+}
+
 func (dn *Daemon) getPendingStateLegacyLogger() (*journalMsg, error) {
 	glog.Info("logger doesn't support --jounald, grepping the journal")
 

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -139,6 +139,7 @@ func RenderBootstrap(
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
+	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -140,6 +140,7 @@ func RenderBootstrap(
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
+	spec.BaseOperatingSystemExtensionsContainer = imgs.BaseOperatingSystemExtensionsContainer
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -17,6 +17,8 @@ type Images struct {
 type RenderConfigImages struct {
 	MachineConfigOperator string `json:"machineConfigOperator"`
 	MachineOSContent      string `json:"machineOSContent"`
+	// The new format image
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
 	// These have to be named differently from the ones in ControllerConfigImages
 	// or we get errors about ambiguous selectors because both structs are
 	// combined in the Images struct.

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -19,6 +19,8 @@ type RenderConfigImages struct {
 	MachineOSContent      string `json:"machineOSContent"`
 	// The new format image
 	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+	// The matching extensions container for the new format image
+	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
 	// These have to be named differently from the ones in ControllerConfigImages
 	// or we get errors about ambiguous selectors because both structs are
 	// combined in the Images struct.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -883,6 +883,7 @@ func (optr *Operator) getOsImageURLs(namespace string) (string, string, string, 
 
 	if hasNewFormat && !hasNewExtensions {
 		// TODO(jkyros): This is okay for now because it's not required, but someday this will be bad
+		glog.Warningf("New format image specified, but no matchine extensions image present")
 	}
 
 	// If we don't have a new format image, and we can't fall back to the old one

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/images.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/images.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	imagesScheme = runtime.NewScheme()
+	imagesCodecs = serializer.NewCodecFactory(imagesScheme)
+)
+
+func init() {
+	if err := imagev1.AddToScheme(imagesScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadImageStreamV1OrDie(objBytes []byte) *imagev1.ImageStream {
+	requiredObj, err := runtime.Decode(imagesCodecs.UniversalDecoder(imagev1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*imagev1.ImageStream)
+}


### PR DESCRIPTION
#### This is a way to give the MCO "new format" image support by: 
- Plumbing `BaseOperatingSystemContainer` and `BaseOperatingSystemExtensionsContainer` all the way through into MachineConfig like OSImageURL

I don't think this is actually how we'll want to do it, this is just the "simplest way" that doesn't "overload" `machine-os-content` with a new format image. 



#### Caveats: 
- *This should not merge*. The moment that https://github.com/openshift/machine-config-operator/commit/a83a3f96cc50f8c68a27e948608ba1b6bebe05ec goes in, the new format images will become required and break everything
- This includes Colin's https://github.com/openshift/machine-config-operator/pull/3017, since we haven't merged it yet, but I would obviously take it out when it does merge. 
- If updating into a release using this, this will work as long as `rhel-coreos-8` (and optionally `rhel-coreos-8-extensions`)  are included in the release
- If building a cluster, it will fail unless you're using an installer that supplies the image-references to the MCO (something like this: https://github.com/jkyros/installer/blob/allow-mco-consume-multiple-images/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L2977 ) 

#### Can I install a cluster using the new format image? Yes, but right now you probably don't want to, because you have to:  

1. Build an installer, say off this branch https://github.com/jkyros/installer/tree/allow-mco-consume-multiple-images
2. Create a payload manually
```
oc adm release new -n ocp --server https://api.ci.l2s4.p1.openshiftapps.com --from-release registry.ci.openshift.org/ocp/releas
e:4.12 --to-image quay.io/jkyros/ocp-release:v4.12  --include=rhel-coreos-8-extensions rhel-coreos-8-extensions=registry.ci.openshift.org/rhcos-dev
el/rhel-coreos-extensions:latest --include=rhel-coreos-8 rhel-coreos-8=quay.io/jkyros/derived-images:rhel-coreos-latest  machine-config-operator=quay.io/jkyros/ma
chine-config-operator:latest 
```
4. Install using your custom installer, overriding the payload: 
 ```
export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/jkyros/ocp-release:v4.12
../openshift-install-dev create cluster ...
```






This PR is in service to: https://issues.redhat.com/browse/MCO-291

