### PR TITLE
configure-ovs: would not retry on some errors

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -3,7 +3,7 @@ path: "/usr/local/bin/configure-ovs.sh"
 contents:
   inline: |
     #!/bin/bash
-    set -eux
+    set -x
 
     # This file is not needed anymore in 4.7+, but when rolling back to 4.6
     # the ovs pod needs it to know ovs is running on the host.
@@ -784,6 +784,7 @@ contents:
 
     # main function
     configure_ovs() {
+      set -eu
       trap "handle_exit" EXIT
 
       # this flag tracks if any config change was made
@@ -950,9 +951,9 @@ contents:
     # infrastructure problems.
     RETRY="${RETRY-15m}"
     while true; do
-      e=0
       # Run configure_ovs in a sub-shell
-      ( configure_ovs "$@" ) || e=$?
+      ( configure_ovs "$@" )
+      e=$?
       [ "$e" -eq 0 ] || [ -z "$RETRY" ] && exit "$e"
       echo "configure_ovs failed, will retry after $RETRY"
       # flag that a retry has happened


### PR DESCRIPTION
configure-ovs would not retry if it exited due to a failed command.

From https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html:

If a compound command or shell function executes in a context where -e is being ignored, none of the commands executed within the compound command or function body will be affected by the -e setting, even if -e is set and a command returns a failure status.

So when we used `( configure_ovs "$@" ) || e=$?`, -e was being ignored within configure_ovs because it was followed by `|| ...`.

So just set -e within configure_ovs. Anything done outside should be simple enough that it should not really matter much.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
