### PR TITLE
OCPBUGS-15613: Soften grep pattern for ingress default router

### DIFF
--- a/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
+++ b/templates/common/on-prem/files/keepalived-script-default-ingress.yaml
@@ -3,4 +3,4 @@ path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_default_ingre
 contents:
   inline: |
     #!/bin/bash
-    /host/bin/crictl -r unix:///host/run/crio/crio.sock pods --namespace openshift-ingress --state Ready | grep -q 'router-default-[[:xdigit:]]\{10\}-[[:alnum:]]\{5\}'
+    chroot /host /bin/crictl pods --namespace openshift-ingress --state Ready | grep -qE 'router-default-[[:alnum:]]{5,}-[[:alnum:]]{5,}'


### PR DESCRIPTION
We have noticed that OCP 4.14 doesn't follow anymore the old pattern for Ingress default router pods, causing `router-default-97fb6b94c-wfxfk` to fail our check. As a consequence, keepalived is not deploying the ingress VIP to the node even if it holds the router pod.

This PR softens the check so that slight changes in the random suffix shouldn't cause us to miss the pod anymore.

Closes: OCPBUGS-15613