### PR TITLE
OCPBUGS-2269: Upgrade failures and MCDPivotError Alert Firing on GCP realtime kernel

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2179,7 +2179,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	var osExtensionsContentDir string
 	var err error
-	if mcDiff.extensions || mcDiff.kernelType {
+	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType {
 
 		// TODO(jkyros): the original intent was that we use the extensions container as a service, but that currently results
 		// in a lot of complexity due to boostrap and firstboot where the service isn't easily available, so for now we are going


### PR DESCRIPTION
It seems like rpm-ostree wants to check the extensions repo if extensions/kernel are set even if they aren't changing as part of the update. 

I consider this a regression I introduced because the OS update check it is present in the "legacy OS" path. Sorry :( 