### PR TITLE
[DNM] OCPBUGS-11437: MCO keeps the pull secret to .orig file once it replaced

### DIFF
--- a/pkg/daemon/config_drift_monitor_test.go
+++ b/pkg/daemon/config_drift_monitor_test.go
@@ -492,7 +492,7 @@ func (tc *configDriftMonitorTestCase) writeIgnitionConfig(t *testing.T, ignConfi
 	// Write files the same way the MCD does.
 	// NOTE: We manually handle the errors here because using require.Nil or
 	// require.NoError will skip the deferred functions, which is undesirable.
-	if err := writeFiles(ignConfig.Storage.Files, true); err != nil {
+	if err := writeFiles(ignConfig.Storage.Files, true, true); err != nil {
 		return fmt.Errorf("could not write ignition config files: %w", err)
 	}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1876,7 +1876,7 @@ func (dn *Daemon) runOnceFromIgnition(ignConfig ign3types.Config) error {
 	if err := dn.writeUnits(ignConfig.Systemd.Units); err != nil {
 		return err
 	}
-	// Unconditionally remove this file in the once-from (classic RHEL)
+	// Unconditionally remove this file in the once-from (classic RsHEL)
 	// case.  We use this file to suppress things like kubelet and SDN
 	// starting on CoreOS during the firstboot/pivot boot, but there's
 	// no such thing on classic RHEL.

--- a/pkg/daemon/file_writers.go
+++ b/pkg/daemon/file_writers.go
@@ -46,7 +46,7 @@ func noOrigFileStampName(fpath string) string {
 	return filepath.Join(noOrigParentDir(), fpath+".mcdnoorig")
 }
 
-func createOrigFile(fromPath, fpath string, isCoreOSVariant bool) error {
+func createOrigFile(fromPath, fpath string, isCoreOSVariant, forceCreate bool) error {
 	if _, err := os.Stat(noOrigFileStampName(fpath)); err == nil {
 		// we already created the no orig file for this default file
 		return nil
@@ -75,6 +75,8 @@ func createOrigFile(fromPath, fpath string, isCoreOSVariant bool) error {
 		} else {
 			orig = true
 		}
+	} else if forceCreate == true {
+		orig = true
 	} else {
 		orig = false
 	}
@@ -166,7 +168,7 @@ func writeDropins(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) er
 		klog.Infof("Writing systemd unit dropin %q", u.Dropins[i].Name)
 		if _, err := os.Stat(withUsrPath(dpath)); err == nil &&
 			isCoreOSVariant {
-			if err := createOrigFile(withUsrPath(dpath), dpath, isCoreOSVariant); err != nil {
+			if err := createOrigFile(withUsrPath(dpath), dpath, isCoreOSVariant, false); err != nil {
 				return err
 			}
 		}
@@ -212,7 +214,7 @@ func writeFiles(files []ign3types.File, skipCertificateWrite, isCoreOSVariant bo
 		if err != nil {
 			return fmt.Errorf("failed to retrieve file ownership for file %q: %w", file.Path, err)
 		}
-		if err := createOrigFile(file.Path, file.Path, isCoreOSVariant); err != nil {
+		if err := createOrigFile(file.Path, file.Path, isCoreOSVariant, false); err != nil {
 			return err
 		}
 		if err := writeFileAtomically(file.Path, decodedContents, defaultDirectoryPermissions, mode, uid, gid); err != nil {
@@ -252,7 +254,7 @@ func writeUnit(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error
 		klog.Infof("Writing systemd unit %q", u.Name)
 		if _, err := os.Stat(withUsrPath(fpath)); err == nil &&
 			isCoreOSVariant {
-			if err := createOrigFile(withUsrPath(fpath), fpath, isCoreOSVariant); err != nil {
+			if err := createOrigFile(withUsrPath(fpath), fpath, isCoreOSVariant, false); err != nil {
 				return err
 			}
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1509,7 +1509,7 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 // writeFiles writes the given files to disk.
 // it doesn't fetch remote files and expects a flattened config file.
 func (dn *Daemon) writeFiles(files []ign3types.File, skipCertificateWrite bool) error {
-	return writeFiles(files, skipCertificateWrite)
+	return writeFiles(files, skipCertificateWrite, dn.os.IsCoreOSVariant())
 }
 
 // Ensures that both the SSH root directory (/home/core/.ssh) as well as any

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -779,11 +779,11 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Back up that normal file
-	err = createOrigFile(controlFile, controlFile, true)
+	err = createOrigFile(controlFile, controlFile, true, true)
 	assert.Nil(t, err)
 
 	// Now try again and make sure it knows it's already backed up
-	err = createOrigFile(controlFile, controlFile, true)
+	err = createOrigFile(controlFile, controlFile, true, true)
 	assert.Nil(t, err)
 
 	// Restore the normal file
@@ -802,7 +802,7 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Back up the relative symlink
-	err = createOrigFile(relativeSymlink, relativeSymlink, true)
+	err = createOrigFile(relativeSymlink, relativeSymlink, true, true)
 	assert.Nil(t, err)
 
 	// Remove the symlink and write a file over it
@@ -813,7 +813,7 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Try to back it up again make sure it knows it's already backed up
-	err = createOrigFile(relativeSymlink, relativeSymlink, true)
+	err = createOrigFile(relativeSymlink, relativeSymlink, true, true)
 	assert.Nil(t, err)
 
 	// Finally, make sure we can restore the relative symlink if we rollback

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -779,11 +779,11 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Back up that normal file
-	err = createOrigFile(controlFile, controlFile)
+	err = createOrigFile(controlFile, controlFile, true)
 	assert.Nil(t, err)
 
 	// Now try again and make sure it knows it's already backed up
-	err = createOrigFile(controlFile, controlFile)
+	err = createOrigFile(controlFile, controlFile, true)
 	assert.Nil(t, err)
 
 	// Restore the normal file
@@ -802,7 +802,7 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Back up the relative symlink
-	err = createOrigFile(relativeSymlink, relativeSymlink)
+	err = createOrigFile(relativeSymlink, relativeSymlink, true)
 	assert.Nil(t, err)
 
 	// Remove the symlink and write a file over it
@@ -813,7 +813,7 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Try to back it up again make sure it knows it's already backed up
-	err = createOrigFile(relativeSymlink, relativeSymlink)
+	err = createOrigFile(relativeSymlink, relativeSymlink, true)
 	assert.Nil(t, err)
 
 	// Finally, make sure we can restore the relative symlink if we rollback


### PR DESCRIPTION
**- OCPBUGS11437**
The pull secret is preserved in the path /etc/machine-config-daemon/orig/var/lib/kubelet/config.json.mcdorig. Whereas, the user needs it to be deleted when the pull secret is being deleted/ replaced. 
**- What is the problem**
There is complaint about that the MCD is creating orig files to preserve files that should not be preserved. To be more specific, the orig preserving system should only preserve files that are originally on the disk, but are now preserving files that are written by Ignition. The root cause is that Ignition writes the files before the MCD takes the control as a result when MCD comes in, it sees all the files written before as files on disk, which is very wrong. 
**- What I did**
Add more constraints for orig file generation: orig files should only be generated on files that 1) claimed by the rpm 2) exist in the usr/etc directory 3) exist before MCD takes control 
**- How to verify it**
Ignition writes files in the /var directory. And now when cat into the orig folder for the MCD, there is no var folder, meaning that files written by Ignition are not preserved now. Specific example would be that catting into /etc/machine-config-daemon/orig/var/lib/kubelet/config.json.mcdori will now return no so such file 


