### PR TITLE
MGMT-14843: ovs-configuration service should copy the statically configured address even if the method isn't manual.

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -297,6 +297,9 @@ contents:
       ipv4_method=$(nmcli -g ipv4.method conn show "$old_conn")
       ipv6_method=$(nmcli -g ipv6.method conn show "$old_conn")
 
+      ipv4_addresses=$(nmcli -g ipv4.addresses conn show "$old_conn")
+      ipv6_addresses=$(nmcli -g ipv6.addresses conn show "$old_conn")
+
       # Warn about an invalid MTU that will most likely fail in one way or
       # another
       if [ ${iface_mtu} -lt 1280 ] && [ "${ipv6_method}" != "disabled" ]; then
@@ -305,7 +308,8 @@ contents:
 
       if ! nmcli connection show "$ovs_interface" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists destroy interface "$bridge_name"
-        if [ "${ipv4_method}" = "manual" ] || [ "${ipv6_method}" = "manual" ]; then
+        # Clone the connection in case the method is manual or in case the an address is set (DHCP + static IP)
+        if [ "${ipv4_method}" = "manual" ] || [ "${ipv4_addresses}" != "" ] || [ "${ipv6_method}" = "manual" ] || [ "${ipv6_addresses}" != "" ]; then
           echo "Static IP addressing detected on default gateway connection: ${old_conn}"
           # clone the old connection to get the address settings
           # prefer cloning vs copying the connection file to avoid problems with selinux


### PR DESCRIPTION
This change relates to the SNO relocation feature, it allows for preserving the statically configured internal IP on the br-ex in case the connection is configured with DHCP.

nmstate connection files allow configuring static IPs on an interface together with DHCP, see https://github.com/nmstate/nmstate/pull/2303 By cloning the existing connection file we should get both IPs (static and the one from DHCP) on the vr-ex bridge.


**- What I did**
I updated ovs-configuration service to preserve static IP configured on the original connection if one is configured (regardless of the connection method)

**- How to verify it**
I tested the resulted br-ex in cases where the original connection had:
1. a single address from DHCP (192.168.128.11), method=auto 
Result:
```
323: br-ex    inet 192.168.128.11/24 brd 192.168.128.255 scope global dynamic noprefixroute br-ex\       valid_lft 2860sec preferred_lft 2860sec
323: br-ex    inet 169.254.169.2/29 brd 169.254.169.7 scope global br-ex\       valid_lft forever preferred_lft forever
```

2. 2 addresses 1 static (192.168.127.10) and the other from DHCP (192.168.126.10). method=auto
Result:
```
6: br-ex    inet 192.168.127.10/24 brd 192.168.127.255 scope global noprefixroute br-ex\       valid_lft forever preferred_lft forever
6: br-ex    inet 192.168.126.10/24 brd 192.168.126.255 scope global dynamic noprefixroute br-ex\       valid_lft 3003sec preferred_lft 3003sec
6: br-ex    inet 169.254.169.2/29 brd 169.254.169.7 scope global br-ex\       valid_lft forever preferred_lft forever

```
**- Description for the changelog**
<!--
Copy static IP address to the br-ex if such exists
-->
