### PR TITLE
OCPNODE-1717: Make cgroupsv2 default in OCP-4.14

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -94,8 +94,8 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) != 0 {
-				t.Errorf("expected no machine configs generated with the default node config, got %v machine configs", len(mcs))
+			if len(mcs) != 2 {
+				t.Errorf("expected %v machine configs generated with the default node config, got 0 machine configs", len(mcs))
 			}
 		})
 	}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -34,13 +34,11 @@ type RenderConfig struct {
 }
 
 const (
-	filesDir            = "files"
-	unitsDir            = "units"
-	platformBase        = "_base"
-	platformOnPrem      = "on-prem"
-	sno                 = "sno"
-	baseMasterKubeletMC = "01-master-kubelet"
-	baseWorkerKubeletMC = "01-worker-kubelet"
+	filesDir       = "files"
+	unitsDir       = "units"
+	platformBase   = "_base"
+	platformOnPrem = "on-prem"
+	sno            = "sno"
 )
 
 // generateTemplateMachineConfigs returns MachineConfig objects from the templateDir and a config object
@@ -124,41 +122,10 @@ func GenerateMachineConfigsForRole(config *RenderConfig, role, templateDir strin
 		if err != nil {
 			return nil, err
 		}
-		// defaulting the CGroups version to "v1"
-		// (TODO) This code can be removed if not required in future releases
-		if name == baseMasterKubeletMC || name == baseWorkerKubeletMC {
-			updateMCwithDefaultCgroupsVersion(nameConfig)
-		}
 		cfgs = append(cfgs, nameConfig)
 	}
 
 	return cfgs, nil
-}
-
-// updateMCwithDefaultCgroupsVersion updates the MC kArgs with the default CGroups version config
-func updateMCwithDefaultCgroupsVersion(mc *mcfgv1.MachineConfig) {
-	// updating the Machine Config resource with the default cgroupv1 config
-	var (
-		kernelArgsv1       = []string{"systemd.unified_cgroup_hierarchy=0", "systemd.legacy_systemd_cgroup_controller=1"}
-		kernelArgsv2       = []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"}
-		adjustedKernelArgs []string
-	)
-	// avoiding the undesired kArgs from the already existing kArgs
-	for _, arg := range mc.Spec.KernelArguments {
-		// only append the args we want to keep, omitting the undesired
-		if !ctrlcommon.InSlice(arg, kernelArgsv2) {
-			adjustedKernelArgs = append(adjustedKernelArgs, arg)
-		}
-	}
-	// appending the desired kArgs to the existing kArgs
-	for _, arg := range kernelArgsv1 {
-		// add the additional that aren't already there
-		if !ctrlcommon.InSlice(arg, adjustedKernelArgs) {
-			adjustedKernelArgs = append(adjustedKernelArgs, arg)
-		}
-	}
-	// overwrite the KernelArguments with the adjusted KernelArgs
-	mc.Spec.KernelArguments = adjustedKernelArgs
 }
 
 func platformStringFromControllerConfigSpec(ic *mcfgv1.ControllerConfigSpec) (string, error) {

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -121,8 +121,11 @@ kind: Node
 metadata:
   name: cluster`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v2" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a node config manifest empty \"cgroupMode\"",
@@ -134,8 +137,10 @@ metadata:
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction`),
 			},
-
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v2" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
@@ -262,6 +267,8 @@ spec:
       memory: 500Mi
 `),
 			},
+			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
+			// internally translates to "v2"
 			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},


### PR DESCRIPTION
1. RHCOS comes up with cgroupsv2 by default.
2. In order to make cgroupsv2 as a default in OCP-4.14, the changes that explicitly set the cgroupsv1 should be removed
3. With this change, all the new OCP clusters by default come up with cgroupsv2.


**- What I did**
Make cgroupsv2 as a default in the newer OCP releases

**- How to verify it**
Deploy OCP-4.14 and execute the following command on any node and observe the following
```
sh-4.4# stat -c %T -f /sys/fs/cgroup/
cgroup2fs
```

**- Description for the changelog**
Remove the explicit setting of cgroupsv1 and make cgroupsv2 a default in OCP 4.14