### PR TITLE
OCPBUGS-8676: Fix kubelet.service node-ip for v6-primary dual-stack

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -30,7 +30,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
-{{- if eq .IPFamilies "DualStack"}}
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}
         --node-ip=${KUBELET_NODE_IP} \

--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -31,7 +31,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
-{{- if eq .IPFamilies "DualStack"}}
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}
         --node-ip=${KUBELET_NODE_IP} \

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -27,7 +27,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
-{{- if eq .IPFamilies "DualStack"}}
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}
         --node-ip=${KUBELET_NODE_IP} \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -30,7 +30,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
-{{- if eq .IPFamilies "DualStack"}}
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}
         --node-ip=${KUBELET_NODE_IP} \

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -31,7 +31,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
-{{- if eq .IPFamilies "DualStack"}}
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}
         --node-ip=${KUBELET_NODE_IP} \

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -27,7 +27,7 @@ contents: |
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
         --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID},${CUSTOM_KUBELET_LABELS} \
-{{- if eq .IPFamilies "DualStack"}}
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}
         --node-ip=${KUBELET_NODE_IP} \


### PR DESCRIPTION
This PR changes conditional statement for dual-stack clusters from

```
{{- if eq .IPFamilies "DualStack"}}
```

into

```
{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
```

This is because by implementing IPv6-primary dual-stack support we have created a separate IPFamiliesType value for such clusters.

Fixes: OCPBUGS-8676