### PR TITLE
OCPSTRAT-729: operator: Drop most of root-ca legacy

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -55,7 +55,7 @@ var (
 func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	// See https://docs.openshift.com/container-platform/4.13/security/certificate_types_descriptions/machine-config-operator-certificates.html
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcsCAFile, "root-ca", "/etc/ssl/kubernetes/ca.crt", "Path to installer-generated root MCS CA")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.mcsCAFile, "root-ca", "/etc/ssl/kubernetes/ca.crt", "This argument is unused and does nothing")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeCAFile, "kube-ca", "", "path to kube-apiserver serving-ca bundle")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.pullSecretFile, "pull-secret", "/assets/manifests/pull.json", "path to secret manifest that contains pull secret.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.destinationDir, "dest-dir", "", "The destination directory where MCO writes the manifests.")

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -51,7 +51,7 @@ type ControllerConfigSpec struct {
 	// kubeAPIServerServingCAData managed Kubelet to API Server Cert... Rotated automatically
 	KubeAPIServerServingCAData []byte `json:"kubeAPIServerServingCAData"`
 
-	// rootCAData specifies the root CA data
+	// rootCAData is unused
 	RootCAData []byte `json:"rootCAData"`
 
 	// cloudProvider specifies the cloud provider CA data

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -125,9 +125,7 @@ func RenderBootstrap(
 		spec.CloudProviderConfig = cloudConf
 	}
 
-	bundle := make([]byte, 0)
-	bundle = append(bundle, filesData[mcsCAFile]...)
-	// Append the kube-ca if given.
+	// Set the kube-ca if given.
 	if _, ok := filesData[kubeAPIServerServingCA]; ok {
 		spec.KubeAPIServerServingCAData = filesData[kubeAPIServerServingCA]
 	}
@@ -136,7 +134,6 @@ func RenderBootstrap(
 		spec.CloudProviderCAData = data
 	}
 
-	spec.RootCAData = bundle
 	spec.PullSecret = nil
 	spec.OSImageURL = imgs.MachineOSContent
 	spec.BaseOSContainerImage = imgs.BaseOSContainerImage

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -492,9 +492,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		internalRegistryPullSecret = nil
 	}
 
-	bundle := make([]byte, 0)
-	bundle = append(bundle, rootCA...)
-
 	// sync up os image url
 	// TODO: this should probably be part of the imgs
 	oscontainer, osextensionscontainer, osimageurl, err := optr.getOsImageURLs(optr.namespace)
@@ -549,7 +546,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	}
 
 	spec.KubeAPIServerServingCAData = kubeAPIServerServingCABytes
-	spec.RootCAData = bundle
 	spec.ImageRegistryBundleData = imgRegistryData
 	spec.ImageRegistryBundleUserData = imgRegistryUsrData
 	spec.PullSecret = &corev1.ObjectReference{Namespace: "openshift-config", Name: "pull-secret"}

--- a/templates/common/_base/files/root-ca.yaml
+++ b/templates/common/_base/files/root-ca.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/ca.crt"
-contents:
-  inline: |
-{{.RootCAData | toString | indent 4}}


### PR DESCRIPTION
Depends:

 - https://github.com/openshift/machine-config-operator/pull/3728
 - https://github.com/openshift/machine-config-operator/pull/3730

---

Drop /etc/kubernetes/ca.crt from node root

xref https://issues.redhat.com/browse/MCO-642?focusedId=22410761&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22410761

As I've been digging into the code more...this "root ca" thing has a
ton of legacy that's actually been slowly cleaned up over time
indirectly.  In the original OCP 4.1, we projected the "MCS CA"
alongside kubelet and cloud CAs into /etc/kubernetes/ca.crt on the node
filesystem.  But that's been severed since then:

Key commits here are e.g.

* https://github.com/openshift/machine-config-operator/commit/7287d4d19f79531e3a6d3e77c927a2495877c7ee
  which *added* the kubelet CA separately (but kept it in the /etc/kubernetes/ca.crt)
* https://github.com/openshift/machine-config-operator/commit/05614046601633fd677e1799c7d4a35bd8431d32
  which removed the kubelet CA from the file entirely

Confusingly, the cloud provider CA code is right there after the
kubelet bits, but it was as far as I can tell never synced into "ca.crt".

As far as I can tell, nothing actually today uses this, so dropping
it is just a general cleanup.

However more specifically, this is an important preparatory cleanup
for adding support for rotating this certificate, which is what
https://issues.redhat.com/browse/MCO-642
is about.

---

operator: Stop managing rootCAData

Nothing was ever using this actually for a long time, so we
can safely stop adding this certificate into the controller-config.

---

