### PR TITLE
OCPBUGS-1761: Substitute skopeo inspect for imageInspect/podman, drop podman inspect fallback

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1901,9 +1901,7 @@ func (dn *Daemon) checkOS(osImageURL string) bool {
 
 	// TODO(jkyros): the header for this functions says "if the digests match"
 	// so I'm wondering if at one point this used to work this way....
-	// TODO(jkyros): and pulling it just to check is so expensive, skopeo works now
-	// if you use the --no-tags argument (doesn't pull tags) so we should probably just do that
-	inspection, err := imageInspect(osImageURL)
+	inspection, err := skopeoInspect(osImageURL)
 	if err != nil {
 		glog.Warningf("Unable to check manifest for matching hash: %s", err)
 	} else if ostreeCommit, ok := inspection.Labels["ostree.commit"]; ok {

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -196,6 +196,48 @@ func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
 
 }
 
+// skopeoInspect is a wrapper around the "skopeo inspect" command. Skopeo gets the proxy
+// from our environment, reads /etc/containers/registries.* so it should be mirror-aware
+// and it handles exponential backoff/retries that take the type of error into account. It's preferred
+// over podmanInspect because it doesn't have to pull the image to inspect it.
+func skopeoInspect(imgURL string) (imgdata *imageInspection, err error) {
+	// TODO(jkyros): This does not handle manifestlists. It looks like if you
+	// run with --raw, you can get the manifests and inspect them separately
+	// but we don't need that yet.
+
+	var authArgs []string
+	if _, err := os.Stat(kubeletAuthFile); err == nil {
+		authArgs = append(authArgs, "--authfile", kubeletAuthFile)
+	}
+
+	// Skopeo requires you to specify your transport
+	if !strings.HasPrefix(imgURL, "docker://") {
+		imgURL = "docker://" + imgURL
+	}
+
+	args := []string{"inspect", "--no-tags", "--retry-times", fmt.Sprintf("%d", numRetriesNetCommands)}
+	args = append(args, authArgs...)
+	args = append(args, imgURL)
+
+	var output []byte
+	// We let skopeo handle the retries, since it's smart enough to know what errors can be retried,
+	// If *we* do the retries, we're just blindly retrying every failure.
+	output, err = runGetOut("skopeo", args...)
+	if err != nil {
+		return
+	}
+
+	var inspection imageInspection
+	err = json.Unmarshal(output, &inspection)
+	if err != nil {
+		err = fmt.Errorf("unmarshaling skopeo inspect: %w", err)
+		return
+	}
+	imgdata = &inspection
+	return
+
+}
+
 // Rebase potentially rebases system if not already rebased.
 func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool, err error) {
 	var (
@@ -291,25 +333,13 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 // IsBootableImage determines if the image is a bootable (new container formet) image, or a wrapper (old container format)
 func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
 
-	// TODO(jkyros): This is duplicated-ish from Rebase(), do we still need to carry this around?
 	var isBootableImage string
-	var imageData *types.ImageInspectInfo
-	var err error
-	if imageData, err = imageInspect(imgURL); err != nil {
-		if err != nil {
-			var podmanImgData *imageInspection
-			glog.Infof("Falling back to using podman inspect")
-
-			if podmanImgData, err = podmanInspect(imgURL); err != nil {
-				return false, err
-			}
-			isBootableImage = podmanImgData.Labels["ostree.bootable"]
-		}
-	} else {
-		isBootableImage = imageData.Labels["ostree.bootable"]
+	imageData, err := skopeoInspect(imgURL)
+	if err != nil {
+		return false, err
 	}
-	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
-	defer exec.Command("podman", "rmi", imgURL).Run()
+
+	isBootableImage = imageData.Labels["ostree.bootable"]
 
 	return isBootableImage == "true", nil
 }


### PR DESCRIPTION
The problem: 

- While checking the format of the `osImageURL` image, we were getting stuck in exponential backoff in podman for minutes trying to pull/inspect an image that could never be pulled/inspected. 

- We did 2 tries on `imageInspect`, then we'd try 6 exponential backoff tries on `podman`, and only then would we degrade (minutes later) 

This PR:
- drops the "podman fallback" in `isBootableImage` and switches to using `skopeo` directly now that we have the `--no-tags` argument
- farms the exponential backoff/retry out to skopeo since it understands the error codes and will only retry if it's a "retryable" error (e.g. network timeout) 

Concerns: 
- If we'd rather do this the "code way" instead of the "shell out to skopeo way", I have that code too, but I'd need drag in more pieces of skopeo/some skopeo libs and bump some deps
- In https://github.com/openshift/machine-config-operator/pull/2539 we looked like we might be leaning toward `oc image info` -- not that there needs to be "one image inspect to rule them all", but I would like to make the smallest mess possible :smile:
- I've tested skopeo in isolation against mirror registry/disconnected use cases, but I have not explicitly tested this code in a disconnected environment

Closes: [OCPBUGS-1761](https://issues.redhat.com/browse/OCPBUGS-1761)