### PR TITLE
fix unit test exit code propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ export GOLANGCI_LINT_CACHE=$(shell echo $${GOLANGCI_LINT_CACHE:-$$GOPATH/cache})
 
 GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 
-UNITTEST_OPTS = -tags=$(GOTAGS) -count=1 -v ./cmd/... ./pkg/... ./lib/...
-
 all: binaries
 
 .PHONY: clean test test-unit test-e2e verify update install-tools
@@ -50,18 +48,7 @@ test: test-unit test-e2e
 
 # Unit tests only (no active cluster required)
 test-unit: install-go-junit-report
-ifdef ARTIFACT_DIR
-	CGO_ENABLED=0 go test -coverprofile=mco-unit-test-coverage.out $(UNITTEST_OPTS) | ./hack/test-with-junit.sh $(@)
-	go tool cover -html=mco-unit-test-coverage.out -o mco-unit-test-coverage.html
-	# Move the test coverage report into ARTIFACT_DIR only when it is not the same as our current dir
-	# This enables test coverage analysis to be collected locally by running:
-	# $ ARTIFACT_DIR="$PWD" make test-unit
-	if [[ "${PWD}" != "${ARTIFACT_DIR}" ]]; then \
-		mv mco-unit-test-coverage.out mco-unit-test-coverage.html "${ARTIFACT_DIR}"; \
-	fi
-else
-	CGO_ENABLED=0 go test $(UNITTEST_OPTS)
-endif
+	./hack/test-unit.sh $(@) $(GOTAGS)
 
 # Run the code generation tasks.
 # Example:
@@ -69,7 +56,7 @@ endif
 update:
 	hack/update-codegen.sh
 	hack/update-templates.sh
- 
+
 go-deps:
 	go mod tidy
 	go mod vendor

--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script exists to run Go unit tests on both a developers local machine as
+# well as in CI. In the presence of the ARTIFACT_DIR environment variable, it
+# will perform test coverage analysis. In all cases, it will propagate the exit
+# code from go test to the caller. This allows the CI job to be marked as
+# "FAILED" whenever a test failure occurs.
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+MAKEFILE_TARGET="${1:-""}"
+GOTAGS="${2:-""}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-""}"
+COVERAGE_REPORT="mco-unit-test-coverage.out"
+
+function run_tests() {
+  test_opts=("$@")
+  CGO_ENABLED=0 go test "${test_opts[@]}" -tags="$GOTAGS" ./cmd/... ./pkg/... ./lib/... | ./hack/test-with-junit.sh "$MAKEFILE_TARGET"
+}
+
+function run_tests_with_coverage() {
+  test_opts=("$@")
+  test_opts+=("-coverprofile=$COVERAGE_REPORT")
+  run_tests "${test_opts[@]}"
+  test_retval="$?"
+
+  html_coverage_report="${COVERAGE_REPORT/.out/.html}"
+  if [[ "${PWD}" != "${ARTIFACT_DIR}" ]]; then
+    echo "Preparing coverage analysis report"
+    go tool cover -html="$COVERAGE_REPORT" -o "$html_coverage_report"
+    mv "$COVERAGE_REPORT" "$html_coverage_report" "$ARTIFACT_DIR";
+  fi
+
+  exit "$test_retval"
+}
+
+if [ ! -n "$MAKEFILE_TARGET" ]; then
+  echo "No Makefile target provided"
+  exit 1
+fi
+
+if [ ! -n "$GOTAGS" ]; then
+  echo "No GOTAGS provided"
+  exit 1
+fi
+
+# Common options to pass to go test
+test_opts=( "-v" "-count=1" )
+
+cd "$REPO_ROOT"
+
+if [ -n "$ARTIFACT_DIR" ]; then
+  run_tests_with_coverage "${test_opts[@]}"
+else
+  echo "ARTIFACT_DIR not set; skipping coverage profile collection"
+  run_tests "${test_opts[@]}"
+  exit "$?"
+fi


### PR DESCRIPTION
**- What I did**

When unit tests run and encounter a failure, they should exit with a non-zero
exit code so the CI system marks the whole job as "FAILED". This fixes that
behavior which was broken in
https://github.com/openshift/machine-config-operator/pull/3428.

**- How to verify it**

Create a purposely-failing test, commit, and push it. Ensure that the OpenShift
CI system marks the job as "FAILED".

**- Description for the changelog**
Ensures unit test failures cause a failing CI job
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
