### PR TITLE
MCO-400: helpers: Do synchronize condition if message changes

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers.go
@@ -33,7 +33,7 @@ func GetMachineConfigPoolCondition(status MachineConfigPoolStatus, condType Mach
 // we are about to add already exists and has the same status and reason then we are not going to update.
 func SetMachineConfigPoolCondition(status *MachineConfigPoolStatus, condition MachineConfigPoolCondition) {
 	currentCond := GetMachineConfigPoolCondition(*status, condition.Type)
-	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
+	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason && currentCond.Message == condition.Message {
 		return
 	}
 	// Do not update lastTransitionTime if the status of the condition doesn't change.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/helpers_test.go
@@ -27,6 +27,24 @@ var (
 		}
 	}
 
+	condUpdatingToV0 = func() MachineConfigPoolCondition {
+		return MachineConfigPoolCondition{
+			Type:    MachineConfigPoolUpdating,
+			Status:  corev1.ConditionTrue,
+			Reason:  "",
+			Message: "Updating to v0",
+		}
+	}
+
+	condUpdatingToV1 = func() MachineConfigPoolCondition {
+		return MachineConfigPoolCondition{
+			Type:    MachineConfigPoolUpdating,
+			Status:  corev1.ConditionTrue,
+			Reason:  "",
+			Message: "Updating to v1",
+		}
+	}
+
 	status = func() *MachineConfigPoolStatus {
 		return &MachineConfigPoolStatus{
 			Conditions: []MachineConfigPoolCondition{condUpdatedFalse()},
@@ -80,6 +98,16 @@ func TestSetMachineConfigPoolCondition(t *testing.T) {
 		cond:   condUpdatedTrue(),
 
 		expectedStatus: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatedTrue()}},
+	}, {
+		status: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatingToV0()}},
+		cond:   condUpdatingToV0(),
+
+		expectedStatus: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatingToV0()}},
+	}, {
+		status: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatingToV0()}},
+		cond:   condUpdatingToV1(),
+
+		expectedStatus: &MachineConfigPoolStatus{Conditions: []MachineConfigPoolCondition{condUpdatingToV1()}},
 	}}
 
 	for idx, test := range tests {


### PR DESCRIPTION
We were debugging something and this bug added *a lot* of additional confusion.  Basically, if the targeted (spec) config changes while we're rolling an update, the status stays at the first config, because we only change the message, and the status helper "diff" logic was ignoring that.

Closes: https://issues.redhat.com/browse/MCO-400
