### PR TITLE
Fix service deps for ovs-configuration

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -7,8 +7,8 @@ contents: |
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
-  Wants=nodeip-configuration.service
-  After=openvswitch.service network.service nodeip-configuration.service
+  Wants=NetworkManager-wait-online.service nodeip-configuration.service
+  After=NetworkManager-wait-online.service openvswitch.service network.service nodeip-configuration.service
   Before=network-online.target kubelet.service crio.service node-valid-hostname.service
 
   [Service]


### PR DESCRIPTION
In #3233 we changed the order of dependencies for ovs-configuration and nodeip-configuration. However, because nodeip-configuration doesn't run everywhere, this means ovs-configuration lost its depenedency on NetworkManager-wait-online in some cases. Since the first patch merged, some upgrade jobs have been having issues that seem to be related to that change. It's not entirely clear why, but since this was an unintended change to the dependencies it seems like a strong candidate.

To fix the problem, we can just have the NetworkManager-wait-online dep in both services. When nodeip-configuration runs it will be redundant, but at least ovs-configuration will always wait for it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
