### PR TITLE
[release-4.11]  OCPBUGS-6002: There are not enough logs in case "oc extract" is stuck in mco first boot in mco first boot

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -309,7 +309,7 @@ func ExtractOSImage(imgURL string) (osImageContentDir string, err error) {
 	}
 
 	// Extract the image
-	args := []string{"image", "extract", "--path", "/:" + osImageContentDir}
+	args := []string{"image", "extract", "-v", "10", "--path", "/:" + osImageContentDir}
 	args = append(args, registryConfig...)
 	args = append(args, imgURL)
 	if _, err = pivotutils.RunExtBackground(cmdRetriesCount, "oc", args...); err != nil {


### PR DESCRIPTION
[release-4.11]  OCPBUGS-5379: There are not enough logs in case "oc extract" is stuck in mco first boot in mco first boot
This is an manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/3493
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
