### PR TITLE
Add RuntimeDefault to ctrcfg

### DIFF
--- a/install/0000_80_machine-config-operator_02_containerruntimeconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_02_containerruntimeconfig.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
 spec:
   group: machineconfiguration.openshift.io
   names:
@@ -85,7 +86,7 @@ spec:
                   defaultRuntime:
                     description: defaultRuntime is the name of the OCI runtime to be used as the default.
                     type: string
-                    pattern: ^$|^runc$
+                    pattern: ^$|^(runc|crun)$
               machineConfigPoolSelector:
                 description: A label selector is a label query over a set of resources.
                   The result of matchLabels and matchExpressions are ANDed. An empty

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -481,7 +481,19 @@ type ContainerRuntimeConfiguration struct {
 	// overlaySize specifies the maximum size of a container image.
 	// This flag can be used to set quota on the size of container images.
 	OverlaySize resource.Quantity `json:"overlaySize,omitempty"`
+
+	// defaultRuntime is the name of the OCI runtime to be used as the default.
+	DefaultRuntime ContainerRuntimeDefaultRuntime `json:"defaultRuntime,omitempty"`
 }
+
+type ContainerRuntimeDefaultRuntime string
+
+const (
+	ContainerRuntimeDefaultRuntimeEmpty   = ""
+	ContainerRuntimeDefaultRuntimeRunc    = "runc"
+	ContainerRuntimeDefaultRuntimeCrun    = "crun"
+	ContainerRuntimeDefaultRuntimeDefault = ContainerRuntimeDefaultRuntimeRunc
+)
 
 // ContainerRuntimeConfigStatus defines the observed state of a ContainerRuntimeConfig
 type ContainerRuntimeConfigStatus struct {

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
@@ -48,7 +48,7 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 				}
 			}
 			// Create the cri-o drop-in files
-			if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || !ctrcfg.LogSizeMax.IsZero() {
+			if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || !ctrcfg.LogSizeMax.IsZero() || ctrcfg.DefaultRuntime != mcfgv1.ContainerRuntimeDefaultRuntimeEmpty {
 				crioFileConfigs := createCRIODropinFiles(cfg)
 				configFileList = append(configFileList, crioFileConfigs...)
 			}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -566,7 +566,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		}
 
 		// Create the cri-o drop-in files
-		if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || !ctrcfg.LogSizeMax.IsZero() {
+		if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || !ctrcfg.LogSizeMax.IsZero() || ctrcfg.DefaultRuntime != mcfgv1.ContainerRuntimeDefaultRuntimeEmpty {
 			crioFileConfigs := createCRIODropinFiles(cfg)
 			configFileList = append(configFileList, crioFileConfigs...)
 		}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -976,6 +976,12 @@ func TestContainerRuntimeConfigOptions(t *testing.T) {
 				LogLevel: "invalid",
 			},
 		},
+		{
+			name: "invalid value of default runtime",
+			config: &mcfgv1.ContainerRuntimeConfiguration{
+				DefaultRuntime: "invalid",
+			},
+		},
 	}
 
 	successTests := []struct {
@@ -1004,6 +1010,12 @@ func TestContainerRuntimeConfigOptions(t *testing.T) {
 			name: "valid log level",
 			config: &mcfgv1.ContainerRuntimeConfiguration{
 				LogLevel: "debug",
+			},
+		},
+		{
+			name: "valid value of default runtime",
+			config: &mcfgv1.ContainerRuntimeConfiguration{
+				DefaultRuntime: "crun",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Update the containerruntimeconfig with `DefaultRuntime` which allows users to specify a different default runtime. At present, the only fully supported options are `"runc"` and `""`. If the cluster has the `TechPreviewNoUpgrade` feature set enabled, then they gain access to `crun` as well.

**- How to verify it**
Launch a cluster with this PR
run `oc describe crd/containerruntimeconfigs.machineconfiguration.openshift.io`
see the presence of `defaultRuntime` field
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for DefaultRuntime in ContainerRuntimeConfig CRD, allowing users to specify a different default OCI runtime for CRI-O to run containers with. At present, the only fully supported options are `"runc"` and `""`. If the cluster has the `TechPreviewNoUpgrade` feature set enabled, then they gain access to `crun` as well.