### PR TITLE
OCPBUGS-12885: daemon: Prepare for new nmstate logic

### DIFF
--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -39,7 +39,17 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 		// If asked, before we try an OS update, persist NIC names so that
 		// we handle the reprovision case with old disk images and Ignition configs
 		// that provide static IP addresses.
-		if err := daemon.PersistNetworkInterfaces("/rootfs"); err != nil {
+		osroot := "/rootfs"
+		newEnough, err := daemon.NmstateIsNewEnoughForCleanup(osroot)
+		if err != nil {
+			return err
+		}
+		if newEnough {
+			err = daemon.PersistNetworkInterfaces2(osroot)
+		} else {
+			err = daemon.PersistNetworkInterfaces1(osroot)
+		}
+		if err != nil {
 			return fmt.Errorf("failed to persist network interfaces: %w", err)
 		}
 		// We're done; this logic is distinct from the *non-containerized* /run/bin/machine-config-daemon

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -574,6 +574,12 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		return err
 	}
 
+	if dn.nmstateNew {
+		if err := PersistNetworkInterfaces2("/"); err != nil {
+			return err
+		}
+	}
+
 	// At this point, we write the now expected to be "current" config to /etc.
 	// When we reboot, we'll find this file and validate that we're in this state,
 	// and that completes an update.


### PR DESCRIPTION
In 4.13 we shipped a version of nmstate which supported a "v0" of NIC name handling.  Then that logic was reworked in https://github.com/nmstate/nmstate/commit/03c7b03bd4c9b0067d3811dbbf72635201519356 (Overall, for the better)
However, actually shipping this will require MCO changes.

Additionally at the same time, we were trying to add support for hosts using Tang, which complicates things because the nmstate logic also now needs to involve kernel arguments.

After some debate, we are going to land code to compute the kernel arguments back in nmstate.  It will have an option to output the set of kernel arguments it wants to change, which then the MCO will pass to rpm-ostree.  This keeps kernel argument handling more centralized.

In this commit, we are just detecting the nmstate version and invoking the *old* logic, which continues to use `--inspect`.

This then reverts the change to effectively lift the "inspect" logic into the MCO.

A followup change here will add the code to handle the *new* nmstate logic which will build on https://github.com/nmstate/nmstate/pull/2361
