### PR TITLE
OCPBUGS-8113: daemon: Only switchkernel if we are doing an OS update or kernel change

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2171,8 +2171,10 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	}
 
 	// Switch to real time kernel
-	if err := dn.switchKernel(oldConfig, newConfig); err != nil {
-		return err
+	if mcDiff.osUpdate || mcDiff.kernelType {
+		if err := dn.switchKernel(oldConfig, newConfig); err != nil {
+			return err
+		}
 	}
 
 	// Apply extensions


### PR DESCRIPTION
This fixes a regression with the previous commit
https://github.com/openshift/machine-config-operator/pull/3580/commits/8ac5beeddc331dd0186844d4714500d17454621d where we would simply fail to roll out on RT node systems any further MachineConfig changes.

Also of note: It seems like this (quite common thing) is actually not in our CI here nor in the periodics.