### PR TITLE
speed up MCO unit tests

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -12,8 +12,13 @@ import (
 )
 
 func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
+	t.Parallel()
+
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
+
 			f := newFixture(t)
 			f.newController()
 

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -474,8 +474,11 @@ var ctrcfgPatchBytes = []uint8{0x7b, 0x22, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0
 // TestContainerRuntimeConfigCreate ensures that a create happens when an existing containerruntime config is created.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestContainerRuntimeConfigCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -511,8 +514,11 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 // TestContainerRuntimeConfigUpdate ensures that an update happens when an existing containerruntime config is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestContainerRuntimeConfigUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -592,8 +598,11 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 // TestImageConfigCreate ensures that a create happens when an image config is created.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestImageConfigCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -634,8 +643,11 @@ func TestImageConfigCreate(t *testing.T) {
 // TestImageConfigUpdate ensures that an update happens when an existing image config is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestImageConfigUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -730,8 +742,11 @@ func TestImageConfigUpdate(t *testing.T) {
 // TestICSPUpdate ensures that an update happens when an existing ICSP is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestICSPUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -833,8 +848,11 @@ func TestICSPUpdate(t *testing.T) {
 }
 
 func TestIDMSUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -936,8 +954,11 @@ func TestIDMSUpdate(t *testing.T) {
 }
 
 func TestITMSUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -1039,6 +1060,7 @@ func TestITMSUpdate(t *testing.T) {
 }
 
 func TestRunImageBootstrap(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
 		for _, tc := range []struct {
 			icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy
@@ -1067,7 +1089,11 @@ func TestRunImageBootstrap(t *testing.T) {
 			},
 		} {
 
+			tc := tc
+			platform := platform
+
 			t.Run(string(platform), func(t *testing.T) {
+				t.Parallel()
 				cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 				pools := []*mcfgv1.MachineConfigPool{
 					helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
@@ -1210,6 +1236,7 @@ func TestRegistriesValidation(t *testing.T) {
 // TestContainerRuntimeConfigOptions tests the validity of allowed and not allowed values
 // for the options in containerruntime config
 func TestContainerRuntimeConfigOptions(t *testing.T) {
+	t.Parallel()
 	var (
 		invalidPidsLimit int64 = 10
 		validPidsLimit   int64 = 2048
@@ -1290,20 +1317,29 @@ func TestContainerRuntimeConfigOptions(t *testing.T) {
 
 	// Failure Tests
 	for _, test := range failureTests {
-		ctrcfg := newContainerRuntimeConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
-		err := validateUserContainerRuntimeConfig(ctrcfg)
-		if err == nil {
-			t.Errorf("%s: failed", test.name)
-		}
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrcfg := newContainerRuntimeConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
+			err := validateUserContainerRuntimeConfig(ctrcfg)
+			if err == nil {
+				t.Errorf("%s: failed", test.name)
+			}
+		})
 	}
 
 	// Successful Tests
 	for _, test := range successTests {
-		ctrcfg := newContainerRuntimeConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
-		err := validateUserContainerRuntimeConfig(ctrcfg)
-		if err != nil {
-			t.Errorf("%s: failed with %v. should have succeeded", test.name, err)
-		}
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrcfg := newContainerRuntimeConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
+			err := validateUserContainerRuntimeConfig(ctrcfg)
+			if err != nil {
+				t.Errorf("%s: failed with %v. should have succeeded", test.name, err)
+			}
+		})
+
 	}
 }
 
@@ -1321,8 +1357,12 @@ func generateManagedKey(ctrcfg *mcfgv1.ContainerRuntimeConfig, generation uint64
 }
 
 func TestCtrruntimeConfigMultiCreate(t *testing.T) {
+	t.Parallel()
+
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -1366,8 +1406,11 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 }
 
 func TestContainerruntimeConfigResync(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestUpdateRegistriesConfig(t *testing.T) {
+	t.Parallel()
 	templateConfig := sysregistriesv2.V2RegistriesConf{ // This matches templates/*/01-*-container-runtime/_base/files/container-registries.yaml
 		UnqualifiedSearchRegistries: []string{"registry.access.redhat.com", "docker.io"},
 	}
@@ -356,7 +357,9 @@ func TestUpdateRegistriesConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := updateRegistriesConfig(templateBytes, tt.insecure, tt.blocked, tt.icspRules, tt.idmsRules, tt.itmsRules)
 			if err != nil {
 				t.Errorf("updateRegistriesConfig() error = %v", err)
@@ -385,6 +388,7 @@ func TestUpdateRegistriesConfig(t *testing.T) {
 }
 
 func TestUpdatePolicyJSON(t *testing.T) {
+	t.Parallel()
 	templateConfig := signature.Policy{
 		Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
 		Transports: map[string]signature.PolicyTransportScopes{
@@ -505,7 +509,9 @@ func TestUpdatePolicyJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := updatePolicyJSON(templateBytes, tt.blocked, tt.allowed, "release-reg.io/image/release")
 			if err == nil && tt.errorExpected {
 				t.Errorf("updatePolicyJSON() error = %v", err)
@@ -534,6 +540,7 @@ func TestUpdatePolicyJSON(t *testing.T) {
 }
 
 func TestValidateRegistriesConfScopes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		insecure    []string
 		blocked     []string
@@ -779,7 +786,9 @@ func TestGetValidBlockAndAllowedRegistries(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotRegistries, gotPolicy, gotAllowed, err := getValidBlockedAndAllowedRegistries(tt.releaseImg, tt.imgSpec, nil, tt.idmsRules)
 			if (err != nil && !tt.expectedErr) || (err == nil && tt.expectedErr) {
 				t.Errorf("getValidBlockedRegistries() error = %v", err)

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
@@ -15,10 +15,13 @@ import (
 )
 
 func TestRunKubeletBootstrap(t *testing.T) {
+	t.Parallel()
 	customSelector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/custom", "")
 
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			pools := []*mcfgv1.MachineConfigPool{
 				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
@@ -96,6 +99,7 @@ func verifyKubeletConfigJSONContents(t *testing.T, mc *mcfgv1.MachineConfig, mcN
 }
 
 func TestGenerateDefaultManagedKeyKubelet(t *testing.T) {
+	t.Parallel()
 	workerPool := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 	masterPool := helpers.NewMachineConfigPool("master", nil, helpers.WorkerSelector, "v0")
 	kcRaw, err := EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion)
@@ -188,15 +192,21 @@ func TestGenerateDefaultManagedKeyKubelet(t *testing.T) {
 			fmt.Errorf("Error found multiple KubeletConfigs targeting MachineConfigPool master. Please apply only one KubeletConfig manifest for each pool during installation"),
 		},
 	} {
-		res, err := generateBootstrapManagedKeyKubelet(tc.pool, managedKeyExist)
-		require.Equal(t, tc.expectedErr, err)
-		require.Equal(t, tc.expectedManagedKey, res)
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			res, err := generateBootstrapManagedKeyKubelet(tc.pool, managedKeyExist)
+			require.Equal(t, tc.expectedErr, err)
+			require.Equal(t, tc.expectedManagedKey, res)
+		})
 	}
 }
 
 func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -440,8 +440,11 @@ func TestKubeletConfigCreate(t *testing.T) {
 }
 
 func TestKubeletConfigMultiCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -489,8 +492,11 @@ func generateManagedKey(kcfg *mcfgv1.KubeletConfig, generation uint64) string {
 }
 
 func TestKubeletConfigAutoSizingReserved(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -532,8 +538,11 @@ func TestKubeletConfigAutoSizingReserved(t *testing.T) {
 }
 
 func TestKubeletConfigLogFile(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -574,8 +583,11 @@ func TestKubeletConfigLogFile(t *testing.T) {
 }
 
 func TestKubeletConfigUpdates(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -660,6 +672,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 }
 
 func TestKubeletConfigDenylistedOptions(t *testing.T) {
+	t.Parallel()
 	failureTests := []struct {
 		name   string
 		config *kubeletconfigv1beta1.KubeletConfiguration
@@ -712,26 +725,36 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 
 	// Failure Tests
 	for _, test := range failureTests {
-		kc := newKubeletConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
-		err := validateUserKubeletConfig(kc)
-		if err == nil {
-			t.Errorf("%s: failed", test.name)
-		}
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			kc := newKubeletConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
+			err := validateUserKubeletConfig(kc)
+			if err == nil {
+				t.Errorf("%s: failed", test.name)
+			}
+		})
 	}
 
 	// Successful Tests
 	for _, test := range successTests {
-		kc := newKubeletConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
-		err := validateUserKubeletConfig(kc)
-		if err != nil {
-			t.Errorf("%s: failed with %v. should have succeeded", test.name, err)
-		}
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			kc := newKubeletConfig(test.name, test.config, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
+			err := validateUserKubeletConfig(kc)
+			if err != nil {
+				t.Errorf("%s: failed with %v. should have succeeded", test.name, err)
+			}
+		})
 	}
 }
 
 func TestKubeletFeatureExists(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "Unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -794,6 +817,7 @@ func getKeyFromConfigNode(node *osev1.Node, t *testing.T) string {
 }
 
 func TestCleanUpStatusConditions(t *testing.T) {
+	t.Parallel()
 	type status struct {
 		curtStatus   []mcfgv1.KubeletConfigCondition
 		newStatus    mcfgv1.KubeletConfigCondition
@@ -863,18 +887,25 @@ func TestCleanUpStatusConditions(t *testing.T) {
 	}
 
 	for _, tc := range conditionsTest {
-		cleanUpStatusConditions(&tc.curtStatus, tc.newStatus)
-		for i := 0; i < len(tc.expectStatus); i++ {
-			if tc.curtStatus[i].Message != tc.expectStatus[i].Message {
-				t.Fatal("expect: ", tc.expectStatus, "actual: ", tc.curtStatus[i])
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			cleanUpStatusConditions(&tc.curtStatus, tc.newStatus)
+			for i := 0; i < len(tc.expectStatus); i++ {
+				if tc.curtStatus[i].Message != tc.expectStatus[i].Message {
+					t.Fatal("expect: ", tc.expectStatus, "actual: ", tc.curtStatus[i])
+				}
 			}
-		}
+		})
 	}
 }
 
 func TestKubeletConfigResync(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -17,8 +17,11 @@ import (
 )
 
 func TestFeatureGateDrift(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
@@ -44,8 +47,11 @@ func TestFeatureGateDrift(t *testing.T) {
 }
 
 func TestFeaturesDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -85,8 +91,11 @@ func TestFeaturesDefault(t *testing.T) {
 }
 
 func TestFeaturesCustomNoUpgrade(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -140,8 +149,11 @@ func TestFeaturesCustomNoUpgrade(t *testing.T) {
 }
 
 func TestBootstrapFeaturesDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
@@ -162,8 +174,11 @@ func TestBootstrapFeaturesDefault(t *testing.T) {
 }
 
 func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -17,8 +17,11 @@ import (
 )
 
 func TestOriginalKubeletConfigDefaultNodeConfig(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
@@ -41,8 +44,11 @@ func TestOriginalKubeletConfigDefaultNodeConfig(t *testing.T) {
 }
 
 func TestNodeConfigDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -74,8 +80,11 @@ func TestNodeConfigDefault(t *testing.T) {
 }
 
 func TestBootstrapNodeConfigDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
@@ -98,8 +107,11 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 }
 
 func TestBootstrapNoNodeConfig(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -243,6 +243,7 @@ func (f *fixture) expectPatchNodeAction(node *corev1.Node, patch []byte) {
 }
 
 func TestGetNodesForPool(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		pool  *mcfgv1.MachineConfigPool
 		nodes []*corev1.Node
@@ -285,7 +286,10 @@ func TestGetNodesForPool(t *testing.T) {
 	}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			f.nodeLister = append(f.nodeLister, test.nodes...)
@@ -303,6 +307,7 @@ func TestGetNodesForPool(t *testing.T) {
 }
 
 func TestGetPrimaryPoolForNode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		pools     []*mcfgv1.MachineConfigPool
 		nodeLabel map[string]string
@@ -389,7 +394,10 @@ func TestGetPrimaryPoolForNode(t *testing.T) {
 	}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			node := newNode("node-0", "v0", "v0")
 			node.Labels = test.nodeLabel
@@ -448,6 +456,7 @@ func newNodeSet(len int) []*corev1.Node {
 }
 
 func TestMaxUnavailable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		poolName   string
 		maxUnavail *intstr.IntOrString
@@ -499,7 +508,10 @@ func TestMaxUnavailable(t *testing.T) {
 	}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			pool := &mcfgv1.MachineConfigPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: test.poolName,
@@ -519,6 +531,7 @@ func TestMaxUnavailable(t *testing.T) {
 }
 
 func TestGetCandidateMachines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		nodes    []*corev1.Node
 		progress int
@@ -652,7 +665,10 @@ func TestGetCandidateMachines(t *testing.T) {
 	}}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			pool := &mcfgv1.MachineConfigPool{
 				Spec: mcfgv1.MachineConfigPoolSpec{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: "v1"}},
@@ -698,6 +714,7 @@ func assertPatchesNode0ToV1(t *testing.T, actions []core.Action) {
 }
 
 func TestSetDesiredMachineConfigAnnotation(t *testing.T) {
+	t.Parallel()
 
 	tests := []struct {
 		node       *corev1.Node
@@ -763,7 +780,10 @@ func TestSetDesiredMachineConfigAnnotation(t *testing.T) {
 	}}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			if test.extraannos != nil {
 				if test.node.Annotations == nil {
@@ -789,6 +809,7 @@ func TestSetDesiredMachineConfigAnnotation(t *testing.T) {
 }
 
 func TestShouldMakeProgress(t *testing.T) {
+	t.Parallel()
 	// nodeWithDesiredConfigTaints is at desired config, so need to do a get on the nodeWithDesiredConfigTaints to check for the taint status
 	nodeWithDesiredConfigTaints := newNodeWithLabel("nodeWithDesiredConfigTaints", "v1", "v1", map[string]string{"node-role/worker": "", "node-role/infra": ""})
 	// Update nodeWithDesiredConfigTaints to have the needed taint and some dummy taint, UpdateInProgress taint should be removed
@@ -833,7 +854,9 @@ func TestShouldMakeProgress(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.TopologyMode(""))
 			mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")
@@ -917,6 +940,7 @@ func TestShouldMakeProgress(t *testing.T) {
 }
 
 func TestEmptyCurrentMachineConfig(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.TopologyMode(""))
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", nil, helpers.MasterSelector, "")
@@ -929,6 +953,7 @@ func TestEmptyCurrentMachineConfig(t *testing.T) {
 }
 
 func TestPaused(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")
 	mcpWorker := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v1")
@@ -955,6 +980,7 @@ func TestPaused(t *testing.T) {
 }
 
 func TestAlertOnPausedKubeletCA(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v1")
 
@@ -1004,6 +1030,7 @@ func TestAlertOnPausedKubeletCA(t *testing.T) {
 }
 
 func TestShouldUpdateStatusOnlyUpdated(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.TopologyMode(""))
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")
@@ -1031,6 +1058,7 @@ func TestShouldUpdateStatusOnlyUpdated(t *testing.T) {
 }
 
 func TestShouldUpdateStatusOnlyNoProgress(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.TopologyMode(""))
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")
@@ -1058,6 +1086,7 @@ func TestShouldUpdateStatusOnlyNoProgress(t *testing.T) {
 }
 
 func TestShouldDoNothing(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.TopologyMode(""))
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")
@@ -1082,6 +1111,7 @@ func TestShouldDoNothing(t *testing.T) {
 }
 
 func TestSortNodeList(t *testing.T) {
+	t.Parallel()
 	node_zoneQQQ := newNodeWithLabel("node-1", "v1", "v1", map[string]string{"topology.kubernetes.io/zone": "QQQ"})
 	node_zoneQQQ.CreationTimestamp = metav1.NewTime(time.Unix(0, 42))
 
@@ -1141,6 +1171,7 @@ func TestSortNodeList(t *testing.T) {
 }
 
 func TestControlPlaneTopology(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.SingleReplicaTopologyMode)
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestIsNodeReady(t *testing.T) {
+	t.Parallel()
 	nodeList := &corev1.NodeList{
 		Items: []corev1.Node{
 			// node1 considered
@@ -119,6 +120,7 @@ func newNodeWithReadyAndDaemonState(name string, currentConfig, desiredConfig st
 }
 
 func TestGetUpdatedMachines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		nodes         []*corev1.Node
 		currentConfig string
@@ -158,7 +160,10 @@ func TestGetUpdatedMachines(t *testing.T) {
 	}}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			updated := getUpdatedMachines(test.currentConfig, test.nodes)
 			if !reflect.DeepEqual(updated, test.updated) {
 				t.Fatalf("mismatch expected: %v got %v", test.updated, updated)
@@ -168,6 +173,7 @@ func TestGetUpdatedMachines(t *testing.T) {
 }
 
 func TestGetReadyMachines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		nodes         []*corev1.Node
 		currentConfig string
@@ -216,7 +222,10 @@ func TestGetReadyMachines(t *testing.T) {
 	}}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			ready := getReadyMachines(test.currentConfig, test.nodes)
 			if !reflect.DeepEqual(ready, test.ready) {
 				t.Fatalf("mismatch expected: %v got %v", test.ready, ready)
@@ -226,6 +235,7 @@ func TestGetReadyMachines(t *testing.T) {
 }
 
 func TestGetUnavailableMachines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		nodes         []*corev1.Node
 		currentConfig string
@@ -292,7 +302,10 @@ func TestGetUnavailableMachines(t *testing.T) {
 	}}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			fmt.Printf("Starting case %d\n", idx)
 			unavail := getUnavailableMachines(test.nodes)
 			var unavailNames []string
@@ -307,6 +320,7 @@ func TestGetUnavailableMachines(t *testing.T) {
 }
 
 func TestCalculateStatus(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		nodes         []*corev1.Node
 		currentConfig string
@@ -634,7 +648,10 @@ func TestCalculateStatus(t *testing.T) {
 		},
 	}}
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case#%d", idx), func(t *testing.T) {
+			t.Parallel()
 			pool := &mcfgv1.MachineConfigPool{
 				Spec: mcfgv1.MachineConfigPoolSpec{
 					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{ObjectReference: corev1.ObjectReference{Name: test.currentConfig}},

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
+	t.Parallel()
 	configNotFound := errors.New("Config Not Found")
 	type config struct {
 		name                 string
@@ -158,7 +159,10 @@ func TestIsMachineConfigPoolConfigurationValid(t *testing.T) {
 		}}
 
 	for idx, test := range tests {
+		idx := idx
+		test := test
 		t.Run(fmt.Sprintf("case #%d", idx), func(t *testing.T) {
+			t.Parallel()
 			getter := func(name string) (*mcfgv1.MachineConfig, error) {
 				for _, c := range test.knownConfigs {
 					if c.name == name {
@@ -228,6 +232,7 @@ func (mcpl *mockMCPLister) Get(name string) (ret *mcfgv1.MachineConfigPool, err 
 }
 
 func TestOperatorSyncStatus(t *testing.T) {
+	t.Parallel()
 	type syncCase struct {
 		syncFuncs          []syncFunc
 		expectOperatorFail bool
@@ -695,6 +700,7 @@ func TestOperatorSyncStatus(t *testing.T) {
 }
 
 func TestInClusterBringUpStayOnErr(t *testing.T) {
+	t.Parallel()
 	optr := &Operator{
 		eventRecorder: &record.FakeRecorder{},
 	}
@@ -749,6 +755,7 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 }
 
 func TestKubeletSkewUnSupported(t *testing.T) {
+	t.Parallel()
 	kasOperator := &configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"},
 		Status: configv1.ClusterOperatorStatus{
@@ -835,6 +842,7 @@ func TestKubeletSkewUnSupported(t *testing.T) {
 }
 
 func TestCustomPoolKubeletSkewUnSupported(t *testing.T) {
+	t.Parallel()
 	customSelector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/custom", "")
 	kasOperator := &configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"},
@@ -923,6 +931,7 @@ func TestCustomPoolKubeletSkewUnSupported(t *testing.T) {
 }
 
 func TestKubeletSkewSupported(t *testing.T) {
+	t.Parallel()
 	kasOperator := &configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"},
 		Status: configv1.ClusterOperatorStatus{
@@ -1009,6 +1018,7 @@ func TestKubeletSkewSupported(t *testing.T) {
 }
 
 func TestGetMinorKubeletVersion(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		version      string
 		minor        int

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSyncCloudConfig(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name                        string
 		infra                       *configv1.Infrastructure
@@ -70,7 +71,9 @@ func TestSyncCloudConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			client := fake.NewSimpleClientset()
 			sharedInformer := informers.NewSharedInformerFactory(client, 0)
 			cmInformer := sharedInformer.Core().V1().ConfigMaps()


### PR DESCRIPTION
**- What I did**

I noticed that the unit test timing breakdown in Prow showed that some of the MCO's unit tests were taking upwards of 30 seconds to run. I parallelized the execution of the slowest unit tests so that they can run substantially faster on both developer workstations as well as in Prow.

**- How to verify it**

Run the unit test suite and compare the execution times to master.

**- Description for the changelog**
Execute unit tests in parallel
