### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12

### DIFF
--- a/install/0000_80_machine-config-operator_02_containerruntimeconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_02_containerruntimeconfig.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec:
   group: machineconfiguration.openshift.io
   names:


### PR DESCRIPTION
This was added in https://github.com/openshift/cluster-version-operator/pull/821 to allow more featuresets and allow for a future migration to include actual gates.  Because usage of this manifest would prevent upgrades, there are not upgrade concerns for this change.

/cc @wking