### PR TITLE
daemon: adapt to latest nmstate code, and handle Tang-pinned hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for fcos/scos
     if [ "${TAGS}" = "fcos" ]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install --nogpgcheck --repofrompath=tmp,"https://jlebon.fedorapeople.org/nmstate-2.2.9-4.jl.rhaos4.13.el8" 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -19,12 +19,12 @@ var firstbootCompleteMachineconfig = &cobra.Command{
 	Run:                   executeFirstbootCompleteMachineConfig,
 }
 
-var maybePersistNics bool
+var persistNics bool
 
 // init executes upon import
 func init() {
 	rootCmd.AddCommand(firstbootCompleteMachineconfig)
-	firstbootCompleteMachineconfig.PersistentFlags().BoolVar(&maybePersistNics, "maybe-persist-nics", false, "Run nmstatectl persist-nic-names")
+	firstbootCompleteMachineconfig.PersistentFlags().BoolVar(&persistNics, "persist-nics", false, "Run nmstatectl persist-nic-names")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 
@@ -35,11 +35,11 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 	exitCh := make(chan error)
 	defer close(exitCh)
 
-	if maybePersistNics {
-		// If asked, before we try an OS update, persist NIC names (if applicable) so that
+	if persistNics {
+		// If asked, before we try an OS update, persist NIC names so that
 		// we handle the reprovision case with old disk images and Ignition configs
 		// that provide static IP addresses.
-		if err := daemon.MaybePersistNetworkInterfaces("/rootfs"); err != nil {
+		if err := daemon.PersistNetworkInterfaces("/rootfs"); err != nil {
 			return fmt.Errorf("failed to persist network interfaces: %w", err)
 		}
 		// We're done; this logic is distinct from the *non-containerized* /run/bin/machine-config-daemon

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -976,13 +976,13 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
 	// This currently will incur a double reboot; see https://github.com/coreos/rpm-ostree/issues/4018
 	if !newEnough {
-		dn.logSystem("rpm-ostree is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
+		logSystem("rpm-ostree is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
 		if err := dn.InplaceUpdateViaNewContainer(mc.Spec.OSImageURL); err != nil {
 			return err
 		}
 		rebootCmd := rebootCommand("extra reboot for in-place update")
 		if err := rebootCmd.Run(); err != nil {
-			dn.logSystem("failed to run reboot: %v", err)
+			logSystem("failed to run reboot: %v", err)
 			return err
 		}
 		// Wait to be killed via SIGTERM; we want to ensure the firstboot process completes before e.g. kubelet.service
@@ -1060,7 +1060,7 @@ func (dn *Daemon) InstallSignalHandler(signaled chan struct{}) {
 // responsible for triggering callbacks to handle updates. Successful
 // updates shouldn't return, and should just reboot the node.
 func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
-	dn.logSystem("Starting to manage node: %s", dn.name)
+	logSystem("Starting to manage node: %s", dn.name)
 	dn.LogSystemData()
 
 	glog.Info("Starting MachineConfigDaemon")
@@ -1573,7 +1573,7 @@ func PersistNetworkInterfaces(osRoot string) error {
 	cmd := exec.Command(nmstateBinary, "persist-nic-names", "--root", osRoot)
 
 	if hostos.IsEL8() {
-		glog.Info("Persisting NIC names for RHEL8 host system")
+		logSystem("Persisting NIC names for RHEL8 host system")
 
 		// nmstate always logs to stderr, so we need to capture/forward that too
 		cmd.Stdout = os.Stdout
@@ -1700,7 +1700,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	// and if we still have a pendingConfig it means we've been killed by kube after 600s
 	// take a stab at that and re-run the drain+reboot routine
 	if state.pendingConfig != nil && bootID == dn.bootID {
-		dn.logSystem("drain interrupted, retrying")
+		logSystem("drain interrupted, retrying")
 		if err := dn.performDrain(); err != nil {
 			return err
 		}
@@ -1723,7 +1723,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		targetOSImageURL := state.currentConfig.Spec.OSImageURL
 		osMatch := dn.checkOS(targetOSImageURL)
 		if !osMatch {
-			dn.logSystem("Bootstrap pivot required to: %s", targetOSImageURL)
+			logSystem("Bootstrap pivot required to: %s", targetOSImageURL)
 
 			// Check to see if we have a layered/new format image
 			isLayeredImage, err := dn.NodeUpdaterClient.IsBootableImage(targetOSImageURL)
@@ -1754,7 +1754,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 			}
 			return dn.reboot(fmt.Sprintf("Node will reboot into config %v", state.currentConfig.GetName()))
 		}
-		dn.logSystem("No bootstrap pivot required; unlinking bootstrap node annotations")
+		logSystem("No bootstrap pivot required; unlinking bootstrap node annotations")
 
 		// Rename the bootstrap node annotations; the
 		// currentConfig's osImageURL should now be *truth*.
@@ -1777,7 +1777,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	if currentOnDisk != nil && state.currentConfig.GetName() != currentOnDisk.GetName() {
 		// The on disk state (if available) is always considered truth.
 		// We want to handle the case where etcd state was restored from a backup.
-		dn.logSystem("Disk currentConfig %s overrides node's currentConfig annotation %s", currentOnDisk.GetName(), state.currentConfig.GetName())
+		logSystem("Disk currentConfig %s overrides node's currentConfig annotation %s", currentOnDisk.GetName(), state.currentConfig.GetName())
 		state.currentConfig = currentOnDisk
 	}
 
@@ -1800,7 +1800,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	}
 
 	if forceFileExists() {
-		dn.logSystem("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
+		logSystem("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 		return dn.triggerUpdateWithMachineConfig(state.currentConfig, state.desiredConfig, true)
 	}
 
@@ -1817,7 +1817,7 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		return wErr
 	}
 
-	dn.logSystem("Validated on-disk state")
+	logSystem("Validated on-disk state")
 
 	// We've validated state. Now, ensure that node is in desired state
 	var inDesiredConfig bool
@@ -2032,7 +2032,7 @@ func (dn *Daemon) completeUpdate(desiredConfigName string) error {
 		return fmt.Errorf("Something went wrong while attempting to uncordon node: %v", err)
 	}
 
-	dn.logSystem("Update completed for config %s and node has been successfully uncordoned", desiredConfigName)
+	logSystem("Update completed for config %s and node has been successfully uncordoned", desiredConfigName)
 	dn.nodeWriter.Eventf(corev1.EventTypeNormal, "Uncordon", fmt.Sprintf("Update completed for config %s and node has been uncordoned", desiredConfigName))
 
 	return nil

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -594,7 +594,7 @@ func (dn *Daemon) syncNode(key string) error {
 		if err := removeIgnitionArtifacts(); err != nil {
 			return err
 		}
-		if err := MaybePersistNetworkInterfaces("/"); err != nil {
+		if err := PersistNetworkInterfaces("/"); err != nil {
 			return err
 		}
 		if err := dn.checkStateOnFirstRun(); err != nil {
@@ -1553,11 +1553,11 @@ func removeIgnitionArtifacts() error {
 	return nil
 }
 
-// MaybePersistNetworkInterfaces runs if the host is RHEL8, which can happen
+// PersistNetworkInterfaces runs if the host is RHEL8, which can happen
 // when scaling up older bootimages and targeting 4.13+ (rhel9).  In this case,
 // we may want to pin NIC interface names that reference static IP addresses.
 // More information in https://issues.redhat.com/browse/OCPBUGS-10787
-func MaybePersistNetworkInterfaces(osRoot string) error {
+func PersistNetworkInterfaces(osRoot string) error {
 	hostos, err := osrelease.GetHostRunningOSFromRoot(osRoot)
 	if err != nil {
 		return fmt.Errorf("checking operating system: %w", err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1574,18 +1574,14 @@ func MaybePersistNetworkInterfaces(osRoot string) error {
 
 	if hostos.IsEL8() {
 		glog.Info("Persisting NIC names for RHEL8 host system")
-	} else {
-		// If we're not on RHEL, just output the current state.  We don't strictly need to do
-		// this but it will greatly help debugging and validation.
-		cmd.Args = append(cmd.Args, "--inspect")
-	}
 
-	// nmstate always logs to stderr, so we need to capture/forward that too
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	glog.Infof("Running: %s", strings.Join(cmd.Args, " "))
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run nmstatectl: %w", err)
+		// nmstate always logs to stderr, so we need to capture/forward that too
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		glog.Infof("Running: %s", strings.Join(cmd.Args, " "))
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to run nmstatectl: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1560,6 +1560,15 @@ func removeIgnitionArtifacts() error {
 // we may want to pin NIC interface names that reference static IP addresses.
 // More information in https://issues.redhat.com/browse/OCPBUGS-10787
 func PersistNetworkInterfaces(osRoot string) error {
+
+	// If the host disables persistent NIC names, then there's no need to persist.
+	if disablesPredictableNames, err := HostDisablesPredictableNicNames(); err != nil {
+		return err
+	} else if disablesPredictableNames {
+		glog.Info("Not persisting NIC names; host has net.ifnames=0")
+		return nil // nothing more to do!
+	}
+
 	hostos, err := osrelease.GetHostRunningOSFromRoot(osRoot)
 	if err != nil {
 		return fmt.Errorf("checking operating system: %w", err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -183,6 +183,10 @@ const (
 
 	// used for certificate syncing
 	caBundleFilePath = "/etc/kubernetes/kubelet-ca.crt"
+
+	// Where nmstate writes the link files if it persisted ifnames.
+	// https://github.com/nmstate/nmstate/blob/03c7b03bd4c9b0067d3811dbbf72635201519356/rust/src/cli/persist_nic.rs#L32-L36
+	systemdNetworkDir = "etc/systemd/network"
 )
 
 type onceFromOrigin int
@@ -1582,9 +1586,60 @@ func PersistNetworkInterfaces(osRoot string) error {
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("failed to run nmstatectl: %w", err)
 		}
+	} else if hostos.IsEL9() {
+		ifnames, err := getIfnamesFromLinkFiles(osRoot)
+		if err != nil {
+			glog.Warningf("Failed to persist NIC names: %v", err)
+			return nil
+		}
+
+		ifnamesKeys := []string{}
+		for ifname := range ifnames {
+			ifnamesKeys = append(ifnamesKeys, ifname)
+		}
+		if len(ifnamesKeys) > 0 {
+			logSystem("Have persisted ifnames for %s", strings.Join(ifnamesKeys, ", "))
+		}
 	}
 
 	return nil
+}
+
+// getIfnamesFromLinkFiles scans /etc/systemd/network for nmstate link files and
+// extracts the pinned network interface names and MAC addresses.
+func getIfnamesFromLinkFiles(osRoot string) (map[string]string, error) {
+	entries, err := os.ReadDir(filepath.Join(osRoot, systemdNetworkDir))
+	if err != nil {
+		return nil, err
+	}
+	ifnames := make(map[string]string)
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), "98-nmstate") || !strings.HasSuffix(entry.Name(), ".link") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(osRoot, systemdNetworkDir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var ifname, mac string
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "MACAddress=") {
+				mac = strings.TrimPrefix(line, "MACAddress=")
+			} else if strings.HasPrefix(line, "Name=") {
+				ifname = strings.TrimPrefix(line, "Name=")
+			}
+		}
+		if err = scanner.Err(); err != nil {
+			return nil, fmt.Errorf("failed to read link file %s: %w", entry.Name(), err)
+		}
+		if ifname == "" || mac == "" {
+			return nil, fmt.Errorf("link file %s missing Name or MACAddress field", entry.Name())
+		}
+		ifnames[ifname] = strings.ToLower(mac)
+	}
+	return ifnames, nil
 }
 
 // When we move from RHCOS 8 -> RHCOS 9, the SSH keys do not get written to the

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -599,9 +599,6 @@ func (dn *Daemon) syncNode(key string) error {
 		if err := removeIgnitionArtifacts(); err != nil {
 			return err
 		}
-		if err := PersistNetworkInterfaces("/"); err != nil {
-			return err
-		}
 		if err := dn.checkStateOnFirstRun(); err != nil {
 			return err
 		}

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -33,7 +33,7 @@ func (dn *Daemon) performDrain() error {
 	}
 
 	if !dn.drainRequired() {
-		dn.logSystem("Drain not required, skipping")
+		logSystem("Drain not required, skipping")
 		dn.nodeWriter.Eventf(corev1.EventTypeNormal, "Drain", "Drain not required, skipping")
 		return nil
 	}
@@ -51,12 +51,12 @@ func (dn *Daemon) performDrain() error {
 		// In either case, we just assume the drain we want has been completed
 		// A third case we can hit this is that the node fails validation upon reboot, and then we use
 		// the forcefile. But in that case, since we never uncordoned, skipping the drain should be fine
-		dn.logSystem("drain is already completed on this node")
+		logSystem("drain is already completed on this node")
 		return nil
 	}
 
 	// We are here, that means we need to cordon and drain node
-	dn.logSystem("Update prepared; requesting cordon and drain via annotation to controller")
+	logSystem("Update prepared; requesting cordon and drain via annotation to controller")
 	startTime := time.Now()
 
 	// We probably don't need to separate out cordon and drain, but we sort of do it today for various scenarios
@@ -88,7 +88,7 @@ func (dn *Daemon) performDrain() error {
 		return fmt.Errorf("Something went wrong while attempting to drain node: %v", err)
 	}
 
-	dn.logSystem("drain complete")
+	logSystem("drain complete")
 	t := time.Since(startTime).Seconds()
 	glog.Infof("Successful drain took %v seconds", t)
 

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -53,8 +53,8 @@ func isArgInUse(arg, cmdLinePath string) (bool, error) {
 		return false, err
 	}
 
-	checkable := string(content)
-	if strings.Contains(checkable, arg) {
+	checkable := strings.TrimSpace(string(content))
+	if strings.Contains(" "+checkable+" ", " "+arg+" ") {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -60,6 +60,18 @@ func isArgInUse(arg, cmdLinePath string) (bool, error) {
 	return false, nil
 }
 
+func HostUsesNetworkingInInitrd() (bool, error) {
+	inUse, err := isArgInUse("rd.neednet=1", "")
+	if err != nil {
+		return false, err
+	}
+	if inUse {
+		return true, nil
+	}
+	// this variant isn't injected by any CoreOS tool, but users may have
+	return isArgInUse("rd.neednet", "")
+}
+
 // parseTuningFile parses the kernel argument tuning file
 func parseTuningFile(tuningFilePath, cmdLinePath string) ([]types.TuneArgument, []types.TuneArgument, error) {
 	addArguments := []types.TuneArgument{}

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -72,6 +72,10 @@ func HostUsesNetworkingInInitrd() (bool, error) {
 	return isArgInUse("rd.neednet", "")
 }
 
+func HostDisablesPredictableNicNames() (bool, error) {
+	return isArgInUse("net.ifnames=0", "")
+}
+
 // parseTuningFile parses the kernel argument tuning file
 func parseTuningFile(tuningFilePath, cmdLinePath string) ([]types.TuneArgument, []types.TuneArgument, error) {
 	addArguments := []types.TuneArgument{}

--- a/pkg/daemon/kernelargs.go
+++ b/pkg/daemon/kernelargs.go
@@ -61,15 +61,16 @@ func isArgInUse(arg, cmdLinePath string) (bool, error) {
 }
 
 func HostUsesNetworkingInInitrd() (bool, error) {
-	inUse, err := isArgInUse("rd.neednet=1", "")
-	if err != nil {
-		return false, err
-	}
-	if inUse {
-		return true, nil
-	}
-	// this variant isn't injected by any CoreOS tool, but users may have
-	return isArgInUse("rd.neednet", "")
+	return true, nil
+	// inUse, err := isArgInUse("rd.neednet=1", "")
+	// if err != nil {
+	// 	return false, err
+	// }
+	// if inUse {
+	// 	return true, nil
+	// }
+	// // this variant isn't injected by any CoreOS tool, but users may have
+	// return isArgInUse("rd.neednet", "")
 }
 
 func HostDisablesPredictableNicNames() (bool, error) {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -601,6 +601,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		return err
 	}
 
+	if err := PersistNetworkInterfaces("/"); err != nil {
+		return err
+	}
+
 	// At this point, we write the now expected to be "current" config to /etc.
 	// When we reboot, we'll find this file and validate that we're in this state,
 	// and that completes an update.

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -75,7 +75,7 @@ func reloadService(name string) error {
 // If at any point an error occurs, we reboot the node so that node has correct configuration.
 func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string, configName string) error {
 	if ctrlcommon.InSlice(postConfigChangeActionReboot, postConfigChangeActions) {
-		dn.logSystem("Rebooting node")
+		logSystem("Rebooting node")
 		return dn.reboot(fmt.Sprintf("Node will reboot into config %s", configName))
 	}
 
@@ -83,7 +83,7 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 		if dn.nodeWriter != nil {
 			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "SkipReboot", "Config changes do not require reboot.")
 		}
-		dn.logSystem("Node has Desired Config %s, skipping reboot", configName)
+		logSystem("Node has Desired Config %s, skipping reboot", configName)
 	}
 
 	if ctrlcommon.InSlice(postConfigChangeActionReloadCrio, postConfigChangeActions) {
@@ -99,7 +99,7 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 		if dn.nodeWriter != nil {
 			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "SkipReboot", "Config changes do not require reboot. Service %s was reloaded.", serviceName)
 		}
-		dn.logSystem("%s config reloaded successfully! Desired config %s has been applied, skipping reboot", serviceName, configName)
+		logSystem("%s config reloaded successfully! Desired config %s has been applied, skipping reboot", serviceName, configName)
 	}
 
 	// We are here, which means reboot was not needed to apply the configuration.
@@ -511,7 +511,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		return &unreconcilableErr{wrappedErr}
 	}
 
-	dn.logSystem("Starting update from %s to %s: %+v", oldConfigName, newConfigName, diff)
+	logSystem("Starting update from %s to %s: %+v", oldConfigName, newConfigName, diff)
 
 	diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
 	actions, err := calculatePostConfigChangeAction(diff, diffFileSet)
@@ -1038,7 +1038,7 @@ func (dn *CoreOSDaemon) updateKernelArguments(oldKernelArguments, newKernelArgum
 	}
 
 	args := append([]string{"kargs"}, kargs...)
-	dn.logSystem("Running rpm-ostree %v", args)
+	logSystem("Running rpm-ostree %v", args)
 	return runRpmOstree(args...)
 }
 
@@ -1175,9 +1175,9 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 	realtimeKernel := []string{"kernel-rt-core", "kernel-rt-modules", "kernel-rt-modules-extra", "kernel-rt-kvm"}
 
 	if oldKtype != newKtype {
-		dn.logSystem("Initiating switch to kernel %s", newKtype)
+		logSystem("Initiating switch to kernel %s", newKtype)
 	} else {
-		dn.logSystem("Re-applying kernel type %s", newKtype)
+		logSystem("Re-applying kernel type %s", newKtype)
 	}
 
 	if newKtype == ctrlcommon.KernelTypeRealtime {
@@ -1882,7 +1882,7 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
 	// This currently will incur a double reboot; see https://github.com/coreos/rpm-ostree/issues/4018
 	if !newEnough {
-		dn.logSystem("rpm-ostree is not new enough for layering; forcing an update via container")
+		logSystem("rpm-ostree is not new enough for layering; forcing an update via container")
 		if err := dn.InplaceUpdateViaNewContainer(newURL); err != nil {
 			return err
 		}
@@ -2021,7 +2021,7 @@ func runCmdSync(cmdName string, args ...string) error {
 }
 
 // Log a message to the systemd journal as well as our stdout
-func (dn *Daemon) logSystem(format string, a ...interface{}) {
+func logSystem(format string, a ...interface{}) {
 	message := fmt.Sprintf(format, a...)
 	glog.Info(message)
 	// Since we're chrooted into the host rootfs with /run mounted,
@@ -2074,7 +2074,7 @@ func (dn *Daemon) reboot(rationale string) error {
 	if dn.nodeWriter != nil {
 		dn.nodeWriter.Eventf(corev1.EventTypeNormal, "Reboot", rationale)
 	}
-	dn.logSystem("initiating reboot: %s", rationale)
+	logSystem("initiating reboot: %s", rationale)
 
 	// reboot, executed async via systemd-run so that the reboot command is executed
 	// in the context of the host asynchronously from us
@@ -2083,14 +2083,14 @@ func (dn *Daemon) reboot(rationale string) error {
 	// either, we just have one for the MCD itself.
 	rebootCmd := rebootCommand(rationale)
 	if err := rebootCmd.Run(); err != nil {
-		dn.logSystem("failed to run reboot: %v", err)
+		logSystem("failed to run reboot: %v", err)
 		mcdRebootErr.Inc()
 		return fmt.Errorf("reboot command failed, something is seriously wrong")
 	}
 	// if we're here, reboot went through successfully, so we set rebootQueued
 	// and we wait for GracefulNodeShutdown
 	dn.rebootQueued = true
-	dn.logSystem("reboot successful")
+	logSystem("reboot successful")
 	return nil
 }
 

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -16,7 +16,7 @@ contents: |
   # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   # Run this via podman because we want to use the nmstatectl binary in our container
-  ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --maybe-persist-nics
+  ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
   # This one was copied out to the host...but actually I'm not sure why we didn't
   # run it via podman to start
   ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig


### PR DESCRIPTION
daemon: call `nmstatectl persist-nic-names --cleanup` after upgrade to el9

The strategy in the latest nmstate code changed so that now we have
to do a call to `nmstatectl persist-nic-names` before the upgrade, and
then another after the upgrade with `--cleanup`. The details of these
changes are in [[1]]. We can use the stamp file it puts down to avoid
unnecessarily calling `nmstatectl` on every boot (see also [[2]]).

[1]: https://github.com/nmstate/nmstate/pull/2306
[2]: https://github.com/nmstate/nmstate/pull/2316

---

daemon: append `ifname=` kargs if `rd.neednet=1`

When using Tang pinning, the node needs networking in the initramfs on
every boot to unlock the rootfs. It's possible that this networking
configuration assumes certain network interface names. So we need to
handle this case as part of [the recent ifname pinning work](https://github.com/openshift/machine-config-operator/pull/3650).

We can detect if initramfs networking is turned on by checking for the
`rd.neednet=1` karg. If that's the case, then before the update, we
emit an `ifname=<NAME>:<MAC>` karg for each interface pinned, and after
the update, we remove the kargs which are found to have been unneeded,
mirroring the logic in nmstate.