### PR TITLE
Bug 2113973: Avoid 'too restrictive' SCC problems by being more explicit

### DIFF
--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -23,6 +23,7 @@ spec:
         memory: 50Mi
     securityContext:
       privileged: true
+      readOnlyRootFilesystem: false
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - name: bootstrap-manifests
@@ -45,6 +46,7 @@ spec:
       mountPath: /etc/mcs/bootstrap
     securityContext:
       privileged: true
+      readOnlyRootFilesystem: false
   hostNetwork: true
   tolerations:
     - key: node-role.kubernetes.io/master

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
             memory: 50Mi
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - mountPath: /rootfs

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -54,6 +54,7 @@ spec:
   - name: coredns
     securityContext:
       privileged: true
+      readOnlyRootFilesystem: false
     image: {{ .Images.CorednsBootstrap }}
     args:
     - "--conf"

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -30,6 +30,7 @@ spec:
   - name: keepalived
     securityContext:
       privileged: true
+      readOnlyRootFilesystem: false
     image: {{.Images.KeepalivedBootstrap}}
     env:
       - name: NSS_SDB_USE_CACHE


### PR DESCRIPTION
Make MCO's privileged pods specify `readOnlyRootFilesystem: false` as part of the securityContext so they will no longer end up matched with "too restrictive" Security Context Constraints (SCCs) on clusters with custom SCCs.

We can't really control what SCCs people set up, and we've had enough folks hit this that we should fix it. 

This should be completely safe, and should have no real effect whatsoever on a cluster with standard/non-custom SCCs, because the default "privileged" SCC our pods get assigned already comes with `readOnlyRootFilesystem: false` : 

```
[jkyros@jkyros-t590 cluster]$ oc get scc privileged
NAME         PRIV   CAPS    SELINUX    RUNASUSER   FSGROUP    SUPGROUP   PRIORITY     READONLYROOTFS   VOLUMES
privileged   true   ["*"]   RunAsAny   RunAsAny    RunAsAny   RunAsAny   <no value>   false            ["*"]
```

Fixes: [BZ 2113973](https://bugzilla.redhat.com/show_bug.cgi?id=2113973 ) 

(Also related to https://bugzilla.redhat.com/show_bug.cgi?id=2057545 ) 