### PR TITLE
4.14: use rhel9 builder for daemon binary

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,6 @@
 # THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
+# TODO switch the default image to rhel9 and drop the rhel8 one in 4.15 because
+# we can require by the time we get to 4.14 that we don't have any rhel8 hosts left
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
@@ -7,10 +9,17 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS rhel9-builder
+ARG TAGS=""
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN make install DESTDIR=./instroot
+
 FROM registry.ci.openshift.org/ocp/4.14:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,4 @@ test-e2e-single-node: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/ | ./hack/test-with-junit.sh $(@)
 
 bootstrap-e2e: install-go-junit-report install-setup-envtest
-	set -o pipefail; CGO_ENABLED=0 go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -35,13 +35,9 @@ fi
 
 mkdir -p ${BIN_PATH}
 
-# Use the containers_image_openpgp flag to avoid the default CGO implementation of signatures dragged in by
-# containers/image/signature, which we use only to edit the /etc/containers/policy.json file without doing any cryptography
-CGO_ENABLED=0
-
 if [[ $WHAT == "machine-config-controller" ]]; then
     GOTAGS="containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 fi
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE}, ${HASH}) for $GOOS/$GOARCH"
-CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}
+GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -18,8 +18,8 @@ contents: |
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
-  ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
+  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
+  ExecStart=/bin/chcon --reference /usr/bin/true /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}


### PR DESCRIPTION
4.13: use rhel9 builder for daemon binary

While attempting to switch builder to rhel9 base, the nmstate binary from
rhel9 fails. With that change reverted for now, let's try just building
the daemon binary on rhel9, so when it gets copied to host for
firstboot, it matches the on-node os version (rhel9)

For https://issues.redhat.com/browse/TRT-1143

(walters: I also snuck in a cleanup to use `chcon --reference` here
 because it avoids hardcoding a SELinux context)

---

build-sys: Drop setting CGO_ENABLED=0

We must dynamically link in general.

---

