### PR TITLE
OCPBUGS-4521: kubelet client certificate verification ca bundle should match kube-apiserver

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -244,20 +244,12 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	if err != nil {
 		return err
 	}
-	// as described by the name this is essentially static, but it no worse than what was here before.  Since changes disrupt workloads
-	// and since must perfectly match what the installer creates, this is effectively frozen in time.
-	initialKubeAPIServerServingCABytes, err := optr.getCAsFromConfigMap("openshift-config", "initial-kube-apiserver-server-ca", "ca-bundle.crt")
+
+	// This is the ca-bundle published by the kube-apiserver that is used terminate client-certificates in the kube cluster.
+	// If the kubelet has a flag to check the in-cluster published ca bundle, that would be ideal.
+	kubeAPIServerServingCABytes, err := optr.getCAsFromConfigMap("openshift-config-managed", "kube-apiserver-client-ca", "ca-bundle.crt")
 	if err != nil {
 		return err
-	}
-
-	// Fetch the following configmap and merge into the the initial CA. The CA is the same for the first year, and will rotate
-	// automatically afterwards.
-	kubeAPIServerServingCABytes, err := optr.getCAsFromConfigMap("openshift-kube-apiserver-operator", "kube-apiserver-to-kubelet-client-ca", "ca-bundle.crt")
-	if err != nil {
-		kubeAPIServerServingCABytes = initialKubeAPIServerServingCABytes
-	} else {
-		kubeAPIServerServingCABytes = mergeCertWithCABundle(initialKubeAPIServerServingCABytes, kubeAPIServerServingCABytes, "kube-apiserver-to-kubelet-signer")
 	}
 
 	bundle := make([]byte, 0)


### PR DESCRIPTION
The kube-apiserver publishes this configmap.  It also publishes one for general delegated authenticaiton consumption, but that won't function when the kube-apiserver is unavailable and these files will still exist.

This should fix https://issues.redhat.com/browse/OCPBUGS-4521.

We need be sure the kubelet doesn't get restarted.  This file is auto-reloaded by the generic apiserver package for the last couple years.

/assign @rphillips 
/cc @simonpasquier 