### PR TITLE
Fix unary operator expected bash error

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -114,9 +114,9 @@ contents:
         set_es $3
     }
 
-    if [ $1 == "true" ]; then
+    if [[ $1 == "true" ]]; then
         dynamic_node_sizing $4
-    elif [ $1 == "false" ]; then
+    elif [[ $1 == "false" ]]; then
         static_node_sizing $2 $3 $4
     else
         echo "Unrecognized command line option. Valid options are \"true\" or \"false\""


### PR DESCRIPTION
Signed-off-by: Kenneth D'souza <kennethdsouza94@gmail.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed `unary operator expected` bash error by using double bracket ` [[`  to evaluate the conditional expressions.

**- How to verify it**
Run the script without any arguments:

Without fix:
```# /tmp/dynamic-system-reserved-calc.sh 
/tmp/dynamic-system-reserved-calc.sh: line 113: [: ==: unary operator expected
/tmp/dynamic-system-reserved-calc.sh: line 115: [: ==: unary operator expected
Unrecognized command line option. Valid options are "true" or "false"
```

With fix:

```$ /tmp/dynamic-system-reserved-calc.sh 
Unrecognized command line option. Valid options are "true" or "false"
```

**- Description for the changelog**
Fix `unary operator expected` bash error

