### PR TITLE
MCO-396: daemon: FCOS workaround, plus SELinux workaround

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -420,9 +421,26 @@ func useKubeletConfigSecrets() error {
 				return err
 			}
 
-			err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
+			runningos, err := GetHostRunningOS()
 			if err != nil {
 				return err
+			}
+
+			// Short term workaround for https://issues.redhat.com/browse/OKD-63
+			if runningos.IsFCOS() {
+				contents, err := ioutil.ReadFile(kubeletAuthFile)
+				if err != nil {
+					return err
+				}
+				// Note 0644 perms for now
+				if err := ioutil.WriteFile("/run/ostree/auth.json", contents, 0o644); err != nil {
+					return err
+				}
+			} else {
+				err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
daemon: Temporarily copy auth file with more open perms on FCOS

This works around an rpm-ostree regression
https://issues.redhat.com/browse/OKD-63

---

daemon: Temporarily `setenforce 0` for inplace update from container

In practice, we should ship a SELinux policy tweak that allows a transition
from `spc_t` -> `install_t` but for now I want to see if this works.

---

