### PR TITLE
daemon: Temporarily copy auth file with more open perms on SCOS too

### DIFF
--- a/pkg/daemon/osrelease.go
+++ b/pkg/daemon/osrelease.go
@@ -33,6 +33,11 @@ func (os OperatingSystem) IsFCOS() bool {
 	return os.ID == "fedora" && os.VariantID == "coreos"
 }
 
+// IsSCOS is true if the OS is SCOS
+func (os OperatingSystem) IsSCOS() bool {
+	return os.ID == "scos"
+}
+
 // IsCoreOSVariant is true if the OS is FCOS or a derivative (ostree+Ignition)
 // which includes SCOS and RHCOS.
 func (os OperatingSystem) IsCoreOSVariant() bool {

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -379,7 +379,7 @@ func useKubeletConfigSecrets() error {
 			}
 
 			// Short term workaround for https://issues.redhat.com/browse/OKD-63
-			if runningos.IsFCOS() {
+			if runningos.IsFCOS() || runningos.IsSCOS() {
 				contents, err := ioutil.ReadFile(kubeletAuthFile)
 				if err != nil {
 					return err


### PR DESCRIPTION
This adds the same workaround that was added to FCOS in `6ccdd574fad38fc7bc2de1e1913c9ade69ba6e55` to SCOS, too.

See: https://issues.redhat.com/browse/OKD-63

/cc @cgwalters 