### PR TITLE
 MCO-356: daemon: Do a secondary in-place update if rpm-ostree is too old

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,14 @@ ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
-RUN if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos-8/fedora-coreos/g' /manifests/*; \
+
+RUN if [[ "${TAGS}" == "fcos" ]]; then \
+    # comment out non-base/extensions image-references entirely for fcos
+    sed -i '/- name: rhel-coreos-8-/,+3 s/^/#/' /manifests/image-references && \
+    # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
+    sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml && \
+    # rewrite image names for fcos 
+    sed -i 's/rhel-coreos-8/fedora-coreos/g' /manifests/* ; \
     elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos-8/centos-stream-coreos-9/g' /manifests/*; fi && \
     if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
 COPY templates /etc/mcc/templates

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -23,31 +23,31 @@ var (
 	}
 
 	bootstrapOpts struct {
-		baremetalRuntimeCfgImage               string
-		cloudConfigFile                        string
-		configFile                             string
-		cloudProviderCAFile                    string
-		corednsImage                           string
-		destinationDir                         string
-		haproxyImage                           string
-		imagesConfigMapFile                    string
-		infraConfigFile                        string
-		infraImage                             string
-		releaseImage                           string
-		keepalivedImage                        string
-		kubeCAFile                             string
-		mcoImage                               string
-		oauthProxyImage                        string
-		networkConfigFile                      string
-		oscontentImage                         string
-		pullSecretFile                         string
-		rootCAFile                             string
-		proxyConfigFile                        string
-		additionalTrustBundleFile              string
-		dnsConfigFile                          string
-		imageReferences                        string
-		baseOperatingSystemContainer           string
-		baseOperatingSystemExtensionsContainer string
+		baremetalRuntimeCfgImage       string
+		cloudConfigFile                string
+		configFile                     string
+		cloudProviderCAFile            string
+		corednsImage                   string
+		destinationDir                 string
+		haproxyImage                   string
+		imagesConfigMapFile            string
+		infraConfigFile                string
+		infraImage                     string
+		releaseImage                   string
+		keepalivedImage                string
+		kubeCAFile                     string
+		mcoImage                       string
+		oauthProxyImage                string
+		networkConfigFile              string
+		oscontentImage                 string
+		pullSecretFile                 string
+		rootCAFile                     string
+		proxyConfigFile                string
+		additionalTrustBundleFile      string
+		dnsConfigFile                  string
+		imageReferences                string
+		baseOSContainerImage           string
+		baseOSExtensionsContainerImage string
 	}
 )
 
@@ -136,11 +136,11 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 		bootstrapOpts.oauthProxyImage = findImageOrDie(imgstream, "oauth-proxy")
 		bootstrapOpts.infraImage = findImageOrDie(imgstream, "pod")
 		bootstrapOpts.haproxyImage = findImageOrDie(imgstream, "haproxy-router")
-		bootstrapOpts.baseOperatingSystemContainer, err = findImage(imgstream, baseOSContainerImageTag)
+		bootstrapOpts.baseOSContainerImage, err = findImage(imgstream, baseOSContainerImageTag)
 		if err != nil {
 			glog.Warningf("Base OS container not found: %s", err)
 		}
-		bootstrapOpts.baseOperatingSystemExtensionsContainer, err = findImage(imgstream, fmt.Sprintf("%s-extensions", baseOSContainerImageTag))
+		bootstrapOpts.baseOSExtensionsContainerImage, err = findImage(imgstream, fmt.Sprintf("%s-extensions", baseOSContainerImageTag))
 		if err != nil {
 			glog.Warningf("Base OS extensions container not found: %s", err)
 		}
@@ -148,14 +148,14 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{
-			MachineConfigOperator:                  bootstrapOpts.mcoImage,
-			MachineOSContent:                       bootstrapOpts.oscontentImage,
-			KeepalivedBootstrap:                    bootstrapOpts.keepalivedImage,
-			CorednsBootstrap:                       bootstrapOpts.corednsImage,
-			BaremetalRuntimeCfgBootstrap:           bootstrapOpts.baremetalRuntimeCfgImage,
-			OauthProxy:                             bootstrapOpts.oauthProxyImage,
-			BaseOperatingSystemContainer:           bootstrapOpts.baseOperatingSystemContainer,
-			BaseOperatingSystemExtensionsContainer: bootstrapOpts.baseOperatingSystemExtensionsContainer,
+			MachineConfigOperator:          bootstrapOpts.mcoImage,
+			MachineOSContent:               bootstrapOpts.oscontentImage,
+			KeepalivedBootstrap:            bootstrapOpts.keepalivedImage,
+			CorednsBootstrap:               bootstrapOpts.corednsImage,
+			BaremetalRuntimeCfgBootstrap:   bootstrapOpts.baremetalRuntimeCfgImage,
+			OauthProxy:                     bootstrapOpts.oauthProxyImage,
+			BaseOSContainerImage:           bootstrapOpts.baseOSContainerImage,
+			BaseOSExtensionsContainerImage: bootstrapOpts.baseOSExtensionsContainerImage,
 		},
 		ControllerConfigImages: operator.ControllerConfigImages{
 			InfraImage:          bootstrapOpts.infraImage,

--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.3.1 // indirect
 	k8s.io/apiserver v0.24.3 // indirect

--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -66,6 +66,10 @@ spec:
             description: MachineConfigSpec is the spec for MachineConfig
             type: object
             properties:
+              baseOSExtensionsContainerImage:
+                description: baseOperatingSystemExtensionContainer specifies the remote location that will be used
+                  to fetch the extensions container matching a new-format OS image
+                type: string
               config:
                 description: Config is a Ignition Config object.
                 type: object

--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -67,7 +67,7 @@ spec:
             type: object
             properties:
               baseOSExtensionsContainerImage:
-                description: baseOperatingSystemExtensionContainer specifies the remote location that will be used
+                description: baseOSExtensionsContainerImage specifies the remote location that will be used
                   to fetch the extensions container matching a new-format OS image
                 type: string
               config:

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -11,8 +11,8 @@ data:
   releaseVersion: 0.0.1-snapshot
   # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
   # progresses towards the default.
-  baseOperatingSystemContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
-  #baseOperatingSystemExtensionsContainer: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
+  baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
+  #baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -12,7 +12,7 @@ data:
   # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
   # progresses towards the default.
   baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
-  #baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
+  baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/image-references
+++ b/install/image-references
@@ -27,11 +27,10 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8
-  # Uncomment this after https://issues.redhat.com/browse/COS-1646 lands
-  # - name: rhel-coreos-8-extensions
-  #   from:
-  #     kind: DockerImage
-  #     name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
+  - name: rhel-coreos-8-extensions
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -47,6 +47,7 @@ func EnsureMachineConfigPool(modified *bool, existing *mcfgv1.MachineConfigPool,
 func ensureMachineConfigSpec(modified *bool, existing *mcfgv1.MachineConfigSpec, required mcfgv1.MachineConfigSpec) {
 	resourcemerge.SetStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
 	resourcemerge.SetStringIfSet(modified, &existing.KernelType, required.KernelType)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOSExtensionsContainerImage, required.BaseOSExtensionsContainerImage)
 
 	if !equality.Semantic.DeepEqual(existing.KernelArguments, required.KernelArguments) {
 		*modified = true

--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -72,8 +72,8 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	resourcemerge.SetStringIfSet(modified, &existing.Platform, required.Platform)
 	resourcemerge.SetStringIfSet(modified, &existing.EtcdDiscoveryDomain, required.EtcdDiscoveryDomain)
 	resourcemerge.SetStringIfSet(modified, &existing.OSImageURL, required.OSImageURL)
-	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemContainer, required.BaseOperatingSystemContainer)
-	resourcemerge.SetStringIfSet(modified, &existing.BaseOperatingSystemExtensionsContainer, required.BaseOperatingSystemExtensionsContainer)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOSContainerImage, required.BaseOSContainerImage)
+	resourcemerge.SetStringIfSet(modified, &existing.BaseOSExtensionsContainerImage, required.BaseOSExtensionsContainerImage)
 	resourcemerge.SetStringIfSet(modified, &existing.NetworkType, required.NetworkType)
 
 	setBytesIfSet(modified, &existing.AdditionalTrustBundle, required.AdditionalTrustBundle)

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -918,12 +918,12 @@ spec:
                   contains the OS update payload. Its value is taken from the data.osImageURL
                   field on the machine-config-osimageurl ConfigMap.
                 type: string
-              baseOperatingSystemContainer:
-                description: baseOperatingSystemContainer is the new format operating system update image.
+              baseOSContainerImage:
+                description: baseOSContainerImage is the new format operating system update image.
                   See https://github.com/openshift/enhancements/pull/1032
                 type: string
-              baseOperatingSystemExtensionsContainer:
-                description: baseOperatingSystemExtensionsContainer is the extensions container matching new format operating system update image.
+              baseOSExtensionsContainerImage:
+                description: baseOSExtensionsContainerImage is the extensions container matching new format operating system update image.
                   See https://github.com/openshift/enhancements/pull/1032
                 type: string
               platform:
@@ -1000,7 +1000,7 @@ spec:
             - ipFamilies
             - kubeAPIServerServingCAData
             - osImageURL
-            - baseOperatingSystemContainer
+            - baseOSContainerImage
             - proxy
             - releaseImage
             - rootCAData

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -200,6 +200,11 @@ type MachineConfigSpec struct {
 	// OSImageURL specifies the remote location that will be used to
 	// fetch the OS.
 	OSImageURL string `json:"osImageURL"`
+
+	// BaseOperatingSystemExtensionContainer specifies the remote location that will be used
+	// to fetch the extensions container matching a new-format OS image
+	BaseOSExtensionsContainerImage string `json:"baseOSExtensionsContainerImage"`
+
 	// Config is a Ignition Config object.
 	Config runtime.RawExtension `json:"config"`
 

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -72,11 +72,11 @@ type ControllerConfigSpec struct {
 	// images is map of images that are used by the controller to render templates under ./templates/
 	Images map[string]string `json:"images"`
 
-	// BaseOperatingSystemContainer is the new-format container image for operating system updates.
-	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+	// BaseOSContainerImage is the new-format container image for operating system updates.
+	BaseOSContainerImage string `json:"baseOSContainerImage"`
 
-	// BaseOperatingSystemExtensionsContainer is the matching extensions container for the new-format container
-	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
+	// BaseOSExtensionsContainerImage is the matching extensions container for the new-format container
+	BaseOSExtensionsContainerImage string `json:"baseOSExtensionsContainerImage"`
 
 	// OSImageURL is the old-format container image that contains the OS update payload.
 	OSImageURL string `json:"osImageURL"`

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -201,7 +201,7 @@ type MachineConfigSpec struct {
 	// fetch the OS.
 	OSImageURL string `json:"osImageURL"`
 
-	// BaseOperatingSystemExtensionContainer specifies the remote location that will be used
+	// BaseOSExtensionsContainerImage specifies the remote location that will be used
 	// to fetch the extensions container matching a new-format OS image
 	BaseOSExtensionsContainerImage string `json:"baseOSExtensionsContainerImage"`
 

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -10,6 +10,9 @@ const (
 	// ReleaseImageVersionAnnotationKey is used to tag the rendered machineconfigs & controller config with the release image version.
 	ReleaseImageVersionAnnotationKey = "machineconfiguration.openshift.io/release-image-version"
 
+	// OSImageURLOverriddenKey is used to tag a rendered machineconfig when OSImageURL has been overridden from default using machineconfig
+	OSImageURLOverriddenKey = "machineconfiguration.openshift.io/os-image-url-overridden"
+
 	// ControllerConfigName is the name of the ControllerConfig object that controllers use
 	ControllerConfigName = "machine-config-controller"
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -49,7 +49,7 @@ import (
 )
 
 // Gates whether or not the MCO uses the new format base OS container image by default
-var UseNewFormatImageByDefault = false
+var UseNewFormatImageByDefault = true
 
 // strToPtr converts the input string to a pointer to itself
 func strToPtr(s string) *string {

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -234,7 +234,8 @@ func TestParseAndConvert(t *testing.T) {
 
 func TestMergeMachineConfigs(t *testing.T) {
 	// variable setup
-	osImageURL := "testURL"
+	cconfig := &mcfgv1.ControllerConfig{}
+	cconfig.Spec.OSImageURL = "testURL"
 	fips := true
 	kargs := []string{"testKarg"}
 	extensions := []string{"testExtensions"}
@@ -246,7 +247,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 		},
 	}
 	inMachineConfigs := []*mcfgv1.MachineConfig{machineConfigFIPS}
-	mergedMachineConfig, err := MergeMachineConfigs(inMachineConfigs, osImageURL)
+	mergedMachineConfig, err := MergeMachineConfigs(inMachineConfigs, cconfig)
 	require.Nil(t, err)
 
 	// check that the outgoing config does have the version string set,
@@ -260,7 +261,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 	require.Nil(t, err)
 	expectedMachineConfig := &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL:      osImageURL,
+			OSImageURL:      cconfig.Spec.OSImageURL,
 			KernelArguments: []string{},
 			Config: runtime.RawExtension{
 				Raw: rawOutIgn,
@@ -325,7 +326,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 		machineConfigIgn,
 		machineConfigFIPS,
 	}
-	mergedMachineConfig, err = MergeMachineConfigs(inMachineConfigs, osImageURL)
+	mergedMachineConfig, err = MergeMachineConfigs(inMachineConfigs, cconfig)
 	require.Nil(t, err)
 
 	expectedMachineConfig = &mcfgv1.MachineConfig{

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -236,6 +236,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 	// variable setup
 	cconfig := &mcfgv1.ControllerConfig{}
 	cconfig.Spec.OSImageURL = "testURL"
+	cconfig.Spec.BaseOSContainerImage = "newformatURL"
 	fips := true
 	kargs := []string{"testKarg"}
 	extensions := []string{"testExtensions"}
@@ -261,7 +262,8 @@ func TestMergeMachineConfigs(t *testing.T) {
 	require.Nil(t, err)
 	expectedMachineConfig := &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
-			OSImageURL:      cconfig.Spec.OSImageURL,
+			// TODO(jkyros): take this back out when we drop machine-os-content
+			OSImageURL:      GetDefaultBaseImageContainer(&cconfig.Spec),
 			KernelArguments: []string{},
 			Config: runtime.RawExtension{
 				Raw: rawOutIgn,

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -563,7 +563,8 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		}
 	}
 
-	merged, err := ctrlcommon.MergeMachineConfigs(configs, cconfig.Spec.OSImageURL)
+	merged, err := ctrlcommon.MergeMachineConfigs(configs, cconfig)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -488,7 +488,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	}
 
 	// Emit an event so it's more visible that OSImageURL was overridden.
-	if generated.Spec.OSImageURL != cc.Spec.OSImageURL {
+	if generated.Spec.OSImageURL != ctrlcommon.GetDefaultBaseImageContainer(&cc.Spec) {
 		ctrl.eventRecorder.Eventf(generated, corev1.EventTypeNormal, "OSImageURLOverridden", "OSImageURL was overridden via machineconfig in %s (was: %s is: %s)", generated.Name, cc.Spec.OSImageURL, generated.Spec.OSImageURL)
 	}
 
@@ -582,10 +582,11 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 	merged.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = version.Hash
 	merged.Annotations[ctrlcommon.ReleaseImageVersionAnnotationKey] = cconfig.Annotations[ctrlcommon.ReleaseImageVersionAnnotationKey]
 
-	// Make it obvious that the OSImageURL has been overridden. If we log this in MergeMachineConfigs, we don't know the name yet, so we're
-	// logging out here instead so it's actually helpful.
-	if merged.Spec.OSImageURL != cconfig.Spec.OSImageURL {
-		glog.Infof("OSImageURL has been overridden via machineconfig in %s (was: %s is: %s)", merged.Name, cconfig.Spec.OSImageURL, merged.Spec.OSImageURL)
+	// The operator needs to know the user overrode this, so it knows if it needs to skip the
+	// OSImageURL check during upgrade -- if the user took over managing OS upgrades this way,
+	// the operator shouldn't stop the rest of the upgrade from progressing/completing.
+	if merged.Spec.OSImageURL != ctrlcommon.GetDefaultBaseImageContainer(&cconfig.Spec) {
+		merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] = "true"
 	}
 
 	return merged, nil

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -550,10 +550,10 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		return nil, fmt.Errorf("Ignoring controller config generated without %s annotation (my version: %s)", daemonconsts.GeneratedByVersionAnnotationKey, version.Raw)
 	}
 
-	if cconfig.Spec.BaseOperatingSystemContainer == "" {
-		glog.Warningf("No BaseOperatingSystemContainer set")
+	if cconfig.Spec.BaseOSContainerImage == "" {
+		glog.Warningf("No BaseOSContainerImage set")
 	} else {
-		glog.Infof("BaseOperatingSystemContainer=%s", cconfig.Spec.BaseOperatingSystemContainer)
+		glog.Infof("BaseOSContainerImage=%s", cconfig.Spec.BaseOSContainerImage)
 	}
 
 	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -293,8 +293,14 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 	if err != nil {
 		return nil, fmt.Errorf("error creating MachineConfig from Ignition config: %w", err)
 	}
+
+	// TODO(jkyros): you might think you can remove this since we override later when we merge
+	// config, but resourcemerge doesn't blank this field out once it's populated
+	// so if you end up on a cluster where it was ever populated in this machineconfig, it
+	// will keep that last value forever once you upgrade...which is a problen now that we allow OSImageURL overrides
+	// because it will look like an override when it shouldn't be. So don't take this out until you've solved that.
 	// And inject the osimageurl here
-	mcfg.Spec.OSImageURL = config.OSImageURL
+	mcfg.Spec.OSImageURL = ctrlcommon.GetDefaultBaseImageContainer(config.ControllerConfigSpec)
 
 	return mcfg, nil
 }

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -75,6 +75,11 @@ const (
 	// "currentConfig" state.  Create this file (empty contents is fine) if you wish the MCD
 	// to proceed and attempt to "reconcile" to the new "desiredConfig" state regardless.
 	MachineConfigDaemonForceFile = "/run/machine-config-daemon-force"
+	// MachineConfigDaemonPersistentForceOnceFile if present on firstboot will have the same
+	// effect as MachineConfigDaemonForceFile, and it will be deleted.  This allows opt-in
+	// to a force reconciliation across a reboot cycle, without introducing the possibility
+	// of unbounded "reboot loops".
+	MachineConfigDaemonPersistentForceOnceFile = "/etc/machine-config-daemon-force-once"
 
 	// coreUser is "core" and currently the only permissible user name
 	CoreUserName  = "core"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -64,6 +64,9 @@ type Daemon struct {
 	// bootedOSImageURL is the currently booted URL of the operating system
 	bootedOSImageURL string
 
+	// bootedOScommit is the commit hash of the currently booted operating system
+	bootedOSCommit string
+
 	// kubeClient allows interaction with Kubernetes, including the node we are running on.
 	kubeClient kubernetes.Interface
 
@@ -213,6 +216,7 @@ func New(
 	var (
 		osImageURL string
 		osVersion  string
+		osCommit   string
 		err        error
 	)
 
@@ -231,11 +235,11 @@ func New(
 		if err != nil {
 			return nil, fmt.Errorf("error initializing rpm-ostree: %w", err)
 		}
-		osImageURL, osVersion, err = nodeUpdaterClient.GetBootedOSImageURL()
+		osImageURL, osVersion, osCommit, err = nodeUpdaterClient.GetBootedOSImageURL()
 		if err != nil {
 			return nil, fmt.Errorf("error reading osImageURL from rpm-ostree: %w", err)
 		}
-		glog.Infof("Booted osImageURL: %s (%s)", osImageURL, osVersion)
+		glog.Infof("Booted osImageURL: %s (%s) %s", osImageURL, osVersion, osCommit)
 	}
 
 	bootID := ""
@@ -267,6 +271,7 @@ func New(
 		os:                    hostos,
 		NodeUpdaterClient:     nodeUpdaterClient,
 		bootedOSImageURL:      osImageURL,
+		bootedOSCommit:        osCommit,
 		bootID:                bootID,
 		exitCh:                exitCh,
 		currentConfigPath:     currentConfigPath,
@@ -1167,7 +1172,7 @@ func (dn *Daemon) convertForceFile() error {
 	err := os.Remove(constants.MachineConfigDaemonPersistentForceOnceFile)
 	if err == nil {
 		dn.logSystem("Found %s; removing and creating %s", constants.MachineConfigDaemonPersistentForceOnceFile, constants.MachineConfigDaemonForceFile)
-		if err := os.WriteFile(constants.MachineConfigDaemonForceFile, []byte(""), 0o644); err != nil {
+		if err := os.WriteFile(constants.MachineConfigDaemonForceFile, []byte(""), 0o600); err != nil {
 			return err
 		}
 	} else if !os.IsNotExist(err) {
@@ -1864,7 +1869,7 @@ func (dn *Daemon) validateOnDiskState(currentConfig *mcfgv1.MachineConfig) error
 	// Be sure we're booted into the OS we expect
 	osMatch := dn.checkOS(currentConfig.Spec.OSImageURL)
 	if !osMatch {
-		return fmt.Errorf("expected target osImageURL %q, have %q", currentConfig.Spec.OSImageURL, dn.bootedOSImageURL)
+		return fmt.Errorf("expected target osImageURL %q, have %q (%q)", currentConfig.Spec.OSImageURL, dn.bootedOSImageURL, dn.bootedOSCommit)
 	}
 
 	if dn.os.IsCoreOSVariant() {
@@ -1888,6 +1893,20 @@ func (dn *Daemon) checkOS(osImageURL string) bool {
 	if !dn.os.IsCoreOSVariant() {
 		glog.Infof(`Not booted into a CoreOS variant, ignoring target OSImageURL %s`, osImageURL)
 		return true
+	}
+
+	// TODO(jkyros): the header for this functions says "if the digests match"
+	// so I'm wondering if at one point this used to work this way....
+	// TODO(jkyros): and pulling it just to check is so expensive, skopeo works now
+	// if you use the --no-tags argument (doesn't pull tags) so we should probably just do that
+	inspection, err := imageInspect(osImageURL)
+	if err != nil {
+		glog.Warningf("Unable to check manifest for matching hash: %s", err)
+	} else if ostreeCommit, ok := inspection.Labels["ostree.commit"]; ok {
+		if ostreeCommit == dn.bootedOSCommit {
+			glog.Infof("We are technically in the right image even if the URL doesn't match (%s == %s)", ostreeCommit, osImageURL)
+			return true
+		}
 	}
 
 	return dn.bootedOSImageURL == osImageURL

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -135,6 +135,13 @@ func (r *RpmOstreeClient) Initialize() error {
 		return err
 	}
 
+	// Commands like update and rebase need the pull secrets to pull images and manifests,
+	// make sure we get access to them when we Initialize
+	err := useKubeletConfigSecrets()
+	if err != nil {
+		return fmt.Errorf("Error while ensuring access to kublet config.json pull secrets: %w", err)
+	}
+
 	return nil
 }
 
@@ -342,13 +349,6 @@ func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
 // RebaseLayered rebases system or errors if already rebased
 func (r *RpmOstreeClient) RebaseLayered(imgURL string) (err error) {
 	glog.Infof("Executing rebase to %s", imgURL)
-
-	// For now, just let ostree use the kublet config.json,
-	err = useKubeletConfigSecrets()
-	if err != nil {
-		return fmt.Errorf("Error while ensuring access to kublet config.json pull secrets: %w", err)
-	}
-
 	return runRpmOstree("rebase", "--experimental", "ostree-unverified-registry:"+imgURL)
 }
 

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestParseVersion(t *testing.T) {
+	verdata := `rpm-ostree:
+  Version: '2022.10'
+  Git: 6b302116c969397fd71899e3b9bb3b8c100d1af9
+  Features:
+   - rust
+   - compose
+   - rhsm
+`
+	var q RpmOstreeVersionData
+	if err := yaml.UnmarshalStrict([]byte(verdata), &q); err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, "2022.10", q.Root.Version)
+	assert.Contains(t, q.Root.Features, "rust")
+	assert.NotContains(t, q.Root.Features, "container")
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2116,15 +2116,14 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		}
 	}
 
-	// TODO(jkyros): We can't currently switch kernels on layered images, so only allow it if they're both default. We'll come back for this when it's supported.
-	// If you did try to switch kernels when using layered image, you would get a "No enabled repositories" error.
-	if !(canonicalizeKernelType(oldConfig.Spec.KernelType) == ctrlcommon.KernelTypeDefault && canonicalizeKernelType(newConfig.Spec.KernelType) == ctrlcommon.KernelTypeDefault) {
-		return fmt.Errorf("Non-default kernels are not currently supported for layered images. (old: %s new %s)", oldConfig.Spec.KernelType, newConfig.Spec.KernelType)
+	// Switch to real time kernel
+	if err := dn.switchKernel(oldConfig, newConfig); err != nil {
+		return err
 	}
 
-	// TODO(jkyros): This is where we will handle Joseph's extensions container
-	if len(newConfig.Spec.Extensions) > 0 {
-		return fmt.Errorf("Extensions are not currently supported with layered images, but extensions were supplied: %s", strings.Join(newConfig.Spec.Extensions, " "))
+	// Apply extensions
+	if err := dn.applyExtensions(oldConfig, newConfig); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -42,9 +42,10 @@ const (
 	// SSH Keys for user "core" will only be written at /home/core/.ssh
 	coreUserSSHPath = "/home/core/.ssh/"
 	// fipsFile is the file to check if FIPS is enabled
-	fipsFile              = "/proc/sys/crypto/fips_enabled"
-	extensionsRepo        = "/etc/yum.repos.d/coreos-extensions.repo"
-	osImageContentBaseDir = "/run/mco-machine-os-content/"
+	fipsFile                   = "/proc/sys/crypto/fips_enabled"
+	extensionsRepo             = "/etc/yum.repos.d/coreos-extensions.repo"
+	osImageContentBaseDir      = "/run/mco-machine-os-content/"
+	osExtensionsContentBaseDir = "/run/mco-extensions/"
 
 	// These are the actions for a node to take after applying config changes. (e.g. a new machineconfig is applied)
 	// "None" means no special action needs to be taken
@@ -238,6 +239,18 @@ func addExtensionsRepo(osImageContentDir string) error {
 	return nil
 }
 
+// addLayeredExtensionsRepo adds a repo into /etc/yum.repos.d/ which we use later to
+// install extensions and rt-kernel. This is separate from addExtensionsRepo because when we're
+// extracting only the extensions container (because with the new format images they are packaged separately),
+// we extract to a different location
+func addLayeredExtensionsRepo(extensionsImageContentDir string) error {
+	repoContent := "[coreos-extensions]\nenabled=1\nmetadata_expire=1m\nbaseurl=" + extensionsImageContentDir + "/usr/share/rpm-ostree/extensions/\ngpgcheck=0\nskip_if_unavailable=False\n"
+	if err := writeFileAtomicallyWithDefaults(extensionsRepo, []byte(repoContent)); err != nil {
+		return err
+	}
+	return nil
+}
+
 // podmanRemove kills and removes a container
 func podmanRemove(cid string) {
 	// Ignore errors here
@@ -318,6 +331,38 @@ func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 		// See https://bugzilla.redhat.com/show_bug.cgi?id=1862979
 		glog.Infof("Falling back to using podman cp to fetch OS image content")
 		if err = podmanCopy(imgURL, osImageContentDir); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// ExtractExtensionsImage extracts the OS extensions content in a temporary directory under /run/machine-os-extensions
+// and returns the path on successful extraction
+func ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, err error) {
+	var registryConfig []string
+	if _, err := os.Stat(kubeletAuthFile); err == nil {
+		registryConfig = append(registryConfig, "--registry-config", kubeletAuthFile)
+	}
+	if err = os.MkdirAll(osExtensionsContentBaseDir, 0o755); err != nil {
+		err = fmt.Errorf("error creating directory %s: %w", osExtensionsContentBaseDir, err)
+		return
+	}
+
+	if osExtensionsImageContentDir, err = ioutil.TempDir(osExtensionsContentBaseDir, "os-extensions-content-"); err != nil {
+		return
+	}
+
+	// Extract the image
+	args := []string{"image", "extract", "--path", "/:" + osExtensionsImageContentDir}
+	args = append(args, registryConfig...)
+	args = append(args, imgURL)
+	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "oc", args...); err != nil {
+		// Workaround fixes for the environment where oc image extract fails.
+		// See https://bugzilla.redhat.com/show_bug.cgi?id=1862979
+		glog.Infof("Falling back to using podman cp to fetch OS image content")
+		if err = podmanCopy(imgURL, osExtensionsImageContentDir); err != nil {
 			return
 		}
 	}
@@ -2074,6 +2119,26 @@ func (dn *Daemon) reboot(rationale string) error {
 }
 
 func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
+
+	var osExtensionsContentDir string
+	var err error
+	if mcDiff.extensions || mcDiff.kernelType {
+
+		// TODO(jkyros): the original intent was that we use the extensions container as a service, but that currently results
+		// in a lot of complexity due to boostrap and firstboot where the service isn't easily available, so for now we are going
+		// to extract them to disk like we did previously.
+		if osExtensionsContentDir, err = ExtractExtensionsImage(newConfig.Spec.BaseOSExtensionsContainerImage); err != nil {
+			return err
+		}
+		// Delete extracted OS image once we are done.
+		defer os.RemoveAll(osExtensionsContentDir)
+
+		if err := addLayeredExtensionsRepo(osExtensionsContentDir); err != nil {
+			return err
+		}
+		defer os.Remove(extensionsRepo)
+	}
+
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateLayeredOS(newConfig); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1922,17 +1922,11 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 		if err != nil {
 			return err
 		}
-		dn.needSecondaryReboot = true
-		// We'll need to do a second reconciliation pass i.e. an extra reboot today, but that won't
-		// be necessary after we ship the newer rpm-ostree into older releases.
-		// See also https://github.com/coreos/rpm-ostree/issues/4018
-		if err := os.WriteFile(constants.MachineConfigDaemonPersistentForceOnceFile, []byte(""), 0o644); err != nil {
-			return err
-		}
-	} else {
-		if err := dn.NodeUpdaterClient.RebaseLayered(newURL); err != nil {
-			return fmt.Errorf("failed to update OS to %s : %w", newURL, err)
-		}
+
+		// TODO(jkyros): we don't need to do anything special here if I teach rpm-ostree this is the same container
+
+	} else if err := dn.NodeUpdaterClient.RebaseLayered(newURL); err != nil {
+		return fmt.Errorf("failed to update OS to %s : %w", newURL, err)
 	}
 
 	return nil

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -139,8 +139,8 @@ func RenderBootstrap(
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
-	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
-	spec.BaseOperatingSystemExtensionsContainer = imgs.BaseOperatingSystemExtensionsContainer
+	spec.BaseOSContainerImage = imgs.BaseOSContainerImage
+	spec.BaseOSExtensionsContainerImage = imgs.BaseOSExtensionsContainerImage
 	spec.ReleaseImage = releaseImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -18,9 +18,9 @@ type RenderConfigImages struct {
 	MachineConfigOperator string `json:"machineConfigOperator"`
 	MachineOSContent      string `json:"machineOSContent"`
 	// The new format image
-	BaseOperatingSystemContainer string `json:"baseOperatingSystemContainer"`
+	BaseOSContainerImage string `json:"baseOSContainerImage"`
 	// The matching extensions container for the new format image
-	BaseOperatingSystemExtensionsContainer string `json:"baseOperatingSystemExtensionsContainer"`
+	BaseOSExtensionsContainerImage string `json:"baseOSExtensionsContainerImage"`
 	// These have to be named differently from the ones in ControllerConfigImages
 	// or we get errors about ambiguous selectors because both structs are
 	// combined in the Images struct.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -260,8 +260,8 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		return err
 	}
 	imgs.MachineOSContent = osimageurl
-	imgs.BaseOperatingSystemContainer = oscontainer
-	imgs.BaseOperatingSystemExtensionsContainer = osextensionscontainer
+	imgs.BaseOSContainerImage = oscontainer
+	imgs.BaseOSExtensionsContainerImage = osextensionscontainer
 
 	// sync up the ControllerConfigSpec
 	infra, network, proxy, dns, err := optr.getGlobalConfig()
@@ -310,8 +310,8 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	spec.RootCAData = bundle
 	spec.PullSecret = &corev1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}
 	spec.OSImageURL = imgs.MachineOSContent
-	spec.BaseOperatingSystemContainer = imgs.BaseOperatingSystemContainer
-	spec.BaseOperatingSystemExtensionsContainer = imgs.BaseOperatingSystemExtensionsContainer
+	spec.BaseOSContainerImage = imgs.BaseOSContainerImage
+	spec.BaseOSExtensionsContainerImage = imgs.BaseOSExtensionsContainerImage
 	spec.Images = map[string]string{
 		templatectrl.MachineConfigOperatorKey: imgs.MachineConfigOperator,
 
@@ -875,9 +875,9 @@ func (optr *Operator) getOsImageURLs(namespace string) (string, string, string, 
 		return "", "", "", fmt.Errorf("refusing to read osImageURL version %q, operator version %q", releaseVersion, optrVersion)
 	}
 
-	newextensions, hasNewExtensions := cm.Data["baseOperatingSystemExtensionsContainer"]
+	newextensions, hasNewExtensions := cm.Data["baseOSExtensionsContainerImage"]
 
-	newformat, hasNewFormat := cm.Data["baseOperatingSystemContainer"]
+	newformat, hasNewFormat := cm.Data["baseOSContainerImage"]
 
 	oldformat, hasOldFormat := cm.Data["osImageURL"]
 
@@ -888,7 +888,7 @@ func (optr *Operator) getOsImageURLs(namespace string) (string, string, string, 
 
 	// If we don't have a new format image, and we can't fall back to the old one
 	if !hasOldFormat && !hasNewFormat {
-		return "", "", "", fmt.Errorf("Missing baseOperatingSystemContainer and osImageURL from configmap")
+		return "", "", "", fmt.Errorf("Missing baseOSContainerImage and osImageURL from configmap")
 	}
 
 	return newformat, newextensions, oldformat, nil


### PR DESCRIPTION


xref https://github.com/coreos/rpm-ostree/commit/89f58028f0bea5b6fa59bdb3506078e09957ec00

On firstboot, the rpm-ostree (and skopeo) running in the system
may be too old to do the native flow.  This hacky bit runs
the new OS image *as a container*, and reboots another time before
doing anything else.

