### PR TITLE
OCPBUGS-14793: Allow userfaultfd syscall to be used by unprivileged users

### DIFF
--- a/templates/common/_base/files/sysctl-userfaultfd.yaml
+++ b/templates/common/_base/files/sysctl-userfaultfd.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/sysctl.d/enable-userfaultfd.conf"
+contents:
+  inline: |
+    vm.unprivileged_userfaultfd = 1


### PR DESCRIPTION
**- What I did**
To implement post-copy migrations in OpenShift Virtualization (CNV), QEMU uses the userfaultfd system call.
lately this syscall was blocked by the kernel by default [[1](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2d5de004e009add27db76c5cdc9f1f7f7dc087e7)]. This effectively broke post-copy migrations.

Instead, there are three ways to grant permission to use userfaultfd [[1](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2d5de004e009add27db76c5cdc9f1f7f7dc087e7)]:
* By allowing unprivileged users to use it explicitly via sysctl
* By granting `CAP_SYS_PTRACE` capability to a process / container
* By exposing the `/dev/userfaultfd` to a container

This basically leaves us with two options:
1. Expose `/dev/userfaultfd` by writing a Kubernetes device plugin. This way every pod can ask for such device.
2. Allow the use of the syscall by toggling sysctl, and use seccomp to allow only VM pods (a.k.a. virt-launcher pods) to use it.

After some discussions, we think that the second option is better in terms of security. The main problem with a device plugin is that every pod on the system can ask to use it and potentially compromise the system. With the second option, only VM pods can use the syscall which narrows down the attack surface. In addition, a device plugin is much more visible to Kubernetes users than a seccomp profile, which is likely to be hidden from most users.

Since the syscall was available to use by anyone in previous versions (before the kernel blocked it), we feel that by allowing it we won't make things worse than what we had in the past, but rather make things more secure since we will now at least use seccomp profiles to deny it from non-VM pods.

Seccomp profiles that disallow the usage of `userfaultfd` syscall is already in place.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2d5de004e009add27db76c5cdc9f1f7f7dc087e7

See this thread for more info: https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1685519481938719.

**- How to verify it**
After booting up a node, the following is expected:
```bash
> cat /proc/sys/vm/unprivileged_userfaultfd 
1
```

In addition, the `userfaultfd` syscall should be available to use for unprivileged users (unless a seccomp profile disallows it).

**- Description for the changelog**
Allow userfaultfd syscall to be used by unprivileged users