### PR TITLE
controller: Don't allow creating the force file via MachineConfig

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -899,6 +899,10 @@ func reconcilable(oldConfig, newConfig *mcfgv1.MachineConfig) (*machineConfigDif
 		if len(f.Append) > 0 {
 			return nil, fmt.Errorf("ignition file %v includes append", f.Path)
 		}
+		// We also disallow writing some special files
+		if f.Path == constants.MachineConfigDaemonForceFile {
+			return nil, fmt.Errorf("cannot create %s via Ignition", f.Path)
+		}
 	}
 
 	// Systemd section


### PR DESCRIPTION
The semantics here will create a permanent reboot loop, which caused a lot of confusion in support case 03304353

The force file was intended as a last ditch *manual* thing; adding it via MachineConfig will just create a reboot loop.

