### PR TITLE
OCPBUGS-7719: Add back cleanupDuplicateMC

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -680,8 +680,36 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		}
 		glog.Infof("Applied ContainerRuntimeConfig %v on MachineConfigPool %v", key, pool.Name)
 	}
+	if err := ctrl.cleanUpDuplicatedMC(); err != nil {
+		return err
+	}
 
 	return ctrl.syncStatusOnly(cfg, nil)
+}
+
+// cleanUpDuplicatedMC removes the MC of non-updated GeneratedByControllerVersionKey if its name contains 'generated-containerruntimeconfig'.
+// BZ 1955517: upgrade when there are more than one configs, the duplicated and upgraded MC will be generated (func getManagedKubeletConfigKey())
+// MC with old GeneratedByControllerVersionKey fails the upgrade.
+func (ctrl *Controller) cleanUpDuplicatedMC() error {
+	generatedCtrCfg := "generated-containerruntime"
+	// Get all machine configs
+	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing containerruntime machine configs: %w", err)
+	}
+	for _, mc := range mcList.Items {
+		if !strings.Contains(mc.Name, generatedCtrCfg) {
+			continue
+		}
+		// delete the containerruntime mc if its degraded
+		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("error deleting degraded containerruntime machine config %s: %w", mc.Name, err)
+			}
+
+		}
+	}
+	return nil
 }
 
 // mergeConfigChanges retrieves the original/default config data from the templates, decodes it and merges in the changes given by the Custom Resource.

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -36,6 +36,7 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	informers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
@@ -1425,6 +1426,86 @@ func TestContainerruntimeConfigResync(t *testing.T) {
 			}
 			val = ccr2.GetAnnotations()[ctrlcommon.MCNameSuffixAnnotationKey]
 			require.Equal(t, "1", val)
+		})
+	}
+}
+
+// TestCleanUpDuplicatedMC test the function removes the MC from the MC list
+// if the MC is of old GeneratedByControllerVersionAnnotationKey.
+func TestCleanUpDuplicatedMC(t *testing.T) {
+	v := version.Hash
+	version.Hash = "3.2.0"
+	versionDegrade := "3.1.0"
+	defer func() {
+		version.Hash = v
+	}()
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.newController()
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+
+			// test case: containerruntimrconfig ccr1, two machine config was generated from it: 99-master-generated-containerruntime, 99-master-generated-containerruntime-1
+			// action: upgrade, only 99-master-generated-containerruntime-1 will update GeneratedByControllerVersionAnnotationKey
+			// expect result: 99-master-generated-containerruntime will be deleted
+			ccr1 := newContainerRuntimeConfig("log-level-1", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
+			ccr1.SetAnnotations(map[string]string{
+				ctrlcommon.MCNameSuffixAnnotationKey: "1",
+			})
+			f.mccrLister = append(f.mccrLister, ccr1)
+			f.objects = append(f.objects, ccr1)
+
+			ctrl := f.newController()
+
+			// machineconfig with wrong version needs to be removed
+			machineConfigDegrade := mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "99-master-generated-containerruntime", UID: types.UID(utilrand.String(5))},
+			}
+			machineConfigDegrade.Annotations = make(map[string]string)
+			machineConfigDegrade.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+			ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigDegrade, metav1.CreateOptions{})
+
+			// MC will be upgraded
+			machineConfigUpgrade := mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "99-master-generated-containerruntime-1", UID: types.UID(utilrand.String(5))},
+			}
+			machineConfigUpgrade.Annotations = make(map[string]string)
+			machineConfigUpgrade.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+			ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigUpgrade, metav1.CreateOptions{})
+
+			// machine config has no substring "generated-xxx" will stay
+			machineConfigDegradeNotGen := mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom-containerruntime", UID: types.UID(utilrand.String(5))},
+			}
+			machineConfigDegradeNotGen.Annotations = make(map[string]string)
+			machineConfigDegradeNotGen.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = versionDegrade
+			ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), &machineConfigDegradeNotGen, metav1.CreateOptions{})
+
+			// before the upgrade, 3 machine config exist
+			mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Len(t, mcList.Items, 3)
+
+			if err := ctrl.syncHandler(getKey(ccr1, t)); err != nil {
+				t.Errorf("syncHandler returned: %v", err)
+			}
+
+			// successful test: only custom and upgraded MCs stay
+			mcList, err = ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, 2, len(mcList.Items))
+			actual := make(map[string]mcfgv1.MachineConfig)
+			for _, mc := range mcList.Items {
+				require.GreaterOrEqual(t, len(mc.Annotations), 1)
+				actual[mc.Name] = mc
+			}
+			_, ok := actual[machineConfigDegradeNotGen.Name]
+			require.True(t, ok, "expect custom-containerruntime in the list, but got false")
+			_, ok = actual[machineConfigUpgrade.Name]
+			require.True(t, ok, "expect 99-master-generated-containerruntime-1 in the list, but got false")
 		})
 	}
 }

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -27,7 +27,10 @@ import (
 )
 
 const (
-	emptyInput = ""
+	emptyInput                    = ""
+	managedNodeConfigKeyPrefix    = "97"
+	managedFeaturesKeyPrefix      = "98"
+	managedKubeletConfigKeyPrefix = "99"
 )
 
 func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, userDefinedSystemReserved map[string]string) *ign3types.File {
@@ -221,7 +224,7 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 
 	// If there is no kubelet config in the list, return the default MC name with no suffix
 	if kcListAll == nil || len(kcListAll.Items) == 0 {
-		return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+		return ctrlcommon.GetManagedKey(pool, client, managedKubeletConfigKeyPrefix, "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 	}
 
 	var kcList []mcfgv1.KubeletConfig
@@ -247,16 +250,16 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		// if an MC name suffix exists, append it to the default MC name and return that as this kubelet config exists and
 		// we are probably doing an update action on it
 		if val != "" {
-			return fmt.Sprintf("99-%s-generated-kubelet-%s", pool.Name, val), nil
+			return fmt.Sprintf("%s-%s-generated-kubelet-%s", managedKubeletConfigKeyPrefix, pool.Name, val), nil
 		}
 		// if the suffix val is "", mc name should not suffixed the cfg to be updated is the first kubelet config has been created
-		return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+		return ctrlcommon.GetManagedKey(pool, client, managedKubeletConfigKeyPrefix, "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 	}
 
 	// If we are here, this means that a new kubelet config was created, so we have to calculate the suffix value for its MC name
 	// if the kubelet config is the only one in the list, mc name should not suffixed since cfg is the first kubelet config to be created
 	if len(kcList) == 1 {
-		return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+		return ctrlcommon.GetManagedKey(pool, client, managedKubeletConfigKeyPrefix, "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 	}
 	suffixNum := 0
 	// Go through the list of kubelet config objects created and get the max suffix value currently created
@@ -282,25 +285,25 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		return "", fmt.Errorf("max number of supported kubelet config (10) has been reached. Please delete old kubelet configs before retrying")
 	}
 	// Return the default MC name with the suffixNum+1 value appended to it
-	return fmt.Sprintf("99-%s-generated-kubelet-%s", pool.Name, strconv.Itoa(suffixNum+1)), nil
+	return fmt.Sprintf("%s-%s-generated-kubelet-%s", managedKubeletConfigKeyPrefix, pool.Name, strconv.Itoa(suffixNum+1)), nil
 }
 
 func getManagedFeaturesKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return ctrlcommon.GetManagedKey(pool, client, "98", "kubelet", getManagedFeaturesKeyDeprecated(pool))
+	return ctrlcommon.GetManagedKey(pool, client, managedFeaturesKeyPrefix, "kubelet", getManagedFeaturesKeyDeprecated(pool))
 }
 
 // Deprecated: use getManagedFeaturesKey
 func getManagedFeaturesKeyDeprecated(pool *mcfgv1.MachineConfigPool) string {
-	return fmt.Sprintf("98-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID)
+	return fmt.Sprintf("%s-%s-%s-kubelet", managedFeaturesKeyPrefix, pool.Name, pool.ObjectMeta.UID)
 }
 
 func getManagedNodeConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return ctrlcommon.GetManagedKey(pool, client, "97", "kubelet", fmt.Sprintf("97-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID))
+	return ctrlcommon.GetManagedKey(pool, client, managedNodeConfigKeyPrefix, "kubelet", fmt.Sprintf("%s-%s-%s-kubelet", managedNodeConfigKeyPrefix, pool.Name, pool.ObjectMeta.UID))
 }
 
 // Deprecated: use getManagedKubeletConfigKey
 func getManagedKubeletConfigKeyDeprecated(pool *mcfgv1.MachineConfigPool) string {
-	return fmt.Sprintf("99-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID)
+	return fmt.Sprintf("%s-%s-%s-kubelet", managedKubeletConfigKeyPrefix, pool.Name, pool.ObjectMeta.UID)
 }
 
 // validates a KubeletConfig and returns an error if invalid

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -665,7 +665,38 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 		}
 		glog.Infof("Applied KubeletConfig %v on MachineConfigPool %v", key, pool.Name)
 	}
+	if err := ctrl.cleanUpDuplicatedMC(managedKubeletConfigKeyPrefix); err != nil {
+		return err
+	}
 	return ctrl.syncStatusOnly(cfg, nil)
+}
+
+// cleanUpDuplicatedMC removes the MC of non-updated GeneratedByControllerVersionKey if its name contains 'generated-kubelet'.
+// BZ 1955517: upgrade when there are more than one configs, the duplicated and upgraded MC will be generated (func getManagedKubeletConfigKey())
+// MC with old GeneratedByControllerVersionKey fails the upgrade.
+// This can also clean up unmanaged machineconfigs that their correcponding pool is removed.
+func (ctrl *Controller) cleanUpDuplicatedMC(prefix string) error {
+	generatedKubeletCfg := "generated-kubelet"
+	// Get all machine configs
+	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing kubelet machine configs: %w", err)
+	}
+	for _, mc := range mcList.Items {
+		if !strings.Contains(mc.Name, generatedKubeletCfg) {
+			continue
+		}
+		if !strings.HasPrefix(mc.Name, prefix) {
+			continue
+		}
+		// delete the mc if its degraded
+		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !macherrors.IsNotFound(err) {
+				return fmt.Errorf("error deleting degraded kubelet machine config %s: %w", mc.Name, err)
+			}
+		}
+	}
+	return nil
 }
 
 func (ctrl *Controller) popFinalizerFromKubeletConfig(kc *mcfgv1.KubeletConfig) error {

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -127,9 +127,12 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 			}
 			return err
 		}); err != nil {
-			return fmt.Errorf("Could not Create/Update MachineConfig: %w", err)
+			return fmt.Errorf("could not Create/Update MachineConfig: %w", err)
 		}
 		glog.Infof("Applied FeatureSet %v on MachineConfigPool %v", key, pool.Name)
+	}
+	if err := ctrl.cleanUpDuplicatedMC(managedFeaturesKeyPrefix); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -170,6 +170,9 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		}
 		glog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
 	}
+	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
+		return err
+	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -1,6 +1,7 @@
 package kubeletconfig
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -112,6 +113,68 @@ func TestBootstrapNoNodeConfig(t *testing.T) {
 			if len(mcs) > 0 {
 				t.Errorf("expected no machine configs with no node config but generated %v", len(mcs))
 			}
+		})
+	}
+}
+
+func TestNodeConfigCustom(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.newController()
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcp1 := helpers.NewMachineConfigPool("custom", nil, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/custom", ""), "v0")
+
+			kc := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""))
+			kubeletConfigKey, err := getManagedKubeletConfigKey(mcp, f.client, kc)
+			require.NoError(t, err)
+
+			nodeKeyCustom, err := getManagedNodeConfigKey(mcp1, f.client)
+			require.NoError(t, err)
+
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/worker": ""}, "dummy://", []ign3types.File{{}})
+			mcs1 := helpers.NewMachineConfig(nodeKeyCustom, map[string]string{}, "dummy://", []ign3types.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = fmt.Sprintf("97-%s-%s-kubelet", mcp.Name, mcp.ObjectMeta.UID)
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+
+			nodeConfig := &osev1.Node{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ctrlcommon.ClusterNodeInstanceName,
+				},
+				Spec: osev1.NodeSpec{
+					CgroupMode: "v1",
+				},
+			}
+
+			nodeConfig.Spec.WorkerLatencyProfile = osev1.DefaultUpdateDefaultReaction
+			nodeConfig.Spec.CgroupMode = osev1.CgroupModeDefault
+			f.nodeLister = append(f.nodeLister, nodeConfig)
+			f.oseobjects = append(f.oseobjects, nodeConfig)
+
+			c := f.newController()
+
+			mcCustom, err := c.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mcs1, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.Equal(t, nodeKeyCustom, mcCustom.Name)
+
+			mcList, err := c.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Len(t, mcList.Items, 1)
+			require.Equal(t, nodeKeyCustom, mcList.Items[0].Name)
+
+			err = c.syncNodeConfigHandler(nodeConfig.Name)
+			require.NoError(t, err)
+
+			mcList, err = c.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Len(t, mcList.Items, 1)
+			require.NotEqual(t, nodeKeyCustom, mcList.Items[0].Name)
 		})
 	}
 }


### PR DESCRIPTION
 https://github.com/openshift/machine-config-operator/pull/2570 was removed by https://github.com/openshift/machine-config-operator/pull/3149 and #3096. Add the #2570 back since the symptom it can fix may still happen.
Possibly the cluster hit bug https://bugzilla.redhat.com/show_bug.cgi?id=2041814 in 4.11, and upgrade to 4.12 that the cleanupDuplicateMC has been removed, so the problematic machineconfig from 4.11 still stayed and then 4.12 to 4.13 upgrade failed at the MC check https://github.com/openshift/machine-config-operator/pull/3501 .

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Add cleanupDuplicateMC to delete unmanaged machinconfigs with generated-kubelet, generated-containerruntim suffix.

**- How to verify it**
1. launch quay.io/openshift-release-dev/ocp-release:4.12.4-x86_64 
2. Add custom pool infra
3. oc edit featuregates.config.openshift.io/cluster
```
spec:
  featureSet: TechPreviewNoUpgrade
```
4. delete custom pool infra
5. upgrade to this patch, `98-infra-generated-kubelet` will not exist.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
