### PR TITLE
OCPBUGS-3909: Don't validate contents and mode for masked units

### DIFF
--- a/pkg/daemon/config_drift_monitor_test.go
+++ b/pkg/daemon/config_drift_monitor_test.go
@@ -12,7 +12,6 @@ import (
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,13 +200,24 @@ func TestConfigDriftMonitor(t *testing.T) {
 		},
 	}
 
+	// Create a mutex for our test cases The mutex is needed because we now
+	// overwrite the origParentDirPath and noOrigParentDirPath global variables
+	// so that our filesystem mutations are confined to a tempdir created by the
+	// test case. However, since this is a global value, we need to be sure that
+	// only one testcase can use it at a time. Other than that, the test suite
+	// does a good job of keeping each individual test case isolated in its own
+	// tempdir.
+	testMutex := &sync.Mutex{}
+
 	for _, testCase := range testCases {
+		// Wire up the mutex to each test case before executing so they don't stomp
+		// on each other.
+		testCase.testMutex = testMutex
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			tmpDir := t.TempDir()
-			defer os.RemoveAll(tmpDir)
 
 			testCase.tmpDir = tmpDir
 			testCase.systemdPath = filepath.Join(tmpDir, pathSystemd)
@@ -236,6 +246,8 @@ type configDriftMonitorTestCase struct {
 	mutateUnit func(string) error
 	// The mutation to apply to the systemd dropin file
 	mutateDropin func(string) error
+	// Mutex to ensure that parallel tests do not stomp on one another
+	testMutex *sync.Mutex
 }
 
 // Runs the test case
@@ -311,6 +323,8 @@ func (tc configDriftMonitorTestCase) run(t *testing.T) {
 	// Mutate the filesystem
 	require.Nil(t, tc.mutate(ignConfig))
 
+	// TODO: Figure out a value to make this work on Macs because they take
+	// longer to report the filesystem activity.
 	timeout := 100 * time.Millisecond
 	start := time.Now()
 
@@ -349,6 +363,19 @@ func (tc configDriftMonitorTestCase) run(t *testing.T) {
 	}
 }
 
+// Permissions in CI are a bit more complicated than they are on an end-user
+// machine since we're running in a container with an unknown username and
+// unknown UID / GID. However, the defaults (-1 / -1) seem to work without
+// issue as evidenced by writeFileAtomicallyWithDefaults() being able to write
+// successfully.
+func setDefaultUIDandGID(file ign3types.File) ign3types.File {
+	file.Node.User.Name = nil
+	file.Node.Group.Name = nil
+	file.User.ID = helpers.IntToPtr(-1)
+	file.Group.ID = helpers.IntToPtr(-1)
+	return file
+}
+
 // Creates the Ignition Config test fixture
 func (tc configDriftMonitorTestCase) getIgnConfig(t *testing.T) ign3types.Config {
 	compressedFile, err := helpers.CreateGzippedIgn3File("/etc/a-compressed-file", "thefilecontents", int(defaultFilePermissions))
@@ -360,8 +387,8 @@ func (tc configDriftMonitorTestCase) getIgnConfig(t *testing.T) ign3types.Config
 		},
 		Storage: ign3types.Storage{
 			Files: []ign3types.File{
-				helpers.CreateEncodedIgn3File("/etc/a-config-file", "thefilecontents", int(defaultFilePermissions)),
-				compressedFile,
+				setDefaultUIDandGID(helpers.CreateEncodedIgn3File("/etc/a-config-file", "thefilecontents", int(defaultFilePermissions))),
+				setDefaultUIDandGID(compressedFile),
 			},
 		},
 		Systemd: ign3types.Systemd{
@@ -378,6 +405,13 @@ func (tc configDriftMonitorTestCase) getIgnConfig(t *testing.T) ign3types.Config
 							Name: "20-unittest-service.conf",
 						},
 					},
+				},
+				// Add a masked systemd unit to ensure that we don't inadvertantly drift.
+				// See: https://issues.redhat.com/browse/OCPBUGS-3909
+				{
+					Name:     "mask-and-contents.service",
+					Contents: helpers.StrToPtr("[Unit]\nDescription=Just random content"),
+					Mask:     helpers.BoolToPtr(true),
 				},
 			},
 		},
@@ -414,28 +448,61 @@ func (tc configDriftMonitorTestCase) getFixtures(t *testing.T) (ign3types.Config
 
 	ignConfig := tc.getIgnConfig(t)
 
-	// Prefix all the ignition files with the temp directory and write to disk.
+	// Prefix all the ignition files with the temp directory.
 	for i, file := range ignConfig.Storage.Files {
 		file.Path = filepath.Join(tc.tmpDir, file.Path)
 		ignConfig.Storage.Files[i] = file
-		tc.writeIgn3FileForTest(t, file)
 	}
 
-	// Prefix all the systemd files with the temp dir and write them.
-	for _, unit := range ignConfig.Systemd.Units {
-		unitPath := getIgn3SystemdUnitPath(tc.systemdPath, unit)
-		tc.writeFileForTest(t, unitPath, unit.Contents)
-		for _, dropin := range unit.Dropins {
-			dropinPath := getIgn3SystemdDropinPath(tc.systemdPath, unit, dropin)
-			tc.writeFileForTest(t, dropinPath, dropin.Contents)
-		}
-	}
+	// Separate the disk write process so that we can be sure that the deferred
+	// functions are run even when we encounter an error.
+	require.NoError(t, tc.writeIgnitionConfig(t, ignConfig))
 
 	// Create a MachineConfig from our Ignition Config
 	mc := helpers.CreateMachineConfigFromIgnition(ignConfig)
 	mc.Name = "config-drift-monitor" + string(uuid.NewUUID())
 
 	return ignConfig, mc
+}
+
+// This needs to be a pointer receiver so we can lock / unlock the mutex.
+func (tc *configDriftMonitorTestCase) writeIgnitionConfig(t *testing.T, ignConfig ign3types.Config) error {
+	t.Helper()
+
+	// This is the only place where this mutex is used throughout this test
+	// suite. We need a mutex because the origParentDirPath and
+	// noOrigParentDirPath variables are global and our individual test cases
+	// execute in parallel.
+	tc.testMutex.Lock()
+	defer tc.testMutex.Unlock()
+
+	// For the purposes of our test, we want all of our filesystem mutations to
+	// be contained within our test temp dir. With this in mind, we temporarily
+	// override these globals with our temp dir.
+	globals := map[string]*string{
+		"usrPath":             &usrPath,
+		"origParentDirPath":   &origParentDirPath,
+		"noOrigParentDirPath": &noOrigParentDirPath,
+	}
+
+	for name := range globals {
+		cleanup := helpers.OverrideGlobalPathVar(t, name, globals[name])
+		defer cleanup()
+	}
+
+	// Write files the same way the MCD does.
+	// NOTE: We manually handle the errors here because using require.Nil or
+	// require.NoError will skip the deferred functions, which is undesirable.
+	if err := writeFiles(ignConfig.Storage.Files); err != nil {
+		return fmt.Errorf("could not write ignition config files: %w", err)
+	}
+
+	// Write systemd units the same way the MCD does.
+	if err := writeUnits(ignConfig.Systemd.Units, tc.systemdPath, true); err != nil {
+		return fmt.Errorf("could not write systemd units: %w", err)
+	}
+
+	return nil
 }
 
 func (tc configDriftMonitorTestCase) onDriftFunc(t *testing.T, err error) {
@@ -460,24 +527,4 @@ func (tc configDriftMonitorTestCase) onDriftFunc(t *testing.T, err error) {
 	if errors.As(tc.expectedErr, &uErr) {
 		assert.ErrorAs(t, err, &uErr)
 	}
-}
-
-func (tc configDriftMonitorTestCase) writeIgn3FileForTest(t *testing.T, file ign3types.File) {
-	t.Helper()
-
-	decodedContents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
-	require.Nil(t, err)
-
-	require.Nil(t, writeFileAtomicallyWithDefaults(file.Path, decodedContents))
-}
-
-func (tc configDriftMonitorTestCase) writeFileForTest(t *testing.T, path string, contents *string) {
-	t.Helper()
-
-	out := ""
-	if contents != nil {
-		out = *contents
-	}
-
-	require.Nil(t, writeFileAtomicallyWithDefaults(path, []byte(out)))
 }

--- a/pkg/daemon/file_writers.go
+++ b/pkg/daemon/file_writers.go
@@ -1,0 +1,302 @@
+package daemon
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/golang/glog"
+	"github.com/google/renameio"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+)
+
+var (
+	origParentDirPath   = filepath.Join("/etc", "machine-config-daemon", "orig")
+	noOrigParentDirPath = filepath.Join("/etc", "machine-config-daemon", "noorig")
+	usrPath             = "/usr"
+)
+
+func origParentDir() string {
+	return origParentDirPath
+}
+
+func noOrigParentDir() string {
+	return noOrigParentDirPath
+}
+
+func origFileName(fpath string) string {
+	return filepath.Join(origParentDir(), fpath+".mcdorig")
+}
+
+// We use this to create a file that indicates that no original file existed on disk
+// when we write a file via a MachineConfig. Otherwise the MCD does not differentiate
+// between "a file existed due to a previous machineconfig" vs "a file existed on disk
+// before the MCD took over". Also see deleteStaleData() above.
+//
+// The "stamp" part of the name indicates it is not an actual backup file, just an
+// empty file to indicate lack of previous existence.
+func noOrigFileStampName(fpath string) string {
+	return filepath.Join(noOrigParentDir(), fpath+".mcdnoorig")
+}
+
+func createOrigFile(fromPath, fpath string) error {
+	if _, err := os.Stat(noOrigFileStampName(fpath)); err == nil {
+		// we already created the no orig file for this default file
+		return nil
+	}
+	if _, err := os.Stat(fpath); os.IsNotExist(err) {
+		// create a noorig file that tells the MCD that the file wasn't present on disk before MCD
+		// took over so it can just remove it when deleting stale data, as opposed as restoring a file
+		// that was shipped _with_ the underlying OS (e.g. a default chrony config).
+		if makeErr := os.MkdirAll(filepath.Dir(noOrigFileStampName(fpath)), 0o755); makeErr != nil {
+			return fmt.Errorf("creating no orig parent dir: %w", makeErr)
+		}
+		return writeFileAtomicallyWithDefaults(noOrigFileStampName(fpath), nil)
+	}
+
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1970959
+	// orig file might exist, but be a relative/dangling symlink
+	if symlinkTarget, err := os.Readlink(origFileName(fpath)); err == nil {
+		if symlinkTarget != "" {
+			return nil
+		}
+	}
+	if _, err := os.Stat(origFileName(fpath)); err == nil {
+		// the orig file is already there and we avoid creating a new one to preserve the real default
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(origFileName(fpath)), 0o755); err != nil {
+		return fmt.Errorf("creating orig parent dir: %w", err)
+	}
+	if out, err := exec.Command("cp", "-a", "--reflink=auto", fromPath, origFileName(fpath)).CombinedOutput(); err != nil {
+		return fmt.Errorf("creating orig file for %q: %s: %w", fpath, string(out), err)
+	}
+	return nil
+}
+
+func writeFileAtomicallyWithDefaults(fpath string, b []byte) error {
+	return writeFileAtomically(fpath, b, defaultDirectoryPermissions, defaultFilePermissions, -1, -1)
+}
+
+// writeFileAtomically uses the renameio package to provide atomic file writing, we can't use renameio.WriteFile
+// directly since we need to 1) Chown 2) go through a buffer since files provided can be big
+func writeFileAtomically(fpath string, b []byte, dirMode, fileMode os.FileMode, uid, gid int) error {
+	dir := filepath.Dir(fpath)
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", dir, err)
+	}
+	t, err := renameio.TempFile(dir, fpath)
+	if err != nil {
+		return err
+	}
+	defer t.Cleanup()
+	// Set permissions before writing data, in case the data is sensitive.
+	if err := t.Chmod(fileMode); err != nil {
+		return err
+	}
+	w := bufio.NewWriter(t)
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if uid != -1 && gid != -1 {
+		if err := t.Chown(uid, gid); err != nil {
+			return err
+		}
+	}
+	return t.CloseAtomicallyReplace()
+}
+
+// write dropins to disk
+func writeDropins(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error {
+	for i := range u.Dropins {
+		dpath := filepath.Join(systemdRoot, u.Name+".d", u.Dropins[i].Name)
+		if u.Dropins[i].Contents == nil || *u.Dropins[i].Contents == "" {
+			glog.Infof("Dropin for %s has no content, skipping write", u.Dropins[i].Name)
+			if _, err := os.Stat(dpath); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return err
+			}
+			glog.Infof("Removing %q, updated file has zero length", dpath)
+			if err := os.Remove(dpath); err != nil {
+				return err
+			}
+			continue
+		}
+
+		glog.Infof("Writing systemd unit dropin %q", u.Dropins[i].Name)
+		if _, err := os.Stat(withUsrPath(dpath)); err == nil &&
+			isCoreOSVariant {
+			if err := createOrigFile(withUsrPath(dpath), dpath); err != nil {
+				return err
+			}
+		}
+		if err := writeFileAtomicallyWithDefaults(dpath, []byte(*u.Dropins[i].Contents)); err != nil {
+			return fmt.Errorf("failed to write systemd unit dropin %q: %w", u.Dropins[i].Name, err)
+		}
+
+		glog.V(2).Infof("Wrote systemd unit dropin at %s", dpath)
+	}
+
+	return nil
+}
+
+// writeFiles writes the given files to disk.
+// it doesn't fetch remote files and expects a flattened config file.
+func writeFiles(files []ign3types.File) error {
+	for _, file := range files {
+		glog.Infof("Writing file %q", file.Path)
+
+		// We don't support appends in the file section, so instead of waiting to fail validation,
+		// let's explicitly fail here.
+		if len(file.Append) > 0 {
+			return fmt.Errorf("found an append section when writing files. Append is not supported")
+		}
+
+		decodedContents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+		if err != nil {
+			return fmt.Errorf("could not decode file %q: %w", file.Path, err)
+		}
+
+		mode := defaultFilePermissions
+		if file.Mode != nil {
+			mode = os.FileMode(*file.Mode)
+		}
+
+		// set chown if file information is provided
+		uid, gid, err := getFileOwnership(file)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve file ownership for file %q: %w", file.Path, err)
+		}
+		if err := createOrigFile(file.Path, file.Path); err != nil {
+			return err
+		}
+		if err := writeFileAtomically(file.Path, decodedContents, defaultDirectoryPermissions, mode, uid, gid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeUnit writes a systemd unit and its dropins to disk
+func writeUnit(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error {
+	if err := writeDropins(u, systemdRoot, isCoreOSVariant); err != nil {
+		return err
+	}
+
+	// write (or cleanup) path in /etc/systemd/system
+	fpath := filepath.Join(systemdRoot, u.Name)
+	if u.Mask != nil && *u.Mask {
+		// if the unit is masked, symlink fpath to /dev/null and return early.
+
+		glog.V(2).Info("Systemd unit masked")
+		if err := os.RemoveAll(fpath); err != nil {
+			return fmt.Errorf("failed to remove unit %q: %w", u.Name, err)
+		}
+		glog.V(2).Infof("Removed unit %q", u.Name)
+
+		if err := renameio.Symlink(pathDevNull, fpath); err != nil {
+			return fmt.Errorf("failed to symlink unit %q to %s: %w", u.Name, pathDevNull, err)
+		}
+		glog.V(2).Infof("Created symlink unit %q to %s", u.Name, pathDevNull)
+
+		// Return early since we don't need to write the file contents in this case.
+		return nil
+	}
+
+	if u.Contents != nil && *u.Contents != "" {
+		glog.Infof("Writing systemd unit %q", u.Name)
+		if _, err := os.Stat(withUsrPath(fpath)); err == nil &&
+			isCoreOSVariant {
+			if err := createOrigFile(withUsrPath(fpath), fpath); err != nil {
+				return err
+			}
+		}
+		if err := writeFileAtomicallyWithDefaults(fpath, []byte(*u.Contents)); err != nil {
+			return fmt.Errorf("failed to write systemd unit %q: %w", u.Name, err)
+		}
+
+		glog.V(2).Infof("Successfully wrote systemd unit %q: ", u.Name)
+	} else if u.Mask != nil && !*u.Mask {
+		// if mask is explicitly set to false, make sure to remove a previous mask
+		// see https://bugzilla.redhat.com/show_bug.cgi?id=1966445
+		// Note that this does not catch all cleanup cases; for example, if the previous machine config specified
+		// Contents, and the current one does not, the previous content will not get cleaned up. For now we're ignoring some
+		// of those edge cases rather than introducing more complexity.
+		glog.V(2).Infof("Ensuring systemd unit %q has no mask at %q", u.Name, fpath)
+		if err := os.RemoveAll(fpath); err != nil {
+			return fmt.Errorf("failed to cleanup %s: %w", fpath, err)
+		}
+	}
+
+	return nil
+}
+
+// writeUnits writes systemd units and their dropins to disk
+func writeUnits(units []ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error {
+	for _, u := range units {
+		if err := writeUnit(u, systemdRoot, isCoreOSVariant); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func lookupUID(username string) (int, error) {
+	osUser, err := user.Lookup(username)
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve UserID for username: %s", username)
+	}
+	glog.V(2).Infof("Retrieved UserId: %s for username: %s", osUser.Uid, username)
+	uid, _ := strconv.Atoi(osUser.Uid)
+	return uid, nil
+}
+
+func lookupGID(group string) (int, error) {
+	osGroup, err := user.LookupGroup(group)
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve GroupID for group: %v", group)
+	}
+	glog.V(2).Infof("Retrieved GroupID: %s for group: %s", osGroup.Gid, group)
+	gid, _ := strconv.Atoi(osGroup.Gid)
+	return gid, nil
+}
+
+// This is essentially ResolveNodeUidAndGid() from Ignition; XXX should dedupe
+func getFileOwnership(file ign3types.File) (int, int, error) {
+	uid, gid := 0, 0 // default to root
+	if file.User.ID != nil {
+		uid = *file.User.ID
+	} else if file.User.Name != nil && *file.User.Name != "" {
+		uid, err := lookupUID(*file.User.Name)
+		if err != nil {
+			return uid, gid, err
+		}
+	}
+
+	if file.Group.ID != nil {
+		gid = *file.Group.ID
+	} else if file.Group.Name != nil && *file.Group.Name != "" {
+		gid, err := lookupGID(*file.Group.Name)
+		if err != nil {
+			return uid, gid, err
+		}
+	}
+	return uid, gid, nil
+}
+
+// Appends the usrPath variable (/usr) to a given path
+func withUsrPath(path string) string {
+	return filepath.Join(usrPath, path)
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -20,7 +19,6 @@ import (
 	"github.com/clarketm/json"
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/golang/glog"
-	"github.com/google/renameio"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,46 +58,6 @@ const (
 	// changes to this path. Note that other files added to the parent directory will not be handled specially
 	GPGNoRebootPath = "/etc/machine-config-daemon/no-reboot/containers-gpg.pub"
 )
-
-var (
-	origParentDirPath   = filepath.Join("/etc", "machine-config-daemon", "orig")
-	noOrigParentDirPath = filepath.Join("/etc", "machine-config-daemon", "noorig")
-)
-
-func writeFileAtomicallyWithDefaults(fpath string, b []byte) error {
-	return writeFileAtomically(fpath, b, defaultDirectoryPermissions, defaultFilePermissions, -1, -1)
-}
-
-// writeFileAtomically uses the renameio package to provide atomic file writing, we can't use renameio.WriteFile
-// directly since we need to 1) Chown 2) go through a buffer since files provided can be big
-func writeFileAtomically(fpath string, b []byte, dirMode, fileMode os.FileMode, uid, gid int) error {
-	dir := filepath.Dir(fpath)
-	if err := os.MkdirAll(dir, dirMode); err != nil {
-		return fmt.Errorf("failed to create directory %q: %w", dir, err)
-	}
-	t, err := renameio.TempFile(dir, fpath)
-	if err != nil {
-		return err
-	}
-	defer t.Cleanup()
-	// Set permissions before writing data, in case the data is sensitive.
-	if err := t.Chmod(fileMode); err != nil {
-		return err
-	}
-	w := bufio.NewWriter(t)
-	if _, err := w.Write(b); err != nil {
-		return err
-	}
-	if err := w.Flush(); err != nil {
-		return err
-	}
-	if uid != -1 && gid != -1 {
-		if err := t.Chown(uid, gid); err != nil {
-			return err
-		}
-	}
-	return t.CloseAtomicallyReplace()
-}
 
 func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
 	return &corev1.ObjectReference{
@@ -1317,7 +1275,7 @@ func (dn *Daemon) deleteStaleData(oldIgnConfig, newIgnConfig ign3types.Config) e
 				// File is owned by an rpm
 				restore = true
 			} else if strings.HasPrefix(f.Path, "/etc") && dn.os.IsCoreOSVariant() {
-				if _, err := os.Stat("/usr" + f.Path); err != nil {
+				if _, err := os.Stat(withUsrPath(f.Path)); err != nil {
 					if !os.IsNotExist(err) {
 						return err
 					}
@@ -1501,94 +1459,17 @@ func (dn *Daemon) presetUnit(unit ign3types.Unit) error {
 	return nil
 }
 
-// write dropins to disk
-func (dn *Daemon) writeDropins(u ign3types.Unit) error {
-	for i := range u.Dropins {
-		dpath := filepath.Join(pathSystemd, u.Name+".d", u.Dropins[i].Name)
-		if u.Dropins[i].Contents == nil || *u.Dropins[i].Contents == "" {
-			glog.Infof("Dropin for %s has no content, skipping write", u.Dropins[i].Name)
-			if _, err := os.Stat(dpath); err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				return err
-			}
-			glog.Infof("Removing %q, updated file has zero length", dpath)
-			if err := os.Remove(dpath); err != nil {
-				return err
-			}
-			continue
-		}
-
-		glog.Infof("Writing systemd unit dropin %q", u.Dropins[i].Name)
-		if _, err := os.Stat("/usr" + dpath); err == nil &&
-			dn.os.IsCoreOSVariant() {
-			if err := createOrigFile("/usr"+dpath, dpath); err != nil {
-				return err
-			}
-		}
-		if err := writeFileAtomicallyWithDefaults(dpath, []byte(*u.Dropins[i].Contents)); err != nil {
-			return fmt.Errorf("failed to write systemd unit dropin %q: %w", u.Dropins[i].Name, err)
-		}
-
-		glog.V(2).Infof("Wrote systemd unit dropin at %s", dpath)
-	}
-	return nil
-}
-
 // writeUnits writes the systemd units to disk
 func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 	var enabledUnits []string
 	var disabledUnits []string
+
+	isCoreOSVariant := dn.os.IsCoreOSVariant()
+
 	for _, u := range units {
-		if err := dn.writeDropins(u); err != nil {
-			return err
+		if err := writeUnit(u, pathSystemd, isCoreOSVariant); err != nil {
+			return fmt.Errorf("daemon could not write systemd unit: %w", err)
 		}
-
-		// write (or cleanup) path in /etc/systemd/system
-		fpath := filepath.Join(pathSystemd, u.Name)
-		if u.Mask != nil && *u.Mask {
-			// if the unit is masked, symlink fpath to /dev/null and continue
-
-			glog.V(2).Info("Systemd unit masked")
-			if err := os.RemoveAll(fpath); err != nil {
-				return fmt.Errorf("failed to remove unit %q: %w", u.Name, err)
-			}
-			glog.V(2).Infof("Removed unit %q", u.Name)
-
-			if err := renameio.Symlink(pathDevNull, fpath); err != nil {
-				return fmt.Errorf("failed to symlink unit %q to %s: %w", u.Name, pathDevNull, err)
-			}
-			glog.V(2).Infof("Created symlink unit %q to %s", u.Name, pathDevNull)
-
-			continue
-		}
-
-		if u.Contents != nil && *u.Contents != "" {
-			glog.Infof("Writing systemd unit %q", u.Name)
-			if _, err := os.Stat("/usr" + fpath); err == nil &&
-				dn.os.IsCoreOSVariant() {
-				if err := createOrigFile("/usr"+fpath, fpath); err != nil {
-					return err
-				}
-			}
-			if err := writeFileAtomicallyWithDefaults(fpath, []byte(*u.Contents)); err != nil {
-				return fmt.Errorf("failed to write systemd unit %q: %w", u.Name, err)
-			}
-
-			glog.V(2).Infof("Successfully wrote systemd unit %q: ", u.Name)
-		} else if u.Mask != nil && !*u.Mask {
-			// if mask is explicitly set to false, make sure to remove a previous mask
-			// see https://bugzilla.redhat.com/show_bug.cgi?id=1966445
-			// Note that this does not catch all cleanup cases; for example, if the previous machine config specified
-			// Contents, and the current one does not, the previous content will not get cleaned up. For now we're ignoring some
-			// of those edge cases rather than introducing more complexity.
-			glog.V(2).Infof("Ensuring systemd unit %q has no mask at %q", u.Name, fpath)
-			if err := os.RemoveAll(fpath); err != nil {
-				return fmt.Errorf("failed to cleanup %s: %w", fpath, err)
-			}
-		}
-
 		// if the unit doesn't note if it should be enabled or disabled then
 		// honour system presets. This to account for an edge case where you
 		// deleted a MachineConfig that enabled/disabled the unit to revert,
@@ -1632,139 +1513,7 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 // writeFiles writes the given files to disk.
 // it doesn't fetch remote files and expects a flattened config file.
 func (dn *Daemon) writeFiles(files []ign3types.File) error {
-	for _, file := range files {
-		glog.Infof("Writing file %q", file.Path)
-
-		// We don't support appends in the file section, so instead of waiting to fail validation,
-		// let's explicitly fail here.
-		if len(file.Append) > 0 {
-			return fmt.Errorf("found an append section when writing files. Append is not supported")
-		}
-
-		decodedContents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
-		if err != nil {
-			return fmt.Errorf("could not decode file %q: %w", file.Path, err)
-		}
-
-		mode := defaultFilePermissions
-		if file.Mode != nil {
-			mode = os.FileMode(*file.Mode)
-		}
-
-		// set chown if file information is provided
-		uid, gid, err := getFileOwnership(file)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve file ownership for file %q: %w", file.Path, err)
-		}
-		if err := createOrigFile(file.Path, file.Path); err != nil {
-			return err
-		}
-		if err := writeFileAtomically(file.Path, decodedContents, defaultDirectoryPermissions, mode, uid, gid); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func origParentDir() string {
-	return origParentDirPath
-}
-
-func noOrigParentDir() string {
-	return noOrigParentDirPath
-}
-
-func origFileName(fpath string) string {
-	return filepath.Join(origParentDir(), fpath+".mcdorig")
-}
-
-// We use this to create a file that indicates that no original file existed on disk
-// when we write a file via a MachineConfig. Otherwise the MCD does not differentiate
-// between "a file existed due to a previous machineconfig" vs "a file existed on disk
-// before the MCD took over". Also see deleteStaleData() above.
-//
-// The "stamp" part of the name indicates it is not an actual backup file, just an
-// empty file to indicate lack of previous existence.
-func noOrigFileStampName(fpath string) string {
-	return filepath.Join(noOrigParentDir(), fpath+".mcdnoorig")
-}
-
-func createOrigFile(fromPath, fpath string) error {
-	if _, err := os.Stat(noOrigFileStampName(fpath)); err == nil {
-		// we already created the no orig file for this default file
-		return nil
-	}
-	if _, err := os.Stat(fpath); os.IsNotExist(err) {
-		// create a noorig file that tells the MCD that the file wasn't present on disk before MCD
-		// took over so it can just remove it when deleting stale data, as opposed as restoring a file
-		// that was shipped _with_ the underlying OS (e.g. a default chrony config).
-		if makeErr := os.MkdirAll(filepath.Dir(noOrigFileStampName(fpath)), 0o755); makeErr != nil {
-			return fmt.Errorf("creating no orig parent dir: %w", makeErr)
-		}
-		return writeFileAtomicallyWithDefaults(noOrigFileStampName(fpath), nil)
-	}
-
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1970959
-	// orig file might exist, but be a relative/dangling symlink
-	if symlinkTarget, err := os.Readlink(origFileName(fpath)); err == nil {
-		if symlinkTarget != "" {
-			return nil
-		}
-	}
-	if _, err := os.Stat(origFileName(fpath)); err == nil {
-		// the orig file is already there and we avoid creating a new one to preserve the real default
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(origFileName(fpath)), 0o755); err != nil {
-		return fmt.Errorf("creating orig parent dir: %w", err)
-	}
-	if out, err := exec.Command("cp", "-a", "--reflink=auto", fromPath, origFileName(fpath)).CombinedOutput(); err != nil {
-		return fmt.Errorf("creating orig file for %q: %s: %w", fpath, string(out), err)
-	}
-	return nil
-}
-
-func lookupUID(username string) (int, error) {
-	osUser, err := user.Lookup(username)
-	if err != nil {
-		return 0, fmt.Errorf("failed to retrieve UserID for username: %s", username)
-	}
-	glog.V(2).Infof("Retrieved UserId: %s for username: %s", osUser.Uid, username)
-	uid, _ := strconv.Atoi(osUser.Uid)
-	return uid, nil
-}
-
-func lookupGID(group string) (int, error) {
-	osGroup, err := user.LookupGroup(group)
-	if err != nil {
-		return 0, fmt.Errorf("failed to retrieve GroupID for group: %v", group)
-	}
-	glog.V(2).Infof("Retrieved GroupID: %s for group: %s", osGroup.Gid, group)
-	gid, _ := strconv.Atoi(osGroup.Gid)
-	return gid, nil
-}
-
-// This is essentially ResolveNodeUidAndGid() from Ignition; XXX should dedupe
-func getFileOwnership(file ign3types.File) (int, int, error) {
-	uid, gid := 0, 0 // default to root
-	if file.User.ID != nil {
-		uid = *file.User.ID
-	} else if file.User.Name != nil && *file.User.Name != "" {
-		uid, err := lookupUID(*file.User.Name)
-		if err != nil {
-			return uid, gid, err
-		}
-	}
-
-	if file.Group.ID != nil {
-		gid = *file.Group.ID
-	} else if file.Group.Name != nil && *file.Group.Name != "" {
-		gid, err := lookupGID(*file.Group.Name)
-		if err != nil {
-			return uid, gid, err
-		}
-	}
-	return uid, gid, nil
+	return writeFiles(files)
 }
 
 func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -33,6 +33,11 @@ func BoolToPtr(b bool) *bool {
 	return &b
 }
 
+// IntToPtr returns a pointer to an int
+func IntToPtr(i int) *int {
+	return &i
+}
+
 // NewMachineConfig returns a basic machine config with supplied labels, osurl & files added
 func NewMachineConfig(name string, labels map[string]string, osurl string, files []ign3types.File) *mcfgv1.MachineConfig {
 	return NewMachineConfigExtended(


### PR DESCRIPTION
**- What I did**

Fixes OCPBUGS-3909. The key here is to ignore the unit contents and file mode when it is masked. I also did a bit of refactoring to reuse the writeFiles and writeSystemdUnits code in the MCD to make this easier to reproduce.

**- How to verify it**

The TestConfigDriftMonitor includes a new test fixture that will cause the test to fail without the implemented fix. There is also a new e2e test case for the Config Drift e2e Test Suite. So one can run either the unit test suite or the e2e suite (or both!). Additionally, to verify my other refactoring changes, the e2e-gcp-op test target should provide adequate coverage for that code.

**- Description for the changelog**
Ignore file content and mode for masked systemd units (fixes OCPBUGS-3909)
