### PR TITLE
OCPBUGS-3988: haproxy - use curl for validation

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -34,8 +34,7 @@ contents:
         - "/bin/bash"
         - "-c"
         - |
-          #/bin/bash
-          /host/bin/oc --kubeconfig /var/lib/kubelet/kubeconfig get nodes
+          /usr/bin/curl -o /dev/null -kLfs https://api-int.{{ .DNS.Spec.BaseDomain }}:6443/healthz
         resources: {}
         volumeMounts:
         - name: chroot-host


### PR DESCRIPTION
Instead of using `oc get nodes` to make sure the deploy was correct. Use the same approach as others components.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>