### PR TITLE
MCO-532: Finish lease type migration

### DIFF
--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -40,7 +40,7 @@ func CreateResourceLock(cb *clients.Builder, componentNamespace, componentName s
 	kubeClient := cb.KubeClientOrDie("leader-election")
 
 	lock, err := resourcelock.New(
-		resourcelock.ConfigMapsLeasesResourceLock,
+		resourcelock.LeasesResourceLock,
 		componentNamespace,
 		componentName,
 		kubeClient.CoreV1(),


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Changes the lease lock resource type from ConfigMapsLeases to LeasesResourceLock. We'll do a follow-up PR to clean up the old lease config maps in a later release.

**- How to verify it**
leader elections should work as before with no complaints, no timing weirdness etc

**- Description for the changelog**
migrate to LeasesResourceLock for leader elections
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
