### PR TITLE
[DNM] [Testing] Set the CGroups version explicitly to "v1"

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -77,13 +77,11 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
-	/*
-		// Set the Cgroups version explicitly to "v1"
-		if nodeConfig.Spec.CgroupMode == emptyInput {
-			nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
-			ctrl.configClient.ConfigV1().Nodes().Update(context.TODO(), nodeConfig, metav1.UpdateOptions{})
-		}
-	*/
+	// Set the Cgroups version explicitly to "v1"
+	if nodeConfig.Spec.CgroupMode == emptyInput {
+		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
+		ctrl.configClient.ConfigV1().Nodes().Update(context.TODO(), nodeConfig, metav1.UpdateOptions{})
+	}
 	// checking if the Node spec is empty and accordingly returning from here.
 	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
 		glog.V(2).Info("empty Node resource found")
@@ -294,12 +292,10 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 		return nil, fmt.Errorf("nodes.config.openshift.io resource not found")
 	}
 	configs := []*mcfgv1.MachineConfig{}
-	/*
-		// Set the Cgroups version explicitly to "v1"
-		if nodeConfig.Spec.CgroupMode == emptyInput {
-			nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
-		}
-	*/
+	// Set the Cgroups version explicitly to "v1"
+	if nodeConfig.Spec.CgroupMode == emptyInput {
+		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
+	}
 	for _, pool := range mcpPools {
 		role := pool.Name
 		// Get MachineConfig

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -78,18 +78,19 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 		t.Run(string(platform), func(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
-			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp1 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			mcps := []*mcfgv1.MachineConfigPool{mcp}
+			mcps = append(mcps, mcp1)
 
 			features := createNewDefaultFeatureGate()
 			configNode := createNewDefaultNodeconfig()
-			configNode.Spec.WorkerLatencyProfile = osev1.DefaultUpdateDefaultReaction
 
 			mcs, err := RunNodeConfigBootstrap("../../../templates", features, cc, configNode, mcps)
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) == 0 {
+			if len(mcs) != 2 {
 				t.Errorf("expected a machine config generated with the default node config, got 0 machine configs")
 			}
 		})

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -114,7 +114,21 @@ spec:
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
 		},
 		{
-			name: "With a node config manifest",
+			name: "With a node config manifest empty spec",
+			manifests: [][]byte{
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster`),
+			},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v1" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+		},
+		{
+			name: "With a node config manifest empty \"cgroupMode\"",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1
 kind: Node
@@ -123,7 +137,10 @@ metadata:
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v1" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
@@ -173,8 +190,8 @@ metadata:
 spec:
   cgroupMode: "v2"`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a config node manifest and without a featuregate manifest",
@@ -190,14 +207,15 @@ spec:
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
 		},
 		{
-			name: "With a node config manifest and master kubelet config manifest",
+			name: "With a node config manifest(CGroupv2, WLP) and master kubelet config manifest",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1
 kind: Node
 metadata:
   name: cluster
 spec:
-  workerLatencyProfile: MediumUpdateAverageReaction`),
+  workerLatencyProfile: MediumUpdateAverageReaction
+  cgroupMode: "v2"`),
 				[]byte(`apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
@@ -217,11 +235,46 @@ spec:
       memory: 500Mi
 `),
 			},
+			// "TechPreviewNoUpgrade" featureset not enabled, hence "CGroupsV2" is not applied
+			// "97-worker-generated-kubelet" is expected to be created to apply the workerlatencyprofile
+			// "97-master-generated-kubelet" is not expected
 			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
-			name: "With a node config manifest and worker kubelet config manifest",
+			name: "With a node config manifest(CGroupv1, WLP) and master kubelet config manifest",
+			manifests: [][]byte{
+				[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  workerLatencyProfile: MediumUpdateAverageReaction
+  cgroupMode: "v1"`),
+				[]byte(`apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: master-kubelet-config
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    podsPerCore: 10
+    maxPods: 250
+    systemReserved:
+      cpu: 1000m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 1000m
+      memory: 500Mi
+`),
+			},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+		},
+		{
+			name: "With a node config manifest(empty cgroupMode) and worker kubelet config manifest",
 			manifests: [][]byte{
 				[]byte(`apiVersion: config.openshift.io/v1
 kind: Node
@@ -248,8 +301,10 @@ spec:
       memory: 500Mi
 `),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet"},
+			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
+			// internally translates to "v1"
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a worker kubelet config manifest",


### PR DESCRIPTION
1. The CGroups version on an OCP cluster can be altered by altering the `nodes.config` resource's `spec.cgroupMode` field
2. It is very likely that the CGroups version would be defaulting to "v2" starting from OCP-4.13 on the underlying RCOS nodes.
3. To avoid unexpected complications, this code explicitly sets the CGroups version to "v1" on the newer OCP-4.13 versions
4. Also improved the bootstrap test cases with a few special case scenarios.

Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
