### PR TITLE
machineconfigpool: Clarify `status.configuration` description

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
@@ -317,8 +317,8 @@ spec:
                         'Failed').
                       type: string
               configuration:
-                description: configuration represents the current MachineConfig object
-                  for the machine config pool.
+                description: configuration represents the MachineConfig object
+                  that last successfully rolled out to all nodes.
                 type: object
                 properties:
                   apiVersion:


### PR DESCRIPTION
The semantics get a little confusing when one has e.g. 3 or more machine configs in play (by applying a new one while an update is in progress for example).  Let's clarify that we only reach spec == status when an update is 100% fully rolled out.  The term "current" here is too ambiguous.
