### PR TITLE
OCPBUGS-13547: Use payload-version flag to set release version consistently across components

### DIFF
--- a/cmd/machine-config-controller/main.go
+++ b/cmd/machine-config-controller/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/cli"
 )
@@ -27,6 +28,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	rootCmd.PersistentFlags().StringVar(&rootOpts.templates, "templates", "/etc/mcc/templates", "Path to the template files used for creating MachineConfig objects")
+	rootCmd.PersistentFlags().StringVar(&version.ReleaseVersion, "payload-version", version.ReleaseVersion, "Version of the openshift release")
 }
 
 func main() {

--- a/cmd/machine-config-daemon/main.go
+++ b/cmd/machine-config-daemon/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/cli"
 )
@@ -22,6 +23,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	rootCmd.PersistentFlags().StringVar(&version.ReleaseVersion, "payload-version", version.ReleaseVersion, "Version of the openshift release")
 }
 
 func main() {

--- a/cmd/machine-config-operator/main.go
+++ b/cmd/machine-config-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/cli"
 )
@@ -20,6 +21,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	rootCmd.PersistentFlags().StringVar(&version.ReleaseVersion, "payload-version", version.ReleaseVersion, "Version of the openshift release")
 }
 
 func main() {

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -46,7 +46,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	runContext, runCancel := context.WithCancel(context.Background())
 
 	// To help debugging, immediately log version
-	glog.Infof("Version: %s (Raw: %s, Hash: %s)", os.Getenv("RELEASE_VERSION"), version.Raw, version.Hash)
+	glog.Infof("Version: %s (Raw: %s, Hash: %s)", version.ReleaseVersion, version.Raw, version.Hash)
 
 	if startOpts.imagesFile == "" {
 		glog.Fatal("--images-json cannot be empty")

--- a/cmd/machine-config-server/main.go
+++ b/cmd/machine-config-server/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/openshift/machine-config-operator/pkg/server"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/cli"
 )
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&rootOpts.cert, "cert", "/etc/ssl/mcs/tls.crt", "cert file for TLS")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.key, "key", "/etc/ssl/mcs/tls.key", "key file for TLS")
 	rootCmd.PersistentFlags().IntVar(&rootOpts.isport, "insecure-port", server.InsecurePort, "insecure port to serve ignition configs")
+	rootCmd.PersistentFlags().StringVar(&version.ReleaseVersion, "payload-version", version.ReleaseVersion, "Version of the openshift release")
 }
 
 func main() {

--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -27,6 +27,7 @@ spec:
         args:
         - "start"
         - "--images-json=/etc/mco/images/images.json"
+        - "--payload-version=0.0.1-snapshot"
         resources:
           requests:
             cpu: 20m

--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -15,6 +15,7 @@ spec:
     - "--manifest-dir=/etc/mcc/bootstrap"
     - "--dest-dir=/etc/mcs/bootstrap"
     - "--pull-secret=/etc/mcc/bootstrap/machineconfigcontroller-pull-secret"
+    - "--payload-version={{.ReleaseVersion}}"
     resources:
       limits:
         memory: 50Mi
@@ -36,6 +37,7 @@ spec:
     command: ["/usr/bin/machine-config-server"]
     args:
       - "bootstrap"
+      - "--payload-version={{.ReleaseVersion}}"
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - name: server-certs

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - "start"
         - "--resourcelock-namespace={{.TargetNamespace}}"
         - "--v=2"
+        - "--payload-version={{.ReleaseVersion}}"
         resources:
           requests:
             cpu: 20m

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         command: ["/usr/bin/machine-config-daemon"]
         args:
           - "start"
+          - "--payload-version={{.ReleaseVersion}}"
         resources:
           requests:
             cpu: 20m

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -22,6 +22,7 @@ spec:
         args:
           - "start"
           - "--apiserver-url={{.APIServerURL}}"
+          - "--payload-version={{.ReleaseVersion}}"
         resources:
           requests:
             cpu: 20m

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -3,13 +3,13 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/golang/glog"
 
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextinformersv1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
@@ -220,7 +220,7 @@ func New(
 	optr.dnsLister = dnsInformer.Lister()
 	optr.dnsListerSynced = dnsInformer.Informer().HasSynced
 
-	optr.vStore.Set("operator", os.Getenv("RELEASE_VERSION"))
+	optr.vStore.Set("operator", version.ReleaseVersion)
 
 	return optr
 }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -26,6 +26,7 @@ import (
 type renderConfig struct {
 	TargetNamespace        string
 	Version                string
+	ReleaseVersion         string
 	ControllerConfig       mcfgv1.ControllerConfigSpec
 	APIServerURL           string
 	Images                 *RenderConfigImages

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -226,11 +226,15 @@ func TestRenderAsset(t *testing.T) {
 		Path: "manifests/machineconfigcontroller/deployment.yaml",
 		RenderConfig: &renderConfig{
 			TargetNamespace: "testing-namespace",
+			ReleaseVersion:  "4.8.0-rc.0",
 			Images: &RenderConfigImages{
 				MachineConfigOperator: "mco-operator-image",
 			},
 		},
-		FindExpected: []string{"image: mco-operator-image"},
+		FindExpected: []string{
+			"image: mco-operator-image",
+			"--payload-version=4.8.0-rc.0",
+		},
 	}, {
 		// Render same template as previous test
 		// But with a template field missing
@@ -244,6 +248,7 @@ func TestRenderAsset(t *testing.T) {
 		Path: "manifests/machineconfigdaemon/daemonset.yaml",
 		RenderConfig: &renderConfig{
 			TargetNamespace: "testing-namespace",
+			ReleaseVersion:  "4.8.0-rc.0",
 			Images: &RenderConfigImages{
 				MachineConfigOperator: "mco-operator-image",
 				OauthProxy:            "oauth-proxy-image",
@@ -260,11 +265,24 @@ func TestRenderAsset(t *testing.T) {
 			"image: oauth-proxy-image",
 			"- name: HTTPS_PROXY\n            value: https://i.am.a.proxy.server",
 			"- name: NO_PROXY\n            value: \"*\"", // Ensure the * is quoted: "*": https://bugzilla.redhat.com/show_bug.cgi?id=1947066
+			"--payload-version=4.8.0-rc.0",
 		},
 	}, {
 		// Bad path, will cause asset error
 		Path:  "BAD PATH",
 		Error: true,
+	}, {
+		Path: "manifests/bootstrap-pod-v2.yaml",
+		RenderConfig: &renderConfig{
+			TargetNamespace: "testing-namespace",
+			ReleaseVersion:  "4.8.0-rc.0",
+			Images: &RenderConfigImages{
+				MachineConfigOperator: "mco-operator-image",
+			},
+		},
+		FindExpected: []string{
+			"--payload-version=4.8.0-rc.0",
+		},
 	}}
 
 	for idx, test := range tests {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1044,6 +1044,7 @@ func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.C
 	return &renderConfig{
 		TargetNamespace:        tnamespace,
 		Version:                version.Raw,
+		ReleaseVersion:         version.ReleaseVersion,
 		ControllerConfig:       *ccSpec,
 		Images:                 imgs,
 		APIServerURL:           apiServerURL,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,9 +2,18 @@ package version
 
 import (
 	"fmt"
+	"os"
+)
+
+const (
+	releaseVersionEnv = "RELEASE_VERSION"
 )
 
 var (
+	// ReleaseVersion is the version of the openshift release.
+	// This will be injected by the payload build process.
+	ReleaseVersion = "0.0.1-snapshot"
+
 	// Raw is the string representation of the version. This will be replaced
 	// with the calculated version at build time.
 	Raw = "v0.0.0-was-not-built-properly"
@@ -30,4 +39,16 @@ func IsFCOS() bool {
 // IsSCOS returns true if CentOS Stream CoreOS-only modifications are enabled
 func IsSCOS() bool {
 	return SCOS
+}
+
+func init() {
+	// TODO: Remove the following env var override to deprecated RELEASE_VERSION.
+	// This is only here for backwards compatibility with the old build process.
+	// For now, it will prepopulate the ReleaseVersion with the value of the env var
+	// prior to flag parsing. This will allow the flag to override the env var.
+	// In the future, we should remove this and only use the flag.
+	rv := os.Getenv(releaseVersionEnv)
+	if rv != "" {
+		ReleaseVersion = rv
+	}
 }

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/controller/node"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
 
@@ -502,6 +503,7 @@ func createClusterVersion(t *testing.T, clientSet *framework.ClientSet, objs ...
 	cv, err := clientSet.ClusterVersions().Create(ctx, cv, metav1.CreateOptions{})
 	require.NoError(t, err)
 
+	cv.Status.Desired.Version = version.ReleaseVersion
 	cv.Status.Desired.Image = controllerConfig.Spec.ReleaseImage
 	cv, err = clientSet.ClusterVersions().UpdateStatus(ctx, cv, metav1.UpdateOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
**- What I did**

Adds a `--payload-version` flag to all the components in this repo (MCC, MCS, MCO, MCD) so that they consistently populate the release version into `version.ReleaseVersion`. The payload version is already used in MCO in a couple of places via env vars, so this includes a backwards compatible env var pre-population, but the intention is to remove that shortly (once the installer populates the flag for the bootstrap) and then the only, and consistent way to set the release version within the MCO suite would be via the flag. In code/tests it can be set via setting `version.ReleaseVersion`.

This should make the usage consistent across the codebase ahead of introducing feature gate changes on top of this.

**- How to verify it**

Should be no functional changes, will want to check the various manifests are generated with the correct versions.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use consistent payload-version flag to load release version information.

N.B: `0.0.1-snapshot` is a magic string that is replaced during the payload build process, so the install manifests for MCO should get the correct version when the payload is built.