### PR TITLE
Add templates for required sysctls max_map_count and arp_announce

### DIFF
--- a/templates/common/_base/files/sysctl-arp.conf.yaml
+++ b/templates/common/_base/files/sysctl-arp.conf.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "/etc/sysctl.d/arp.conf"
+contents:
+  inline: |
+    # Needed by the OpenShift SDN. See
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1758552
+    net.ipv4.conf.all.arp_announce = 2

--- a/templates/common/_base/files/sysctl-vm-max-map.conf.yaml
+++ b/templates/common/_base/files/sysctl-vm-max-map.conf.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "/etc/sysctl.d/vm-max-map.conf"
+contents:
+  inline: |
+    # Needed for OpenShift Logging (ElasticSearch). See
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1793714
+    vm.max_map_count = 262144


### PR DESCRIPTION
**- What I did**
Add two files to templates/common/_base/files for setting sysctls vm.max_map_count and net.ipv4.all.arp_announce.

In OpenShift 4.13 we are planning to make the Node Tuning Operator an optional feature (composable OCP). Two sysctls currently set by NTO are needed for functional reasons, and should be set even in clusters where NTO is disabled.

vm.max_map_count=262144 is needed for OpenShift Logging to work (ElasticSearch), see [RH BZ#1793714](https://bugzilla.redhat.com/show_bug.cgi?id=1793714).
net.ipv4.conf.all.arp_announce=2 is needed for the OpenShift SDN (see [RH BZ#1758552](https://bugzilla.redhat.com/show_bug.cgi?id=1758552)).

NTO will remain enabled by default and will continue to apply recommended default tunings to improve scalability and performance, while providing the option for users to apply custom TuneD profiles.

**- How to verify it**
Ensure that /etc/sysctl.d/arp.conf and /etc/sysctl.d/vm-max-map.conf are created, and that the sysctl values are set correctly even when these sysctls are not set by NTO.

**- Description for the changelog**
Add templates for required sysctls max_map_count and arp_announce

/cc @jmencak 