### PR TITLE
OCPBUGS-2197: OCPBUGS-2122: update: Inject proxy data for firstboot

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1936,7 +1936,8 @@ func (dn *Daemon) InplaceUpdateViaNewContainer(target string) error {
 	} else {
 		glog.Info("SELinux is not enforcing")
 	}
-	err = runCmdSync("systemd-run", "--unit", "machine-config-daemon-update-rpmostree-via-container", "--collect", "--wait", "--", "podman", "run", "--authfile", "/var/lib/kubelet/config.json", "--privileged", "--pid=host", "--net=host", "--rm", "-v", "/:/run/host", target, "rpm-ostree", "ex", "deploy-from-self", "/run/host")
+
+	err = runCmdSync("systemd-run", "--unit", "machine-config-daemon-update-rpmostree-via-container", "--collect", "--wait", "--", "podman", "run", "--env-file", "/etc/mco/proxy.env", "--authfile", "/var/lib/kubelet/config.json", "--privileged", "--pid=host", "--net=host", "--rm", "-v", "/:/run/host", target, "rpm-ostree", "ex", "deploy-from-self", "/run/host")
 	if err != nil {
 		return err
 	}

--- a/templates/common/_base/units/rpm-ostreed-proxy.service.yaml
+++ b/templates/common/_base/units/rpm-ostreed-proxy.service.yaml
@@ -1,0 +1,8 @@
+name: rpm-ostreed.service
+dropins:
+  - name: 10-mco-default-env.conf
+    contents: |
+      {{if .Proxy -}}
+      [Service]
+      EnvironmentFile=/etc/mco/proxy.env
+      {{end -}}


### PR DESCRIPTION
The least invasive fix for ensuring we get the proxy setup in the unit.

Closes: https://issues.redhat.com/browse/OCPBUGS-2197
