### PR TITLE
[release-4.12] OCPBUGS-9993: Revert "daemon: Temporarily copy auth file with more open perms on FCOS"

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -367,26 +367,9 @@ func useKubeletConfigSecrets() error {
 				return err
 			}
 
-			runningos, err := GetHostRunningOS()
+			err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
 			if err != nil {
 				return err
-			}
-
-			// Short term workaround for https://issues.redhat.com/browse/OKD-63
-			if runningos.IsFCOS() || runningos.IsSCOS() {
-				contents, err := os.ReadFile(kubeletAuthFile)
-				if err != nil {
-					return err
-				}
-				// Note 0644 perms for now
-				if err := os.WriteFile("/run/ostree/auth.json", contents, 0o644); err != nil {
-					return err
-				}
-			} else {
-				err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
-				if err != nil {
-					return err
-				}
 			}
 		}
 	}


### PR DESCRIPTION
This reverts commit 6ccdd574fad38fc7bc2de1e1913c9ade69ba6e55. Cherry-pick of #3594 on release-4.12 branch

**- What I did**
Reverted one of commits introduced in https://github.com/openshift/machine-config-operator/pull/3358 to fix OKD-63. This workaround however breaks Assisted Installer flow, which runs mcd start on Live ISO where /var/lib/kubelet/config.json is not yet created.

**- How to verify it**
Install OKD FCOS/SCOS

**- Description for the changelog**
