### PR TITLE
OCPBUGS-5379: There are not enough logs in case "oc extract" is stuck in mco first boot

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -323,7 +323,7 @@ func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 	}
 
 	// Extract the image
-	args := []string{"image", "extract", "--path", "/:" + osImageContentDir}
+	args := []string{"image", "extract", "-v", "10", "--path", "/:" + osImageContentDir}
 	args = append(args, registryConfig...)
 	args = append(args, imgURL)
 	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "oc", args...); err != nil {
@@ -355,7 +355,7 @@ func ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, 
 	}
 
 	// Extract the image
-	args := []string{"image", "extract", "--path", "/:" + osExtensionsImageContentDir}
+	args := []string{"image", "extract", "-v", "10", "--path", "/:" + osExtensionsImageContentDir}
 	args = append(args, registryConfig...)
 	args = append(args, imgURL)
 	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "oc", args...); err != nil {


### PR DESCRIPTION
OCPBUGS-5379: There are not enough logs in case "oc extract" is stuck in mco first boot

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added more verbosity for ox extract command
**- How to verify it**
check logs of any installation
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
