### PR TITLE
TRT-540: Add privileged label to infra namespaces

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -28,6 +28,10 @@ metadata:
   labels:
     name: openshift-openstack-infra
     openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
 ---
 apiVersion: v1
 kind: Namespace
@@ -41,6 +45,10 @@ metadata:
   labels:
     name: openshift-kni-infra
     openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
 ---
 apiVersion: v1
 kind: Namespace
@@ -54,6 +62,10 @@ metadata:
   labels:
     name: openshift-ovirt-infra
     openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
 ---
 apiVersion: v1
 kind: Namespace
@@ -67,6 +79,10 @@ metadata:
   labels:
     name: openshift-vsphere-infra
     openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
 ---
 apiVersion: v1
 kind: Namespace
@@ -80,4 +96,8 @@ metadata:
   labels:
     name: openshift-nutanix-infra
     openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
 


### PR DESCRIPTION
This has been affecting kubelet creating mirror pods for keepalived, haproxy etc.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add privileged labels to infra namespaces.

**- How to verify it**
Kubelet logs should not have errors about "Failed creating a mirror pod for .... is forbidden: violates PodSecurity" error. 

**- Description for the changelog**
Since this PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1369, many pods are affected and fail to create. The infra namespaces are affecting kubelets. The following are some sample errors. 

```
Sep 02 14:02:06.914534 hckrs6pg-c805c-7czxl-master-0.novalocal kubenswrapper[1782]: E0902 14:02:06.914490    1782 kubelet.go:1713] "Failed creating a mirror pod for" err="pods \"keepalived-hckrs6pg-c805c-7czxl-master-0{color}" is forbidden: violates PodSecurity \"restricted:latest\": host namespaces (hostNetwork=true), privileged (containers \"keepalived\", \"keepalived-monitor\" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (containers \"render-config-keepalived\", \"keepalived\", \"keepalived-monitor\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers \"render-config-keepalived\", \"keepalived\", \"keepalived-monitor\" must set securityContext.capabilities.drop=[\"ALL\"]), restricted volume types (volumes \"resource-dir\", \"script-dir\", \"kubeconfig\", \"kubeconfigvarlib\", \"conf-dir\", \"chroot-host\" use restricted volume type \"hostPath\"), runAsNonRoot != true (pod or containers \"render-config-keepalived\", \"keepalived\", \"keepalived-monitor\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers \"render-config-keepalived\", \"keepalived\", \"keepalived-monitor\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")" pod="openshift-openstack-infra/keepalived-hckrs6pg-c805c-7czxl-master-0"

Sep 02 14:02:37.926925 hckrs6pg-c805c-7czxl-master-0.novalocal kubenswrapper[1782]: E0902 14:02:37.925692    1782 kubelet.go:1713] "Failed creating a mirror pod for" err="pods \"coredns-hckrs6pg-c805c-7czxl-master-0{color}" is forbidden: violates PodSecurity \"restricted:latest\": host namespaces (hostNetwork=true), privileged (containers \"coredns\", \"coredns-monitor\" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (containers \"render-config-coredns\", \"coredns\", \"coredns-monitor\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers \"render-config-coredns\", \"coredns\", \"coredns-monitor\" must set securityContext.capabilities.drop=[\"ALL\"]), restricted volume types (volumes \"resource-dir\", \"kubeconfig\", \"conf-dir\", \"nm-resolv\" use restricted volume type \"hostPath\"), runAsNonRoot != true (pod or containers \"render-config-coredns\", \"coredns\", \"coredns-monitor\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers \"render-config-coredns\", \"coredns\", \"coredns-monitor\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")" pod="openshift-openstack-infra/coredns-hckrs6pg-c805c-7czxl-master-0"

Sep 02 14:03:04.918144 hckrs6pg-c805c-7czxl-master-0.novalocal kubenswrapper[1782]: E0902 14:03:04.918067    1782 kubelet.go:1713] "Failed creating a mirror pod for" err="pods \"haproxy-hckrs6pg-c805c-7czxl-master-0{color}" is forbidden: violates PodSecurity \"restricted:latest\": host namespaces (hostNetwork=true), privileged (container \"haproxy-monitor\" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (containers \"verify-api-int-resolvable\", \"haproxy\", \"haproxy-monitor\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers \"verify-api-int-resolvable\", \"haproxy\", \"haproxy-monitor\" must set securityContext.capabilities.drop=[\"ALL\"]), restricted volume types (volumes \"resource-dir\", \"kubeconfigvarlib\", \"conf-dir\", \"chroot-host\" use restricted volume type \"hostPath\"), runAsNonRoot != true (pod or containers \"verify-api-int-resolvable\", \"haproxy\", \"haproxy-monitor\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers \"verify-api-int-resolvable\", \"haproxy\", \"haproxy-monitor\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")" pod="openshift-openstack-infra/haproxy-hckrs6pg-c805c-7czxl-master-0"
```

You can see the error in this job run: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-shiftstack-shiftstack-ci-main-periodic-4.12-e2e-openstack-serial/1567141456282390528/artifacts/e2e-openstack-serial/gather-extra/artifacts/nodes/c1fh9587-c805c-lqm8z-master-0/journal