### PR TITLE
OCPNODE-1714: files: add skip_mount_home to storage.conf

### DIFF
--- a/templates/common/_base/files/container-storage.yaml
+++ b/templates/common/_base/files/container-storage.yaml
@@ -52,6 +52,12 @@ contents:
     # remap-user = "storage"
     # remap-group = "storage"
 
+    [storage.options.overlay]
+    # Storage Options for overlay
+
+    # Do not create a PRIVATE bind mount on the home directory.
+    skip_mount_home = "true"
+
     [storage.options.thinpool]
     # Storage Options for thinpool
 
@@ -115,4 +121,3 @@ contents:
     # attempt to complete IO when ENOSPC (no space) error is returned by
     # underlying storage device.
     # xfs_nospace_max_retries = "0"
-    


### PR DESCRIPTION
When a privileged user creates a container that mounts `/` (or any parent of `/var/lib/containers/storage`), they often expect to be able to inspect the container mountpoint `/var/lib/containers/storage/overlay/.../merged`. However, if `skip_mount_home` isn't specified, that is mounted private, and is not accessible to containers.

In openshift 3, the behavior worked with `skip_mount_home` present, and many consider it a regression.

It was removed because there were concerns on kernel performance of the recursive mounts, but I have collaborated with a member of perf/scale to check that's not the case anymore.

Thus, I think we can safely set this field by default and allow privileged containers to have the access one naively expects.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
