### PR TITLE
OCPBUGS-4656: vsphere: check that /etc/hostname is not empty

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -7,7 +7,6 @@ contents:
 
     # only run if the hostname is not set
     test -s /etc/hostname && exit 0 || :
-    echo "Current hostname: $(cat /etc/hostname)"
 
     if vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
         /usr/bin/hostnamectl set-hostname --static ${vm_name}

--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -6,7 +6,8 @@ contents:
     set -e
 
     # only run if the hostname is not set
-    test -f /etc/hostname && exit 0 || :
+    test -s /etc/hostname && exit 0 || :
+    echo "Current hostname: $(cat /etc/hostname)"
 
     if vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
         /usr/bin/hostnamectl set-hostname --static ${vm_name}

--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -6,7 +6,6 @@ contents: |
   Requires=vmtoolsd.service
   After=vmtoolsd.service
 
-  ConditionPathExists=!/etc/hostname
   ConditionVirtualization=vmware
   
   Before=kubelet.service
@@ -17,7 +16,7 @@ contents: |
   ExecStart=/usr/local/bin/vsphere-hostname.sh
   Restart=on-failure
   RestartSec=15
+  StartLimitIntervalSec=0
 
   [Install]
   WantedBy=multi-user.target
-


### PR DESCRIPTION
**- What I did**

Instead of checking that `/etc/hostname` exists `vsphere-hostname` service should verify that the hostname is set, meaning the file is not empty. Starting from Fedora 37 an empty hostname file is created.
This also removes condition to start `vsphere-hostname` and allow indefinite retries

**- How to verify it**

Run OKD 4.12 on vsphere, ensure that workers join the cluster on CI

**- Description for the changelog**
Update `vsphere-hostname` service check that the hostname is set

Closes https://issues.redhat.com/browse/OKD-91