### PR TITLE
OpenStack: restrict IPv6 configuration

### DIFF
--- a/templates/common/openstack/files/ipv6-config.yaml
+++ b/templates/common/openstack/files/ipv6-config.yaml
@@ -1,3 +1,4 @@
+{{- if eq .IPFamilies "DualStack"}}
 mode: 0600
 path: "/etc/NetworkManager/system-connections/nmconnection.template"
 contents:
@@ -7,3 +8,4 @@ contents:
     [ipv6]
     addr-gen-mode=eui64
     method=auto
+{{- end}}


### PR DESCRIPTION
The creation of a new connection profile affects installations
that are configured with additional networks resulting in wrong node-ip
selection. Let's restrict the IPv6 configuration for only dual-stack
clusters, which is what is supported at the moment to unblock other
testings that rely on additional networks.

Related to: https://issues.redhat.com/browse/OCPBUGS-15233
