### PR TITLE
OCPBUGS-2197: update: Set proxy for inplace container update too

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1937,7 +1937,7 @@ func (dn *Daemon) InplaceUpdateViaNewContainer(target string) error {
 		glog.Info("SELinux is not enforcing")
 	}
 
-	err = runCmdSync("systemd-run", "--unit", "machine-config-daemon-update-rpmostree-via-container", "--collect", "--wait", "--", "podman", "run", "--env-file", "/etc/mco/proxy.env", "--authfile", "/var/lib/kubelet/config.json", "--privileged", "--pid=host", "--net=host", "--rm", "-v", "/:/run/host", target, "rpm-ostree", "ex", "deploy-from-self", "/run/host")
+	err = runCmdSync("systemd-run", "--unit", "machine-config-daemon-update-rpmostree-via-container", "-p", "EnvironmentFile=-/etc/mco/proxy.env", "--collect", "--wait", "--", "podman", "run", "--env-file", "/etc/mco/proxy.env", "--authfile", "/var/lib/kubelet/config.json", "--privileged", "--pid=host", "--net=host", "--rm", "-v", "/:/run/host", target, "rpm-ostree", "ex", "deploy-from-self", "/run/host")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We need the proxy environment set for the *podman* invocation, not the rpm-ostree invocation inside the container, which today just scrapes data out of the container image and doesn't itself fetch again.

When my initial attempt at this didn't work, I confused myself into thinking we need the proxy inside the container too, but we don't today.  (In the future, we might actually do the pull from there, so let's keep it)

The previous PR fixed proxy clusters for fresh installs; this should fix them for inplace upgrades from 4.11 too.

Closes: https://github.com/openshift/machine-config-operator/issues/3378