### PR TITLE
MCO MCO-424: daemon: Remove old legacy OS update path

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -282,20 +282,6 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 	return
 }
 
-// IsBootableImage determines if the image is a bootable (new container formet) image, or a wrapper (old container format)
-func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
-
-	var isBootableImage string
-	var imageData *types.ImageInspectInfo
-	var err error
-	if imageData, _, err = imageInspect(imgURL); err != nil {
-		return false, err
-	}
-	isBootableImage = imageData.Labels["ostree.bootable"]
-
-	return isBootableImage == "true", nil
-}
-
 // RpmOstreeIsNewEnoughForLayering returns true if the version of rpm-ostree on the
 // host system is new enough for layering.
 // VersionData represents the static information about rpm-ostree.


### PR DESCRIPTION
This must be dead code in 4.14.  There's no going back.  Everything in 4.12 really should have transitioned, and certainly 4.13 and very much most definitely 4.14.

Deleting code is good on general principle, but very specifically this cost me hours of debugging because I modified the legacy update path when trying something, not the new one.
