### PR TITLE
OCPNODE-1330: Set the CGroups version explicitly to "v1"

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,6 +170,14 @@ func (b *Bootstrap) Run(destDir string) error {
 		configs = append(configs, featureConfigs...)
 	}
 
+	if nodeConfig == nil {
+		nodeConfig = &apicfgv1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ctrlcommon.ClusterNodeInstanceName,
+			},
+			Spec: apicfgv1.NodeSpec{},
+		}
+	}
 	if nodeConfig != nil {
 		nodeConfigs, err := kubeletconfig.RunNodeConfigBootstrap(b.templatesDir, featureGate, cconfig, nodeConfig, pools)
 		if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -461,6 +461,7 @@ func (ctrl *Controller) addAnnotation(cfg *mcfgv1.KubeletConfig, annotationKey, 
 
 // syncKubeletConfig will sync the kubeletconfig with the given key.
 // This function is not meant to be invoked concurrently with the same key.
+//
 //nolint:gocyclo
 func (ctrl *Controller) syncKubeletConfig(key string) error {
 	startTime := time.Now()
@@ -571,10 +572,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		// updating the originalKubeConfig based on the nodeConfig on a worker node
 		if role == ctrlcommon.MachineConfigPoolWorker {
 			updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
-		}
-		// updating the machine config resource with the relevant cgroup configuration
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
 		}
 
 		// Get the default API Server Security Profile

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -112,9 +112,6 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 		if rawCfgIgn == nil {
 			continue
 		}
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
-		}
 
 		mc.Spec.Config.Raw = rawCfgIgn
 		mc.ObjectMeta.Annotations = map[string]string{
@@ -179,8 +176,9 @@ func (ctrl *Controller) deleteFeature(obj interface{}) {
 	glog.V(4).Infof("Deleted Feature %s and restored default config", features.Name)
 }
 
-//nolint:gocritic
 // generateFeatureMap returns a map of enabled/disabled feature gate selection with exclusion list
+//
+//nolint:gocritic
 func generateFeatureMap(features *osev1.FeatureGate, exclusions ...string) (*map[string]bool, error) {
 	rv := make(map[string]bool)
 	if features == nil {
@@ -279,10 +277,6 @@ func RunFeatureGateBootstrap(templateDir string, features *osev1.FeatureGate, no
 		mc.Spec.Config.Raw = rawCfgIgn
 		mc.ObjectMeta.Annotations = map[string]string{
 			ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,
-		}
-		// updating the machine config resource with the relevant cgroup configuration
-		if isTechPreviewNoUpgradeEnabled(features) {
-			updateMachineConfigwithCgroup(nodeConfig, mc)
 		}
 
 		machineConfigs = append(machineConfigs, mc)

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -78,18 +78,19 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 		t.Run(string(platform), func(t *testing.T) {
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
-			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp1 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			mcps := []*mcfgv1.MachineConfigPool{mcp}
+			mcps = append(mcps, mcp1)
 
 			features := createNewDefaultFeatureGate()
 			configNode := createNewDefaultNodeconfig()
-			configNode.Spec.WorkerLatencyProfile = osev1.DefaultUpdateDefaultReaction
 
 			mcs, err := RunNodeConfigBootstrap("../../../templates", features, cc, configNode, mcps)
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) == 0 {
+			if len(mcs) != 2 {
 				t.Errorf("expected a machine config generated with the default node config, got 0 machine configs")
 			}
 		})

--- a/test/e2e/kubeletcfg_test.go
+++ b/test/e2e/kubeletcfg_test.go
@@ -49,14 +49,14 @@ func TestKubeletConfigMaxPods(t *testing.T) {
 		},
 	}
 
-	runTestWithKubeletCfg(t, "max-pods", `"maxPods": (\S+)`, "100,", "200,", kc1, kc2)
+	runTestWithKubeletCfg(t, "max-pods", `["]maxPods["]: (\S+)`, "100,", "200,", kc1, kc2)
 }
 
 // runTestWithKubeletCfg creates a kubelet config and checks whether the expected updates were applied, then deletes the kubelet config and makes
 // sure the node rolled back as expected
 // testName is a string to identify the objects created (MCP, MC, kubeletConfig)
 // regex key is the searching critera in the kubelet.conf. It is expected that a single field is in a capture group, and this field
-//   should equal expectedConfValue upon update
+// should equal expectedConfValue upon update
 // kc1 and kc2 are the kubelet configs to update to and rollback from
 func runTestWithKubeletCfg(t *testing.T, testName, regexKey, expectedConfVal1, expectedConfVal2 string, kc1, kc2 *mcfgv1.KubeletConfig) {
 	cs := framework.NewClientSet("")
@@ -90,7 +90,7 @@ func runTestWithKubeletCfg(t *testing.T, testName, regexKey, expectedConfVal1, e
 	// cache the old configuration value to check against later
 	node := helpers.GetSingleNodeByRole(t, cs, poolName)
 	// the kubelet.conf format is yaml when in the default state and becomes a json when we apply a kubelet config CR
-	defaultConfVal := getValueFromKubeletConfig(t, cs, node, `maxPods: (\S+)`, kubeletPath) + ","
+	defaultConfVal := getValueFromKubeletConfig(t, cs, node, `["]maxPods["]: (\S+)`, kubeletPath) + ","
 	if defaultConfVal == expectedConfVal1 || defaultConfVal == expectedConfVal2 {
 		t.Logf("default configuration value %s same as values being tested against. Consider updating the test", defaultConfVal)
 		return
@@ -155,7 +155,7 @@ func runTestWithKubeletCfg(t *testing.T, testName, regexKey, expectedConfVal1, e
 	// ensure config rolls back as expected
 	helpers.WaitForPoolComplete(t, cs, poolName, defaultTarget)
 	// verify that the config value rolled back to the default value
-	restoredConfValue := getValueFromKubeletConfig(t, cs, node, `maxPods: (\S+)`, kubeletPath) + ","
+	restoredConfValue := getValueFromKubeletConfig(t, cs, node, `["]maxPods["]: (\S+)`, kubeletPath) + ","
 	require.Equal(t, restoredConfValue, defaultConfVal, "kubelet config deletion didn't cause node to roll back to default config")
 }
 


### PR DESCRIPTION
1. The CGroups version on an OCP cluster can be altered by altering the `nodes.config` resource's `spec.cgroupMode` field
2. It is very likely that the CGroups version would be defaulting to "v2" starting from OCP-4.13([RHEL-9](https://issues.redhat.com//browse/RHEL-9)) on the underlying RHCOS nodes.
3. To avoid unexpected complications, this code explicitly sets the CGroups version to "v1" on the newer OCP-4.13 versions
4. Also improved the bootstrap test cases, fixed a corner case issue

Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added code to explicitly set the `cgroupMode` to "v1", if found empty, in the newer OCP clusters(4.13)
**- How to verify it**
1. Deploy an OCP cluster (version = 4.13)
2. Debug into any of the nodes and observe the `CGroupsV1` configuration by executing the following command
```
sh-4.4# stat -c %T -f /sys/fs/cgroup/
tmpfs
```
Also observe the kernelArguments in the newly rendered machine config objects for the master and worker pools as follows:
```
kernelArguments:
  - systemd.unified_cgroup_hierarchy=0
  - systemd.legacy_systemd_cgroup_controller=1
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Explicitly set the `CGroups` configuration to `v1`, if found empty, in the newer version of OCP (4.13)