### PR TITLE
OCPBUGS-4370: Add label to VIP via keepalived

### DIFF
--- a/manifests/on-prem/keepalived.conf.tmpl
+++ b/manifests/on-prem/keepalived.conf.tmpl
@@ -24,7 +24,7 @@ vrrp_instance {{.Cluster.Name}}_API_{{$i}} {
         auth_pass {{.Cluster.Name}}_api_vip
     }
     virtual_ipaddress {
-        {{ .Cluster.APIVIP }}/{{ .Cluster.VIPNetmask }}
+        {{ .Cluster.APIVIP }}/{{ .Cluster.VIPNetmask }} label {{ .VRRPInterface }}:vip
     }
 }
 {{end}}`}}

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -88,7 +88,7 @@ contents:
             auth_pass {{`{{ .Cluster.Name }}`}}_api_vip
         }
         virtual_ipaddress {
-            {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+            {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}} label {{`{{ .VRRPInterface }}`}}:vip
         }
         track_script {
             chk_ocp_lb
@@ -128,7 +128,7 @@ contents:
             auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
-            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}} label {{`{{ .VRRPInterface }}`}}:vip
         }
         track_script {
             chk_ingress

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -61,7 +61,7 @@ contents:
             auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
         }
         virtual_ipaddress {
-            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}}
+            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}} label {{`{{ .VRRPInterface }}`}}:vip
         }
         track_script {
             chk_ingress


### PR DESCRIPTION
With this change whenever keepalived adds an IP address to the interface, the IP will be explicitly labeled as "vip". This is in order for anyone relying on the output of `ip a` to be able to distinguish between the IP addresses configured by the network and IP addresses coming from keepalived.

Until now looking only at the output of `ip a` wasn't a reliable way of distinguishing host IP from VIP. There were heuristics possible like e.g. treating IP with /32 as VIP but those are not always as reliable as we would like (e.g. for IPv6 the mask /128 is used also by real host IP).

Contributes-to: OCPBUGS-4370