### PR TITLE
kubelet: Drop two deprecated CLI flags

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -41,7 +41,6 @@ contents: |
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-        --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}
 

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -26,7 +26,6 @@ contents: |
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \

--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -40,7 +40,6 @@ contents: |
         {{cloudConfigFlag . }} \
         --provider-id=alicloud://${KUBELET_NODE_NAME} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-        --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}
 

--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -26,7 +26,6 @@ contents: |
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -38,7 +38,6 @@ contents: |
         {{cloudConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-        --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}
 

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -23,7 +23,6 @@ contents: |
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -26,7 +26,6 @@ contents: |
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -40,7 +40,6 @@ contents: |
         {{cloudConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
-        --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}
 

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -26,7 +26,6 @@ contents: |
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -39,7 +39,6 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
         --provider-id=alicloud://${KUBELET_NODE_NAME} \
-        --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}
 

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -37,7 +37,6 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
-        --pod-infra-container-image={{.Images.infraImageKey}} \
         --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY} \
         --v=${KUBELET_LOG_LEVEL}
 

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -23,7 +23,6 @@ contents: |
         --config=/etc/kubernetes/kubelet.conf \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --container-runtime=remote \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \


### PR DESCRIPTION
kubelet: Drop deprecated `--container-runtime=remote` argument

I saw this in logs:

```
Oct 12 17:10:41.304877 build0-gstfj-ci-builds-worker-b-gj8vg kubenswrapper[1732]: Flag --container-runtime has been deprecated, will be removed in 1.27 as the only valid value is 'remote'
```

Just trying to make in the dent in log spam I see and set us
up for the ability to rebase to 1.27 later.

---

kubelet: Drop deprecated `--pod-infra-container-image`

```
Oct 12 17:10:41.308614 build0-gstfj-ci-builds-worker-b-gj8vg kubenswrapper[1732]: Flag --pod-infra-container-image has been deprecated, will be removed in 1.27. Image garbage collector will get sandbox image information from CRI.
```

---

