### PR TITLE
trivial: Fix namespace for kube api server operator

### DIFF
--- a/docs/MachineConfigDaemon.md
+++ b/docs/MachineConfigDaemon.md
@@ -159,7 +159,7 @@ Most reboot exceptions also skip a drain, but some have to reload crio.
 The "None" action only performs the corresponding file write; it does not trigger a drain or a reboot. This action is taken for changes to the following items:
 
 1. [SSH Keys](./Update-SSHKeys.md): updated by changing `ignition.passwd.users.sshAuthorizedKeys` in a MachineConfig
-2. kube-apiserver-to-kubelet-signer CA cert: located at `/etc/kubernetes/kubelet-ca.crt` and autorotated by the openshift-kubeapiserver operator after a 1 year expiry
+2. kube-apiserver-to-kubelet-signer CA cert: located at `/etc/kubernetes/kubelet-ca.crt` and autorotated by the openshift-kube-apiserver operator after a 1 year expiry
 3. [Pull Secret](./PullSecret.md): cluster-wide, located at `/var/lib/kubelet/config.json`
 
 #### "Reload Crio" Action


### PR DESCRIPTION
The documentation references openshift-kubeapiserver operator, which should map to
https://github.com/openshift/cluster-kube-apiserver-operator. If you look in an OpenShift cluster for that namespace, it doesn't exist. This commit updates the documentation to use openshift-kube-apiserver, which is the namespace for the operator.

**- Description for the changelog**

Update documentation to reference the proper namespace for the `openshift-kube-apiserver` operator.
