### PR TITLE
Dockerfile: Remove SCOS extensions image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@ COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroo
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
 
-RUN if [[ "${TAGS}" == "fcos" ]]; then \
-    # comment out non-base/extensions image-references entirely for fcos
+RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
+    # comment out non-base/extensions image-references entirely for fcos/scos
     sed -i '/- name: rhel-coreos-8-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
-    sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml && \
-    # rewrite image names for fcos 
-    sed -i 's/rhel-coreos-8/fedora-coreos/g' /manifests/* ; \
+    sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
+    # rewrite image names for fcos/scos
+    if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos-8/fedora-coreos/g' /manifests/*; \
     elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos-8/centos-stream-coreos-9/g' /manifests/*; fi && \
     if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
 COPY templates /etc/mcc/templates


### PR DESCRIPTION
SCOS will at least initially not be shipping an extensions image, so comment out all references to it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
