### PR TITLE
OCPBUGS-10235:Add quotes to variable with -z

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
@@ -5,7 +5,7 @@ contents:
     #!/bin/bash
     set -ex -o pipefail
 
-    if [ -z $DHCP6_IP6_ADDRESS ]
+    if [ -z "$DHCP6_IP6_ADDRESS" ]
     then
         >&2 echo "Not a DHCP6 address. Ignoring."
         exit 0


### PR DESCRIPTION
properly quote DHCP IP6 ADDRESS variable in shell script

fixes https://issues.redhat.com/browse/OCPBUGS-10235

**- Description for the changelog**

shell script error fix
