### PR TITLE
OCPBUGS-11997: Prevent NM from unsetting the hostname

### DIFF
--- a/templates/common/_base/files/usr-local-bin-mco-hostname.yaml
+++ b/templates/common/_base/files/usr-local-bin-mco-hostname.yaml
@@ -19,6 +19,8 @@ contents:
             sleep 1
         done
         echo "node identified as $(</proc/sys/kernel/hostname)"
+        echo "saving hostname to prevent NetworkManager from ever unsetting it"
+        hostnamectl set-hostname --static --transient $(</proc/sys/kernel/hostname)
         exit 0
     }
 
@@ -61,4 +63,3 @@ contents:
         --gcp) set_gcp_hostname;;
         *) echo "Unhandled arg $arg"; exit 1
     esac
-


### PR DESCRIPTION
It has been discovered that in environments that use revDNS for setting the hostname instead of DHCP Option 12 it is possible to intermittently lose it and try to register as `localhost.localdomain`.

It happens in a scenario when we obtain the hostname from the DNS server (PTR record for the IP address of the node), later we lose DNS for any reason and during this time we reload the NM configuration. Because of its design, if the revDNS is not available anymore instead of persisting the previous name, NetworkManger will unset it completely leaving the node visible as `localhost.localdomain`.

In order to prevent this behaviour we are modifying `node-valid-hostname.service` so that instead of only waiting for the non-localhost name to appear once (without detecting if it can intermittently disappear in the future) it also sets it using `hostnamectl set-hostname` so that NetworkManager will not try unsetting it even if no valid form is available anymore.

The change is valid as a platform-agnostic change because we never allow to change the hostname during lifetime of the node. Thus, a scenario where we would like NetworkManager to update the hostname based on a changed revDNS record is not a valid one.

This change is valid for DHCP Option 12 and revDNS-based hostnames because changing hostname via updating Option 12 field is not allowed as well.

Fixes: OCPBUGS-11997