### PR TITLE
OCPBUGS-2935: daemon: Stop setting I/O scheduler to bfq

### DIFF
--- a/pkg/daemon/controlplane.go
+++ b/pkg/daemon/controlplane.go
@@ -5,64 +5,8 @@ package daemon
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
-
-	"github.com/golang/glog"
 )
-
-// setRootDeviceSchedulerBFQ switches to the `bfq` I/O scheduler
-// for the root block device to better share I/O between etcd
-// and other processes.  See
-// https://github.com/openshift/machine-config-operator/issues/1897
-// Note this is the current systemd default in Fedora, but not RHEL8,
-// except for NVMe devices.
-func setRootDeviceSchedulerBFQ() error {
-	sched := "bfq"
-
-	rootDevSysfs, err := getRootBlockDeviceSysfs()
-	if err != nil {
-		return err
-	}
-
-	schedulerPath := filepath.Join(rootDevSysfs, "/queue/scheduler")
-	schedulerContentsBuf, err := ioutil.ReadFile(schedulerPath)
-	if err != nil {
-		return err
-	}
-	schedulerContents := string(schedulerContentsBuf)
-	schedSupported := false
-	for _, v := range strings.Split(schedulerContents, " ") {
-		switch v {
-		case fmt.Sprintf("[%s]", sched):
-			glog.Infof("Device %s already uses scheduler %s", rootDevSysfs, sched)
-			return nil
-		case sched:
-			schedSupported = true
-			break
-		}
-	}
-	if !schedSupported {
-		glog.Infof("Device %s does not support the %s scheduler", rootDevSysfs, sched)
-		return nil
-	}
-
-	f, err := os.OpenFile(schedulerPath, os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = f.Write([]byte(sched))
-	if err != nil {
-		return err
-	}
-	glog.Infof("Set root blockdev %s to use scheduler %v", rootDevSysfs, sched)
-
-	return nil
-}
 
 // updateOstreeObjectSync enables "per-object-fsync" which helps avoid
 // latency spikes for etcd; see https://github.com/ostreedev/ostree/pull/2152

--- a/pkg/daemon/coreos.go
+++ b/pkg/daemon/coreos.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/golang/glog"
 )
@@ -31,46 +30,6 @@ const ignitionProvisioningPath = "/etc/.ignition-result.json"
 // We only really care about the provisioning date right now.
 type ignitionReport struct {
 	ProvisioningDate string `json:"provisioningDate"`
-}
-
-// byLabel returns the udev generated symlink to the block device with the given label
-func byLabel(label string) string {
-	return fmt.Sprintf("/dev/disk/by-label/%s", label)
-}
-
-// getParentDeviceSysfs returns e.g. /sys/devices/pci0000:00/0000:00:05.0/virtio2/block/vda from /dev/vda4, though
-// it can be more complex than that with e.g. NVMe.
-func getParentDeviceSysfs(device string) (string, error) {
-	target, err := os.Readlink(device)
-	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", device, err)
-	}
-	sysfsDevLink := fmt.Sprintf("/sys/class/block/%s", filepath.Base(target))
-	sysfsDev, err := filepath.EvalSymlinks(sysfsDevLink)
-	if err != nil {
-		return "", fmt.Errorf("parsing %s: %w", sysfsDevLink, err)
-	}
-	if _, err := os.Stat(filepath.Join(sysfsDev, "partition")); err == nil {
-		sysfsDev = filepath.Dir(sysfsDev)
-	}
-	return sysfsDev, nil
-}
-
-// getRootBlockDeviceSysfs returns the path to the block
-// device backing the root partition on a FCOS system
-func getRootBlockDeviceSysfs() (string, error) {
-	// Check for the `crypt_rootfs` label; this exists for RHCOS >= 4.3 but <= 4.6.
-	// See https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/automated-policy-based-disk-encryption.md
-	luksRoot := byLabel("crypt_rootfs")
-	if _, err := os.Stat(luksRoot); err == nil {
-		return getParentDeviceSysfs(luksRoot)
-	}
-	// This is what we expect on FCOS and RHCOS <= 4.2
-	root := byLabel("root")
-	if _, err := os.Stat(root); err == nil {
-		return getParentDeviceSysfs(root)
-	}
-	return "", fmt.Errorf("failed to find %s", root)
 }
 
 func logAlephInformation() error {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -383,22 +383,6 @@ func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newC
 	}
 
 	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType {
-		// When we're going to apply an OS update, switch the block
-		// scheduler to BFQ to apply more fairness between etcd
-		// and the OS update. Only do this on masters since etcd
-		// only operates on masters, and RHEL compute nodes can't
-		// do this.
-		// Add nil check since firstboot also goes through this path,
-		// which doesn't have a node object yet.
-		// This is okay because we know if we made it here, we are going
-		// to reboot and this setting does not persist across reboots.
-		if dn.node != nil {
-			if _, isControlPlane := dn.node.Labels[ctrlcommon.MasterLabel]; isControlPlane {
-				if err := setRootDeviceSchedulerBFQ(); err != nil {
-					return err
-				}
-			}
-		}
 		// We emitted this event before, so keep it
 		if dn.nodeWriter != nil {
 			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "InClusterUpgrade", fmt.Sprintf("Updating from oscontainer %s", newConfig.Spec.OSImageURL))


### PR DESCRIPTION
This apparently provoked a kernel bug and caused a lockup.  Previously we did the BFQ work as a way to try to preserve fairness and avoid etcd disruption during in-place OS updates.

But from my point of view that was a total failure, and dynamically switching to a non-default I/O scheduler is just asking to provoke bugs.

The move to layering will help with OS updates because we now start only pulling and writing to disk something much closer to *what actually changed*.

The previous OS update path of pulling a single giant image to the container storage, then writing it to the host, then deleting it involves a lot more I/O and disruption.
