### PR TITLE
OCPBUGS-16128:  daemon: Copy matching binary to host, re-exec with it

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,6 @@
 # THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
+# TODO switch the default image to rhel9 and drop the rhel8 one in 4.15 because
+# we can require by the time we get to 4.14 that we don't have any rhel8 hosts left
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
@@ -7,10 +9,17 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS rhel9-builder
+ARG TAGS=""
+WORKDIR /go/src/github.com/openshift/machine-config-operator
+COPY . .
+RUN make install DESTDIR=./instroot
+
 FROM registry.ci.openshift.org/ocp/4.14:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,4 @@ test-e2e-single-node: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/ | ./hack/test-with-junit.sh $(@)
 
 bootstrap-e2e: install-go-junit-report install-setup-envtest
-	set -o pipefail; CGO_ENABLED=0 go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)

--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -3,8 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
-	"syscall"
 	"time"
 
 	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
@@ -26,6 +24,7 @@ var persistNics bool
 // init executes upon import
 func init() {
 	rootCmd.AddCommand(firstbootCompleteMachineconfig)
+	firstbootCompleteMachineconfig.PersistentFlags().StringVar(&startOpts.rootMount, "root-mount", "/rootfs", "where the nodes root filesystem is mounted for chroot and file manipulation.")
 	firstbootCompleteMachineconfig.PersistentFlags().BoolVar(&persistNics, "persist-nics", false, "Run nmstatectl persist-nic-names")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
@@ -44,16 +43,11 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 		if err := daemon.PersistNetworkInterfaces("/rootfs"); err != nil {
 			return fmt.Errorf("failed to persist network interfaces: %w", err)
 		}
+		return nil
 	}
 
-	klog.Infof(`Calling chroot("%s")`, startOpts.rootMount)
-	if err := syscall.Chroot(startOpts.rootMount); err != nil {
-		return fmt.Errorf("failed to chroot to %s: %w", startOpts.rootMount, err)
-	}
-
-	klog.V(2).Infof("Moving to / inside the chroot")
-	if err := os.Chdir("/"); err != nil {
-		return fmt.Errorf("failed to change directory to /: %w", err)
+	if err := daemon.ReexecuteForTargetRoot(startOpts.rootMount); err != nil {
+		return fmt.Errorf("failed to re-exec: %w", err)
 	}
 
 	dn, err := daemon.New(exitCh)

--- a/cmd/machine-config-daemon/pivot.sh
+++ b/cmd/machine-config-daemon/pivot.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/sh
-set -xeuo pipefail
-# This script just exists for "CLI compatibility" for admins
-# to use interactively via ssh/oc debug node.
-exec /run/bin/machine-config-daemon pivot "$@"

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"net/url"
 	"os"
-	"syscall"
 
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -72,14 +71,8 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		}
 	}
 
-	klog.Infof(`Calling chroot("%s")`, startOpts.rootMount)
-	if err := syscall.Chroot(startOpts.rootMount); err != nil {
-		klog.Fatalf("Unable to chroot to %s: %s", startOpts.rootMount, err)
-	}
-
-	klog.V(2).Infof("Moving to / inside the chroot")
-	if err := os.Chdir("/"); err != nil {
-		klog.Fatalf("Unable to change directory to /: %s", err)
+	if err := daemon.ReexecuteForTargetRoot(startOpts.rootMount); err != nil {
+		klog.Fatalf("failed to re-exec: %+v", err)
 	}
 
 	if startOpts.nodeName == "" {

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -1,23 +1,17 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"flag"
-	"fmt"
-	"io"
 	"net/url"
 	"os"
-	"path/filepath"
 	"syscall"
 
-	"github.com/google/renameio"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
-	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -56,35 +50,6 @@ func init() {
 	startCmd.PersistentFlags().BoolVar(&startOpts.kubeletHealthzEnabled, "kubelet-healthz-enabled", true, "kubelet healthz endpoint monitoring")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeletHealthzEndpoint, "kubelet-healthz-endpoint", "http://localhost:10248/healthz", "healthz endpoint to check health")
 	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8797", "URL for prometheus metrics listener")
-}
-
-func selfCopyToHost() error {
-	selfExecutableFd, err := os.Open("/proc/self/exe")
-	if err != nil {
-		return fmt.Errorf("opening our binary: %w", err)
-	}
-	defer selfExecutableFd.Close()
-	if err := os.MkdirAll(filepath.Dir(daemonconsts.HostSelfBinary), 0o755); err != nil {
-		return err
-	}
-	t, err := renameio.TempFile(filepath.Dir(daemonconsts.HostSelfBinary), daemonconsts.HostSelfBinary)
-	if err != nil {
-		return err
-	}
-	defer t.Cleanup()
-	var mode os.FileMode = 0o755
-	if err := t.Chmod(mode); err != nil {
-		return err
-	}
-	_, err = io.Copy(bufio.NewWriter(t), selfExecutableFd)
-	if err != nil {
-		return err
-	}
-	if err := t.CloseAtomicallyReplace(); err != nil {
-		return err
-	}
-	klog.Infof("Copied self to /run/bin/machine-config-daemon on host")
-	return nil
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -145,13 +110,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		if err != nil {
 			klog.Fatalf("%v", err)
 		}
-		return
-	}
-
-	// In the cluster case, for now we copy our binary out to the host
-	// for SELinux reasons, see https://bugzilla.redhat.com/show_bug.cgi?id=1839065
-	if err := selfCopyToHost(); err != nil {
-		klog.Fatalf("%v", fmt.Errorf("copying self to host: %w", err))
 		return
 	}
 

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -35,13 +35,9 @@ fi
 
 mkdir -p ${BIN_PATH}
 
-# Use the containers_image_openpgp flag to avoid the default CGO implementation of signatures dragged in by
-# containers/image/signature, which we use only to edit the /etc/containers/policy.json file without doing any cryptography
-CGO_ENABLED=0
-
 if [[ $WHAT == "machine-config-controller" ]]; then
     GOTAGS="containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 fi
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE}, ${HASH}) for $GOOS/$GOARCH"
-CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}
+GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -61,9 +61,6 @@ const (
 	// For more information, see https://github.com/openshift/pivot/pull/25/commits/c77788a35d7ee4058d1410e89e6c7937bca89f6c#diff-04c6e90faac2675aa89e2176d2eec7d8R44
 	EtcPivotFile = "/etc/pivot/image-pullspec"
 
-	// HostSelfBinary is the path where we copy our own binary to the host
-	HostSelfBinary = "/run/bin/machine-config-daemon"
-
 	// MachineConfigEncapsulatedPath contains all of the data from a MachineConfig object
 	// except the Spec/Config object; this supports inverting+encapsulating a MachineConfig
 	// object so that Ignition can process it on first boot, and then the MCD can act on

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -423,6 +423,107 @@ func PrepareNamespace(target string) error {
 	return nil
 }
 
+// ReexecuteForTargetRoot detects the OS in the host root filesystem, then
+// copies the appropriate binary into `/run/bin/` there, then does a `chroot`
+// and re-executes the new binary.
+func ReexecuteForTargetRoot(target string) error {
+	// Nothing to do in this case
+	if target == "/" {
+		return nil
+	}
+	// Extra check to avoid recursion
+	reexecEnv := "_MCD_DID_REEXEC"
+	if _, ok := os.LookupEnv(reexecEnv); ok {
+		return nil
+	}
+
+	sourceOsVersion, err := osrelease.GetHostRunningOSFromRoot("/")
+	if err != nil {
+		return fmt.Errorf("failed to get source OS: %w", err)
+	}
+
+	targetOsVersion, err := osrelease.GetHostRunningOSFromRoot(target)
+	if err != nil {
+		return fmt.Errorf("failed to get target OS: %w", err)
+	}
+
+	var sourceBinarySuffix string
+	if sourceOsVersion.IsLikeRHEL() && targetOsVersion.IsLikeRHEL() {
+		sourceMajor := sourceOsVersion.BaseVersionMajor()
+		targetMajor := targetOsVersion.BaseVersionMajor()
+		if sourceMajor == "8" && targetMajor == "9" {
+			sourceBinarySuffix = ".rhel9"
+			klog.Info("container is rhel8, target is rhel9")
+		} else if sourceMajor == "9" && targetMajor == "8" {
+			// This code path shouldn't be hit right now because our container image
+			// is built from rhel8, but let's handle it for consistency in the future
+			// when we're likely to switch the container image to RHEL9.  Then
+			// it will be needed for both scaleup from old rhel8 bootimages as well
+			// as the case where a cluster is upgraded from
+			// 4.12 -> 4.14 or beyond and we have a stray worker node still on
+			// 4.12 (rhel8).
+			sourceBinarySuffix = ".rhel8"
+			klog.Info("container is rhel9, target is rhel8")
+		} else {
+			// Otherwise, we assume that there's no suffixing needed.  Hopefully
+			// by RHEL10 the MCD will have fundamentally changed and we won't be doing the
+			// chroot() thing anymore.
+			klog.Info("not chrooting for source=rhel-%s target=rhel-%s", sourceMajor, targetMajor)
+		}
+	} else {
+		klog.Info("assuming we can use container binary chroot() to host")
+	}
+	sourceBinary := "/usr/bin/machine-config-daemon" + sourceBinarySuffix
+	src, err := os.Open(sourceBinary)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", sourceBinary, err)
+	}
+	defer src.Close()
+
+	targetBinBase := "run/bin/machine-config-daemon"
+	targetBin := filepath.Join(target, targetBinBase)
+	targetBinDir := filepath.Dir(targetBin)
+	if _, err := os.Stat(targetBinDir); err != nil {
+		if err := os.Mkdir(targetBinDir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", targetBinDir, err)
+		}
+	}
+
+	f, err := os.Create(targetBin)
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", targetBin, err)
+	}
+	if _, err := io.Copy(f, src); err != nil {
+		f.Close()
+		return fmt.Errorf("writing %s: %w", targetBin, err)
+	}
+	if err := f.Chmod(0o755); err != nil {
+		return err
+	}
+	// Must close our writable fd
+	f.Close()
+
+	if err := syscall.Chroot(target); err != nil {
+		return fmt.Errorf("failed to chroot to %s: %w", target, err)
+	}
+
+	if err := os.Chdir("/"); err != nil {
+		return fmt.Errorf("failed to change directory to /: %w", err)
+	}
+
+	// Now we will see the binary in the target root
+	targetBin = "/" + targetBinBase
+	// We have a "belt and suspenders" approach for detecting the case where
+	// we're running in the target root.  First we inject --root-mount=/, and
+	// we also set an environment variable to be really sure.
+	newArgv := []string{targetBin}
+	newArgv = append(newArgv, os.Args[1:]...)
+	newArgv = append(newArgv, "--root-mount=/")
+	newEnv := append(os.Environ(), fmt.Sprintf("%s=1", reexecEnv))
+	klog.Infof("Invoking re-exec %s", targetBin)
+	return syscall.Exec(targetBin, newArgv, newEnv)
+}
+
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
 func (dn *Daemon) worker() {

--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -18,6 +18,7 @@ const (
 const (
 	coreos string = "coreos"
 	fedora string = "fedora"
+	rhel   string = "rhel"
 	rhcos  string = "rhcos"
 	scos   string = "scos"
 )
@@ -56,7 +57,32 @@ func (os OperatingSystem) OSRelease() osrelease.OSRelease {
 	return os.osrelease
 }
 
-// IsEL is true if the OS is an Enterprise Linux variant,
+// IsLikeRHEL is true if the OS is RHEL-like.
+func (os OperatingSystem) IsLikeRHEL() bool {
+	if os.osrelease.ID == "rhel" {
+		return true
+	}
+	for _, v := range strings.Split(os.osrelease.ID_LIKE, " ") {
+		if v == "rhel" {
+			return true
+		}
+	}
+	return false
+}
+
+// BaseVersion gets the VERSION_ID field, but prefers RHEL_VERSION if it exists
+// as it does for RHEL CoreOS.
+func (os OperatingSystem) BaseVersion() string {
+	return os.version
+}
+
+// BaseVersionMajor returns the first number in a `.` separated BaseVersion.
+// For example with VERSION_ID=9.2, this will return 9.
+func (os OperatingSystem) BaseVersionMajor() string {
+	return strings.Split(os.BaseVersion(), ".")[0]
+}
+
+// IsEL is true if the OS is an Enterprise Linux variant of CoreOS
 // i.e. RHEL CoreOS (RHCOS) or CentOS Stream CoreOS (SCOS)
 func (os OperatingSystem) IsEL() bool {
 	return os.id == rhcos || os.id == scos

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -17,7 +17,7 @@ contents: |
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
-  ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig
+  ExecStart=/usr/bin/podman run --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -17,6 +17,7 @@ contents: |
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
+  ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -17,9 +17,6 @@ contents: |
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
-  # This one was copied out to the host...but actually I'm not sure why we didn't
-  # run it via podman to start
-  ExecStart=/run/bin/machine-config-daemon firstboot-complete-machineconfig
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -18,8 +18,8 @@ contents: |
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
-  ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
+  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
+  ExecStart=/bin/chcon --reference /usr/bin/true /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -15,11 +15,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  # See https://github.com/coreos/fedora-coreos-tracker/issues/354
-  ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
-  ExecStart=/bin/chcon --reference /usr/bin/true /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}


### PR DESCRIPTION
4.13: use rhel9 builder for daemon binary

While attempting to switch builder to rhel9 base, the nmstate binary from
rhel9 fails. With that change reverted for now, let's try just building
the daemon binary on rhel9, so when it gets copied to host for
firstboot, it matches the on-node os version (rhel9)

For https://issues.redhat.com/browse/TRT-1143

(walters: I also snuck in a cleanup to use `chcon --reference` here
 because it avoids hardcoding a SELinux context)

---

build-sys: Drop setting CGO_ENABLED=0

We must dynamically link in general.

---

daemon: Run firstboot as a container image too

As the TODOs say, I am now no longer sure why we did the
"copy self to host" instead of always running from the container.

IOW, this makes firstboot work *exactly the same* as the daemonset
running after kube is up.

We really need to do this now because now we need to ensure
that the code flows here in a dynamic linking world properly
handle matching the target host system.

---

daemon: Copy matching binary to host, re-exec with it

In the general case as we want to dynamically link our Go code,
we simply must have a binary matching the host system in general.

We're already building both into the image; this changes our
entrypoint logic to always do:

- copy matching binary to /rootfs/run/bin/machine-config-daemon
- chroot /rootfs
- execve(/run/bin/machine-config-daemon, --root-mount=/ ...)

The presence of both `--root-mount=/` and a "guard environment variable"
avoid recursion.

---

