### PR TITLE
OCPNODE-1495 : Default the cgroup version to "v1" via base template controller

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -77,6 +77,9 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
+	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
+		return err
+	}
 	// checking if the Node spec is empty and accordingly returning from here.
 	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
 		glog.V(2).Info("empty Node resource found")
@@ -158,9 +161,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 			return fmt.Errorf("Could not Create/Update MachineConfig, error: %w", err)
 		}
 		glog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
-	}
-	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
-		return err
 	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -77,10 +77,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
-	// Set the Cgroups version explicitly to "v1"
-	if nodeConfig.Spec.CgroupMode == emptyInput {
-		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
-	}
 	// checking if the Node spec is empty and accordingly returning from here.
 	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
 		glog.V(2).Info("empty Node resource found")
@@ -125,13 +121,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		if role == ctrlcommon.MachineConfigPoolWorker {
 			// updating the kubelet configuration with the Node specific configuration.
 			err = updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
-			if err != nil {
-				return err
-			}
-		}
-		// Setting the CGroups version to "v1" explicitly
-		if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV1 {
-			err := updateMachineConfigwithCgroup(nodeConfig, mc)
 			if err != nil {
 				return err
 			}
@@ -278,12 +267,13 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 	if nodeConfig == nil {
 		return nil, fmt.Errorf("nodes.config.openshift.io resource not found")
 	}
+	// checking if the Node spec is empty and accordingly returning from here.
+	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
+		glog.V(2).Info("empty Node resource found")
+		return nil, nil
+	}
 	configs := []*mcfgv1.MachineConfig{}
 
-	// Set the Cgroups version explicitly to "v1"
-	if nodeConfig.Spec.CgroupMode == emptyInput {
-		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV1
-	}
 	for _, pool := range mcpPools {
 		role := pool.Name
 		// Get MachineConfig
@@ -307,14 +297,6 @@ func RunNodeConfigBootstrap(templateDir string, features *osev1.FeatureGate, cco
 				return nil, err
 			}
 		}
-		// Setting the CGroups version to "v1" explicitly
-		if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV1 {
-			err := updateMachineConfigwithCgroup(nodeConfig, mc)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		// The following code updates the MC with the relevant CGroups version
 		err = updateMachineConfigwithCgroup(nodeConfig, mc)
 		if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -91,8 +91,8 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) != 2 {
-				t.Errorf("expected a machine config generated with the default node config, got 0 machine configs")
+			if len(mcs) != 0 {
+				t.Errorf("expected no machine configs generated with the default node config, got %v machine configs", len(mcs))
 			}
 		})
 	}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -32,11 +32,13 @@ type RenderConfig struct {
 }
 
 const (
-	filesDir       = "files"
-	unitsDir       = "units"
-	platformBase   = "_base"
-	platformOnPrem = "on-prem"
-	sno            = "sno"
+	filesDir            = "files"
+	unitsDir            = "units"
+	platformBase        = "_base"
+	platformOnPrem      = "on-prem"
+	sno                 = "sno"
+	baseMasterKubeletMC = "01-master-kubelet"
+	baseWorkerKubeletMC = "01-worker-kubelet"
 )
 
 // generateTemplateMachineConfigs returns MachineConfig objects from the templateDir and a config object
@@ -120,10 +122,41 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 		if err != nil {
 			return nil, err
 		}
+		// defaulting the CGroups version to "v1"
+		// (TODO) This code can be removed if not required in future releases
+		if name == baseMasterKubeletMC || name == baseWorkerKubeletMC {
+			updateMCwithDefaultCgroupsVersion(nameConfig)
+		}
 		cfgs = append(cfgs, nameConfig)
 	}
 
 	return cfgs, nil
+}
+
+// updateMCwithDefaultCgroupsVersion updates the MC kArgs with the default CGroups version config
+func updateMCwithDefaultCgroupsVersion(mc *mcfgv1.MachineConfig) {
+	// updating the Machine Config resource with the default cgroupv1 config
+	var (
+		kernelArgsv1       = []string{"systemd.unified_cgroup_hierarchy=0", "systemd.legacy_systemd_cgroup_controller=1"}
+		kernelArgsv2       = []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"}
+		adjustedKernelArgs []string
+	)
+	// avoiding the undesired kArgs from the already existing kArgs
+	for _, arg := range mc.Spec.KernelArguments {
+		// only append the args we want to keep, omitting the undesired
+		if !ctrlcommon.InSlice(arg, kernelArgsv2) {
+			adjustedKernelArgs = append(adjustedKernelArgs, arg)
+		}
+	}
+	// appending the desired kArgs to the existing kArgs
+	for _, arg := range kernelArgsv1 {
+		// add the additional that aren't already there
+		if !ctrlcommon.InSlice(arg, adjustedKernelArgs) {
+			adjustedKernelArgs = append(adjustedKernelArgs, arg)
+		}
+	}
+	// overwrite the KernelArguments with the adjusted KernelArgs
+	mc.Spec.KernelArguments = adjustedKernelArgs
 }
 
 func platformStringFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, error) {

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -111,11 +111,8 @@ kind: Node
 metadata:
   name: cluster`),
 			},
-			// "CgroupMode" field in the nodes.config resource is empty
-			// Internally it gets updated to "v1" explicitly
-			// Hence, 97-{master/worker}-generated-kubelet are expected
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
 		},
 		{
 			name: "With a node config manifest empty \"cgroupMode\"",
@@ -127,10 +124,8 @@ metadata:
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction`),
 			},
-			// "CgroupMode" field in the nodes.config resource is empty
-			// Internally it gets updated to "v1" explicitly
-			// Hence, 97-{master/worker}-generated-kubelet are expected
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
@@ -257,8 +252,6 @@ spec:
       memory: 500Mi
 `),
 			},
-			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
-			// internally translates to "v1"
 			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},

--- a/test/e2e/kubeletcfg_test.go
+++ b/test/e2e/kubeletcfg_test.go
@@ -49,7 +49,7 @@ func TestKubeletConfigMaxPods(t *testing.T) {
 		},
 	}
 
-	runTestWithKubeletCfg(t, "max-pods", `["]maxPods["]: (\S+)`, "100,", "200,", kc1, kc2)
+	runTestWithKubeletCfg(t, "max-pods", `"?maxPods"?: (\S+)`, "100,", "200,", kc1, kc2)
 }
 
 // runTestWithKubeletCfg creates a kubelet config and checks whether the expected updates were applied, then deletes the kubelet config and makes
@@ -90,7 +90,7 @@ func runTestWithKubeletCfg(t *testing.T, testName, regexKey, expectedConfVal1, e
 	// cache the old configuration value to check against later
 	node := helpers.GetSingleNodeByRole(t, cs, poolName)
 	// the kubelet.conf format is yaml when in the default state and becomes a json when we apply a kubelet config CR
-	defaultConfVal := getValueFromKubeletConfig(t, cs, node, `["]maxPods["]: (\S+)`, kubeletPath) + ","
+	defaultConfVal := getValueFromKubeletConfig(t, cs, node, `"?maxPods"?: (\S+)`, kubeletPath) + ","
 	if defaultConfVal == expectedConfVal1 || defaultConfVal == expectedConfVal2 {
 		t.Logf("default configuration value %s same as values being tested against. Consider updating the test", defaultConfVal)
 		return
@@ -155,7 +155,7 @@ func runTestWithKubeletCfg(t *testing.T, testName, regexKey, expectedConfVal1, e
 	// ensure config rolls back as expected
 	helpers.WaitForPoolComplete(t, cs, poolName, defaultTarget)
 	// verify that the config value rolled back to the default value
-	restoredConfValue := getValueFromKubeletConfig(t, cs, node, `["]maxPods["]: (\S+)`, kubeletPath) + ","
+	restoredConfValue := getValueFromKubeletConfig(t, cs, node, `"?maxPods"?: (\S+)`, kubeletPath) + ","
 	require.Equal(t, restoredConfValue, defaultConfVal, "kubelet config deletion didn't cause node to roll back to default config")
 }
 


### PR DESCRIPTION
Node gets rebooted due to the creation of (`97-{master/worker}-generated-kubelet`) while explicitly setting the cgroups version to `"v1"`.
Moreover, in the future releases, if the cgroups version defaults to `"v2"`, on an upgrade, the above created MCs are not required. So, the `co/machine-config` gets degraded due to the presence of the unwanted `97-{master/worker}-generated-kubelet` MCs.
Following is the sample error log snippet due to the present of unwanted MCs.
```
I0222 16:30:59.551346       1 render_controller.go:377] Error syncing machineconfigpool worker: Ignoring MC 97-worker-generated-kubelet generated by older version f4c13d6e7004ec37f81fd28f4db3823f1d9b3b86 (my version: d4d98db75d7d3565db1b02bd4ce6a9daef4eca86)
I0222 16:31:00.074122       1 render_controller.go:377] Error syncing machineconfigpool master: Ignoring MC 97-master-generated-kubelet generated by older version f4c13d6e7004ec37f81fd28f4db3823f1d9b3b86 (my version: d4d98db75d7d3565db1b02bd4ce6a9daef4eca86)
E0222 16:32:21.485196       1 render_controller.go:382] Ignoring MC 97-worker-generated-kubelet generated by older version f4c13d6e7004ec37f81fd28f4db3823f1d9b3b86 (my version: d4d98db75d7d3565db1b02bd4ce6a9daef4eca86)
I0222 16:32:21.486084       1 render_controller.go:383] Dropping machineconfigpool "worker" out of the queue: Ignoring MC 97-worker-generated-kubelet generated by older version f4c13d6e7004ec37f81fd28f4db3823f1d9b3b86 (my version: d4d98db75d7d3565db1b02bd4ce6a9daef4eca86)
E0222 16:32:22.005221       1 render_controller.go:382] Ignoring MC 97-master-generated-kubelet generated by older version f4c13d6e7004ec37f81fd28f4db3823f1d9b3b86 (my version: d4d98db75d7d3565db1b02bd4ce6a9daef4eca86)
I0222 16:32:22.006038       1 render_controller.go:383] Dropping machineconfigpool "master" out of the queue: Ignoring MC 97-master-generated-kubelet generated by older version f4c13d6e7004ec37f81fd28f4db3823f1d9b3b86 (my version: d4d98db75d7d3565db1b02bd4ce6a9daef4eca86)
```


<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Default the cgroups version to `v1` in the future versions of OCP by updating the Kernel Args in the default MCs i.e `01-master-kubelet` & `01-worker-kubelet` instead of updating the [nodes.config.openshift.io](https://github.com/openshift/api/blob/master/config/v1/types_node.go#L19) CR
**- How to verify it**
Deploy the OCP cluster with this MCO change and observe the CGroupsv1 related KArgs are updated in the `01-master-kubelet` & `01-worker-kubelet` machine configs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Explicitly set the cgroups version to `v1` in the newer OCP clusters by updating the KArgs of the `01-master-kubelet`  & the `01-worker-kubelet` machine configs


/cc @yuqi-zhang @harche 