### PR TITLE
daemon: Use just one NodeUpdaterClient instance

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1418,7 +1418,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 			if isLayeredImage {
 				// If this is a new format image, we don't have to extract it,
 				// we can just update it the proper way
-				if err := updateLayeredOS(state.currentConfig); err != nil {
+				if err := dn.updateLayeredOS(state.currentConfig); err != nil {
 					return err
 				}
 			} else {
@@ -1426,7 +1426,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 				if err != nil {
 					return err
 				}
-				if err := updateOS(state.currentConfig, osImageContentDir); err != nil {
+				if err := dn.updateOS(state.currentConfig, osImageContentDir); err != nil {
 					return err
 				}
 				if err := os.RemoveAll(osImageContentDir); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1840,11 +1840,10 @@ func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 }
 
 // updateOS updates the system OS to the one specified in newConfig
-func updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
+func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
 	newURL := config.Spec.OSImageURL
 	glog.Infof("Updating OS to %s", newURL)
-	client := NewNodeUpdaterClient()
-	if _, err := client.Rebase(newURL, osImageContentDir); err != nil {
+	if _, err := dn.NodeUpdaterClient.Rebase(newURL, osImageContentDir); err != nil {
 		return fmt.Errorf("failed to update OS to %s : %w", newURL, err)
 	}
 
@@ -1852,11 +1851,10 @@ func updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
 }
 
 // updateLayeredOS updates the system OS to the one specified in newConfig
-func updateLayeredOS(config *mcfgv1.MachineConfig) error {
+func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
 	glog.Infof("Updating OS to layered image %s", newURL)
-	client := NewNodeUpdaterClient()
-	if err := client.RebaseLayered(newURL); err != nil {
+	if err := dn.NodeUpdaterClient.RebaseLayered(newURL); err != nil {
 		return fmt.Errorf("failed to update OS to %s : %w", newURL, err)
 	}
 
@@ -2069,7 +2067,7 @@ func (dn *Daemon) reboot(rationale string) error {
 func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
 	// Update OS
 	if mcDiff.osUpdate {
-		if err := updateLayeredOS(newConfig); err != nil {
+		if err := dn.updateLayeredOS(newConfig); err != nil {
 			nodeName := ""
 			if dn.node != nil {
 				nodeName = dn.node.Name
@@ -2142,7 +2140,7 @@ func (dn *CoreOSDaemon) applyLegacyOSChanges(mcDiff machineConfigDiff, oldConfig
 
 	// Update OS
 	if mcDiff.osUpdate {
-		if err := updateOS(newConfig, osImageContentDir); err != nil {
+		if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
 			nodeName := ""
 			if dn.node != nil {
 				nodeName = dn.node.Name

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -99,8 +99,10 @@ func TestUpdateOS(t *testing.T) {
 		},
 	}
 
+	d := newMockDaemon()
+
 	// should return an error
-	if err := updateOS(differentMcfg, ""); err == expectedError {
+	if err := d.updateOS(differentMcfg, ""); err == expectedError {
 		t.Error("Expected an error. Got none.")
 	}
 }
@@ -164,8 +166,8 @@ func TestReconcilable(t *testing.T) {
 	// Verify Raid changes react as expected
 	oldIgnCfg.Storage.Raid = []ign3types.Raid{
 		{
-			Name:  "data",
-			Level: "stripe",
+			Name:    "data",
+			Level:   "stripe",
 			Devices: []ign3types.Device{"/dev/vda", "/dev/vdb"},
 		},
 	}


### PR DESCRIPTION
Drive by cleanup I noticed while working on the code; the daemon
has an instance of this, so use it rather than creating
a new one.
