### PR TITLE
4.13: Revert rhel9 binaries builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,10 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel9-builder
-ARG TAGS=""
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY . .
-RUN make install DESTDIR=./instroot
-
 FROM registry.ci.openshift.org/ocp/4.13:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
-COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel9-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,7 +7,7 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel9-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,17 +7,10 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel9-builder
-ARG TAGS=""
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY . .
-RUN make install DESTDIR=./instroot
-
 FROM registry.ci.openshift.org/ocp/4.13:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
-COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ] || [ "${TAGS}" = "scos" ]; then \

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -18,7 +18,7 @@ contents: |
   # See https://github.com/coreos/fedora-coreos-tracker/issues/354
   ExecStart=/bin/sh -c '/bin/mkdir -p /run/bin && chcon --reference=/usr/bin /run/bin'
   ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
-  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon.rhel9 /host/run/bin/machine-config-daemon
+  ExecStart=/usr/bin/podman run --rm --net=host -v /run/bin:/host/run/bin:z --entrypoint=cp '{{ .Images.machineConfigOperator }}' /usr/bin/machine-config-daemon /host/run/bin
   ExecStart=/bin/chcon system_u:object_r:bin_t:s0 /run/bin/machine-config-daemon
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env


### PR DESCRIPTION
This reverts commit ce6cadfb71ca0b3d958fe4f2f939f48c5406e2cf and
2619e1b0b41bf8c713e03de60ea8a11737c3c5b9 (the fixup). These introduced a
regression that causes bootimages on rhel8 to be broken.

To hopefully not break 4.13, we have decided revert some changes for 4.13 golang builder,
and work towards a better solution via https://issues.redhat.com/browse/OCPBUGS-16128