### PR TITLE
OCPBUGS-10414: Fix regex dot in coredns config file

### DIFF
--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -12,12 +12,12 @@ contents:
         cache 30
         reload
         template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match .*.apps.{{ .DNS.Spec.BaseDomain }}
+            match .*[.]apps.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (onPremPlatformIngressIPs .)) 0 }}{{ index (onPremPlatformIngressIPs .) 0 }}{{ end }}"
             fallthrough
         }
         template IN {{`{{ .Cluster.IngressVIPEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
-            match .*.apps.{{ .DNS.Spec.BaseDomain }}
+            match .*[.]apps.{{ .DNS.Spec.BaseDomain }}
             {{ if gt (len (onPremPlatformIngressIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (onPremPlatformIngressIPs .) 1 }}"{{ end }}
             fallthrough
         }


### PR DESCRIPTION
We are fixing an incorrect use of the dot in the coredns configuration file. Currently we are using simply a dot character (`.`) whereas we should be using a regex dot (`[.]`). With this change our coredns configuration is going to match only entries of a form `*.apps` and not `*apps`.

Closes: OCPBUGS-10414