### PR TITLE
configure-ovs: permanent retry on failure

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -4,6 +4,7 @@ contents:
   inline: |
     #!/bin/bash
     set -eux
+
     # This file is not needed anymore in 4.7+, but when rolling back to 4.6
     # the ovs pod needs it to know ovs is running on the host.
     touch /var/run/ovs-config-executed
@@ -16,9 +17,6 @@ contents:
     NM_CONN_CONF_PATH="$NM_CONN_ETC_PATH"
     # This is where we want our keyfiles to finally reside
     NM_CONN_SET_PATH="${NM_CONN_SET_PATH:-$NM_CONN_RUN_PATH}"
-
-    # this flag tracks if any config change was made
-    nm_config_changed=0
 
     MANAGED_NM_CONN_SUFFIX="-slave-ovs-clone"
     # Workaround to ensure OVS is installed due to bug in systemd Requires:
@@ -403,7 +401,7 @@ contents:
     # Reloads NM NetworkManager profiles if any configuration change was done.
     # Accepts a list of devices that should be re-connect after reload.
     reload_profiles_nm() {
-      if [ $nm_config_changed -eq 0 ]; then
+      if [ ${nm_config_changed:-0} -eq 0 ]; then
         # no config was changed, no need to reload
         return
       fi
@@ -751,18 +749,30 @@ contents:
     # Setup an exit trap to rollback on error
     handle_exit() {
       e=$?
-      [ $e -eq 0 ] && print_state && exit 0
+      tdir=$(mktemp -u -d -t "configure-ovs-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX")
+      
+      if [ $e -eq 0 ]; then
+        print_state
+        # remove previous troubleshooting information
+        rm -rf "$(dirname "$tdir")/configure-ovs-*"
+        exit 0
+      fi
 
       echo "ERROR: configure-ovs exited with error: $e"
       print_state
 
-      # copy configuration to tmp
-      dir=$(mktemp -d -t "configure-ovs-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX")
+      # remove previous troubleshooting information except the oldest one
+      mapfile -t tdirs < <(compgen -G "$(dirname "$tdir")/configure-ovs-*")
+      unset -v "tdirs[0]"
+      for dir in "${tdirs[@]}"; do rm -rf "$dir"; done
+
+      # copy configuration to tmp for troubleshooting
+      mkdir -p "$tdir"
       update_nm_conn_conf_files br-ex phys0
-      copy_nm_conn_files "$dir"
+      copy_nm_conn_files "$tdir"
       update_nm_conn_conf_files br-ex1 phys1
-      copy_nm_conn_files "$dir"
-      echo "Copied OVS configuration to $dir for troubleshooting"
+      copy_nm_conn_files "$tdir"
+      echo "Copied OVS configuration to $tdir for troubleshooting"
 
       # attempt to restore the previous network state
       echo "Attempting to restore previous configuration..."
@@ -771,156 +781,181 @@ contents:
 
       exit $e
     }
-    trap "handle_exit" EXIT
 
-    # Check that we are provided a valid NM connection path
-    if [ "$NM_CONN_SET_PATH" != "$NM_CONN_CONF_PATH" ] && [ "$NM_CONN_SET_PATH" != "$NM_CONN_RUN_PATH" ]; then
-      echo "Error: Incorrect NM connection path: $NM_CONN_SET_PATH is not $NM_CONN_CONF_PATH nor $NM_CONN_RUN_PATH"
-      exit 1
-    fi
+    # main function
+    configure_ovs() {
+      trap "handle_exit" EXIT
 
-    # Clean up old config on behalf of mtu-migration
-    if ! systemctl -q is-enabled mtu-migration; then
-      echo "Cleaning up left over mtu migration configuration"
-      rm -rf /etc/cno/mtu-migration
-    fi
+      # this flag tracks if any config change was made
+      nm_config_changed=0
 
-    if ! rpm -qa | grep -q openvswitch; then
-      echo "Warning: Openvswitch package is not installed!"
-      exit 1
-    fi
+      # Check that we are provided a valid NM connection path
+      if [ "$NM_CONN_SET_PATH" != "$NM_CONN_CONF_PATH" ] && [ "$NM_CONN_SET_PATH" != "$NM_CONN_RUN_PATH" ]; then
+        echo "Error: Incorrect NM connection path: $NM_CONN_SET_PATH is not $NM_CONN_CONF_PATH nor $NM_CONN_RUN_PATH"
+        exit 1
+      fi
 
-    # print initial state
-    print_state
+      # Clean up old config on behalf of mtu-migration
+      if ! systemctl -q is-enabled mtu-migration; then
+        echo "Cleaning up left over mtu migration configuration"
+        rm -rf /etc/cno/mtu-migration
+      fi
 
-    if [ "$1" == "OVNKubernetes" ]; then
-      # Configures NICs onto OVS bridge "br-ex"
-      # Configuration is either auto-detected or provided through a config file written already in Network Manager
-      # key files under /etc/NetworkManager/system-connections/
-      # Managing key files is outside of the scope of this script
+      if ! rpm -qa | grep -q openvswitch; then
+        echo "Warning: Openvswitch package is not installed!"
+        exit 1
+      fi
 
-      # if the interface is of type vmxnet3 add multicast capability for that driver
-      # History: BZ:1854355 
-      function configure_driver_options {
-        intf=$1
-        if [ ! -f "/sys/class/net/${intf}/device/uevent" ]; then
-          echo "Device file doesn't exist, skipping setting multicast mode"
-        else
-          driver=$(cat "/sys/class/net/${intf}/device/uevent" | grep DRIVER | awk -F "=" '{print $2}')
-          echo "Driver name is" $driver
-          if [ "$driver" = "vmxnet3" ]; then
-            ip link set dev "${intf}" allmulticast on
+      # print initial state
+      print_state
+
+      if [ "$1" == "OVNKubernetes" ]; then
+        # Configures NICs onto OVS bridge "br-ex"
+        # Configuration is either auto-detected or provided through a config file written already in Network Manager
+        # key files under /etc/NetworkManager/system-connections/
+        # Managing key files is outside of the scope of this script
+
+        # if the interface is of type vmxnet3 add multicast capability for that driver
+        # History: BZ:1854355
+        function configure_driver_options {
+          intf=$1
+          if [ ! -f "/sys/class/net/${intf}/device/uevent" ]; then
+            echo "Device file doesn't exist, skipping setting multicast mode"
+          else
+            driver=$(cat "/sys/class/net/${intf}/device/uevent" | grep DRIVER | awk -F "=" '{print $2}')
+            echo "Driver name is" $driver
+            if [ "$driver" = "vmxnet3" ]; then
+              ip link set dev "${intf}" allmulticast on
+            fi
+          fi
+        }
+
+        ovnk_config_dir='/etc/ovnk'
+        ovnk_var_dir='/var/lib/ovnk'
+        extra_bridge_file="${ovnk_config_dir}/extra_bridge"
+        iface_default_hint_file="${ovnk_var_dir}/iface_default_hint"
+        ip_hint_file="/run/nodeip-configuration/primary-ip"
+
+        # make sure to create ovnk_config_dir if it does not exist, yet
+        mkdir -p "${ovnk_config_dir}"
+        # make sure to create ovnk_var_dir if it does not exist, yet
+        mkdir -p "${ovnk_var_dir}"
+
+        # For upgrade scenarios, make sure that we stabilize what we already configured
+        # before. If we do not have a valid interface hint, find the physical interface
+        # that's attached to ovs-if-phys0.
+        # If we find such an interface, write it to the hint file.
+        iface_default_hint=$(get_iface_default_hint "${iface_default_hint_file}")
+        if [ "${iface_default_hint}" == "" ]; then
+          current_interface=$(get_bridge_physical_interface ovs-if-phys0)
+          if [ "${current_interface}" != "" ]; then
+            write_iface_default_hint "${iface_default_hint_file}" "${current_interface}"
           fi
         fi
-      }
 
-      ovnk_config_dir='/etc/ovnk'
-      ovnk_var_dir='/var/lib/ovnk'
-      extra_bridge_file="${ovnk_config_dir}/extra_bridge"
-      iface_default_hint_file="${ovnk_var_dir}/iface_default_hint"
-      ip_hint_file="/run/nodeip-configuration/primary-ip"
-
-      # make sure to create ovnk_config_dir if it does not exist, yet
-      mkdir -p "${ovnk_config_dir}"
-      # make sure to create ovnk_var_dir if it does not exist, yet
-      mkdir -p "${ovnk_var_dir}"
-
-      # For upgrade scenarios, make sure that we stabilize what we already configured
-      # before. If we do not have a valid interface hint, find the physical interface
-      # that's attached to ovs-if-phys0.
-      # If we find such an interface, write it to the hint file.
-      iface_default_hint=$(get_iface_default_hint "${iface_default_hint_file}")
-      if [ "${iface_default_hint}" == "" ]; then
-        current_interface=$(get_bridge_physical_interface ovs-if-phys0)
-        if [ "${current_interface}" != "" ]; then
-          write_iface_default_hint "${iface_default_hint_file}" "${current_interface}"
+        # delete iface_default_hint_file if it has the same content as extra_bridge_file
+        # in that case, we must also force a reconfiguration of our network interfaces
+        # to make sure that we reconcile this conflict
+        if [ -f "${iface_default_hint_file}" ] &&
+          [ -f "${extra_bridge_file}" ] &&
+          [ "$(cat "${iface_default_hint_file}")" == "$(cat "${extra_bridge_file}")" ]; then
+          echo "${iface_default_hint_file} and ${extra_bridge_file} share the same content"
+          echo "Deleting file ${iface_default_hint_file} to choose a different interface"
+          rm -f "${iface_default_hint_file}"
+          rm -f /run/configure-ovs-boot-done
         fi
-      fi
 
-      # delete iface_default_hint_file if it has the same content as extra_bridge_file
-      # in that case, we must also force a reconfiguration of our network interfaces
-      # to make sure that we reconcile this conflict
-      if [ -f "${iface_default_hint_file}" ] &&
-         [ -f "${extra_bridge_file}" ] &&
-         [ "$(cat "${iface_default_hint_file}")" == "$(cat "${extra_bridge_file}")" ]; then
-        echo "${iface_default_hint_file} and ${extra_bridge_file} share the same content"
-        echo "Deleting file ${iface_default_hint_file} to choose a different interface"
-        rm -f "${iface_default_hint_file}"
-        rm -f /run/configure-ovs-boot-done
-      fi
-
-      # on every boot we rollback and generate the configuration again, to take
-      # in any changes that have possibly been applied in the standard
-      # configuration sources
-      if [ ! -f /run/configure-ovs-boot-done ]; then
-        echo "Running on boot, restoring previous configuration before proceeding..."
-        rollback_nm
-        print_state
-      fi
-      touch /run/configure-ovs-boot-done
-
-      iface=$(get_nodeip_interface "${iface_default_hint_file}" "${extra_bridge_file}" "${ip_hint_file}")
-
-      if [ "$iface" != "br-ex" ]; then
-        # Default gateway is not br-ex.
-        # Some deployments use a temporary solution where br-ex is moved out from the default gateway interface
-        # and bound to a different nic (https://github.com/trozet/openshift-ovn-migration).
-        # This is now supported through an extra bridge if requested. If that is the case, we rollback.
-        # We also rollback if it looks like we need to configure things, just in case there are any leftovers
-        # from previous attempts.
-        if [ -f "$extra_bridge_file" ] || [ -z "$(nmcli connection show --active br-ex 2> /dev/null)" ]; then
-          echo "Bridge br-ex is not active, restoring previous configuration before proceeding..."
+        # on every boot we rollback and generate the configuration again, to take
+        # in any changes that have possibly been applied in the standard
+        # configuration sources
+        if [ ! -f /run/configure-ovs-boot-done ]; then
+          echo "Running on boot, restoring previous configuration before proceeding..."
           rollback_nm
           print_state
         fi
-      fi
+        touch /run/configure-ovs-boot-done
 
-      convert_to_bridge "$iface" "br-ex" "phys0" "${BRIDGE_METRIC}"
+        iface=$(get_nodeip_interface "${iface_default_hint_file}" "${extra_bridge_file}" "${ip_hint_file}")
 
-      # Check if we need to configure the second bridge
-      if [ -f "$extra_bridge_file" ] && (! nmcli connection show br-ex1 &> /dev/null || ! nmcli connection show ovs-if-phys1 &> /dev/null); then
-        interface=$(head -n 1 $extra_bridge_file)
-        convert_to_bridge "$interface" "br-ex1" "phys1" "${BRIDGE1_METRIC}"
-      fi
-
-      # Check if we need to remove the second bridge
-      if [ ! -f "$extra_bridge_file" ] && (nmcli connection show br-ex1 &> /dev/null || nmcli connection show ovs-if-phys1 &> /dev/null); then
-        remove_ovn_bridges br-ex1 phys1
-      fi
-
-      # Remove bridges created by openshift-sdn
-      ovs-vsctl --timeout=30 --if-exists del-br br0
-
-      # Make sure everything is activated. Do it in a specific order:
-      # - activate br-ex first, due to autoconnect-slaves this will also
-      #   activate ovs-port-br-ex, ovs-port-phys0 and ovs-if-phys0. It is
-      #   important that ovs-if-phys0 activates with br-ex to avoid the
-      #   ovs-if-phys0 profile being overridden with a profile generated from
-      #   kargs. The activation of ovs-if-phys0, if a bond, might cause the
-      #   slaves to re-activate, but it should be with our profiles since they
-      #   have higher priority
-      # - make sure that ovs-if-phys0 and its slaves, if any, are activated.
-      # - finally activate ovs-if-br-ex which holds the IP configuration.
-      connections=(br-ex ovs-if-phys0)
-      if [ -f "$extra_bridge_file" ]; then
-        connections+=(br-ex1 ovs-if-phys1)
-      fi
-      while IFS= read -r connection; do
-        if [[ $connection == *"$MANAGED_NM_CONN_SUFFIX" ]]; then
-          connections+=("$connection")
+        if [ "$iface" != "br-ex" ]; then
+          # Default gateway is not br-ex.
+          # Some deployments use a temporary solution where br-ex is moved out from the default gateway interface
+          # and bound to a different nic (https://github.com/trozet/openshift-ovn-migration).
+          # This is now supported through an extra bridge if requested. If that is the case, we rollback.
+          # We also rollback if it looks like we need to configure things, just in case there are any leftovers
+          # from previous attempts.
+          if [ -f "$extra_bridge_file" ] || [ -z "$(nmcli connection show --active br-ex 2> /dev/null)" ]; then
+            echo "Bridge br-ex is not active, restoring previous configuration before proceeding..."
+            rollback_nm
+            print_state
+          fi
         fi
-      done < <(nmcli -g NAME c)
-      connections+=(ovs-if-br-ex)
-      if [ -f "$extra_bridge_file" ]; then
-        connections+=(ovs-if-br-ex1)
+
+        convert_to_bridge "$iface" "br-ex" "phys0" "${BRIDGE_METRIC}"
+
+        # Check if we need to configure the second bridge
+        if [ -f "$extra_bridge_file" ] && (! nmcli connection show br-ex1 &> /dev/null || ! nmcli connection show ovs-if-phys1 &> /dev/null); then
+          interface=$(head -n 1 $extra_bridge_file)
+          convert_to_bridge "$interface" "br-ex1" "phys1" "${BRIDGE1_METRIC}"
+        fi
+
+        # Check if we need to remove the second bridge
+        if [ ! -f "$extra_bridge_file" ] && (nmcli connection show br-ex1 &> /dev/null || nmcli connection show ovs-if-phys1 &> /dev/null); then
+          remove_ovn_bridges br-ex1 phys1
+        fi
+
+        # Remove bridges created by openshift-sdn
+        ovs-vsctl --timeout=30 --if-exists del-br br0
+
+        # Make sure everything is activated. Do it in a specific order:
+        # - activate br-ex first, due to autoconnect-slaves this will also
+        #   activate ovs-port-br-ex, ovs-port-phys0 and ovs-if-phys0. It is
+        #   important that ovs-if-phys0 activates with br-ex to avoid the
+        #   ovs-if-phys0 profile being overridden with a profile generated from
+        #   kargs. The activation of ovs-if-phys0, if a bond, might cause the
+        #   slaves to re-activate, but it should be with our profiles since they
+        #   have higher priority
+        # - make sure that ovs-if-phys0 and its slaves, if any, are activated.
+        # - finally activate ovs-if-br-ex which holds the IP configuration.
+        connections=(br-ex ovs-if-phys0)
+        if [ -f "$extra_bridge_file" ]; then
+          connections+=(br-ex1 ovs-if-phys1)
+        fi
+        while IFS= read -r connection; do
+          if [[ $connection == *"$MANAGED_NM_CONN_SUFFIX" ]]; then
+            connections+=("$connection")
+          fi
+        done < <(nmcli -g NAME c)
+        connections+=(ovs-if-br-ex)
+        if [ -f "$extra_bridge_file" ]; then
+          connections+=(ovs-if-br-ex1)
+        fi
+        activate_nm_connections "${connections[@]}"
+        try_to_bind_ipv6_address
+        set_nm_conn_files
+      elif [ "$1" == "OpenShiftSDN" ]; then
+        # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
+        rollback_nm
+        
+        # Remove bridges created by ovn-kubernetes
+        ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local
       fi
-      activate_nm_connections "${connections[@]}"
-      try_to_bind_ipv6_address
-      set_nm_conn_files
-    elif [ "$1" == "OpenShiftSDN" ]; then
-      # Revert changes made by /usr/local/bin/configure-ovs.sh during SDN migration.
-      rollback_nm
-      
-      # Remove bridges created by ovn-kubernetes
-      ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local
-    fi
+    }
+
+    # Retry configure_ovs until it succeeds.
+    # By default, retry every 15 minutes to give enough time to gather
+    # troubleshooting information in between. Note that configure_ovs has other
+    # internal retry mechanisms. This retry is intended to give some
+    # self-healing capabilities to temporary but not necessarily short-lived
+    # infrastructure problems.
+    RETRY="${RETRY-15m}"
+    while true; do
+      e=0
+      # Run configure_ovs in a sub-shell
+      ( configure_ovs "$@" ) || e=$?
+      [ "$e" -eq 0 ] || [ -z "$RETRY" ] && exit "$e"
+      echo "configure_ovs failed, will retry after $RETRY"
+      # flag that a retry has happened
+      touch /tmp/configure-ovs-retry
+      sleep "$RETRY"
+    done


### PR DESCRIPTION
Retry configure_ovs until it succeeds.

By default, retry every 15 minutes to give enough time to gather
troubleshooting information in between. Note that configure_ovs has other
internal retry mechanisms. This retry is intended to give some
self-healing capabilities to temporary but not necessarily short-lived
infrastructure problems.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
