### PR TITLE
OCPBUGS-5188: MCCDrainErr should reference the affected node

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -48,7 +48,7 @@ spec:
             namespace: openshift-machine-config-operator
             severity: warning
           annotations:
-            message: "Drain failed on {{ $labels.node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} -l k8s-app=machine-config-controller -c machine-config-controller"
+            message: "Drain failed on {{ $labels.exported_node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -32,11 +32,11 @@ var (
 		}, []string{"pool"})
 
 	// MCCDrainErr logs failed drain
-	MCCDrainErr = prometheus.NewGauge(
+	MCCDrainErr = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "mcc_drain_err",
 			Help: "logs failed drain",
-		})
+		}, []string{"node"})
 )
 
 func RegisterMCCMetrics() error {
@@ -50,7 +50,7 @@ func RegisterMCCMetrics() error {
 		return fmt.Errorf("could not register machine-config-controller metrics: %w", err)
 	}
 
-	MCCDrainErr.Set(0)
+	MCCDrainErr.Reset()
 
 	return nil
 }

--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -348,7 +348,7 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 		glog.Infof("Previous node drain found. Drain has been going on for %v hours", duration.Hours())
 		if duration > ctrl.cfg.DrainTimeoutDuration {
 			glog.Errorf("node %s: drain exceeded timeout: %v. Will continue to retry.", node.Name, ctrl.cfg.DrainTimeoutDuration)
-			ctrlcommon.MCCDrainErr.Set(1)
+			ctrlcommon.MCCDrainErr.WithLabelValues(node.Name).Set(1)
 		}
 		break
 	}
@@ -387,7 +387,7 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 	delete(ctrl.ongoingDrains, node.Name)
 
 	// Clear the MCCDrainErr, if any.
-	ctrlcommon.MCCDrainErr.Set(0)
+	ctrlcommon.MCCDrainErr.WithLabelValues(node.Name).Set(0)
 
 	return nil
 }


### PR DESCRIPTION
**- What I did**

I adjusted the parameters for the MCCDrainErr since it was reporting the node
that the Drain Controller is running on; not the node that couldn't be drained.

This was reported in https://issues.redhat.com/browse/OCPBUGS-5188

**- How to verify it**

Follow the replication instructions in the aforementioned bug.

**- Description for the changelog**
MCCDrainErr should reference the affected node
