### PR TITLE
getPoolsForNode: Use constant MachineConfigPoolWorker instead of "worker" string

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -603,7 +603,7 @@ func (ctrl *Controller) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.MachineCon
 	for _, pool := range pools {
 		if pool.Name == ctrlcommon.MachineConfigPoolMaster {
 			master = pool
-		} else if pool.Name == "worker" {
+		} else if pool.Name == ctrlcommon.MachineConfigPoolWorker {
 			worker = pool
 		} else {
 			custom = append(custom, pool)


### PR DESCRIPTION
In getPoolsForNode, pool.Name == "worker" should use the constant, the same as for master.