### PR TITLE
Bug 2027000: The user is ignored when we create a new file using a MachineConfig

### DIFF
--- a/pkg/daemon/file_writers.go
+++ b/pkg/daemon/file_writers.go
@@ -276,10 +276,11 @@ func lookupGID(group string) (int, error) {
 // This is essentially ResolveNodeUidAndGid() from Ignition; XXX should dedupe
 func getFileOwnership(file ign3types.File) (int, int, error) {
 	uid, gid := 0, 0 // default to root
+	var err error    // create default error var
 	if file.User.ID != nil {
 		uid = *file.User.ID
 	} else if file.User.Name != nil && *file.User.Name != "" {
-		uid, err := lookupUID(*file.User.Name)
+		uid, err = lookupUID(*file.User.Name)
 		if err != nil {
 			return uid, gid, err
 		}
@@ -288,7 +289,7 @@ func getFileOwnership(file ign3types.File) (int, int, error) {
 	if file.Group.ID != nil {
 		gid = *file.Group.ID
 	} else if file.Group.Name != nil && *file.Group.Name != "" {
-		gid, err := lookupGID(*file.Group.Name)
+		gid, err = lookupGID(*file.Group.Name)
 		if err != nil {
 			return uid, gid, err
 		}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed an assignment typo that caused user and group lookup values to be lost.

**- How to verify it**
Follow reproduction instructions on the [bug](https://issues.redhat.com/browse/OCPBUGSM-37597) to create a new file with the core user. It should now assign the correct user and group names as expected.

**- Description for the changelog**
OCPBUGSM-37597: daemon: Fixed uid/gid assignment typo
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

