### PR TITLE
Preserve logs from Podman executions

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -17,8 +17,8 @@ contents: |
   RemainAfterExit=yes
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
-  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json --quiet '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --quiet --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
+  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
+  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
   ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env


### PR DESCRIPTION
This PR removes the `--quiet` flag from Podman operations so that we have ability to see error messages in case something fails. It has been observed that `podman pull` does not always succeed in the first attempt and while it is wrapped with `while` (so that the installation does not fail), by using `--quiet` we are not able to investigate why the attempt failed.

As we are modifying a systemd unit, the logs are going to be saved in the journald thus we are not creating a danger of polluting a random location with those logs.