### PR TITLE
OCPBUGS-13860: Fix missing apiVersion and kind fields for embedded resources

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -15,13 +15,14 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
+	configclientscheme "github.com/openshift/client-go/config/clientset/versioned/scheme"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubeErrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1037,7 +1038,43 @@ func (optr *Operator) getGlobalConfig() (*configv1.Infrastructure, *configv1.Net
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, nil, nil, err
 	}
+
+	// the client removes apiversion/kind (gvk) from all objects during decoding and re-adds it when they are reencoded for
+	// transmission, which is normally fine, but the re-add does not recurse into embedded objects, so we have to explicitly
+	// re-inject apiversion/kind here so our embedded objects will still validate when embedded in ControllerConfig
+	// See: https://issues.redhat.com/browse/OCPBUGS-13860
+	infra = infra.DeepCopy()
+	err = setGVK(infra, configclientscheme.Scheme)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("Failed setting gvk for infra object: %w", err)
+	}
+	dns = dns.DeepCopy()
+	err = setGVK(dns, configclientscheme.Scheme)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("Failed setting gvk for dns object: %w", err)
+	}
+
 	return infra, network, proxy, dns, nil
+}
+
+// setGVK sets the group/version/kind of an object based on the supplied client schema. This
+// is used by the MCO to re-populate the apiVersion and Kind fields in our embedded objects since
+// they get stripped out when the client decodes the object (this stripping behavior is an upstream
+// kube decision and not a decision by the MCO)
+func setGVK(obj runtime.Object, scheme *runtime.Scheme) error {
+	gvks, _, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		return err
+	}
+	// For our usage we will only probably ever get back one gvk, but just in case
+	for _, gvk := range gvks {
+		if gvk.Kind == "" || gvk.Version == "" {
+			continue
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		break
+	}
+	return nil
 }
 
 func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *RenderConfigImages, apiServerURL string, pointerConfigData []byte) *renderConfig {


### PR DESCRIPTION
`Apiversion` and `Kind` fields on the Infrastructure object "go missing" once the Infrastructure object gets updated (due to cache/lister behavior), which causes validation errors when the MCO tries to embed the new Infrastructure in ControllerConfig.  

This PR makes sure the GVK (and by extension Apiversion/Kind) are always populated for our embedded infrastructure and dns resources so they will validate as embedded resources. 

**- What I did**

Use the client scheme to inject the group, version, kind (GVK) back into the object so it gets explicitly included when we embed the object in ControllerConfig, allowing the embedded objects to validate. 

**- How to verify it**

1. Mutate the the cluster infrastructure object harmlessly e.g. : `oc annotate infrastructure cluster break.the.mco=yep` 
2. Observe that the `machine-config-operator` logs do not show an error like:
`2023-05-17T20:45:04.627320107Z I0517 20:45:04.627281       1 event.go:285] Event(v1.ObjectReference{Kind:"", Namespace:"", Name:"machine-config", UID:"d52d09f4-f7bb-497a-a5c3-92861aa6796f", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'OperatorDegraded: MachineConfigControllerFailed' Failed to resync 4.14.0-0.ci.test-2023-05-17-193937-ci-op-dcrr8kjq-latest because: ControllerConfig.machineconfiguration.openshift.io "machine-config-controller" is invalid: [spec.infra.apiVersion: Required value: must not be empty, spec.infra.kind: Required value: must not be empty, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]`

**- Description for the changelog**
MCO no longer fails to reconcile ControllerConfig when Infrastructure object changes 

Fixes: [OCPBUGS-13860](https://issues.redhat.com/browse/OCPBUGS-13860)