### PR TITLE
OCPBUGS-15580: 4.13: Dockerfile: update rhel7 nmstate pin

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -19,9 +19,10 @@ RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config-operator_05_osimageurl.yaml; fi && \
     # rewrite image names for fcos/scos
+    # XXX: pin nmstate to 2.2.9 until we've replaced `--inspect` (see https://github.com/openshift/machine-config-operator/pull/3706)
     if [ "${TAGS}" = "fcos" ]; then sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate > 2.2' && dnf clean all && rm -rf /var/cache/dnf/*
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install nmstate-2.2.9-6.rhaos4.13.el8 && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
Confusingly, this Dockerfile doesn't seem to be autogenerated, and is also what is using for ART builds.

Match the nmstate pin so we unbreak 4.13 builds.

