### PR TITLE
Bug 1853264: Fix unbound cardinality for MCDRebootErr and MCDPivotErr

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -55,7 +55,7 @@ spec:
       rules:
         - alert: MCDRebootError
           expr: |
-             mcd_reboot_err_total > 0
+             mcd_reboots_failed_total > 0
           labels:
             severity: critical
           annotations:
@@ -73,7 +73,7 @@ spec:
       rules:
         - alert: MCDPivotError
           expr: |
-            mcd_pivot_err_total > 0
+            mcd_pivot_errors_total > 0
           labels:
             severity: warning
           annotations:

--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -55,7 +55,7 @@ spec:
       rules:
         - alert: MCDRebootError
           expr: |
-             mcd_reboot_err > 0
+             mcd_reboot_err_total > 0
           labels:
             severity: critical
           annotations:
@@ -73,11 +73,11 @@ spec:
       rules:
         - alert: MCDPivotError
           expr: |
-            mcd_pivot_err > 0
+            mcd_pivot_err_total > 0
           labels:
             severity: warning
           annotations:
-            message: "Error detected in pivot logs on {{ $labels.node }} "
+            message: "Error detected in pivot logs on {{ $labels.node }} , upgrade may be blocked. For more details:  oc logs -f -n openshift-machine-config-operator {{ $labels.pod }} -c machine-config-daemon "
     - name: mcd-kubelet-health-state-error
       rules:
         - alert: KubeletHealthState

--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -55,11 +55,11 @@ spec:
       rules:
         - alert: MCDRebootError
           expr: |
-             mcd_reboots_failed_total > 0
+            max by(namespace, node, pod) (increase(mcd_reboots_failed_total[15m])) > 0
           labels:
             severity: critical
           annotations:
-            message: "Reboot failed on {{ $labels.node }} , update may be blocked"
+            message: "Reboot failed on {{ $labels.node }} , update may be blocked. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon "
     - name: mcd-drain-error
       rules:
         - alert: MCDDrainError
@@ -73,11 +73,11 @@ spec:
       rules:
         - alert: MCDPivotError
           expr: |
-            mcd_pivot_errors_total > 0
+            max by(namespace, node, pod) (increase(mcd_pivot_errors_total[15m])) > 0
           labels:
             severity: warning
           annotations:
-            message: "Error detected in pivot logs on {{ $labels.node }} , upgrade may be blocked. For more details:  oc logs -f -n openshift-machine-config-operator {{ $labels.pod }} -c machine-config-daemon "
+            message: "Error detected in pivot logs on {{ $labels.node }} , upgrade may be blocked. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon "
     - name: mcd-kubelet-health-state-error
       rules:
         - alert: KubeletHealthState

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -23,7 +23,7 @@ var (
 	// MCDSSHAccessed shows ssh access count for a node
 	MCDSSHAccessed = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "ssh_accessed",
+			Name: "ssh_accessed_total",
 			Help: "indicates a successful SSH login",
 		})
 
@@ -34,12 +34,12 @@ var (
 			Help: "logs failed drain",
 		})
 
-	// MCDPivotErr shows errors encountered during pivot
-	MCDPivotErr = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "mcd_pivot_err",
-			Help: "errors encountered during pivot",
-		}, []string{"node", "pivot_target", "err"})
+	// MCDPivotErr flags error encountered during pivot
+	MCDPivotErr = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mcd_pivot_err_total",
+			Help: "error encountered during pivot",
+		}, []string{})
 
 	// MCDState is state of mcd for indicated node (ex: degraded)
 	MCDState = prometheus.NewGaugeVec(
@@ -55,11 +55,11 @@ var (
 			Help: "state of kubelet health monitor",
 		})
 
-	// MCDRebootErr logs success/failure of reboot and errors
-	MCDRebootErr = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "mcd_reboot_err",
-		}, []string{"node", "message", "err"})
+	// MCDRebootErr tallys failed reboot attempts
+	MCDRebootErr = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mcd_reboot_err_total",
+		}, []string{})
 
 	// MCDUpdateState logs completed update or error
 	MCDUpdateState = prometheus.NewGaugeVec(
@@ -89,9 +89,7 @@ func registerMCDMetrics() error {
 	}
 
 	MCDDrainErr.Set(0)
-	MCDPivotErr.WithLabelValues("", "", "").Set(0)
 	KubeletHealthState.Set(0)
-	MCDRebootErr.WithLabelValues("", "", "").Set(0)
 	MCDUpdateState.WithLabelValues("", "").Set(0)
 
 	return nil

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -23,7 +23,7 @@ var (
 	// MCDSSHAccessed shows ssh access count for a node
 	MCDSSHAccessed = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "ssh_accessed_total",
+			Name: "ssh_accesses_total",
 			Help: "Total number of SSH access occurred.",
 		})
 

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -24,7 +24,7 @@ var (
 	MCDSSHAccessed = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "ssh_accessed_total",
-			Help: "indicates a successful SSH login",
+			Help: "Total number of SSH access occurred.",
 		})
 
 	// MCDDrainErr logs failed drain
@@ -35,11 +35,11 @@ var (
 		})
 
 	// MCDPivotErr flags error encountered during pivot
-	MCDPivotErr = prometheus.NewCounterVec(
+	MCDPivotErr = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "mcd_pivot_err_total",
-			Help: "error encountered during pivot",
-		}, []string{})
+			Name: "mcd_pivot_errors_total",
+			Help: "Total number of errors encountered during pivot.",
+		})
 
 	// MCDState is state of mcd for indicated node (ex: degraded)
 	MCDState = prometheus.NewGaugeVec(
@@ -56,10 +56,11 @@ var (
 		})
 
 	// MCDRebootErr tallys failed reboot attempts
-	MCDRebootErr = prometheus.NewCounterVec(
+	MCDRebootErr = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "mcd_reboot_err_total",
-		}, []string{})
+			Name: "mcd_reboots_failed_total",
+			Help: "Total number of reboots that failed.",
+		})
 
 	// MCDUpdateState logs completed update or error
 	MCDUpdateState = prometheus.NewGaugeVec(

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2170,14 +2170,14 @@ func (dn *Daemon) reboot(rationale string) error {
 	// either, we just have one for the MCD itself.
 	if err := rebootCmd.Run(); err != nil {
 		dn.logSystem("failed to run reboot: %v", err)
-		MCDRebootErr.WithLabelValues().Inc()
+		MCDRebootErr.Inc()
 	}
 
 	// wait to be killed via SIGTERM from the kubelet shutting down
 	time.Sleep(defaultRebootTimeout)
 
 	// if everything went well, this should be unreachable.
-	MCDRebootErr.WithLabelValues().Inc()
+	MCDRebootErr.Inc()
 	return fmt.Errorf("reboot failed; this error should be unreachable, something is seriously wrong")
 }
 
@@ -2211,7 +2211,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateLayeredOS(newConfig); err != nil {
-			MCDPivotErr.WithLabelValues().Inc()
+			MCDPivotErr.Inc()
 			return err
 		}
 		if dn.nodeWriter != nil {
@@ -2279,7 +2279,7 @@ func (dn *CoreOSDaemon) applyLegacyOSChanges(mcDiff machineConfigDiff, oldConfig
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
-			MCDPivotErr.WithLabelValues().Inc()
+			MCDPivotErr.Inc()
 			return err
 		}
 		if dn.nodeWriter != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1307,6 +1307,7 @@ func (dn *Daemon) isPathInDropins(path string, systemd *ign3types.Systemd) bool 
 // all the files, units that are present in the old config but not in the new one.
 // this function will error out if it fails to delete a file (with the exception
 // of simply warning if the error is ENOENT since that's the desired state).
+//
 //nolint:gocyclo
 func (dn *Daemon) deleteStaleData(oldIgnConfig, newIgnConfig ign3types.Config) error {
 	glog.Info("Deleting stale data")
@@ -2169,14 +2170,14 @@ func (dn *Daemon) reboot(rationale string) error {
 	// either, we just have one for the MCD itself.
 	if err := rebootCmd.Run(); err != nil {
 		dn.logSystem("failed to run reboot: %v", err)
-		MCDRebootErr.WithLabelValues(dn.node.Name, "failed to run reboot", err.Error()).SetToCurrentTime()
+		MCDRebootErr.WithLabelValues().Inc()
 	}
 
 	// wait to be killed via SIGTERM from the kubelet shutting down
 	time.Sleep(defaultRebootTimeout)
 
 	// if everything went well, this should be unreachable.
-	MCDRebootErr.WithLabelValues(dn.node.Name, "reboot failed", "this error should be unreachable, something is seriously wrong").SetToCurrentTime()
+	MCDRebootErr.WithLabelValues().Inc()
 	return fmt.Errorf("reboot failed; this error should be unreachable, something is seriously wrong")
 }
 
@@ -2210,11 +2211,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateLayeredOS(newConfig); err != nil {
-			nodeName := ""
-			if dn.node != nil {
-				nodeName = dn.node.Name
-			}
-			MCDPivotErr.WithLabelValues(nodeName, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
+			MCDPivotErr.WithLabelValues().Inc()
 			return err
 		}
 		if dn.nodeWriter != nil {
@@ -2282,11 +2279,7 @@ func (dn *CoreOSDaemon) applyLegacyOSChanges(mcDiff machineConfigDiff, oldConfig
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
-			nodeName := ""
-			if dn.node != nil {
-				nodeName = dn.node.Name
-			}
-			MCDPivotErr.WithLabelValues(nodeName, newConfig.Spec.OSImageURL, err.Error()).SetToCurrentTime()
+			MCDPivotErr.WithLabelValues().Inc()
 			return err
 		}
 		if dn.nodeWriter != nil {


### PR DESCRIPTION
Metrics shouldn't log failure, that should be done by logs Rename metrics name to match with metric type being used i.e Counter: ssh_accessed->  ssh_accessed_total
mcd_pivot_err -> mcd_pivot_err_total
mcd_reboot_err -> mcd_reboot_err_total

Followup of PR- https://github.com/openshift/machine-config-operator/pull/2394/ Metric types- https://prometheus.io/docs/concepts/metric_types/ Metric naming-  https://prometheus.io/docs/practices/naming/

Co-authored-by: Kirsten Garrison <kikis.github@gmail.com>