### PR TITLE
Bug 2056387: fix alibaba kubelet node name unit

### DIFF
--- a/templates/common/alibabacloud/files/usr-local-bin-alibaba-kubelet-nodename.yaml
+++ b/templates/common/alibabacloud/files/usr-local-bin-alibaba-kubelet-nodename.yaml
@@ -3,12 +3,12 @@ path: "/usr/local/bin/alibaba-kubelet-nodename"
 contents:
   inline: |
     #!/bin/bash
-    set -e -o pipefail
+    set -euo pipefail
 
-    NODECONF=/etc/systemd/system/kubelet.service.d/20-alibaba-node-name.conf
+    ENV_FILE=/run/kubelet-alibaba.env
 
-    if [ -e "${NODECONF}" ]; then
-        echo "Not replacing existing ${NODECONF}"
+    if [ -e "${ENV_FILE}" ]; then
+        echo "Not replacing existing ${ENV_FILE}"
         exit 0
     fi
     
@@ -20,7 +20,6 @@ contents:
     INSTANCEID=$(curl -s ${META_EP}/instance-id)
 
    
-    cat > "${NODECONF}" <<EOF
-    [Service]
-    Environment="KUBELET_NODE_NAME=${REGIONID}.${INSTANCEID}"
+    cat > "${ENV_FILE}" <<EOF
+    KUBELET_NODE_NAME=${REGIONID}.${INSTANCEID}
     EOF

--- a/templates/common/alibabacloud/files/usr-local-lib-systemd-system-generators-alibaba-kubelet-extra-env-generator.sh.yaml
+++ b/templates/common/alibabacloud/files/usr-local-lib-systemd-system-generators-alibaba-kubelet-extra-env-generator.sh.yaml
@@ -1,0 +1,31 @@
+mode: 0755
+path: "/usr/local/lib/systemd/system-generators/alibaba-kubelet-extra-env-generator.sh"
+contents:
+  inline: |
+    #!/bin/sh
+    set -euo pipefail
+
+    # This systemd.generator(7) determines the alibaba nodename and sets
+    # it as a variable for the kubelet.service unit file.
+    #
+    # Place in /usr/local/lib/systemd/system-generators
+
+    # Generators don't have logging right now
+    # https://github.com/systemd/systemd/issues/15638
+    exec 1>/dev/kmsg; exec 2>&1
+
+    # If invoked with no arguments (for testing) write to /tmp.
+    earlydir="/tmp"
+    if [ -n "$2" ]; then
+        earlydir="$2"
+    fi
+
+    kubelet_service_d_dir="$earlydir/kubelet.service.d"
+    node_env="$kubelet_service_d_dir/alibaba-extra-env.conf"
+
+    mkdir -p "$kubelet_service_d_dir"
+
+    # This must NOT be a here-document otherwise this script will generate this error:
+    #   alibaba-kubelet-extra-env-generator.sh: cannot create temp file for here-document: Read-only file system
+
+    echo -e "[Service]\nEnvironmentFile=/run/kubelet-alibaba.env" > "${node_env}"


### PR DESCRIPTION
**- What I did**
- [x] Change usr-local-bin-alibaba-kubelet-nodename to generate a
       systemd environment file. This fixes bug 2056387 systemctl
       daemon-reload to alibaba-kubelet-nodename.service.yaml.
- [x] Add a systemd generator so that the kubelet.service will source
       the env file generated by usr-local-bin-alibaba-kubelet-nodename.
- [x] Test the new unit file fixes bug 2056387.


Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2056387

**- How to verify it**
1. Ensure the file gets placed: /usr/local/bin/alibaba-kubelet-nodename
1. Ensure the file gets placed: /usr/local/lib/systemd/system-generators/alibaba-kubelet-extra-env-generator.sh
1. Reload systemd with "systemctl daemon-reload"
1. Ensure that kubelet.service now lists a generator with "systemctl status kubelet". Should look something like:
```
● kubelet.service - Kubernetes Kubelet
   Loaded: loaded (/etc/systemd/system/kubelet.service; enabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/kubelet.service.d
           └─10-mco-default-madv.conf, 20-logging.conf
           /run/systemd/generator.early/kubelet.service.d
           └─alibaba-extra-env.conf
```

Additionally, try adding a rhel node to an existing cluster on Alibaba by adapting these instructions:
https://docs.openshift.com/container-platform/4.11/machine_management/adding-rhel-compute.html

**- Description for the changelog**
Changed /usr/local/bin/alibaba-kubelet-nodename to output and env file and added a generator so that kubelet.service consumes that env file.