### PR TITLE
[release-4.10] OCPBUGS-4830: daemon: gate done state on uncordon completion

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1230,18 +1230,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 // updateConfigAndState updates node to desired state, labels nodes as done and uncordon
 func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 	// In the case where we had a pendingConfig, make that now currentConfig.
-	// We update the node annotation, delete the state file, etc.
 	if state.pendingConfig != nil {
-		if dn.recorder != nil {
-			dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "NodeDone", fmt.Sprintf("Setting node %s, currentConfig %s to Done", dn.node.Name, state.pendingConfig.GetName()))
-		}
-		if err := dn.nodeWriter.SetDone(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, state.pendingConfig.GetName()); err != nil {
-			return true, errors.Wrap(err, "error setting node's state to Done")
-		}
-		if out, err := dn.storePendingState(state.pendingConfig, 0); err != nil {
-			return true, errors.Wrapf(err, "failed to reset pending config: %s", string(out))
-		}
-
 		state.currentConfig = state.pendingConfig
 	}
 
@@ -1263,6 +1252,17 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 			if err := dn.completeUpdate(state.pendingConfig.GetName()); err != nil {
 				MCDUpdateState.WithLabelValues("", err.Error()).SetToCurrentTime()
 				return inDesiredConfig, err
+			}
+
+			// We update the node annotation, delete the state file, etc.
+			if dn.recorder != nil {
+				dn.recorder.Eventf(getNodeRef(dn.node), corev1.EventTypeNormal, "NodeDone", fmt.Sprintf("Setting node %s, currentConfig %s to Done", dn.node.Name, state.pendingConfig.GetName()))
+			}
+			if err := dn.nodeWriter.SetDone(dn.kubeClient.CoreV1().Nodes(), dn.nodeLister, dn.name, state.pendingConfig.GetName()); err != nil {
+				return true, errors.Wrap(err, "error setting node's state to Done")
+			}
+			if out, err := dn.storePendingState(state.pendingConfig, 0); err != nil {
+				return true, errors.Wrapf(err, "failed to reset pending config: %s", string(out))
 			}
 		}
 		// If we're degraded here, it means we got an error likely on startup and we retried.


### PR DESCRIPTION
The "complete update" workflow in the daemon today is quite convoluted,
which can cause the daemon to never uncordon the node, if the first
attempt reaches the timeout.

This patch moves the storePendingState to the very end of update
completion, such that if the drain fails, we just start from the
beginning again.

This problem is mitigated in 4.11+ since the drain is conducted by the
controller, but in 4.10 and prior the MCD is still doing the
drain/uncordon. We should probably rework this logic entirely, but for
4.10, let's take the less risky/less effort route of just fixing the one
issue above.

The associated bug above is targetted towards master, so the verification
will fail. Since this fix is only required for 4.10 and prior, we could either
1. do some dummy clones
2. have someone override the bug check

But for now, I will keep it linked as such.

This is a bit harder to test by hand, since you probably need to create a
scenario where the uncordon fails by... maybe deleting all apiserver pods
for awhile. Instead, I tested this by doing: https://github.com/yuqi-zhang/machine-config-operator/tree/fix-uncordon-retries-4.10-test 
where I always fail. Without this patch, it will uncordon and "fail" silently.
With this patch, it will continue retrying.