### PR TITLE
OCPBUGS-3508: Don't make https call to http endpoint

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-script-both.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-script-both.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script_bo
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz
+    /usr/bin/curl -o /dev/null -kLfs http://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz

--- a/templates/master/00-master/on-prem/files/keepalived-script.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-script.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script.sh
 contents:
   inline: |
     #!/bin/bash
-    /usr/bin/curl -o /dev/null -kLfs https://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ]
+    /usr/bin/curl -o /dev/null -kLfs http://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ]


### PR DESCRIPTION
The haproxy health check is not an https endpoint and calling it with https always fails. This is causing our loadbalancer to misbehave because we're relying entirely on the localhost healthcheck, which causes unnecessary failover.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Fixed a bug in the keepalived healthcheck that was causing it to always fail.
