### PR TITLE
MCO-596: Deprecate the login monitor

### DIFF
--- a/docs/MachineConfigDaemon.md
+++ b/docs/MachineConfigDaemon.md
@@ -178,10 +178,6 @@ The "Reload Crio" action performs the file write and runs a `systemctl reload cr
 
 1. **Selected** `/etc/containers/registries.conf` changes: this file is generally changed via ICSP object changes. Node drain will take place except for changes specified [above](#Without-Drain).
 
-## Annotating on SSH access
-
-RHCOS nodes in Openshift are not meant to be manually accessed via SSH. MCD uses logind to watch for login sessions, which, upon detection, warns the user and annotates the node with `machineconfiguration.openshift.io/ssh=accessed`. This in turn will be used to warn cluster admins.
-
 ## Config Drift Detection
 
 ### Overview

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -16,13 +16,6 @@ var (
 			Help: "os that MCD is running on and version if RHCOS",
 		}, []string{"os", "version"})
 
-	// mcdSSHAccessed shows ssh access count for a node
-	mcdSSHAccessed = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "ssh_accesses_total",
-			Help: "Total number of SSH access occurred.",
-		})
-
 	// mcdPivotErr flags error encountered during pivot
 	mcdPivotErr = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -72,7 +65,6 @@ func UpdateStateMetric(metric *prometheus.GaugeVec, labels ...string) {
 func RegisterMCDMetrics() error {
 	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
 		hostOS,
-		mcdSSHAccessed,
 		mcdPivotErr,
 		mcdState,
 		kubeletHealthState,


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the unused SSH login monitor and related metrics. We put out a deprecation notice for this in 4.12. This is also part of our effort to make the MCO less dependent on journal reads. 

**- How to verify it**
I ran the basics on my local cluster, but CI should ensure that this doesn't break any existing functionality. 

**- Description for the changelog**
daemon: removed login monitor
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
