### PR TITLE
OCPBUGS-5520: MCDPivotError alert fires due temporary transient failures 

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -77,7 +77,8 @@ spec:
       rules:
         - alert: MCDPivotError
           expr: |
-            max by(namespace, node, pod) (increase(mcd_pivot_errors_total[15m])) > 0
+            mcd_pivot_errors_total > 0
+          for: 2m
           labels:
             namespace: openshift-machine-config-operator
             severity: warning

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -24,8 +24,8 @@ var (
 		})
 
 	// mcdPivotErr flags error encountered during pivot
-	mcdPivotErr = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	mcdPivotErr = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "mcd_pivot_errors_total",
 			Help: "Total number of errors encountered during pivot.",
 		})

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2231,6 +2231,9 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		}
 	}
 
+	// if we're here, we've successfully pivoted, or pivoting wasn't necessary, so we reset the error gauge
+	mcdPivotErr.Set(0)
+
 	defer func() {
 		// Operations performed by rpm-ostree on the booted system are available
 		// as staged deployment. It gets applied only when we reboot the system.
@@ -2298,6 +2301,9 @@ func (dn *CoreOSDaemon) applyLegacyOSChanges(mcDiff machineConfigDiff, oldConfig
 			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "OSUpgradeSkipped", "OS upgrade skipped; new MachineConfig (%s) has same OS image (%s) as old MachineConfig (%s)", newConfig.Name, newConfig.Spec.OSImageURL, oldConfig.Name)
 		}
 	}
+
+	// if we're here, we've successfully pivoted, or pivoting wasn't necessary, so we reset the error gauge
+	mcdPivotErr.Set(0)
 
 	defer func() {
 		// Operations performed by rpm-ostree on the booted system are available


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- Changed mcd pivot error count to a prometheus gauge, allowing for resets
- on a successful pivot(or if a pivot wasn't necessary), we reset the pivot error count to 0
- adjusted the prometheus rule to be an absolute check with a `for:` expression. This will prevent transient changes.

**- How to verify it**

To trigger this alert replace the rpm-ostree exec file in a worker node, following these steps:

```
$ mount -o remount,rw /usr
$ mv /usr/bin/rpm-ostree /usr/bin/rpm-ostree2
$ vi  /usr/bin/rpm-ostree

The content of the new rpm-ostree file should be:
#!/bin/bash
if [ "$1" == "rebase" ];
then
exit -1
else
/usr/bin/rpm-ostree2 $@
fi
exit $?

$ chmod +x  /usr/bin/rpm-ostree
```

Then, apply a new machineconfig that can cause a pivot. 
To clear the error:
```

$ mount -o remount,rw /usr
$ mv /usr/bin/rpm-ostree2 /usr/bin/rpm-ostree
```

**- Description for the changelog**
OCPBUGS-5520: changed mcdpivot error behavior & prometheus rule
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
