### PR TITLE
[release-4.11] on-prem: add condition to image pull and send to background

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -52,7 +52,14 @@ contents:
         # Pull container image outside of the timeout to workaround possible
         # image corruption
         # https://github.com/containers/podman/issues/14003
-        /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}
+        if ! /usr/bin/podman image exists {{ .Images.baremetalRuntimeCfgImage }}; then
+            # Send process to background.
+            # Multiple podman pulls may occur in parallel wasting bandwidth therefore this
+            # needs to be removed when podman image corruption issue is resolved.
+            /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }} &
+            # Wait until image is available or timeout and exit.
+            timeout 80s bash -c 'until /usr/bin/podman image exists {{ .Images.baremetalRuntimeCfgImage }}; do sleep 1; done'
+        fi
 
         NAMESERVER_IP=$(timeout 20s /usr/bin/podman run --rm \
             --authfile /var/lib/kubelet/config.json \


### PR DESCRIPTION
Ideally, we would like to pull required images
before resolv prepender but this doesnt seem to
be possible.

NM dispatcher has a timeout value which isn't
being respected.

Add a hack to check if image is available, and if
not, pull the image in the background.

Block until image pull is complete or exit. Include timeout less than NM dispatcher timeout.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
