### PR TITLE
daemon: Run firstboot as a container image too

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,6 @@
 # THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
+# TODO switch the default image to rhel9 and drop the rhel8 one in 4.15 because
+# we can require by the time we get to 4.14 that we don't have any rhel8 hosts left
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
@@ -7,10 +9,17 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS rhel9-builder
+ARG TAGS=""
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN make install DESTDIR=./instroot
+
 FROM registry.ci.openshift.org/ocp/4.14:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,4 @@ test-e2e-single-node: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/ | ./hack/test-with-junit.sh $(@)
 
 bootstrap-e2e: install-go-junit-report install-setup-envtest
-	set -o pipefail; CGO_ENABLED=0 go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)

--- a/cmd/machine-config-daemon/pivot.sh
+++ b/cmd/machine-config-daemon/pivot.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/sh
-set -xeuo pipefail
-# This script just exists for "CLI compatibility" for admins
-# to use interactively via ssh/oc debug node.
-exec /run/bin/machine-config-daemon pivot "$@"

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -1,23 +1,17 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"flag"
-	"fmt"
-	"io"
 	"net/url"
 	"os"
-	"path/filepath"
 	"syscall"
 
-	"github.com/google/renameio"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
-	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -56,35 +50,6 @@ func init() {
 	startCmd.PersistentFlags().BoolVar(&startOpts.kubeletHealthzEnabled, "kubelet-healthz-enabled", true, "kubelet healthz endpoint monitoring")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeletHealthzEndpoint, "kubelet-healthz-endpoint", "http://localhost:10248/healthz", "healthz endpoint to check health")
 	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8797", "URL for prometheus metrics listener")
-}
-
-func selfCopyToHost() error {
-	selfExecutableFd, err := os.Open("/proc/self/exe")
-	if err != nil {
-		return fmt.Errorf("opening our binary: %w", err)
-	}
-	defer selfExecutableFd.Close()
-	if err := os.MkdirAll(filepath.Dir(daemonconsts.HostSelfBinary), 0o755); err != nil {
-		return err
-	}
-	t, err := renameio.TempFile(filepath.Dir(daemonconsts.HostSelfBinary), daemonconsts.HostSelfBinary)
-	if err != nil {
-		return err
-	}
-	defer t.Cleanup()
-	var mode os.FileMode = 0o755
-	if err := t.Chmod(mode); err != nil {
-		return err
-	}
-	_, err = io.Copy(bufio.NewWriter(t), selfExecutableFd)
-	if err != nil {
-		return err
-	}
-	if err := t.CloseAtomicallyReplace(); err != nil {
-		return err
-	}
-	klog.Infof("Copied self to /run/bin/machine-config-daemon on host")
-	return nil
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -145,13 +110,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		if err != nil {
 			klog.Fatalf("%v", err)
 		}
-		return
-	}
-
-	// In the cluster case, for now we copy our binary out to the host
-	// for SELinux reasons, see https://bugzilla.redhat.com/show_bug.cgi?id=1839065
-	if err := selfCopyToHost(); err != nil {
-		klog.Fatalf("%v", fmt.Errorf("copying self to host: %w", err))
 		return
 	}
 

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -35,13 +35,9 @@ fi
 
 mkdir -p ${BIN_PATH}
 
-# Use the containers_image_openpgp flag to avoid the default CGO implementation of signatures dragged in by
-# containers/image/signature, which we use only to edit the /etc/containers/policy.json file without doing any cryptography
-CGO_ENABLED=0
-
 if [[ $WHAT == "machine-config-controller" ]]; then
     GOTAGS="containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 fi
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE}, ${HASH}) for $GOOS/$GOARCH"
-CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}
+GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -61,9 +61,6 @@ const (
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44
 	EtcPivotFile = "/etc/pivot/image-pullspec"
 
-	// HostSelfBinary is the path where we copy our own binary to the host
-	HostSelfBinary = "/run/bin/machine-config-daemon"
-
 	// MachineConfigEncapsulatedPath contains all of the data from a MachineConfig object
 	// except the Spec/Config object; this supports inverting+encapsulating a MachineConfig
 	// object so that Ignition can process it on first boot, and then the MCD can act on

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -17,9 +17,6 @@ contents: |
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
-  # This one was copied out to the host...but actually I'm not sure why we didn't
-  # run it via podman to start
-  ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -18,8 +18,8 @@ contents: |
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
-  ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
+  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
+  ExecStart=/bin/chcon --reference /usr/bin/true /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -15,11 +15,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  # See https://github.com/coreos/fedora-coreos-tracker/issues/354
-  ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
-  ExecStart=/bin/chcon --reference /usr/bin/true /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}


### PR DESCRIPTION

daemon: Run firstboot as a container image too

As the TODOs say, I am now no longer sure why we did the
"copy self to host" instead of always running from the container.

IOW, this makes firstboot work *exactly the same* as the daemonset
running after kube is up.

We really need to do this now because now we need to ensure
that the code flows here in a dynamic linking world properly
handle matching the target host system.

---

