### PR TITLE
OCPBUGS-14399 : Minor fix to support `protectKernelDefaults` field in Kubelet Config

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/imdario/mergo"
@@ -33,6 +34,7 @@ const (
 	managedNodeConfigKeyPrefix    = "97"
 	managedFeaturesKeyPrefix      = "98"
 	managedKubeletConfigKeyPrefix = "99"
+	protectKernelDefaultsStr      = "\"protectKernelDefaults\":false"
 )
 
 func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, userDefinedSystemReserved map[string]string) *ign3types.File {
@@ -455,6 +457,14 @@ func generateKubeletIgnFiles(kubeletConfig *mcfgv1.KubeletConfig, originalKubeCo
 		// Remove them here to prevent the specKubeletConfig merge overwriting them.
 		specKubeletConfig.FeatureGates = nil
 
+		// "protectKernelDefaults" is a boolean, optional field with `omitempty` json tag in the upstream kubelet configuration
+		// This field has been set to `true` by default in OCP recently
+		// As this field is an optional one with the above tag, it gets omitted when a user inputs it to `false`
+		// Reference: https://github.com/golang/go/issues/13284
+		// Adding a workaround to decide if the user has actually set the field to `false`
+		if strings.Contains(string(kubeletConfig.Spec.KubeletConfig.Raw), protectKernelDefaultsStr) {
+			originalKubeConfig.ProtectKernelDefaults = false
+		}
 		// Merge the Old and New
 		err = mergo.Merge(originalKubeConfig, specKubeletConfig, mergo.WithOverride)
 		if err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
"Fixes: https://issues.redhat.com/browse/OCPBUGS-14399"

**- What I did**
Added a small workaround to support the `protectKernelDefaults` field of the Kubelet Config when user sets it to `false`
**- How to verify it**
Apply the following kubeletconfig to the OCP cluster and observe that the same has been reflected in the /etc/kubernetes/kubelet.conf file of the worker nodes
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: worker-protect-kernel-defaults
spec:
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
  kubeletConfig:
    protectKernelDefaults: false
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`protectKernelDefaults` is set to `true` in the OCP by default [recently](https://github.com/openshift/machine-config-operator/pull/3556). Now, configuring this field via `kubeletconfig` to `false` doesn't take effect due to [this](https://github.com/golang/go/issues/13284) behavior.
This PR adds a minor fix that allow a user to set the field to `false`