### PR TITLE
Revert " add Passwd to bootstrap served ignition"

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -370,13 +370,9 @@ func ConvertRawExtIgnitionToV3_1(inRawExtIgn *runtime.RawExtension) (runtime.Raw
 	return outRawExt, nil
 }
 
-func ConvertV3ToV2Ignition(cfg ign3types.Config) (ign2types.Config, error) {
-	return convertIgnition3to2(cfg)
-}
-
 // ConvertRawExtIgnitionToV2 ensures that the Ignition config in
 // the RawExtension is spec v2.2, or translates to it.
-func ConvertRawExtIgnitionToV2Raw(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
+func ConvertRawExtIgnitionToV2(inRawExtIgn *runtime.RawExtension) (runtime.RawExtension, error) {
 	ignCfg, rpt, err := ign3.Parse(inRawExtIgn.Raw)
 	if err != nil || rpt.IsFatal() {
 		return runtime.RawExtension{}, fmt.Errorf("parsing Ignition config spec v3.2 failed with error: %w\nReport: %v", err, rpt)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1547,10 +1547,6 @@ func (dn *Daemon) useNewSSHKeyPath() bool {
 func (dn *Daemon) updateSSHKeys(newUsers, oldUsers []ign3types.PasswdUser) error {
 	klog.Info("updating SSH keys")
 
-	for _, u := range newUsers {
-		klog.Infof("Provided User: %s with %d keys", u.Name, len(u.SSHAuthorizedKeys))
-	}
-
 	// Checking to see if absent users need to be deconfigured
 	deconfigureAbsentUsers(newUsers, oldUsers)
 

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -169,7 +169,7 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		serveConf = &converted31
 	} else {
 		// Can only be 2.2 here
-		converted2, err := ctrlcommon.ConvertRawExtIgnitionToV2Raw(conf)
+		converted2, err := ctrlcommon.ConvertRawExtIgnitionToV2(conf)
 		if err != nil {
 			w.Header().Set("Content-Length", "0")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,21 +76,15 @@ func appendEncapsulated(conf *igntypes.Config, mc *mcfgv1.MachineConfig, version
 	// requires an empty Ignition version.
 	if version == nil || version.Slice()[0] == 3 {
 		tmpIgnCfg := ctrlcommon.NewIgnConfig()
-		tmpIgnCfg.Passwd = conf.Passwd
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {
 			return fmt.Errorf("error marshalling Ignition config: %w", err)
 		}
 	} else {
-		v2, err := ctrlcommon.ConvertV3ToV2Ignition(*conf)
-		if err != nil {
-			return err
-		}
 		tmpIgnCfg := ign2types.Config{
 			Ignition: ign2types.Ignition{
 				Version: ign2types.MaxVersion.String(),
 			},
-			Passwd: v2.Passwd,
 		}
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -1,10 +1,8 @@
 package e2e_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1009,108 +1007,6 @@ func TestMCDRotatesCertsOnPausedPool(t *testing.T) {
 
 }
 
-func TestFirstBootHasSSHKeys(t *testing.T) {
-	cs := framework.NewClientSet("")
-	outNodeYoungest := bytes.NewBuffer([]byte{})
-	outErr := bytes.NewBuffer([]byte{})
-	// get nodes by newest
-	cmdCombined := "oc get nodes --sort-by .metadata.creationTimestamp | tail -n 1"
-	cmd := exec.Command("bash", "-c", cmdCombined)
-	cmd.Stdout = outNodeYoungest
-	cmd.Stderr = outErr
-	err := cmd.Run()
-	require.Nil(t, err, fmt.Sprintf("Got stdout: %s and stderr: %s", outNodeYoungest.String(), outErr))
-	// get top machineset
-	cmdCombined = "oc -n openshift-machine-api -o name get machinesets | head -n 1"
-	cmd = exec.Command("bash", "-c", cmdCombined)
-	outMSet := bytes.NewBuffer([]byte{})
-	outErr = bytes.NewBuffer([]byte{})
-	cmd.Stdout = outMSet
-	cmd.Stderr = outErr
-	err = cmd.Run()
-	require.Nil(t, err, fmt.Sprintf("Got stdout: %s and stderr: %s", outMSet.String(), outErr))
-	mset := strings.Trim(strings.Split(outMSet.String(), "/")[1], "\n")
-	// scale a 2nd machine
-	cmdCombined = "oc scale --replicas=2  machineset " + mset + " -n openshift-machine-api"
-	cmd = exec.Command("bash", "-c", cmdCombined)
-	outScale := bytes.NewBuffer([]byte{})
-	outErr = bytes.NewBuffer([]byte{})
-	cmd.Stdout = outMSet
-	cmd.Stderr = outErr
-	err = cmd.Run()
-	require.Nil(t, err, fmt.Sprintf("Got stdout: %s and stderr: %s", outScale.String(), outErr))
-	outNodeYoungestNew := &bytes.Buffer{}
-	nodeStr := strings.Split(outNodeYoungest.String(), " ")[0]
-	t.Cleanup(func() {
-		if len(outNodeYoungestNew.String()) > 0 && strings.Split(outNodeYoungestNew.String(), " ")[0] != nodeStr {
-			// scale down
-			cmdCombined = "oc scale --replicas=1  machineset " + mset + " -n openshift-machine-api"
-			cmd = exec.Command("bash", "-c", cmdCombined)
-			outScale := bytes.NewBuffer([]byte{})
-			outErr = bytes.NewBuffer([]byte{})
-			cmd.Stdout = outMSet
-			cmd.Stderr = outErr
-			err = cmd.Run()
-			splitNodes := []string{}
-			require.Nil(t, err, fmt.Sprintf("Got stdout: %s and stderr: %s", outScale.String(), outErr))
-			if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
-				outNodeYoungestNew = bytes.NewBuffer([]byte{})
-				outErr = bytes.NewBuffer([]byte{})
-				// get all nodes
-				cmdCombined = "oc get nodes"
-				cmd := exec.Command("bash", "-c", cmdCombined)
-				cmd.Stdout = outNodeYoungestNew
-				cmd.Stderr = outErr
-				err := cmd.Run()
-				require.Nil(t, err, fmt.Sprintf("Got stdout: %s and stderr: %s", outNodeYoungestNew.String(), outErr))
-				splitNodes = strings.Split(outNodeYoungestNew.String(), "\n")
-				for _, n := range splitNodes {
-					// find the one with scheduling disabled and delete it
-					if strings.Contains(n, "SchedulingDisabled") {
-						return false, nil
-					}
-				}
-				return true, nil
-			}); err != nil {
-				t.Fatalf("did not get old node upon cleanup: %s", splitNodes)
-			}
-		}
-
-	})
-	nodeSplit := []string{"", ""}
-	if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
-		outNodeYoungestNew = bytes.NewBuffer([]byte{})
-		outErr = bytes.NewBuffer([]byte{})
-		// get nodes over and over
-		cmdCombined = "oc get nodes --sort-by .metadata.creationTimestamp | tail -n 1"
-		cmd := exec.Command("bash", "-c", cmdCombined)
-		cmd.Stdout = outNodeYoungestNew
-		cmd.Stderr = outErr
-		err := cmd.Run()
-		require.Nil(t, err, fmt.Sprintf("Got stdout: %s and stderr: %s", outNodeYoungestNew.String(), outErr))
-		nodeSplit = strings.SplitN(outNodeYoungestNew.String(), " ", 2)
-		// if node name != first node name and it is ready, we have a node
-		if nodeSplit[0] != nodeStr && strings.Contains(nodeSplit[1], "Ready") && !strings.Contains(nodeSplit[1], "NotReady") {
-			return true, nil
-		}
-		return false, nil
-	}); err != nil {
-		t.Fatal("did not get new node")
-	}
-
-	nodes, err := helpers.GetNodesByRole(cs, "worker")
-	require.Nil(t, err)
-	foundNode := false
-	for _, node := range nodes {
-		if node.Name == nodeSplit[0] && strings.Contains(nodeSplit[1], "Ready") && !strings.Contains(nodeSplit[1], "NotReady") {
-			foundNode = true
-			out := helpers.ExecCmdOnNode(t, cs, node, "cat", "/rootfs/home/core/.ssh/authorized_keys.d/ignition")
-			t.Logf("Got ssh key file data: %s", out)
-			require.NotEmpty(t, out)
-		}
-	}
-	require.True(t, foundNode)
-}
 func createMCToAddFileForRole(name, role, filename, data string) *mcfgv1.MachineConfig {
 	mcadd := helpers.CreateMC(fmt.Sprintf("%s-%s", name, uuid.NewUUID()), role)
 


### PR DESCRIPTION
Reverts openshift/machine-config-operator#3811, tracked by [TRT-1168](https://issues.redhat.com//browse/TRT-1168)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get nightly payloads flowing again.

Workers are failing to provision on the nightly hypershift job (see jira above for details). The first payload hypershift broke contains this PR https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2023-07-27-223709.   After testing this revert, hypershift is installing again so this broke something related to ignition and hypershift.

See our test of this revert here, which made it past install: https://pr-payload-tests.ci.openshift.org/runs/ci/dbd6fba0-2d7f-11ee-909e-43c555f2ca09-0

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run `/payload-job periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance` on the unrevert to confirm hypershift installs.
 
cc: @cdoern, @sinnykumari 