### PR TITLE
COS-1926, MCO-116, OCPBUGS-8703, OCPBUGS-9951: rhel coreos 9 4.13 katamari

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,12 @@ COPY install /manifests
 
 RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
     # comment out non-base/extensions image-references entirely for fcos/scos
-    sed -i '/- name: rhel-coreos-8-/,+3 s/^/#/' /manifests/image-references && \
+    sed -i '/- name: rhel-coreos-[89]-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
     # rewrite image names for fcos/scos
-    if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos-8/fedora-coreos/g' /manifests/*; \
-    elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos-8/centos-stream-coreos-9/g' /manifests/*; fi && \
+    if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
+    elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
     if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY install /manifests
 
 RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
     # comment out non-base/extensions image-references entirely for fcos/scos
-    sed -i '/- name: rhel-coreos-[89]-/,+3 s/^/#/' /manifests/image-references && \
+    sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
     # rewrite image names for fcos/scos

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -79,8 +79,8 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.oauthProxyImage, "oauth-proxy-image", "", "Image for origin oauth proxy.")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baseOSContainerImage, "baseos-image", "", "Image for rhel-coreos-8")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baseOSExtensionsContainerImage, "baseos-extensions-image", "", "Image for rhel-coreos-8-extensions")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baseOSContainerImage, "baseos-image", "", "ostree-bootable container image reference")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baseOSExtensionsContainerImage, "baseos-extensions-image", "", "Image with extensions")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.imageReferences, "image-references", "", "File containing imagestreams (from cluster-version-operator)")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.cloudProviderCAFile, "cloud-provider-ca-file", "", "path to cloud provider CA certificate")
 
@@ -114,7 +114,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
-	baseOSContainerImageTag := "rhel-coreos-8"
+	baseOSContainerImageTag := "rhel-coreos"
 	if version.IsFCOS() {
 		baseOSContainerImageTag = "fedora-coreos"
 	} else if version.IsSCOS() {

--- a/docs/UsingLayering.md
+++ b/docs/UsingLayering.md
@@ -8,8 +8,8 @@ Layering lets you "layer" additional content on top of a Base OS Image using "co
 
 As of 4.12:
 
-- The MCO uses the `rhel-coreos-8` [native format](https://coreos.github.io/rpm-ostree/container/) base OS image by default instead of `machine-os-content`
-- You can "layer" user content on top of that `rhel-coreos-8` image using a container build, and that content will be applied during a rebase
+- The MCO uses the `rhel-coreos-8` [native format](https://coreos.github.io/rpm-ostree/container/) base OS image by default instead of `machine-os-content` (and in 4.13+, the image is `rhel-coreos`)
+- You can "layer" user content on top of that `rhel-coreos` image using a container build, and that content will be applied during a rebase
 - The MCO will allow `OSImageURL` to be overridden *on a per-pool basis* with such an layered image
 
 While layering is powerful, it's also an "advanced" use of the MCO, and it comes with some trade-offs.
@@ -36,13 +36,13 @@ Nothing will stop you at this point from using a completely arbitrary image, but
 #### On an existing cluster
 
 ```bash
-oc adm release info --image-for rhel-coreos-8
+oc adm release info --image-for rhel-coreos
 ```
 
 #### Or before you build your cluster
 
 ```bash
-oc adm release info --image-for rhel-coreos-8 quay.io/openshift-release-dev/ocp-release:your_release_here
+oc adm release info --image-for rhel-coreos quay.io/openshift-release-dev/ocp-release:your_release_here
 ```
 
 ### 2. "Layer" Some Content On Top Of It

--- a/install/0000_80_machine-config-operator_05_osimageurl.yaml
+++ b/install/0000_80_machine-config-operator_05_osimageurl.yaml
@@ -11,8 +11,8 @@ data:
   releaseVersion: 0.0.1-snapshot
   # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
   # progresses towards the default.
-  baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8"
-  baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions"
+  baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos"
+  baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/image-references
+++ b/install/image-references
@@ -23,14 +23,14 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-os-content
-  - name: rhel-coreos-8
+  - name: rhel-coreos
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8
-  - name: rhel-coreos-8-extensions
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos
+  - name: rhel-coreos-extensions
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-8-extensions
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -84,4 +84,13 @@ const (
 
 	// changes to registries.conf will cause a crio reload and require extra logic about whether to drain
 	ContainerRegistryConfPath = "/etc/containers/registries.conf"
+
+	// SSH Keys for user "core" will only be written at /home/core/.ssh
+	CoreUserSSHPath = "/home/" + CoreUserName + "/.ssh"
+
+	// SSH keys in RHCOS 8 will be written to /home/core/.ssh/authorized_keys
+	RHCOS8SSHKeyPath = CoreUserSSHPath + "/authorized_keys"
+
+	// SSH keys in RHCOS 9 / FCOS / SCOS will be written to /home/core/.ssh/authorized_keys.d/ignition
+	RHCOS9SSHKeyPath = CoreUserSSHPath + "/authorized_keys.d/ignition"
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1500,6 +1500,71 @@ func removeIgnitionArtifacts() error {
 	return nil
 }
 
+// When we move from RHCOS 8 -> RHCOS 9, the SSH keys do not get written to the
+// new location before the node reboots into RHCOS 9 because:
+//
+// 1. When the upgrade configs are written to the node, it is still running
+// RHCOS 8, so the keys are not being written to the new location since the
+// location is inferred from the currently booted OS.
+// 2. The node reboots into RHCOS 9 to complete the upgrade.
+// 3. The "are we on the latest config" functions detect that we are indeed on
+// the latest config and so it does not attempt to perform an update.
+//
+// To work around that check on bootup if the we should use the new SSH key
+// path and if the old SSH key path exists, we know that we need to migrate tot
+// he new key path by calling dn.updateSSHKeyLocation().
+func (dn *Daemon) isSSHKeyLocationUpdateRequired() (bool, error) {
+	if !dn.useNewSSHKeyPath() {
+		// Return early because we're not using the new SSH key path.
+		return false, nil
+	}
+
+	oldKeyExists, err := fileExists(constants.RHCOS8SSHKeyPath)
+	if err != nil {
+		return false, err
+	}
+
+	newKeyExists, err := fileExists(constants.RHCOS9SSHKeyPath)
+	if err != nil {
+		return false, err
+	}
+
+	// If the old key exists and the new key does not, we need to update.
+	return oldKeyExists && !newKeyExists, nil
+}
+
+// Decode the Ignition config and perform the SSH key update.
+func (dn *Daemon) updateSSHKeyLocation(cfg *mcfgv1.MachineConfig) error {
+	glog.Infof("SSH key location update required. Moving SSH keys from %q to %q.", constants.RHCOS8SSHKeyPath, constants.RHCOS9SSHKeyPath)
+
+	ignConfig, err := ctrlcommon.ParseAndConvertConfig(cfg.Spec.Config.Raw)
+	if err != nil {
+		return fmt.Errorf("ignition failure when updating SSH key location: %w", err)
+	}
+
+	if err := dn.updateSSHKeys(ignConfig.Passwd.Users); err != nil {
+		return fmt.Errorf("could not write SSH keys to new location: %w", err)
+	}
+
+	return nil
+}
+
+// Determines if we need to update the SSH key location and performs the
+// necessary update if so.
+func (dn *Daemon) updateSSHKeyLocationIfNeeded(cfg *mcfgv1.MachineConfig) error {
+	sshKeyLocationUpdateRequired, err := dn.isSSHKeyLocationUpdateRequired()
+	if err != nil {
+		return fmt.Errorf("unable to determine if SSH key location update is required: %w", err)
+	}
+
+	if !sshKeyLocationUpdateRequired {
+		glog.Infof("SSH key location (%q) up-to-date!", constants.RHCOS9SSHKeyPath)
+		return nil
+	}
+
+	return dn.updateSSHKeyLocation(cfg)
+}
+
 // checkStateOnFirstRun is a core entrypoint for our state machine.
 // It determines whether we're in our desired state, or if we're
 // transitioning between states, and whether or not we need to update
@@ -1650,6 +1715,13 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	if forceFileExists() {
 		dn.logSystem("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 		return dn.triggerUpdateWithMachineConfig(state.currentConfig, state.desiredConfig)
+	}
+
+	// When upgrading the OS, it is possible that the SSH key location will
+	// change. We should detect whether that is the case and update before we
+	// check for any config drift.
+	if err := dn.updateSSHKeyLocationIfNeeded(expectedConfig); err != nil {
+		return err
 	}
 
 	if err := dn.validateOnDiskState(expectedConfig); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2177,8 +2177,10 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	}
 
 	// Switch to real time kernel
-	if err := dn.switchKernel(oldConfig, newConfig); err != nil {
-		return err
+	if mcDiff.osUpdate || mcDiff.kernelType {
+		if err := dn.switchKernel(oldConfig, newConfig); err != nil {
+			return err
+		}
 	}
 
 	// Apply extensions

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1167,7 +1167,7 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 	}
 
 	// TODO: Drop this code and use https://github.com/coreos/rpm-ostree/issues/2542 instead
-	defaultKernel := []string{"kernel", "kernel-core", "kernel-modules", "kernel-modules-extra"}
+	defaultKernel := []string{"kernel", "kernel-core", "kernel-modules", "kernel-modules-core", "kernel-modules-extra"}
 	// Note this list explicitly does *not* include kernel-rt as that is a meta-package that tries to pull in a lot
 	// of other dependencies we don't want for historical reasons.
 	// kernel-rt also has a split off kernel-rt-kvm subpackage because it's in a separate subscription in RHEL.

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2120,6 +2120,22 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		defer os.Remove(extensionsRepo)
 	}
 
+	defer func() {
+		// Operations performed by rpm-ostree on the booted system are available
+		// as staged deployment. It gets applied only when we reboot the system.
+		// In case of an error during any rpm-ostree transaction, removing pending deployment
+		// should be sufficient to discard any applied changes.
+		if retErr != nil {
+			// Print out the error now so that if we fail to cleanup -p, we don't lose it.
+			glog.Infof("Rolling back applied changes to OS due to error: %v", retErr)
+			if err := removePendingDeployment(); err != nil {
+				errs := kubeErrs.NewAggregate([]error{err, retErr})
+				retErr = fmt.Errorf("error removing staged deployment: %w", errs)
+				return
+			}
+		}
+	}()
+
 	// If we have an OS update *or* a kernel type change, then we must undo the RT kernel
 	// enablement.
 	if mcDiff.osUpdate || mcDiff.kernelType {
@@ -2147,22 +2163,6 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	// if we're here, we've successfully pivoted, or pivoting wasn't necessary, so we reset the error gauge
 	mcdPivotErr.Set(0)
-
-	defer func() {
-		// Operations performed by rpm-ostree on the booted system are available
-		// as staged deployment. It gets applied only when we reboot the system.
-		// In case of an error during any rpm-ostree transaction, removing pending deployment
-		// should be sufficient to discard any applied changes.
-		if retErr != nil {
-			// Print out the error now so that if we fail to cleanup -p, we don't lose it.
-			glog.Infof("Rolling back applied changes to OS due to error: %v", retErr)
-			if err := removePendingDeployment(); err != nil {
-				errs := kubeErrs.NewAggregate([]error{err, retErr})
-				retErr = fmt.Errorf("error removing staged deployment: %w", errs)
-				return
-			}
-		}
-	}()
 
 	if mcDiff.kargs {
 		if err := dn.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2249,8 +2249,10 @@ func (dn *CoreOSDaemon) applyLegacyOSChanges(mcDiff machineConfigDiff, oldConfig
 	}
 
 	// Switch to real time kernel
-	if err := dn.switchKernel(oldConfig, newConfig); err != nil {
-		return err
+	if mcDiff.osUpdate || mcDiff.kernelType {
+		if err := dn.switchKernel(oldConfig, newConfig); err != nil {
+			return err
+		}
 	}
 
 	// Apply extensions

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2120,6 +2120,12 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		defer os.Remove(extensionsRepo)
 	}
 
+	// Always clean up pending, because the RT kernel switch logic below operates on booted,
+	// not pending.
+	if err := removePendingDeployment(); err != nil {
+		return fmt.Errorf("failed to remove pending deployment: %w", err)
+	}
+
 	defer func() {
 		// Operations performed by rpm-ostree on the booted system are available
 		// as staged deployment. It gets applied only when we reboot the system.

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -493,6 +493,9 @@ func TestWriteFiles(t *testing.T) {
 	}
 }
 
+// This test provides a false sense of security. Given the combination of the
+// mock mode in the MCD coupled with the inputs into this test, it effectively
+// no-ops and does not test what we think it tests.
 func TestUpdateSSHKeys(t *testing.T) {
 	d := newMockDaemon()
 

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -174,6 +174,12 @@ contents:
             remove_stale
             add_rules
             echo "done applying vip rules"
+            # Arbitrary delay to avoid synchronizing too quickly on file changes; the VIP
+            # file could change multiple times quickly, but we don't need to react instantly
+            # to every change.  Most crucially we want to be sure we don't trip over the
+            # default systemd StartLimitBurst/StartLimitIterval settings which are 5 and 10s
+            # respectively.
+            sleep 3
             ;;
         cleanup)
             clear_rules

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -796,7 +796,9 @@ func TestIgn3Cfg(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", "/rootfs/home/core/.ssh/authorized_keys")
+	sshPaths := helpers.GetSSHPaths(helpers.GetOSReleaseForNode(t, cs, infraNode).OS)
+
+	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", filepath.Join("/rootfs", sshPaths.Expected))
 	if !strings.Contains(foundSSH, "1234_test_ign3") {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSH)
 	}

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -382,6 +383,28 @@ func TestNoReboot(t *testing.T) {
 	oldInfraRenderedConfig := helpers.GetMcName(t, cs, "infra")
 
 	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	sshKeyContent := "test adding authorized key without node reboot"
+
+	nodeOS := helpers.GetOSReleaseForNode(t, cs, infraNode).OS
+
+	sshPaths := helpers.GetSSHPaths(nodeOS)
+
+	t.Logf("Expecting SSH keys to be in %s", sshPaths.Expected)
+
+	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
+		// Write an SSH key to the old location on the node because the update process should remove this file.
+		t.Logf("Writing SSH key to %s to ensure that it will be removed later", sshPaths.NotExpected)
+		bashCmd := fmt.Sprintf("printf '%s' > %s", sshKeyContent, filepath.Join("/rootfs", sshPaths.NotExpected))
+		helpers.ExecCmdOnNode(t, cs, infraNode, "/bin/bash", "-c", bashCmd)
+	}
+
+	// Delete the expected SSH keys directory to ensure that the directories are
+	// (re)created correctly by the MCD. This targets the upgrade case where that
+	// directory may not previously exist. Note: This will need to be revisited
+	// once Config Drift Monitor is aware of SSH keys.
+	helpers.ExecCmdOnNode(t, cs, infraNode, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+
 	output := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
 	oldTime := strings.Split(output, " ")[0]
 	t.Logf("Node %s initial uptime: %s", infraNode.Name, oldTime)
@@ -390,17 +413,18 @@ func TestNoReboot(t *testing.T) {
 	// Adding authorized key for user core
 	testIgnConfig := ctrlcommon.NewIgnConfig()
 	testPasswdHash := "testpass"
-	testSSHKey := ign3types.PasswdUser{
-		Name:              "core",
-		SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{"test adding authorized key without node reboot"},
-		PasswordHash:      &testPasswdHash,
-	}
 
-	testIgnConfig.Passwd.Users = append(testIgnConfig.Passwd.Users, testSSHKey)
+	testIgnConfig.Passwd.Users = []ign3types.PasswdUser{
+		{
+			Name:              "core",
+			SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{ign3types.SSHAuthorizedKey(sshKeyContent)},
+			PasswordHash:      &testPasswdHash,
+		},
+	}
 
 	addAuthorizedKey := &mcfgv1.MachineConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("authorzied-key-infra-%s", uuid.NewUUID()),
+			Name:   fmt.Sprintf("authorized-key-infra-%s", uuid.NewUUID()),
 			Labels: helpers.MCLabelForRole("infra"),
 		},
 		Spec: mcfgv1.MachineConfigSpec{
@@ -426,8 +450,11 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/home/core/.ssh/authorized_keys")
-	if !strings.Contains(foundSSHKey, "test adding authorized key without node reboot") {
+	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
+	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
+
+	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	if !strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSHKey)
 	}
 	t.Logf("Node %s has SSH key", infraNode.Name)
@@ -437,9 +464,10 @@ func TestNoReboot(t *testing.T) {
 	if currentEtcShadowContents == initialEtcShadowContents {
 		t.Fatalf("updated password hash not found in etc/shadow, got %s", currentEtcShadowContents)
 	}
+
 	t.Logf("Node %s has Password Hash", infraNode.Name)
 
-	usernameAndGroup := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "stat", "--format=%U %G", "/home/core/.ssh/authorized_keys"), "\n"), " ")
+	usernameAndGroup := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "stat", "--format=%U %G", sshPaths.Expected), "\n"), " ")
 	assert.Equal(t, usernameAndGroup, []string{constants.CoreUserName, constants.CoreGroupName})
 
 	output = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
@@ -476,10 +504,13 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/home/core/.ssh/authorized_keys")
-	if strings.Contains(foundSSHKey, "test adding authorized key without node reboot") {
+	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	if strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("Node %s did not rollback successfully", infraNode.Name)
 	}
+
+	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
+	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
 
 	t.Logf("Node %s has successfully rolled back", infraNode.Name)
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -512,16 +513,16 @@ func execCmdOnNode(cs *framework.ClientSet, node corev1.Node, subArgs ...string)
 	return cmd, nil
 }
 
-// IsOKDCluster checks whether the Upstream field on the CV spec references OKD's update server
+// IsOKDCluster checks whether the Upstream field on the CV spec references an OKD release controller
 func IsOKDCluster(cs *framework.ClientSet) (bool, error) {
 	cv, err := cs.ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
-	if cv.Spec.Upstream == "https://origin-release.svc.ci.openshift.org/graph" {
-		return true, nil
-	}
-	return false, nil
+
+	// TODO: Adjust this as OKD becomes available for different platforms, e.g., arm64.
+	okdReleaseControllers := sets.NewString("https://amd64.origin.releases.ci.openshift.org/graph")
+	return okdReleaseControllers.Has(string(cv.Spec.Upstream)), nil
 }
 
 func MCLabelForRole(role string) map[string]string {

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -382,6 +382,28 @@ func CreateMCP(t *testing.T, cs *framework.ClientSet, mcpName string) func() {
 	}
 }
 
+type SSHPaths struct {
+	// The path where SSH keys are expected to be found.
+	Expected string
+	// The path where SSH keys are *not* expected to be found.
+	NotExpected string
+}
+
+// Determines where to expect SSH keys for the core user on a given node based upon the node's OS.
+func GetSSHPaths(os osrelease.OperatingSystem) SSHPaths {
+	if os.IsEL9() || os.IsSCOS() || os.IsFCOS() {
+		return SSHPaths{
+			Expected:    constants.RHCOS9SSHKeyPath,
+			NotExpected: constants.RHCOS8SSHKeyPath,
+		}
+	}
+
+	return SSHPaths{
+		Expected:    constants.RHCOS8SSHKeyPath,
+		NotExpected: constants.RHCOS9SSHKeyPath,
+	}
+}
+
 // MCPNameToRole converts a mcpName to a node role label
 func MCPNameToRole(mcpName string) string {
 	return fmt.Sprintf("node-role.kubernetes.io/%s", mcpName)
@@ -392,23 +414,87 @@ func CreateMC(name, role string) *mcfgv1.MachineConfig {
 	return NewMachineConfig(name, MCLabelForRole(role), "", nil)
 }
 
+// Asserts that a given file is present on the underlying node.
+func AssertFileOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
+	t.Helper()
+
+	path = canonicalizeNodeFilePath(path)
+
+	out, err := ExecCmdOnNodeWithError(cs, node, "stat", path)
+
+	return assert.NoError(t, err, "expected to find file %s on %s, got:\n%s\nError: %s", path, node.Name, out, err)
+}
+
+// Asserts that a given file is *not* present on the underlying node.
+func AssertFileNotOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
+	t.Helper()
+
+	path = canonicalizeNodeFilePath(path)
+
+	out, err := ExecCmdOnNodeWithError(cs, node, "stat", path)
+
+	return assert.Error(t, err, "expected not to find file %s on %s, got:\n%s", path, node.Name, out) &&
+		assert.Contains(t, out, "No such file or directory", "expected command output to contain 'No such file or directory', got: %s", out)
+}
+
+// Adds the /rootfs onto a given file path, if not already present.
+func canonicalizeNodeFilePath(path string) string {
+	rootfs := "/rootfs"
+
+	if !strings.HasPrefix(path, rootfs) {
+		return filepath.Join(rootfs, path)
+	}
+
+	return path
+}
+
 // ExecCmdOnNode finds a node's mcd, and oc rsh's into it to execute a command on the node
 // all commands should use /rootfs as root
 func ExecCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subArgs ...string) string {
+	t.Helper()
+
+	cmd, err := execCmdOnNode(cs, node, subArgs...)
+	require.Nil(t, err, "could not prepare to exec cmd %v on node %s: %s", subArgs, node.Name, err)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
+	return string(out)
+}
+
+// ExecCmdOnNodeWithError behaves like ExecCmdOnNode, with the exception that
+// any errors are returned to the caller for inspection. This allows one to
+// execute a command that is expected to fail; e.g., stat /nonexistant/file.
+func ExecCmdOnNodeWithError(cs *framework.ClientSet, node corev1.Node, subArgs ...string) (string, error) {
+	cmd, err := execCmdOnNode(cs, node, subArgs...)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// ExecCmdOnNode finds a node's mcd, and oc rsh's into it to execute a command on the node
+// all commands should use /rootfs as root
+func execCmdOnNode(cs *framework.ClientSet, node corev1.Node, subArgs ...string) (*exec.Cmd, error) {
 	// Check for an oc binary in $PATH.
 	path, err := exec.LookPath("oc")
 	if err != nil {
-		t.Fatalf("could not locate oc command: %s", err)
+		return nil, fmt.Errorf("could not locate oc command: %w", err)
 	}
 
 	// Get the kubeconfig file path
 	kubeconfig, err := cs.GetKubeconfig()
 	if err != nil {
-		t.Fatalf("could not get kubeconfig: %s", err)
+		return nil, fmt.Errorf("could not get kubeconfig: %w", err)
 	}
 
 	mcd, err := mcdForNode(cs, &node)
-	require.Nil(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("could not get MCD for node %s: %w", node.Name, err)
+	}
+
 	mcdName := mcd.ObjectMeta.Name
 
 	entryPoint := path
@@ -423,11 +509,7 @@ func ExecCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subA
 	// $KUBECONFIG, oc will be unaware of it. To remedy, we explicitly set
 	// KUBECONFIG to the value held by the clientset.
 	cmd.Env = append(cmd.Env, "KUBECONFIG="+kubeconfig)
-	cmd.Stderr = os.Stderr
-
-	out, err := cmd.Output()
-	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
-	return string(out)
+	return cmd, nil
 }
 
 // IsOKDCluster checks whether the Upstream field on the CV spec references OKD's update server


### PR DESCRIPTION
This rolls together the following PRs:

- https://github.com/openshift/machine-config-operator/pull/3603
- https://github.com/openshift/machine-config-operator/pull/3601
- https://github.com/openshift/machine-config-operator/pull/3602
- https://github.com/openshift/machine-config-operator/pull/3597

---
daemon: Clean up `switchKernel` a bit

De-duplicate calls to `canonicalizeKernelType` to make the
logic easier to read.  Also add a few comments.

(cherry picked from commit b75c7afdbc8c6551dbdd9480faf484623fd20ceb)

---

vendor: Bump coreos/rpm-ostree-client-go

In prep for usage in MCD.

(cherry picked from commit cae67a648f4ee4250eab06c7fd09454160e8582e)

---

daemon: Make switchKernel less stateful

This is prep for fixing RHEL9 upgrades while maintaining `kernel-rt`.

Previously the `switchKernel` logic tried to carefully handle
all 4 cases (default -> default, default -> rt, rt -> default, rt -> rt).

But, the last one (rt -> rt) was not quite right because
the previous `rpm-ostree rebase` command already preserved the previous
kernel.  In fact it was pretty expensive to do things this way
because we'd e.g. regenerate the initramfs *twice*.

To say this another way: when doing a RHEL9 update, it's actually
the first `rpm-ostree rebase` command which fails before we
even get to `switchKernel`.

And the reason is due to the introduction of a new `-core` subpackage;
xref https://issues.redhat.com/browse/OCPBUGS-8113

So here's the new logic to handle this:

- Before we do the `rebase` operation to the new OS, we detect
  any previous overrides of any packages starting with `kernel-rt`
  and we remove them.  Notably this avoids hardcoding any specific
  kernel subpackages; we just remove *everything* starting with
  `kernel-rt` which should be more robust to subpackage changes
  in the future.
- Consequently the `rebase` operation will hence start out by deploying the
  stock image i.e. with throughput kernel (though note we *are*
  carefully preserving other local overrides)
- The `switchKernel` function now longer needs to take the *previous*
  machineconfig state into account (except for logging).
  Instead, we just detect if the target is RT, and if so we then we
  apply the latest packages.

This significantly simplifies the logic in `switchKernel`, and will
help fix RHEL9 upgrades.

(cherry picked from commit 8ac5beeddc331dd0186844d4714500d17454621d)

---

Merge pull request #3595 from cgwalters/backport-switchkernel-4.13

OCPBUGS-8703: Backport switchkernel 4.13
---

ensures that RHCOS 9 SSH keys are in the right place

---

OKD release controller is out-of-date

---

ensures SSH keys get moved to the correct location

When we move from RHCOS 8 -> RHCOS 9, the SSH keys are not being written
to the new location because:

1. When the upgrade configs are written to the node, it is still running RHCOS 8, so the keys are not being written to the new location.
2. The node reboots into RHCOS 9 to complete the upgrade.
3. The "are we on the latest config" functions detect that we are indeed on the latest config and so it does not attempt to perform an update.

---

teaches TestIgn3Cfg about the new RHCOS 9 key path

---

checks perms for SSH key path dirs as well

---

Switch to rhel-coreos (9)

ref: https://issues.redhat.com/browse/COS-1983

We introduced a new `rhel-coreos` that is RHEL 9 to aid having a switch be
an atomic operation.  After design discussion we realized it's easier
to have an "unversioned" image though, so this drops the `-8`.

---

daemon: Also override `kernel-modules-core`

Unfortunately rpm-ostree requires this right now; we have an issue
and code to provide a better API in https://github.com/coreos/rpm-ostree/issues/2542
But using that will require shipping the updated rpm-ostree in RHEL 8.6.z
or at least OCP 4.12.z, which is problematic.

Because we know the new MCD will always be upgrading to RHEL9,
for now let's update this hardcoded list.  In the future we can
detect when the running host has `--remove-installed-kernel` and
use it instead.

---

openshift-azure-routes: Avoid synchronizing too quickly

Rapid file changes triggering the path unit can start the
service here frequently, and then this can cause the start
limit to be hit, and then systemd will refuse further
activations (unless we bumped the limit).

I don't think we need to synchronize the iptables
rules more than once every 3 seconds.

---

daemon: Move cleanup of pending deployment earlier

We hit a confusing failure in https://issues.redhat.com/browse/OCPBUGS-8113
where the MCD will get stuck if deploying the RT kernel fails, because
the switch to the RT kernel operates from the *booted* deployment
state, but by default rpm-ostree wants to operate from pending.

Move up the "cleanup pending deployment on failure" `defer` to
right before we do anything else.

---

daemon: Always remove pending deployment before we do updates

The RT kernel switch logic operates from the *booted* deployment,
not pending.  I had in my head that the MCO always cleaned up
pending, but due to another bug we didn't.

There's no reason to leave this cleanup to a defer; do it
before we do anything else.

(But keep the defer because it's cleaner to *also* cleanup if
 we fail)

---

daemon: Only switchkernel if we are doing an OS update or kernel change

This fixes a regression with the previous commit
https://github.com/openshift/machine-config-operator/pull/3580/commits/8ac5beeddc331dd0186844d4714500d17454621d
where we would simply fail to roll out on RT node systems any further MachineConfig
changes.

---

Dockerfile: Fix removing extensions for fcos/scos

Last minute change in #3496 resulted in the number being removed from
the end of the `rhel-coros-8/9` image, it is now just simply in there as
`rhel-coreos`, and as a result the regex that was scraping out the
extensions images (because fcos/scos dont' ship them) no longer works.

This adjusts the sed command in the Dockerfile so it matches again now
that the number is missing, and the extensions are properly removed.

(cherry picked from commit cb2958d4c94da534c4d9e24db96a579b67e9d290)

---

