### PR TITLE
OCPBUGS-10598: Splitting NetworkManager-onprem.conf.yaml to 2 files:

### DIFF
--- a/templates/common/_base/files/NetworkManager-ipv6.conf.yaml
+++ b/templates/common/_base/files/NetworkManager-ipv6.conf.yaml
@@ -1,0 +1,7 @@
+mode: 0644
+path: "/etc/NetworkManager/conf.d/01-ipv6.conf"
+contents:
+  inline: |
+    [connection]
+    ipv6.dhcp-duid=ll
+    ipv6.dhcp-iaid=mac

--- a/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
+++ b/templates/common/on-prem/files/NetworkManager-onprem.conf.yaml
@@ -5,7 +5,4 @@ contents:
     {{ if gt (len (onPremPlatformAPIServerInternalIPs .)) 0 -}}
     [main]
     rc-manager=unmanaged
-    [connection]
-    ipv6.dhcp-duid=ll
-    ipv6.dhcp-iaid=mac
     {{ end -}}


### PR DESCRIPTION
1. NetworkManager-onprem.conf.yaml will set unmanaged field as before and will do it only for onprem platforms as before
2. NetworkManager-ipv6.conf.yaml will set ipv6 flags for all platforms

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
