### PR TITLE
OCPBUGS-19992: Add v6-primary dual stack support to VSphere UPI

### DIFF
--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -37,7 +37,7 @@ contents: |
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set \
-    {{if eq .IPFamilies "IPv6" -}}
+    {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
     --prefer-ipv6 \
     {{end -}}
     --retry-on-failure \


### PR DESCRIPTION
Because this unit merged after the v6-primary PR it is missing the logic to allow node ip selection work in v6-primary envs. I don't believe v6-primary dual stack is supported on this platform yet anyway, but it likely will be soon and we don't want to let these unit files diverge anyway.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Make sure nodeip-configuration on VSphere UPI clusters supports v6-primary dual stack.