### PR TITLE
configure-ovs: Ensure output nm folder exists

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -25,6 +25,7 @@ contents:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1888017
     copy_nm_conn_files() {
       local dst_path="$1"
+      mkdir -p ${dst_path}
       for src in "${MANAGED_NM_CONN_FILES[@]}"; do
         src_path=$(dirname "$src")
         file=$(basename "$src")


### PR DESCRIPTION
There are circumstances where /run/NetworkManager/system-connections folder does not exist. In that case, even if the whole configuration process runs correctly, the final .nmconnection file copy fails and reverts the conf.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>

