### PR TITLE
OCPBUGS-11992: ControllerConfig's Proxy field should not be marked as embedded resource

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -1715,7 +1715,6 @@ spec:
                       CIDRs for which the proxy should not be used.
                     type: string
                 type: object
-                x-kubernetes-embedded-resource: true
               pullSecret:
                 description: pullSecret is the default pull secret that needs to be
                   installed on all machines.

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -85,7 +85,6 @@ type ControllerConfigSpec struct {
 	ReleaseImage string `json:"releaseImage"`
 
 	// proxy holds the current proxy configuration for the nodes
-	// +kubebuilder:validation:EmbeddedResource
 	// +nullable
 	Proxy *configv1.ProxyStatus `json:"proxy"`
 


### PR DESCRIPTION
I introduced a regression in #3662 by tagging the controllerconfig's "proxy" field as an embedded resource. While it is "embedded" ( `*configv1.ProxyStatus`) , it is just the "status" portion of the proxy object, and it has no metadata (and thus will fail validation as an embedded resource). 

**- What I did**
Removed the tagging of proxy as an embedded resource. Infra and DNS are still correct. 

**- How to verify it**
Add a proxy, make sure controllerconfig still gets generated instead of a validation failure such as: 
```
2023-04-19T12:38:15.240508503Z E0419 12:38:15.240437 1 operator.go:342] ControllerConfig.machineconfiguration.openshift.io "machine-config-controller" is invalid: [spec.proxy.apiVersion: Required value: must not be empty, spec.proxy.kind: Required value: must not be empty, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```
**- Description for the changelog**
MCO no longer erroneously regards proxy as embedded resource 

Fixes: [OCPBUGS-11992](https://issues.redhat.com/browse/OCPBUGS-11992)