### PR TITLE
Force string format when logging rpm-ostree status

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1300,7 +1300,7 @@ func (dn *Daemon) LogSystemData() {
 		if err != nil {
 			glog.Fatalf("unable to get rpm-ostree status: %s", err)
 		}
-		glog.Info(out)
+		glog.Infof("%s", out)
 
 		logProvisioningInformation()
 	}


### PR DESCRIPTION
Ran across this accidentally while trying to reproduce a different issue, we're outputting unreadable bytes right now :) 

```
I1027 19:17:02.068070    2294 update.go:2106] Starting to manage node: ip-10-0-188-48.us-west-1.compute.internal
I1027 19:17:02.074272    2294 rpm-ostree.go:417] Running captured: rpm-ostree status
I1027 19:17:02.107054    2294 daemon.go:1303] [83 116 97 116 101 58 32 105 100 108 101 10 68 101 112 108 111 121 109 101 110 116 115 58 10 42 32 111 115 116 114 101 101 45 117 110 118 101 114 105 102 105 101 100 45 114 101 103 105 115 116 114 121 58 113 117 97 121 46 105 111 47 111 112 101 110 115 104 105 102 116 45 114 101 108 101 97 115 101 45 100 101 118 47 111 99 112 45 118 52 46 48 45 97 114 116 45 100 101 118 64 115 104 97 50 53 54 58 100 49 54 101 51 101 51 49 100 100 55 50 55 102 56 52 56 49 98 102 52 54 56 100 98 99 48 48 54 52 56 48 52 98 51 51 98 51 100 53 97 101 53 100 100 57 51 50 48 52 48 97 57 102 51 101 57 98 102 51 55 51 50 57 10 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 68 105 103 101 115 116 58 32 115 104 97 50 53 54 58 100 49 54 101 51 101 51 49 100 100 55 50 55 102 56 52 56 49 98 102 52 54 56 100 98 99 48 48 54 52 56 48 52 98 51 51 98 51 100 53 97 101 53 100 100 57 51 50 48 52 48 97 57 102 51 101 57 98 102 51 55 51 50 57 10 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 84 105 109 101 115 116 97 109 112 58 32 50 48 50 50 45 49 48 45 50 55 84 49 57 58 49 54 58 50 54 90 10 10 32 32 50 51 97 101 56 102 99 101 52 97 98 56 100 97 52 48 98 100 50 49 97 57 52 100 52 54 55 48 97 52 52 100 53 54 48 55 101 54 52 50 55 51 49 98 57 53 51 102 50 51 102 102 97 53 99 97 101 53 55 99 55 52 48 54 10 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 86 101 114 115 105 111 110 58 32 52 49 50 46 56 54 46 50 48 50 50 48 57 51 48 50 51 49 55 45 48 32 40 50 48 50 50 45 48 57 45 51 48 84 50 51 58 50 48 58 49 51 90 41 10]
```

It used to look more like: 
```
I1027 18:48:44.803350    1419 rpm-ostree.go:353] Running captured: rpm-ostree status
I1027 18:48:44.881102    1419 daemon.go:1220] State: idle
Deployments:
* pivot://quay.io/openshift/okd-content@sha256:7510bab99574c9551f0a395373f34c9a8168e03be93b99289135a2efa58d846f
             CustomOrigin: Managed by machine-config-operator
                  Version: 411.36.202210130930-0 (2022-10-13T09:35:24Z)

  fedora:fedora/x86_64/coreos/stable
                  Version: 36.20220716.3.1 (2022-07-25T18:45:58Z)
                   Commit: 4e2f304fe4af38272772514b2bd685c4b4981422f553b53e469f8df3c01d883f
             GPGSignature: Valid signature by 53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4
```