### PR TITLE
OCPBUGS-3621: Revert "Substitute skopeo inspect for imageInspect/podman"

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1901,7 +1901,9 @@ func (dn *Daemon) checkOS(osImageURL string) bool {
 
 	// TODO(jkyros): the header for this functions says "if the digests match"
 	// so I'm wondering if at one point this used to work this way....
-	inspection, err := skopeoInspect(osImageURL)
+	// TODO(jkyros): and pulling it just to check is so expensive, skopeo works now
+	// if you use the --no-tags argument (doesn't pull tags) so we should probably just do that
+	inspection, err := imageInspect(osImageURL)
 	if err != nil {
 		glog.Warningf("Unable to check manifest for matching hash: %s", err)
 	} else if ostreeCommit, ok := inspection.Labels["ostree.commit"]; ok {

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -191,48 +191,6 @@ func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
 
 }
 
-// skopeoInspect is a wrapper around the "skopeo inspect" command. Skopeo gets the proxy
-// from our environment, reads /etc/containers/registries.* so it should be mirror-aware
-// and it handles exponential backoff/retries that take the type of error into account. It's preferred
-// over podmanInspect because it doesn't have to pull the image to inspect it.
-func skopeoInspect(imgURL string) (imgdata *imageInspection, err error) {
-	// TODO(jkyros): This does not handle manifestlists. It looks like if you
-	// run with --raw, you can get the manifests and inspect them separately
-	// but we don't need that yet.
-
-	var authArgs []string
-	if _, err := os.Stat(kubeletAuthFile); err == nil {
-		authArgs = append(authArgs, "--authfile", kubeletAuthFile)
-	}
-
-	// Skopeo requires you to specify your transport
-	if !strings.HasPrefix(imgURL, "docker://") {
-		imgURL = "docker://" + imgURL
-	}
-
-	args := []string{"inspect", "--no-tags", "--retry-times", fmt.Sprintf("%d", numRetriesNetCommands)}
-	args = append(args, authArgs...)
-	args = append(args, imgURL)
-
-	var output []byte
-	// We let skopeo handle the retries, since it's smart enough to know what errors can be retried,
-	// If *we* do the retries, we're just blindly retrying every failure.
-	output, err = runGetOut("skopeo", args...)
-	if err != nil {
-		return
-	}
-
-	var inspection imageInspection
-	err = json.Unmarshal(output, &inspection)
-	if err != nil {
-		err = fmt.Errorf("unmarshaling skopeo inspect: %w", err)
-		return
-	}
-	imgdata = &inspection
-	return
-
-}
-
 // Rebase potentially rebases system if not already rebased.
 func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool, err error) {
 	var (
@@ -328,13 +286,25 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 // IsBootableImage determines if the image is a bootable (new container formet) image, or a wrapper (old container format)
 func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
 
+	// TODO(jkyros): This is duplicated-ish from Rebase(), do we still need to carry this around?
 	var isBootableImage string
-	imageData, err := skopeoInspect(imgURL)
-	if err != nil {
-		return false, err
-	}
+	var imageData *types.ImageInspectInfo
+	var err error
+	if imageData, err = imageInspect(imgURL); err != nil {
+		if err != nil {
+			var podmanImgData *imageInspection
+			glog.Infof("Falling back to using podman inspect")
 
-	isBootableImage = imageData.Labels["ostree.bootable"]
+			if podmanImgData, err = podmanInspect(imgURL); err != nil {
+				return false, err
+			}
+			isBootableImage = podmanImgData.Labels["ostree.bootable"]
+		}
+	} else {
+		isBootableImage = imageData.Labels["ostree.bootable"]
+	}
+	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
+	defer exec.Command("podman", "rmi", imgURL).Run()
 
 	return isBootableImage == "true", nil
 }


### PR DESCRIPTION
This reverts commit 08831f071793fd0d25462744b768a8253b7ac96d.

skopeo gained --no-tags option recently, older RHCOS node may not have this feature causing upgrade/node scale-up to fail.
Fixes: OCPBUGS-3621