### PR TITLE
OCPBUGS-5356: changed error handling so no runtime error

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -173,7 +173,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	// Use kubelet kubeconfig file to get the URL to kube-api-server
 	kubeconfig, err := clientcmd.LoadFromFile("/etc/kubernetes/kubeconfig")
 	if err != nil {
-		glog.Errorf("failed to load kubelet kubeconfig: %v", err)
+		glog.Fatalf("failed to load kubelet kubeconfig: %v", err)
 	}
 	clusterName := kubeconfig.Contexts[kubeconfig.CurrentContext].Cluster
 	apiURL := kubeconfig.Clusters[clusterName].Server


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Changed error handling so that runtime is not interrupted if kubeconfig gets moved or renamed

**- How to verify it**
1. Remove / change the name of the file "/etc/kubernetes/kubeconfig"
2. Delete machine-config-daemon pod
3. inspect logs to see that there is no runtime error

**- Description for the changelog**
<!--
changed error handling from `Errorf` to `Fatalf` to stop runtime if kubeconfig gets moved or renamed
-->
