### PR TITLE
[WIP] Attempt at feature-gating the default image choice

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -157,6 +157,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+			ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
 			ctx.ClientBuilder.KubeClientOrDie("render-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("render-controller"),
 		),

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -183,7 +183,7 @@ func (b *Bootstrap) Run(destDir string) error {
 		configs = append(configs, kconfigs...)
 	}
 
-	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig)
+	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig, featureGate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -294,7 +294,10 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 		return nil, fmt.Errorf("error creating MachineConfig from Ignition config: %w", err)
 	}
 	// And inject the osimageurl here
-	mcfg.Spec.OSImageURL = config.OSImageURL
+	// TODO(jkyros): if we include this here, we can't tell if a user did it or not, it bites us when we're
+	// trying to switch between oldformat/newformat. We can safely exclude it because it gets superceded by what's in
+	// controllerconfig when we merge configs anyway
+	//mcfg.Spec.OSImageURL = config.OSImageURL
 
 	return mcfg, nil
 }


### PR DESCRIPTION
- I was trying to find a good way to "soft" gate the default behavior of defaulting to the new format image ( per https://github.com/openshift/machine-config-operator/pull/3258)
- It occurred to me that it needed to be gated both during bootstrap and during live operation and I was basically re-implementing feature gates poorly, so I figured maybe I should just try to use them.  

- This is just trying to see what it feels like to have the controller bootstrap and "live" render controller react to feature gates. 

- I thought about just pushing the featuregates into controllerconfig (they currently only make it into renderconfig right now), but: 
  - some of our other controllers already look directly at the feature gates
  - we'd have to weirdly merge featuregates also into controllerconfig during bootstrap
  - so I shied away from doing that unless we want to decide something like "controllers will always read featuregates from controllerconfig".  

- I think I'm probably"cheating" by "soft" using featuregates since I don't actually require a featureset be enabled

This does seem to work though -- if you set the featuregate at installtime (e.g. `openshift-install create manifests` and putting something like 
```apiVersion: config.openshift.io/v1
kind: FeatureGate
metadata:
  name: cluster
spec:
  customNoUpgrade:
    enabled:
    - MCONewContainerImageFormat
```
 in the manifests folder. 