### PR TITLE
MCO-654: forcefile should always trigger an OS update

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -680,8 +680,9 @@ func newMachineConfigDiff(oldConfig, newConfig *mcfgv1.MachineConfig) (*machineC
 	kargsEmpty := len(oldConfig.Spec.KernelArguments) == 0 && len(newConfig.Spec.KernelArguments) == 0
 	extensionsEmpty := len(oldConfig.Spec.Extensions) == 0 && len(newConfig.Spec.Extensions) == 0
 
+	force := forceFileExists()
 	return &machineConfigDiff{
-		osUpdate:   oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL,
+		osUpdate:   oldConfig.Spec.OSImageURL != newConfig.Spec.OSImageURL || force,
 		kargs:      !(kargsEmpty || reflect.DeepEqual(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments)),
 		fips:       oldConfig.Spec.FIPS != newConfig.Spec.FIPS,
 		passwd:     !reflect.DeepEqual(oldIgn.Passwd, newIgn.Passwd),


### PR DESCRIPTION
**- What I did**

currently, the forcefile sometimes gets stopped from triggering an osupdate if one of our other priorities gets in the way. The forcefile should alwyas trigger and end to end update, re-applying all changes if the osImageURL is different. This will get many customers out of this half baked reboot loop we have been seeing.

**- How to verify it**

when using the forcefile, should always see `Updating OS` indicating a full reboot, especially when there is a config mismatch with the osImageURLs.

**- Description for the changelog**

the forcefile now always triggers a full os update.