### PR TITLE
Add a retry mechanism to syncGeneratedMachineConfig to speed it up

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,6 +24,11 @@ var (
 		Duration: 100 * time.Millisecond,
 		Jitter:   1.0,
 	}
+	RenderBackoff = wait.Backoff{
+		Steps:    5,
+		Duration: time.Second,
+		Jitter:   1.0,
+	}
 	// NodeUpdateInProgressTaint is a taint applied by MCC when the update of node starts.
 	NodeUpdateInProgressTaint = &corev1.Taint{
 		Key:    "UpdateInProgress",

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -456,7 +456,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return ctrl.syncFailingStatus(pool, fmt.Errorf("no MachineConfigs found matching selector %v", selector))
 	}
 
-	if err = retry.RetryOnConflict(constants.RenderBackoff, func() error {
+	if err = RetryOnErr(constants.RenderBackoff, func() error {
 		pool, mcs, err := ctrl.getLatestMcpAndMcs(pool.Name)
 		if err != nil {
 			return err
@@ -690,4 +690,12 @@ func getMachineConfigsForPool(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.
 		return nil, fmt.Errorf("couldn't find any MachineConfigs for pool: %v", pool.Name)
 	}
 	return out, nil
+}
+
+func RetryOnErr(bacoff wait.Backoff, fn func() error) error {
+	return retry.OnError(bacoff, IsError, fn)
+}
+
+func IsError(err error) bool {
+	return err != nil
 }

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -435,7 +435,8 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	}
 
 	if err := ctrl.syncGeneratedMachineConfig(pool, mcs); err != nil {
-		return ctrl.syncFailingStatus(pool, err)
+		ctrl.syncFailingStatus(pool, err)
+		return err
 	}
 
 	return ctrl.syncAvailableStatus(pool)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: #3560

**- What I did**
to get the lastest mcp and mcs to retry sync when syncGeneratedMachineConfig failed 

**- How to verify it**
This is an accidental problem

**- Description for the changelog**
Add a retry mechanism to syncGeneratedMachineConfig to speed it up