### PR TITLE
Github issue #3798 add machineconfig resource to cluster-reader cluster role

### DIFF
--- a/install/0000_80_machine-config-operator_00_clusterreader_clusterrole.yaml
+++ b/install/0000_80_machine-config-operator_00_clusterreader_clusterrole.yaml
@@ -29,6 +29,7 @@ rules:
       - controllerconfigs
       - kubeletconfigs
       - machineconfigpools
+      - machineconfigs
     verbs:
       - get
       - list


### PR DESCRIPTION
…er role

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add machineconfigs resource to cluster-reader cluster role 
**- How to verify it**
Provide access to machineconfigs resource from UI or OC cli
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
add machineconfig resource to cluster-reader cluster role