### PR TITLE
OCPBUGS-4877: End the operator's "unknown field" logspam by marking controllerconfig embedded fields as embedded so they validate

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -159,6 +159,7 @@ spec:
                 required:
                 - spec
                 type: object
+                x-kubernetes-embedded-resource: true
               etcdDiscoveryDomain:
                 description: etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain
                   instead
@@ -1632,6 +1633,7 @@ spec:
                 required:
                 - spec
                 type: object
+                x-kubernetes-embedded-resource: true
               ipFamilies:
                 description: ipFamilies indicates the IP families in use by the cluster
                   network
@@ -1713,6 +1715,7 @@ spec:
                       CIDRs for which the proxy should not be used.
                     type: string
                 type: object
+                x-kubernetes-embedded-resource: true
               pullSecret:
                 description: pullSecret is the default pull secret that needs to be
                   installed on all machines.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -85,14 +85,17 @@ type ControllerConfigSpec struct {
 	ReleaseImage string `json:"releaseImage"`
 
 	// proxy holds the current proxy configuration for the nodes
+	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	Proxy *configv1.ProxyStatus `json:"proxy"`
 
 	// infra holds the infrastructure details
+	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	Infra *configv1.Infrastructure `json:"infra"`
 
 	// dns holds the cluster dns details
+	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	DNS *configv1.DNS `json:"dns"`
 


### PR DESCRIPTION
I think `ServerSideFieldValidation` got turned on by default around kube 1.25/ OpenShift 4.12, which means we get additional schema validation now, and that validation apparently doesn't care for the metadata of the other CRD objects we embed in `ControllerConfig` (proxy,infra,dns) . The metadata fields are "special", and those embedded types aren't currently marked as embedded, so they aren't expected by default to have metadata. 

```
2022-12-13T23:11:51.511167249Z W1213 23:11:51.511120       1 warnings.go:70] unknown field "spec.dns.metadata.creationTimestamp"
2022-12-13T23:11:51.511167249Z W1213 23:11:51.511140       1 warnings.go:70] unknown field "spec.dns.metadata.generation"
2022-12-13T23:11:51.511167249Z W1213 23:11:51.511143       1 warnings.go:70] unknown field "spec.dns.metadata.managedFields"
2022-12-13T23:11:51.511167249Z W1213 23:11:51.511146       1 warnings.go:70] unknown field "spec.dns.metadata.name"
```


<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- Added the `x-kubernetes-embedded-resource: true` [annotation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#rawextension) to our CRD for embedded types (proxy,infra,dns) so the api knows they are embedded resources and will validate their metadata. (This shouldn't have any other side-effects, my understanding is this setting is precisely for this scenario and means "this is another CRD type we've embedded here, it has metadata, just validate it plzkthx")  

- Added a matching kubebuilder annotation `	// +kubebuilder:validation:EmbeddedResource
`  in `types.go` which will ensure the annotation persists if/when someone regenerates our CRD

**- How to verify it**

Build a cluster, observe that "unknown field" messages e.g. `unknown field "spec.infra.metadata.name"` no longer occur for the `machine-config-controller`, something like: 
```
oc logs -f machine-config-controller-676b655cb4-g6xz8 | grep -i unknown
```
**- Description for the changelog**

ControllerConfig updates no longer cause `machine-config-operator` to emit validation warnings for embedded (dns/infra/proxy) types
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixes: [OCPBUGS-4877](https://issues.redhat.com/browse/OCPBUGS-4877)