### PR TITLE
Round off SYSTEM_RESERVED_MEMORY if value is in decimal

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -40,6 +40,7 @@ contents:
         if (($total_memory >= 0)); then # 2% of any memory above 128GB
             recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.02 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
         fi
+        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory | awk '{printf("%d\n",$1 + 0.5)}') # Round off so we avoid float conversions
         echo "SYSTEM_RESERVED_MEMORY=${recommended_systemreserved_memory}Gi">> ${NODE_SIZES_ENV}
     }
     function dynamic_cpu_sizing {


### PR DESCRIPTION
Signed-off-by: Kenneth D'souza <kennethdsouza94@gmail.com>

Closes: #3298 

**- What I did**
Added code to make sure  kubelet-auto-sizing script  recommends SYSTEM_RESERVED_MEMORY size in power of 2^n, as in some cases the value reported can be in decimal. 

**- How to verify it**
Pass RAM size as 377Gi to the script:

Before patch:
SYSTEM_RESERVED_MEMORY=14.3Gi

After patch:
SYSTEM_RESERVED_MEMORY=14Gi

**- Description for the changelog**

Round off SYSTEM_RESERVED_MEMORY if value is in decimal

