### PR TITLE
OCPBUGS-15728: Fix machine config drifts when deploying with platform external

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -1116,8 +1116,25 @@ spec:
                                 type: string
                             type: object
                           external:
-                            description: External contains settings specific to the
-                              generic External infrastructure provider.
+                            description: External contains settings specific to the generic External infrastructure provider.
+                            properties:
+                              cloudControllerManager:
+                                description: cloudControllerManager contains settings specific to the external Cloud Controller Manager (a.k.a. CCM or CPI). When omitted, new nodes will be not tainted and no extra initialization from the cloud controller manager is expected.
+                                properties:
+                                  state:
+                                    description: "state determines whether or not an external Cloud Controller Manager is expected to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager \n Valid values are \"External\", \"None\" and omitted. When set to \"External\", new nodes will be tainted as uninitialized when created, preventing them from running workloads until they are initialized by the cloud controller manager. When omitted or set to \"None\", new nodes will be not tainted and no extra initialization from the cloud controller manager is expected."
+                                    enum:
+                                      - ""
+                                      - External
+                                      - None
+                                    type: string
+                                    x-kubernetes-validations:
+                                      - message: state is immutable once set
+                                        rule: self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                  - message: state may not be added or removed once set
+                                    rule: (has(self.state) == has(oldSelf.state)) || (!has(oldSelf.state) && self.state != "External")
                             type: object
                           gcp:
                             description: GCP contains settings specific to the Google

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -90,6 +90,7 @@ func newFixture(t *testing.T) *fixture {
 			apicfgv1.FeatureGateExternalCloudProvider,
 			apicfgv1.FeatureGateExternalCloudProviderAzure,
 			apicfgv1.FeatureGateExternalCloudProviderGCP,
+			apicfgv1.FeatureGateExternalCloudProviderExternal,
 		},
 	)
 	return f

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -180,7 +180,7 @@ func platformStringFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (st
 		return "", fmt.Errorf("cannot generate MachineConfigs when no platformStatus.type is set")
 	case platformBase:
 		return "", fmt.Errorf("platform _base unsupported")
-	case configv1.AWSPlatformType, configv1.AlibabaCloudPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.KubevirtPlatformType, configv1.PowerVSPlatformType, configv1.NonePlatformType, configv1.NutanixPlatformType:
+	case configv1.AWSPlatformType, configv1.AlibabaCloudPlatformType, configv1.AzurePlatformType, configv1.BareMetalPlatformType, configv1.GCPPlatformType, configv1.OpenStackPlatformType, configv1.LibvirtPlatformType, configv1.OvirtPlatformType, configv1.VSpherePlatformType, configv1.KubevirtPlatformType, configv1.PowerVSPlatformType, configv1.NonePlatformType, configv1.ExternalPlatformType, configv1.NutanixPlatformType:
 		return strings.ToLower(string(ic.Infra.Status.PlatformStatus.Type)), nil
 	default:
 		// platformNone is used for a non-empty, but currently unsupported platform.

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -28,8 +28,8 @@ func TestMain(m *testing.M) {
 func TestCloudProvider(t *testing.T) {
 	dummyTemplate := []byte(`{{cloudProvider .}}`)
 
-	externalEnabledFG := featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure}, nil)
-	externalDisabledFG := featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure})
+	externalEnabledFG := featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure, cloudprovider.ExternalCloudProviderFeatureExternal}, nil)
+	externalDisabledFG := featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure, cloudprovider.ExternalCloudProviderFeatureExternal})
 
 	cases := []struct {
 		platform          configv1.PlatformType
@@ -148,8 +148,8 @@ func TestCloudProvider(t *testing.T) {
 func TestCloudConfigFlag(t *testing.T) {
 	dummyTemplate := []byte(`{{cloudConfigFlag .}}`)
 
-	externalEnabledFG := featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure}, nil)
-	externalDisabledFG := featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure})
+	externalEnabledFG := featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure, cloudprovider.ExternalCloudProviderFeatureExternal}, nil)
+	externalDisabledFG := featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureAzure, cloudprovider.ExternalCloudProviderFeatureExternal})
 
 	cases := []struct {
 		platform          configv1.PlatformType
@@ -352,6 +352,7 @@ var (
 		"libvirt":                "./test_data/controller_config_libvirt.yaml",
 		"mtu-migration":          "./test_data/controller_config_mtu_migration.yaml",
 		"none":                   "./test_data/controller_config_none.yaml",
+		"external":               "./test_data/controller_config_external.yaml",
 		"vsphere":                "./test_data/controller_config_vsphere.yaml",
 		"kubevirt":               "./test_data/controller_config_kubevirt.yaml",
 		"powervs":                "./test_data/controller_config_powervs.yaml",
@@ -399,7 +400,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 			t.Fatalf("failed to get controllerconfig config: %v", err)
 		}
 
-		fgAccess := featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureAzure, cloudprovider.ExternalCloudProviderFeatureGCP})
+		fgAccess := featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureAzure, cloudprovider.ExternalCloudProviderFeatureGCP, cloudprovider.ExternalCloudProviderFeatureExternal})
 
 		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, fgAccess, nil}, templateDir)
 		if err != nil {

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -427,7 +427,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
-	fgAccess := featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature}, nil)
+	fgAccess := featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{cloudprovider.ExternalCloudProviderFeature, cloudprovider.ExternalCloudProviderFeatureExternal}, nil)
 
 	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`), fgAccess)
 	if err != nil {

--- a/pkg/controller/template/test_data/controller_config_external.yaml
+++ b/pkg/controller/template/test_data/controller_config_external.yaml
@@ -1,0 +1,28 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 3
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      platformStatus:
+        type: "External"
+        external:
+          cloudControllerManager:
+            state: "External"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

We found two errors while installing the recently added platform type External in a non-integrated provider (OCI).
The machine-config operator is getting stuck with the following message:

~~~
$ oc get co machine-config
NAME             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
machine-config             True        True          True       21h     Unable to apply 4.14.0-0.nightly-2023-06-27-233015: 
error during syncRequiredMachineConfigPools: [context deadline exceeded, failed to update clusteroperator:
 [client rate limiter Wait returned an error: context deadline exceeded, error MachineConfigPool master 
is not ready, retrying. Status: (pool degraded: true total: 3, ready 0, updated: 0, unavailable: 3)]]

~~~

Errors:

1) External platform wasn't recognized by controller in `platformStringFromControllerConfigSpec()`
~~~
    W0629 22:10:08.773484       1 render.go:189] Warning: the controller config referenced an unsupported platform: External
~~~

2) unknown fields:

~~~
    W0629 22:10:09.572725       1 warnings.go:70] unknown field "spec.infra.status.platformStatus.external.cloudControllerManager"

~~~

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
