### PR TITLE
OCPBUGS-12456: fix duplicate RotateKubeletServerCertificate setting

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -26,7 +26,6 @@ contents:
     systemCgroups: /system.slice
     featureGates:
       APIPriorityAndFairness: true
-      RotateKubeletServerCertificate: true
       DownwardAPIHugePages: true
       OpenShiftPodSecurityAdmission: true
       RetroactiveDefaultStorageClass: false

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -26,7 +26,6 @@ contents:
     systemCgroups: /system.slice
     featureGates:
       APIPriorityAndFairness: true
-      RotateKubeletServerCertificate: true
       DownwardAPIHugePages: true
       OpenShiftPodSecurityAdmission: true
       RetroactiveDefaultStorageClass: false


### PR DESCRIPTION
Fixed a duplicate featuregate key causing errors on the new 1.27 rebase.