### PR TITLE
OCPBUGS-2866: daemon: Continually retry rollback removal

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1536,9 +1536,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return fmt.Errorf("error detecting previous SSH accesses: %w", err)
 	}
 
-	if err := dn.removeRollback(); err != nil {
-		return fmt.Errorf("Failed to remove rollback: %w", err)
-	}
+	dn.removeRollback()
 
 	// Bootstrapping state is when we have the node annotations file
 	if state.bootstrapping {


### PR DESCRIPTION
For https://issues.redhat.com/browse/OCPBUGS-2866

Basically everything we do in general needs to be part of a retry loop.  In this case, it's very possible that during system startup we're contending with a lot of other pods landing on the node and starting to do work, and this causes I/O or CPU contention that causes us to lose the DBus 25 second method timeout.

(This DBus timeout has repeatedly caused problems, but fixing
 that is not easy right now)
