### PR TITLE
OCPBUGS-1662: mcd_update_state metric should have a single time-series per node

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1347,7 +1347,7 @@ func (dn *Daemon) getStateAndConfigs(pendingConfigName string) (*stateAndConfigs
 		}
 	}
 
-	mcdState.WithLabelValues(state, degradedReason).SetToCurrentTime()
+	UpdateStateMetric(mcdState, state, degradedReason)
 
 	return &stateAndConfigs{
 		bootstrapping: bootstrapping,
@@ -1690,7 +1690,7 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 			// let's mark it done!
 			glog.Infof("Completing pending config %s", state.pendingConfig.GetName())
 			if err := dn.completeUpdate(state.pendingConfig.GetName()); err != nil {
-				mcdUpdateState.WithLabelValues("", err.Error()).SetToCurrentTime()
+				UpdateStateMetric(mcdUpdateState, "", err.Error())
 				return inDesiredConfig, err
 			}
 
@@ -1711,13 +1711,13 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, error) {
 		if state.state == constants.MachineConfigDaemonStateDegraded {
 			if err := dn.nodeWriter.SetDone(state.currentConfig.GetName()); err != nil {
 				errLabelStr := fmt.Sprintf("error setting node's state to Done: %v", err)
-				mcdUpdateState.WithLabelValues("", errLabelStr).SetToCurrentTime()
+				UpdateStateMetric(mcdUpdateState, "", errLabelStr)
 				return inDesiredConfig, fmt.Errorf("error setting node's state to Done: %w", err)
 			}
 		}
 
 		glog.Infof("In desired config %s", state.currentConfig.GetName())
-		mcdUpdateState.WithLabelValues(state.currentConfig.GetName(), "").SetToCurrentTime()
+		UpdateStateMetric(mcdUpdateState, state.currentConfig.GetName(), "")
 	}
 
 	// No errors have occurred. Returns true if currentConfig == desiredConfig, false otherwise (needs update)

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -59,6 +59,16 @@ var (
 		}, []string{"config", "err"})
 )
 
+// Updates metric with new labels & timestamp, deletes any existing
+// gauges stored in the metric prior to doing so.
+// More context: https://issues.redhat.com/browse/OCPBUGS-1662
+// We are using these metrics as a node state logger, so it is undesirable
+// to have multiple metrics of the same kind when the state changes.
+func UpdateStateMetric(metric *prometheus.GaugeVec, labels ...string) {
+	metric.Reset()
+	metric.WithLabelValues(labels...).SetToCurrentTime()
+}
+
 func RegisterMCDMetrics() error {
 	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
 		hostOS,
@@ -75,7 +85,6 @@ func RegisterMCDMetrics() error {
 	}
 
 	kubeletHealthState.Set(0)
-	mcdUpdateState.WithLabelValues("", "").Set(0)
 
 	return nil
 }

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -146,7 +146,7 @@ func (nw *clusterNodeWriter) SetDone(dcAnnotation string) error {
 		// clear out any Degraded/Unreconcilable reason
 		constants.MachineConfigDaemonReasonAnnotationKey: "",
 	}
-	mcdState.WithLabelValues(constants.MachineConfigDaemonStateDone, "").SetToCurrentTime()
+	UpdateStateMetric(mcdState, constants.MachineConfigDaemonStateDone, "")
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -161,7 +161,7 @@ func (nw *clusterNodeWriter) SetWorking() error {
 	annos := map[string]string{
 		constants.MachineConfigDaemonStateAnnotationKey: constants.MachineConfigDaemonStateWorking,
 	}
-	mcdState.WithLabelValues(constants.MachineConfigDaemonStateWorking, "").SetToCurrentTime()
+	UpdateStateMetric(mcdState, constants.MachineConfigDaemonStateWorking, "")
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -181,7 +181,7 @@ func (nw *clusterNodeWriter) SetUnreconcilable(err error) error {
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateUnreconcilable,
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
-	mcdState.WithLabelValues(constants.MachineConfigDaemonStateUnreconcilable, truncatedErr).SetToCurrentTime()
+	UpdateStateMetric(mcdState, constants.MachineConfigDaemonStateUnreconcilable, truncatedErr)
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,
@@ -205,7 +205,7 @@ func (nw *clusterNodeWriter) SetDegraded(err error) error {
 		constants.MachineConfigDaemonStateAnnotationKey:  constants.MachineConfigDaemonStateDegraded,
 		constants.MachineConfigDaemonReasonAnnotationKey: truncatedErr,
 	}
-	mcdState.WithLabelValues(constants.MachineConfigDaemonStateDegraded, truncatedErr).SetToCurrentTime()
+	UpdateStateMetric(mcdState, constants.MachineConfigDaemonStateDegraded, truncatedErr)
 	respChan := make(chan response, 1)
 	nw.writer <- message{
 		annos:           annos,


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a new function to clear old gauges in a gaugevec when we update them. `mcd_state` and `mcd_update_state` will both use this function. 

**- How to verify it**
Trigger a state change orr a config change and observe the above metrics. They should set their value to None and no longer be tracked by the mcd after the change

**- Description for the changelog**
OCPBUGS-1662: daemon: state metrics will clear old values when updated
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
