### PR TITLE
Mount /run/nodeip-configuration into keepalived containers

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -33,6 +33,9 @@ contents:
       - name: chroot-host
         hostPath:
           path: "/"
+      - name: nodeip-configuration
+        hostPath:
+          path: "/run/nodeip-configuration"
       initContainers:
       - name: render-config-keepalived
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -55,6 +58,8 @@ contents:
           mountPath: "/config"
         - name: conf-dir
           mountPath: "/etc/keepalived"
+        - name: nodeip-configuration
+          mountPath: "/run/nodeip-configuration"
         imagePullPolicy: IfNotPresent
       containers:
       - name: keepalived
@@ -184,6 +189,8 @@ contents:
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
+        - name: nodeip-configuration
+          mountPath: "/run/nodeip-configuration"
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:


### PR DESCRIPTION
This is required so the keepalived configuration code can use the ip information written to that directory for selecting ips for keepalived to use.

Pre-req to https://github.com/openshift/baremetal-runtimecfg/pull/200

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
