### PR TITLE
OCPBUGS-12885: daemon: Add support for new nmstate logic

### DIFF
--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -39,7 +39,17 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 		// If asked, before we try an OS update, persist NIC names so that
 		// we handle the reprovision case with old disk images and Ignition configs
 		// that provide static IP addresses.
-		if err := daemon.PersistNetworkInterfaces("/rootfs"); err != nil {
+		osroot := "/rootfs"
+		newEnough, err := daemon.NmstateIsNewEnoughForCleanup(osroot)
+		if err != nil {
+			return err
+		}
+		if newEnough {
+			err = daemon.PersistNetworkInterfaces2(osroot)
+		} else {
+			err = daemon.PersistNetworkInterfaces1(osroot)
+		}
+		if err != nil {
 			return fmt.Errorf("failed to persist network interfaces: %w", err)
 		}
 		// We're done; this logic is distinct from the *non-containerized* /run/bin/machine-config-daemon

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -574,6 +574,12 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		return err
 	}
 
+	if dn.nmstateNew {
+		if err := PersistNetworkInterfaces2("/"); err != nil {
+			return err
+		}
+	}
+
 	// At this point, we write the now expected to be "current" config to /etc.
 	// When we reboot, we'll find this file and validate that we're in this state,
 	// and that completes an update.


### PR DESCRIPTION
Builds on https://github.com/openshift/machine-config-operator/pull/3719

---

This implements new logic on top of https://github.com/nmstate/nmstate/pull/2361

Here we additionally proxy the kernel arguments.

After this lands and works, we can delete the old "v1" NIC persistence
logic.