### PR TITLE
MCO-597: Remove the MCO's dependency on journal reads

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -124,8 +124,6 @@ type Daemon struct {
 
 	currentConfigPath string
 
-	loggerSupportsJournal bool
-
 	// Config Drift Monitor
 	configDriftMonitor ConfigDriftMonitor
 
@@ -268,35 +266,21 @@ func New(
 			return nil, fmt.Errorf("failed to read boot ID: %w", err)
 		}
 	}
-
-	// RHEL 7.6/Centos 7 logger (util-linux) doesn't have the --journald flag
-	loggerSupportsJournal := true
-	if !mock {
-		if hostos.IsLikeTraditionalRHEL7() {
-			loggerOutput, err := exec.Command("logger", "--help").CombinedOutput()
-			if err != nil {
-				return nil, fmt.Errorf("running logger --help: %w", err)
-			}
-			loggerSupportsJournal = strings.Contains(string(loggerOutput), "--journald")
-		}
-	}
-
 	// report OS & version (if RHCOS or FCOS) to prometheus
 	hostOS.WithLabelValues(hostos.ToPrometheusLabel(), osVersion).Set(1)
 
 	return &Daemon{
-		mock:                  mock,
-		booting:               true,
-		rebootQueued:          false,
-		os:                    hostos,
-		NodeUpdaterClient:     nodeUpdaterClient,
-		bootedOSImageURL:      osImageURL,
-		bootedOSCommit:        osCommit,
-		bootID:                bootID,
-		exitCh:                exitCh,
-		currentConfigPath:     currentConfigPath,
-		loggerSupportsJournal: loggerSupportsJournal,
-		configDriftMonitor:    NewConfigDriftMonitor(),
+		mock:               mock,
+		booting:            true,
+		rebootQueued:       false,
+		os:                 hostos,
+		NodeUpdaterClient:  nodeUpdaterClient,
+		bootedOSImageURL:   osImageURL,
+		bootedOSCommit:     osCommit,
+		bootID:             bootID,
+		exitCh:             exitCh,
+		currentConfigPath:  currentConfigPath,
+		configDriftMonitor: NewConfigDriftMonitor(),
 	}, nil
 }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed a flag related to journal reads/writes that hasn't been used in a while. This should clean up all our journal dependencies, with the only exception being the boot listing done at daemon startup(which doesn't exit fatally, just errors and proceeds).

**- How to verify it**
Tests should pass without any complaints, since this is dead code.

**- Description for the changelog**
daemon: remove dead journal flag
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
