### PR TITLE
OCPBUGS-4963: Enable base nodeip-configuration for vsphere upi

### DIFF
--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -1,7 +1,18 @@
-# NOTE: When making changes to this service, be sure they are replicated in the
-# VSphere-specific service in templates/common/vsphere/units.
-name: nodeip-configuration.service
-enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{end}}
+# This is a VSphere UPI-specific version of nodeip-configuration, which is
+# needed because of the way template precedence works in MCO. Most UPI
+# platforms get this from the _base directory because their platform is set
+# to None. However, VSphere UPI sets platform to VSphere and determines
+# whether it should be IPI or UPI based on whether the API VIPs field is
+# populated. Because platform is set to VSphere, we instead get the IPI
+# version of nodeip-configuration in the on-prem directory. This is disabled
+# for UPI deployments because it relies on the existence of a VIP to help with
+# IP selection.
+# This all means we don't have a good way to keep the _base version of the
+# service unless we put some platform-specific logic in the template processing
+# code. Instead, we create this duplicate version of the service that will
+# only be enabled for VSphere UPI deployments.
+name: nodeip-configuration-vsphere-upi.service
+enabled: {{if eq (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP


### PR DESCRIPTION
When the base nodeip-configuration service was added for UPI, the
vsphere platform was missed because it has a unique UPI configuration.
Instead of using platform None, it uses platform vsphere but does
not set the VIP fields. As a result, neither nodeip-configuration
service was enabled on that platform and multiple nic behavior is
problematic.

Because the _base nodeip-configuration service is overwritten by the
IPI version in the on-prem directory, we need a separate service for
VSphere UPI that can be enabled when platform is "VSphere" and the
API VIPs field is not set. This is the inverse logic to the one in
the on-prem directory, so only one will ever be enabled at a time.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Enabled the nodeip-configuration service for the VSphere UPI platform.
