### PR TITLE
[release-4.12] OCPBUGS-14071: Imageinspect takes type of error into account, drop podman inspect fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.0.0
 	github.com/ashcrow/osrelease v0.0.0-20180626175927-9b292693c55c
 	github.com/clarketm/json v1.14.1
+	github.com/containers/common v0.49.0
 	github.com/containers/image/v5 v5.22.0
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/storage v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
+github.com/containers/common v0.49.0 h1:RvXl6DV+AIiWFAInr9kda8v0kNFYp8Gi6TdMDJxiN0s=
+github.com/containers/common v0.49.0/go.mod h1:veUB/Ny3z9uCvwQTsG1/hxI+9xOprONp3mH3jO4mYqg=
 github.com/containers/image/v5 v5.22.0 h1:KemxPmD4D2YYOFZN2SgoTk7nBFcnwPiPW0MqjYtknSE=
 github.com/containers/image/v5 v5.22.0/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1898,9 +1898,7 @@ func (dn *Daemon) checkOS(osImageURL string) bool {
 
 	// TODO(jkyros): the header for this functions says "if the digests match"
 	// so I'm wondering if at one point this used to work this way....
-	// TODO(jkyros): and pulling it just to check is so expensive, skopeo works now
-	// if you use the --no-tags argument (doesn't pull tags) so we should probably just do that
-	inspection, err := imageInspect(osImageURL)
+	inspection, _, err := imageInspect(osImageURL)
 	if err != nil {
 		glog.Warningf("Unable to check manifest for matching hash: %s", err)
 	} else if ostreeCommit, ok := inspection.Labels["ostree.commit"]; ok {

--- a/pkg/daemon/image-inspect.go
+++ b/pkg/daemon/image-inspect.go
@@ -3,35 +3,20 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"math"
 	"strings"
-	"time"
 
+	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/image"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
 )
 
 const (
 	// Number of retry we want to perform
 	cmdRetriesCount = 2
 )
-
-func retryIfNecessary(ctx context.Context, operation func() error) error {
-	err := operation()
-	for attempt := 0; err != nil && attempt < cmdRetriesCount; attempt++ {
-		delay := time.Duration(int(math.Pow(2, float64(attempt)))) * time.Second
-		fmt.Printf("Warning: failed, retrying in %s ... (%d/%d)", delay, attempt+1, cmdRetriesCount)
-		select {
-		case <-time.After(delay):
-			break
-		case <-ctx.Done():
-			return err
-		}
-		err = operation()
-	}
-	return err
-}
 
 // newDockerImageSource creates an image source for an image reference.
 // The caller must call .Close() on the returned ImageSource.
@@ -52,36 +37,61 @@ func newDockerImageSource(ctx context.Context, sys *types.SystemContext, name st
 
 // This function has been inspired from upstream skopeo inspect, see https://github.com/containers/skopeo/blob/master/cmd/skopeo/inspect.go
 // We can use skopeo inspect directly once fetching RepoTags becomes optional in skopeo.
-func imageInspect(imageName string) (*types.ImageInspectInfo, error) {
+// TODO(jkyros): I know we said we eventually wanted to use skopeo inspect directly, but it is really great being able
+// to know what the error is by using the libraries directly :)
+//
+//nolint:unparam
+func imageInspect(imageName string) (*types.ImageInspectInfo, *digest.Digest, error) {
 	var (
 		src        types.ImageSource
 		imgInspect *types.ImageInspectInfo
 		err        error
 	)
 
+	retryOpts := retry.Options{
+		MaxRetry: cmdRetriesCount,
+	}
+
 	ctx := context.Background()
 	sys := &types.SystemContext{AuthFilePath: kubeletAuthFile}
 
-	if err := retryIfNecessary(ctx, func() error {
+	// retry.IfNecessary takes into account whether the error is "retryable"
+	// so we don't keep looping on errors that will never resolve
+	if err := retry.IfNecessary(ctx, func() error {
 		src, err = newDockerImageSource(ctx, sys, imageName)
 		return err
-	}); err != nil {
-		return nil, fmt.Errorf("error parsing image name %q: %w", imageName, err)
+	}, &retryOpts); err != nil {
+		return nil, nil, fmt.Errorf("error parsing image name %q: %w", imageName, err)
+	}
+
+	var rawManifest []byte
+	if err := retry.IfNecessary(ctx, func() error {
+		rawManifest, _, err = src.GetManifest(ctx, nil)
+
+		return err
+	}, &retryOpts); err != nil {
+		return nil, nil, fmt.Errorf("error retrieving image manifest %q: %w", imageName, err)
+	}
+
+	// get the digest here because it's not part of the image inspection
+	digest, err := manifest.Digest(rawManifest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error retrieving image digest: %q: %w", imageName, err)
 	}
 
 	defer src.Close()
 
 	img, err := image.FromUnparsedImage(ctx, sys, image.UnparsedInstance(src, nil))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing manifest for image: %w", err)
+		return nil, nil, fmt.Errorf("error parsing manifest for image %q: %w", imageName, err)
 	}
 
-	if err := retryIfNecessary(ctx, func() error {
+	if err := retry.IfNecessary(ctx, func() error {
 		imgInspect, err = img.Inspect(ctx)
 		return err
-	}); err != nil {
-		return nil, err
+	}, &retryOpts); err != nil {
+		return nil, nil, err
 	}
 
-	return imgInspect, nil
+	return imgInspect, &digest, nil
 }

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -285,25 +285,13 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 // IsBootableImage determines if the image is a bootable (new container formet) image, or a wrapper (old container format)
 func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
 
-	// TODO(jkyros): This is duplicated-ish from Rebase(), do we still need to carry this around?
 	var isBootableImage string
 	var imageData *types.ImageInspectInfo
 	var err error
 	if imageData, err = imageInspect(imgURL); err != nil {
-		if err != nil {
-			var podmanImgData *imageInspection
-			glog.Infof("Falling back to using podman inspect")
-
-			if podmanImgData, err = podmanInspect(imgURL); err != nil {
-				return false, err
-			}
-			isBootableImage = podmanImgData.Labels["ostree.bootable"]
-		}
-	} else {
-		isBootableImage = imageData.Labels["ostree.bootable"]
+		return false, err
 	}
-	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
-	defer exec.Command("podman", "rmi", imgURL).Run()
+	isBootableImage = imageData.Labels["ostree.bootable"]
 
 	return isBootableImage == "true", nil
 }

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -214,7 +214,7 @@ func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool
 	}
 
 	var imageData *types.ImageInspectInfo
-	if imageData, err = imageInspect(imgURL); err != nil {
+	if imageData, _, err = imageInspect(imgURL); err != nil {
 		if err != nil {
 			var podmanImgData *imageInspection
 			glog.Infof("Falling back to using podman inspect")
@@ -288,7 +288,7 @@ func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
 	var isBootableImage string
 	var imageData *types.ImageInspectInfo
 	var err error
-	if imageData, err = imageInspect(imgURL); err != nil {
+	if imageData, _, err = imageInspect(imgURL); err != nil {
 		return false, err
 	}
 	isBootableImage = imageData.Labels["ostree.bootable"]

--- a/vendor/github.com/containers/common/LICENSE
+++ b/vendor/github.com/containers/common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containers/common/pkg/retry/retry.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry.go
@@ -1,0 +1,121 @@
+package retry
+
+import (
+	"context"
+	"io"
+	"math"
+	"net"
+	"net/url"
+	"syscall"
+	"time"
+
+	"github.com/docker/distribution/registry/api/errcode"
+	errcodev2 "github.com/docker/distribution/registry/api/v2"
+	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
+)
+
+// Options defines the option to retry.
+type Options struct {
+	MaxRetry int           // The number of times to possibly retry.
+	Delay    time.Duration // The delay to use between retries, if set.
+}
+
+// RetryOptions is deprecated, use Options.
+type RetryOptions = Options // nolint:revive
+
+// RetryIfNecessary deprecated function use IfNecessary.
+func RetryIfNecessary(ctx context.Context, operation func() error, options *Options) error { // nolint:revive
+	return IfNecessary(ctx, operation, options)
+}
+
+// IfNecessary retries the operation in exponential backoff with the retry Options.
+func IfNecessary(ctx context.Context, operation func() error, options *Options) error {
+	err := operation()
+	for attempt := 0; err != nil && isRetryable(err) && attempt < options.MaxRetry; attempt++ {
+		delay := time.Duration(int(math.Pow(2, float64(attempt)))) * time.Second
+		if options.Delay != 0 {
+			delay = options.Delay
+		}
+		logrus.Warnf("Failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, options.MaxRetry, err)
+		select {
+		case <-time.After(delay):
+			break
+		case <-ctx.Done():
+			return err
+		}
+		err = operation()
+	}
+	return err
+}
+
+func isRetryable(err error) bool {
+	switch err {
+	case nil:
+		return false
+	case context.Canceled, context.DeadlineExceeded:
+		return false
+	default: // continue
+	}
+
+	type unwrapper interface {
+		Unwrap() error
+	}
+
+	switch e := err.(type) {
+
+	case errcode.Error:
+		switch e.Code {
+		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeDenied,
+			errcodev2.ErrorCodeNameUnknown, errcodev2.ErrorCodeManifestUnknown:
+			return false
+		}
+		return true
+	case *net.OpError:
+		return isRetryable(e.Err)
+	case *url.Error: // This includes errors returned by the net/http client.
+		if e.Err == io.EOF { // Happens when a server accepts a HTTP connection and sends EOF
+			return true
+		}
+		return isRetryable(e.Err)
+	case syscall.Errno:
+		return isErrnoRetryable(e)
+	case errcode.Errors:
+		// if this error is a group of errors, process them all in turn
+		for i := range e {
+			if !isRetryable(e[i]) {
+				return false
+			}
+		}
+		return true
+	case *multierror.Error:
+		// if this error is a group of errors, process them all in turn
+		for i := range e.Errors {
+			if !isRetryable(e.Errors[i]) {
+				return false
+			}
+		}
+		return true
+	case net.Error:
+		if e.Timeout() {
+			return true
+		}
+		if unwrappable, ok := e.(unwrapper); ok {
+			err = unwrappable.Unwrap()
+			return isRetryable(err)
+		}
+	case unwrapper: // Test this last, because various error types might implement .Unwrap()
+		err = e.Unwrap()
+		return isRetryable(err)
+	}
+
+	return false
+}
+
+func isErrnoRetryable(e error) bool {
+	switch e {
+	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
+		return true
+	}
+	return isErrnoERESTART(e)
+}

--- a/vendor/github.com/containers/common/pkg/retry/retry_linux.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry_linux.go
@@ -1,0 +1,9 @@
+package retry
+
+import (
+	"syscall"
+)
+
+func isErrnoERESTART(e error) bool {
+	return e == syscall.ERESTART
+}

--- a/vendor/github.com/containers/common/pkg/retry/retry_unsupported.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package retry
+
+func isErrnoERESTART(e error) bool {
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,6 +112,9 @@ github.com/chavacava/garif
 # github.com/clarketm/json v1.14.1
 ## explicit
 github.com/clarketm/json
+# github.com/containers/common v0.49.0
+## explicit; go 1.17
+github.com/containers/common/pkg/retry
 # github.com/containers/image/v5 v5.22.0
 ## explicit; go 1.17
 github.com/containers/image/v5/docker


### PR DESCRIPTION
Manual 4.12 cherry-pick of https://github.com/openshift/machine-config-operator/pull/3413

~~had to bump `go-health` because it had dependency issues~~ 
