### PR TITLE
4.13: use rhel9 builder for daemon binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,17 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel9-builder
+ARG TAGS=""
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN make install DESTDIR=./instroot
+
 FROM registry.ci.openshift.org/ocp/4.13:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,10 +7,17 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel9-builder
+ARG TAGS=""
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN make install DESTDIR=./instroot
+
 FROM registry.ci.openshift.org/ocp/4.13:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -18,7 +18,7 @@ contents: |
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
+  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
   ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env


### PR DESCRIPTION
While attempting to switch builder to rhel9 base, the nmstate binary from rhel9 fails. With that change reverted for now, this aims to build a separate MCD binary off the rhel9 builder, for the mcd-firstboot.service to use. This way, the image MCD runs on rhel8, and the host runs on rhel9, matching the on-disk OS version.

If any rhel8 nodes (non-rhcos) are present, I think it should have skipped this process, so that shouldn't be affected.

This is an alternative to https://github.com/openshift/machine-config-operator/pull/3758