### PR TITLE
OCPBUGS-6009: Increase NM Wait Online Timeout

### DIFF
--- a/templates/common/_base/units/NetworkManager-wait-online-timeout.service.yaml
+++ b/templates/common/_base/units/NetworkManager-wait-online-timeout.service.yaml
@@ -1,0 +1,6 @@
+name:  NetworkManager-wait-online.service
+dropins:
+  - name: 10-increase-timeout.conf
+    contents: |
+      [Service]
+      Environment=NM_ONLINE_TIMEOUT=120


### PR DESCRIPTION
Services like `nodeip-configuration` depends on
NetworkManager-wait-online.service to start when network stability has been reached. In some complex deployments, more than the default value of 60 seconds is needed to complete all connections, and starting subsequent services with such a state brings hard-to-debug issues.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>
