### PR TITLE
daemon: Explicitly pull image before running

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1926,7 +1926,17 @@ func (dn *Daemon) InplaceUpdateViaNewContainer(target string) error {
 		glog.Info("SELinux is not enforcing")
 	}
 
-	err = runCmdSync("systemd-run", "--unit", "machine-config-daemon-update-rpmostree-via-container", "-p", "EnvironmentFile=-/etc/mco/proxy.env", "--collect", "--wait", "--", "podman", "run", "--env-file", "/etc/mco/proxy.env", "--authfile", "/var/lib/kubelet/config.json", "--privileged", "--pid=host", "--net=host", "--rm", "-v", "/:/run/host", target, "rpm-ostree", "ex", "deploy-from-self", "/run/host")
+	systemdPodmanArgs := []string{"--unit", "machine-config-daemon-update-rpmostree-via-container", "-p", "EnvironmentFile=-/etc/mco/proxy.env", "--collect", "--wait", "--", "podman"}
+	pullArgs := append([]string{}, systemdPodmanArgs...)
+	pullArgs = append(pullArgs, "pull", "--authfile", "/var/lib/kubelet/config.json", target)
+	err = runCmdSync("systemd-run", pullArgs...)
+	if err != nil {
+		return err
+	}
+
+	runArgs := append([]string{}, systemdPodmanArgs...)
+	runArgs = append(runArgs, "run", "--env-file", "/etc/mco/proxy.env", "--authfile", "/var/lib/kubelet/config.json", "--privileged", "--pid=host", "--net=host", "--rm", "-v", "/:/run/host", target, "rpm-ostree", "ex", "deploy-from-self", "/run/host")
+	err = runCmdSync("systemd-run", runArgs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is first just a generally good idea, because we often want to apply different timeouts and runtime constraints to the pull versus execution.

But second and more important, this should fix a bug we're seeing where really old versions of podman that are in the 4.2 bootimages don't honor `--authfile` when specified as part of `podman run`.

xref https://issues.redhat.com/browse/OCPBUGS-4769