### PR TITLE
Bug OCPBUGS-15233: OpenStack: fix IPv6 configuration

### DIFF
--- a/templates/common/openstack/files/ipv6-config.yaml
+++ b/templates/common/openstack/files/ipv6-config.yaml
@@ -1,11 +1,6 @@
-{{- if eq .IPFamilies "DualStack"}}
-mode: 0600
-path: "/etc/NetworkManager/system-connections/nmconnection.template"
+mode: 0644
+path: "/etc/NetworkManager/conf.d/02-ipv6.conf"
 contents:
   inline: |
     [connection]
-    type=ethernet
-    [ipv6]
-    addr-gen-mode=eui64
-    method=auto
-{{- end}}
+    ipv6.addr-gen-mode=0


### PR DESCRIPTION
When using an additional network in the cluster, this network
would end up being considered as the node ip network, when in
fact the first network should be the one to be used. This happens
because at certain moment the addresses on the primary interface
are not available, which results node-ip selection based on the default route.
Using connection profile to configure IPv6 is causing this issue, so
this commit moves the `addr-gen-mode` configuration to the global config.
The `method` configuration is not needed anymore as is already the default one.
