### PR TITLE
MCO-605: MCO-550: Remove Certificates from MachineConfig

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -255,7 +255,18 @@ func (b *Bootstrap) Run(destDir string) error {
 			return err
 		}
 	}
-	return nil
+	buf := bytes.Buffer{}
+	err = encoder.Encode(cconfig, &buf)
+	if err != nil {
+		return err
+	}
+	cconfigDir := filepath.Join(destDir, "controller-config")
+	if err := os.MkdirAll(cconfigDir, 0o764); err != nil {
+		return err
+	}
+	klog.Infof("writing the following controllerConfig to disk: %s", string(buf.Bytes()))
+	return os.WriteFile(filepath.Join(cconfigDir, "machine-config-controller.yaml"), buf.Bytes(), 0o664)
+
 }
 
 func getPullSecretFromSecret(sData []byte) ([]byte, error) {

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -186,6 +186,7 @@ func TestBootstrapRun(t *testing.T) {
 				if f.Path == "/etc/containers/registries.conf" {
 					registriesConfig = f
 				}
+				require.False(t, f.Path == "/etc/kubernetes/kubelet-ca.crt")
 			}
 			require.NotNil(t, registriesConfig)
 			contents, err := ctrlcommon.DecodeIgnitionFileContents(registriesConfig.Contents.Source, registriesConfig.Contents.Compression)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -180,7 +180,9 @@ const (
 	imageCAFilePath = "/etc/docker/certs.d"
 
 	// used for certificate syncing
-	caBundleFilePath = "/etc/kubernetes/kubelet-ca.crt"
+	caBundleFilePath      = "/etc/kubernetes/kubelet-ca.crt"
+	cloudCABundleFilePath = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
+	userCABundleFilePath  = "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
 
 	// Where nmstate writes the link files if it persisted ifnames.
 	// https://github.com/nmstate/nmstate/blob/03c7b03bd4c9b0067d3811dbbf72635201519356/rust/src/cli/persist_nic.rs#L32-L36

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1204,8 +1204,27 @@ func (dn *Daemon) deleteStaleData(oldIgnConfig, newIgnConfig ign3types.Config) e
 		newFileSet[f.Path] = struct{}{}
 	}
 
+	// need to skip these on upgrade if they are in a MC, or else we will remove all certs!
+	certsToSkip := []string{
+		userCABundleFilePath,
+		caBundleFilePath,
+		cloudCABundleFilePath,
+	}
 	for _, f := range oldIgnConfig.Storage.Files {
 		if _, ok := newFileSet[f.Path]; ok {
+			continue
+		}
+		skipBecauseCert := false
+		for _, cert := range certsToSkip {
+			if cert == f.Path {
+				skipBecauseCert = true
+				break
+			}
+		}
+		if strings.Contains(filepath.Dir(f.Path), imageCAFilePath) {
+			skipBecauseCert = true
+		}
+		if skipBecauseCert {
 			continue
 		}
 		if _, err := os.Stat(noOrigFileStampName(f.Path)); err == nil {

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -28,9 +28,9 @@ type renderConfig struct {
 	Version                string
 	ReleaseVersion         string
 	ControllerConfig       mcfgv1.ControllerConfigSpec
+	KubeAPIServerServingCA string
 	APIServerURL           string
 	Images                 *RenderConfigImages
-	KubeAPIServerServingCA string
 	Infra                  configv1.Infrastructure
 	Constants              map[string]string
 	PointerConfig          string

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1420,8 +1420,8 @@ func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.C
 		ReleaseVersion:         version.ReleaseVersion,
 		ControllerConfig:       *ccSpec,
 		Images:                 imgs,
-		APIServerURL:           apiServerURL,
 		KubeAPIServerServingCA: kubeAPIServerServingCA,
+		APIServerURL:           apiServerURL,
 		PointerConfig:          string(pointerConfigData),
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -209,3 +209,20 @@ func MigrateKernelArgsIfNecessary(conf *ign3types.Config, mc *mcfgv1.MachineConf
 	}
 	return nil
 }
+
+func addDataAndMaybeAppendToIgnition(path string, data []byte, ignConf *ign3types.Config) {
+	exists := false
+	for idx, file := range ignConf.Storage.Files {
+		if file.Path == path {
+			exists = true
+			d := getEncodedContent(string(data))
+			if len(data) > 0 {
+				ignConf.Storage.Files[idx].Contents.Source = &d
+			}
+			break
+		}
+	}
+	if !exists && len(data) > 0 {
+		appendFileToIgnition(ignConf, path, (string(data)))
+	}
+}

--- a/pkg/server/testdata/controller-config/machine-config-controller.yaml
+++ b/pkg/server/testdata/controller-config/machine-config-controller.yaml
@@ -1,0 +1,39 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ControllerConfig
+metadata:
+  name: machine-config-controller
+  annotations:
+    machineconfiguration.openshift.io/generated-by-version: "v0.0.0-was-not-built-properly"
+spec:
+  additionalTrustBundle: null
+  cloudProviderConfig: ""
+  clusterDNSIP: 172.30.0.10
+  images:
+    baremetalRuntimeCfgImage: ""
+    corednsImage: ""
+    haproxyImage: ""
+    infraImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    keepalivedImage: ""
+    kubeClientAgentImageKey: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    metadata:
+      creationTimestamp: null
+      name: cluster
+    spec:
+      cloudConfig:
+        name: ""
+    status:
+      apiServerInternalURI: https://api-int.domain.example.com:6443
+      apiServerURL: https://api.domain.example.com:6443
+      infrastructureName: lab-0aaaa
+      infrastructureTopology: HighlyAvailable
+      controlPlaneTopology: HighlyAvailable
+      platformStatus:
+        type: None
+  kubeAPIServerServingCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCktVQkUgQVBJIFNFUlZFUiBTRVJWSU5HIENBIERBVEEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  osImageURL: registry.product.example.org/ocp/4.2-DATE-VERSION@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+  releaseImage: release-registry.product.example.org/ocp/4.2-date-version@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  proxy: null
+  rootCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClJPT1QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==

--- a/templates/common/_base/files/additional-trust-bundle.yaml
+++ b/templates/common/_base/files/additional-trust-bundle.yaml
@@ -1,7 +1,0 @@
-mode: 0600
-path: "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
-contents:
-  inline: |
-{{if .AdditionalTrustBundle -}}
-{{.AdditionalTrustBundle | toString | indent 4}}
-{{end -}}

--- a/templates/common/_base/files/cloud-provider-ca.yaml
+++ b/templates/common/_base/files/cloud-provider-ca.yaml
@@ -1,7 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
-contents:
-  inline: |
-{{if .CloudProviderCAData -}}
-{{.CloudProviderCAData | toString | indent 4}}
-{{end -}}

--- a/templates/common/_base/files/kubelet-ca.yaml
+++ b/templates/common/_base/files/kubelet-ca.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/kubelet-ca.crt"
-contents:
-  inline: |
-{{.KubeAPIServerServingCAData | toString | indent 4}}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -456,7 +456,7 @@ func WaitForCADataToAppear(t *testing.T, cs *framework.ClientSet) error {
 func WaitForMCDToSyncCert(t *testing.T, cs *framework.ClientSet, node corev1.Node, resourceVersion string) error {
 	ctx := context.TODO()
 
-	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
 		n, err := cs.CoreV1Interface.Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
**- What I did**

In order to remove certificates from MC, the MCS needs to read the controller config both in the bootstrap server and the cluster server. Once this is in place, removing the certs from machine configs consists of ensuring the rendered configs do not contain the kube data to write into the files of the machine config. Accomplish this by deleting cert templates

**- How to verify it**

`oc describe mc/xxxx` the raw config/storage/files should no longer contain the following certs:

/etc/kubernetes/kubelet-ca.crt
/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem
/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt

**- Description for the changelog**

ensure the MCS properly writes certificate data directly to ignition while also ensuring that all MachineConfigs do not have certificates in them.
