### PR TITLE
install/0000_90_machine-config-operator_01_prometheus-rules: Use labels for MCC logs

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -45,7 +45,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
+            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} -l k8s-app=machine-config-controller -c machine-config-controller"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule


### PR DESCRIPTION
Avoiding the `machine-config-controller-xxxxx` from c90d7e4001 (#3169), so users don't need to manually replace a pod-name placeholder.

Moving to a label selector also automatically gets us `--tail=10` limiting, so we aren't flooded by old history:

```console
$ oc logs --help | grep -A1 tail
    --tail=-1:
        Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided.
```

That limiting might remove older `Cannot evict pod ...` messages, but the `-f`/`--follow` means that if there's still a problem, we'll get a fresh log complaining about it soon.