### PR TITLE
OCPBUGS-4101: Do not allow empty system reserved values

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -43,19 +43,19 @@ func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, use
 		autoNodeSizing = strconv.FormatBool(*autoSystemReserved)
 	}
 
-	if val, ok := userDefinedSystemReserved["memory"]; ok {
+	if val, ok := userDefinedSystemReserved["memory"]; ok && val != "" {
 		systemReservedMemory = val
 	} else {
 		systemReservedMemory = "1Gi"
 	}
 
-	if val, ok := userDefinedSystemReserved["cpu"]; ok {
+	if val, ok := userDefinedSystemReserved["cpu"]; ok && val != "" {
 		systemReservedCPU = val
 	} else {
 		systemReservedCPU = "500m"
 	}
 
-	if val, ok := userDefinedSystemReserved["ephemeral-storage"]; ok {
+	if val, ok := userDefinedSystemReserved["ephemeral-storage"]; ok && val != "" {
 		systemReservedEphemeralStorage = val
 	} else {
 		systemReservedEphemeralStorage = "1Gi"

--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -78,19 +78,40 @@ contents:
     function dynamic_pid_sizing {
         echo "Not implemented yet"
     }
+    function set_memory {
+        SYSTEM_RESERVED_MEMORY=$1
+        if [ -z "${SYSTEM_RESERVED_MEMORY}" ]; then
+            SYSTEM_RESERVED_MEMORY="1Gi"
+        fi
+        echo "SYSTEM_RESERVED_MEMORY=${SYSTEM_RESERVED_MEMORY}" >> ${NODE_SIZES_ENV}
+    }
+    function set_cpu {
+        SYSTEM_RESERVED_CPU=$1
+        if [ -z "${SYSTEM_RESERVED_CPU}" ]; then
+            SYSTEM_RESERVED_CPU="500m"
+        fi
+        echo "SYSTEM_RESERVED_CPU=${SYSTEM_RESERVED_CPU}" >> ${NODE_SIZES_ENV}
+    }
+    function set_es {
+        SYSTEM_RESERVED_ES=$1
+        if [ -z "${SYSTEM_RESERVED_ES}" ]; then
+            SYSTEM_RESERVED_ES="1Gi"
+        fi
+        echo "SYSTEM_RESERVED_ES=${SYSTEM_RESERVED_ES}" >> ${NODE_SIZES_ENV}
+    }
     function dynamic_node_sizing {
         rm -f ${NODE_SIZES_ENV}
         dynamic_memory_sizing
         dynamic_cpu_sizing
-        echo "SYSTEM_RESERVED_ES=$1" >> ${NODE_SIZES_ENV}
+        set_es $1
         #dynamic_ephemeral_sizing
         #dynamic_pid_sizing
     }
     function static_node_sizing {
         rm -f ${NODE_SIZES_ENV}
-        echo "SYSTEM_RESERVED_MEMORY=$1" >> ${NODE_SIZES_ENV}
-        echo "SYSTEM_RESERVED_CPU=$2" >> ${NODE_SIZES_ENV}
-        echo "SYSTEM_RESERVED_ES=$3" >> ${NODE_SIZES_ENV}
+        set_memory $1
+        set_cpu $2
+        set_es $3
     }
 
     if [ $1 == "true" ]; then


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: https://issues.redhat.com/browse/OCPBUGS-4101

**- What I did**
Make sure none of the system reserved values end up empty and make kubelet crash during startup. 

**- How to verify it**
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: system1-reserved-config
spec:
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
  kubeletConfig:
    systemReserved:
      cpu: 500m
      memory: 1500Mi
      ephemeral-storage: "" 
```
Even after deploying that MC, the kubelet should start up and come up with default value of the ephemeral storage for system reserved (1Gi)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Force default values of system reserved in case empty values were supplied.