### PR TITLE
OCPBUGS-11124, OCPBUGS-11411: Remove systemd-pcrphase dependency on network

### DIFF
--- a/templates/common/_base/units/pcrphase.service.yaml
+++ b/templates/common/_base/units/pcrphase.service.yaml
@@ -1,0 +1,30 @@
+name: systemd-pcrphase.service
+enabled: true
+contents: |
+  #  SPDX-License-Identifier: LGPL-2.1-or-later
+  #
+  #  This file is part of systemd.
+  #
+  #  systemd is free software; you can redistribute it and/or modify it
+  #  under the terms of the GNU Lesser General Public License as published by
+  #  the Free Software Foundation; either version 2.1 of the License, or
+  #  (at your option) any later version.
+
+  # This is a manually copy-pasted unit definition with `After=` section removed.
+  # It is because dependency on remote-fs.target causes lockdown in case of any
+  # network issues, causing this service to block ability to login to the node.
+  # Related issues: OCPBUGS-11124, OCPBUGS-11411
+
+  [Unit]
+  Description=TPM2 PCR Barrier (User)
+  Documentation=man:systemd-pcrphase.service(8)
+  Before=systemd-user-sessions.service
+  AssertPathExists=!/etc/initrd-release
+  ConditionSecurity=tpm2
+  ConditionPathExists=/sys/firmware/efi/efivars/StubPcrKernelImage-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/usr/lib/systemd/systemd-pcrphase ready
+  ExecStop=/usr/lib/systemd/systemd-pcrphase shutdown


### PR DESCRIPTION
This PR removes `After=` section from the definition of systemd-pcrphase. It is because currently it blocks possibility to SSH into the node which for any reason has nodeip-configuration or configure-ovs not succeeding.

The self-healing functionality of the latter creates a scenario in which network-online.targed is not yet reached but we already want to access the node for debugging purposes.

At the same time as by default systemd-pcrphase blocks user sessions and depends on remote-fs, this creates a deadlock. In order to remediate this situation, we are removing dependency on remote-fs here. It is justified as OpenShift nodes are not meant to use remote home directories.

Fixes: OCPBUGS-11124
Fixes: OCPBUGS-11411