### PR TITLE
OCPBUGS-642: Fix .ssh directory not owned by core when created by Machine Config Daemon

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1722,6 +1722,15 @@ func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
 	glog.Infof("Writing SSHKeys at %q", authKeyPath)
 
+	// Creating coreUserSSHPath in advance if it doesn't exist in order to ensure it is owned by core user
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=2107113
+	if _, err := os.Stat(coreUserSSHPath); os.IsNotExist(err) {
+		mkdirCoreCommand := exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", coreUserSSHPath)
+		if err := mkdirCoreCommand.Run(); err != nil {
+			return err
+		}
+	}
+
 	if err := writeFileAtomically(authKeyPath, []byte(keys), os.FileMode(0700), os.FileMode(0600), uid, gid); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes: OCPBUGS-642 (release-4.10 backport of BZ#2107113)

- What I did: Create the `~core/.ssh` directory in advance if it didn't previously exist and chown it to `core` user
- How to verify it: Create a cluster without SSH keys and configure those via machine-config post-install. Before fix, `~core/.ssh` user was owned by `root`, with this fix, it is owned by `core` user as expected
- Description for the changelog: Fix .ssh directory not owned by core when created by Machine Config Daemon

