### PR TITLE
OPNET-208: Prefer ipv6 on v6-primary dual stack deployments

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -115,9 +115,10 @@ type ControllerConfigSpec struct {
 type IPFamiliesType string
 
 const (
-	IPFamiliesIPv4      IPFamiliesType = "IPv4"
-	IPFamiliesIPv6      IPFamiliesType = "IPv6"
-	IPFamiliesDualStack IPFamiliesType = "DualStack"
+	IPFamiliesIPv4                 IPFamiliesType = "IPv4"
+	IPFamiliesIPv6                 IPFamiliesType = "IPv6"
+	IPFamiliesDualStack            IPFamiliesType = "DualStack"
+	IPFamiliesDualStackIPv6Primary IPFamiliesType = "DualStackIPv6Primary"
 )
 
 // Network contains network related configuration

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -196,10 +196,13 @@ func clusterDNSIP(iprange string) (string, error) {
 }
 
 func ipFamilies(serviceCIDRs []string) (mcfgv1.IPFamiliesType, error) {
-	var ipv4, ipv6 bool
-	for _, cidr := range serviceCIDRs {
+	var ipv4, ipv6, v6primary bool
+	for i, cidr := range serviceCIDRs {
 		if utilnet.IsIPv6CIDRString(cidr) {
 			ipv6 = true
+			if i == 0 {
+				v6primary = true
+			}
 		} else {
 			ipv4 = true
 		}
@@ -207,6 +210,9 @@ func ipFamilies(serviceCIDRs []string) (mcfgv1.IPFamiliesType, error) {
 
 	switch {
 	case ipv4 && ipv6:
+		if v6primary {
+			return mcfgv1.IPFamiliesDualStackIPv6Primary, nil
+		}
 		return mcfgv1.IPFamiliesDualStack, nil
 	case ipv4:
 		return mcfgv1.IPFamiliesIPv4, nil

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -68,7 +68,7 @@ func TestIPFamilies(t *testing.T) {
 		Output: mcfgv1.IPFamiliesDualStack,
 	}, {
 		Ranges: []string{"2001:db8::/32", "192.168.2.0/20"},
-		Output: mcfgv1.IPFamiliesDualStack,
+		Output: mcfgv1.IPFamiliesDualStackIPv6Primary,
 	}, {
 		Ranges: []string{},
 		Error:  true,

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -24,7 +24,7 @@ contents: |
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set \
-    {{if eq .IPFamilies "IPv6" -}}
+    {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
     --prefer-ipv6 \
     {{end -}}
     --retry-on-failure \

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -31,6 +31,9 @@ contents: |
     {{if not (isOpenShiftManagedDefaultLB .) -}}
     --user-managed-lb \
     {{end -}}
+    {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
+    --prefer-ipv6 \
+    {{end -}}
     --retry-on-failure \
     {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}}; \
     do \


### PR DESCRIPTION
In ipv6-primary dual stack clusters we need to pass --prefer-ipv6 to runtimecfg so it knows to select the ipv6 address as the primary node ip. This adds a new network type value for this case and the necessary logic to use it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Add support for ipv6-primary dual stack clusters.
