### PR TITLE
OCPBUGS-12980: daemon: write certs in firstboot-complete path

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1015,7 +1015,10 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	}
 
 	dn.skipReboot = true
-	err = dn.update(nil, &mc, true)
+	// This "false" is a compatibility for IBM's use case, where they are using the MCD to write the full configuration instead of just
+	// the encapsulated config. This shouldn't affect normal OCP operations, but will allow anyone using this code to write configs to
+	// still get the kubelet cert
+	err = dn.update(nil, &mc, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As a compatibility fix for IBM's use case. Should revisit the actual IBM workflow.