### PR TITLE
OCPBUGS-2757: Reconcile successfully if already booted into target

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2177,6 +2177,12 @@ func (dn *Daemon) reboot(rationale string) error {
 }
 
 func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
+	// Override the computed diff if the booted state differs from the oldConfig
+	// https://issues.redhat.com/browse/OCPBUGS-2757
+	if mcDiff.osUpdate && dn.bootedOSImageURL == newConfig.Spec.OSImageURL {
+		glog.Infof("Already in desired image %s", newConfig.Spec.OSImageURL)
+		mcDiff.osUpdate = false
+	}
 
 	var osExtensionsContentDir string
 	var err error


### PR DESCRIPTION
This is part of a big mess in our control logic around the problem domain of "which is canonical: the machineconfig hash or the node state".

In the case of doing a manual `rpm-ostree rollback`, one will get "torn" state because the MCO will think it should be in config A, but we got reverted to config B (kind of, except for stuff in `/var`...).  Eventually the goal is to make
node state == container image

But, let's not error out if we're already in the expected container image in this case.
