### PR TITLE
OCPBUGS-4820: Controller version mismatch causing degradation during upgrades

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -188,6 +188,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
+			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -29,7 +29,7 @@ rules:
   verbs: ["create"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources: ["daemonsets"]
   verbs: ["get"]

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -80,7 +80,7 @@ func (f *fixture) newController() *Controller {
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.schedulerClient, noResyncPeriodFunc())
 	c := New(i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), i.Machineconfiguration().V1().MachineConfigPools(), k8sI.Core().V1().Nodes(),
-		ci.Config().V1().Schedulers(), f.kubeclient, f.client)
+		k8sI.Core().V1().Pods(), ci.Config().V1().Schedulers(), f.kubeclient, f.client)
 
 	c.ccListerSynced = alwaysReady
 	c.mcpListerSynced = alwaysReady
@@ -219,7 +219,9 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "controllerconfigs") ||
 				action.Matches("watch", "controllerconfigs") ||
 				action.Matches("list", "nodes") ||
-				action.Matches("watch", "nodes")) {
+				action.Matches("watch", "nodes") ||
+				action.Matches("list", "pods") ||
+				action.Matches("watch", "pods")) {
 			continue
 		}
 		ret = append(ret, action)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -489,6 +489,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
+			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Added a new function called getOperatorNodeName() ~Fleshed out the findEtcdLeader stub~ in the controller that helps us queue control plane nodes for updates.  I'll do a subsequent commit for bumping the timeout, but want to run a few tests with the queuing in place first. 

**- Description for the changelog**
controller: defer update of node running operator
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
