### PR TITLE
OCPBUGS-12951: daemon: Don't traverse `/run/ostree/auth.json` symlink

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -346,7 +346,7 @@ func (r *RpmOstreeClient) RebaseLayered(imgURL string) (err error) {
 // useKubeletConfigSecrets gives the rpm-ostree client access to secrets in the kubelet config.json by symlinking so that
 // rpm-ostree can use those secrets to pull images. It does this by symlinking the kubelet's config.json into /run/ostree.
 func useKubeletConfigSecrets() error {
-	if _, err := os.Stat("/run/ostree/auth.json"); err != nil {
+	if _, err := os.Lstat("/run/ostree/auth.json"); err != nil {
 
 		if errors.Is(err, os.ErrNotExist) {
 


### PR DESCRIPTION
In the case that we've already written the link, but there is no `/var/lib/kubelet/config.json`, we will try to re-create the link and fail.

I believe this can happen in the assisted installer path, and only if we end up re-trying an initialization.

https://issues.redhat.com/browse/OCPBUGS-12951
