### PR TITLE
MCO-565: MCO-568: MCO-659: MCO-660 On-cluster build opt-in function, building machine-os-builder stub, RBAC and service acct inclusions. Deletes deployment rather than scale down to 0 without label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MCO_COMPONENTS = daemon controller server operator
-EXTRA_COMPONENTS = apiserver-watcher
+EXTRA_COMPONENTS = apiserver-watcher machine-os-builder
 ALL_COMPONENTS = $(patsubst %,machine-config-%,$(MCO_COMPONENTS)) $(EXTRA_COMPONENTS)
 PREFIX ?= /usr
 GO111MODULE?=on

--- a/cmd/machine-os-builder/main.go
+++ b/cmd/machine-os-builder/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const componentName = "machine-os-builder"
+
+var (
+	rootCmd = &cobra.Command{
+		Use:   componentName,
+		Short: "Run Machine OS Builder",
+		Long:  "",
+	}
+)
+
+func init() {
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+}
+
+func main() {
+	fmt.Println("Hello, World!")
+	<-time.After(876000 * time.Hour)
+}

--- a/cmd/machine-os-builder/start.go
+++ b/cmd/machine-os-builder/start.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+var (
+	startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "Starts Machine OS Builder",
+		Long:  "",
+		Run:   runStartCmd,
+	}
+
+	startOpts struct {
+		kubeconfig string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
+}
+
+func runStartCmd(_ *cobra.Command, _ []string) {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	klog.V(2).Infof("Options parsed: %+v", startOpts)
+
+	// To help debugging, immediately log version
+	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+}

--- a/cmd/machine-os-builder/version.go
+++ b/cmd/machine-os-builder/version.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of Machine OS Builder",
+		Long:  `All software has versions. This is Machine OS Builder's.`,
+		Run:   runVersionCmd,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func runVersionCmd(_ *cobra.Command, _ []string) {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	program := "MachineConfigController"
+	version := version.Raw + "-" + version.Hash
+
+	fmt.Println(program, version)
+}

--- a/manifests/machineosbuilder/clusterrole.yaml
+++ b/manifests/machineosbuilder/clusterrole.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: machine-os-builder
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch"]
+- apiGroups: ["machineconfiguration.openshift.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["*"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["images", "clusterversions", "featuregates", "nodes", "nodes/status"]
+  verbs: ["*"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["imagecontentsourcepolicies"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["etcds"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["image.openshift.io"]
+  resources: ["images"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+- apiGroups: ["image.openshift.io"]
+  resources: ["imagestreams"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+- apiGroups: ["build.openshift.io"]
+  resources: ["builds","buildconfigs","buildconfigs/instantiate"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "create", "delete"]
+- apiGroups: ["extensions"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - "*"

--- a/manifests/machineosbuilder/clusterrolebinding-anyuid.yaml
+++ b/manifests/machineosbuilder/clusterrolebinding-anyuid.yaml
@@ -1,0 +1,16 @@
+# (zzlotnik): Grant the machine-os-builder service account the ability to start
+# pods with UID 1000 for builds. This allows us to run Buildah in an
+# unprivileged pod for better security than allowing it to run in a privileged
+# pod.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: machine-os-builder-anyuid
+roleRef:
+  name: "system:openshift:scc:anyuid"
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+subjects:
+  - name: machine-os-builder
+    kind: ServiceAccount
+    namespace: "{{.TargetNamespace}}"

--- a/manifests/machineosbuilder/clusterrolebinding-service-account.yaml
+++ b/manifests/machineosbuilder/clusterrolebinding-service-account.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: machine-os-builder
+roleRef:
+  kind: ClusterRole
+  name: machine-os-builder
+subjects:
+  - kind: ServiceAccount
+    namespace: "{{.TargetNamespace}}"
+    name: machine-os-builder

--- a/manifests/machineosbuilder/deployment.yaml
+++ b/manifests/machineosbuilder/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: machine-os-builder
+  namespace: "{{.TargetNamespace}}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: machine-os-builder
+  template:
+    metadata:
+      labels:
+        k8s-app: machine-os-builder
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    spec:
+      containers:
+      - name: machine-os-builder
+        image: "{{.Images.MachineConfigOperator}}"
+        command: ["/usr/bin/machine-os-builder"]
+        args:
+        - start
+        - -v4
+      serviceAccountName: machine-os-builder

--- a/manifests/machineosbuilder/events-clusterrole.yaml
+++ b/manifests/machineosbuilder/events-clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: machine-os-builder-events
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]

--- a/manifests/machineosbuilder/events-rolebinding-default.yaml
+++ b/manifests/machineosbuilder/events-rolebinding-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-os-builder-events
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: machine-os-builder-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-os-builder

--- a/manifests/machineosbuilder/events-rolebinding-target.yaml
+++ b/manifests/machineosbuilder/events-rolebinding-target.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-os-builder-events
+  namespace: {{.TargetNamespace}}
+roleRef:
+  kind: ClusterRole
+  name: machine-os-builder-events
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-os-builder

--- a/manifests/machineosbuilder/sa.yaml
+++ b/manifests/machineosbuilder/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{.TargetNamespace}}
+  name: machine-os-builder

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -39,6 +39,7 @@ const (
 
 	// MachineConfigPoolMaster is the MachineConfigPool name given to the master
 	MachineConfigPoolMaster = "master"
+
 	// MachineConfigPoolWorker is the MachineConfigPool name given to the worker
 	MachineConfigPoolWorker = "worker"
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -362,6 +362,7 @@ func (optr *Operator) sync(key string) error {
 		{"MachineConfigDaemon", optr.syncMachineConfigDaemon},
 		{"MachineConfigController", optr.syncMachineConfigController},
 		{"MachineConfigServer", optr.syncMachineConfigServer},
+		{"MachineOSBuilder", optr.syncMachineOSBuilder},
 		// this check must always run last since it makes sure the pools are in sync/upgrading correctly
 		{"RequiredPools", optr.syncRequiredMachineConfigPools},
 	}

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -41,7 +41,6 @@ import (
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/server"
 	"github.com/openshift/machine-config-operator/pkg/version"
-
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
 
@@ -680,6 +679,7 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig) error {
 	return optr.syncControllerConfig(config)
 }
 
+// syncs machine os builder
 func (optr *Operator) syncMachineOSBuilder(config *renderConfig) error {
 	klog.V(4).Info("Machine OS Builder sync started")
 	defer func() {
@@ -735,32 +735,67 @@ func (optr *Operator) reconcileMachineOSBuilder(mob *appsv1.Deployment) error {
 		return fmt.Errorf("could not determine if Machine OS Builder is running: %w", err)
 	}
 
-	// If the deployment does not exist and we do not have any opted-in pools, we
-	// should create the deployment with zero replicas so that it exists.
-	if apierrors.IsNotFound(err) && len(layeredMCPs) == 0 {
-		klog.Infof("Creating Machine OS Builder deployment")
-		return optr.updateMachineOSBuilderDeployment(mob, 0)
-	}
-
-	// If we have opted-in pools and the Machine OS Builder deployment is not
-	// running, scale it up.
-	if len(layeredMCPs) != 0 && !isRunning {
-		layeredMCPNames := []string{}
-		for _, mcp := range layeredMCPs {
-			layeredMCPNames = append(layeredMCPNames, mcp.Name)
+	// If we have opted-in pools and the Machine OS Builder deployment is either
+	// not running or doesn't have the correct replica count, scale it up.
+	correctReplicaCount := optr.hasCorrectReplicaCount(mob)
+	if len(layeredMCPs) != 0 && (!isRunning || !correctReplicaCount) {
+		if !correctReplicaCount {
+			klog.Infof("Adjusting Machine OS Builder pod replica count because MachineConfigPool(s) opted into layering")
+			return optr.updateMachineOSBuilderDeployment(mob, 1)
 		}
-		klog.Infof("Starting Machine OS Builder pod because MachineConfigPool(s) opted into layering: %v", layeredMCPNames)
-		return optr.updateMachineOSBuilderDeployment(mob, 1)
+		klog.Infof("Starting Machine OS Builder pod because MachineConfigPool(s) opted into layering")
+		return optr.startMachineOSBuilderDeployment(mob)
 	}
 
 	// If we do not have opted-in pools and the Machine OS Builder deployment is
 	// running, scale it down.
 	if len(layeredMCPs) == 0 && isRunning {
 		klog.Infof("Shutting down Machine OS Builder pod because no MachineConfigPool(s) opted into layering")
-		return optr.updateMachineOSBuilderDeployment(mob, 0)
+		return optr.stopMachineOSBuilderDeployment(mob.Name)
 	}
 
 	// No-op if everything is in the desired state.
+	return nil
+}
+
+// Delete the Machine OS Builder Deployment
+func (optr *Operator) stopMachineOSBuilderDeployment(name string) error {
+	return optr.kubeClient.AppsV1().Deployments(ctrlcommon.MCONamespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+// Determines if the Machine OS Builder has the correct replica count.
+func (optr *Operator) hasCorrectReplicaCount(mob *appsv1.Deployment) bool {
+	apiMob, err := optr.deployLister.Deployments(ctrlcommon.MCONamespace).Get(mob.Name)
+	if err == nil && *apiMob.Spec.Replicas == 1 {
+		return true
+	}
+	return false
+}
+
+func (optr *Operator) updateMachineOSBuilderDeployment(mob *appsv1.Deployment, replicas int32) error {
+	_, updated, err := mcoResourceApply.ApplyDeployment(optr.kubeClient.AppsV1(), mob)
+	if err != nil {
+		return fmt.Errorf("could not apply Machine OS Builder deployment: %w", err)
+	}
+
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: mob.ObjectMeta,
+		Spec: autoscalingv1.ScaleSpec{
+			Replicas: replicas,
+		},
+	}
+
+	_, err = optr.kubeClient.AppsV1().Deployments(ctrlcommon.MCONamespace).UpdateScale(context.TODO(), mob.Name, scale, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("could not scale Machine OS Builder: %w", err)
+	}
+
+	if updated {
+		if err := optr.waitForDeploymentRollout(mob); err != nil {
+			return fmt.Errorf("could not wait for Machine OS Builder deployment rollout: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -778,22 +813,11 @@ func (optr *Operator) isMachineOSBuilderRunning(mob *appsv1.Deployment) (bool, e
 }
 
 // Updates the Machine OS Builder Deployment, creating it if it does not exist.
-func (optr *Operator) updateMachineOSBuilderDeployment(mob *appsv1.Deployment, replicas int32) error {
+func (optr *Operator) startMachineOSBuilderDeployment(mob *appsv1.Deployment) error {
+	// start machine os builder deployment
 	_, updated, err := mcoResourceApply.ApplyDeployment(optr.kubeClient.AppsV1(), mob)
 	if err != nil {
 		return fmt.Errorf("could not apply Machine OS Builder deployment: %w", err)
-	}
-
-	scale := &autoscalingv1.Scale{
-		ObjectMeta: mob.ObjectMeta,
-		Spec: autoscalingv1.ScaleSpec{
-			Replicas: replicas,
-		},
-	}
-
-	_, err = optr.kubeClient.AppsV1().Deployments(ctrlcommon.MCONamespace).UpdateScale(context.TODO(), mob.Name, scale, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("could not scale Machine OS Builder: %w", err)
 	}
 
 	if updated {

--- a/test/e2e/mob_test.go
+++ b/test/e2e/mob_test.go
@@ -11,17 +11,21 @@ import (
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
 func TestMachineOSBuilder(t *testing.T) {
+	//add an assertion to see if deployment object is present or absent
+	//correlate that with pod detection
+
 	cs := framework.NewClientSet("")
 	mcpName := "test-mcp"
 	namespace := "openshift-machine-config-operator"
 	mobPodNamePrefix := "machine-os-builder"
 
 	cleanup := helpers.CreateMCP(t, cs, mcpName)
-	time.Sleep(5 * time.Second) // Wait a bit to ensure MCP is fully created
+	time.Sleep(10 * time.Second) // Wait a bit to ensure MCP is fully created
 
 	// added retry because another process was modifying the MCP concurrently
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -41,13 +45,28 @@ func TestMachineOSBuilder(t *testing.T) {
 	})
 	require.Nil(t, retryErr)
 
+	// assertion to see if the deployment object is present after setting the label
+	ctx := context.TODO()
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		exists, err := helpers.CheckDeploymentExists(cs, "machine-os-builder", namespace)
+		return exists, err
+	})
+	require.NoError(t, err, "Failed to check the existence of the Machine OS Builder deployment")
+
 	// wait for Machine OS Builder pod to start
-	err := helpers.WaitForPodStart(cs, mobPodNamePrefix, namespace)
+	err = helpers.WaitForPodStart(cs, mobPodNamePrefix, namespace)
 	require.NoError(t, err, "Failed to start the Machine OS Builder pod")
 
 	// delete the MachineConfigPool
 	cleanup()
-	time.Sleep(5 * time.Second)
+	time.Sleep(20 * time.Second)
+
+	// assertion to see if the deployment object is absent after deleting the MCP
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		exists, err := helpers.CheckDeploymentExists(cs, "machine-os-builder", namespace)
+		return !exists, err
+	})
+	require.NoError(t, err, "Failed to check the absence of the Machine OS Builder deployment")
 
 	// wait for Machine OS Builder pod to stop
 	err = helpers.WaitForPodStop(cs, mobPodNamePrefix, namespace)

--- a/test/e2e/mob_test.go
+++ b/test/e2e/mob_test.go
@@ -1,0 +1,55 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func TestMachineOSBuilder(t *testing.T) {
+	cs := framework.NewClientSet("")
+	mcpName := "test-mcp"
+	namespace := "openshift-machine-config-operator"
+	mobPodNamePrefix := "machine-os-builder"
+
+	cleanup := helpers.CreateMCP(t, cs, mcpName)
+	time.Sleep(5 * time.Second) // Wait a bit to ensure MCP is fully created
+
+	// added retry because another process was modifying the MCP concurrently
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+
+		// Get the latest MCP
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Set the label
+		mcp.ObjectMeta.Labels[ctrlcommon.LayeringEnabledPoolLabel] = ""
+
+		// Try to update the MCP
+		_, err = cs.MachineConfigPools().Update(context.TODO(), mcp, metav1.UpdateOptions{})
+		return err
+	})
+	require.Nil(t, retryErr)
+
+	// wait for Machine OS Builder pod to start
+	err := helpers.WaitForPodStart(cs, mobPodNamePrefix, namespace)
+	require.NoError(t, err, "Failed to start the Machine OS Builder pod")
+
+	// delete the MachineConfigPool
+	cleanup()
+	time.Sleep(5 * time.Second)
+
+	// wait for Machine OS Builder pod to stop
+	err = helpers.WaitForPodStop(cs, mobPodNamePrefix, namespace)
+	require.NoError(t, err, "Failed to stop the Machine OS Builder pod")
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -372,6 +372,22 @@ func WaitForPodStop(cs *framework.ClientSet, podPrefix, namespace string) error 
 	})
 }
 
+// CheckDeploymentExists checks if a deployment with the given name in the given namespace exists.
+func CheckDeploymentExists(cs *framework.ClientSet, name, namespace string) (bool, error) {
+	ctx := context.TODO()
+	_, err := cs.Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, err
+}
+
 // GetMonitoringToken retrieves the token from the openshift-monitoring secrets in the prometheus-k8s namespace.
 // It is equivalent to "oc sa get-token prometheus-k8s -n openshift-monitoring"
 func GetMonitoringToken(_ *testing.T, cs *framework.ClientSet) (string, error) {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
reverts "[MCO-565](https://issues.redhat.com//browse/MCO-565): [MCO-568](https://issues.redhat.com//browse/MCO-568): [MCO-659](https://issues.redhat.com//browse/MCO-659): [MCO-660](https://issues.redhat.com//browse/MCO-660) On-cluster build opt-in function, building machine-os-builder stub, RBAC and service acct inclusions" to delete machine-os-builder deployment when label is removed, rather than scale down to 0.

Please provide the following information:
-->

**- What I did**
changed so that machine-os-builder deployment is removed when "layering-enabled" label is removed, rather than scale the deployment down to 0.

**- How to verify it**
`~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com 
❯ oc describe mcp | grep "layering-enabled"
Labels:       machineconfiguration.openshift.io/layering-enabled=
          f:machineconfiguration.openshift.io/layering-enabled:

~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com took 5s 
❯ oc get pods
NAME                                         READY   STATUS      RESTARTS   AGE
machine-config-controller-5d695f9d96-qtzdh   2/2     Running     0          3m45s
machine-config-daemon-f2p4d                  2/2     Running     0          3m27s
machine-config-daemon-hh2vg                  2/2     Running     0          3m35s
machine-config-daemon-mt8l6                  2/2     Running     0          3m51s
machine-config-daemon-n5qht                  2/2     Running     0          3m43s
machine-config-daemon-nntrk                  2/2     Running     0          3m25s
machine-config-daemon-t6895                  2/2     Running     0          3m24s
machine-config-operator-5cb58c56bb-fhk7d     2/2     Running     0          3m45s
machine-config-server-7669w                  1/1     Running     0          3m52s
machine-config-server-tscbw                  1/1     Running     0          3m45s
machine-config-server-vzqtd                  1/1     Running     0          3m37s
machine-os-builder-67f76d7f49-cdmfz          1/1     Running     0          3m19s
mco-image-build-build                        0/1     Completed   0          11m

~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com 
❯ oc get deployment
NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
machine-config-controller   1/1     1            1           6h53m
machine-config-operator     1/1     1            1           6h58m
machine-os-builder          1/1     1            1           3m24s

~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com 
❯ oc label mcp/on-cluster-build 'machineconfiguration.openshift.io/layering-enabled-'
machineconfigpool.machineconfiguration.openshift.io/on-cluster-build unlabeled

~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com took 5s 
❯ oc get pods
NAME                                         READY   STATUS      RESTARTS   AGE
machine-config-controller-5d695f9d96-qtzdh   2/2     Running     0          4m21s
machine-config-daemon-f2p4d                  2/2     Running     0          4m3s
machine-config-daemon-hh2vg                  2/2     Running     0          4m11s
machine-config-daemon-mt8l6                  2/2     Running     0          4m27s
machine-config-daemon-n5qht                  2/2     Running     0          4m19s
machine-config-daemon-nntrk                  2/2     Running     0          4m1s
machine-config-daemon-t6895                  2/2     Running     0          4m
machine-config-operator-5cb58c56bb-fhk7d     2/2     Running     0          4m21s
machine-config-server-7669w                  1/1     Running     0          4m28s
machine-config-server-tscbw                  1/1     Running     0          4m21s
machine-config-server-vzqtd                  1/1     Running     0          4m13s
mco-image-build-build                        0/1     Completed   0          12m
^C%                                                                                                                                                       
~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com took 8s 
❯ oc get deployment
NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
machine-config-controller   1/1     1            1           6h54m
machine-config-operator     1/1     1            1           6h59m`

**- Description for the changelog**
<!--
changed so that machine-os-builder deployment is removed when "layering-enabled" label is removed, rather than scale the deployment down to 0.
-->
