### PR TITLE
OCPBUGS-8260: [release-4.11] backport cleanupDuplicateMC

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -25,6 +25,12 @@ import (
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 )
 
+const (
+	managedNodeConfigKeyPrefix    = "97"
+	managedFeaturesKeyPrefix      = "98"
+	managedKubeletConfigKeyPrefix = "99"
+)
+
 func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, userDefinedSystemReserved map[string]string) *ign3types.File {
 	var autoNodeSizing string
 	var systemReservedMemory string
@@ -149,7 +155,7 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 
 	// If there is no kubelet config in the list, return the default MC name with no suffix
 	if kcListAll == nil || len(kcListAll.Items) == 0 {
-		return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+		return ctrlcommon.GetManagedKey(pool, client, managedKubeletConfigKeyPrefix, "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 	}
 
 	var kcList []mcfgv1.KubeletConfig
@@ -175,16 +181,16 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		// if an MC name suffix exists, append it to the default MC name and return that as this kubelet config exists and
 		// we are probably doing an update action on it
 		if val != "" {
-			return fmt.Sprintf("99-%s-generated-kubelet-%s", pool.Name, val), nil
+			return fmt.Sprintf("%s-%s-generated-kubelet-%s", managedKubeletConfigKeyPrefix, pool.Name, val), nil
 		}
 		// if the suffix val is "", mc name should not suffixed the cfg to be updated is the first kubelet config has been created
-		return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+		return ctrlcommon.GetManagedKey(pool, client, managedKubeletConfigKeyPrefix, "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 	}
 
 	// If we are here, this means that a new kubelet config was created, so we have to calculate the suffix value for its MC name
 	// if the kubelet config is the only one in the list, mc name should not suffixed since cfg is the first kubelet config to be created
 	if len(kcList) == 1 {
-		return ctrlcommon.GetManagedKey(pool, client, "99", "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
+		return ctrlcommon.GetManagedKey(pool, client, managedKubeletConfigKeyPrefix, "kubelet", getManagedKubeletConfigKeyDeprecated(pool))
 	}
 	suffixNum := 0
 	// Go through the list of kubelet config objects created and get the max suffix value currently created
@@ -210,25 +216,25 @@ func getManagedKubeletConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclien
 		return "", fmt.Errorf("max number of supported kubelet config (10) has been reached. Please delete old kubelet configs before retrying")
 	}
 	// Return the default MC name with the suffixNum+1 value appended to it
-	return fmt.Sprintf("99-%s-generated-kubelet-%s", pool.Name, strconv.Itoa(suffixNum+1)), nil
+	return fmt.Sprintf("%s-%s-generated-kubelet-%s", managedKubeletConfigKeyPrefix, pool.Name, strconv.Itoa(suffixNum+1)), nil
 }
 
 func getManagedFeaturesKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return ctrlcommon.GetManagedKey(pool, client, "98", "kubelet", getManagedFeaturesKeyDeprecated(pool))
+	return ctrlcommon.GetManagedKey(pool, client, managedFeaturesKeyPrefix, "kubelet", getManagedFeaturesKeyDeprecated(pool))
 }
 
 // Deprecated: use getManagedFeaturesKey
 func getManagedFeaturesKeyDeprecated(pool *mcfgv1.MachineConfigPool) string {
-	return fmt.Sprintf("98-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID)
+	return fmt.Sprintf("%s-%s-%s-kubelet", managedFeaturesKeyPrefix, pool.Name, pool.ObjectMeta.UID)
 }
 
 func getManagedNodeConfigKey(pool *mcfgv1.MachineConfigPool, client mcfgclientset.Interface) (string, error) {
-	return ctrlcommon.GetManagedKey(pool, client, "97", "kubelet", fmt.Sprintf("97-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID))
+	return ctrlcommon.GetManagedKey(pool, client, managedNodeConfigKeyPrefix, "kubelet", fmt.Sprintf("%s-%s-%s-kubelet", managedNodeConfigKeyPrefix, pool.Name, pool.ObjectMeta.UID))
 }
 
 // Deprecated: use getManagedKubeletConfigKey
 func getManagedKubeletConfigKeyDeprecated(pool *mcfgv1.MachineConfigPool) string {
-	return fmt.Sprintf("99-%s-%s-kubelet", pool.Name, pool.ObjectMeta.UID)
+	return fmt.Sprintf("%s-%s-%s-kubelet", managedKubeletConfigKeyPrefix, pool.Name, pool.ObjectMeta.UID)
 }
 
 // validates a KubeletConfig and returns an error if invalid

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -132,9 +132,12 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 			}
 			return err
 		}); err != nil {
-			return fmt.Errorf("Could not Create/Update MachineConfig: %w", err)
+			return fmt.Errorf("could not Create/Update MachineConfig: %w", err)
 		}
 		glog.Infof("Applied FeatureSet %v on MachineConfigPool %v", key, pool.Name)
+	}
+	if err := ctrl.cleanUpDuplicatedMC(managedFeaturesKeyPrefix); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -161,6 +161,9 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		}
 		glog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
 	}
+	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
+		return err
+	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -1,6 +1,7 @@
 package kubeletconfig
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -110,6 +111,68 @@ func TestBootstrapNoNodeConfig(t *testing.T) {
 			if len(mcs) > 0 {
 				t.Errorf("expected no machine configs with no node config but generated %v", len(mcs))
 			}
+		})
+	}
+}
+
+func TestNodeConfigCustom(t *testing.T) {
+	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.newController()
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			mcp1 := helpers.NewMachineConfigPool("custom", nil, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/custom", ""), "v0")
+
+			kc := newKubeletConfig("smaller-max-pods", &kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""))
+			kubeletConfigKey, err := getManagedKubeletConfigKey(mcp, f.client, kc)
+			require.NoError(t, err)
+
+			nodeKeyCustom, err := getManagedNodeConfigKey(mcp1, f.client)
+			require.NoError(t, err)
+
+			mcs := helpers.NewMachineConfig(kubeletConfigKey, map[string]string{"node-role/worker": ""}, "dummy://", []ign3types.File{{}})
+			mcs1 := helpers.NewMachineConfig(nodeKeyCustom, map[string]string{}, "dummy://", []ign3types.File{{}})
+			mcsDeprecated := mcs.DeepCopy()
+			mcsDeprecated.Name = fmt.Sprintf("97-%s-%s-kubelet", mcp.Name, mcp.ObjectMeta.UID)
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp)
+
+			nodeConfig := &osev1.Node{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ctrlcommon.ClusterNodeInstanceName,
+				},
+				Spec: osev1.NodeSpec{
+					CgroupMode: "v1",
+				},
+			}
+
+			nodeConfig.Spec.WorkerLatencyProfile = osev1.DefaultUpdateDefaultReaction
+			nodeConfig.Spec.CgroupMode = osev1.CgroupModeDefault
+			f.nodeLister = append(f.nodeLister, nodeConfig)
+			f.oseobjects = append(f.oseobjects, nodeConfig)
+
+			c := f.newController()
+
+			mcCustom, err := c.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mcs1, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.Equal(t, nodeKeyCustom, mcCustom.Name)
+
+			mcList, err := c.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Len(t, mcList.Items, 1)
+			require.Equal(t, nodeKeyCustom, mcList.Items[0].Name)
+
+			err = c.syncNodeConfigHandler(nodeConfig.Name)
+			require.NoError(t, err)
+
+			mcList, err = c.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Len(t, mcList.Items, 1)
+			require.NotEqual(t, nodeKeyCustom, mcList.Items[0].Name)
 		})
 	}
 }


### PR DESCRIPTION
backport cleanupDuplicateMC #3559   to 4.11 and add new callers: nodes, featureGates handler

Add back https://github.com/openshift/machine-config-operator/pull/2570

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
