### PR TITLE
MCO-424: Drop `machine-os-content` references

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -133,7 +133,6 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 		imgstream := resourceread.ReadImageStreamV1OrDie(imageRefData)
 
 		bootstrapOpts.mcoImage = findImageOrDie(imgstream, "machine-config-operator")
-		bootstrapOpts.oscontentImage = findImageOrDie(imgstream, "machine-os-content")
 		bootstrapOpts.keepalivedImage = findImageOrDie(imgstream, "keepalived-ipfailover")
 		bootstrapOpts.corednsImage = findImageOrDie(imgstream, "coredns")
 		bootstrapOpts.baremetalRuntimeCfgImage = findImageOrDie(imgstream, "baremetal-runtimecfg")
@@ -155,7 +154,6 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 	imgs := operator.Images{
 		RenderConfigImages: operator.RenderConfigImages{
 			MachineConfigOperator:          bootstrapOpts.mcoImage,
-			MachineOSContent:               bootstrapOpts.oscontentImage,
 			KeepalivedBootstrap:            bootstrapOpts.keepalivedImage,
 			CorednsBootstrap:               bootstrapOpts.corednsImage,
 			BaremetalRuntimeCfgBootstrap:   bootstrapOpts.baremetalRuntimeCfgImage,

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -16,4 +16,4 @@ data:
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )
-  osImageURL: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content"
+  osImageURL: ""

--- a/install/image-references
+++ b/install/image-references
@@ -20,13 +20,6 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-rbac-proxy
-  # This one is special, it's the OS payload
-  # https://github.com/openshift/machine-config-operator/issues/183
-  # See the machine-config-osimageurl configmap.
-  - name: machine-os-content
-    from:
-      kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content
   - name: rhel-coreos
     from:
       kind: DockerImage

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -56,9 +56,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/scheme"
 )
 
-// Gates whether or not the MCO uses the new format base OS container image by default
-var UseNewFormatImageByDefault = true
-
 // strToPtr converts the input string to a pointer to itself
 func strToPtr(s string) *string {
 	return &s
@@ -1058,13 +1055,9 @@ func GetIgnitionFileDataByPath(config *ign3types.Config, path string) ([]byte, e
 	return nil, nil
 }
 
-// GetDefaultBaseImageContainer is kind of a "soft feature gate" for using the "new format" image by default, its behavior
-// is determined by the "UseNewFormatImageByDefault" boolean
+// GetDefaultBaseImageContainer returns the default bootable host base image.
 func GetDefaultBaseImageContainer(cconfigspec *mcfgv1.ControllerConfigSpec) string {
-	if UseNewFormatImageByDefault {
-		return cconfigspec.BaseOSContainerImage
-	}
-	return cconfigspec.OSImageURL
+	return cconfigspec.BaseOSContainerImage
 }
 
 // Configures common template FuncMaps used across all renderers.

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -138,7 +138,6 @@ func RenderBootstrap(
 
 	spec.RootCAData = bundle
 	spec.PullSecret = nil
-	spec.OSImageURL = imgs.MachineOSContent
 	spec.BaseOSContainerImage = imgs.BaseOSContainerImage
 	spec.BaseOSExtensionsContainerImage = imgs.BaseOSExtensionsContainerImage
 	spec.ReleaseImage = releaseImage

--- a/pkg/operator/images.go
+++ b/pkg/operator/images.go
@@ -16,7 +16,6 @@ type Images struct {
 // RenderConfigImages are image names used to render templates under ./manifests/
 type RenderConfigImages struct {
 	MachineConfigOperator string `json:"machineConfigOperator"`
-	MachineOSContent      string `json:"machineOSContent"`
 	// The new format image
 	BaseOSContainerImage string `json:"baseOSContainerImage"`
 	// The matching extensions container for the new format image


### PR DESCRIPTION
xref https://github.com/openshift/enhancements/blob/master/enhancements/ocp-coreos-layering/ocp-coreos-layering.md

This is part of https://issues.redhat.com/browse/MCO-392

Since we've landed the new format image usage in the latest nightly, it's time to try dropping it from our image references entirely.
