### PR TITLE
MCO-564: Make NodeController aware of BuildController

### DIFF
--- a/pkg/controller/common/layered_node_state.go
+++ b/pkg/controller/common/layered_node_state.go
@@ -1,0 +1,215 @@
+package common
+
+import (
+	"fmt"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// This is intended to provide a singular way to interrogate node objects to
+// determine if they're in a specific state. A secondary goal is to provide a
+// singular way to mutate node objects for the purposes of updating their
+// current configurations.
+//
+// The eventual goal is to replace all of the node status functions in
+// status.go with this code, then repackage this so that it can be used by any
+// portion of the MCO which needs to interrogate or mutate node state.
+type LayeredNodeState struct {
+	node *corev1.Node
+}
+
+func NewLayeredNodeState(n *corev1.Node) *LayeredNodeState {
+	return &LayeredNodeState{node: n}
+}
+
+// Augements the isNodeDoneAt() check with determining if the current / desired
+// image annotations match the pools' values.
+func (l *LayeredNodeState) IsDoneAt(mcp *mcfgv1.MachineConfigPool) bool {
+	return isNodeDoneAt(l.node, mcp) && l.isDesiredImageEqualToPool(mcp) && l.isCurrentImageEqualToPool(mcp)
+}
+
+// The original behavior of getUnavailableMachines is: getUnavailableMachines
+// returns the set of nodes which are either marked unscheduleable, or have a
+// MCD actively working. If the MCD is actively working (or hasn't started)
+// then the node *may* go unschedulable in the future, so we don't want to
+// potentially start another node update exceeding our maxUnavailable. Somewhat
+// the opposite of getReadyNodes().
+//
+// This augments this check by determining if the desired iamge annotation is
+// equal to what the pool expects.
+func (l *LayeredNodeState) IsUnavailable(mcp *mcfgv1.MachineConfigPool) bool {
+	return isNodeUnavailable(l.node) && l.isDesiredImageEqualToPool(mcp)
+}
+
+// Checks that the desired machineconfig and image annotations equal the ones
+// specified by the pool.
+func (l *LayeredNodeState) IsDesiredEqualToPool(mcp *mcfgv1.MachineConfigPool) bool {
+	return l.isDesiredMachineConfigEqualToPool(mcp) && l.isDesiredImageEqualToPool(mcp)
+}
+
+// Compares the MachineConfig specified by the MachineConfigPool to the one
+// specified by the node's desired MachineConfig annotation.
+func (l *LayeredNodeState) isDesiredMachineConfigEqualToPool(mcp *mcfgv1.MachineConfigPool) bool {
+	return l.node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] == mcp.Spec.Configuration.Name
+}
+
+// Determines if the nodes desired image is equal to the expected value from
+// the MachineConfigPool.
+func (l *LayeredNodeState) isDesiredImageEqualToPool(mcp *mcfgv1.MachineConfigPool) bool {
+	return l.isImageAnnotationEqualToPool(daemonconsts.DesiredImageAnnotationKey, mcp)
+}
+
+// Determines if the nodes current image is equal to the expected value from
+// the MachineConfigPool.
+func (l *LayeredNodeState) isCurrentImageEqualToPool(mcp *mcfgv1.MachineConfigPool) bool {
+	return l.isImageAnnotationEqualToPool(daemonconsts.CurrentImageAnnotationKey, mcp)
+}
+
+// Determines if a nodes' image annotation is equal to the expected value from
+// the MachineConfigPool. If the pool is layered, this value should equal the
+// OS image value, if the value is available. If the pool is not layered, then
+// any image annotations should not be present on the node.
+func (l *LayeredNodeState) isImageAnnotationEqualToPool(anno string, mcp *mcfgv1.MachineConfigPool) bool {
+	lps := NewLayeredPoolState(mcp)
+
+	val, ok := l.node.Annotations[anno]
+
+	if lps.IsLayered() && lps.HasOSImage() {
+		// If the pool is layered and has an OS image, check that it equals the
+		// node annotations' value.
+		return lps.GetOSImage() == val
+	}
+
+	// If the pool is not layered, this annotation should not exist.
+	return val == "" || !ok
+}
+
+// Sets the desired annotations from the MachineConfigPool, according to the
+// following rules:
+//
+// 1. The desired MachineConfig annotation will always be set to match the one
+// specified in the MachineConfigPool.
+// 2. If the pool is layered and has the OS image available, it will set the
+// desired image annotation.
+// 3. If the pool is not layered and does not have the OS image available, it
+// will remove the desired image annotation.
+//
+// Note: This will create a deep copy of the node object first to avoid
+// mutating any underlying caches.
+func (l *LayeredNodeState) SetDesiredStateFromPool(mcp *mcfgv1.MachineConfigPool) {
+	node := l.Node()
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+
+	node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] = mcp.Spec.Configuration.Name
+
+	lps := NewLayeredPoolState(mcp)
+
+	if lps.IsLayered() && lps.HasOSImage() {
+		node.Annotations[daemonconsts.DesiredImageAnnotationKey] = lps.GetOSImage()
+	} else {
+		delete(node.Annotations, daemonconsts.DesiredImageAnnotationKey)
+	}
+
+	l.node = node
+}
+
+// Returns a deep copy of the underlying node object.
+func (l *LayeredNodeState) Node() *corev1.Node {
+	return l.node.DeepCopy()
+}
+
+// All functions below this line were copy / pasted from
+// pkg/controller/node/status.go. A future cleanup effort will integrate these
+// more seamlessly into the above struct.
+
+// isNodeDone returns true if the current == desired and the MCD has marked done.
+func isNodeDone(node *corev1.Node) bool {
+	if node.Annotations == nil {
+		return false
+	}
+	cconfig, ok := node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey]
+	if !ok || cconfig == "" {
+		return false
+	}
+	dconfig, ok := node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]
+	if !ok || dconfig == "" {
+		return false
+	}
+
+	return cconfig == dconfig && isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDone)
+}
+
+// isNodeDoneAt checks whether a node is fully updated to a targetConfig
+func isNodeDoneAt(node *corev1.Node, pool *mcfgv1.MachineConfigPool) bool {
+	return isNodeDone(node) && node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] == pool.Spec.Configuration.Name
+}
+
+// isNodeUnavailable is a helper function for getUnavailableMachines
+// See the docs of getUnavailableMachines for more info
+func isNodeUnavailable(node *corev1.Node) bool {
+	// Unready nodes are unavailable
+	if !isNodeReady(node) {
+		return true
+	}
+	// Ready nodes are not unavailable
+	if isNodeDone(node) {
+		return false
+	}
+	// Now we know the node isn't ready - the current config must not
+	// equal target.  We want to further filter down on the MCD state.
+	// If a MCD is in a terminal (failing) state then we can safely retarget it.
+	// to a different config.  Or to say it another way, a node is unavailable
+	// if the MCD is working, or hasn't started work but the configs differ.
+	return !isNodeMCDFailing(node)
+}
+
+// isNodeMCDState checks the MCD state against the state parameter
+func isNodeMCDState(node *corev1.Node, state string) bool {
+	dstate, ok := node.Annotations[daemonconsts.MachineConfigDaemonStateAnnotationKey]
+	if !ok || dstate == "" {
+		return false
+	}
+
+	return dstate == state
+}
+
+func checkNodeReady(node *corev1.Node) error {
+	for i := range node.Status.Conditions {
+		cond := &node.Status.Conditions[i]
+		// We consider the node for scheduling only when its:
+		// - NodeReady condition status is ConditionTrue,
+		// - NodeDiskPressure condition status is ConditionFalse,
+		// - NodeNetworkUnavailable condition status is ConditionFalse.
+		if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
+			return fmt.Errorf("node %s is reporting NotReady=%v", node.Name, cond.Status)
+		}
+		if cond.Type == corev1.NodeDiskPressure && cond.Status != corev1.ConditionFalse {
+			return fmt.Errorf("node %s is reporting OutOfDisk=%v", node.Name, cond.Status)
+		}
+		if cond.Type == corev1.NodeNetworkUnavailable && cond.Status != corev1.ConditionFalse {
+			return fmt.Errorf("node %s is reporting NetworkUnavailable=%v", node.Name, cond.Status)
+		}
+	}
+	// Ignore nodes that are marked unschedulable
+	if node.Spec.Unschedulable {
+		return fmt.Errorf("node %s is reporting Unschedulable", node.Name)
+	}
+	return nil
+}
+
+func isNodeReady(node *corev1.Node) bool {
+	return checkNodeReady(node) == nil
+}
+
+// isNodeMCDFailing checks if the MCD has unsuccessfully applied an update
+func isNodeMCDFailing(node *corev1.Node) bool {
+	if node.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] == node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] {
+		return false
+	}
+	return isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDegraded) ||
+		isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateUnreconcilable)
+}

--- a/pkg/controller/common/layered_node_state_test.go
+++ b/pkg/controller/common/layered_node_state_test.go
@@ -1,0 +1,193 @@
+package common
+
+import (
+	"testing"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	machineConfigV0 string = "rendered-machineconfig-v1"
+	machineConfigV1 string = "rendered-machineconfig-v2"
+	imageV0         string = "registry.host.com/org/repo:tag-1"
+	imageV1         string = "registry.host.com/org/repo:tag-2"
+)
+
+func newNode(current, desired string) *corev1.Node {
+	return helpers.NewNodeBuilder("").WithCurrentConfig(current).WithDesiredConfig(desired).Node()
+}
+
+func newLayeredNode(currentConfig, desiredConfig, currentImage, desiredImage string) *corev1.Node {
+	nb := helpers.NewNodeBuilder("")
+	nb.WithCurrentConfig(currentConfig).WithDesiredConfig(desiredConfig)
+	nb.WithCurrentImage(currentImage).WithDesiredImage(desiredImage)
+	return nb.Node()
+}
+
+func newMachineConfigPool(currentConfig string) *mcfgv1.MachineConfigPool {
+	return helpers.NewMachineConfigPoolBuilder("").WithMachineConfig(currentConfig).MachineConfigPool()
+}
+
+func newLayeredMachineConfigPool(currentConfig string) *mcfgv1.MachineConfigPool {
+	return helpers.NewMachineConfigPoolBuilder("").WithMachineConfig(currentConfig).WithLayeringEnabled().MachineConfigPool()
+}
+
+func newLayeredMachineConfigPoolWithImage(currentConfig, currentImage string) *mcfgv1.MachineConfigPool {
+	return helpers.NewMachineConfigPoolBuilder("").WithMachineConfig(currentConfig).WithImage(currentImage).MachineConfigPool()
+}
+
+func TestLayeredNodeState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		node *corev1.Node
+		pool *mcfgv1.MachineConfigPool
+
+		isDoneAt             bool
+		isUnavailable        bool
+		isDesiredEqualToPool bool
+	}{
+		{
+			name:                 "Updated non-layered node",
+			node:                 newNode(machineConfigV0, machineConfigV0),
+			pool:                 newMachineConfigPool(machineConfigV0),
+			isDesiredEqualToPool: true,
+			isDoneAt:             true,
+		},
+		{
+			name:     "Out-of-date non-layered node",
+			node:     newNode(machineConfigV0, machineConfigV0),
+			pool:     newMachineConfigPool(machineConfigV1),
+			isDoneAt: false,
+		},
+		{
+			name:                 "Fully transitioned layered node",
+			node:                 newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+			pool:                 newLayeredMachineConfigPoolWithImage(machineConfigV0, imageV0),
+			isDesiredEqualToPool: true,
+			isDoneAt:             true,
+		},
+		{
+			name: "Layered node changes image only",
+			node: newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+			pool: newLayeredMachineConfigPoolWithImage(machineConfigV0, imageV1),
+		},
+		{
+			name:                 "Layered node changes machineconfigs and image",
+			node:                 newLayeredNode(machineConfigV0, machineConfigV1, imageV0, imageV1),
+			pool:                 newLayeredMachineConfigPoolWithImage(machineConfigV1, imageV1),
+			isUnavailable:        true,
+			isDesiredEqualToPool: true,
+		},
+		{
+			name: "Out-of-date layered image",
+			node: newLayeredNode(machineConfigV1, machineConfigV1, imageV0, imageV0),
+			pool: newLayeredMachineConfigPoolWithImage(machineConfigV1, imageV1),
+		},
+		{
+			node:                 newLayeredNode(machineConfigV0, machineConfigV1, imageV1, imageV1),
+			pool:                 newLayeredMachineConfigPoolWithImage(machineConfigV1, imageV1),
+			name:                 "layered node machineconfig outdated",
+			isUnavailable:        true,
+			isDesiredEqualToPool: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lns := NewLayeredNodeState(test.node)
+
+			if test.pool != nil {
+				assert.Equal(t, test.isDoneAt, lns.IsDoneAt(test.pool), "IsDoneAt()")
+				assert.Equal(t, test.isDesiredEqualToPool, lns.IsDesiredEqualToPool(test.pool), "IsDesiredEqualToPool()")
+				assert.Equal(t, test.isUnavailable, lns.IsUnavailable(test.pool), "IsUnavailablePool()")
+			}
+
+			if t.Failed() {
+				helpers.DumpNodesAndPools(t, []*corev1.Node{test.node}, []*mcfgv1.MachineConfigPool{test.pool})
+			}
+		})
+	}
+}
+
+func TestLayeredNodeStateIsMutated(t *testing.T) {
+	tests := []struct {
+		name                  string
+		pool                  *mcfgv1.MachineConfigPool
+		node                  *corev1.Node
+		expectedImage         string
+		expectedMachineConfig string
+	}{
+		{
+			name: "layered node loses desired image because pool is not layered",
+			pool: newMachineConfigPool(machineConfigV0),
+			node: newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+		},
+		{
+			name: "layered node loses desired image because pool has no image",
+			pool: newLayeredMachineConfigPool(machineConfigV0),
+			node: newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+		},
+		{
+			name: "layered node loses desired image because pool has no image and MachineConfig changes",
+			pool: newLayeredMachineConfigPool(machineConfigV1),
+			node: newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+		},
+		{
+			name:          "unlayered node becomes layered because pool is layered",
+			pool:          newLayeredMachineConfigPoolWithImage(machineConfigV0, imageV0),
+			node:          newNode(machineConfigV0, machineConfigV0),
+			expectedImage: imageV0,
+		},
+		{
+			name: "unlayered node MachineConfig changes",
+			pool: newMachineConfigPool(machineConfigV1),
+			node: newNode(machineConfigV0, machineConfigV0),
+		},
+		{
+			name:          "layered node image changes",
+			pool:          newLayeredMachineConfigPoolWithImage(machineConfigV0, imageV1),
+			node:          newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+			expectedImage: imageV1,
+		},
+		{
+			name:                  "layered node image and MachineConfig changes",
+			pool:                  newLayeredMachineConfigPoolWithImage(machineConfigV1, imageV1),
+			node:                  newLayeredNode(machineConfigV0, machineConfigV0, imageV0, imageV0),
+			expectedImage:         imageV1,
+			expectedMachineConfig: machineConfigV1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			lns := NewLayeredNodeState(test.node)
+			lns.SetDesiredStateFromPool(test.pool)
+
+			updatedNode := lns.Node()
+
+			if test.expectedImage == "" {
+				assert.NotContains(t, updatedNode.Annotations, daemonconsts.DesiredImageAnnotationKey)
+			} else {
+				assert.Equal(t, test.expectedImage, updatedNode.Annotations[daemonconsts.DesiredImageAnnotationKey])
+			}
+
+			assert.Equal(t, test.pool.Spec.Configuration.Name, updatedNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
+
+			// Ensure that the original node and updated node are not the same object
+			// nor that they have the same value.
+			assert.NotEqual(t, test.node, updatedNode)
+			assert.True(t, test.node != updatedNode)
+		})
+	}
+}

--- a/pkg/controller/common/layered_pool_state.go
+++ b/pkg/controller/common/layered_pool_state.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+// This is intended to provide a singular way to interrogate MachineConfigPool
+// objects to determine if they're in a specific state or not. The eventual
+// goal is to use this to mutate the MachineConfigPool object to provide a
+// single and consistent interface for that purpose. In this current state, we
+// do not perform any mutations.
+type LayeredPoolState struct {
+	pool *mcfgv1.MachineConfigPool
+}
+
+func NewLayeredPoolState(pool *mcfgv1.MachineConfigPool) *LayeredPoolState {
+	return &LayeredPoolState{pool: pool}
+}
+
+// Determines if a MachineConfigPool is layered by looking for the layering
+// enabled label.
+func (l *LayeredPoolState) IsLayered() bool {
+	if l.pool == nil {
+		return false
+	}
+
+	if l.pool.Labels == nil {
+		return false
+	}
+
+	return IsLayeredPool(l.pool)
+}
+
+// Returns the OS image, if one is present.
+func (l *LayeredPoolState) GetOSImage() string {
+	osImage := l.pool.Annotations[ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey]
+	return osImage
+}
+
+// Determines if a given MachineConfigPool has an available OS image. Returns
+// false if the annotation is missing or set to an empty string.
+func (l *LayeredPoolState) HasOSImage() bool {
+	if l.pool.Labels == nil {
+		return false
+	}
+
+	val, ok := l.pool.Annotations[ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey]
+	return ok && val != ""
+}
+
+// Determines if an OS image build is a success.
+func (l *LayeredPoolState) IsBuildSuccess() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolBuildSuccess)
+}
+
+// Determines if an OS image build is pending.
+func (l *LayeredPoolState) IsBuildPending() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolBuildPending)
+}
+
+// Determines if an OS image build is in progress.
+func (l *LayeredPoolState) IsBuilding() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolBuilding)
+}
+
+// Determines if an OS image build has failed.
+func (l *LayeredPoolState) IsBuildFailure() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolBuildFailed)
+}

--- a/pkg/controller/common/layered_pool_state_test.go
+++ b/pkg/controller/common/layered_pool_state_test.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestLayeredPoolState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		pool           *mcfgv1.MachineConfigPool
+		isLayered      bool
+		hasOSImage     bool
+		isBuildSuccess bool
+		isBuildPending bool
+		isBuilding     bool
+		isBuildFailure bool
+		buildCondition mcfgv1.MachineConfigPoolConditionType
+	}{
+		{
+			name: "unlayered pool",
+			pool: newMachineConfigPool(""),
+		},
+		{
+			name:      "layered pool, no OS image",
+			pool:      newLayeredMachineConfigPool(""),
+			isLayered: true,
+		},
+		{
+			name:       "layered pool, with OS image",
+			pool:       newLayeredMachineConfigPoolWithImage("", imageV1),
+			isLayered:  true,
+			hasOSImage: true,
+		},
+		{
+			name:           "layered pool, with OS image, building",
+			pool:           newLayeredMachineConfigPoolWithImage("", imageV1),
+			isLayered:      true,
+			hasOSImage:     true,
+			buildCondition: mcfgv1.MachineConfigPoolBuilding,
+			isBuilding:     true,
+		},
+		{
+			name:           "layered pool, with OS image, build pending",
+			pool:           newLayeredMachineConfigPoolWithImage("", imageV1),
+			isLayered:      true,
+			hasOSImage:     true,
+			buildCondition: mcfgv1.MachineConfigPoolBuildPending,
+			isBuildPending: true,
+		},
+		{
+			name:           "layered pool, with OS image, build success",
+			pool:           newLayeredMachineConfigPoolWithImage("", imageV1),
+			isLayered:      true,
+			hasOSImage:     true,
+			buildCondition: mcfgv1.MachineConfigPoolBuildSuccess,
+			isBuildSuccess: true,
+		},
+		{
+			name:           "layered pool, with OS image, build failed",
+			pool:           newLayeredMachineConfigPoolWithImage("", imageV1),
+			isLayered:      true,
+			hasOSImage:     true,
+			buildCondition: mcfgv1.MachineConfigPoolBuildFailed,
+			isBuildFailure: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if test.buildCondition != "" {
+				cond := mcfgv1.NewMachineConfigPoolCondition(test.buildCondition, corev1.ConditionTrue, "", "")
+				mcfgv1.SetMachineConfigPoolCondition(&test.pool.Status, *cond)
+			}
+
+			lps := NewLayeredPoolState(test.pool)
+
+			assert.Equal(t, test.isLayered, lps.IsLayered(), "is layered mismatch %s", spew.Sdump(test.pool.Labels))
+			assert.Equal(t, test.hasOSImage, lps.HasOSImage(), "has OS image mismatch %s", spew.Sdump(test.pool.Annotations))
+			assert.Equal(t, test.isBuildSuccess, lps.IsBuildSuccess(), "is build success mismatch %s", spew.Sdump(test.pool.Status))
+			assert.Equal(t, test.isBuildPending, lps.IsBuildPending(), "is build pending mismatch %s", spew.Sdump(test.pool.Status))
+			assert.Equal(t, test.isBuilding, lps.IsBuilding(), "is building mismatch %s", spew.Sdump(test.pool.Status))
+			assert.Equal(t, test.isBuildFailure, lps.IsBuildFailure(), "is build failure mismatch %s", spew.Sdump(test.pool.Status))
+		})
+	}
+}

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -140,6 +140,7 @@ func (nw *clusterNodeWriter) SetDone(dcAnnotation string) error {
 		// clear out any Degraded/Unreconcilable reason
 		constants.MachineConfigDaemonReasonAnnotationKey: "",
 	}
+
 	UpdateStateMetric(mcdState, constants.MachineConfigDaemonStateDone, "")
 	respChan := make(chan response, 1)
 	nw.writer <- message{

--- a/test/helpers/nodebuilder.go
+++ b/test/helpers/nodebuilder.go
@@ -1,0 +1,173 @@
+package helpers
+
+import (
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NodeBuilder provides a more fluent API for creating Node objects for tests.
+// Instead of creating multiple specific functions for each particular node
+// configuration, this allows one to create nodes thusly:
+//
+// NewNodeBuilder("node-0").WithCurrentConfig(currentConfig).WithDesiredConfig(desiredConfig).Node()
+type NodeBuilder struct {
+	node          *corev1.Node
+	currentConfig string
+	desiredConfig string
+	currentImage  string
+	desiredImage  string
+	mcdState      string
+}
+
+func NewNodeBuilder(name string) *NodeBuilder {
+	n := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	return &NodeBuilder{node: n}
+}
+
+func (n *NodeBuilder) WithEqualConfigsAndImages(config, image string) *NodeBuilder {
+	return n.WithEqualConfigs(config).WithEqualImages(image)
+}
+
+func (n *NodeBuilder) WithEqualImages(image string) *NodeBuilder {
+	return n.WithImages(image, image)
+}
+
+func (n *NodeBuilder) WithEqualConfigs(config string) *NodeBuilder {
+	return n.WithConfigs(config, config)
+}
+
+func (n *NodeBuilder) WithAnnotations(annos map[string]string) *NodeBuilder {
+	if n.node.Annotations == nil {
+		n.node.Annotations = map[string]string{}
+	}
+
+	for k, v := range annos {
+		if k == daemonconsts.MachineConfigDaemonStateAnnotationKey {
+			n.mcdState = v
+		}
+
+		if k == daemonconsts.CurrentImageAnnotationKey {
+			n.currentImage = v
+		}
+
+		if k == daemonconsts.DesiredImageAnnotationKey {
+			n.desiredImage = v
+		}
+
+		if k == daemonconsts.CurrentMachineConfigAnnotationKey {
+			n.currentConfig = v
+		}
+
+		if k == daemonconsts.DesiredMachineConfigAnnotationKey {
+			n.desiredConfig = v
+		}
+
+		n.node.Annotations[k] = v
+	}
+
+	return n
+}
+
+func (n *NodeBuilder) WithTaint(taint corev1.Taint) *NodeBuilder {
+	if n.node.Spec.Taints == nil {
+		n.node.Spec.Taints = []corev1.Taint{}
+	}
+
+	n.node.Spec.Taints = append(n.node.Spec.Taints, taint)
+	return n
+}
+
+func (n *NodeBuilder) WithConfigsAndImages(currentConfig, desiredConfig, currentImage, desiredImage string) *NodeBuilder {
+	return n.WithConfigs(currentConfig, desiredConfig).WithImages(currentImage, desiredImage)
+}
+
+func (n *NodeBuilder) WithConfigs(current, desired string) *NodeBuilder {
+	return n.WithCurrentConfig(current).WithDesiredConfig(desired)
+}
+
+func (n *NodeBuilder) WithCurrentConfig(current string) *NodeBuilder {
+	return n.WithAnnotations(map[string]string{
+		daemonconsts.CurrentMachineConfigAnnotationKey: current,
+	})
+}
+
+func (n *NodeBuilder) WithDesiredConfig(desired string) *NodeBuilder {
+	return n.WithAnnotations(map[string]string{
+		daemonconsts.DesiredMachineConfigAnnotationKey: desired,
+	})
+}
+
+func (n *NodeBuilder) WithImages(current, desired string) *NodeBuilder {
+	return n.WithCurrentImage(current).WithDesiredImage(desired)
+}
+
+func (n *NodeBuilder) WithCurrentImage(current string) *NodeBuilder {
+	return n.WithAnnotations(map[string]string{
+		daemonconsts.CurrentImageAnnotationKey: current,
+	})
+}
+
+func (n *NodeBuilder) WithDesiredImage(desired string) *NodeBuilder {
+	return n.WithAnnotations(map[string]string{
+		daemonconsts.DesiredImageAnnotationKey: desired,
+	})
+}
+
+func (n *NodeBuilder) WithMCDState(state string) *NodeBuilder {
+	return n.WithAnnotations(map[string]string{
+		daemonconsts.MachineConfigDaemonStateAnnotationKey: state,
+	})
+}
+
+func (n *NodeBuilder) WithLabels(labels map[string]string) *NodeBuilder {
+	if n.node.Labels == nil {
+		n.node.Labels = map[string]string{}
+	}
+
+	for k, v := range labels {
+		n.node.Labels[k] = v
+	}
+
+	return n
+}
+
+func (n *NodeBuilder) WithNodeReady() *NodeBuilder {
+	return n.withNodeReady(corev1.ConditionTrue)
+}
+
+func (n *NodeBuilder) WithNodeNotReady() *NodeBuilder {
+	return n.withNodeReady(corev1.ConditionFalse)
+}
+
+func (n *NodeBuilder) withNodeReady(status corev1.ConditionStatus) *NodeBuilder {
+	return n.WithStatus(corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: status}}})
+}
+
+func (n *NodeBuilder) WithStatus(s corev1.NodeStatus) *NodeBuilder {
+	n.node.Status = s
+	return n
+}
+
+func (n *NodeBuilder) Node() *corev1.Node {
+	if n.mcdState != "" {
+		return n.node
+	}
+
+	if n.currentConfig != "" || n.desiredConfig != "" || n.currentImage != "" || n.desiredImage != "" {
+		var state string
+		if n.currentImage == n.desiredImage && n.currentConfig == n.desiredConfig {
+			state = daemonconsts.MachineConfigDaemonStateDone
+		} else {
+			state = daemonconsts.MachineConfigDaemonStateWorking
+		}
+		n.node.Annotations[daemonconsts.MachineConfigDaemonStateAnnotationKey] = state
+	}
+
+	return n.node.DeepCopy()
+}

--- a/test/helpers/poolbuilder.go
+++ b/test/helpers/poolbuilder.go
@@ -1,0 +1,172 @@
+package helpers
+
+import (
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// MachineConfigPoolBuilder provides a more fluent API for creating
+// MachineConfigPool objects for tests. Instead of creating multiple specific
+// functions for each particular node configuration, this allows one to create
+// nodes thusly:
+//
+// NewMachineConfigPoolBuilder("worker").WithMachineConfig(currentConfig).MachineConfigPool()
+//
+// It is aware of the rules around creating layering-enabled
+// MachineConfigPools. For example, if one sets an image with the WithImage()
+// method, it will automatically set the layering annotation.
+type MachineConfigPoolBuilder struct {
+	name           string
+	currentConfig  string
+	annos          map[string]string
+	labels         map[string]string
+	mcSelector     *metav1.LabelSelector
+	nodeSelector   *metav1.LabelSelector
+	conditions     []*mcfgv1.MachineConfigPoolCondition
+	maxUnavailable *intstr.IntOrString
+	paused         bool
+}
+
+func NewMachineConfigPoolBuilder(name string) *MachineConfigPoolBuilder {
+	return &MachineConfigPoolBuilder{name: name}
+}
+
+func (m *MachineConfigPoolBuilder) WithName(name string) *MachineConfigPoolBuilder {
+	m.name = name
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithPaused() *MachineConfigPoolBuilder {
+	m.paused = true
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithMaxUnavailable(n int) *MachineConfigPoolBuilder {
+	// TODO: Update k8s.io/apimachinery since this now uses an int32 instead of an int.
+	tmp := intstr.FromInt(n)
+	m.maxUnavailable = &tmp
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithMachineConfig(mc string) *MachineConfigPoolBuilder {
+	m.currentConfig = mc
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithLayeringEnabled() *MachineConfigPoolBuilder {
+	// TODO(zzlotnik): Fix circular import which will not allow us to import the
+	// annotation / label key constants from pkg/controller/common/constants.go.
+	return m.WithLabels(map[string]string{
+		"machineconfiguration.openshift.io/layering-enabled": "",
+	})
+}
+
+func (m *MachineConfigPoolBuilder) WithImage(image string) *MachineConfigPoolBuilder {
+	if image != "" {
+		// TODO(zzlotnik): Fix circular import which will not allow us to import the
+		// annotation / label key constants from pkg/controller/common/constants.go.
+		m.WithAnnotations(map[string]string{
+			"machineconfiguration.openshift.io/newestImageEquivalentConfig": image,
+		})
+	}
+
+	return m.WithLayeringEnabled()
+}
+
+func (m *MachineConfigPoolBuilder) WithAnnotations(annos map[string]string) *MachineConfigPoolBuilder {
+	if m.annos == nil {
+		m.annos = map[string]string{}
+	}
+
+	for k, v := range annos {
+		m.annos[k] = v
+	}
+
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithLabels(labels map[string]string) *MachineConfigPoolBuilder {
+	if m.labels == nil {
+		m.labels = map[string]string{}
+	}
+
+	for k, v := range labels {
+		m.labels[k] = v
+	}
+
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) isBuildConditionType(condType mcfgv1.MachineConfigPoolConditionType) bool {
+	buildConditionTypes := map[mcfgv1.MachineConfigPoolConditionType]struct{}{
+		mcfgv1.MachineConfigPoolBuildPending: {},
+		mcfgv1.MachineConfigPoolBuilding:     {},
+		mcfgv1.MachineConfigPoolBuildSuccess: {},
+		mcfgv1.MachineConfigPoolBuildFailed:  {},
+	}
+
+	_, ok := buildConditionTypes[condType]
+	return ok
+}
+
+func (m *MachineConfigPoolBuilder) WithCondition(condType mcfgv1.MachineConfigPoolConditionType, status corev1.ConditionStatus, reason, message string) *MachineConfigPoolBuilder {
+	if m.conditions == nil {
+		m.conditions = []*mcfgv1.MachineConfigPoolCondition{}
+	}
+
+	if m.isBuildConditionType(condType) {
+		m.WithLayeringEnabled()
+	}
+
+	condition := mcfgv1.NewMachineConfigPoolCondition(condType, status, reason, message)
+	m.conditions = append(m.conditions, condition)
+
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithNodeSelector(ns *metav1.LabelSelector) *MachineConfigPoolBuilder {
+	m.nodeSelector = ns
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) WithMachineConfigSelector(mcs *metav1.LabelSelector) *MachineConfigPoolBuilder {
+	m.mcSelector = mcs
+	return m
+}
+
+func (m *MachineConfigPoolBuilder) MachineConfigPool() *mcfgv1.MachineConfigPool {
+	mcp := NewMachineConfigPool(m.name, m.mcSelector, m.nodeSelector, m.currentConfig)
+
+	mcp.Spec.Paused = m.paused
+	mcp.Spec.MaxUnavailable = m.maxUnavailable
+
+	if m.annos != nil {
+		if mcp.Annotations == nil {
+			mcp.Annotations = map[string]string{}
+		}
+
+		for k, v := range m.annos {
+			mcp.Annotations[k] = v
+		}
+	}
+
+	if m.labels != nil {
+		if mcp.Labels == nil {
+			mcp.Labels = map[string]string{}
+		}
+
+		for k, v := range m.labels {
+			mcp.Labels[k] = v
+		}
+	}
+
+	if m.conditions != nil {
+		for _, condition := range m.conditions {
+			mcfgv1.SetMachineConfigPoolCondition(&mcp.Status, *condition)
+		}
+	}
+
+	return mcp
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -18,6 +18,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
+	"github.com/davecgh/go-spew/spew"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
@@ -885,4 +886,75 @@ func mcdForNode(cs *framework.ClientSet, node *corev1.Node) (*corev1.Pod, error)
 		return nil, fmt.Errorf("too many (%d) MCDs for node %s", len(mcdList.Items), node.Name)
 	}
 	return &mcdList.Items[0], nil
+}
+
+func DumpNodesAndPools(t *testing.T, nodes []*corev1.Node, pools []*mcfgv1.MachineConfigPool) {
+	t.Helper()
+
+	sb := &strings.Builder{}
+
+	fmt.Fprintln(sb, "")
+	fmt.Fprintln(sb, "===== Nodes =====")
+	for _, node := range nodes {
+		fmt.Fprintln(sb, dumpNode(node, false))
+		fmt.Fprintln(sb, "=========")
+	}
+	fmt.Fprintln(sb, "")
+	fmt.Fprintln(sb, "====== Pools ======")
+
+	for _, pool := range pools {
+		fmt.Fprintln(sb, dumpPool(pool, false))
+		fmt.Fprintln(sb, "===================")
+	}
+
+	t.Log(sb.String())
+}
+
+func dumpNode(node *corev1.Node, silentNil bool) string {
+	sb := &strings.Builder{}
+
+	fmt.Fprintln(sb, "")
+
+	if node != nil {
+		if node.Name != "" {
+			fmt.Fprintf(sb, "Node Name: %s\n", node.Name)
+		}
+		fmt.Fprintln(sb, "")
+		fmt.Fprintf(sb, "Node Annotations: %s", spew.Sdump(node.Annotations))
+		fmt.Fprintln(sb, "")
+		fmt.Fprintf(sb, "Node Labels: %s", spew.Sdump(node.Labels))
+		fmt.Fprintln(sb, "")
+
+		conditions := "<empty>"
+		if len(node.Status.Conditions) != 0 {
+			conditions = spew.Sdump(node.Status.Conditions)
+		}
+		fmt.Fprintf(sb, "Node Conditions: %s\n", conditions)
+	} else if !silentNil {
+		fmt.Fprintln(sb, "Node was nil")
+	}
+
+	return sb.String()
+}
+
+func dumpPool(pool *mcfgv1.MachineConfigPool, silentNil bool) string {
+	sb := &strings.Builder{}
+
+	fmt.Fprintln(sb, "")
+
+	if pool != nil {
+		if pool.Name != "" {
+			fmt.Fprintf(sb, "Pool Name: %q\n", pool.Name)
+		}
+		fmt.Fprintln(sb, "")
+		fmt.Fprintf(sb, "Pool Annotations: %s", spew.Sdump(pool.Annotations))
+		fmt.Fprintln(sb, "")
+		fmt.Fprintf(sb, "Pool Labels: %s", spew.Sdump(pool.Labels))
+		fmt.Fprintln(sb, "")
+		fmt.Fprintf(sb, "Pool Config: %q\n", pool.Spec.Configuration.Name)
+	} else if !silentNil {
+		fmt.Fprintln(sb, "Pool was nil")
+	}
+
+	return sb.String()
 }


### PR DESCRIPTION
**- What I did**

This makes NodeController aware of BuildController. Specifically, it will
propagate the final OS image pullspec from the MachineConfigPool annotation
(`machineconfiguration.openshift.io/newestImageEquivalentConfig`) into the
currentImage and desiredImage annotations for each node in the target pool.

**- How to verify it**

I've written a small Go binary that can be used to help aid in these steps: https://github.com/openshift/machine-config-operator/pull/3852. It is not required, but does make the setup / teardown process of this much easier.

1. Bring up an OpenShift cluster.
2. Create a new MachineConfigPool or use an existing MachineConfigPool.
3. Opt a pool into layering by adding the `machineconfiguration.openshift.io/layering-enabled` label onto a MachineConfigPool.
4. Set `machineconfiguration.openshift.io/newestImageEquivalentConfig` to an arbitrary value, e.g., `registry.hostname.com/org/repo:tag-1`.
5. Set the `BuildSuccess` condition on the MachineConfigPool. Note: You may have to use my onclusterbuilds binary found here https://github.com/openshift/machine-config-operator/pull/3852 in order to easily do that: `$ ./onclustertesting set-build-status --pool=<poolname> --type BuildSuccess --status=true`
6. Add a node to a pool by setting the `node-role.kubernetes.io/<poolname>` label on the node.

At this point, you should see the MachineConfigPool transition into the `Updating` status. You should also see that the node you've added to the pool has the annotation `machineconfiguration.openshift.io/desiredImage: "registry.hostname.com/org/repo:tag-1"` present. Once the node gets the `machineconfiguration.openshift.io/currentImage: "registry.hostname.com/org/repo:tag-1"` annotation it will move onto the next node in the pool until no more nodes require an update. Adding the `currentImage` annotation will become the job of the MCD once https://github.com/openshift/machine-config-operator/pull/3848 lands. Until that PR lands, you will have to add the `currentImage` annotation to the node to simulate the MCD's behavior.

**- Description for the changelog**
Makes NodeController aware of BuildController
