### PR TITLE
MCO-417: MCO-418: MCD watches/create/update password with MachineConfig

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfig.crd.yaml
@@ -153,6 +153,9 @@ spec:
                               type: array
                               items:
                                 type: string
+                            passwordHash:
+                              description: Password hash to set for the core user.
+                              type: string
                   storage:
                     description: Storage describes the desired state of the system's
                       storage devices.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Created a SetPasswordHash function to allow a user to create a password; MCD learns to make/update a password for the user core based on what is provided by MachineConfig.

**- How to verify it**
Set a password for the user core by adding a machine config that specifies the password (following ignition format). Shell into the pod and log in as core (not from root, or the password option will not prompt), verifying that your password works.

**- Description for the changelog**
SetPassword Hash allows users to create and update their password for core (password cannot be empty); edited verifyUserFields allows the user field verification if the password or ssh key exists. 

