### PR TITLE
OCPBUGS-11670: mcc_drain_err metric should not be served for removed nodes

### DIFF
--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -387,7 +387,9 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 	delete(ctrl.ongoingDrains, node.Name)
 
 	// Clear the MCCDrainErr, if any.
-	ctrlcommon.MCCDrainErr.WithLabelValues(node.Name).Set(0)
+	if ctrlcommon.MCCDrainErr.DeleteLabelValues(node.Name) {
+		glog.Infof("Cleaning up MCCDrain error for node(%s) as drain was completed", node.Name)
+	}
 
 	return nil
 }

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -556,6 +556,12 @@ func (ctrl *Controller) deleteNode(obj interface{}) {
 	if pools == nil {
 		return
 	}
+
+	// Clear any associated MCCDrainErr, if any.
+	if ctrlcommon.MCCDrainErr.DeleteLabelValues(node.Name) {
+		glog.Infof("Cleaning up MCCDrain error for node(%s) as it is being deleted", node.Name)
+	}
+
 	glog.V(4).Infof("Node %s delete", node.Name)
 	for _, pool := range pools {
 		ctrl.enqueueMachineConfigPool(pool)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added clean-up of any existing drain errors associated with a node during its deletion. Also changed the function to clear the drain error when a drain is complete, as `DeleteLabelValues(node.Name)` seemed like the right way to do this than `WithLabelValues(node.Name).Set(0)`
**- How to verify it**
Trigger a drain error(this happens if a drain goes longer than an hour), and then delete the node. The drain error should disappear at node deletion. I manually set a drain error in the drain logic to test this, but if there's a faster way to do this let me know (: 
**- Description for the changelog**
controller: improved MCCDrainError cleanup
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
