### PR TITLE
Accomodate ART limitation in parsing [[]] bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroo
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
 
-RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
+RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \
     # comment out non-base/extensions image-references entirely for fcos/scos
     sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
     # rewrite image names for fcos/scos
-    if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
-    elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
+    if [ "${TAGS}" = "fcos" ]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
+    elif [ "${TAGS}" = "scos" ]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
     if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -13,14 +13,14 @@ COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroo
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
 COPY install /manifests
 
-RUN if [[ "${TAGS}" == "fcos" ]] || [[ "${TAGS}" == "scos" ]]; then \
+RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \
     # comment out non-base/extensions image-references entirely for fcos/scos
     sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
     # rewrite image names for fcos/scos
-    if [[ "${TAGS}" == "fcos" ]]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
-    elif [[ "${TAGS}" == "scos" ]]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
+    if [ "${TAGS}" = "fcos" ]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
+    elif [ "${TAGS}" = "scos" ]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
     if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]


### PR DESCRIPTION
The downstream build pipeline parses bash in Dockerfile `RUN` commands in order to smooth over yum/dnf invocations that break downstream builds. For example, upstream Dockerfiles may use `--disablerepo`  /  `--enablerepo` / `microdnf` -- none of which will work as intended in brew/koji builds. 
The intent of this feature is to allow, to a reasonable extent, teams to use the same Dockerfile for upstream and downstream -- preventing the overhead of managing two nearly identical files.
When processing changes introduced by https://github.com/openshift/machine-config-operator/commit/c1f5e353969a8b4db33b9f4867be3b9fd37b2e5d , a limitation in the bashlex parser has been discovered where it cannot handle the (admittedly commonplace / proper) `[[ .. ]]` test syntax. 
Many OCP repos rely on this parsing feature, so the simplest course of action is to use the supported `[ .. ]` syntax in the MCO Dockerfile.
