### PR TITLE
OCPBUGS-5388: update: Also work around bug2111817 when removing rollback

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -686,6 +686,9 @@ func (dn *Daemon) removeRollback() error {
 		// do not attempt to rollback on non-RHCOS/FCOS machines
 		return nil
 	}
+	if err := bug2111817Workaround(); err != nil {
+		return err
+	}
 	return runRpmOstree("cleanup", "-r")
 }
 


### PR DESCRIPTION
Obviously we should ship the updated rpm-ostree.  It's queued, but delayed for some reason.  I will debug that.

But, we already are carrying the workaround code for upgrades, so we might as well apply this to the rollback path too.

https://issues.redhat.com/browse/OCPBUGS-2866
