### PR TITLE
Revert "End the operator's "unknown field" logspam by marking controllerconfig embedded fields as embedded so they validate"

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -159,7 +159,6 @@ spec:
                 required:
                 - spec
                 type: object
-                x-kubernetes-embedded-resource: true
               etcdDiscoveryDomain:
                 description: etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain
                   instead
@@ -1633,7 +1632,6 @@ spec:
                 required:
                 - spec
                 type: object
-                x-kubernetes-embedded-resource: true
               ipFamilies:
                 description: ipFamilies indicates the IP families in use by the cluster
                   network
@@ -1715,7 +1713,6 @@ spec:
                       CIDRs for which the proxy should not be used.
                     type: string
                 type: object
-                x-kubernetes-embedded-resource: true
               pullSecret:
                 description: pullSecret is the default pull secret that needs to be
                   installed on all machines.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -85,17 +85,14 @@ type ControllerConfigSpec struct {
 	ReleaseImage string `json:"releaseImage"`
 
 	// proxy holds the current proxy configuration for the nodes
-	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	Proxy *configv1.ProxyStatus `json:"proxy"`
 
 	// infra holds the infrastructure details
-	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	Infra *configv1.Infrastructure `json:"infra"`
 
 	// dns holds the cluster dns details
-	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	DNS *configv1.DNS `json:"dns"`
 


### PR DESCRIPTION
Reverts openshift/machine-config-operator#3662 ; tracked by OCPBUGS-11992

TRT suspects this PR as being a possible cause of a recent payload regression. We are floating this revert to perform additional testing.

aws-proxy jobs are failing with workers unable to come up. Example job run[1].  On the console, the workers report 500 errors trying to retrieve the worker ignition[2]. 

Logs are reporting: 

```
2023-04-19T12:29:38.244051716Z I0419 12:29:38.244006 1 container_runtime_config_controller.go:415] Error syncing image config openshift-config: could not get ControllerConfig controllerconfig.machineconfiguration.openshift .io "machine-config-controller" not found 2023-04-19T12:29:56.507515526Z I0419 12:29:56.507472 1 render_controller.go:377] Error syncing machineconfigpool worker: controllerconfig.machineconfiguration.openshift.io "machine-config-controller" not found

./pods/machine-config-operator-6d7c6c8ccf-m7c57/machine-config-operator/machine-config-operator/logs/current.log:2023-04-19T12:38:15.240508503Z E0419 12:38:15.240437 1 operator.go:342] ControllerConfig.machineconfiguration.openshift.io "machine-config-controller" is invalid: [spec.proxy.apiVersion: Required value: must not be empty, spec.proxy.kind: Required value: must not be empty, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-ovn-proxy/1648560213655031808
[2] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-ovn-proxy/1648560213655031808/artifacts/e2e-aws-ovn-proxy/gather-aws-console/artifacts/i-071b5af3ddb12e55c