### PR TITLE
daemon: Remove even more dead legacy OS update code

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/image/v5/types"
 	rpmostreeclient "github.com/coreos/rpmostree-client-go/pkg/client"
 	"github.com/opencontainers/go-digest"
 	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
@@ -188,98 +187,6 @@ func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
 	imgdata = &imagedataArray[0]
 	return
 
-}
-
-// Rebase potentially rebases system if not already rebased.
-func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool, err error) {
-	var (
-		ostreeCsum    string
-		ostreeVersion string
-	)
-	defaultDeployment, _, err := r.GetBootedAndStagedDeployment()
-	if err != nil {
-		return
-	}
-
-	previousPivot := ""
-	if len(defaultDeployment.CustomOrigin) > 0 {
-		if strings.HasPrefix(defaultDeployment.CustomOrigin[0], "pivot://") {
-			previousPivot = defaultDeployment.CustomOrigin[0][len("pivot://"):]
-			klog.Infof("Previous pivot: %s", previousPivot)
-		} else {
-			klog.Infof("Previous custom origin: %s", defaultDeployment.CustomOrigin[0])
-		}
-	} else {
-		klog.Info("Current origin is not custom")
-	}
-
-	var imageData *types.ImageInspectInfo
-	if imageData, _, err = imageInspect(imgURL); err != nil {
-		if err != nil {
-			var podmanImgData *imageInspection
-			klog.Infof("Falling back to using podman inspect")
-			if podmanImgData, err = podmanInspect(imgURL); err != nil {
-				return
-			}
-			ostreeCsum = podmanImgData.Labels["com.coreos.ostree-commit"]
-			ostreeVersion = podmanImgData.Labels["version"]
-		}
-	} else {
-		ostreeCsum = imageData.Labels["com.coreos.ostree-commit"]
-		ostreeVersion = imageData.Labels["version"]
-	}
-	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
-	defer exec.Command("podman", "rmi", imgURL).Run()
-
-	repo := fmt.Sprintf("%s/srv/repo", osImageContentDir)
-
-	// Now we need to figure out the commit to rebase to
-	// Commit label takes priority
-	if ostreeCsum != "" {
-		if ostreeVersion != "" {
-			klog.Infof("Pivoting to: %s (%s)", ostreeVersion, ostreeCsum)
-		} else {
-			klog.Infof("Pivoting to: %s", ostreeCsum)
-		}
-	} else {
-		klog.Infof("No com.coreos.ostree-commit label found in metadata! Inspecting...")
-		var refText []byte
-		refText, err = runGetOut("ostree", "refs", "--repo", repo)
-		if err != nil {
-			return
-		}
-		refs := strings.Split(strings.TrimSpace(string(refText)), "\n")
-		if len(refs) == 1 {
-			klog.Infof("Using ref %s", refs[0])
-			var ostreeCsumBytes []byte
-			ostreeCsumBytes, err = runGetOut("ostree", "rev-parse", "--repo", repo, refs[0])
-			if err != nil {
-				return
-			}
-			ostreeCsum = strings.TrimSpace(string(ostreeCsumBytes))
-		} else if len(refs) > 1 {
-			err = fmt.Errorf("multiple refs found in repo")
-			return
-		} else {
-			// XXX: in the future, possibly scan the repo to find a unique .commit object
-			err = fmt.Errorf("no refs found in repo")
-			return
-		}
-	}
-
-	// This will be what will be displayed in `rpm-ostree status` as the "origin spec"
-	customURL := fmt.Sprintf("pivot://%s", imgURL)
-	klog.Infof("Executing rebase from repo path %s with customImageURL %s and checksum %s", repo, customURL, ostreeCsum)
-
-	args := []string{"rebase", "--experimental", fmt.Sprintf("%s:%s", repo, ostreeCsum),
-		"--custom-origin-url", customURL, "--custom-origin-description", "Managed by machine-config-operator"}
-
-	if err = runRpmOstree(args...); err != nil {
-		return
-	}
-
-	changed = true
-	return
 }
 
 // RpmOstreeIsNewEnoughForLayering returns true if the version of rpm-ostree on the

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1688,17 +1688,6 @@ func removeNonIgnitionKeyPathFragments() error {
 	return nil
 }
 
-// updateOS updates the system OS to the one specified in newConfig
-func (dn *Daemon) updateOS(config *mcfgv1.MachineConfig, osImageContentDir string) error {
-	newURL := config.Spec.OSImageURL
-	klog.Infof("Updating OS to %s", newURL)
-	if _, err := dn.NodeUpdaterClient.Rebase(newURL, osImageContentDir); err != nil {
-		return fmt.Errorf("failed to update OS to %s : %w", newURL, err)
-	}
-
-	return nil
-}
-
 // InplaceUpdateViaNewContainer runs rpm-ostree ex deploy-via-self
 // via a privileged container.  This is needed on firstboot of old
 // nodes as well as temporarily for 4.11 -> 4.12 upgrades.


### PR DESCRIPTION
This code could have also been removed in
https://github.com/openshift/machine-config-operator/pull/3583/commits/85b297c1a063a7e130e82afb2fd2230ffd5c5fcc "daemon: Remove old legacy OS update path"

Beyond just removing dead code, a motivation is that calling `imageInspect()` which is trying to do out-of-band inspection of the booted image, which creates problems with fully-disconnected environments: https://issues.redhat.com/browse/RFE-4482
