### PR TITLE
[release-4.12] OCPBUGS-3504: On-prem: Ensure resolv-prepender respects NM dispatcher timeout

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -20,89 +20,140 @@ contents:
     {{end -}}
     {{end -}}
 
-    # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain and static hostname was not already set
-    if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] ; then
-       STATIC_HOSTNAME="$(test ! -e /etc/hostname && echo -n || cat /etc/hostname | xargs)"
+    function pull_baremetal_runtime_cfg_image {
+        # This function must be executed as a background process and therefore the trap will only apply to this background
+        # process. Do not let SIGTERM interrupt image pull due to image corruption issue [1]. Remove when issue is resolved.
+        # [1] https://github.com/containers/podman/issues/14003
+        trap "" SIGTERM
+        >&2 echo "NM resolv-prepender: Starting download of baremetal runtime cfg image"
+        /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}
+        >&2 echo "NM resolv-prepender: Download of baremetal runtime cfg image completed"
+        trap - SIGTERM
+    }
 
-       if [[ -z "$STATIC_HOSTNAME" || "$STATIC_HOSTNAME" == "localhost.localdomain" ]] ; then
- 
-          # run with systemd-run to avoid selinux problems
-          systemd-run --property=Type=oneshot --unit resolve-prepender-hostnamectl -Pq \
-              hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
-       fi
-    fi
-    
-    case "$STATUS" in
-        up|dhcp4-change|dhcp6-change)
-        >&2 echo "NM resolv-prepender triggered by ${1} ${2}."
+    function resolv_prepender {
+        # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain and static hostname was not already set
+        if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] ; then
+           STATIC_HOSTNAME="$(test ! -e /etc/hostname && echo -n || cat /etc/hostname | xargs)"
 
-        # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
-        timeout 20s /bin/bash <<EOF
-            >&2 echo  "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
+           if [[ -z "$STATIC_HOSTNAME" || "$STATIC_HOSTNAME" == "localhost.localdomain" ]] ; then
+              # run with systemd-run to avoid selinux problems
+              systemd-run --property=Type=oneshot --unit resolve-prepender-hostnamectl -Pq \
+                  hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
+           fi
+        fi
+
+        case "$STATUS" in
+            up|dhcp4-change|dhcp6-change)
+            >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
+
+            # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
             while ! grep nameserver /var/run/NetworkManager/resolv.conf; do
                 >&2 echo  "NM resolv-prepender: NM resolv.conf still empty of nameserver"
                 sleep 0.5
             done
-    EOF
-        # Ensure resolv.conf exists and contains nameservers before we try to run podman
-        if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
-            cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
-        fi
 
-        # Pull container image outside of the timeout to workaround possible
-        # image corruption
-        # https://github.com/containers/podman/issues/14003
-        /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}
-
-        NAMESERVER_IP=$(timeout 20s /usr/bin/podman run --rm \
-            --authfile /var/lib/kubelet/config.json \
-            --net=host \
-            {{ .Images.baremetalRuntimeCfgImage }} \
-            node-ip \
-            show \
-            --retry-on-failure \
-            {{range onPremPlatformAPIServerInternalIPs . }}"{{.}}" {{end}} \
-            {{range onPremPlatformIngressIPs . }}"{{.}}" {{end}})
-        DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
-        if [[ -n "$NAMESERVER_IP" ]]; then
-            if systemctl -q is-enabled systemd-resolved; then
-                >&2 echo "NM resolv-prepender: Setting up systemd-resolved for OKD domain and local IP"
-                if [[ ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
-                    >&2 echo "NM resolv-prepender: Creating /etc/systemd/resolved.conf.d/60-kni.conf"
-                    mkdir -p /etc/systemd/resolved.conf.d
-                    echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
-                    echo "DNS=$NAMESERVER_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                    echo "Domains=$DOMAINS" >> /etc/systemd/resolved.conf.d/60-kni.conf
-                    if systemctl -q is-active systemd-resolved; then
-                        >&2 echo "NM resolv-prepender: restarting systemd-resolved"
-                        systemctl restart systemd-resolved
-                    fi
-                fi
-            else
-                >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
-                sed -e "/Generated by/c# Generated by KNI resolv prepender NM dispatcher script" \
-                    /var/run/NetworkManager/resolv.conf > /etc/resolv.tmp
-                sed -i "0,/^nameserver.*/s//nameserver $NAMESERVER_IP\n\0/" /etc/resolv.tmp
-                if ! grep -q search /etc/resolv.tmp; then
-                    # Make sure we have a search entry
-                    echo "search {{.DNS.Spec.BaseDomain}}" >> /etc/resolv.tmp
-                else
-                    # Make sure cluster domain is first in the search list
-                    sed -i "s/^search \(.*\)/search {{.DNS.Spec.BaseDomain}} \1/" /etc/resolv.tmp
-                    # Remove duplicate cluster domain entries
-                    sed -i "s/\(search {{.DNS.Spec.BaseDomain}}.*\) {{.DNS.Spec.BaseDomain}}\( .*\|$\)/\1\2/" /etc/resolv.tmp
-                fi
-                # Only leave the first 3 nameservers in /etc/resolv.conf
-                sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' /etc/resolv.tmp
-                mv -f /etc/resolv.tmp /etc/resolv.conf
-                # Workaround for bz 1929160. Reload NetworkManager to force it to
-                # re-run the lookup of the hostname now that we know we have DNS
-                # servers configured correctly in resolv.conf.
-                nmcli general reload dns-rc
+            # Ensure resolv.conf exists and contains nameservers before we try to pull image or run podman
+            if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
+                cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
             fi
-        fi
-        ;;
-        *)
-        ;;
-    esac
+
+            # If the overall script ends before the NM timeout and before this image pull is done, this image pull will be orphaned from
+            # the parent and continue running without NM being aware of it.
+            # As long as this script ends by itself before the NM timeout, the image pull will continue in the background without being
+            # killed by NM or interupted by SIGTERM due to timeout.
+            # Once the image corruption issue is resolved, remove sending to background and ensure it respects NM
+            # timeout.
+            # [1] https://github.com/containers/podman/issues/14003
+            if ! /usr/bin/podman image exists {{ .Images.baremetalRuntimeCfgImage }}; then
+                # Multiple image pulls may occur in parallel wasting bandwidth therefore this
+                # needs to be removed when podman image corruption issue is resolved.
+                pull_baremetal_runtime_cfg_image &
+            fi
+
+            # This function is subject to a timeout. The timeout may interrupt podman run's image pull if the image is
+            # not available and cause image corruption [1]. Image should be available or being pulled before we reach
+            # this point. Wait until its available.
+            # [1] https://github.com/containers/podman/issues/14003
+            until /usr/bin/podman image exists {{ .Images.baremetalRuntimeCfgImage }}; do
+                >&2 echo "NM resolv-prepender: Waiting for baremetal runtime cfg image to be available"
+                sleep 1
+            done
+
+            # Image must exist before reaching this point otherwise timeout may cause image corruption.
+            NAMESERVER_IP=$(/usr/bin/podman run --rm \
+                --authfile /var/lib/kubelet/config.json \
+                --net=host \
+                {{ .Images.baremetalRuntimeCfgImage }} \
+                node-ip \
+                show \
+                --retry-on-failure \
+                {{range onPremPlatformAPIServerInternalIPs . }}"{{.}}" {{end}} \
+                {{range onPremPlatformIngressIPs . }}"{{.}}" {{end}})
+            DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
+            if [[ -n "$NAMESERVER_IP" ]]; then
+                if systemctl -q is-enabled systemd-resolved; then
+                    >&2 echo "NM resolv-prepender: Configure for OKD domain and local IP"
+                    mkdir -p /etc/systemd/resolved.conf.d
+                    KNICONFTMPPATH="$(mktemp)"
+                    KNICONFPATH="/etc/systemd/resolved.conf.d/60-kni.conf"
+                    KNICONFDONEPATH="/run/resolv-prepender-kni-conf-done"
+                    echo "[Resolve]" > "${KNICONFTMPPATH}"
+                    echo "DNS=$NAMESERVER_IP" >> "${KNICONFTMPPATH}"
+                    echo "Domains=$DOMAINS" >> "${KNICONFTMPPATH}"
+
+                    # If KNI conf is not created or doesn't match what is generated or
+                    # if we haven't completed a full update - create or update it
+                    if [[ ! -f "${"KNICONFPATH"} ]] || [[ ! -f "${"KNICONFDONEPATH"} ]] || ! cmp --silent "${KNICONFPATH}" "${KNICONFTMPPATH}"; then
+                        >&2 echo "NM resolv-prepender: Creating/updating /etc/systemd/resolved.conf.d/60-kni.conf"
+                        rm -f "${KNICONFDONEPATH}"
+                        mv -f "${KNICONFTMPPATH}" "${KNICONFPATH}"
+                    fi
+
+                    if [[ ! -f "${KNICONFDONEPATH}" ]]; then
+                        if systemctl -q is-active systemd-resolved; then
+                            >&2 echo "NM resolv-prepender: Restarting systemd-resolved"
+                            systemctl restart systemd-resolved
+                        fi
+                        touch "${KNICONFDONEPATH}"
+                    fi
+                else
+                    >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
+                    RESOLVCONFTMPPATH="$(mktemp)"
+                    sed -e "/Generated by/c# Generated by KNI resolv prepender NM dispatcher script" \
+                        /var/run/NetworkManager/resolv.conf > "${RESOLVCONFTMPPATH}"
+                    sed -i "0,/^nameserver.*/s//nameserver $NAMESERVER_IP\n\0/" "${RESOLVCONFTMPPATH}"
+                    if ! grep -q search "${RESOLVCONFTMPPATH}"; then
+                        # Make sure we have a search entry
+                        echo "search {{.DNS.Spec.BaseDomain}}" >> "${RESOLVCONFTMPPATH}"
+                    else
+                        # Make sure cluster domain is first in the search list
+                        sed -i "s/^search \(.*\)/search {{.DNS.Spec.BaseDomain}} \1/" "${RESOLVCONFTMPPATH}"
+                        # Remove duplicate cluster domain entries
+                        sed -i "s/\(search {{.DNS.Spec.BaseDomain}}.*\) {{.DNS.Spec.BaseDomain}}\( .*\|$\)/\1\2/" "${RESOLVCONFTMPPATH}"
+                    fi
+                    # Only leave the first 3 nameservers in /etc/resolv.conf
+                    sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' "${RESOLVCONFTMPPATH}"
+                    mv -f "${RESOLVCONFTMPPATH}" /etc/resolv.conf
+                    # Workaround for bz 1929160. Reload NetworkManager to force it to
+                    # re-run the lookup of the hostname now that we know we have DNS
+                    # servers configured correctly in resolv.conf.
+                    nmcli general reload dns-rc
+                fi
+            fi
+            ;;
+            *)
+            ;;
+        esac
+    }
+
+    export IFACE STATUS DHCP6_FQDN_FQDN IP4_DOMAINS IP6_DOMAINS
+    export -f resolv_prepender pull_baremetal_runtime_cfg_image
+    # Given an overall Network Manager dispatcher timeout of 90 seconds, and 3 events which may occur within
+    # this time period (up, dhcp4, dhcp6), we must enforce a time limit for each event.
+    if ! timeout 30s bash -c resolv_prepender; then
+        >&2 echo "NM resolv-prepender: Timeout occurred"
+        exit 1
+    fi
+
     {{ end -}}


### PR DESCRIPTION
Ideally, we would like to pull required images
before resolv prepender but this doesnt seem to
be possible.

NM dispatcher has a timeout value which isn't
being respected. This PR fixes this.

If required image is already available, do not
attempt to pull the image.
If not, pull required image in background and
never allow SIGTERM to be sent to the podman
pull process in order not to encounter image
corruption issue.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
