### PR TITLE
OCPBUGS-7559: Remove hard requirement for the afterburn from early-running aws-related services

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
@@ -11,12 +11,24 @@ contents:
         echo "Not replacing existing ${NODECONF}"
         exit 0
     fi
+    
+    # afterburn service is expected to be used for metadata retrival, see respective systemd unit.
+    # However, on older OCP boot images does not contain afterburn service, check if afterburn variables are there
+    # otherwise try to communicate IMDS here.
+    # metadata related afterburn doc: https://coreos.github.io/afterburn/usage/attributes/
+    
+    HOSTNAME=${AFTERBURN_AWS_HOSTNAME:-}
+    if [[ -z "${HOSTNAME}" ]]; then
+      HOSTNAME=$(curl -fSs http://169.254.169.254/2022-09-24/meta-data/local-hostname)
+      if [[ -z "${HOSTNAME}" ]]; then
+        echo "Can not obtain hostname from the metadata service."
+        exit 1
+      fi 
+    fi
 
     # For compatibility with the AWS in-tree provider
     # Set node name to be instance name instead of the default FQDN hostname
-    # afterburn service is using for metadata retrival, see respective systemd unit
-    # metadata related afterburn doc: https://coreos.github.io/afterburn/usage/attributes/
     cat > "${NODECONF}" <<EOF
     [Service]
-    Environment="KUBELET_NODE_NAME=${AFTERBURN_AWS_HOSTNAME}"
+    Environment="KUBELET_NODE_NAME=${HOSTNAME}"
     EOF

--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-providerid.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-providerid.yaml
@@ -12,15 +12,29 @@ contents:
         exit 0
     fi
 
+    # afterburn service is expected to be used for metadata retrival, see respective systemd unit.
+    # However, on older OCP boot images does not contain afterburn service, check if afterburn variables are there
+    # otherwise try to communicate IMDS here.
+    # metadata related afterburn doc: https://coreos.github.io/afterburn/usage/attributes/
+    
+    INSTANCE_ID=${AFTERBURN_AWS_INSTANCE_ID:-}
+    AVAILABILITY_ZONE=${AFTERBURN_AWS_AVAILABILITY_ZONE:-}
+    if [[ -z "${INSTANCE_ID}" ]] || [[ -z "${AVAILABILITY_ZONE}" ]]; then
+      INSTANCE_ID=$(curl -fSs http://169.254.169.254/2022-09-24/meta-data/instance-id)
+      AVAILABILITY_ZONE=$(curl -fSs http://169.254.169.254/2022-09-24/meta-data/placement/availability-zone)
+      if [[ -z "${INSTANCE_ID}" ]] || [[ -z "${AVAILABILITY_ZONE}" ]]; then
+        echo "Can not obtain instance-id and availability zone info from the metadata service."
+        exit 1
+      fi 
+    fi
+
     # Due to a potential mismatch between Hostname and PrivateDNSName with clusters that use custom DHCP Option Sets
     # which can cause issues in cloud controller manager node syncing
     # (see: https://github.com/kubernetes/cloud-provider-aws/issues/384),
     # set KUBELET_PROVIDERID to be a fully qualified AWS instace provider id.
     # This new variable is later used to populate the kubelet's `provider-id` flag, later set on the Node .spec
     # and used by the cloud controller manager's node controller to retrieve the Node's backing instance.
-    # This is obtained by using afterburn service variables, in turn obtained from metadata retrival.
-    # See respective systemd unit metadata related afterburn doc: https://coreos.github.io/afterburn/usage/attributes/
     cat > "${NODECONF}" <<EOF
     [Service]
-    Environment="KUBELET_PROVIDERID=aws:///${AFTERBURN_AWS_AVAILABILITY_ZONE}/${AFTERBURN_AWS_INSTANCE_ID}"
+    Environment="KUBELET_PROVIDERID=aws:///${AVAILABILITY_ZONE}/${INSTANCE_ID}"
     EOF

--- a/templates/common/aws/units/aws-kubelet-nodename.service.yaml
+++ b/templates/common/aws/units/aws-kubelet-nodename.service.yaml
@@ -6,7 +6,9 @@ contents: |
 
   # Run afterburn service for collect info from metadata server
   # see: https://coreos.github.io/afterburn/usage/attributes/
-  Requires=afterburn.service
+  # Not required due to OCP 4.1 boot image does not contain afterburn service
+  # see: https://issues.redhat.com/browse/OCPBUGS-7559
+  Wants=afterburn.service
   After=afterburn.service
 
   # Wait for NetworkManager to report it's online
@@ -15,7 +17,8 @@ contents: |
   Before=kubelet.service
 
   [Service]
-  EnvironmentFile=/run/metadata/afterburn
+  # Mark afterburn environment file optional, due to it is possible that afterburn service was not executed
+  EnvironmentFile=-/run/metadata/afterburn
   ExecStart=/usr/local/bin/aws-kubelet-nodename
   Type=oneshot
 

--- a/templates/common/aws/units/aws-kubelet-providerid.service.yaml
+++ b/templates/common/aws/units/aws-kubelet-providerid.service.yaml
@@ -6,7 +6,9 @@ contents: |
 
   # Run afterburn service for collect info from metadata server
   # see: https://coreos.github.io/afterburn/usage/attributes/
-  Requires=afterburn.service
+  # Not required due to OCP 4.1 boot image does not contain afterburn service
+  # see: https://issues.redhat.com/browse/OCPBUGS-7559
+  Wants=afterburn.service
   After=afterburn.service
 
   # Wait for NetworkManager to report it's online
@@ -15,7 +17,8 @@ contents: |
   Before=kubelet.service
 
   [Service]
-  EnvironmentFile=/run/metadata/afterburn
+  # Mark afterburn environment file optional, due to it is possible that afterburn service was not executed
+  EnvironmentFile=-/run/metadata/afterburn
   ExecStart=/usr/local/bin/aws-kubelet-providerid
   Type=oneshot
 


### PR DESCRIPTION
In older versions of OCP (4.1 specifically) boot image does not contain the afterburn service.
This causes instance provisioning issues within
clusters that use bootimages from OCP 4.1 and below.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This commit adds fallback logic into service scripts that try to communicate with IMDS via curl
if afterburn populated environment variables were not found.

**- How to verify it**
Use bootimage from the OCP 4.1 for machine boot. Machine should come successfully.

For ocp 4.12+
1. Update user-data-secret for using ignition 2.2.0 
- ```oc -n openshift-machine-api get -o json secret worker-user-data | jq '.data.userData | @base64d | fromjson' | jq '.networkd = {} | .passwd = {} | .storage = {} | .systemd = {} | .ignition.version = "2.2.0" | .ignition.security.tls.certificateAuthorities[0].verification = {} | .ignition.config.append = .ignition.config.merge | del(.ignition.config.merge) | .ignition.config.append[0].verification = {}' >v2.2.json```
- ```oc -n openshift-machine-api set data secret/worker-user-data --from-file=userData=v2.2.json```
- ```oc -n openshift-machine-api set data secret/worker-user-data-managed --from-file=userData=v2.2.json```
2. Update one of machinesets to use AMI from OCP 4.1
- ```REGION="$(oc get -o json infrastructure cluster | jq -r .status.platformStatus.aws.region)"```
- ```AMI="$(curl -s https://raw.githubusercontent.com/openshift/installer/release-4.1/data/data/rhcos.json | jq -r ".amis[\"${REGION}\"].hvm")"```
- ```oc -n openshift-machine-api patch machineset MACHINESET_NAME --type json -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/providerSpec/value/ami\", \"value\": {\"id\": \"${AMI}\"}}]"```
3. Trigger machine creation using edited machineset (scale up, or delete existing machineset-managed machine) 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Related prs:
- https://github.com/openshift/machine-config-operator/pull/2988
- https://github.com/openshift/machine-config-operator/pull/3170/
