### PR TITLE
OCPBUGS-2177: MCO-634: add support for a node pool hierarchy

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -25,6 +25,17 @@ spec:
             severity: warning
           annotations:
             message: "Drain failed on {{ $labels.exported_node }} , updates may be blocked. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
+    - name: mcc-pool-alert
+      rules:
+        - alert: MCCPoolAlert
+          expr: |
+            mcc_pool_alert > 0
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "Triggers when nodes in a pool have overlapping labels such as master, worker, and a custom label therefore a choice must be made as to which is honored."
+            description: "Node {{ $labels.node }} has triggered a pool alert due to a label change"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -30,12 +30,19 @@ var (
 			Name: "mcc_drain_err",
 			Help: "logs failed drain",
 		}, []string{"node"})
+	// MCCPoolAlert logs when the pool configuration changes in a way the user should know.
+	MCCPoolAlert = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mcc_pool_alert",
+			Help: "pool status alert",
+		}, []string{"pool", "alert"})
 )
 
 func RegisterMCCMetrics() error {
 	err := RegisterMetrics([]prometheus.Collector{
 		OSImageURLOverride,
 		MCCDrainErr,
+		MCCPoolAlert,
 	})
 
 	if err != nil {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -619,15 +619,21 @@ func (ctrl *Controller) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.MachineCon
 	if len(custom) > 1 {
 		return nil, fmt.Errorf("node %s belongs to %d custom roles, cannot proceed with this Node", node.Name, len(custom))
 	} else if len(custom) == 1 {
-		// We don't support making custom pools for masters
+		pls := []*mcfgv1.MachineConfigPool{}
 		if master != nil {
-			return nil, fmt.Errorf("node %s has both master role and custom role %s", node.Name, custom[0].Name)
+			// if we have a custom pool and master, defer to master and return.
+			glog.Infof("Found master node that matches selector for custom pool %v, defaulting to master. This node will not have any custom role configuration as a result. Please review the node to make sure this is intended", custom[0].Name)
+			ctrlcommon.MCCPoolAlert.WithLabelValues(custom[0].Name, fmt.Sprintf("Given both master and custom pools. Defaulting to master: custom %v", custom[0].Name)).Set(1)
+			pls = append(pls, master)
+		} else {
+			ctrlcommon.MCCPoolAlert.WithLabelValues(custom[0].Name, "Applying custom label for pool").Set(0)
+			pls = append(pls, custom[0])
 		}
-		// One custom role, let's use its pool
-		pls := []*mcfgv1.MachineConfigPool{custom[0]}
 		if worker != nil {
 			pls = append(pls, worker)
 		}
+		// this allows us to have master, worker, infra but be in the master pool.
+		// or if !worker and !master then we just use the custom pool.
 		return pls, nil
 	} else if master != nil {
 		// In the case where a node is both master/worker, have it live under

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -352,8 +352,10 @@ func TestGetPrimaryPoolForNode(t *testing.T) {
 		},
 		nodeLabel: map[string]string{"node-role/master": "", "node-role/infra": ""},
 
-		expected: nil,
-		err:      true,
+		// https://issues.redhat.com/browse/OCPBUGS-2177 a user should
+		// be able to label something as infra but retain master if it exists
+		expected: helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
+		err:      false,
 	}, {
 		pools: []*mcfgv1.MachineConfigPool{
 			helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),


### PR DESCRIPTION

**- What I did**

if a node specifies a custom label while already being a master node, the MCO should default to master similar to how we do with master,worker nodes. The label is retained but the pool selection of the custom label is not honored.


**- How to verify it**

create a cluster, label master node as infra, push a custom mcp with a nodeSelector for this label, push a mc that updates a file to enqueue an update. `oc get mcp` should eventually list 3 nodes in worker and master pool rather than the current state which removes the node from all pools.

**- Description for the changelog**

allow users to set custom labels on master nodes, deferring to the master pool rather than the custom pool if a custom mcp specifies the nodeSelector.

Signed-off-by: Charlie Doern <cdoern@redhat.com>
