### PR TITLE
Copy azure-routes throttling to alibaba-routes too.

### DIFF
--- a/templates/master/00-master/alibabacloud/files/opt-libexec-openshift-alibabacloud-routes-sh.yaml
+++ b/templates/master/00-master/alibabacloud/files/opt-libexec-openshift-alibabacloud-routes-sh.yaml
@@ -168,6 +168,12 @@ contents:
             remove_stale
             add_rules
             echo "done applying vip rules"
+            # Arbitrary delay to avoid synchronizing too quickly on file changes; the VIP
+            # file could change multiple times quickly, but we don't need to react instantly
+            # to every change.  Most crucially we want to be sure we don't trip over the
+            # default systemd StartLimitBurst/StartLimitInterval settings which are 5 and 10s
+            # respectively.
+            sleep 3
             ;;
         cleanup)
             clear_rules

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -177,7 +177,7 @@ contents:
             # Arbitrary delay to avoid synchronizing too quickly on file changes; the VIP
             # file could change multiple times quickly, but we don't need to react instantly
             # to every change.  Most crucially we want to be sure we don't trip over the
-            # default systemd StartLimitBurst/StartLimitIterval settings which are 5 and 10s
+            # default systemd StartLimitBurst/StartLimitInterval settings which are 5 and 10s
             # respectively.
             sleep 3
             ;;


### PR DESCRIPTION
https://github.com/openshift/machine-config-operator/pull/3596/commits/b7a5887775d60d5351444546dbd9354904ce4d35 added throttling to openshift-azure-routes but did not make the same change to the basically-identical openshift-alibaba-routes, which presumably also needs it.

(Should we try to merge these into a single script? I'm not good enough with ignition-ese to be able to figure out how to install something on azure and alibaba but nowhere else. Or I guess we could install the script everywhere but only install the systemd files that reference it on azure and alibaba? FWIW I have some further PRs coming to synchronize gcp-routes with azure/alibaba-routes a bit more, but it's still fairly different and couldn't be merged with the other two unless we just had some big gcp-only sections.)

/cc @cgwalters 