### PR TITLE
OCPBUGS-14674: set pool alert back to zero in more default scenarios.

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -36,7 +36,7 @@ spec:
             severity: warning
           annotations:
             summary: "Triggers when nodes in a pool have overlapping labels such as master, worker, and a custom label therefore a choice must be made as to which is honored."
-            description: "Node {{ $labels.node }} has triggered a pool alert due to a label change. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon"
+            description: "Node {{ $labels.exported_node }} has triggered a pool alert due to a label change. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -35,7 +35,7 @@ var (
 		prometheus.GaugeOpts{
 			Name: "mcc_pool_alert",
 			Help: "pool status alert",
-		}, []string{"pool", "alert"})
+		}, []string{"node"})
 )
 
 func RegisterMCCMetrics() error {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -626,10 +626,10 @@ func (ctrl *Controller) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.MachineCon
 		if master != nil {
 			// if we have a custom pool and master, defer to master and return.
 			klog.Infof("Found master node that matches selector for custom pool %v, defaulting to master. This node will not have any custom role configuration as a result. Please review the node to make sure this is intended", custom[0].Name)
-			ctrlcommon.MCCPoolAlert.WithLabelValues(custom[0].Name, fmt.Sprintf("Given both master and custom pools. Defaulting to master: custom %v", custom[0].Name)).Set(1)
+			ctrlcommon.MCCPoolAlert.WithLabelValues(node.Name).Set(1)
 			pls = append(pls, master)
 		} else {
-			ctrlcommon.MCCPoolAlert.WithLabelValues(custom[0].Name, "Applying custom label for pool").Set(0)
+			ctrlcommon.MCCPoolAlert.WithLabelValues(node.Name).Set(0)
 			pls = append(pls, custom[0])
 		}
 		if worker != nil {
@@ -643,9 +643,11 @@ func (ctrl *Controller) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.MachineCon
 		// the master pool. This occurs in CodeReadyContainers and general
 		// "single node" deployments, which one may want to do for testing bare
 		// metal, etc.
+		ctrlcommon.MCCPoolAlert.WithLabelValues(node.Name).Set(0)
 		return []*mcfgv1.MachineConfigPool{master}, nil
 	}
 	// Otherwise, it's a worker with no custom roles.
+	ctrlcommon.MCCPoolAlert.WithLabelValues(node.Name).Set(0)
 	return []*mcfgv1.MachineConfigPool{worker}, nil
 }
 


### PR DESCRIPTION
**- What I did**

set pool alert back to zero in more default scenarios.
this entails alerting users when only applying worker, master, or custom, or a combination

without these `.Set(0)` lines, the alert will be firing when it should not.

Also, change the metric to just log node name so the label is easier to track down and reset.

**- How to verify it**

1. Create a custom MCP

apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
  name: infra
spec:
  machineConfigSelector:
    matchExpressions:
      - { key: machineconfiguration.openshift.io/role, operator: In, values: [master,infra] }
  nodeSelector:
    matchLabels:
      node-role.kubernetes.io/infra: ""


2. Label a master node so that it is included in the new custom MCP

$ oc label node $( oc get nodes -l node-role.kubernetes.io/master -ojsonpath="{.items[0].metadata.name}" ) node-role.kubernetes.io/infra=""

3. Verify that the alert is fired

alias thanosalerts='curl -s -k -H "Authorization: Bearer $ ( oc -n openshift-monitoring create token prometheus-k8s )" https://$( oc get route -n openshift-monitoring thanos-querier -o jsonpath={.spec.host} )/api/v1/alerts | jq '

$ thanosalerts |grep alertname
  ....
          "alertname": "MCCPoolAlert",


4. Remove the label from the node to fix the problem

$ oc label node $( oc get nodes -l node-role.kubernetes.io/master -ojsonpath="{.items[0].metadata.name}" ) node-role.kubernetes.io/infra-

5. The alert should be removed.

**- Description for the changelog**

Alter MCCPoolAlert so that it sets to zero with custom labels each time a pool switch occurs.
