### PR TITLE
OCPBUGS-10787: Persist static IP addressed NIC names from rhel8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
     # rewrite image names for fcos/scos
     if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,5 +1,6 @@
 # THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 # FIXME once we can depend on a new enough host that supports globs for COPY,
@@ -7,10 +8,20 @@ COPY . .
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
 FROM registry.ci.openshift.org/ocp/4.13:base
+ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
-RUN if ! rpm -q util-linux; then yum install -y util-linux && yum clean all && rm -rf /var/cache/yum/*; fi
+
+RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
+    # comment out non-base/extensions image-references entirely for fcos/scos
+    sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
+    # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
+    sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
+    # rewrite image names for fcos/scos
+    if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
+    elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -62,6 +62,11 @@ func (os OperatingSystem) IsEL() bool {
 	return os.id == rhcos || os.id == scos
 }
 
+// IsEL8 is true if the OS is RHCOS 8 or SCOS 8
+func (os OperatingSystem) IsEL8() bool {
+	return os.IsEL() && strings.HasPrefix(os.version, "8.") || os.version == "8"
+}
+
 // IsEL9 is true if the OS is RHCOS 9 or SCOS 9
 func (os OperatingSystem) IsEL9() bool {
 	return os.IsEL() && strings.HasPrefix(os.version, "9.") || os.version == "9"
@@ -103,6 +108,13 @@ func (os OperatingSystem) ToPrometheusLabel() string {
 // GetHostRunningOS reads os-release to generate the OperatingSystem data.
 func GetHostRunningOS() (OperatingSystem, error) {
 	return newOperatingSystem(EtcOSReleasePath, LibOSReleasePath)
+}
+
+// GetHostRunningOSFromRoot reads the os-release data from an alternative root
+func GetHostRunningOSFromRoot(root string) (OperatingSystem, error) {
+	etcPath := filepath.Join(root, EtcOSReleasePath)
+	libPath := filepath.Join(root, LibOSReleasePath)
+	return newOperatingSystem(etcPath, libPath)
 }
 
 // Generates the OperatingSystem data from strings which contain the desired

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -15,6 +15,10 @@ contents: |
   RemainAfterExit=yes
   # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
+  # Run this via podman because we want to use the nmstatectl binary in our container
+  ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --maybe-persist-nics
+  # This one was copied out to the host...but actually I'm not sure why we didn't
+  # run it via podman to start
   ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env


### PR DESCRIPTION
When upgrading rhel8 -> rhel9, some NIC names may change; e.g. the `mlx5` driver started emitting port information.

This breaks static IP addressing which references those interfaces.

We're going to land code in nmstate to address this; see https://github.com/nmstate/nmstate/pull/2301

- For a few reasons; one is that this isn't an OCP specific problem
- nmstate is in Rust
- nmstate already parses network interface information
- Adding more glue into the MCO is undesirable

However...to solve the bootstrap problem here in that we don't have this nmstate code on 4.12, add it to the MCD binary.

---

TESTING FLOW:

The true verification for this PR is:

- Install a 4.12 (RHEL 8) cluster on a machine that uses e.g. `mlx5` for ethernet with a _static IP address_
- Upgrade to a release image which contains this PR.

