### PR TITLE
Don't run azure-routes/alibaba-routes at startup

### DIFF
--- a/templates/master/00-master/alibabacloud/units/openshift-alibabacloud-routes.path.yaml
+++ b/templates/master/00-master/alibabacloud/units/openshift-alibabacloud-routes.path.yaml
@@ -3,13 +3,9 @@ enabled: true
 contents: |
   [Unit]
   Description=Watch for downfile changes
-  Before=kubelet.service
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
 
   [Path]
   PathExistsGlob=/run/cloud-routes/*
   PathChanged=/run/cloud-routes/
   MakeDirectory=true
-
-  [Install]
-  RequiredBy=kubelet.service

--- a/templates/master/00-master/azure/units/openshift-azure-routes.path.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes.path.yaml
@@ -3,13 +3,9 @@ enabled: true
 contents: |
   [Unit]
   Description=Watch for downfile changes
-  Before=kubelet.service
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
 
   [Path]
   PathExistsGlob=/run/cloud-routes/*
   PathChanged=/run/cloud-routes/
   MakeDirectory=true
-
-  [Install]
-  RequiredBy=kubelet.service


### PR DESCRIPTION
We were running azure-routes/alibaba-routes at startup before kubelet started, presumably with the idea being "kubelet needs to connect to the apiserver, so we need to make sure that the rules are set up correctly before kubelet starts". But the routes scripts only do anything when apiserver-watcher is reporting that the local apiserver is up and running, which is guaranteed not to be the case before kubelet starts (since both apiserver-watcher and apiserver are started by kubelet) so this is a no-op.

Right?

@squeed any thoughts (besides "ha ha ha not my problem" :slightly_smiling_face: )