### PR TITLE
OCPBUGS-4122: Do not add deep nested scope to atomic transport

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -462,8 +462,16 @@ func updatePolicyJSON(data []byte, internalBlocked, internalAllowed []string, re
 		}
 	}
 
-	policyObj.Transports["atomic"] = transportScopes
 	policyObj.Transports["docker"] = transportScopes
+	// The “atomic” policy is the same as the “docker” policy, but “atomic” does not support three or more
+	// scope segments, so filter those scopes out.
+	policyObj.Transports["atomic"] = make(signature.PolicyTransportScopes)
+	for reg, config := range transportScopes {
+		if strings.Count(reg, "/") >= 3 {
+			continue
+		}
+		policyObj.Transports["atomic"][reg] = config
+	}
 
 	policyJSON, err := json.Marshal(policyObj)
 	if err != nil {


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
If the registry from image CR has three or more segments, do not add it to atomic transport.
fix: https://issues.redhat.com/browse/OCPBUGS-4122
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
