### PR TITLE
OPNET-303,OCPBUGS-25744: Remove weights from ingress check script

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -167,7 +167,7 @@ contents:
             - /bin/bash
             - -c
             - |
-              [ ! -s "/etc/keepalived/keepalived.conf" ] || (echo "State = FAULT" > /tmp/keepalived.data && kill -s SIGUSR1 "$(pgrep -o keepalived)" && for i in $(seq 5); do grep -q "State = FAULT" /tmp/keepalived.data && sleep 1 || exit 0; done && exit 1)
+              [ ! -s "/etc/keepalived/keepalived.conf" ] || (echo "" > /tmp/keepalived.data && kill -s SIGUSR1 "$(pgrep -o keepalived)" && for i in $(seq 5); do grep -q "VRRP Instance" /tmp/keepalived.data && exit 0 || sleep 1; done && exit 1)
           initialDelaySeconds: 20
           timeoutSeconds: 5
         terminationMessagePolicy: FallbackToLogsOnError

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -41,7 +41,6 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
-        weight 20
         rise 3
         fall 2
     }

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -14,7 +14,6 @@ contents:
     vrrp_script chk_ingress {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
         interval 1
-        weight 20
         rise 3
         fall 2
     }


### PR DESCRIPTION
Previously, because we had weights set for both check scripts for ingress, keepalived would always assign the ingress VIP somewhere, even if there were no ingress controllers available. While normally this is not a problem, this behavior is not ideal in circumstances such as remote workers where one worker per remote subnet will take the VIP because they can't coordinate with the other subnets.

The advantage of removing the weight from the check script is that if there is no ingress controller running on the node it will never take the VIP, even if no other node in the cluster has taken it. This allows us to deploy remote workers without the extra step of disabling keepalived. As long as the ingress pods are deployed to the correct nodes keepalived will handle assigning the VIP on its own, even across subnets that can't communicate directly with each other.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Changed keepalived config so nodes without an ingress pod will go to a fault state and never take the ingress VIP, even if no other node has the VIP. This simplifies deployment in remote worker scenarios.
