### PR TITLE
kubevirt: Configure IPv6 arp proxy default gw

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -70,3 +70,11 @@ aliases:
   assisted-reviewers:
     - tsorya
     - eranco74
+  kubevirt-approvers:
+    - davidvossel
+    - orenc1
+    - qinqon
+  kubevirt-reviewers:
+    - davidvossel
+    - orenc1
+    - qinqon

--- a/templates/common/kubevirt/OWNERS
+++ b/templates/common/kubevirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - kubevirt-approvers
+reviewers:
+  - kubevirt-reviewers

--- a/templates/common/kubevirt/files/001-nmstate-disable-ipv6-autoconf.yaml
+++ b/templates/common/kubevirt/files/001-nmstate-disable-ipv6-autoconf.yaml
@@ -1,0 +1,14 @@
+path: "/etc/nmstate/001-nmstate-disable-ipv6-autoconf.yml"
+contents:
+  inline: |
+    capture:
+      ethernet-nics: interfaces.type=="ethernet"
+    desiredState:
+      interfaces:
+      - name: "{{`{{ capture.ethernet-nics.interfaces.0.name }}`}}"
+        type: ethernet
+        state: up
+        ipv6:
+          enabled: true
+          dhcp: true
+          autoconf: false

--- a/templates/common/kubevirt/files/002-nmstate-arp-proxy-ipv6-gw.yaml
+++ b/templates/common/kubevirt/files/002-nmstate-arp-proxy-ipv6-gw.yaml
@@ -1,0 +1,11 @@
+path: "/etc/nmstate/002-nmstate-arp-proxy-ipv6-gw.yml"
+contents:
+  inline: |
+    capture:
+      ethernet-nics: interfaces.type=="ethernet"
+    desiredState:
+      routes:
+        config:
+        - destination: ::/0
+          next-hop-interface: "{{`{{ capture.ethernet-nics.interfaces.0.name }}`}}"
+          next-hop-address: fe80::1


### PR DESCRIPTION
**- What I did**
The live migration feature implemented at [1] creates a stable default
gw for IPv4 and IPv6, for IPv4 it's delivered using DHCPv4 but for IPv6
there is not support for routes at DHCPv6. This change harcoded the IPv6
stable default gw using ignition.

[1] ovn-org/ovn-kubernetes#3478


**- How to verify it**

**- Description for the changelog**
Add kubevirt configuration for disable ipv6 autoconf and add arp proxy ipv6 gw
