### PR TITLE
OCPBUGS-1945: Increase rise value for api healthchecks to avoid flapping

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -22,17 +22,15 @@ contents:
         script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script.sh"
         interval 2
         weight 20
-        rise 3
+        rise 15
         fall 3
     }
 
     vrrp_script chk_ocp_both {
         script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script_both.sh"
         interval 2
-        # Use a smaller weight for this check so it won't trigger the move from
-        # bootstrap to master by itself.
         weight 5
-        rise 3
+        rise 15
         fall 3
     }
 

--- a/templates/master/00-master/on-prem/files/keepalived-script-both.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-script-both.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script_bo
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:{{`{{ .LBConfig.LbPort }}`}}/readyz && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz
+    timeout 1 /etc/keepalived/chk_ocp_script.sh || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz


### PR DESCRIPTION
We've run into a problem in some unstable clusters where api health checks are failing intermittently and causing the API VIP to move around excessively. This exacerbates the instability of the cluster because each time a failover happens every connection gets dropped and has to reconnect, which further increases the load on an already troubled apiserver.

This change takes the approach of increasing the rise value for the api health checks such that once a node has failed once, it has to wait at least 30 seconds before it can be considered "healthy". This way, if the problem is api instability there will likely be another failure within 30 seconds that keeps the node at the same lower priority. As long as the instability persists, all nodes will stay in an error state at the same priority  and the VIP will remain on whichever node it is already on.

There are some remaining problems, unfortunately. When the cluster recovers, the nodes will race to see which one becomes healthy first. That node will then take the VIP (if it didn't already have it) and cause reconnects. The possibility exists that this reintroduces instability into the API.

However, in my local testing this drastically improves the stability of the VIP in flaky api scenarios (simulated by intermittently blocking api traffic with iptables). It may not be perfect, but it should be an improvement and it's relatively safe since none of the changes are all that drastic.

This change also fixes a bug in the check script that looks at both haproxy and the local apiserver. Previously, if the haproxy call hung it would prevent us from ever checking the local apiserver because the overall check timeout that we set would kill the script before we got there. This may have contributed to the problem since it means not only was the haproxy check flaky, but the localhost one was as well. I added a shorter timeout for the haproxy call to ensure we have time to check localhost before the overall timeout.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
