### PR TITLE
OCPBUGS-14612: Improve logging for IPI deployments

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -8,6 +8,7 @@ contents:
       maxconn 20000
       mode    tcp
       log     /var/run/haproxy/haproxy-log.sock local0
+      log-format "%ci:%cp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
       option  dontlognull
       retries 3
       timeout http-request 30s


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Improve logging format of KNI haproxy logs to display tcplogs + frondend IP and frontend port.

The current logging format is not very verbose:
~~~
<134>Jun  2 22:54:02 haproxy[11]: Connect from ::1:42424 to ::1:9445 (main/TCP)
<134>Jun  2 22:54:04 haproxy[11]: Connect from ::1:42436 to ::1:9445 (main/TCP)
<134>Jun  2 22:54:04 haproxy[11]: Connect from ::1:42446 to ::1:9445 (main/TCP)
~~~

It lacks critical information for troubleshooting, such as load-balancing destination and timestamps. 
https://www.haproxy.com/blog/introduction-to-haproxy-logging recommends the following for tcp mode:
~~~
When in TCP mode, which is set by adding mode tcp, you should also add [option tcplog](https://www.haproxy.com/documentation/hapee/1-8r1/onepage/#option%20tcplog).
~~~

Because `option tcplog` actually loses information about the frontend IP and port that are being hit, I modified the logging format slightly to be:
~~~
log-format "%ci:%cp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
~~~

**- How to verify it**

Check the kni haproxy logs which will be more verbose now:
~~~
[akaris@workstation kubernetes (debug-apiserver-scc)]$ oc logs -n openshift-kni-infra                                haproxy-master-2 --tail=10
Defaulted container "haproxy" out of: haproxy, haproxy-monitor, verify-api-int-resolvable (init)
<134>Jun  6 13:09:44 haproxy[16]: ::ffff:192.168.111.1:37732 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:43.179] main masters/master-2 1/0/883 134324 -- 65/65/64/45/0 0/0
<134>Jun  6 13:09:49 haproxy[16]: ::1:38180 -> ::1:9445 [06/Jun/2023:13:09:49.279] main masters/master-0 1/0/3 3317 -- 65/65/64/16/0 0/0
<134>Jun  6 13:09:51 haproxy[16]: ::ffff:192.168.111.1:37734 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:50.478] main masters/master-2 1/0/1341 14630 -- 66/66/65/45/0 0/0
<134>Jun  6 13:09:51 haproxy[16]: ::ffff:192.168.111.1:37736 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:51.149] main masters/master-1 1/0/672 109397 -- 65/65/64/3/0 0/0
<134>Jun  6 13:09:55 haproxy[16]: ::1:40502 -> ::1:9445 [06/Jun/2023:13:09:55.301] main masters/master-0 1/0/3 3317 -- 65/65/64/16/0 0/0
<134>Jun  6 13:09:56 haproxy[16]: ::ffff:192.168.111.23:52916 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:56.595] main masters/master-2 1/0/3 2848 -- 66/66/65/45/0 0/0
<134>Jun  6 13:09:56 haproxy[16]: ::ffff:192.168.111.23:52924 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:56.595] main masters/master-1 1/0/3 2856 -- 65/65/64/3/0 0/0
<134>Jun  6 13:09:59 haproxy[16]: ::ffff:192.168.111.1:37738 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:58.001] main masters/master-0 1/0/1030 14630 -- 66/66/65/16/0 0/0
<134>Jun  6 13:09:59 haproxy[16]: ::ffff:192.168.111.1:37740 -> ::ffff:192.168.111.22:9445 [06/Jun/2023:13:09:58.518] main masters/master-2 1/0/518 4493 -- 65/65/64/45/0 0/0
<134>Jun  6 13:10:01 haproxy[16]: ::1:40510 -> ::1:9445 [06/Jun/2023:13:10:01.319] main masters/master-1 1/0/4 3317 -- 65/65/64/3/0 0/0
~~~

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
