### PR TITLE
Add client certificate and key to service monitor

### DIFF
--- a/install/0000_90_machine-config-operator_00_servicemonitor.yaml
+++ b/install/0000_90_machine-config-operator_00_servicemonitor.yaml
@@ -27,6 +27,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: machine-config-controller.openshift-machine-config-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   namespaceSelector:
     matchNames:
     - openshift-machine-config-operator
@@ -63,6 +65,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: machine-config-daemon.openshift-machine-config-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   namespaceSelector:
     matchNames:
     - openshift-machine-config-operator


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added client certificates based on https://github.com/deads2k/openshift-enhancements/blob/master/enhancements/monitoring/client-cert-scraping.md

**- How to verify it**
Monitor ServiceMonitor for openshift-machine-config-operator namespace.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:

-->
Add client certificate and key to service monitor so that prometheus scraper does not depend on API server availability.
