### PR TITLE
Log on-prem service output persistently

### DIFF
--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -25,6 +25,9 @@ contents:
       - name: nm-resolv
         hostPath:
           path: "/var/run/NetworkManager"
+      - name: host
+        hostPath:
+          path: "/"
       initContainers:
       - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -52,14 +55,34 @@ contents:
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
         imagePullPolicy: IfNotPresent
+      - name: create-on-prem-log-path
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          mkdir -p /host/var/log/on-prem-networking
+          # The unprivileged haproxy container needs write access too
+          chmod 775 /host/var/log/on-prem-networking
+        resources: {}
+        volumeMounts:
+        - name: host
+          mountPath: "/host"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
       containers:
       - name: coredns
         securityContext:
           privileged: true
         image: {{.Images.corednsImage}}
-        args:
-        - "--conf"
-        - "/etc/coredns/Corefile"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          mv -f /host/var/log/on-prem-networking/coredns.log /host/var/log/on-prem-networking/coredns.previous.log
+          /usr/bin/coredns --conf /etc/coredns/Corefile | tee /host/var/log/on-prem-networking/coredns.log
         resources:
           requests:
             cpu: 100m
@@ -67,6 +90,8 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
+        - name: host
+          mountPath: "/host"
         livenessProbe:
           httpGet:
             path: /health
@@ -83,14 +108,11 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-        - corednsmonitor
-        - "/var/lib/kubelet/kubeconfig"
-        - "/config/Corefile.tmpl"
-        - "/etc/coredns/Corefile"
-        - "--api-vips"
-        - "{{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
-        - "--ingress-vips"
-        - "{{- range $index, $ip := onPremPlatformIngressIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - /bin/bash
+        - -c
+        - |
+          mv -f /host/var/log/on-prem-networking/coredns-monitor.log /host/var/log/on-prem-networking/coredns-monitor.previous.log
+          corednsmonitor "/var/lib/kubelet/kubeconfig" "/config/Corefile.tmpl" "/etc/coredns/Corefile" "--api-vips" "{{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}" "--ingress-vips" "{{- range $index, $ip := onPremPlatformIngressIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}" 2>&1 | tee /host/var/log/on-prem-networking/coredns-monitor.log
         resources:
           requests:
             cpu: 100m
@@ -104,6 +126,8 @@ contents:
           mountPath: "/etc/coredns"
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
+        - name: host
+          mountPath: "/host"
         imagePullPolicy: IfNotPresent        
       hostNetwork: true
       tolerations:

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -61,6 +61,23 @@ contents:
         - name: nodeip-configuration
           mountPath: "/run/nodeip-configuration"
         imagePullPolicy: IfNotPresent
+      - name: create-on-prem-log-path
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          mkdir -p /host/var/log/on-prem-networking
+          # The unprivileged haproxy container needs write access too
+          chmod 775 /host/var/log/on-prem-networking
+        resources: {}
+        volumeMounts:
+        - name: chroot-host
+          mountPath: "/host"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
       containers:
       - name: keepalived
         securityContext:
@@ -111,33 +128,38 @@ contents:
             fi
           }
 
+          run_keepalived() {
+            # Ensure that we don't have stale VIPs configured
+            # See https://bugzilla.redhat.com/show_bug.cgi?id=1931505
+            {{- range onPremPlatformAPIServerInternalIPs . }}
+            remove_vip "{{.}}"
+            {{- end }}
+            {{- range onPremPlatformIngressIPs . }}
+            remove_vip "{{.}}"
+            {{- end }}
+            declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
+            export -f msg_handler
+            export -f reload_keepalived
+            export -f sigterm_handler
+
+            # in remote worker case sleep forever
+            if [ -f "/run/nodeip-configuration/remote-worker" ]; then
+              sleep infinity
+              exit 0
+            fi
+
+            trap sigterm_handler SIGTERM
+            if [ -s "/etc/keepalived/keepalived.conf" ]; then
+                /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+            fi
+
+            rm -f "$keepalived_sock"
+            socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
+          }
+
           set -ex
-          # Ensure that we don't have stale VIPs configured
-          # See https://bugzilla.redhat.com/show_bug.cgi?id=1931505
-          {{- range onPremPlatformAPIServerInternalIPs . }}
-          remove_vip "{{.}}"
-          {{- end }}
-          {{- range onPremPlatformIngressIPs . }}
-          remove_vip "{{.}}"
-          {{- end }}
-          declare -r keepalived_sock="/var/run/keepalived/keepalived.sock"
-          export -f msg_handler
-          export -f reload_keepalived
-          export -f sigterm_handler
-
-          # in remote worker case sleep forever
-          if [ -f "/run/nodeip-configuration/remote-worker" ]; then
-             sleep infinity
-             exit 0
-          fi
-
-          trap sigterm_handler SIGTERM
-          if [ -s "/etc/keepalived/keepalived.conf" ]; then
-              /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
-          fi
-
-          rm -f "$keepalived_sock"
-          socat UNIX-LISTEN:${keepalived_sock},fork system:'bash -c msg_handler'
+          mv -f /host/var/log/on-prem-networking/keepalived.log /host/var/log/on-prem-networking/keepalived.previous.log || :
+          run_keepalived 2>&1 | tee /host/var/log/on-prem-networking/keepalived.log
         resources:
           requests:
             cpu: 100m
@@ -178,6 +200,7 @@ contents:
         - -c
         - |
           #/bin/bash
+          mv -f /host/var/log/on-prem-networking/keepalived-monitor.log /host/var/log/on-prem-networking/keepalived-monitor.previous.log
           # in remote worker case sleep forever
           if [ -f "/run/nodeip-configuration/remote-worker" ]; then
               sleep infinity
@@ -185,7 +208,7 @@ contents:
           fi
           api_vips={{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}
           ingress_vips={{- range $index, $ip := onPremPlatformIngressIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}
-          dynkeepalived /var/lib/kubelet/kubeconfig /config/keepalived.conf.tmpl /etc/keepalived/keepalived.conf --api-vips "${api_vips}" --ingress-vips "${ingress_vips}"
+          dynkeepalived /var/lib/kubelet/kubeconfig /config/keepalived.conf.tmpl /etc/keepalived/keepalived.conf --api-vips "${api_vips}" --ingress-vips "${ingress_vips}" 2>&1 | tee /host/var/log/on-prem-networking/keepalived-monitor.log
         resources:
           requests:
             cpu: 100m

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -43,6 +43,23 @@ contents:
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
         imagePullPolicy: IfNotPresent
+      - name: create-on-prem-log-path
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          mkdir -p /host/var/log/on-prem-networking
+          # The unprivileged haproxy container needs write access too
+          chmod 775 /host/var/log/on-prem-networking
+        resources: {}
+        volumeMounts:
+        - name: chroot-host
+          mountPath: "/host"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
       containers:
       - name: haproxy
         image: {{.Images.haproxyImage}}
@@ -53,7 +70,8 @@ contents:
         - "/bin/bash"
         - "-c"
         - |
-          #/bin/bash
+          #!/bin/bash
+          mv -f /host/var/log/on-prem-networking/haproxy.log /host/var/log/on-prem-networking/haproxy.previous.log
           verify_old_haproxy_ps_being_deleted()
           {
             local prev_pids
@@ -99,7 +117,7 @@ contents:
           export -f reload_haproxy
           export -f verify_old_haproxy_ps_being_deleted
           rm -f "$haproxy_sock" "$haproxy_log_sock"
-          socat UNIX-RECV:${haproxy_log_sock} STDOUT &
+          socat UNIX-RECV:${haproxy_log_sock} STDOUT | tee /host/var/log/on-prem-networking/haproxy.log &
           if [ -s "/etc/haproxy/haproxy.cfg" ]; then
               /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
           fi
@@ -113,6 +131,8 @@ contents:
           mountPath: "/etc/haproxy"
         - name: run-dir
           mountPath: "/var/run/haproxy"
+        - name: chroot-host
+          mountPath: "/host"
         livenessProbe:
           initialDelaySeconds: 50
           httpGet:
@@ -125,12 +145,12 @@ contents:
           privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
-        - monitor
-        - "/var/lib/kubelet/kubeconfig"
-        - "/config/haproxy.cfg.tmpl"
-        - "/etc/haproxy/haproxy.cfg"
-        - "--api-vips"
-        - "{{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "/bin/bash"
+        - "-c"
+        - |
+          #!/bin/bash
+          mv -f /host/var/log/on-prem-networking/haproxy-monitor.log /host/var/log/on-prem-networking/haproxy-monitor.previous.log
+          monitor "/var/lib/kubelet/kubeconfig" "/config/haproxy.cfg.tmpl" "/etc/haproxy/haproxy.cfg" "--api-vips" "{{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}" 2>&1 | tee /host/var/log/on-prem-networking/haproxy-monitor.log
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Currently we only have logs from after the last reboot of a node for these services. This can make it extremely difficult to debug certain problems, particularly during upgrade when all nodes must reboot.

To get around that, this patch tees all service output to a folder in /var/log. As a followup, we will add that directory to the log collection step of must-gather so we can see logs from the previous run of a service as well.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Send on-prem networking service output to filesystem so it can be persisted over reboots.
