### PR TITLE
fixes config decompression lint issue

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -585,8 +585,6 @@ func decompressPayload(r io.Reader) ([]byte, error) {
 		return nil, errConfigNotGzipped
 	}
 
-	out := bytes.NewBuffer([]byte{})
-
 	gz, err := gzip.NewReader(in)
 	if err != nil {
 		return nil, fmt.Errorf("initialize gzip reader failed: %w", err)
@@ -594,12 +592,12 @@ func decompressPayload(r io.Reader) ([]byte, error) {
 
 	defer gz.Close()
 
-	// Decompress our payload.
-	if _, err := io.Copy(out, gz); err != nil {
+	data, err := ioutil.ReadAll(gz)
+	if err != nil {
 		return nil, fmt.Errorf("decompression failed: %w", err)
 	}
 
-	return out.Bytes(), nil
+	return data, nil
 }
 
 // Function to remove duplicated files/units/users from a V2 MC, since the translator


### PR DESCRIPTION
**- What I did**

Fixes a lint issue with the gosec linter. Specifically, it fixes gosec rule G110.

**- How to verify it**

Run the unit tests and run the gosec linter.

**- Description for the changelog**
Fixes gosec lint G110
