### PR TITLE
daemon: Only try to apply layered changes if BaseOSExtensionsContainerImage is not empty

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2180,7 +2180,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	var osExtensionsContentDir string
 	var err error
-	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType {
+	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType) {
 
 		// TODO(jkyros): the original intent was that we use the extensions container as a service, but that currently results
 		// in a lot of complexity due to boostrap and firstboot where the service isn't easily available, so for now we are going


### PR DESCRIPTION
**- What I did**
In OKD, the BaseOSExtensionsContainerImage image reference does not
exist. The change from https://github.com/openshift/machine-config-operator/commit/343475a40a3fe17f725ef4415333379ef3fd621b
broke OKD installations by trying to always extract the extensions from
the image during the initial rebase.

Fix this by making the daemon only try to extract the extensions when
the image-reference in not empty.

Without this, we're currently seeing:
```
Oct 20 21:37:52 ip-10-0-154-20 machine-config-daemon[1210]: I1020 21:37:52.841553    1210 run.go:19] Running: nice -- ionice -c 3 oc image extract --path /:/run/mco-extensions/os-extensions-content-3040886363 --registry-config /var/lib/kubelet/config.json
Oct 20 21:37:53 ip-10-0-154-20 machine-config-daemon[1210]: error: "" is not a valid image reference: repository name must have at least one component
```

**- How to verify it**
/test okd-scos-e2e-aws

**- Description for the changelog**

/hold
