### PR TITLE
OCPBUGS-13404,OCPBUGS-14298: Dockerfile: pin to nmstate-2.2.9-6.rhaos4.13.el8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
     # rewrite image names for fcos/scos
+    # XXX: pin nmstate to 2.2.9 until we've replaced `--inspect` (see https://github.com/openshift/machine-config-operator/pull/3706)
     if [ "${TAGS}" = "fcos" ]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install nmstate-2.2.9-6.rhaos4.13.el8 && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
The nmstate operator team wants to use newer nmstate in 4.13. We still
want an older nmstate because we use `--inspect` which is useful for
diagnostic purposes.

Until we replace it, just pin to the build of nmstate we need for our
purposes.

Related: https://github.com/openshift/machine-config-operator/pull/3706

