### PR TITLE
OCPBUGS-197: daemon: Add a workaround for bug 2111817

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -99,6 +100,30 @@ func (r *RpmOstreeClient) loadStatus() (*rpmOstreeState, error) {
 	return &rosState, nil
 }
 
+// See https://bugzilla.redhat.com/show_bug.cgi?id=2111817
+func bug2111817Workaround() error {
+	targetUnit := "/run/systemd/system/rpm-ostreed.service.d/bug2111817.conf"
+	// Do nothing if the file exists
+	if _, err := os.Stat(targetUnit); err == nil {
+		return nil
+	}
+	err := os.MkdirAll(filepath.Dir(targetUnit), 0o755)
+	if err != nil {
+		return err
+	}
+	dropin := `[Service]
+InaccessiblePaths=
+`
+	if err := writeFileAtomicallyWithDefaults(targetUnit, []byte(dropin)); err != nil {
+		return err
+	}
+	if err := runCmdSync("systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+	glog.Infof("Enabled workaround for bug 2111817")
+	return nil
+}
+
 func (r *RpmOstreeClient) Initialize() error {
 	// This replicates https://github.com/coreos/rpm-ostree/pull/2945
 	// and can be removed when we have a new enough rpm-ostree with
@@ -130,6 +155,10 @@ func (r *RpmOstreeClient) Initialize() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if err := bug2111817Workaround(); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
systemd's implementation of `InaccessiblePaths` has
quadratic behavior in number of mounts.
The fix to rpm-ostree is inbound.  But...adding this workaround which
has the MCD dynamically reconfigure the system to drop that config will
help unstick clusters so they can get the real fix.

Manual backport of PR https://github.com/openshift/machine-config-operator/pull/329