### PR TITLE
OCPBUGS-16227: add Passwd to bootstrap served ignition

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -370,9 +370,13 @@ func ConvertRawExtIgnitionToV3_1(inRawExtIgn *runtime.RawExtension) (runtime.Raw
 	return outRawExt, nil
 }
 
+func ConvertV3ToV2Ignition(cfg ign3types.Config) (ign2types.Config, error) {
+	return convertIgnition3to2(cfg)
+}
+
 // ConvertRawExtIgnitionToV2 ensures that the Ignition config in
 // the RawExtension is spec v2.2, or translates to it.
-func ConvertRawExtIgnitionToV2(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
+func ConvertRawExtIgnitionToV2Raw(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
 	ignCfg, rpt, err := ign3.Parse(inRawExtIgn.Raw)
 	if err != nil || rpt.IsFatal() {
 		return runtime.RawExtension{}, fmt.Errorf("parsing Ignition config spec v3.2 failed with error: %w\nReport: %v", err, rpt)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1547,6 +1547,10 @@ func (dn *Daemon) useNewSSHKeyPath() bool {
 func (dn *Daemon) updateSSHKeys(newUsers, oldUsers []ign3types.PasswdUser) error {
 	klog.Info("updating SSH keys")
 
+	for _, u := range newUsers {
+		klog.Infof("Provided User: %s with %d keys", u.Name, len(u.SSHAuthorizedKeys))
+	}
+
 	// Checking to see if absent users need to be deconfigured
 	deconfigureAbsentUsers(newUsers, oldUsers)
 

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -169,7 +169,7 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		serveConf = &converted31
 	} else {
 		// Can only be 2.2 here
-		converted2, err := ctrlcommon.ConvertRawExtIgnitionToV2(conf)
+		converted2, err := ctrlcommon.ConvertRawExtIgnitionToV2Raw(conf)
 		if err != nil {
 			w.Header().Set("Content-Length", "0")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,15 +76,21 @@ func appendEncapsulated(conf *igntypes.Config, mc *mcfgv1.MachineConfig, version
 	// requires an empty Ignition version.
 	if version == nil || version.Slice()[0] == 3 {
 		tmpIgnCfg := ctrlcommon.NewIgnConfig()
+		tmpIgnCfg.Passwd = conf.Passwd
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {
 			return fmt.Errorf("error marshalling Ignition config: %w", err)
 		}
 	} else {
+		v2, err := ctrlcommon.ConvertV3ToV2Ignition(*conf)
+		if err != nil {
+			return err
+		}
 		tmpIgnCfg := ign2types.Config{
 			Ignition: ign2types.Ignition{
 				Version: ign2types.MaxVersion.String(),
 			},
+			Passwd: v2.Passwd,
 		}
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {


### PR DESCRIPTION
This ensures that the first nodes always know about core, and the authorized ssh keys.

New nodes should get the full passwd config since it is now in the data the MCS serves via the appenders.

now, all machineConfigs should have the core user (even firstboot) and all scaled nodes should have a filled /home/core/.ssh/authorized_keys.d/ignition
