### PR TITLE
OCPBUGS-631: Pull container image as a separate step

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -49,6 +49,10 @@ contents:
             cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
         fi
 
+        # Pull container image outside of the timeout to workaround possible
+        # image corruption
+        # https://github.com/containers/podman/issues/14003
+        /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}
 
         NAMESERVER_IP=$(timeout 20s /usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \


### PR DESCRIPTION
In order to avoid a podman issue [1] causing a layer corruption when an
image pull is killed midway, let's move the image pull outside of the
timeout command.

The timeout was recently reduced to 20 seconds with [2] making the issue
more likely to happen.

[1] https://github.com/containers/podman/issues/14003
[2] https://github.com/openshift/machine-config-operator/pull/3271