### PR TITLE
OCPBUGS-6004: Adding network type parameter to nodeip-configuration service

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -28,6 +28,7 @@ contents: |
     --prefer-ipv6 \
     {{end -}}
     --retry-on-failure \
+    --network-type {{.NetworkType}} \
     ${NODEIP_HINT:-${KUBELET_NODEIP_HINT:-}}; \
     do \
     sleep 5; \


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
depends on https://github.com/openshift/baremetal-runtimecfg/pull/215

**- What I did**
Added network type param to nodeip-configuration service

**- How to verify it**
Run any test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
