### PR TITLE
MCO-116: Ensures that SSH keys are in the right place on RHCOS 9

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -84,4 +84,13 @@ const (
 
 	// changes to registries.conf will cause a crio reload and require extra logic about whether to drain
 	ContainerRegistryConfPath = "/etc/containers/registries.conf"
+
+	// SSH Keys for user "core" will only be written at /home/core/.ssh
+	CoreUserSSHPath = "/home/" + CoreUserName + "/.ssh"
+
+	// SSH keys in RHCOS 8 will be written to /home/core/.ssh/authorized_keys
+	RHCOS8SSHKeyPath = CoreUserSSHPath + "/authorized_keys"
+
+	// SSH keys in RHCOS 9 / FCOS / SCOS will be written to /home/core/.ssh/authorized_keys.d/ignition
+	RHCOS9SSHKeyPath = CoreUserSSHPath + "/authorized_keys.d/ignition"
 )

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1549,6 +1549,29 @@ func (dn *Daemon) writeFiles(files []ign3types.File) error {
 	return writeFiles(files)
 }
 
+// Ensures that both the SSH root directory (/home/core/.ssh) as well as any
+// subdirectories are created with the correct (0700) permissions.
+func createSSHKeyDir(authKeyDir string) error {
+	glog.Infof("Creating missing SSH key dir at %s", authKeyDir)
+
+	mkdir := func(dir string) error {
+		return exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", dir).Run()
+	}
+
+	// Create the root SSH key directory (/home/core/.ssh) first.
+	if err := mkdir(filepath.Dir(constants.RHCOS8SSHKeyPath)); err != nil {
+		return err
+	}
+
+	// For RHCOS 8, creating /home/core/.ssh is all that is needed.
+	if authKeyDir == constants.RHCOS8SSHKeyPath {
+		return nil
+	}
+
+	// Create the next level of the SSH key directory (/home/core/.ssh/authorized_keys.d) for RHCOS 9 cases.
+	return mkdir(filepath.Dir(constants.RHCOS9SSHKeyPath))
+}
+
 func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
 	uid, err := lookupUID(constants.CoreUserName)
 	if err != nil {
@@ -1568,9 +1591,7 @@ func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=2107113
 	authKeyDir := filepath.Dir(authKeyPath)
 	if _, err := os.Stat(authKeyDir); os.IsNotExist(err) {
-		glog.Infof("Creating missing SSH key dir at %s", authKeyDir)
-		mkdirCoreCommand := exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", authKeyDir)
-		if err := mkdirCoreCommand.Run(); err != nil {
+		if err := createSSHKeyDir(authKeyDir); err != nil {
 			return err
 		}
 	}
@@ -1579,7 +1600,7 @@ func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
 		return err
 	}
 
-	glog.V(2).Infof("Wrote SSH keys to %s", authKeyPath)
+	glog.V(2).Infof("Wrote SSH keys to %q", authKeyPath)
 
 	return nil
 }
@@ -1617,6 +1638,13 @@ func (dn *Daemon) SetPasswordHash(newUsers []ign3types.PasswdUser) error {
 	return nil
 }
 
+// Determines if we should use the new SSH key path
+// (/home/core/.ssh/authorized_keys.d/ignition) or the old SSH key path
+// (/home/core/.ssh/authorized_keys)
+func (dn *Daemon) useNewSSHKeyPath() bool {
+	return dn.os.IsEL9() || dn.os.IsFCOS() || dn.os.IsSCOS()
+}
+
 // Update a given PasswdUser's SSHKey
 func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 	if len(newUsers) == 0 {
@@ -1651,10 +1679,14 @@ func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 		// Check if the authorized_keys file at the legacy path exists. If it does, remove it.
 		// It will be recreated at the new fragment path by the atomicallyWriteSSHKey function
 		// that is called right after.
-		if dn.os.IsEL9() || dn.os.IsSCOS() || dn.os.IsFCOS() {
+		if dn.useNewSSHKeyPath() {
 			authKeyPath = constants.RHCOS9SSHKeyPath
 
 			if err := cleanSSHKeyPaths(); err != nil {
+				return err
+			}
+
+			if err := removeNonIgnitionKeyPathFragments(); err != nil {
 				return err
 			}
 		}
@@ -1666,20 +1698,40 @@ func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 	return nil
 }
 
-// Removes the old SSH key path (/home/core/.ssh/authorized_keys), if found.
-func cleanSSHKeyPaths() error {
-	_, err := os.Stat(constants.RHCOS8SSHKeyPath)
+// Determines if a file exists by checking for the presence or lack thereof of
+// an error when stat'ing the file. Returns any other error.
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	// If there is no error, the file definitely exists.
 	if err == nil {
-		err := os.RemoveAll(constants.RHCOS8SSHKeyPath)
-		if err != nil {
-			return fmt.Errorf("failed to remove path '%s': %w", constants.RHCOS8SSHKeyPath, err)
-		}
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		// This shouldn't ever happen
-		return fmt.Errorf("unexpectedly failed to get info for path '%s': %w", constants.RHCOS8SSHKeyPath, err)
+		return true, nil
 	}
 
-	return removeNonIgnitionKeyPathFragments()
+	// If the error matches fs.ErrNotExist, the file definitely does not exist.
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+
+	// An unexpected error occurred.
+	return false, fmt.Errorf("cannot stat file: %w", err)
+}
+
+// Removes the old SSH key path (/home/core/.ssh/authorized_keys), if found.
+func cleanSSHKeyPaths() error {
+	oldKeyExists, err := fileExists(constants.RHCOS8SSHKeyPath)
+	if err != nil {
+		return err
+	}
+
+	if !oldKeyExists {
+		return nil
+	}
+
+	if err := os.RemoveAll(constants.RHCOS8SSHKeyPath); err != nil {
+		return fmt.Errorf("failed to remove path '%s': %w", constants.RHCOS8SSHKeyPath, err)
+	}
+
+	return nil
 }
 
 // Ensures authorized_keys.d/ignition is the only fragment that exists within the /home/core/.ssh dir.

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"os/user"
@@ -36,8 +37,6 @@ const (
 	defaultDirectoryPermissions os.FileMode = 0o755
 	// defaultFilePermissions houses the default mode to use when no file permissions are provided
 	defaultFilePermissions os.FileMode = 0o644
-	// SSH Keys for user "core" will only be written at /home/core/.ssh
-	coreUserSSHPath = "/home/core/.ssh/"
 	// fipsFile is the file to check if FIPS is enabled
 	fipsFile                   = "/proc/sys/crypto/fips_enabled"
 	extensionsRepo             = "/etc/yum.repos.d/coreos-extensions.repo"
@@ -1550,7 +1549,7 @@ func (dn *Daemon) writeFiles(files []ign3types.File) error {
 	return writeFiles(files)
 }
 
-func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
+func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
 	uid, err := lookupUID(constants.CoreUserName)
 	if err != nil {
 		return err
@@ -1561,23 +1560,16 @@ func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
 		return err
 	}
 
-	var authKeyPath string
-	if dn.os.IsEL9() || dn.os.IsFCOS() {
-		// In FCOS and EL9, ignition writes the SSH key to ~/.ssh/authorized_keys.d/ignition,
-		// and the ssh-key-dir sshd AuthorizedKeysCommand binary reads it from there.
-		authKeyPath = filepath.Join(coreUserSSHPath, "authorized_keys.d", "ignition")
-	} else {
-		authKeyPath = filepath.Join(coreUserSSHPath, "authorized_keys")
-	}
-
 	// Keys should only be written to "/home/core/.ssh"
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
-	glog.Infof("Writing SSHKeys at %q", authKeyPath)
+	glog.Infof("Writing SSH keys to %q", authKeyPath)
 
-	// Creating coreUserSSHPath in advance if it doesn't exist in order to ensure it is owned by core user
+	// Creating CoreUserSSHPath in advance if it doesn't exist in order to ensure it is owned by core user
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=2107113
-	if _, err := os.Stat(coreUserSSHPath); os.IsNotExist(err) {
-		mkdirCoreCommand := exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", coreUserSSHPath)
+	authKeyDir := filepath.Dir(authKeyPath)
+	if _, err := os.Stat(authKeyDir); os.IsNotExist(err) {
+		glog.Infof("Creating missing SSH key dir at %s", authKeyDir)
+		mkdirCoreCommand := exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", authKeyDir)
 		if err := mkdirCoreCommand.Run(); err != nil {
 			return err
 		}
@@ -1587,7 +1579,7 @@ func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
 		return err
 	}
 
-	glog.V(2).Infof("Wrote SSHKeys at %s", authKeyPath)
+	glog.V(2).Infof("Wrote SSH keys to %s", authKeyPath)
 
 	return nil
 }
@@ -1650,50 +1642,69 @@ func (dn *Daemon) updateSSHKeys(newUsers []ign3types.PasswdUser) error {
 			concatSSHKeys = concatSSHKeys + string(k) + "\n"
 		}
 	}
+
+	authKeyPath := constants.RHCOS8SSHKeyPath
+
 	if !dn.mock {
-		authKeyPath := filepath.Join(coreUserSSHPath, "authorized_keys")
-		authKeyFragmentDirPath := filepath.Join(coreUserSSHPath, "authorized_keys.d")
+		// In RHCOS 8.6 or lower, the keys were written to `/home/core/.ssh/authorized_keys`.
+		// RHCOS 9.0+, FCOS, and SCOS will however expect the keys at `/home/core/.ssh/authorized_keys.d/ignition`.
+		// Check if the authorized_keys file at the legacy path exists. If it does, remove it.
+		// It will be recreated at the new fragment path by the atomicallyWriteSSHKey function
+		// that is called right after.
+		if dn.os.IsEL9() || dn.os.IsSCOS() || dn.os.IsFCOS() {
+			authKeyPath = constants.RHCOS9SSHKeyPath
 
-		if dn.os.IsFCOS() {
-			// In older versions of OKD, the keys were written to `/home/core/.ssh/authorized_keys`.
-			// Newer versions of OKD will however expect the keys at `/home/core/.ssh/authorized_keys.d/ignition`.
-			// Check if the authorized_keys file at the legacy path exists. If it does, remove it.
-			// It will be recreated at the new fragment path by the atomicallyWriteSSHKey function
-			// that is called right after.
-			_, err := os.Stat(authKeyPath)
-			if err == nil {
-				err := os.RemoveAll(authKeyPath)
-				if err != nil {
-					return fmt.Errorf("failed to remove path '%s': %w", authKeyPath, err)
-				}
-			} else if !os.IsNotExist(err) {
-				// This shouldn't ever happen
-				return fmt.Errorf("unexpectedly failed to get info for path '%s': %w", authKeyPath, err)
-			}
-
-			// Ensure authorized_keys.d/ignition is the only fragment that exists
-			keyFragmentsDir, err := ctrlcommon.ReadDir(authKeyFragmentDirPath)
-			if err == nil {
-				for _, fragment := range keyFragmentsDir {
-					if fragment.Name() != "ignition" {
-						keyPath := filepath.Join(authKeyFragmentDirPath, fragment.Name())
-						err := os.RemoveAll(keyPath)
-						if err != nil {
-							return fmt.Errorf("failed to remove path '%s': %w", keyPath, err)
-						}
-					}
-				}
-			} else if !os.IsNotExist(err) {
-				// This shouldn't ever happen
-				return fmt.Errorf("unexpectedly failed to get info for path '%s': %w", authKeyFragmentDirPath, err)
+			if err := cleanSSHKeyPaths(); err != nil {
+				return err
 			}
 		}
 
 		// Note we write keys only for the core user and so this ignores the user list
-		if err := dn.atomicallyWriteSSHKey(concatSSHKeys); err != nil {
-			return err
-		}
+		return dn.atomicallyWriteSSHKey(authKeyPath, concatSSHKeys)
 	}
+
+	return nil
+}
+
+// Removes the old SSH key path (/home/core/.ssh/authorized_keys), if found.
+func cleanSSHKeyPaths() error {
+	_, err := os.Stat(constants.RHCOS8SSHKeyPath)
+	if err == nil {
+		err := os.RemoveAll(constants.RHCOS8SSHKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to remove path '%s': %w", constants.RHCOS8SSHKeyPath, err)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		// This shouldn't ever happen
+		return fmt.Errorf("unexpectedly failed to get info for path '%s': %w", constants.RHCOS8SSHKeyPath, err)
+	}
+
+	return removeNonIgnitionKeyPathFragments()
+}
+
+// Ensures authorized_keys.d/ignition is the only fragment that exists within the /home/core/.ssh dir.
+func removeNonIgnitionKeyPathFragments() error {
+	// /home/core/.ssh/authorized_keys.d
+	authKeyFragmentDirPath := filepath.Dir(constants.RHCOS9SSHKeyPath)
+	// ignition
+	authKeyFragmentBasename := filepath.Base(constants.RHCOS9SSHKeyPath)
+
+	keyFragmentsDir, err := ctrlcommon.ReadDir(authKeyFragmentDirPath)
+	if err == nil {
+		for _, fragment := range keyFragmentsDir {
+			if fragment.Name() != authKeyFragmentBasename {
+				keyPath := filepath.Join(authKeyFragmentDirPath, fragment.Name())
+				err := os.RemoveAll(keyPath)
+				if err != nil {
+					return fmt.Errorf("failed to remove path '%s': %w", keyPath, err)
+				}
+			}
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		// This shouldn't ever happen
+		return fmt.Errorf("unexpectedly failed to get info for path '%s': %w", constants.RHCOS9SSHKeyPath, err)
+	}
+
 	return nil
 }
 

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -493,6 +493,9 @@ func TestWriteFiles(t *testing.T) {
 	}
 }
 
+// This test provides a false sense of security. Given the combination of the
+// mock mode in the MCD coupled with the inputs into this test, it effectively
+// no-ops and does not test what we think it tests.
 func TestUpdateSSHKeys(t *testing.T) {
 	d := newMockDaemon()
 

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -796,7 +796,9 @@ func TestIgn3Cfg(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", "/rootfs/home/core/.ssh/authorized_keys")
+	sshPaths := helpers.GetSSHPaths(helpers.GetOSReleaseForNode(t, cs, infraNode).OS)
+
+	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", filepath.Join("/rootfs", sshPaths.Expected))
 	if !strings.Contains(foundSSH, "1234_test_ign3") {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSH)
 	}

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -382,6 +383,28 @@ func TestNoReboot(t *testing.T) {
 	oldInfraRenderedConfig := helpers.GetMcName(t, cs, "infra")
 
 	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	sshKeyContent := "test adding authorized key without node reboot"
+
+	nodeOS := helpers.GetOSReleaseForNode(t, cs, infraNode).OS
+
+	sshPaths := helpers.GetSSHPaths(nodeOS)
+
+	t.Logf("Expecting SSH keys to be in %s", sshPaths.Expected)
+
+	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
+		// Write an SSH key to the old location on the node because the update process should remove this file.
+		t.Logf("Writing SSH key to %s to ensure that it will be removed later", sshPaths.NotExpected)
+		bashCmd := fmt.Sprintf("printf '%s' > %s", sshKeyContent, filepath.Join("/rootfs", sshPaths.NotExpected))
+		helpers.ExecCmdOnNode(t, cs, infraNode, "/bin/bash", "-c", bashCmd)
+	}
+
+	// Delete the expected SSH keys directory to ensure that the directories are
+	// (re)created correctly by the MCD. This targets the upgrade case where that
+	// directory may not previously exist. Note: This will need to be revisited
+	// once Config Drift Monitor is aware of SSH keys.
+	helpers.ExecCmdOnNode(t, cs, infraNode, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+
 	output := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
 	oldTime := strings.Split(output, " ")[0]
 	t.Logf("Node %s initial uptime: %s", infraNode.Name, oldTime)
@@ -390,17 +413,18 @@ func TestNoReboot(t *testing.T) {
 	// Adding authorized key for user core
 	testIgnConfig := ctrlcommon.NewIgnConfig()
 	testPasswdHash := "testpass"
-	testSSHKey := ign3types.PasswdUser{
-		Name:              "core",
-		SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{"test adding authorized key without node reboot"},
-		PasswordHash:      &testPasswdHash,
-	}
 
-	testIgnConfig.Passwd.Users = append(testIgnConfig.Passwd.Users, testSSHKey)
+	testIgnConfig.Passwd.Users = []ign3types.PasswdUser{
+		{
+			Name:              "core",
+			SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{ign3types.SSHAuthorizedKey(sshKeyContent)},
+			PasswordHash:      &testPasswdHash,
+		},
+	}
 
 	addAuthorizedKey := &mcfgv1.MachineConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("authorzied-key-infra-%s", uuid.NewUUID()),
+			Name:   fmt.Sprintf("authorized-key-infra-%s", uuid.NewUUID()),
 			Labels: helpers.MCLabelForRole("infra"),
 		},
 		Spec: mcfgv1.MachineConfigSpec{
@@ -426,8 +450,11 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/home/core/.ssh/authorized_keys")
-	if !strings.Contains(foundSSHKey, "test adding authorized key without node reboot") {
+	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
+	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
+
+	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	if !strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSHKey)
 	}
 	t.Logf("Node %s has SSH key", infraNode.Name)
@@ -437,9 +464,10 @@ func TestNoReboot(t *testing.T) {
 	if currentEtcShadowContents == initialEtcShadowContents {
 		t.Fatalf("updated password hash not found in etc/shadow, got %s", currentEtcShadowContents)
 	}
+
 	t.Logf("Node %s has Password Hash", infraNode.Name)
 
-	usernameAndGroup := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "stat", "--format=%U %G", "/home/core/.ssh/authorized_keys"), "\n"), " ")
+	usernameAndGroup := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "stat", "--format=%U %G", sshPaths.Expected), "\n"), " ")
 	assert.Equal(t, usernameAndGroup, []string{constants.CoreUserName, constants.CoreGroupName})
 
 	output = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
@@ -476,10 +504,13 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/home/core/.ssh/authorized_keys")
-	if strings.Contains(foundSSHKey, "test adding authorized key without node reboot") {
+	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	if strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("Node %s did not rollback successfully", infraNode.Name)
 	}
+
+	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
+	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
 
 	t.Logf("Node %s has successfully rolled back", infraNode.Name)
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -512,16 +513,16 @@ func execCmdOnNode(cs *framework.ClientSet, node corev1.Node, subArgs ...string)
 	return cmd, nil
 }
 
-// IsOKDCluster checks whether the Upstream field on the CV spec references OKD's update server
+// IsOKDCluster checks whether the Upstream field on the CV spec references an OKD release controller
 func IsOKDCluster(cs *framework.ClientSet) (bool, error) {
 	cv, err := cs.ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
-	if cv.Spec.Upstream == "https://origin-release.svc.ci.openshift.org/graph" {
-		return true, nil
-	}
-	return false, nil
+
+	// TODO: Adjust this as OKD becomes available for different platforms, e.g., arm64.
+	okdReleaseControllers := sets.NewString("https://amd64.origin.releases.ci.openshift.org/graph")
+	return okdReleaseControllers.Has(string(cv.Spec.Upstream)), nil
 }
 
 func MCLabelForRole(role string) map[string]string {

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -382,6 +382,28 @@ func CreateMCP(t *testing.T, cs *framework.ClientSet, mcpName string) func() {
 	}
 }
 
+type SSHPaths struct {
+	// The path where SSH keys are expected to be found.
+	Expected string
+	// The path where SSH keys are *not* expected to be found.
+	NotExpected string
+}
+
+// Determines where to expect SSH keys for the core user on a given node based upon the node's OS.
+func GetSSHPaths(os osrelease.OperatingSystem) SSHPaths {
+	if os.IsEL9() || os.IsSCOS() || os.IsFCOS() {
+		return SSHPaths{
+			Expected:    constants.RHCOS9SSHKeyPath,
+			NotExpected: constants.RHCOS8SSHKeyPath,
+		}
+	}
+
+	return SSHPaths{
+		Expected:    constants.RHCOS8SSHKeyPath,
+		NotExpected: constants.RHCOS9SSHKeyPath,
+	}
+}
+
 // MCPNameToRole converts a mcpName to a node role label
 func MCPNameToRole(mcpName string) string {
 	return fmt.Sprintf("node-role.kubernetes.io/%s", mcpName)
@@ -392,23 +414,87 @@ func CreateMC(name, role string) *mcfgv1.MachineConfig {
 	return NewMachineConfig(name, MCLabelForRole(role), "", nil)
 }
 
+// Asserts that a given file is present on the underlying node.
+func AssertFileOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
+	t.Helper()
+
+	path = canonicalizeNodeFilePath(path)
+
+	out, err := ExecCmdOnNodeWithError(cs, node, "stat", path)
+
+	return assert.NoError(t, err, "expected to find file %s on %s, got:\n%s\nError: %s", path, node.Name, out, err)
+}
+
+// Asserts that a given file is *not* present on the underlying node.
+func AssertFileNotOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
+	t.Helper()
+
+	path = canonicalizeNodeFilePath(path)
+
+	out, err := ExecCmdOnNodeWithError(cs, node, "stat", path)
+
+	return assert.Error(t, err, "expected not to find file %s on %s, got:\n%s", path, node.Name, out) &&
+		assert.Contains(t, out, "No such file or directory", "expected command output to contain 'No such file or directory', got: %s", out)
+}
+
+// Adds the /rootfs onto a given file path, if not already present.
+func canonicalizeNodeFilePath(path string) string {
+	rootfs := "/rootfs"
+
+	if !strings.HasPrefix(path, rootfs) {
+		return filepath.Join(rootfs, path)
+	}
+
+	return path
+}
+
 // ExecCmdOnNode finds a node's mcd, and oc rsh's into it to execute a command on the node
 // all commands should use /rootfs as root
 func ExecCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subArgs ...string) string {
+	t.Helper()
+
+	cmd, err := execCmdOnNode(cs, node, subArgs...)
+	require.Nil(t, err, "could not prepare to exec cmd %v on node %s: %s", subArgs, node.Name, err)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
+	return string(out)
+}
+
+// ExecCmdOnNodeWithError behaves like ExecCmdOnNode, with the exception that
+// any errors are returned to the caller for inspection. This allows one to
+// execute a command that is expected to fail; e.g., stat /nonexistant/file.
+func ExecCmdOnNodeWithError(cs *framework.ClientSet, node corev1.Node, subArgs ...string) (string, error) {
+	cmd, err := execCmdOnNode(cs, node, subArgs...)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// ExecCmdOnNode finds a node's mcd, and oc rsh's into it to execute a command on the node
+// all commands should use /rootfs as root
+func execCmdOnNode(cs *framework.ClientSet, node corev1.Node, subArgs ...string) (*exec.Cmd, error) {
 	// Check for an oc binary in $PATH.
 	path, err := exec.LookPath("oc")
 	if err != nil {
-		t.Fatalf("could not locate oc command: %s", err)
+		return nil, fmt.Errorf("could not locate oc command: %w", err)
 	}
 
 	// Get the kubeconfig file path
 	kubeconfig, err := cs.GetKubeconfig()
 	if err != nil {
-		t.Fatalf("could not get kubeconfig: %s", err)
+		return nil, fmt.Errorf("could not get kubeconfig: %w", err)
 	}
 
 	mcd, err := mcdForNode(cs, &node)
-	require.Nil(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("could not get MCD for node %s: %w", node.Name, err)
+	}
+
 	mcdName := mcd.ObjectMeta.Name
 
 	entryPoint := path
@@ -423,11 +509,7 @@ func ExecCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subA
 	// $KUBECONFIG, oc will be unaware of it. To remedy, we explicitly set
 	// KUBECONFIG to the value held by the clientset.
 	cmd.Env = append(cmd.Env, "KUBECONFIG="+kubeconfig)
-	cmd.Stderr = os.Stderr
-
-	out, err := cmd.Output()
-	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
-	return string(out)
+	return cmd, nil
 }
 
 // IsOKDCluster checks whether the Upstream field on the CV spec references OKD's update server


### PR DESCRIPTION
**- What I did**

This ensures that SSH keys are in the correct place for RHCOS 9 / FCOS / SCOS nodes. This also ensures that the upgrade path between RHCOS 8 and RHCOS 9 is validated.

**- How to verify it**

1. Launch an RHCOS 9 OCP cluster (or launch an OKD cluster).
2. Run the `TestNoReboot` MCO e2e test against the cluster.
3. Ensure that for RHCOS 8 that the SSH key exists in /home/core/.ssh/authorized_keys and for RHCOS 9 / OKD that the SSH key exists in /home/core/.ssh/authorized_keys.d/ignition.
4. For RHCOS 9 / OKD, there should not be a key present in /home/core/.ssh/authorized_keys.

Validating the RHCOS 8 -> RHCOS 9 upgrade flow:
1. Launch an OpenShift cluster that runs on RHCOS 8 (e.g., [4.13.0-ec.3](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.13.0-ec.3)) using clusterbot or manually.
2. Perform a build that combines this PR and https://github.com/openshift/machine-config-operator/pull/3485 using clusterbot (e.g., `> build openshift/machine-config-operator#3485,openshift/machine-config-operator#3534`). Begin the upgrade process: `$ oc adm upgrade --force --to-image="<clusterbot release pullspec>" --allow-explicit-upgrade`.
3. Alternatively, instead Step 2 above which is time-consuming, one can create a MachineConfig that sets `.spec.osImageURL` to `registry.ci.openshift.org/ocp/4.13:rhel-coreos-9`, apply that, and wait for it to roll out.
4. Watch the MCD logs for the following text: `SSH key location update required. Moving SSH keys from /home/core/.ssh/authorized_keys to /home/core/.ssh/authorized_keys.d/ignition`
5. Once the upgrade is complete, `$ oc debug node/<random node> stat /host/home/core/.ssh/authorized_keys` (which should fail). As well as: `$ oc debug node/<random node> stat /host/home/core/.ssh/authorized_keys.d/ignition`, which should succeed.
6. Post-upgrade, reboot the node.
7. Watch the MCD logs for the following text: `SSH key location up-to-date!`. 

**- Description for the changelog**
Ensures SSH keys are placed correctly for RHCOS 9
