### PR TITLE
OCPBUGS-10379: configure-ovs: support UUID in vlan.parent

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -226,6 +226,13 @@ contents:
           echo "ERROR: unable to determine vlan_parent for vlan connection: ${old_conn}"
           exit 1
         fi
+
+        if nmcli connection show "$vlan_parent" &> /dev/null; then
+          # if the VLAN connection is configured with a connection UUID as parent, we need to find the underlying device
+          # and create the bridge against it, as the parent connection can be replaced by another bridge.
+          vlan_parent=$(nmcli --get-values GENERAL.DEVICES conn show ${vlan_parent})
+        fi
+
         extra_phys_args=( dev "${vlan_parent}" id "${vlan_id}" )
       elif [ "$(nmcli --get-values connection.type conn show ${old_conn})" == "bond" ]; then
         iface_type=bond


### PR DESCRIPTION
In configuring VLANs, Network Manager setting `vlan.parent` can contain (a) the device which the virtual LAN is using or (b) a connection that holds the device.

In case of (b), if br-ex1 is built on top of a VLAN of the br-ex related connection (C), when br-ex1 connection is activated the target connection C is not active and a `Failed to find a compatible device for this connection` error is raised.

To solve this problem, the ovs-if-physX VLAN must be configured with the underlying device of C.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support secondary bridge VLAN based on primary bridge connection.
