### PR TITLE
OCPBUGS-1565: Prevent possible split-brain scenario with keepalived unicast

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -57,6 +57,16 @@ contents:
     {{`{{ range $i, $config := .Configs }}`}}
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
 
+    {{`{{$participateInAPIVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .LBConfig.Backends}}
+    {{- if eq $nonVirtualIP .Address}}
+    {{$participateInAPIVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInAPIVRPP}}`}}
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API_{{`{{$i}}`}} {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -85,7 +95,18 @@ contents:
             chk_ocp_both
         }
     }
+    {{`{{end}}`}}
 
+    {{`{{$participateInIngressVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .IngressConfig.Peers}}
+    {{- if eq $nonVirtualIP .}}
+    {{$participateInIngressVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInIngressVRPP}}`}}
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS_{{`{{$i}}`}} {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -114,4 +135,5 @@ contents:
             chk_default_ingress
         }
     }
+    {{`{{ end }}`}}
     {{`{{ end }}`}}

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -30,6 +30,16 @@ contents:
     {{`{{ range $i, $config := .Configs }}`}}
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
 
+    {{`{{$participateInIngressVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .IngressConfig.Peers}}
+    {{- if eq $nonVirtualIP .}}
+    {{$participateInIngressVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInIngressVRPP}}`}}
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS_{{`{{$i}}`}} {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -58,4 +68,5 @@ contents:
             chk_default_ingress
         }
     }
+    {{`{{ end }}`}}
     {{`{{ end }}`}}


### PR DESCRIPTION
Ensure that nodes that don't appear in the list of possible peers do not
participate in VRRP, as it would cause a split-brain scenario where
nodes would be fighting for the VIP.

Nodes that failed to register with the cluster but still participate in
VRRP believe they are the master (not receiving VRRP from other nodes),
and other nodes constantly re-electing a master, since they receive VRRP
from the rogue nodes claiming they own the VIP.