### PR TITLE
OpenStack: configure ipv6 addresses

### DIFF
--- a/templates/common/openstack/files/ipv6-config.yaml
+++ b/templates/common/openstack/files/ipv6-config.yaml
@@ -1,0 +1,9 @@
+mode: 0600
+path: "/etc/NetworkManager/system-connections/nmconnection.template"
+contents:
+  inline: |
+    [connection]
+    type=ethernet
+    [ipv6]
+    addr-gen-mode=eui64
+    method=auto


### PR DESCRIPTION
This commit makes sure the br-ex interface of masters and workers
consistently gets the same IPv6 and mac addresses that were configured
in the OpenStack Ports for the control plane and api/ingress VIPs by
including ipv6.addr-gen-mode with eui64 and method auto by default.

Partially implements: https://github.com/openshift/enhancements/pull/1365