### PR TITLE
OCPBUGS-5872: Wrap podman commands in a while loop

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -26,7 +26,7 @@ contents:
         # [1] https://github.com/containers/podman/issues/14003
         trap "" SIGTERM
         >&2 echo "NM resolv-prepender: Starting download of baremetal runtime cfg image"
-        /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}
+        while ! /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}; do sleep 1; done
         >&2 echo "NM resolv-prepender: Download of baremetal runtime cfg image completed"
         trap - SIGTERM
     }


### PR DESCRIPTION
This PR changes the logic of executing `podman pull` inside the NM
resolv-prepender by wrapping it in a while loop.

It has been observed that in some scenarios, when network is not yet
ready when the prepender script is executed, image may not be pulled
correctly. This ultimately can lead to a scenario when the node being
installed never pivots correctly causing the OCP installation to fail.

Fixes: OCPBUGS-5872