### PR TITLE
[wip] nodeip-configuration.service prefer non-private addresses for IPv6

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -26,6 +26,7 @@ contents: |
     set \
     {{if eq .IPFamilies "IPv6" -}}
     --prefer-ipv6 \
+    --prefer-global \
     {{end -}}
     --retry-on-failure \
     ${NODEIP_HINT:-${KUBELET_NODEIP_HINT:-}}; \


### PR DESCRIPTION
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**
launch openshift/baremetal-runtimecfg#199,openshift/machine-config-operator#3379 metal,ipv6

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
