### PR TITLE
OCPNODE-1330 : Set the CGroups version explicitly to "v1"

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,6 +170,14 @@ func (b *Bootstrap) Run(destDir string) error {
 		configs = append(configs, featureConfigs...)
 	}
 
+	if nodeConfig == nil {
+		nodeConfig = &apicfgv1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ctrlcommon.ClusterNodeInstanceName,
+			},
+			Spec: apicfgv1.NodeSpec{},
+		}
+	}
 	if nodeConfig != nil {
 		nodeConfigs, err := kubeletconfig.RunNodeConfigBootstrap(b.templatesDir, featureGate, cconfig, nodeConfig, pools)
 		if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -461,6 +461,7 @@ func (ctrl *Controller) addAnnotation(cfg *mcfgv1.KubeletConfig, annotationKey, 
 
 // syncKubeletConfig will sync the kubeletconfig with the given key.
 // This function is not meant to be invoked concurrently with the same key.
+//
 //nolint:gocyclo
 func (ctrl *Controller) syncKubeletConfig(key string) error {
 	startTime := time.Now()
@@ -571,10 +572,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		// updating the originalKubeConfig based on the nodeConfig on a worker node
 		if role == ctrlcommon.MachineConfigPoolWorker {
 			updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
-		}
-		// updating the machine config resource with the relevant cgroup configuration
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
 		}
 
 		// Get the default API Server Security Profile

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -112,9 +112,6 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		if rawCfgIgn == nil {
 			continue
 		}
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
-		}
 
 		mc.Spec.Config.Raw = rawCfgIgn
 		mc.ObjectMeta.Annotations = map[string]string{
@@ -179,8 +176,9 @@ func (ctrl *Controller) deleteFeature(obj interface{}) {
 	glog.V(4).Infof("Deleted Feature %s and restored default config", features.Name)
 }
 
-//nolint:gocritic
 // generateFeatureMap returns a map of enabled/disabled feature gate selection with exclusion list
+//
+//nolint:gocritic
 func generateFeatureMap(features *osev1.FeatureGate, exclusions ...string) (*map[string]bool, error) {
 	rv := make(map[string]bool)
 	if features == nil {
@@ -279,10 +277,6 @@ func RunFeatureGateBootstrap(templateDir string, features *osev1.FeatureGate, no
 		mc.Spec.Config.Raw = rawCfgIgn
 		mc.ObjectMeta.Annotations = map[string]string{
 			ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,
-		}
-		// updating the machine config resource with the relevant cgroup configuration
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
 		}
 
 		machineConfigs = append(machineConfigs, mc)

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -78,18 +78,19 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 		t.Run(string(platform), func(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
-			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp1 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			mcps := []*mcfgv1.MachineConfigPool{mcp}
+			mcps = append(mcps, mcp1)
 
 			features := createNewDefaultFeatureGate()
 			configNode := createNewDefaultNodeconfig()
-			configNode.Spec.WorkerLatencyProfile = osev1.DefaultUpdateDefaultReaction
 
 			mcs, err := RunNodeConfigBootstrap("../../../templates", features, cc, configNode, mcps)
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) == 0 {
+			if len(mcs) != 2 {
 				t.Errorf("expected a machine config generated with the default node config, got 0 machine configs")
 			}
 		})


### PR DESCRIPTION
1. The CGroups version on an OCP cluster can be altered by altering the `nodes.config` resource's `spec.cgroupMode` field
2. It is very likely that the CGroups version would be defaulting to "v2" starting from OCP-4.13 on the underlying RCOS nodes.
3. To avoid unexpected complications, this code explicitly sets the CGroups version to "v1" on the newer OCP-4.13 versions
4. Also improved the bootstrap test cases with a few special case scenarios.

Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added code to explicitly set the `cgroupMode` to "v1", if found empty, in the newer OCP clusters(4.13)
**- How to verify it**
1. Deploy an OCP cluster (version = 4.13)
2. Debug into any of the nodes and observe the `CGroupsV1` configuration by executing the following command
```
sh-4.4# stat -c %T -f /sys/fs/cgroup/
tmpfs
```
Also observe the kernelArguments in the newly rendered machine config objects for the master and worker pools as follows:
```
kernelArguments:
  - systemd.unified_cgroup_hierarchy=0
  - systemd.legacy_systemd_cgroup_controller=1
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Explicitly set the `CGroups` configuration to `v1`, if found empty, in the newer version of OCP (4.13)
