### PR TITLE
MCO-420: Migrate drain alert to drain controller

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -66,7 +66,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		ctrlctx := ctrlcommon.CreateControllerContext(cb, ctx.Done(), componentName)
 
 		// Start the metrics handler
-		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctrlctx.Stop)
+		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctrlctx.Stop, ctrlcommon.RegisterMCCMetrics)
 
 		controllers := createControllers(ctrlctx)
 		draincontroller := drain.New(

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -70,6 +70,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 		controllers := createControllers(ctrlctx)
 		draincontroller := drain.New(
+			drain.DefaultConfig(),
 			ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctrlctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -226,7 +226,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// Start local metrics listener
-	go daemon.StartMetricsListener(startOpts.promMetricsURL, stopCh)
+	go ctrlcommon.StartMetricsListener(startOpts.promMetricsURL, stopCh, daemon.RegisterMCDMetrics)
 
 	ctx := ctrlcommon.CreateControllerContext(cb, stopCh, componentName)
 	// create the daemon instance. this also initializes kube client items

--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -31,12 +31,21 @@ spec:
             severity: critical
           annotations:
             summary: "Paused machine configuration pool '{{$labels.pool}}' is blocking a necessary certificate rotation and must be unpaused before the current kube-apiserver-to-kubelet-signer certificate expires in {{ $value | humanizeDuration }}."
-            description: "Machine config pools have a 'pause' feature, which allows config to be rendered, but prevents it from being rolled out to the nodes. This alert indicates that a certificate rotation has taken place, and the new kubelet-ca certificate bundle has been rendered into a machine config, but because the pool '{{$labels.pool}}' is paused, the config cannot be rolled out to the nodes in that pool. You will notice almost immediately that for nodes in pool '{{$labels.pool}}', pod logs will not be visible in the console and interactive commands (oc log, oc exec, oc debug, oc attach) will not work. You must unpause machine config pool '{{$labels.pool}}' to let the certificates through before the kube-apiserver-to-kubelet-signer certificate expires. You have approximately {{ $value | humanizeDuration }} remaining before this happens and nodes in '{{$labels.pool}}' cease to function properly." 
+            description: "Machine config pools have a 'pause' feature, which allows config to be rendered, but prevents it from being rolled out to the nodes. This alert indicates that a certificate rotation has taken place, and the new kubelet-ca certificate bundle has been rendered into a machine config, but because the pool '{{$labels.pool}}' is paused, the config cannot be rolled out to the nodes in that pool. You will notice almost immediately that for nodes in pool '{{$labels.pool}}', pod logs will not be visible in the console and interactive commands (oc log, oc exec, oc debug, oc attach) will not work. You must unpause machine config pool '{{$labels.pool}}' to let the certificates through before the kube-apiserver-to-kubelet-signer certificate expires. You have approximately {{ $value | humanizeDuration }} remaining before this happens and nodes in '{{$labels.pool}}' cease to function properly."
             runbook_url: https://github.com/openshift/blob/master/alerts/machine-config-operator/MachineConfigControllerPausedPoolKubeletCA.md
     - name: os-image-override.rules
       rules:
         - expr: sum(os_image_url_override)
           record: os_image_url_override:sum
+    - name: mcc-drain-error
+      rules:
+        - alert: MCCDrainError
+          expr: |
+            mcc_drain_err > 0
+          labels:
+            severity: warning
+          annotations:
+            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -60,15 +69,6 @@ spec:
             severity: critical
           annotations:
             message: "Reboot failed on {{ $labels.node }} , update may be blocked. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon "
-    - name: mcd-drain-error
-      rules:
-        - alert: MCDDrainError
-          expr: |
-            mcd_drain_err > 0
-          labels:
-            severity: warning
-          annotations:
-            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
     - name: mcd-pivot-error
       rules:
         - alert: MCDPivotError

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/golang/glog"
@@ -29,13 +30,28 @@ var (
 			Name: "os_image_url_override",
 			Help: "state of OS image override",
 		}, []string{"pool"})
+
+	// MCCDrainErr logs failed drain
+	MCCDrainErr = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mcc_drain_err",
+			Help: "logs failed drain",
+		})
 )
 
 func RegisterMCCMetrics() error {
-	return RegisterMetrics([]prometheus.Collector{
+	err := RegisterMetrics([]prometheus.Collector{
 		MachineConfigControllerPausedPoolKubeletCA,
 		OSImageURLOverride,
 	})
+
+	if err != nil {
+		return fmt.Errorf("could not register machine-config-controller metrics: %w", err)
+	}
+
+	MCCDrainErr.Set(0)
+
+	return nil
 }
 
 func RegisterMetrics(metrics []prometheus.Collector) error {

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -43,6 +43,7 @@ func RegisterMCCMetrics() error {
 	err := RegisterMetrics([]prometheus.Collector{
 		MachineConfigControllerPausedPoolKubeletCA,
 		OSImageURLOverride,
+		MCCDrainErr,
 	})
 
 	if err != nil {

--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -373,7 +373,6 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 			ctrl.logNode(node, "Drain failed. Drain has been failing for more than %v minutes. Waiting %v minutes then retrying. "+
 				"Error message from drain: %v", ctrl.cfg.DrainRequeueFailingThreshold.Minutes(), ctrl.cfg.DrainRequeueFailingDelay.Minutes(), err)
 			ctrl.enqueueAfter(node, ctrl.cfg.DrainRequeueFailingDelay)
-			ctrlcommon.MCCDrainErr.Set(1)
 		} else {
 			ctrl.logNode(node, "Drain failed. Waiting %v minute then retrying. Error message from drain: %v",
 				ctrl.cfg.DrainRequeueDelay.Minutes(), err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1841,7 +1841,6 @@ func (dn *Daemon) completeUpdate(desiredConfigName string) error {
 		if err == wait.ErrWaitTimeout {
 			failMsg := fmt.Sprintf("failed to uncordon node: %s after 10 minutes. Please see machine-config-controller logs for more information", dn.node.Name)
 			dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedToUncordon", failMsg)
-			mcdDrainErr.Set(1)
 			return fmt.Errorf(failMsg)
 		}
 		return fmt.Errorf("Something went wrong while attempting to uncordon node: %v", err)

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -52,7 +52,6 @@ func (dn *Daemon) performDrain() error {
 		// A third case we can hit this is that the node fails validation upon reboot, and then we use
 		// the forcefile. But in that case, since we never uncordoned, skipping the drain should be fine
 		dn.logSystem("drain is already completed on this node")
-		mcdDrainErr.Set(0)
 		return nil
 	}
 
@@ -84,7 +83,6 @@ func (dn *Daemon) performDrain() error {
 		if err == wait.ErrWaitTimeout {
 			failMsg := fmt.Sprintf("failed to drain node: %s after 1 hour. Please see machine-config-controller logs for more information", dn.node.Name)
 			dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedToDrain", failMsg)
-			mcdDrainErr.Set(1)
 			return fmt.Errorf(failMsg)
 		}
 		return fmt.Errorf("Something went wrong while attempting to drain node: %v", err)
@@ -93,7 +91,6 @@ func (dn *Daemon) performDrain() error {
 	dn.logSystem("drain complete")
 	t := time.Since(startTime).Seconds()
 	glog.Infof("Successful drain took %v seconds", t)
-	mcdDrainErr.Set(0)
 
 	return nil
 }

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -52,7 +52,7 @@ func (dn *Daemon) performDrain() error {
 		// A third case we can hit this is that the node fails validation upon reboot, and then we use
 		// the forcefile. But in that case, since we never uncordoned, skipping the drain should be fine
 		dn.logSystem("drain is already completed on this node")
-		MCDDrainErr.Set(0)
+		mcdDrainErr.Set(0)
 		return nil
 	}
 
@@ -84,7 +84,7 @@ func (dn *Daemon) performDrain() error {
 		if err == wait.ErrWaitTimeout {
 			failMsg := fmt.Sprintf("failed to drain node: %s after 1 hour. Please see machine-config-controller logs for more information", dn.node.Name)
 			dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedToDrain", failMsg)
-			MCDDrainErr.Set(1)
+			mcdDrainErr.Set(1)
 			return fmt.Errorf(failMsg)
 		}
 		return fmt.Errorf("Something went wrong while attempting to drain node: %v", err)
@@ -93,7 +93,7 @@ func (dn *Daemon) performDrain() error {
 	dn.logSystem("drain complete")
 	t := time.Since(startTime).Seconds()
 	glog.Infof("Successful drain took %v seconds", t)
-	MCDDrainErr.Set(0)
+	mcdDrainErr.Set(0)
 
 	return nil
 }
@@ -128,6 +128,7 @@ func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig i
 // 1. A new mirror is added to an existing registry that has `mirror-by-digest-only=true`
 // 2. A new registry has been added that has `mirror-by-digest-only=true`
 // See https://bugzilla.redhat.com/show_bug.cgi?id=1943315
+//
 //nolint:gocyclo
 func isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig ign3types.Config) (bool, error) {
 	// /etc/containers/registries.conf contains config in toml format. Parse the file

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -1,124 +1,90 @@
 package daemon
 
 import (
-	"context"
-	"net/http"
+	"fmt"
 
-	"github.com/golang/glog"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// MCD Metrics
 var (
-	// DefaultBindAddress is the port for the metrics listener
-	DefaultBindAddress = ":8797"
-
-	// HostOS shows os that MCD is running on and version if RHCOS
-	HostOS = prometheus.NewGaugeVec(
+	// hostOS shows os that MCD is running on and version if RHCOS
+	hostOS = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "mcd_host_os_and_version",
 			Help: "os that MCD is running on and version if RHCOS",
 		}, []string{"os", "version"})
 
-	// MCDSSHAccessed shows ssh access count for a node
-	MCDSSHAccessed = prometheus.NewCounter(
+	// mcdSSHAccessed shows ssh access count for a node
+	mcdSSHAccessed = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "ssh_accesses_total",
 			Help: "Total number of SSH access occurred.",
 		})
 
-	// MCDDrainErr logs failed drain
-	MCDDrainErr = prometheus.NewGauge(
+	// mcdDrainErr logs failed drain
+	mcdDrainErr = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "mcd_drain_err",
 			Help: "logs failed drain",
 		})
 
-	// MCDPivotErr flags error encountered during pivot
-	MCDPivotErr = prometheus.NewCounter(
+	// mcdPivotErr flags error encountered during pivot
+	mcdPivotErr = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "mcd_pivot_errors_total",
 			Help: "Total number of errors encountered during pivot.",
 		})
 
-	// MCDState is state of mcd for indicated node (ex: degraded)
-	MCDState = prometheus.NewGaugeVec(
+	// mcdState is state of mcd for indicated node (ex: degraded)
+	mcdState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "mcd_state",
 			Help: "state of daemon on specified node",
 		}, []string{"state", "reason"})
 
-	// KubeletHealthState logs kubelet health failures and tallys count
-	KubeletHealthState = prometheus.NewGauge(
+	// kubeletHealthState logs kubelet health failures and tallys count
+	kubeletHealthState = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "mcd_kubelet_state",
 			Help: "state of kubelet health monitor",
 		})
 
-	// MCDRebootErr tallys failed reboot attempts
-	MCDRebootErr = prometheus.NewCounter(
+	// mcdRebootErr tallys failed reboot attempts
+	mcdRebootErr = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "mcd_reboots_failed_total",
 			Help: "Total number of reboots that failed.",
 		})
 
-	// MCDUpdateState logs completed update or error
-	MCDUpdateState = prometheus.NewGaugeVec(
+	// mcdUpdateState logs completed update or error
+	mcdUpdateState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "mcd_update_state",
 			Help: "completed update config or error",
 		}, []string{"config", "err"})
-
-	metricsList = []prometheus.Collector{
-		HostOS,
-		MCDSSHAccessed,
-		MCDDrainErr,
-		MCDPivotErr,
-		MCDState,
-		KubeletHealthState,
-		MCDRebootErr,
-		MCDUpdateState,
-	}
 )
 
-func registerMCDMetrics() error {
-	for _, metric := range metricsList {
-		err := prometheus.Register(metric)
-		if err != nil {
-			return err
-		}
+func RegisterMCDMetrics() error {
+	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
+		hostOS,
+		mcdSSHAccessed,
+		mcdDrainErr,
+		mcdPivotErr,
+		mcdState,
+		kubeletHealthState,
+		mcdRebootErr,
+		mcdUpdateState,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not register MCC metrics: %w", err)
 	}
 
-	MCDDrainErr.Set(0)
-	KubeletHealthState.Set(0)
-	MCDUpdateState.WithLabelValues("", "").Set(0)
+	mcdDrainErr.Set(0)
+	kubeletHealthState.Set(0)
+	mcdUpdateState.WithLabelValues("", "").Set(0)
 
 	return nil
-}
-
-// StartMetricsListener is metrics listener via http on localhost
-func StartMetricsListener(addr string, stopCh chan struct{}) {
-	if addr == "" {
-		addr = DefaultBindAddress
-	}
-
-	glog.Info("Registering Prometheus metrics")
-	if err := registerMCDMetrics(); err != nil {
-		glog.Errorf("unable to register metrics: %v", err)
-	}
-
-	glog.Infof("Starting metrics listener on %s", addr)
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	s := http.Server{Addr: addr, Handler: mux}
-
-	go func() {
-		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			glog.Errorf("metrics listener exited with error: %v", err)
-		}
-	}()
-	<-stopCh
-	if err := s.Shutdown(context.Background()); err != http.ErrServerClosed {
-		glog.Errorf("error stopping metrics listener: %v", err)
-	}
 }

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -23,13 +23,6 @@ var (
 			Help: "Total number of SSH access occurred.",
 		})
 
-	// mcdDrainErr logs failed drain
-	mcdDrainErr = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "mcd_drain_err",
-			Help: "logs failed drain",
-		})
-
 	// mcdPivotErr flags error encountered during pivot
 	mcdPivotErr = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -70,7 +63,6 @@ func RegisterMCDMetrics() error {
 	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
 		hostOS,
 		mcdSSHAccessed,
-		mcdDrainErr,
 		mcdPivotErr,
 		mcdState,
 		kubeletHealthState,
@@ -79,10 +71,9 @@ func RegisterMCDMetrics() error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("could not register MCC metrics: %w", err)
+		return fmt.Errorf("could not register machine-config-daemon metrics: %w", err)
 	}
 
-	mcdDrainErr.Set(0)
 	kubeletHealthState.Set(0)
 	mcdUpdateState.WithLabelValues("", "").Set(0)
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2154,14 +2154,14 @@ func (dn *Daemon) reboot(rationale string) error {
 	// either, we just have one for the MCD itself.
 	if err := rebootCmd.Run(); err != nil {
 		dn.logSystem("failed to run reboot: %v", err)
-		MCDRebootErr.Inc()
+		mcdRebootErr.Inc()
 	}
 
 	// wait to be killed via SIGTERM from the kubelet shutting down
 	time.Sleep(defaultRebootTimeout)
 
 	// if everything went well, this should be unreachable.
-	MCDRebootErr.Inc()
+	mcdRebootErr.Inc()
 	return fmt.Errorf("reboot failed; this error should be unreachable, something is seriously wrong")
 }
 
@@ -2195,7 +2195,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateLayeredOS(newConfig); err != nil {
-			MCDPivotErr.Inc()
+			mcdPivotErr.Inc()
 			return err
 		}
 		if dn.nodeWriter != nil {
@@ -2263,7 +2263,7 @@ func (dn *CoreOSDaemon) applyLegacyOSChanges(mcDiff machineConfigDiff, oldConfig
 	// Update OS
 	if mcDiff.osUpdate {
 		if err := dn.updateOS(newConfig, osImageContentDir); err != nil {
-			MCDPivotErr.Inc()
+			mcdPivotErr.Inc()
 			return err
 		}
 		if dn.nodeWriter != nil {

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -146,7 +146,7 @@ func (nw *clusterNodeWriter) SetDone(dcAnnotation string) error {
 		// clear out any Degraded/Unreconcilable reason
 		constants.MachineConfigDaemonReasonAnnotationKey: "",
 	}
-	MCDState.WithLabelValues(constants.MachineConfigDaemonStateDone, "").SetToCurrentTime()
+	mcdState.WithLabelValues(constants.MachineConfigDaemonStateDone, "").SetToCurrentTime()
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -161,7 +161,7 @@ func (nw *clusterNodeWriter) SetWorking() error {
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateWorking,
 	}
-	MCDState.WithLabelValues(constants.MachineConfigDaemonStateWorking, "").SetToCurrentTime()
+	mcdState.WithLabelValues(constants.MachineConfigDaemonStateWorking, "").SetToCurrentTime()
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -181,7 +181,7 @@ func (nw *clusterNodeWriter) SetUnreconcilable(err error) error {
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateUnreconcilable,
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
-	MCDState.WithLabelValues(constants.MachineConfigDaemonStateUnreconcilable, truncatedErr).SetToCurrentTime()
+	mcdState.WithLabelValues(constants.MachineConfigDaemonStateUnreconcilable, truncatedErr).SetToCurrentTime()
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -205,7 +205,7 @@ func (nw *clusterNodeWriter) SetDegraded(err error) error {
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateDegraded,
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
-	MCDState.WithLabelValues(constants.MachineConfigDaemonStateDegraded, truncatedErr).SetToCurrentTime()
+	mcdState.WithLabelValues(constants.MachineConfigDaemonStateDegraded, truncatedErr).SetToCurrentTime()
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -220,7 +220,7 @@ func (nw *clusterNodeWriter) SetDegraded(err error) error {
 
 // SetSSHAccessed sets the ssh annotation to accessed
 func (nw *clusterNodeWriter) SetSSHAccessed() error {
-	MCDSSHAccessed.Inc()
+	mcdSSHAccessed.Inc()
 	annos := map[string]string{
 		machineConfigDaemonSSHAccessAnnotationKey: machineConfigDaemonSSHAccessValue,
 	}


### PR DESCRIPTION
**- What I did**

This PR does the following:
- Consolidates duplicate code between the `pkg/controller/common/metrics.go` and `pkg/daemon/metrics.go` files.
- Makes the Prometheus metrics for the MCD private to the `daemon` package since they're not used elsewhere.
- Renames `MCDDrainErr` to `MCCDrainErr` and migrates it to `pkg/controller/common/metrics.go`.
- Refactors drain controller logic by extracting the drain code into a separate function for clarity.
- Adds MCCDrainErr to the refactored drain node logic.

**- How to verify it**

TBD

**- Description for the changelog**
Rename MCDDrainErr to MCCDrainErr and move into drain controller
