### PR TITLE
[OCPCLOUD-1640] Report bootstrapping completion for Cluster API

### DIFF
--- a/templates/common/_base/units/capi-bootrstrap-sentinel-file.service.yaml
+++ b/templates/common/_base/units/capi-bootrstrap-sentinel-file.service.yaml
@@ -1,0 +1,14 @@
+name: capi-bootrstrap-sentinel-file.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Create a CAPI bootstrap sentinel file like it is described in https://cluster-api.sigs.k8s.io/developer/providers/bootstrap.html
+  # This file's required for Cluster API providers only, it has no effect if we use Machine API.
+  After=kubelet.service crio.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/bin/env bash -c "/usr/bin/mkdir -p /run/cluster-api && /usr/bin/touch /run/cluster-api/bootstrap-success.complete"
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
**- What I did**
On tech preview clusters, where we use Cluster API instead of Machine API, we need to create an empty file to report that the bootstrapping was successful.

Normally there is a special controller for it, but in OpenShift we use MCO+ignition to bootstrap machines, so we have to create this file here.

For more information:
https://cluster-api.sigs.k8s.io/developer/providers/bootstrap.html
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/defaults.go#L81-L83
