### PR TITLE
OCPBUGS-6092: Improvements for `configure-ovs.sh`

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -158,6 +158,11 @@ contents:
       # store old conn for later
       old_conn=$(nmcli --fields UUID,DEVICE conn show --active | awk "/\s${iface}\s*\$/ {print \$1}")
 
+      if [[ -z "$old_conn" ]]; then
+        echo "ERROR: cannot find connection for interface: ${iface}"
+        exit 1
+      fi
+
       # create bridge
       if ! nmcli connection show "$bridge_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-br "$bridge_name"
@@ -358,9 +363,7 @@ contents:
       echo "Reverting any previous OVS configuration"
       
       remove_ovn_bridges br-ex phys0
-      if [ -d "/sys/class/net/br-ex1" ]; then
-        remove_ovn_bridges br-ex1 phys1
-      fi
+      remove_ovn_bridges br-ex1 phys1
       
       echo "OVS configuration successfully reverted"
     }


### PR DESCRIPTION
`remove_ovn_bridge` function is idempotent, so there is no need to conditionally invoke it.

Add early exit in `convert_to_bridge` if unable to find the connection for the given interface. This should reduce the noise in case of error.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
