### PR TITLE
azure: add NM script to increase rx/tx

### DIFF
--- a/templates/master/00-master/azure/files/etc-NetworkManager-dispatcherd-99-azure-increase-rx-tx-ring-buffer.yaml
+++ b/templates/master/00-master/azure/files/etc-NetworkManager-dispatcherd-99-azure-increase-rx-tx-ring-buffer.yaml
@@ -1,0 +1,10 @@
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/99-azure-increase-rx-tx-ring-buffer"
+contents:
+  inline: |
+    #!/bin/bash
+    driver=$(nmcli -t -m tabular -f general.driver dev show "${DEVICE_IFACE}")
+    if [[ "$2" == "up" && "${driver}" == "hv_netvsc" && -f /usr/sbin/ethtool ]]; then
+      logger -s "99-azure-increase-rx-tx-ring-buffer triggered by ${2} on device ${DEVICE_IFACE}."
+      ethtool -G ${DEVICE_IFACE} rx 9362 tx 2560
+    fi


### PR DESCRIPTION
Default TX/RX settings on the main interface are too small in Azure, periodically making etcd throw errors:

```
dropped internal Raft message since sending buffer is full (overloaded network)
```

According to https://access.redhat.com/solutions/5637801 this needs to have TX/RX buffers increased

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
