### PR TITLE
DNM: Set the cgroups version to "v1" explicitly

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -77,6 +77,11 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
+	// Set the Cgroups version explicitly to "v1"
+	if nodeConfig.Spec.CgroupMode == emptyInput {
+		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
+		ctrl.configClient.ConfigV1().Nodes().Update(context.TODO(), nodeConfig, metav1.UpdateOptions{})
+	}
 	// checking if the Node spec is empty and accordingly returning from here.
 	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
 		glog.V(2).Info("empty Node resource found")
@@ -125,19 +130,31 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 				return err
 			}
 		}
-		if isTechPreviewNoUpgradeEnabled(features) {
-			if nodeConfig.Spec.CgroupMode == "" && nodeConfig.Spec.WorkerLatencyProfile != "" && role == ctrlcommon.MachineConfigPoolMaster {
-				continue
+		// Setting the CGroups version to "v1" explicitly
+		if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV1 {
+			err := updateMachineConfigwithCgroup(nodeConfig, mc)
+			if err != nil {
+				return err
 			}
+		}
+		// The following code updates the CGroups version to "v2"
+		// only if the "TechPreviewNoUpgrade" featureset is enabled
+		if isTechPreviewNoUpgradeEnabled(features) {
 			// updating the machine config resource with the relevant cgroup configuration
 			err := updateMachineConfigwithCgroup(nodeConfig, mc)
 			if err != nil {
 				return err
 			}
-		} else if nodeConfig.Spec.WorkerLatencyProfile == "" {
-			return nil
-		} else if role == ctrlcommon.MachineConfigPoolMaster {
-			continue
+		} else if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV2 {
+			if nodeConfig.Spec.WorkerLatencyProfile == emptyInput {
+				// avoid the unnecessary creation/update of the machine config object (so the reboot)
+				// as the "TechPreviewNoUpgrade" featureSet is not enabled
+				return nil
+			} else if role == ctrlcommon.MachineConfigPoolMaster {
+				// "TechPreviewNoUpgrade" not enabled, "cgroupMode" set to "v2" isn't effective
+				// "WorkerLatencyProfile" is relevant only to the worker mcp and hence returning from here
+				continue
+			}
 		}
 		// Encode the new config into raw JSON
 		cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)
@@ -295,20 +312,33 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 				return nil, err
 			}
 		}
-		// updating the machine config resource with the relevant cgroup configuration
-		if isTechPreviewNoUpgradeEnabled(features) {
-			if nodeConfig.Spec.CgroupMode == "" && nodeConfig.Spec.WorkerLatencyProfile != "" && role == ctrlcommon.MachineConfigPoolMaster {
-				continue
+		// Setting the CGroups version to "v1" explicitly
+		if nodeConfig.Spec.CgroupMode == emptyInput || nodeConfig.Spec.CgroupMode == osev1.CgroupModeV1 {
+			nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
+			err := updateMachineConfigwithCgroup(nodeConfig, mc)
+			if err != nil {
+				return nil, err
 			}
+		}
+
+		// The following code updates the CGroups version to "v2"
+		// only if the "TechPreviewNoUpgrade" featureset is enabled
+		if isTechPreviewNoUpgradeEnabled(features) {
 			// updating the machine config resource with the relevant cgroup configuration
 			err := updateMachineConfigwithCgroup(nodeConfig, mc)
 			if err != nil {
 				return nil, err
 			}
-		} else if nodeConfig.Spec.WorkerLatencyProfile == "" {
-			return nil, nil
-		} else if role == ctrlcommon.MachineConfigPoolMaster {
-			continue
+		} else if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV2 {
+			if nodeConfig.Spec.WorkerLatencyProfile == emptyInput {
+				// avoid the unnecessary creation/update of the machine config object (so the reboot)
+				// as the "TechPreviewNoUpgrade" featureSet is not enabled
+				return nil, nil
+			} else if role == ctrlcommon.MachineConfigPoolMaster {
+				// "TechPreviewNoUpgrade" not enabled, "cgroupMode" set to "v2" isn't effective
+				// "WorkerLatencyProfile" is relevant only to the worker mcp
+				continue
+			}
 		}
 		// Encode the new config into raw JSON
 		cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)
@@ -327,6 +357,5 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 		}
 		configs = append(configs, mc)
 	}
-
 	return configs, nil
 }

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -114,7 +114,21 @@ spec:
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
 		},
 		{
-			name: "With a node config manifest",
+			name: "With a node config manifest empty spec",
+			manifests: [][]byte{
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster`),
+			},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v1" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+		},
+		{
+			name: "With a node config manifest empty \"cgroupMode\"",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1
 kind: Node
@@ -123,7 +137,10 @@ metadata:
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v1" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
@@ -173,8 +190,8 @@ metadata:
 spec:
   cgroupMode: "v2"`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a config node manifest and without a featuregate manifest",
@@ -190,14 +207,15 @@ spec:
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
 		},
 		{
-			name: "With a node config manifest and master kubelet config manifest",
+			name: "With a node config manifest(CGroupv2, WLP) and master kubelet config manifest",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1
 kind: Node
 metadata:
   name: cluster
 spec:
-  workerLatencyProfile: MediumUpdateAverageReaction`),
+  workerLatencyProfile: MediumUpdateAverageReaction
+  cgroupMode: "v2"`),
 				[]byte(`apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
@@ -217,11 +235,46 @@ spec:
       memory: 500Mi
 `),
 			},
+			// "TechPreviewNoUpgrade" featureset not enabled, hence "CGroupsV2" is not applied
+			// "97-worker-generated-kubelet" is expected to be created to apply the workerlatencyprofile
+			// "97-master-generated-kubelet" is not expected
 			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
-			name: "With a node config manifest and worker kubelet config manifest",
+			name: "With a node config manifest(CGroupv1, WLP) and master kubelet config manifest",
+			manifests: [][]byte{
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  workerLatencyProfile: MediumUpdateAverageReaction
+  cgroupMode: "v1"`),
+				[]byte(`apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: master-kubelet-config
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    podsPerCore: 10
+    maxPods: 250
+    systemReserved:
+      cpu: 1000m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 1000m
+      memory: 500Mi
+`),
+			},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+		},
+		{
+			name: "With a node config manifest(empty cgroupMode) and worker kubelet config manifest",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1
 kind: Node
@@ -248,8 +301,10 @@ spec:
       memory: 500Mi
 `),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet"},
+			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
+			// internally translates to "v1"
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a worker kubelet config manifest",


### PR DESCRIPTION


<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added code to set the cgroups version to "v1" in the `cgroupMode` field of the `nodes.config.openshift.io` resource
**- How to verify it**
1. Get the `nodes.config.openshift.io` object and observe the `cgroupMode` field in the `spec` set to `"v1"`
2. Observe the following kernel arguments appended in the newly created machine config object.
```
kernelArguments:
  - systemd.unified_cgroup_hierarchy=0
  - systemd.legacy_systemd_cgroup_controller=1
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Set the cgroups version to "v1" explicitly
