### PR TITLE
OCPBUGS-4039: NM resolve prepender: remove extra quotes in OKD flow

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -104,7 +104,7 @@ contents:
 
                     # If KNI conf is not created or doesn't match what is generated or
                     # if we haven't completed a full update - create or update it
-                    if [[ ! -f "${"KNICONFPATH"} ]] || [[ ! -f "${"KNICONFDONEPATH"} ]] || ! cmp --silent "${KNICONFPATH}" "${KNICONFTMPPATH}"; then
+                    if [[ ! -f "${KNICONFPATH}" ]] || [[ ! -f "${KNICONFDONEPATH}" ]] || ! cmp --silent "${KNICONFPATH}" "${KNICONFTMPPATH}"; then
                         >&2 echo "NM resolv-prepender: Creating/updating /etc/systemd/resolved.conf.d/60-kni.conf"
                         rm -f "${KNICONFDONEPATH}"
                         mv -f "${KNICONFTMPPATH}" "${KNICONFPATH}"


### PR DESCRIPTION
Fix bash script syntax to make OKD branch pass as correctly.

Bug was introduced in #3394
