### PR TITLE
Fix typo in ctrcfg,kcfg docs

### DIFF
--- a/docs/ContainerRuntimeConfigDesign.md
+++ b/docs/ContainerRuntimeConfigDesign.md
@@ -91,7 +91,7 @@ spec:
 Save your `ctrcfg` locally, for example as highpids.yaml
 
 The label in the above example corresponds to the worker MachineConfigPool. By default the master/worker
-MachineConfigPool has labels pools.operator.machineconfiguration.openshift.io/{worker|master}: "" in OCP 4.6 and later. If you have a custom pool, or have an earlier OCP version, you can instead create a label youself as follows:
+MachineConfigPool has labels pools.operator.machineconfiguration.openshift.io/{worker|master}: "" in OCP 4.6 and later. If you have a custom pool, or have an earlier OCP version, you can instead create a label yourself as follows:
 
 ```
 apiVersion: machineconfiguration.openshift.io/v1
@@ -175,6 +175,6 @@ The ContainerRuntimeConfigController would perform the following steps:
 
 5. Serialize the ContainerRuntimeConfig to the respective toml files: storage.conf, and crio.conf
 
-5. Create or Update the ignition /etc/containers/storage.conf and /etc/crio/crio.conf files within a 99-[role]-containerruntime-managed MachineConfig
+6. Create or Update the ignition /etc/containers/storage.conf and /etc/crio/crio.conf files within a 99-[role]-containerruntime-managed MachineConfig
 
 After deletion of the ContainerRuntimeConfig instance the config will be reverted to the original storage and crio config.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -200,7 +200,7 @@ oc adm release new -n origin --server https://api.ci.openshift.org \
 
 `{version number}` is an openshift version, for example 4.5
 
-Make sure you're using a relatively new `oc` binary from `openshift/origin`. The image must be pullable by
+Make sure you're using a relatively new `oc` binary from `openshift/oc`. The image must be pullable by
 remote resources (nodes), therefore using a local registry might not work.
 
 Any registry credentials need to be present in `~/.docker/config.json` for `oc` to interact with the registry.

--- a/docs/KubeletConfigDesign.md
+++ b/docs/KubeletConfigDesign.md
@@ -90,7 +90,7 @@ uses more IO, CPU, and resources on all the machines within the pool.
 Save your `kubeletconfig` locally, for example as maxpods.yaml
 
 The label in the above example corresponds to the worker MachineConfigPool. By default the master/worker
-MachineConfigPool has labels pools.operator.machineconfiguration.openshift.io/{worker|master}: "" in OCP 4.6 and later. If you have a custom pool, or have an earlier OCP version, you can instead create a label youself as follows:
+MachineConfigPool has labels pools.operator.machineconfiguration.openshift.io/{worker|master}: "" in OCP 4.6 and later. If you have a custom pool, or have an earlier OCP version, you can instead create a label yourself as follows:
 
 ```
 apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix typos in docs/ContainerRuntimeConfigDesign.md, docs/KubeletConfigDesign.md