### PR TITLE
[on-prem]: Add missing bits for dual-stack ingress VIPs

### DIFF
--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -27,9 +27,10 @@ contents:
         fall 2
     }
 
+    {{`{{ range $i, $config := .Configs }}`}}
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
 
-    vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS_{{`{{$i}}`}} {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
         virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
@@ -57,3 +58,4 @@ contents:
             chk_default_ingress
         }
     }
+    {{`{{ end }}`}}


### PR DESCRIPTION
The keepalived config template change for workers was missing from https://github.com/openshift/machine-config-operator/pull/3269. This adds it.