### PR TITLE
Hypershift: remove error message on return

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -223,9 +223,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		if err := dn.RunHypershift(stopCh, exitCh); err != nil {
 			ctrlcommon.WriteTerminationError(err)
 		}
-
-		// We shouldn't ever get here
-		glog.Fatalf("Unexpected error, hypershift mode state machine returned: %v", err)
+		return
 	}
 
 	// Start local metrics listener


### PR DESCRIPTION
This will return when the pod terminates, so no reason to have a confusing error message here when its not an error.