### PR TITLE
OCPBUGS-1616: Revert "Merge pull request #3311 from sairameshv/cgroupv2"

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/imdario/mergo"
 	osev1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,11 +23,6 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
-)
-
-const (
-	emptyInput      = ""
-	cgroupv2Feature = "CGroupsV2"
 )
 
 func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, userDefinedSystemReserved map[string]string) *ign3types.File {
@@ -99,26 +93,6 @@ func createNewDefaultNodeconfig() *osev1.Node {
 	}
 }
 
-func getFeatures(ctrl *Controller) (*osev1.FeatureGate, error) {
-	features, err := ctrl.featLister.Get(ctrlcommon.ClusterFeatureInstanceName)
-	if errors.IsNotFound(err) {
-		features = createNewDefaultFeatureGate()
-	} else if err != nil {
-		return nil, err
-	}
-	return features, nil
-}
-
-func getConfigNode(ctrl *Controller, key string) (*osev1.Node, error) {
-	nodeConfig, err := ctrl.nodeConfigLister.Get(ctrlcommon.ClusterNodeInstanceName)
-	if errors.IsNotFound(err) {
-		return nil, fmt.Errorf("missing node configuration, key: %v", key)
-	} else if err != nil {
-		return nil, err
-	}
-	return nodeConfig, nil
-}
-
 // updateOriginalKubeConfigwithNodeConfig updates the original Kubelet Configuration based on the Nodespecific configuration
 func updateOriginalKubeConfigwithNodeConfig(node *osev1.Node, originalKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
 	if node == nil {
@@ -136,83 +110,10 @@ func updateOriginalKubeConfigwithNodeConfig(node *osev1.Node, originalKubeletCon
 		originalKubeletConfig.NodeStatusUpdateFrequency = metav1.Duration{Duration: osev1.LowNodeStatusUpdateFrequency}
 	case osev1.DefaultUpdateDefaultReaction:
 		originalKubeletConfig.NodeStatusUpdateFrequency = metav1.Duration{Duration: osev1.DefaultNodeStatusUpdateFrequency}
-	case emptyInput:
-		return nil
 	default:
 		return fmt.Errorf("unknown worker latency profile type found %v, failed to update the original kubelet configuration", node.Spec.WorkerLatencyProfile)
 	}
 	// The kubelet configuration can be updated based on the cgroupmode as well here.
-	return nil
-}
-
-// isTechPreviewNoUpgradeEnabled returns a boolean accordingly if a feature is enabled
-// (TODO) This can be generically used in future by passing any feature as an argument.
-func isTechPreviewNoUpgradeEnabled(features *osev1.FeatureGate) bool {
-	if features == nil {
-		return false
-	}
-	if features.Spec.FeatureGateSelection.FeatureSet == osev1.TechPreviewNoUpgrade {
-		featureSet, ok := osev1.FeatureSets[osev1.TechPreviewNoUpgrade]
-		if !ok {
-			return false
-		}
-		for _, val := range featureSet.Enabled {
-			if val == cgroupv2Feature {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// updateMachineConfigwithCgroup updates the Machine Config object based on the cgroup mode present in the Config Node resource.
-func updateMachineConfigwithCgroup(node *osev1.Node, mc *mcfgv1.MachineConfig) error {
-	if node == nil {
-		return fmt.Errorf("node configuration not found, failed to update the machine config with the cgroup information")
-	}
-	if reflect.DeepEqual(node.Spec, osev1.NodeSpec{}) {
-		return fmt.Errorf("empty config node resource spec found")
-	}
-	if mc == nil || reflect.DeepEqual(mc.Spec, mcfgv1.MachineConfigSpec{}) {
-		return fmt.Errorf("machine config not found, failed to update the machine config with the cgroup information")
-	}
-	// updating the Machine Config resource with the relevant cgroup config
-	var (
-		kernelArgsv1       = []string{"systemd.unified_cgroup_hierarchy=0", "systemd.legacy_systemd_cgroup_controller=1"}
-		kernelArgsv2       = []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"}
-		kernelArgstoRemove []string
-		kernelArgstoAdd    []string
-	)
-	switch node.Spec.CgroupMode {
-	case osev1.CgroupModeV1:
-		kernelArgstoAdd = append(kernelArgstoAdd, kernelArgsv1...)
-		kernelArgstoRemove = append(kernelArgstoRemove, kernelArgsv2...)
-	case osev1.CgroupModeV2:
-		kernelArgstoAdd = append(kernelArgstoAdd, kernelArgsv2...)
-		kernelArgstoRemove = append(kernelArgstoRemove, kernelArgsv1...)
-	case emptyInput:
-		return nil
-	default:
-		return fmt.Errorf("unknown cgroup mode found %v, failed to update the machine config resource", node.Spec.CgroupMode)
-	}
-	for _, arg := range kernelArgstoRemove {
-		for key, value := range mc.Spec.KernelArguments {
-			if arg == value {
-				mc.Spec.KernelArguments = append(mc.Spec.KernelArguments[:key], mc.Spec.KernelArguments[key+1:]...)
-			}
-		}
-	}
-	for _, arg := range kernelArgstoAdd {
-		var present bool
-		for _, value := range mc.Spec.KernelArguments {
-			if arg == value {
-				present = true
-			}
-		}
-		if !present {
-			mc.Spec.KernelArguments = append(mc.Spec.KernelArguments, arg)
-		}
-	}
 	return nil
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -22,9 +22,7 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			return nil, err
 		}
 	}
-	if nodeConfig == nil {
-		nodeConfig = createNewDefaultNodeconfig()
-	}
+
 	for _, kubeletConfig := range kubeletConfigs {
 		// use selector since label matching part of a KubeletConfig is not handled during the bootstrap
 		selector, err := metav1.LabelSelectorAsSelector(kubeletConfig.Spec.MachineConfigPoolSelector)
@@ -46,6 +44,9 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			}
 			// updating the originalKubeConfig based on the nodeConfig on a worker node
 			if role == ctrlcommon.MachineConfigPoolWorker {
+				if nodeConfig == nil {
+					nodeConfig = createNewDefaultNodeconfig()
+				}
 				updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
 			}
 			if kubeletConfig.Spec.TLSSecurityProfile != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -535,6 +535,9 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 	nodeConfig, err := ctrl.nodeConfigLister.Get(ctrlcommon.ClusterNodeInstanceName)
 	if macherrors.IsNotFound(err) {
 		nodeConfig = createNewDefaultNodeconfig()
+	} else if err != nil {
+		err := fmt.Errorf("could not fetch Node: %v", err)
+		return ctrl.syncStatusOnly(cfg, err)
 	}
 
 	for _, pool := range mcpPools {
@@ -571,10 +574,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		// updating the originalKubeConfig based on the nodeConfig on a worker node
 		if role == ctrlcommon.MachineConfigPoolWorker {
 			updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
-		}
-		// updating the machine config resource with the relevant cgroup configuration
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
 		}
 
 		// Get the default API Server Security Profile

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -158,38 +158,6 @@ spec:
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
 		},
 		{
-			name: "With a featuregate manifest and a config node manifest",
-			manifests: [][]byte{
-				[]byte(`apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: TechPreviewNoUpgrade`),
-				[]byte(`apiVersion: config.openshift.io/v1
-kind: Node
-metadata:
-  name: cluster
-spec:
-  cgroupMode: "v2"`),
-			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
-		},
-		{
-			name: "With a config node manifest and without a featuregate manifest",
-			manifests: [][]byte{
-				[]byte(`apiVersion: config.openshift.io/v1
-kind: Node
-metadata:
-  name: cluster
-spec:
-  cgroupMode: "v2"`),
-			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
-		},
-		{
 			name: "With a node config manifest and master kubelet config manifest",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1


### PR DESCRIPTION
This reverts commit a627415c240b4c7dd2f9e90f659690d9c0f623f3, reversing changes made to 26eaa2c19b8d0434de7eca9f2c3806ef7fc9f05a.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Reverting the change so as to fix the CI failures for now.
**- How to verify it**

**- Description for the changelog**
Fixes: https://issues.redhat.com/browse/OCPBUGS-1616
1. The changes are breaking the techpreview CI jobs.
2. The rendered configs in bootstrap and the controller generated differ by the config Node changes
    like nodeStatusUpdate frequency and the kernel arguments to enable the cgroupv2 mode.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
