### PR TITLE
OCPBUGS-8523: Revert "daemon: Temporarily copy auth file with more open perms on FCOS"         

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -14,7 +14,6 @@ import (
 	rpmostreeclient "github.com/coreos/rpmostree-client-go/pkg/client"
 	"github.com/golang/glog"
 	"github.com/opencontainers/go-digest"
-	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
 	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
 	"gopkg.in/yaml.v2"
 )
@@ -356,26 +355,9 @@ func useKubeletConfigSecrets() error {
 				return err
 			}
 
-			runningos, err := osrelease.GetHostRunningOS()
+			err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
 			if err != nil {
 				return err
-			}
-
-			// Short term workaround for https://issues.redhat.com/browse/OKD-63
-			if runningos.IsFCOS() || runningos.IsSCOS() {
-				contents, err := os.ReadFile(kubeletAuthFile)
-				if err != nil {
-					return err
-				}
-				// Note 0644 perms for now
-				if err := os.WriteFile("/run/ostree/auth.json", contents, 0o644); err != nil {
-					return err
-				}
-			} else {
-				err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
-				if err != nil {
-					return err
-				}
 			}
 		}
 	}


### PR DESCRIPTION
This reverts commit 6ccdd574fad38fc7bc2de1e1913c9ade69ba6e55.

**- What I did**
Reverted one of commits introduced in #3358 to fix OKD-63. This workaround however breaks Assisted Installer flow, which runs `mcd start` on Live ISO where /var/lib/kubelet/config.json is not yet created.

**- How to verify it**
Install OKD FCOS/SCOS

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
