### PR TITLE
OCPNODE-1211: enable graceful node shutdown

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -23,6 +23,15 @@ contents:
     protectKernelDefaults: true
     rotateCertificates: true
     serializeImagePulls: false
+    shutdownGracePeriodByPodPriority:
+      - priority: 0
+        shutdownGracePeriodSeconds: 3900
+      - priority: 10000
+        shutdownGracePeriodSeconds: 3900
+      - priority: 2000000000
+        shutdownGracePeriodSeconds: 2100
+      - priority: 2000001000
+        shutdownGracePeriodSeconds: 2100
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
     nodeStatusUpdateFrequency: 10s

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -23,6 +23,15 @@ contents:
     protectKernelDefaults: true
     rotateCertificates: true
     serializeImagePulls: false
+    shutdownGracePeriodByPodPriority:
+      - priority: 0
+        shutdownGracePeriodSeconds: 3900
+      - priority: 10000
+        shutdownGracePeriodSeconds: 3900
+      - priority: 2000000000
+        shutdownGracePeriodSeconds: 2100
+      - priority: 2000001000
+        shutdownGracePeriodSeconds: 2100
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
     nodeStatusUpdateFrequency: 10s


### PR DESCRIPTION
**- What I did**
Enable graceful shutdown. Upstream [information](https://kubernetes.io/blog/2022/12/16/kubernetes-1-26-non-graceful-node-shutdown-beta/).

> This feature allows stateful workloads to failover to a different node after the original node is shut down or in a non-recoverable state, such as the hardware failure or broken OS [or reboot].



```
❯ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.13-e2e-aws-sdn-serial/1654734077120483328/artifacts/e2e-aws-sdn-serial/gather-extra/artifacts/pods.json | jq -r '[.items[] | select(.spec.terminationGracePeriodSeconds != null)] | sort_by(.spec.terminationGracePeriodSeconds)[] | (.spec.terminationGracePeriodSeconds | tostring) + "\t" + (.metad
ata | .namespace + "\t" + .name)' | tail -n12
194     openshift-kube-apiserver        kube-apiserver-ip-10-0-136-18.us-west-1.compute.internal
194     openshift-kube-apiserver        kube-apiserver-ip-10-0-205-38.us-west-1.compute.internal
600     openshift-machine-config-operator       machine-config-daemon-cc5ds
600     openshift-machine-config-operator       machine-config-daemon-dh6lz
600     openshift-machine-config-operator       machine-config-daemon-gx2k7
600     openshift-machine-config-operator       machine-config-daemon-lgl4k
600     openshift-machine-config-operator       machine-config-daemon-mcnjm
600     openshift-machine-config-operator       machine-config-daemon-tf5v9
600     openshift-monitoring    prometheus-k8s-0
600     openshift-monitoring    prometheus-k8s-1
3600    openshift-ingress       router-default-556545fb5f-9bnl9
3600    openshift-ingress       router-default-556545fb5f-kcf9x
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
