### PR TITLE
Add TimeoutSec to nodeip-configuration.service

### DIFF
--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -36,6 +36,9 @@ contents: |
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
+  # Allow 5 minutes for this service to startup. This should be ample time to
+  # determine if we're going to work, or if we need to fail and address problems.
+  TimeoutSec=300
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
OCPBUGS-7182: Add TimeoutSec to nodeip-configuration.service

When baremetal nodes use mirror-registry, we still depend on the upstream release images to be available. If this is not the case, then the nodeip-configuration.service will infinitly try to start. This ultimately blocks the node from booting up, which increases the difficulty in recovering the node.

Subsequently, this change simply adds a Timeout to the systemd service to ensure that we aren't blocked and the node can be booted into a state that is easier to recover.

**- What I did**
Added `TimeoutSec=300` to `nodeip-configuration.service`

**- How to verify it**
Try to reboot any node without the upstream image being available. This job should now timeout and allow the node to boot. Prior to the change, it would hang for infinity waiting for the service to start.

**- Description for the changelog**
Add TimeoutSec to `nodeip-configuration.service` to avoid having nodes that can't boot.
