### PR TITLE
Bug-2051533: Adding day2 remote worker node requires manually approving CSRs

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -20,11 +20,16 @@ contents:
     {{end -}}
     {{end -}}
 
-    # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain
-    if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]]; then
-        # run with systemd-run to avoid selinux problems
-        systemd-run --property=Type=oneshot --unit resolve-prepender-hostnamectl -Pq \
-            hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
+    # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain and static hostname was not already set
+    if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] ; then
+       STATIC_HOSTNAME="$(test ! -e /etc/hostname && echo -n || cat /etc/hostname | xargs)"
+
+       if [[ -z "$STATIC_HOSTNAME" || "$STATIC_HOSTNAME" == "localhost.localdomain" ]] ; then
+ 
+          # run with systemd-run to avoid selinux problems
+          systemd-run --property=Type=oneshot --unit resolve-prepender-hostnamectl -Pq \
+              hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
+       fi
     fi
     
     case "$STATUS" in


### PR DESCRIPTION
The Assisted Installer sets the hostname of a node by writing to the
file /etc/hostname.  When using with IPv6, the hostname is being
overwritten by NetworkManager when DHCPv6 reply contains FDQN.  In this
case the FDQN is written to the file /etc/hostname, thus overriding the
requsted hostname of the Assisted Installer.
This change will cause the FDQN to be written to /etc/hostname file only
if the file didn't exist, or the file was empty, or it contained the
default hostname (localhost.localdomain).
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2051533
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**
Tested on live environment
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Set static hostname only if it was not set before in /etc/hostname

/cc @tsorya 
/cc @celebdor 