### PR TITLE
daemon: Remove noisy log message

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -530,7 +530,6 @@ func (dn *Daemon) syncNode(key string) error {
 		if oldReason != newReason {
 			glog.Infof("Transitioned from degraded/unreconcilable reason %v -> %v", oldReason, newReason)
 		}
-		glog.Infof("State and Reason: %v %v", newState, newReason)
 		dn.node = node
 	}
 


### PR DESCRIPTION
The whole reason we're doing the "state diff" here is so that we only log when transitioning.  This log message effectively prints the same thing every time we've done a sync, which adds noise to logs unnecessarily.  In this MCD pod log I'm looking at it ends with 163 instances of this.