### PR TITLE
OCPBUGS-16888: daemon: no need to reexec when target and source rhel version is same

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -476,6 +476,7 @@ func ReexecuteForTargetRoot(target string) error {
 			// by RHEL10 the MCD will have fundamentally changed and we won't be doing the
 			// chroot() thing anymore.
 			klog.Infof("not chrooting for source=rhel-%s target=rhel-%s", sourceMajor, targetMajor)
+			return nil
 		}
 	} else {
 		klog.Info("assuming we can use container binary chroot() to host")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
