### PR TITLE
openshift-azure-routes: Avoid synchronizing too quickly

### DIFF
--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -174,6 +174,12 @@ contents:
             remove_stale
             add_rules
             echo "done applying vip rules"
+            # Arbitrary delay to avoid synchronizing too quickly on file changes; the VIP
+            # file could change multiple times quickly, but we don't need to react instantly
+            # to every change.  Most crucially we want to be sure we don't trip over the
+            # default systemd StartLimitBurst/StartLimitIterval settings which are 5 and 10s
+            # respectively.
+            sleep 3
             ;;
         cleanup)
             clear_rules


### PR DESCRIPTION
Rapid file changes triggering the path unit can start the service here frequently, and then this can cause the start limit to be hit, and then systemd will refuse further activations (unless we bumped the limit).

I don't think we need to synchronize the iptables
rules more than once every 3 seconds.

This isn't the fix for https://issues.redhat.com/browse/TRT-876 ...but I am pretty sure we want to avoid this service entering a permanently failed state.

Split out of https://github.com/openshift/machine-config-operator/pull/3485