### PR TITLE
OCPBUGS-11092: daemon: write certificate in OnceFrom and HyperShift

### DIFF
--- a/pkg/daemon/config_drift_monitor_test.go
+++ b/pkg/daemon/config_drift_monitor_test.go
@@ -492,7 +492,7 @@ func (tc *configDriftMonitorTestCase) writeIgnitionConfig(t *testing.T, ignConfi
 	// Write files the same way the MCD does.
 	// NOTE: We manually handle the errors here because using require.Nil or
 	// require.NoError will skip the deferred functions, which is undesirable.
-	if err := writeFiles(ignConfig.Storage.Files); err != nil {
+	if err := writeFiles(ignConfig.Storage.Files, true); err != nil {
 		return fmt.Errorf("could not write ignition config files: %w", err)
 	}
 

--- a/pkg/daemon/file_writers.go
+++ b/pkg/daemon/file_writers.go
@@ -153,9 +153,9 @@ func writeDropins(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) er
 
 // writeFiles writes the given files to disk.
 // it doesn't fetch remote files and expects a flattened config file.
-func writeFiles(files []ign3types.File) error {
+func writeFiles(files []ign3types.File, skipCertificateWrite bool) error {
 	for _, file := range files {
-		if file.Path == caBundleFilePath {
+		if skipCertificateWrite && file.Path == caBundleFilePath {
 			// TODO remove this special case once we have a better way to do this
 			glog.V(4).Infof("Skipping file %s during writeFiles", caBundleFilePath)
 			continue

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -481,7 +481,7 @@ func TestWriteFiles(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := d.writeFiles(test.files)
+			err := d.writeFiles(test.files, true)
 			assert.Equal(t, test.expectedErr, err)
 			if test.expectedContents != nil {
 				fileContents, err := os.ReadFile(filePath)


### PR DESCRIPTION
We introduced the functionality for the daemon to always sync the kubelet CA cert contents, but this broke RHEL8 installs since those machines use a special daemon OnceFrom mode to write all the file content, and it wasn't getting the CA cert bundle anymore.

Add the ability to specify which type of update should or should not skip the certificate write, so RHEL8 and HyperShift are still functional under the new workflow.

