### PR TITLE
fix certExpiry description

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
@@ -431,7 +431,7 @@ spec:
                 description: The certificate expiry dates from the controller config
                 type: array
                 items:
-                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                  description: the certExpiry contains specific information about a certificate stored in the controllerConfig.
                   type: object
                   properties:
                     bundle:


### PR DESCRIPTION
the certExpiry description is wrong, probably from copying the formatting from elsewhere.