### PR TITLE
OPNET-133: Enabling remote worker feature only for baremetal platform

### DIFF
--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -27,6 +27,7 @@ contents: |
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set --retry-on-failure \
+    --platform {{ .Infra.Status.PlatformStatus.Type }} \
     {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}}; \
     do \
     sleep 5; \


### PR DESCRIPTION
[OPNET-133](https://issues.redhat.com//browse/OPNET-133): Enabling remote worker feature only for baremetal platform
Pass platform type to node-ip service

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
