### PR TITLE
OCPBUGS-13825: The machine-config-controller pod restart in SNO+1 causing daemonsets to restart

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -337,7 +337,8 @@ func (ctrl *Controller) getMastersSchedulable() (bool, error) {
 			return sched.Spec.MastersSchedulable, nil
 		}
 	}
-	return false, nil
+	// If the scheduler list is empty, or there is no match. Return an error so it is a no-op.
+	return false, fmt.Errorf("cluster scheduler couldn't be found")
 }
 
 // Determine if a given Node is a master


### PR DESCRIPTION
If the controller is killed and restarted, there is a race condition where the scheduler lists are checked before the cache sync is complete. This happens outside the work queue, within an event callback(`checkMasterNodesOnAdd`) so the wait for cache sync is skipped. By returning an error on an empty scheduler list, the controller will not take any action on the nodes by default and consequently, will (hopefully) not flip the master node between scheduleble and unschedulable when the controller is unexpectedly killed. 

How to test:
Deleting the controller pod should not unschedule the master nodes. This was observed on SNO and SNO+1 nodes according to the bug. 
