### PR TITLE
OCPBUGS-7903:  Pool degraded with error: rpm-ostree kargs: signal: terminated

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1928,7 +1928,9 @@ func (dn *Daemon) reboot(rationale string) error {
 		mcdRebootErr.Inc()
 		return fmt.Errorf("reboot command failed, something is seriously wrong")
 	}
-	// if we're here, reboot went through successfully
+	// if we're here, reboot went through successfully, so we set rebootQueued
+	// and we wait for GracefulNodeShutdown
+	dn.rebootQueued = true
 	dn.logSystem("reboot successful")
 	return nil
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a flag that indicated reboot is pending; when the flag is set we skip node syncs

**- How to verify it**
I used a regular cluster and simulated a long reboots from happening with the following method. 

```
-On any node, do the following commands:
$ mount -o remount,rw /usr
$ mv /usr/bin/systemd-run /usr/bin/systemd-run2
$ vi  /usr/bin/systemd-run

#!/bin/bash
if [ "$2" == "machine-config-daemon-reboot" ];
then
exit 0
else
/usr/bin/systemd-run2 $@
fi
exit $?

$ chmod +x  /usr/bin/systemd-run

-Then, apply an MC that will cause a reboot.
```

This fake script returns a good value, so the daemon thinks that a reboot is queued. To undo, do a manual reboot and restore the old systemd-run binary.

**- Description for the changelog**
OCPBUGS-7903:  daemon: Added no-op sync while waiting on node reboot
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
