### PR TITLE
OCPBUGS-11162:Do not trigger openshift-azure-routes/openshift-alibaba-routes service based on file existence

### DIFF
--- a/templates/master/00-master/alibabacloud/files/opt-libexec-openshift-alibabacloud-routes-sh.yaml
+++ b/templates/master/00-master/alibabacloud/files/opt-libexec-openshift-alibabacloud-routes-sh.yaml
@@ -14,6 +14,11 @@ contents:
     # We check /run/cloud-routes/ for files $VIP.up and $VIP.down. If the .up file
     # exists, then we redirect traffic destined for that vip to ourselves via iptables.
     # A systemd unit watches the directory for changes.
+    #
+    # TODO: Address the potential issue where apiserver-watcher could create multiple files
+    # and openshift-alibabacloud-routes doesn't detect all of them because file change events
+    # are not queued when the service is already running.
+    # https://github.com/openshift/machine-config-operator/pull/3643#issuecomment-1497234369
 
     set -euo pipefail
 

--- a/templates/master/00-master/alibabacloud/files/opt-libexec-openshift-alibabacloud-routes-sh.yaml
+++ b/templates/master/00-master/alibabacloud/files/opt-libexec-openshift-alibabacloud-routes-sh.yaml
@@ -30,6 +30,7 @@ contents:
         local chain="${2}"
 
         if ! iptables -w -t "${table}" -S "${chain}" &> /dev/null ; then
+            echo "creating ${chain} chain in ${table} table"
             iptables -w -t "${table}" -N "${chain}";
         fi;
     }
@@ -43,6 +44,7 @@ contents:
         local chain="${2}"
 
         if ! ip6tables -w -t "${table}" -S "${chain}" &> /dev/null ; then
+            echo "creating ${chain} chain in ${table} table"
             ip6tables -w -t "${table}" -N "${chain}";
         fi;
     }
@@ -54,6 +56,7 @@ contents:
         shift 2
 
         if ! iptables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
+            echo "adding \"$@\" to ${chain} chain in ${table} table"
             iptables -w -t "${table}" -A "${chain}" "$@"
         fi
     }
@@ -68,6 +71,7 @@ contents:
         shift 2
 
         if ! ip6tables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
+            echo "adding \"$@\" to ${chain} chain in ${table} table"
             ip6tables -w -t "${table}" -A "${chain}" "$@"
         fi
     }
@@ -130,6 +134,7 @@ contents:
     }
 
     clear_rules() {
+        echo "clearing rules from ${CHAIN_NAME} chain in nat table"
         iptables -t nat -F "${CHAIN_NAME}" || true
     }
 

--- a/templates/master/00-master/alibabacloud/units/openshift-alibabacloud-routes.path.yaml
+++ b/templates/master/00-master/alibabacloud/units/openshift-alibabacloud-routes.path.yaml
@@ -7,7 +7,6 @@ contents: |
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
 
   [Path]
-  PathExistsGlob=/run/cloud-routes/*
   PathChanged=/run/cloud-routes/
   MakeDirectory=true
 

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -20,6 +20,11 @@ contents:
     # We check /run/cloud-routes/ for files $VIP.up and $VIP.down. If the .up file
     # exists, then we redirect traffic destined for that vip to ourselves via iptables.
     # A systemd unit watches the directory for changes.
+    #
+    # TODO: Address the potential issue where apiserver-watcher could create multiple files
+    # and openshift-azure-routes doesn't detect all of them because file change events are not queued
+    # when the service is already running.
+    # https://github.com/openshift/machine-config-operator/pull/3643#issuecomment-1497234369
 
     set -euo pipefail
 
@@ -179,12 +184,6 @@ contents:
             remove_stale
             add_rules
             echo "done applying vip rules"
-            # Arbitrary delay to avoid synchronizing too quickly on file changes; the VIP
-            # file could change multiple times quickly, but we don't need to react instantly
-            # to every change.  Most crucially we want to be sure we don't trip over the
-            # default systemd StartLimitBurst/StartLimitIterval settings which are 5 and 10s
-            # respectively.
-            sleep 3
             ;;
         cleanup)
             clear_rules

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -36,6 +36,7 @@ contents:
         local chain="${2}"
 
         if ! iptables -w -t "${table}" -S "${chain}" &> /dev/null ; then
+            echo "creating ${chain} chain in ${table} table"
             iptables -w -t "${table}" -N "${chain}";
         fi;
     }
@@ -49,6 +50,7 @@ contents:
         local chain="${2}"
 
         if ! ip6tables -w -t "${table}" -S "${chain}" &> /dev/null ; then
+            echo "creating ${chain} chain in ${table} table"
             ip6tables -w -t "${table}" -N "${chain}";
         fi;
     }
@@ -60,6 +62,7 @@ contents:
         shift 2
 
         if ! iptables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
+            echo "adding \"$@\" to ${chain} chain in ${table} table"
             iptables -w -t "${table}" -A "${chain}" "$@"
         fi
     }
@@ -74,6 +77,7 @@ contents:
         shift 2
 
         if ! ip6tables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
+            echo "adding \"$@\" to ${chain} chain in ${table} table"
             ip6tables -w -t "${table}" -A "${chain}" "$@"
         fi
     }
@@ -136,6 +140,7 @@ contents:
     }
 
     clear_rules() {
+        echo "clearing rules from ${CHAIN_NAME} chain in nat table"
         iptables -t nat -F "${CHAIN_NAME}" || true
     }
 

--- a/templates/master/00-master/azure/units/openshift-azure-routes.path.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes.path.yaml
@@ -7,7 +7,6 @@ contents: |
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
 
   [Path]
-  PathExistsGlob=/run/cloud-routes/*
   PathChanged=/run/cloud-routes/
   MakeDirectory=true
 


### PR DESCRIPTION
There was a [change](https://github.com/systemd/systemd/commit/708961c7011b7578d3e6e10ca463d15edb62b5c1) in systemd that re-checks the files watched with PathExistsGlob once the service finishes:

> With this commit, systemd rechecks all paths specs whenever the triggered unit deactivates. If any PathExists=, PathExistsGlob= or DirectoryNotEmpty= predicate passes, the triggered unit is reactivated

This means that openshift-azure-routes will get triggered all the time as long there are files in /run/cloud-routes.

Removed the PathExistsGlob, openshift-azure-routes.service will get
triggered with PathChanged=/run/cloud-routes every time apiserver-watcher
writes to a file in that directory.
Additionally improved logging to always log operations that change the iptables.

Second commit reverts https://github.com/openshift/machine-config-operator/commit/b7a5887775d60d5351444546dbd9354904ce4d35
openshift-azure-routes should not be stalled since this can cause it to miss file events.
After apiserver-watcher marks a VIP as down it can mark it as up again in the next two seconds,
the script should be triggered straight away.