### PR TITLE
Update approvers and reviewers list with current active members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,12 @@
 
 approvers:
   - cgwalters
-  - kikisdeliveryservice
   - sinnykumari
   - yuqi-zhang
+  - cheesesashimi
+  - jkyros
 reviewers:
   - cgwalters
-  - kikisdeliveryservice
   - sinnykumari
   - yuqi-zhang
   - cheesesashimi


### PR DESCRIPTION
Updating OWNERS list with current active MCO members to make sure that PRs gets assigned for review/approval accordingly.

Thanks @kikisdeliveryservice  for all the MCO contribution! If you would like to continue being a reviewer, your input will be always welcome :heart: 