### PR TITLE
OCPNODE-1146 Add cgroup confiuration support in MCO

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -22,7 +22,9 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			return nil, err
 		}
 	}
-
+	if nodeConfig == nil {
+		nodeConfig = createNewDefaultNodeconfig()
+	}
 	for _, kubeletConfig := range kubeletConfigs {
 		// use selector since label matching part of a KubeletConfig is not handled during the bootstrap
 		selector, err := metav1.LabelSelectorAsSelector(kubeletConfig.Spec.MachineConfigPoolSelector)
@@ -44,9 +46,6 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			}
 			// updating the originalKubeConfig based on the nodeConfig on a worker node
 			if role == ctrlcommon.MachineConfigPoolWorker {
-				if nodeConfig == nil {
-					nodeConfig = createNewDefaultNodeconfig()
-				}
 				updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
 			}
 			if kubeletConfig.Spec.TLSSecurityProfile != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -535,9 +535,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 	nodeConfig, err := ctrl.nodeConfigLister.Get(ctrlcommon.ClusterNodeInstanceName)
 	if macherrors.IsNotFound(err) {
 		nodeConfig = createNewDefaultNodeconfig()
-	} else if err != nil {
-		err := fmt.Errorf("could not fetch Node: %v", err)
-		return ctrl.syncStatusOnly(cfg, err)
 	}
 
 	for _, pool := range mcpPools {
@@ -574,6 +571,10 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		// updating the originalKubeConfig based on the nodeConfig on a worker node
 		if role == ctrlcommon.MachineConfigPoolWorker {
 			updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
+		}
+		// updating the machine config resource with the relevant cgroup configuration
+		if isTechPreviewNoUpgradeEnabled(features) {
+			updateMachineConfigwithCgroup(nodeConfig, mc)
 		}
 
 		// Get the default API Server Security Profile

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -67,19 +67,13 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 	}()
 
 	// Fetch the Feature Gates
-	features, err := ctrl.featLister.Get(ctrlcommon.ClusterFeatureInstanceName)
-	if errors.IsNotFound(err) {
-		glog.V(2).Infof("Using the default featuregates")
-		features = createNewDefaultFeatureGate()
-	} else if err != nil {
+	features, err := getFeatures(ctrl)
+	if err != nil {
 		return err
 	}
 	// Fetch the Node
-	nodeConfig, err := ctrl.nodeConfigLister.Get(ctrlcommon.ClusterNodeInstanceName)
-	if errors.IsNotFound(err) {
-		glog.V(2).Infof("Node configuration %v is missing", key)
-		return fmt.Errorf("missing node configuration, key: %v", key)
-	} else if err != nil {
+	nodeConfig, err := getConfigNode(ctrl, key)
+	if err != nil {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
@@ -97,10 +91,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 
 	for _, pool := range mcpPools {
 		role := pool.Name
-		// the workerlatencyprofile's configuration change will be applied only on the worker nodes.
-		if role != ctrlcommon.MachineConfigPoolWorker {
-			continue
-		}
 		// Get MachineConfig
 		key, err := getManagedNodeConfigKey(pool, ctrl.client)
 		if err != nil {
@@ -127,10 +117,27 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		if err != nil {
 			return err
 		}
-		// updating the kubelet configuration with the Node specific configuration.
-		err = updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
-		if err != nil {
-			return err
+		// the workerlatencyprofile's configuration change will be applied only on the worker nodes.
+		if role == ctrlcommon.MachineConfigPoolWorker {
+			// updating the kubelet configuration with the Node specific configuration.
+			err = updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
+			if err != nil {
+				return err
+			}
+		}
+		if isTechPreviewNoUpgradeEnabled(features) {
+			if nodeConfig.Spec.CgroupMode == "" && nodeConfig.Spec.WorkerLatencyProfile != "" && role == ctrlcommon.MachineConfigPoolMaster {
+				continue
+			}
+			// updating the machine config resource with the relevant cgroup configuration
+			err := updateMachineConfigwithCgroup(nodeConfig, mc)
+			if err != nil {
+				return err
+			}
+		} else if nodeConfig.Spec.WorkerLatencyProfile == "" {
+			return nil
+		} else if role == ctrlcommon.MachineConfigPoolMaster {
+			continue
 		}
 		// Encode the new config into raw JSON
 		cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)
@@ -267,9 +274,6 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 
 	for _, pool := range mcpPools {
 		role := pool.Name
-		if role != ctrlcommon.MachineConfigPoolWorker {
-			continue
-		}
 		// Get MachineConfig
 		key, err := getManagedNodeConfigKey(pool, nil)
 		if err != nil {
@@ -284,10 +288,27 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 		if err != nil {
 			return nil, err
 		}
-		// updating the kubelet configuration with the Node specific configuration.
-		err = updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
-		if err != nil {
-			return nil, err
+		if role == ctrlcommon.MachineConfigPoolWorker {
+			// updating the kubelet configuration with the Node specific configuration.
+			err = updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
+		// updating the machine config resource with the relevant cgroup configuration
+		if isTechPreviewNoUpgradeEnabled(features) {
+			if nodeConfig.Spec.CgroupMode == "" && nodeConfig.Spec.WorkerLatencyProfile != "" && role == ctrlcommon.MachineConfigPoolMaster {
+				continue
+			}
+			// updating the machine config resource with the relevant cgroup configuration
+			err := updateMachineConfigwithCgroup(nodeConfig, mc)
+			if err != nil {
+				return nil, err
+			}
+		} else if nodeConfig.Spec.WorkerLatencyProfile == "" {
+			return nil, nil
+		} else if role == ctrlcommon.MachineConfigPoolMaster {
+			continue
 		}
 		// Encode the new config into raw JSON
 		cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -158,6 +158,38 @@ spec:
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
 		},
 		{
+			name: "With a featuregate manifest and a config node manifest",
+			manifests: [][]byte{
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade`),
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  cgroupMode: "v2"`),
+			},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
+		},
+		{
+			name: "With a config node manifest and without a featuregate manifest",
+			manifests: [][]byte{
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  cgroupMode: "v2"`),
+			},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
+		},
+		{
 			name: "With a node config manifest and master kubelet config manifest",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1


### PR DESCRIPTION
Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added the code to modify the cgroup configuration on all the nodes based on the user provided input of the [cgroupMode](https://github.com/openshift/api/blob/master/config/v1/types_node.go#L36) in the nodes.config.openshift.io custom resource.

**- How to verify it**
By default the `cgroupv1` is enabled on all the nodes of an OCP cluster. Edit the `cgroupMode` field of the `nodes.config.openshift.io` custom resource's `spec` and observe the following kernel arguments appended in the newly created machine config object.
```
kernelArguments:
  - systemd.unified_cgroup_hierarchy=1
  - cgroup_no_v1="all"
  - psi=1
```
Also observe the `cgroupv2` output when the following command is run inside any node.
```
sh-4.4# stat -c %T -f /sys/fs/cgroup/
cgroup2fs
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added support to enable `cgroupv2` configuration on all the nodes of an OCP cluster.