### PR TITLE
Accept new image format, consume in controllerconfig, but stop there 

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -23,29 +23,31 @@ var (
 	}
 
 	bootstrapOpts struct {
-		baremetalRuntimeCfgImage  string
-		cloudConfigFile           string
-		configFile                string
-		cloudProviderCAFile       string
-		corednsImage              string
-		destinationDir            string
-		haproxyImage              string
-		imagesConfigMapFile       string
-		infraConfigFile           string
-		infraImage                string
-		releaseImage              string
-		keepalivedImage           string
-		kubeCAFile                string
-		mcoImage                  string
-		oauthProxyImage           string
-		networkConfigFile         string
-		oscontentImage            string
-		pullSecretFile            string
-		rootCAFile                string
-		proxyConfigFile           string
-		additionalTrustBundleFile string
-		dnsConfigFile             string
-		imageReferences           string
+		baremetalRuntimeCfgImage               string
+		cloudConfigFile                        string
+		configFile                             string
+		cloudProviderCAFile                    string
+		corednsImage                           string
+		destinationDir                         string
+		haproxyImage                           string
+		imagesConfigMapFile                    string
+		infraConfigFile                        string
+		infraImage                             string
+		releaseImage                           string
+		keepalivedImage                        string
+		kubeCAFile                             string
+		mcoImage                               string
+		oauthProxyImage                        string
+		networkConfigFile                      string
+		oscontentImage                         string
+		pullSecretFile                         string
+		rootCAFile                             string
+		proxyConfigFile                        string
+		additionalTrustBundleFile              string
+		dnsConfigFile                          string
+		imageReferences                        string
+		baseOperatingSystemContainer           string
+		baseOperatingSystemExtensionsContainer string
 	}
 )
 
@@ -127,16 +129,26 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.oauthProxyImage = findImageOrDie(imgstream, "oauth-proxy")
 		bootstrapOpts.infraImage = findImageOrDie(imgstream, "pod")
 		bootstrapOpts.haproxyImage = findImageOrDie(imgstream, "haproxy-router")
+		bootstrapOpts.baseOperatingSystemContainer, err = findImage(imgstream, "rhel-coreos-8")
+		if err != nil {
+			glog.Warningf("Base OS container not found: %s", err)
+		}
+		bootstrapOpts.baseOperatingSystemExtensionsContainer, err = findImage(imgstream, "rhel-coreos-8-extensions")
+		if err != nil {
+			glog.Warningf("Base OS extensions container not found: %s", err)
+		}
 	}
 
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{
-			MachineConfigOperator:        bootstrapOpts.mcoImage,
-			MachineOSContent:             bootstrapOpts.oscontentImage,
-			KeepalivedBootstrap:          bootstrapOpts.keepalivedImage,
-			CorednsBootstrap:             bootstrapOpts.corednsImage,
-			BaremetalRuntimeCfgBootstrap: bootstrapOpts.baremetalRuntimeCfgImage,
-			OauthProxy:                   bootstrapOpts.oauthProxyImage,
+			MachineConfigOperator:                  bootstrapOpts.mcoImage,
+			MachineOSContent:                       bootstrapOpts.oscontentImage,
+			KeepalivedBootstrap:                    bootstrapOpts.keepalivedImage,
+			CorednsBootstrap:                       bootstrapOpts.corednsImage,
+			BaremetalRuntimeCfgBootstrap:           bootstrapOpts.baremetalRuntimeCfgImage,
+			OauthProxy:                             bootstrapOpts.oauthProxyImage,
+			BaseOperatingSystemContainer:           bootstrapOpts.baseOperatingSystemContainer,
+			BaseOperatingSystemExtensionsContainer: bootstrapOpts.baseOperatingSystemExtensionsContainer,
 		},
 		ControllerConfigImages: operator.ControllerConfigImages{
 			InfraImage:          bootstrapOpts.infraImage,

--- a/install/0000_80_machine-config-operator_02_images.configmap.yaml
+++ b/install/0000_80_machine-config-operator_02_images.configmap.yaml
@@ -11,11 +11,11 @@ data:
   images.json: >
     {
       "releaseVersion": "0.0.1-snapshot",
-      "machineConfigOperator": "registry.svc.ci.openshift.org/openshift:machine-config-operator",
-      "infraImage": "registry.svc.ci.openshift.org/openshift:pod",
-      "keepalivedImage": "registry.svc.ci.openshift.org/openshift:keepalived-ipfailover",
-      "corednsImage": "registry.svc.ci.openshift.org/openshift:coredns",
-      "haproxyImage": "registry.svc.ci.openshift.org/openshift:haproxy-router",
-      "baremetalRuntimeCfgImage": "registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg",
-      "oauthProxy": "registry.svc.ci.openshift.org/openshift:oauth-proxy"
+      "machineConfigOperator": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator",
+      "infraImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:pod",
+      "keepalivedImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:keepalived-ipfailover",
+      "corednsImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:coredns",
+      "haproxyImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router",
+      "baremetalRuntimeCfgImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:baremetal-runtimecfg",
+      "oauthProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy"
     }

--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: machine-config-operator
-        image: registry.svc.ci.openshift.org/openshift:machine-config-operator
+        image: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
         args:
         - "start"
         - "--images-json=/etc/mco/images/images.json"

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,6 +9,10 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
+  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
+  # progresses towards the default.
+  baseOperatingSystemContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
+  baseOperatingSystemExtensionsContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,6 +9,10 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
-  # The OS payload, managed by the daemon + pivot + rpm-ostree
-  # https://github.com/openshift/machine-config-operator/issues/183
+  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
+  # progresses towards the default.
+  baseOperatingSystemContainer: "registry.ci.openshift.org/openshift:rhel-coreos"
+  # The OS payload used for 4.10 and below; more information in
+  # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
+  # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )
   osImageURL: "registry.svc.ci.openshift.org/openshift:machine-os-content"

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -9,9 +9,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 data:
   releaseVersion: 0.0.1-snapshot
-  # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
-  # progresses towards the default.
-  baseOperatingSystemContainer: "registry.ci.openshift.org/openshift:rhel-coreos"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -12,4 +12,4 @@ data:
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )
-  osImageURL: "registry.svc.ci.openshift.org/openshift:machine-os-content"
+  osImageURL: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content"

--- a/install/image-references
+++ b/install/image-references
@@ -7,35 +7,35 @@ spec:
   - name: machine-config-operator
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:machine-config-operator
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
   - name: pod
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:pod
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:pod
   - name: oauth-proxy
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:oauth-proxy
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy
   # This one is special, it's the OS payload
   # https://github.com/openshift/machine-config-operator/issues/183
   # See the machine-config-osimageurl configmap.
   - name: machine-os-content
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:machine-os-content
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content
   - name: keepalived-ipfailover
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:keepalived-ipfailover
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:keepalived-ipfailover
   - name: coredns
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:coredns
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:coredns
   - name: haproxy-router
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:haproxy-router
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router
   - name: baremetal-runtimecfg
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:baremetal-runtimecfg
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:baremetal-runtimecfg

--- a/install/image-references
+++ b/install/image-references
@@ -23,6 +23,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:machine-os-content
+  - name: rhel-coreos
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:rhel-coreos
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/install/image-references
+++ b/install/image-references
@@ -23,6 +23,14 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content
+  - name: rhel-coreos-8
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8
+  - name: rhel-coreos-8-extensions
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/install/image-references
+++ b/install/image-references
@@ -23,10 +23,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:machine-os-content
-  - name: rhel-coreos
-    from:
-      kind: DockerImage
-      name: registry.ci.openshift.org/openshift:rhel-coreos
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -72,6 +72,8 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	resourcemerge.SetStringIfSet(modified, &existing.Platform, required.Platform)
 	resourcemerge.SetStringIfSet(modified, &existing.EtcdDiscoveryDomain, required.EtcdDiscoveryDomain)
 	resourcemerge.SetStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemContainer, required.BaseOperatingSystemContainer)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemExtensionsContainer, required.BaseOperatingSystemExtensionsContainer)
 	resourcemerge.SetStringIfSet(modified, &existing.NetworkType, required.NetworkType)
 
 	setBytesIfSet(modified, &existing.AdditionalTrustBundle, required.AdditionalTrustBundle)

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -918,6 +918,10 @@ spec:
                   contains the OS update payload. Its value is taken from the data.osImageURL
                   field on the machine-config-osimageurl ConfigMap.
                 type: string
+              baseOperatingSystemContainer:
+                description: baseOperatingSystemContainer is the new format operating system update image.
+                  See https://github.com/openshift/enhancements/pull/1032
+                type: string
               platform:
                 description: platform is deprecated, use Infra.Status.PlatformStatus.Type
                   instead
@@ -992,6 +996,7 @@ spec:
             - ipFamilies
             - kubeAPIServerServingCAData
             - osImageURL
+            - baseOperatingSystemContainer
             - proxy
             - releaseImage
             - rootCAData

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -922,6 +922,10 @@ spec:
                 description: baseOperatingSystemContainer is the new format operating system update image.
                   See https://github.com/openshift/enhancements/pull/1032
                 type: string
+              baseOperatingSystemExtensionsContainer:
+                description: baseOperatingSystemExtensionsContainer is the extensions container matching new format operating system update image.
+                  See https://github.com/openshift/enhancements/pull/1032
+                type: string
               platform:
                 description: platform is deprecated, use Infra.Status.PlatformStatus.Type
                   instead

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -72,8 +72,10 @@ type ControllerConfigSpec struct {
 	// images is map of images that are used by the controller to render templates under ./templates/
 	Images map[string]string `json:"images"`
 
-	// osImageURL is the location of the container image that contains the OS update payload.
-	// Its value is taken from the data.osImageURL field on the machine-config-osimageurl ConfigMap.
+	// BaseOperatingSystemContainer is the new-format container image for operating system updates.
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+
+	// OSImageURL is the old-format container image that contains the OS update payload.
 	OSImageURL string `json:"osImageURL"`
 
 	// releaseImage is the image used when installing the cluster

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -75,6 +75,9 @@ type ControllerConfigSpec struct {
 	// BaseOperatingSystemContainer is the new-format container image for operating system updates.
 	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
 
+	// BaseOperatingSystemExtensionsContainer is the matching extensions container for the new-format container
+	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
+
 	// OSImageURL is the old-format container image that contains the OS update payload.
 	OSImageURL string `json:"osImageURL"`
 

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -550,6 +550,12 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		return nil, fmt.Errorf("Ignoring controller config generated without %s annotation (my version: %s)", daemonconsts.GeneratedByVersionAnnotationKey, version.Raw)
 	}
 
+	if cconfig.Spec.BaseOperatingSystemContainer == "" {
+		glog.Warningf("No BaseOperatingSystemContainer set")
+	} else {
+		glog.Infof("BaseOperatingSystemContainer=%s", cconfig.Spec.BaseOperatingSystemContainer)
+	}
+
 	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid
 	for _, config := range configs {
 		if err := ctrlcommon.ValidateMachineConfig(config.Spec); err != nil {

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -139,6 +139,7 @@ func RenderBootstrap(
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
+	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -140,6 +140,7 @@ func RenderBootstrap(
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
+	spec.BaseOperatingSystemExtensionsContainer = imgs.BaseOperatingSystemExtensionsContainer
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -17,6 +17,8 @@ type Images struct {
 type RenderConfigImages struct {
 	MachineConfigOperator string `json:"machineConfigOperator"`
 	MachineOSContent      string `json:"machineOSContent"`
+	// The new format image
+	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
 	// These have to be named differently from the ones in ControllerConfigImages
 	// or we get errors about ambiguous selectors because both structs are
 	// combined in the Images struct.

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -19,6 +19,8 @@ type RenderConfigImages struct {
 	MachineOSContent      string `json:"machineOSContent"`
 	// The new format image
 	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+	// The matching extensions container for the new format image
+	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
 	// These have to be named differently from the ones in ControllerConfigImages
 	// or we get errors about ambiguous selectors because both structs are
 	// combined in the Images struct.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -883,6 +883,7 @@ func (optr *Operator) getOsImageURLs(namespace string) (string, string, string, 
 
 	if hasNewFormat && !hasNewExtensions {
 		// TODO(jkyros): This is okay for now because it's not required, but someday this will be bad
+		glog.Warningf("New format image specified, but no matching extensions image present")
 	}
 
 	// If we don't have a new format image, and we can't fall back to the old one


### PR DESCRIPTION
As discussed in https://github.com/openshift/machine-config-operator/pull/3258, this:
- allows the MCO to consume the new image format
- adds the new `rhel-coreos-8` and `rhel-coreos-8-extensions` images to the MCO's `image-references` file so after this they will show up in nightlies 
- propagates the new base image and extensions container into controllerconfig

Once this is in, and the MCO can accept the new argument, we will need to: 
- PR something like this https://github.com/jkyros/installer/commit/cdf785897ec64ffab940fa912c15e938021749a2 to the installer to dump out the images file so the MCO can consume it during bootstrap 

And then once that is in, we can go back to https://github.com/openshift/machine-config-operator/pull/3258 and decide if/when/how we want the MCO to use the new format image by default. 