### PR TITLE
Don't reference `rhel-coreos-8-extensions` yet

### DIFF
--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -12,7 +12,7 @@ data:
   # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
   # progresses towards the default.
   baseOperatingSystemContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
-  baseOperatingSystemExtensionsContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
+  #baseOperatingSystemExtensionsContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/image-references
+++ b/install/image-references
@@ -27,10 +27,11 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8
-  - name: rhel-coreos-8-extensions
-    from:
-      kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
+  # Uncomment this after https://issues.redhat.com/browse/COS-1646 lands
+  # - name: rhel-coreos-8-extensions
+  #   from:
+  #     kind: DockerImage
+  #     name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage


### PR DESCRIPTION
This reverts part of https://github.com/openshift/machine-config-operator/pull/3286

While we did land `rhel-coreos-8` in both CI and ART/nightlies, the
corresponding extensions container is currently only in CI, not in
ART/nightly builds.  We're working on it in https://issues.redhat.com/browse/COS-1646
(Which will also need to have code changes from ART similar to
 https://issues.redhat.com/browse/ART-3883)
