### PR TITLE
OCPBUGS-15087: templates: Order after rhcos-growpart

### DIFF
--- a/templates/common/_base/units/kubelet-auto-node-size.service.yaml
+++ b/templates/common/_base/units/kubelet-auto-node-size.service.yaml
@@ -5,6 +5,7 @@ contents: |
   Description=Dynamically sets the system reserved for the kubelet
   Wants=network-online.target
   After=network-online.target ignition-firstboot-complete.service
+  After=rhcos-growpart.service # https://issues.redhat.com/browse/OCPBUGS-15087
   Before=kubelet.service crio.service
   [Service]
   # Need oneshot to delay kubelet

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -8,6 +8,7 @@ contents: |
   # This "stamp file" is unlinked when we complete
   # machine-config-daemon-firstboot.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
+  After=rhcos-growpart.service # https://issues.redhat.com/browse/OCPBUGS-15087
   # Run after crio-wipe so the pulled MCD image is protected against a corrupted storage from a forced shutdown
   Wants=network-online.target crio-wipe.service
   After=network-online.target crio-wipe.service

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -7,6 +7,7 @@ contents: |
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service crio-wipe.service
   After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  After=rhcos-growpart.service # https://issues.redhat.com/browse/OCPBUGS-15087
   Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]

--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -43,7 +43,16 @@ contents:
 
             # Ensure resolv.conf exists and contains nameservers before we try to pull image or run podman
             if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
-                cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+                cp -Z /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+            fi
+
+            # Now, if we're still in a firstboot scenario, then we're done.
+            # Before we run kubelet, we currently always do an OS update and reboot.
+            # There is currently a dependency loop between rhcos-growpart.service
+            # and this code (which pulls a container image) on RHCOS 4.6 and below,
+            # which this also works around.
+            if test -f /etc/ignition-machine-config-encapsulated.json; then
+                exit 0
             fi
 
             # Ensure baremetalRuntimeCfgImage is pulled in a reliable way before trying to use it

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -8,6 +8,7 @@ contents: |
   # different subnet or a deprecated address
   Wants=NetworkManager-wait-online.service crio-wipe.service
   After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  After=rhcos-growpart.service # https://issues.redhat.com/browse/OCPBUGS-15087
   Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -18,6 +18,7 @@ contents: |
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service crio-wipe.service
   After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  After=rhcos-growpart.service # https://issues.redhat.com/browse/OCPBUGS-15087
   Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-15087

Unfortunately on RHCOS 4.6 we do the filesystem resizing in the real root, which requires services running in the real root to order against us.

This is not true of RHCOS 4.7 and above.  But, because we need to maintain compatibility with older bootimages for newer OCP setups, add ordering to the services which invoke `podman pull` which may pull a large amount of data.
