### PR TITLE
OCPBUGS-14965: Run hostnamectl with systemd-run

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-static-dhcp.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcp.yaml
@@ -64,5 +64,6 @@ contents:
 
     if [ -n "${DHCP4_HOST_NAME:-}" ]
     then
-        hostnamectl set-hostname --static --transient "$DHCP4_HOST_NAME"
+        systemd-run --property=Type=oneshot --unit static-dhcp-hostnamectl -Pq \
+          hostnamectl set-hostname --static --transient "$DHCP4_HOST_NAME"
     fi


### PR DESCRIPTION
This was fixed for the resolv-prepender script in
https://github.com/openshift/machine-config-operator/commit/1953269ebc168065345e465bac9c832b71bfb016 but it was recently pointed out that we are doing the same thing in static-dhcp dispatcher script too. Although I doubt anyone is still using that feature, it is still technically supported so we should fix it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Fixed SELinux issue in static-dhcp dispatcher script.
