### PR TITLE
OCPBUGS-7896: MCO should not add keepalived pod manifests in case of VSPHERE UPI

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -646,6 +646,8 @@ func isOpenShiftManagedDefaultLB(cfg RenderConfig) bool {
 				}
 				return lbType == configv1.LoadBalancerTypeOpenShiftManagedDefault
 			}
+			glog.Info("VSphere UPI doesn't populate VSphere PlatformStatus field. In that case we should return false")
+			return false
 		case configv1.NutanixPlatformType:
 			if cfg.Infra.Status.PlatformStatus.Nutanix != nil {
 				if cfg.Infra.Status.PlatformStatus.Nutanix.LoadBalancer != nil {
@@ -658,5 +660,5 @@ func isOpenShiftManagedDefaultLB(cfg RenderConfig) bool {
 			return true
 		}
 	}
-	return true
+	return false
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
OCPBUGS-7896: MCO should not add keepalived pod manifests in case of VSPHERE UPI

**- What I did**


**- How to verify it**
Install vsphere upi and verify keepalived is not part of vsphere upi

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
