### PR TITLE
OCPBUGS-1257: Have keepalived check for haproxy status for API VIP

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -16,6 +16,7 @@ contents:
       timeout client       86400s
       timeout server       86400s
       timeout tunnel       86400s
+    {{`{{- if gt (len .LBConfig.Backends) 0 }}`}}
     frontend  main
       bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
       default_backend masters
@@ -24,6 +25,7 @@ contents:
       mode http
       monitor-uri /haproxy_ready
       option dontlognull
+    {{`{{- end }}`}}
     listen stats
       bind localhost:{{`{{ .LBConfig.StatPort }}`}}
       mode http

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -10,14 +10,14 @@ contents:
     }
 
     # These are separate checks to provide the following behavior:
-    # If the loadbalanced endpoint is responding then all is well regardless
-    # of what the local api status is. Both checks will return success and
+    # If the loadbalancer is healthy then all is well regardless
+    # of what the local API status is. Both checks will return success and
     # we'll have the maximum priority. This means as long as there is a node
     # with a functional loadbalancer it will get the VIP.
-    # If all of the loadbalancers go down but the local api is still running,
+    # If all of the loadbalancers go down but the local API is still running,
     # the _both check will still succeed and allow any node with a functional
-    # api to take the VIP. This isn't preferred because it means all api
-    # traffic will go through one node, but at least it keeps the api available.
+    # API to take the VIP. This isn't preferred because it means all API
+    # traffic will go through one node, but at least it keeps the API available.
     vrrp_script chk_ocp_lb {
         script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script.sh"
         interval 2

--- a/templates/master/00-master/on-prem/files/keepalived-script-both.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-script-both.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script_bo
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:{{`{{ .LBConfig.LbPort }}`}}/readyz && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz

--- a/templates/master/00-master/on-prem/files/keepalived-script.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-script.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script.sh
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:{{`{{ .LBConfig.LbPort }}`}}/readyz && [ -e /var/run/keepalived/iptables-rule-exists ]
+    /usr/bin/curl -o /dev/null -kLfs https://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ]


### PR DESCRIPTION
Keepalived was wrongly checking the status of the load-balanced
kube-apiserver, overstepping over HAProxy's responsibility.
Keepalived is responsible for moving the API VIP to a node where HAProxy
is functioning correctly. As a consequence, it should be checking for
the local HAProxy's readiness.

The previous check would make a request to the local API port, effectively
testing that the local HAProxy was correctly distributing traffic,
however, this check could fail if the selected API server was able to
handle the request, unnecessarily forcing a VIP failover.

This becomes important during recovery from an outage. When none of the
kube-apiservers are healthy this health check will fail continuously,
and the API VIP will move uselessly between masters. However the
situation is much worse when only one of the kube-apiservers is up. In
this case there is a high probability that it is overloaded and at least
rate limiting incoming connections. This may lead us to fail the
keepalived health check and fail the VIP over to the next HAProxy. This
will cause all open kube-apiserver connections to reset, even the
established ones. This increases the load on the kube-apiserver and
increases the probability that the health check will fail again.

This commit changes the keepalived API VIP check to look at the
readiness of HAProxy via it's monitoring interface.