### PR TITLE
OCPBUGS-11652: kubelet: add enableSystemLogQuery

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -15,6 +15,7 @@ contents:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
     containerLogMaxSize: 50Mi
+    enableSystemLogQuery: true
     maxPods: 250
     kubeAPIQPS: 50
     kubeAPIBurst: 100

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -15,6 +15,7 @@ contents:
       - {{.ClusterDNSIP}}
     clusterDomain: cluster.local
     containerLogMaxSize: 50Mi
+    enableSystemLogQuery: true
     maxPods: 250
     kubeAPIQPS: 50
     kubeAPIBurst: 100


### PR DESCRIPTION
Now that the `oc adm node-logs` feature has been upstreamed, enable the kubelet config flag introduced in 1.27 to allow the feature to work downstream.
