### PR TITLE
MCO-664: adds e2e for on-cluster build dev preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ Dockerfile.rhel7: Dockerfile Makefile
 test-e2e: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/ | ./hack/test-with-junit.sh $(@)
 
+test-e2e-layering: install-go-junit-report
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-layering | ./hack/test-with-junit.sh $(@)
+
 test-e2e-single-node: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/ | ./hack/test-with-junit.sh $(@)
 

--- a/test/e2e-layering/helpers_test.go
+++ b/test/e2e-layering/helpers_test.go
@@ -1,0 +1,154 @@
+package e2e_layering
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+// Identifies a secret in the MCO namespace that has permissions to push to the ImageStream used for the test.
+func getBuilderPushSecretName(cs *framework.ClientSet) (string, error) {
+	secrets, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, secret := range secrets.Items {
+		if strings.HasPrefix(secret.Name, "builder-dockercfg") {
+			return secret.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find matching secret name in namespace %s", ctrlcommon.MCONamespace)
+}
+
+// Gets the ImageStream pullspec for the ImageStream used for the test.
+func getImagestreamPullspec(cs *framework.ClientSet, name string) (string, error) {
+	is, err := cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:latest", is.Status.DockerImageRepository), nil
+}
+
+// Creates an OpenShift ImageStream in the MCO namespace for the test and
+// registers a cleanup function.
+func createImagestream(t *testing.T, cs *framework.ClientSet, name string) func() {
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ctrlcommon.MCONamespace,
+		},
+	}
+
+	_, err := cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).Create(context.TODO(), is, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Created ImageStream %q", name)
+
+	return makeIdempotentAndRegister(t, func() {
+		require.NoError(t, cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).Delete(context.TODO(), name, metav1.DeleteOptions{}))
+		t.Logf("Deleted ImageStream %q", name)
+	})
+}
+
+// Creates the on-cluster-build-custom-dockerfile ConfigMap and registers a cleanup function.
+func createCustomDockerfileConfigMap(t *testing.T, cs *framework.ClientSet, customDockerfiles map[string]string) func() {
+	return createConfigMap(t, cs, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "on-cluster-build-custom-dockerfile",
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		Data: customDockerfiles,
+	})
+}
+
+// Creates a given ConfigMap and registers a cleanup function to delete it.
+func createConfigMap(t *testing.T, cs *framework.ClientSet, cm *corev1.ConfigMap) func() {
+	_, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Created ConfigMap %q", cm.Name)
+
+	return makeIdempotentAndRegister(t, func() {
+		require.NoError(t, cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{}))
+		klog.Infof("Deleted ConfigMap %q", cm.Name)
+	})
+}
+
+// Creates a given Secret and registers a cleanup function to delete it.
+func createSecret(t *testing.T, cs *framework.ClientSet, secret *corev1.Secret) func() {
+	_, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Created secret %q", secret.Name)
+
+	return makeIdempotentAndRegister(t, func() {
+		require.NoError(t, cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}))
+		t.Logf("Deleted secret %q", secret.Name)
+	})
+}
+
+// Copies the global pull secret from openshift-config/pull-secret into the MCO
+// namespace so that it can be used by the build processes.
+func copyGlobalPullSecret(t *testing.T, cs *framework.ClientSet) func() {
+	globalPullSecret, err := cs.CoreV1Interface.Secrets("openshift-config").Get(context.TODO(), "pull-secret", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	secretCopy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      globalPullSecretCloneName,
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		Data: globalPullSecret.Data,
+		Type: globalPullSecret.Type,
+	}
+
+	cleanup := createSecret(t, cs, secretCopy)
+	t.Logf("Cloned global pull secret %q into namespace %q as %q", "pull-secret", ctrlcommon.MCONamespace, secretCopy.Name)
+
+	return makeIdempotentAndRegister(t, func() {
+		cleanup()
+		t.Logf("Deleted global pull secret copy %q", secretCopy.Name)
+	})
+}
+
+// Waits for the target MachineConfigPool to reach a state defined in a supplied function.
+func waitForPoolToReachState(t *testing.T, cs *framework.ClientSet, poolName string, condFunc func(*mcfgv1.MachineConfigPool) bool) {
+	err := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineconfigurationV1Interface.MachineConfigPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		return condFunc(mcp), nil
+	})
+
+	require.NoError(t, err, "MachineConfigPool %q did not reach desired state", poolName)
+}
+
+// Registers a cleanup function, making it idempotent, and wiring up the
+// skip-cleanup flag to it which will cause cleanup to be skipped, if set.
+func makeIdempotentAndRegister(t *testing.T, cleanupFunc func()) func() {
+	out := helpers.MakeIdempotent(func() {
+		if !skipCleanup {
+			cleanupFunc()
+		}
+	})
+	t.Cleanup(out)
+	return out
+}

--- a/test/e2e-layering/onclusterbuild_test.go
+++ b/test/e2e-layering/onclusterbuild_test.go
@@ -1,0 +1,227 @@
+package e2e_layering
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/controller/build"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// The MachineConfigPool to create for the tests.
+	layeredMCPName string = "layered"
+
+	// The ImageStream name to use for the tests.
+	imagestreamName string = "os-image"
+
+	// The name of the global pull secret copy to use for the tests.
+	globalPullSecretCloneName string = "global-pull-secret-copy"
+
+	// The custom Dockerfile content to build for the tests.
+	cowsayDockerfile string = `FROM quay.io/centos/centos:stream9 AS centos
+RUN dnf install -y epel-release
+FROM configs AS final
+COPY --from=centos /etc/yum.repos.d /etc/yum.repos.d
+COPY --from=centos /etc/pki/rpm-gpg/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
+RUN sed -i 's/\$stream/9-stream/g' /etc/yum.repos.d/centos*.repo && \
+    rpm-ostree install cowsay`
+)
+
+var skipCleanup bool
+
+func init() {
+	// Skips running the cleanup functions. Useful for debugging tests.
+	flag.BoolVar(&skipCleanup, "skip-cleanup", false, "Skips running the cleanup functions")
+}
+
+// Holds elements common for each on-cluster build tests.
+type onClusterBuildTestOpts struct {
+	// Which image builder type to use for the test.
+	imageBuilderType string
+
+	// The custom Dockerfiles to use for the test. This is a map of MachineConfigPool name to Dockerfile content.
+	customDockerfiles map[string]string
+
+	// What node(s) should be targeted for the test.
+	targetNodes []*corev1.Node
+
+	// What MachineConfigPool name to use for the test.
+	poolName string
+}
+
+// Tests that an on-cluster build can be performed with the OpenShift Image Builder.
+func TestOnClusterBuildsOpenshiftImageBuilder(t *testing.T) {
+	runOnClusterBuildTest(t, onClusterBuildTestOpts{
+		imageBuilderType: build.OpenshiftImageBuilder,
+		poolName:         layeredMCPName,
+		customDockerfiles: map[string]string{
+			layeredMCPName: cowsayDockerfile,
+		},
+	})
+}
+
+// Tests tha an on-cluster build can be performed with the Custom Pod Builder.
+func TestOnClusterBuildsCustomPodBuilder(t *testing.T) {
+	runOnClusterBuildTest(t, onClusterBuildTestOpts{
+		imageBuilderType: build.CustomPodImageBuilder,
+		poolName:         layeredMCPName,
+		customDockerfiles: map[string]string{
+			layeredMCPName: cowsayDockerfile,
+		},
+	})
+}
+
+// Tests that an on-cluster build can be performed and that the resulting image
+// is rolled out to an opted-in node.
+func TestOnClusterBuildRollsOutImage(t *testing.T) {
+	imagePullspec := runOnClusterBuildTest(t, onClusterBuildTestOpts{
+		imageBuilderType: build.OpenshiftImageBuilder,
+		poolName:         layeredMCPName,
+		customDockerfiles: map[string]string{
+			layeredMCPName: cowsayDockerfile,
+		},
+	})
+
+	cs := framework.NewClientSet("")
+	node := helpers.GetRandomNode(t, cs, "worker")
+	t.Cleanup(makeIdempotentAndRegister(t, func() {
+		helpers.DeleteNodeAndMachine(t, node)
+	}))
+	helpers.LabelNode(t, cs, node, helpers.MCPNameToRole(layeredMCPName))
+	helpers.WaitForNodeImageChange(t, cs, node, imagePullspec)
+
+	t.Log(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "cowsay", "Moo!"))
+}
+
+// Sets up and performs an on-cluster build for a given set of parameters.
+// Returns the built image pullspec for later consumption.
+func runOnClusterBuildTest(t *testing.T, testOpts onClusterBuildTestOpts) string {
+	cs := framework.NewClientSet("")
+
+	t.Logf("Running with ImageBuilder type: %s", testOpts.imageBuilderType)
+
+	prepareForTest(t, cs, testOpts)
+
+	optPoolIntoLayering(t, cs, testOpts.poolName)
+
+	t.Logf("Wait for build to start")
+	waitForPoolToReachState(t, cs, testOpts.poolName, func(mcp *mcfgv1.MachineConfigPool) bool {
+		return ctrlcommon.NewLayeredPoolState(mcp).IsBuilding()
+	})
+
+	t.Logf("Build started! Waiting for completion...")
+	imagePullspec := ""
+	waitForPoolToReachState(t, cs, testOpts.poolName, func(mcp *mcfgv1.MachineConfigPool) bool {
+		lps := ctrlcommon.NewLayeredPoolState(mcp)
+		if lps.HasOSImage() && lps.IsBuildSuccess() {
+			imagePullspec = lps.GetOSImage()
+			return true
+		}
+
+		if lps.IsBuildFailure() {
+			t.Fatalf("Build unexpectedly failed.")
+		}
+
+		return false
+	})
+
+	t.Logf("MachineConfigPool %q has finished building. Got image: %s", testOpts.poolName, imagePullspec)
+
+	return imagePullspec
+}
+
+// Adds the layeringEnabled label to the target MachineConfigPool and registers
+// / returns a function to unlabel it.
+func optPoolIntoLayering(t *testing.T, cs *framework.ClientSet, pool string) func() {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		mcp, err := cs.MachineconfigurationV1Interface.MachineConfigPools().Get(context.TODO(), pool, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if mcp.Labels == nil {
+			mcp.Labels = map[string]string{}
+		}
+
+		mcp.Labels[ctrlcommon.LayeringEnabledPoolLabel] = ""
+
+		_, err = cs.MachineconfigurationV1Interface.MachineConfigPools().Update(context.TODO(), mcp, metav1.UpdateOptions{})
+		if err == nil {
+			t.Logf("Added label %q to MachineConfigPool %s to opt into layering", ctrlcommon.LayeringEnabledPoolLabel, pool)
+		}
+		return err
+	})
+
+	require.NoError(t, err)
+
+	return makeIdempotentAndRegister(t, func() {
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			mcp, err := cs.MachineconfigurationV1Interface.MachineConfigPools().Get(context.TODO(), pool, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			delete(mcp.Labels, ctrlcommon.LayeringEnabledPoolLabel)
+
+			_, err = cs.MachineconfigurationV1Interface.MachineConfigPools().Update(context.TODO(), mcp, metav1.UpdateOptions{})
+			if err == nil {
+				t.Logf("Removed label %q to MachineConfigPool %s to opt out of layering", ctrlcommon.LayeringEnabledPoolLabel, pool)
+			}
+			return err
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+// Prepares for an on-cluster build test by performing the following:
+// - Gets the Docker Builder secret name from the MCO namespace.
+// - Creates the imagestream to use for the test.
+// - Clones the global pull secret into the MCO namespace.
+// - Creates the on-cluster-build-config ConfigMap.
+// - Creates the target MachineConfigPool and waits for it to get a rendered config.
+// - Creates the on-cluster-build-custom-dockerfile ConfigMap.
+//
+// Each of the object creation steps registers an idempotent cleanup function
+// that will delete the object at the end of the test.
+func prepareForTest(t *testing.T, cs *framework.ClientSet, testOpts onClusterBuildTestOpts) {
+	pushSecretName, err := getBuilderPushSecretName(cs)
+	require.NoError(t, err)
+
+	imagestreamName := "os-image"
+	t.Cleanup(createImagestream(t, cs, imagestreamName))
+
+	t.Cleanup(copyGlobalPullSecret(t, cs))
+
+	finalPullspec, err := getImagestreamPullspec(cs, imagestreamName)
+	require.NoError(t, err)
+
+	cmCleanup := createConfigMap(t, cs, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      build.OnClusterBuildConfigMapName,
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		Data: map[string]string{
+			build.BaseImagePullSecretNameConfigKey:  globalPullSecretCloneName,
+			build.FinalImagePushSecretNameConfigKey: pushSecretName,
+			build.FinalImagePullspecConfigKey:       finalPullspec,
+			build.ImageBuilderTypeConfigMapKey:      testOpts.imageBuilderType,
+		},
+	})
+
+	t.Cleanup(cmCleanup)
+
+	t.Cleanup(makeIdempotentAndRegister(t, helpers.CreateMCP(t, cs, testOpts.poolName)))
+
+	t.Cleanup(createCustomDockerfileConfigMap(t, cs, testOpts.customDockerfiles))
+
+	_, err = helpers.WaitForRenderedConfig(t, cs, testOpts.poolName, "00-worker")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**- What I did**

I added an e2e test suite specifically targeting the on-cluster build dev preview. This is separate and distinct from the e2e and e2e-single-node suites and will have its own test stage in the OpenShift CI configs. The tests contained perform the following functions:

- Runs an on-cluster build using the OpenShift Image Builder.
- Runs an on-cluster build using the custom Pod Builder.
- Runs an on-cluster build and rolls out the final image to a cluster node, then verifies that the expected binaries are present.

For testing purposes, I temporarily modified the `make test-e2e` target to execute this new test suite so that I could verify that it runs successfully in CI. Those results can be seen in [this Prow job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/3807/pull-ci-openshift-machine-config-operator-master-e2e-gcp-op/1694814818122338304). In particular, [this log file](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/3807/pull-ci-openshift-machine-config-operator-master-e2e-gcp-op/1694814818122338304/artifacts/e2e-gcp-op/test/build-log.txt) shows the output generated from this test.

**- How to verify it**

1. Bring up an OpenShift 4.14 cluster.
2. `$ cd test/e2e-layering`
3. `$ go test -count=1 -v .`

All tests should pass. 

**- Description for the changelog**
Adds e2e tests for on-cluster builds