### PR TITLE
OPNET-197: Remove node-ip from kubelet for dual-stack vSphere

### DIFF
--- a/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/vsphere/units/kubelet.service.yaml
@@ -1,0 +1,49 @@
+name: kubelet.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service network-online.target
+  Requires=crio.service kubelet-auto-node-size.service
+  After=network-online.target crio.service kubelet-auto-node-size.service
+  After=ostree-finalize-staged.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- end}}
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+  EnvironmentFile=/etc/node-sizing.env
+
+  ExecStart=/usr/local/bin/kubenswrapper \
+      /usr/bin/kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
+        --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --node-ip=${KUBELET_NODE_IP} \
+        --minimum-container-ttl-duration=6m0s \
+        --cloud-provider={{cloudProvider .}} \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        {{cloudConfigFlag . }} \
+        --hostname-override=${KUBELET_NODE_NAME} \
+        --provider-id=${KUBELET_PROVIDERID} \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
+        --v=${KUBELET_LOG_LEVEL}
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/vsphere/units/kubelet.service.yaml
@@ -1,0 +1,48 @@
+name: kubelet.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Wants=rpc-statd.service network-online.target
+  Requires=crio.service kubelet-auto-node-size.service
+  After=network-online.target crio.service kubelet-auto-node-size.service
+  After=ostree-finalize-staged.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- end}}
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+  EnvironmentFile=/etc/node-sizing.env
+
+  ExecStart=/usr/local/bin/kubenswrapper \
+      /usr/bin/kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime=remote \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+        --node-ip=${KUBELET_NODE_IP} \
+        --minimum-container-ttl-duration=6m0s \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --cloud-provider={{cloudProvider .}} \
+        {{cloudConfigFlag . }} \
+        --hostname-override=${KUBELET_NODE_NAME} \
+        --provider-id=${KUBELET_PROVIDERID} \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
+        --v=${KUBELET_LOG_LEVEL}
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
This PR modifies the kubelet systemd unit for vSphere platform so that in case of dual-stack networking we do not pass `--node-ip` parameter.

This change is part of onboarding vSphere platform to dual-stack networking but due to the fact that it's currently impossible to pass dual-stack IPs as `--node-ip` and to use `--cloud-provider` at the same time, we are using a temporary workaround that removes explicit node IP setting and lets kubelet pick it automatically.

This change will no longer be needed when the upstream enhancement https://github.com/kubernetes/enhancements/pull/3706 gets implemented, but currently seems like the most reasonable solution to enable such a setup.

This change creates a limitation that vSphere dual-stack cluster should be used only on a single NIC configurations due to the fact that we will be relying on the kubelet logic to select IP addresses and this proven problematic in the past. In order to avoid kubelet selecting wrong interfaces, we want customers to only use this configuration with a single NIC in order to reduce the scope of kubelet's possible mistakes.

Closes: [OPNET-197](https://issues.redhat.com//browse/OPNET-197)

/cc @cybertron 