### PR TITLE
OCPNODE-1717: Update config node spec while explicitly updating the cgroups mode

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -91,8 +91,8 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) != 0 {
-				t.Errorf("expected no machine configs generated with the default node config, got %v machine configs", len(mcs))
+			if len(mcs) != 2 {
+				t.Errorf("expected %v machine configs generated with the default node config, got 0 machine configs", len(mcs))
 			}
 		})
 	}

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -115,8 +115,11 @@ kind: Node
 metadata:
   name: cluster`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v1" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a node config manifest empty \"cgroupMode\"",
@@ -132,7 +135,10 @@ metadata:
 					WorkerLatencyProfile: configv1.MediumUpdateAverageReaction,
 				},
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			// "CgroupMode" field in the nodes.config resource is empty
+			// Internally it gets updated to "v1" explicitly
+			// Hence, 97-{master/worker}-generated-kubelet are expected
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
@@ -244,6 +250,8 @@ spec:
       memory: 500Mi
 `),
 			},
+			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
+			// internally translates to "v1"
 			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},


### PR DESCRIPTION
- Future OCP releases will default to cgroupsv2
- During the upgrades, in order to honor the cgroupsv1 on the existing cluster, there should be a reference in the node spec for the future code to depend on deciding the cgroup version.
- Hence, this code updates the config node spec whenever the cgroupsv1 is explicitly set
