### PR TITLE
Fix machine-config-operator logspam when extensions container is not present

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -138,12 +138,7 @@ func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	// TODO(jkyros): take this out, I just want to see when/why it's empty?
-	j, _ := json.MarshalIndent(bootedDeployment, "", "    ")
-	glog.Infof("%s", j)
-
 	// the canonical image URL is stored in the custom origin field.
-
 	osImageURL := ""
 	if len(bootedDeployment.CustomOrigin) > 0 {
 		if strings.HasPrefix(bootedDeployment.CustomOrigin[0], "pivot://") {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -882,16 +882,11 @@ func (optr *Operator) getOsImageURLs(namespace string) (string, string, string, 
 		return "", "", "", fmt.Errorf("refusing to read osImageURL version %q, operator version %q", releaseVersion, optrVersion)
 	}
 
-	newextensions, hasNewExtensions := cm.Data["baseOSExtensionsContainerImage"]
+	newextensions, _ := cm.Data["baseOSExtensionsContainerImage"]
 
 	newformat, hasNewFormat := cm.Data["baseOSContainerImage"]
 
 	oldformat, hasOldFormat := cm.Data["osImageURL"]
-
-	if hasNewFormat && !hasNewExtensions {
-		// TODO(jkyros): This is okay for now because it's not required, but someday this will be bad
-		glog.Warningf("New format image specified, but no matching extensions image present")
-	}
 
 	// If we don't have a new format image, and we can't fall back to the old one
 	if !hasOldFormat && !hasNewFormat {


### PR DESCRIPTION

Operator was spamming every sync if the extensions container wasn't present in the `machine-config-osimageurl` configmap. This is okay now for the MCO because we've shipped the extensions container and it's always present, but things like OKD don't ship an extensions container so they would get a bunch of spam. 

```
W0923 14:37:41.798239       1 sync.go:886] New format image specified, but no matching extensions image present
W0923 14:38:39.329934       1 sync.go:886] New format image specified, but no matching extensions image present
W0923 14:38:44.497008       1 sync.go:886] New format image specified, but no matching extensions image present
```