### PR TITLE
OCPBUGS-9685: daemon: Always remove pending deployment before we do updates

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2120,6 +2120,22 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		defer os.Remove(extensionsRepo)
 	}
 
+	defer func() {
+		// Operations performed by rpm-ostree on the booted system are available
+		// as staged deployment. It gets applied only when we reboot the system.
+		// In case of an error during any rpm-ostree transaction, removing pending deployment
+		// should be sufficient to discard any applied changes.
+		if retErr != nil {
+			// Print out the error now so that if we fail to cleanup -p, we don't lose it.
+			glog.Infof("Rolling back applied changes to OS due to error: %v", retErr)
+			if err := removePendingDeployment(); err != nil {
+				errs := kubeErrs.NewAggregate([]error{err, retErr})
+				retErr = fmt.Errorf("error removing staged deployment: %w", errs)
+				return
+			}
+		}
+	}()
+
 	// If we have an OS update *or* a kernel type change, then we must undo the RT kernel
 	// enablement.
 	if mcDiff.osUpdate || mcDiff.kernelType {
@@ -2147,22 +2163,6 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	// if we're here, we've successfully pivoted, or pivoting wasn't necessary, so we reset the error gauge
 	mcdPivotErr.Set(0)
-
-	defer func() {
-		// Operations performed by rpm-ostree on the booted system are available
-		// as staged deployment. It gets applied only when we reboot the system.
-		// In case of an error during any rpm-ostree transaction, removing pending deployment
-		// should be sufficient to discard any applied changes.
-		if retErr != nil {
-			// Print out the error now so that if we fail to cleanup -p, we don't lose it.
-			glog.Infof("Rolling back applied changes to OS due to error: %v", retErr)
-			if err := removePendingDeployment(); err != nil {
-				errs := kubeErrs.NewAggregate([]error{err, retErr})
-				retErr = fmt.Errorf("error removing staged deployment: %w", errs)
-				return
-			}
-		}
-	}()
 
 	if mcDiff.kargs {
 		if err := dn.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2120,6 +2120,12 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		defer os.Remove(extensionsRepo)
 	}
 
+	// Always clean up pending, because the RT kernel switch logic below operates on booted,
+	// not pending.
+	if err := removePendingDeployment(); err != nil {
+		return fmt.Errorf("failed to remove pending deployment: %w", err)
+	}
+
 	defer func() {
 		// Operations performed by rpm-ostree on the booted system are available
 		// as staged deployment. It gets applied only when we reboot the system.


### PR DESCRIPTION
This is followup to https://github.com/openshift/machine-config-operator/pull/3580 - we're fixing the case where deploying the RT kernel fails and we want to retry.

---

daemon: Move cleanup of pending deployment earlier

We hit a confusing failure in https://issues.redhat.com/browse/OCPBUGS-8113
where the MCD will get stuck if deploying the RT kernel fails, because
the switch to the RT kernel operates from the *booted* deployment
state, but by default rpm-ostree wants to operate from pending.

Move up the "cleanup pending deployment on failure" `defer` to
right before we do anything else.

---

daemon: Always remove pending deployment before we do updates

The RT kernel switch logic operates from the *booted* deployment,
not pending.  I had in my head that the MCO always cleaned up
pending, but due to another bug we didn't.

There's no reason to leave this cleanup to a defer; do it
before we do anything else.

(But keep the defer because it's cleaner to *also* cleanup if
 we fail)

---

