### PR TITLE
metrics: Add metric for OS image override

### DIFF
--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -22,8 +22,16 @@ var (
 			Help: "Set to the unix timestamp in utc of the current certificate expiry date if a certificate rotation is pending in specified paused pool",
 		}, []string{"pool"})
 
+	// OSImageURLOverride tells whether cluster is using default OS image or has been overridden by user
+	OSImageURLOverride = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "os_image_url_override",
+			Help: "state of OS image override",
+		}, []string{"pool"})
+
 	metricsList = []prometheus.Collector{
 		MachineConfigControllerPausedPoolKubeletCA,
+		OSImageURLOverride,
 	}
 )
 

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -487,9 +487,13 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		return err
 	}
 
-	// Emit an event so it's more visible that OSImageURL was overridden.
+	// Emit event and collect metric when OSImageURL was overridden.
 	if generated.Spec.OSImageURL != cc.Spec.OSImageURL {
+		ctrlcommon.OSImageURLOverride.WithLabelValues(pool.Name).Set(1)
 		ctrl.eventRecorder.Eventf(generated, corev1.EventTypeNormal, "OSImageURLOverridden", "OSImageURL was overridden via machineconfig in %s (was: %s is: %s)", generated.Name, cc.Spec.OSImageURL, generated.Spec.OSImageURL)
+	} else {
+		// Reset metric when OSImageURL has not been overridden
+		ctrlcommon.OSImageURLOverride.WithLabelValues(pool.Name).Set(0)
 	}
 
 	source := []corev1.ObjectReference{}


### PR DESCRIPTION
Adding os_image_url_override metric to gather data on whether a cluster is overriding the default OS image.