### PR TITLE
Bug 2109963: Master node in SchedulingDisabled after upgrade from 4.10.24 -> 4.11.0-rc.4

### DIFF
--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -412,7 +412,7 @@ func (ctrl *Controller) cordonOrUncordonNode(desired bool, node *corev1.Node, dr
 			return false, nil
 		}
 
-		if node.Spec.Unschedulable != desired {
+		if updatedNode.Spec.Unschedulable != desired {
 			// See https://bugzilla.redhat.com/show_bug.cgi?id=2022387
 			ctrl.logNode(node, "RunCordonOrUncordon() succeeded but node is still not in %s state, retrying", verb)
 			return false, nil


### PR DESCRIPTION
Drain controller was still using the cached lookup for the "did the cordon work" safety check even though the logging message was using the live value. 

It seems that if the apiserver was under heavy load or in some unreliable state, the MCO would allow a cordoned node to sneak through, thinking it had uncordoned it.  

This PR makes the safety check also use the live/uncached value. 

@yuqi-zhang I thought I'd just fix this quick since I saw it and I was in here, but if you'd rather do something different, I'm 100% cool with it. 

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2109963