### PR TITLE
OKD: Add build args for FCOS and SCOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 # FIXME once we can depend on a new enough host that supports globs for COPY,
@@ -6,10 +7,13 @@ COPY . .
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
 FROM registry.ci.openshift.org/ocp/4.12:base
+ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
-RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
+RUN if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos-8/fedora-coreos/g' /manifests/*; \
+    elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos-8/centos-stream-coreos-9/g' /manifests/*; fi && \
+    if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -112,6 +112,13 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
+	baseOSContainerImageTag := "rhel-coreos-8"
+	if version.IsFCOS() {
+		baseOSContainerImageTag = "fedora-coreos"
+	} else if version.IsSCOS() {
+		baseOSContainerImageTag = "centos-stream-coreos-9"
+	}
+
 	if bootstrapOpts.imageReferences != "" {
 		imageRefData, err := ioutil.ReadFile(bootstrapOpts.imageReferences)
 		if err != nil {
@@ -129,11 +136,11 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.oauthProxyImage = findImageOrDie(imgstream, "oauth-proxy")
 		bootstrapOpts.infraImage = findImageOrDie(imgstream, "pod")
 		bootstrapOpts.haproxyImage = findImageOrDie(imgstream, "haproxy-router")
-		bootstrapOpts.baseOperatingSystemContainer, err = findImage(imgstream, "rhel-coreos-8")
+		bootstrapOpts.baseOperatingSystemContainer, err = findImage(imgstream, baseOSContainerImageTag)
 		if err != nil {
 			glog.Warningf("Base OS container not found: %s", err)
 		}
-		bootstrapOpts.baseOperatingSystemExtensionsContainer, err = findImage(imgstream, "rhel-coreos-8-extensions")
+		bootstrapOpts.baseOperatingSystemExtensionsContainer, err = findImage(imgstream, fmt.Sprintf("%s-extensions", baseOSContainerImageTag))
 		if err != nil {
 			glog.Warningf("Base OS extensions container not found: %s", err)
 		}

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -4,7 +4,7 @@ set -eu
 
 REPO=github.com/openshift/machine-config-operator
 WHAT=${WHAT:-machine-config-operator}
-GOTAGS=${GOTAGS:-}
+GOTAGS="${GOTAGS:-} ${TAGS:-}"
 GLDFLAGS=${GLDFLAGS:-}
 
 eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,20 @@ var (
 
 	// String is the human-friendly representation of the version.
 	String = fmt.Sprintf("MachineConfigOperator %s", Raw)
+
+	// FCOS is a setting to enable Fedora CoreOS-only modifications
+	FCOS = false
+
+	// SCOS is a setting to enable CentOS Stream CoreOS-only modifications
+	SCOS = false
 )
+
+// IsFCOS returns true if Fedora CoreOS-only modifications are enabled
+func IsFCOS() bool {
+	return FCOS
+}
+
+// IsSCOS returns true if CentOS Stream CoreOS-only modifications are enabled
+func IsSCOS() bool {
+	return SCOS
+}

--- a/pkg/version/version_fcos.go
+++ b/pkg/version/version_fcos.go
@@ -1,0 +1,7 @@
+//go:build fcos
+
+package version
+
+func init() {
+	FCOS = true
+}

--- a/pkg/version/version_scos.go
+++ b/pkg/version/version_scos.go
@@ -1,0 +1,7 @@
+//go:build scos
+
+package version
+
+func init() {
+	SCOS = true
+}


### PR DESCRIPTION
Follow up to https://github.com/openshift/machine-config-operator/pull/3286

**- What I did**

This change introduces the TAGS build-arg in `Dockerfile` which is
propagated through to the Go build as a build constraint (aka build tag).
Supported values for TAGS are `fcos` and `scos`, with `fcos` taking
precedence if both are specified.
This is necessary to modify the otherwise hard-coded imagestream tag
`rhel-coreos-8` used for the RHCOS8 OS container image to be either
`fedora-coreos` in OKD on FCOS, or `centos-stream-coreos-9` in OKD on
SCOS.

**- How to verify it**
- CI does not break
- manually built image (e.g. with `podman build -f Dockerfile --build-arg TAGS="scos"`) has IS tag named `centos-stream-coreos-9` in `/manifests/image-references`

**- Description for the changelog**
OKD: Add build args for FCOS and SCOS

/cc @cgwalters 
/cc @vrutkovs 
