### PR TITLE
OCPBUGS-14945: add HostToContainer propagation to all hostPath volume mounts

### DIFF
--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -29,8 +29,10 @@ spec:
     volumeMounts:
     - name: bootstrap-manifests
       mountPath: /etc/mcc/bootstrap
+      mountPropagation: HostToContainer
     - name: server-basedir
       mountPath: /etc/mcs/bootstrap
+      mountPropagation: HostToContainer
   containers:
   - name: machine-config-server
     image: {{.Images.MachineConfigOperator}}
@@ -42,10 +44,13 @@ spec:
     volumeMounts:
     - name: server-certs
       mountPath: /etc/ssl/mcs
+      mountPropagation: HostToContainer
     - name: bootstrap-kubeconfig
       mountPath: /etc/kubernetes/kubeconfig
+      mountPropagation: HostToContainer
     - name: server-basedir
       mountPath: /etc/mcs/bootstrap
+      mountPropagation: HostToContainer
     securityContext:
       privileged: true
       readOnlyRootFilesystem: false

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -36,6 +36,7 @@ spec:
         volumeMounts:
           - mountPath: /rootfs
             name: rootfs
+            mountPropagation: HostToContainer
         env:
           - name: NODE_NAME
             valueFrom:

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -43,12 +43,15 @@ spec:
     volumeMounts:
     - name: kubeconfig
       mountPath: "/etc/kubernetes/kubeconfig"
+      mountPropagation: HostToContainer
     - name: resource-dir
       mountPath: "/config"
+      mountPropagation: HostToContainer
     - name: conf-dir
       mountPath: "/etc/coredns"
     - name: manifests
       mountPath: "/opt/openshift/manifests"
+      mountPropagation: HostToContainer
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -90,6 +90,7 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/keepalived"
+      mountPropagation: HostToContainer
     - name: run-dir
       mountPath: "/var/run/keepalived"
     livenessProbe:
@@ -131,14 +132,18 @@ spec:
     volumeMounts:
     - name: resource-dir
       mountPath: "/config"
+      mountPropagation: HostToContainer
     - name: kubeconfig
       mountPath: "/etc/kubernetes/kubeconfig"
+      mountPropagation: HostToContainer
     - name: conf-dir
       mountPath: "/etc/keepalived"
+      mountPropagation: HostToContainer
     - name: run-dir
       mountPath: "/var/run/keepalived"
     - name: manifests
       mountPath: "/opt/openshift/manifests"
+      mountPropagation: HostToContainer
     imagePullPolicy: IfNotPresent
   hostNetwork: true
   tolerations:

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -45,12 +45,16 @@ contents:
         volumeMounts:
         - name: kubeconfig
           mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
         - name: resource-dir
           mountPath: "/config"
+          mountPropagation: HostToContainer
         - name: conf-dir
           mountPath: "/etc/coredns"
+          mountPropagation: HostToContainer
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
       containers:
       - name: coredns
@@ -98,12 +102,16 @@ contents:
         volumeMounts:
         - name: kubeconfig
           mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
         - name: resource-dir
           mountPath: "/config"
+          mountPropagation: HostToContainer
         - name: conf-dir
           mountPath: "/etc/coredns"
+          mountPropagation: HostToContainer
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent        
       hostNetwork: true
       tolerations:

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -54,12 +54,16 @@ contents:
         volumeMounts:
         - name: kubeconfig
           mountPath: "/etc/kubernetes"
+          mountPropagation: HostToContainer
         - name: script-dir
           mountPath: "/config"
+          mountPropagation: HostToContainer
         - name: conf-dir
           mountPath: "/etc/keepalived"
+          mountPropagation: HostToContainer
         - name: nodeip-configuration
           mountPath: "/run/nodeip-configuration"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
       containers:
       - name: keepalived
@@ -145,14 +149,18 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/keepalived"
+          mountPropagation: HostToContainer
         - name: run-dir
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
+          mountPropagation: HostToContainer
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
         - name: nodeip-configuration
           mountPath: "/run/nodeip-configuration"
+          mountPropagation: HostToContainer
         livenessProbe:
           exec:
             command:
@@ -193,16 +201,21 @@ contents:
         volumeMounts:
         - name: resource-dir
           mountPath: "/config"
+          mountPropagation: HostToContainer
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
         - name: conf-dir
           mountPath: "/etc/keepalived"
+          mountPropagation: HostToContainer
         - name: run-dir
           mountPath: "/var/run/keepalived"
         - name: chroot-host
           mountPath: "/host"
+          mountPropagation: HostToContainer
         - name: nodeip-configuration
           mountPath: "/run/nodeip-configuration"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:

--- a/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/alibabacloud/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -31,6 +31,7 @@ contents:
         volumeMounts:
         - mountPath: /rootfs
           name: rootfs
+          mountPropagation: HostToContainer
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical

--- a/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -31,6 +31,7 @@ contents:
         volumeMounts:
         - mountPath: /rootfs
           name: rootfs
+          mountPropagation: HostToContainer
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical

--- a/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/master/00-master/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -31,6 +31,7 @@ contents:
         volumeMounts:
         - mountPath: /rootfs
           name: rootfs
+          mountPropagation: HostToContainer
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -39,8 +39,10 @@ contents:
         volumeMounts:
         - name: chroot-host
           mountPath: "/host"
+          mountPropagation: HostToContainer
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
       containers:
       - name: haproxy
@@ -110,6 +112,7 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"
+          mountPropagation: HostToContainer
         - name: run-dir
           mountPath: "/var/run/haproxy"
         livenessProbe:
@@ -137,14 +140,18 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"
+          mountPropagation: HostToContainer
         - name: run-dir
           mountPath: "/var/run/haproxy"
         - name: resource-dir
           mountPath: "/config"
+          mountPropagation: HostToContainer
         - name: chroot-host
           mountPath: "/host"
+          mountPropagation: HostToContainer
         - name: kubeconfigvarlib
           mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true


### PR DESCRIPTION
In order to not break specific volume drivers, all volume mounts who's source is a hostPath must use mountPropagation: HostToContainer

All volumeMounts that come form this type of volume now have the mountPropagation specified.
