### PR TITLE
Bug 2105003: on-prem: improvements on resolv-prepender

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -47,12 +47,13 @@ contents:
         fi
 
 
-        NAMESERVER_IP=$(/usr/bin/podman run --rm \
+        NAMESERVER_IP=$(timeout 20s /usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \
             --net=host \
             {{ .Images.baremetalRuntimeCfgImage }} \
             node-ip \
             show \
+            --retry-on-failure \
             "{{ onPremPlatformAPIServerInternalIP . }}" \
             "{{ onPremPlatformIngressIP . }}")
         DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -21,7 +21,12 @@ contents:
     {{end -}}
 
     # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
-    [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
+    if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]]; then
+        # run with systemd-run to avoid selinux problems
+        systemd-run --property=Type=oneshot --unit resolve-prepender-hostnamectl -Pq \
+            hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
+    fi
+    
     case "$STATUS" in
         up|dhcp4-change|dhcp6-change)
         >&2 echo "NM resolv-prepender triggered by ${1} ${2}."

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -33,13 +33,11 @@ contents:
 
         # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
         timeout 20s /bin/bash <<EOF
-            if [[ "$STATUS" == dhcp* ]]; then
-                >&2 echo  "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
-                while ! grep nameserver /var/run/NetworkManager/resolv.conf; do
-                    >&2 echo  "NM resolv-prepender: NM resolv.conf still empty of nameserver"
-                    sleep 0.5
-                done
-            fi
+            >&2 echo  "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
+            while ! grep nameserver /var/run/NetworkManager/resolv.conf; do
+                >&2 echo  "NM resolv-prepender: NM resolv.conf still empty of nameserver"
+                sleep 0.5
+            done
     EOF
         # Ensure resolv.conf exists and contains nameservers before we try to run podman
         if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -32,7 +32,7 @@ contents:
         >&2 echo "NM resolv-prepender triggered by ${1} ${2}."
 
         # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
-        timeout 45s /bin/bash <<EOF
+        timeout 20s /bin/bash <<EOF
             if [[ "$STATUS" == dhcp* ]]; then
                 >&2 echo  "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
                 while ! grep nameserver /var/run/NetworkManager/resolv.conf; do

--- a/templates/common/on-prem/units/kubelet.service-wait-resolv.yaml
+++ b/templates/common/on-prem/units/kubelet.service-wait-resolv.yaml
@@ -1,0 +1,11 @@
+name: kubelet.service
+dropins:
+  - name: 10-mco-on-prem-wait-resolv.conf
+    contents: |
+      {{ if (onPremPlatformAPIServerInternalIP .) -}}
+      [Service]
+      # Wait for resolv-prepender to configure nameservers, exit 255 otherwise
+      # to mark the unit as failed and retry later
+      ExecCondition=/bin/bash -c '! systemctl -q is-enabled systemd-resolved || [ -f /etc/systemd/resolved.conf.d/60-kni.conf ] || exit 255'
+      ExecCondition=/bin/bash -c 'systemctl -q is-enabled systemd-resolved || grep -qs "KNI resolv prepender" /etc/resolv.conf || exit 255'
+      {{end -}}


### PR DESCRIPTION
Work around several resolv-prepender issues:

- hostnamectl fails due to being denied by selinux
- resolv-prepender waits more than the overall NM timeout, making devices to not come up
- resolv-prepender copies resolv.conf without nameservers
- kubelet starts before resolve-prepender has had a chance to set resolv.conf and openshift-dns coredns pods fail to start.
