### PR TITLE
OCPBUGS-5379: First boot service should timeout on extract to be able to retry, adding more logs to extract coammand

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -323,10 +323,10 @@ func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 	}
 
 	// Extract the image
-	args := []string{"image", "extract", "--path", "/:" + osImageContentDir}
+	args := []string{"20m", "oc", "image", "extract", "--v", "10", "--path", "/:" + osImageContentDir}
 	args = append(args, registryConfig...)
 	args = append(args, imgURL)
-	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "oc", args...); err != nil {
+	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "timeout", args...); err != nil {
 		// Workaround fixes for the environment where oc image extract fails.
 		// See https://bugzilla.redhat.com/show_bug.cgi?id=1862979
 		glog.Infof("Falling back to using podman cp to fetch OS image content")
@@ -355,10 +355,10 @@ func ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, 
 	}
 
 	// Extract the image
-	args := []string{"image", "extract", "--path", "/:" + osExtensionsImageContentDir}
+	args := []string{"20m", "oc", "image", "extract", "--v", "10", "--path", "/:" + osExtensionsImageContentDir}
 	args = append(args, registryConfig...)
 	args = append(args, imgURL)
-	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "oc", args...); err != nil {
+	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "timeout", args...); err != nil {
 		// Workaround fixes for the environment where oc image extract fails.
 		// See https://bugzilla.redhat.com/show_bug.cgi?id=1862979
 		glog.Infof("Falling back to using podman cp to fetch OS image content")


### PR DESCRIPTION
OCPBUGS-5379: First boot service should timeout on extract to be able to retry, adding more logs to extract coammand #3490

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
1. Added timeout to oc extract command in order to fail and retry after 20 minutes
2. Added debug logs to "ox extract" in order to see where command is stuck to be able to debug better next time

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
