### PR TITLE
[release-4.11] OCPBUGS-11556: Prevent possible split-brain scenario with keepalived unicast

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -56,6 +56,16 @@ contents:
 
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
 
+    {{`{{$participateInAPIVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .LBConfig.Backends}}
+    {{- if eq $nonVirtualIP .Address}}
+    {{$participateInAPIVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInAPIVRPP}}`}}
     vrrp_instance {{`{{ .Cluster.Name }}`}}_API {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -84,7 +94,18 @@ contents:
             chk_ocp_both
         }
     }
+    {{`{{end}}`}}
 
+    {{`{{$participateInIngressVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .IngressConfig.Peers}}
+    {{- if eq $nonVirtualIP .}}
+    {{$participateInIngressVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInIngressVRPP}}`}}
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -113,3 +134,4 @@ contents:
             chk_default_ingress
         }
     }
+    {{`{{ end }}`}}

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -29,6 +29,16 @@ contents:
 
     {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
 
+    {{`{{$participateInIngressVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .IngressConfig.Peers}}
+    {{- if eq $nonVirtualIP .}}
+    {{$participateInIngressVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInIngressVRPP}}`}}
     vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS {
         state BACKUP
         interface {{`{{ .VRRPInterface }}`}}
@@ -57,3 +67,4 @@ contents:
             chk_default_ingress
         }
     }
+    {{`{{ end }}`}}


### PR DESCRIPTION
This is a cherry-pick of #3562. It did not backport cleanly due to the dual stack VIP changes between 4.11 and 4.12.

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
