### PR TITLE
Rename KUBELET_NODEIP_HINT to just NODEIP_HINT

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -27,7 +27,7 @@ contents: |
     --prefer-ipv6 \
     {{end -}}
     --retry-on-failure \
-    $KUBELET_NODEIP_HINT; \
+    ${NODEIP_HINT:-${KUBELET_NODEIP_HINT:-}}; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
Per the design discussed in
https://github.com/openshift/enhancements/pull/1179 we are going to use this hint variable for more than just Kubelet IP selection, so it makes more sense for it to have a non-service-specific name.

This changes the variable reference so it will initially look for $NODEIP_HINT, and failing that it will fall back to the previous name $KUBELET_NODEIP_HINT. Note that the old name was never formally documented because it was only intended to be used in exceptional cases. This new name will be included in the official documentation, but we maintain compatibility with the old name to avoid breaking existing users on upgrade.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Renamed KUBELET_NODEIP_HINT to NODEIP_HINT, while maintaining compatibility with the old name
