### PR TITLE
operator: Stop mounting /etc/kubernetes/ca.crt

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -37,8 +37,6 @@ spec:
             value: "0.0.1-snapshot"
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - name: root-ca
-          mountPath: /etc/ssl/kubernetes/ca.crt
         - name: images
           mountPath: /etc/mco/images
       - name: kube-rbac-proxy
@@ -87,9 +85,6 @@ spec:
       - name: images
         configMap:
           name: machine-config-operator-images
-      - name: root-ca
-        hostPath:
-          path: /etc/kubernetes/ca.crt
       - name: proxy-tls
         secret:
           secretName: mco-proxy-tls


### PR DESCRIPTION
xref https://issues.redhat.com/browse/MCO-642?focusedId=22410761&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22410761

As far as I can tell, the operator has actually never read this file.  It's only on the bootstrap path.

In fact, I believe this is dead code since
1f94f06b52ddf00ebc8377e1737a8fd68b4f357a
which dates to the very creation of OCP 4.

This is preparatory cleanup for adding support for rotation.
