### PR TITLE
OCPBUGS-17433: Sync featuregate controller during the node config controller sync

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -196,7 +196,7 @@ func generateKubeConfigIgnFromFeatures(cc *mcfgv1.ControllerConfig, templatesDir
 	if err != nil {
 		return nil, err
 	}
-	if nodeConfig != nil {
+	if nodeConfig != nil && role == ctrlcommon.MachineConfigPoolWorker {
 		updateOriginalKubeConfigwithNodeConfig(nodeConfig, originalKubeConfig)
 	}
 

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -177,6 +177,14 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		}
 	}
 
+	// syncing the featuregate controller
+	features, err := ctrl.featLister.Get(ctrlcommon.ClusterFeatureInstanceName)
+	if err == nil {
+		err := ctrl.syncFeatureHandler(features.Name)
+		if err != nil {
+			return fmt.Errorf("could not sync featuregate controller %v, err: %w", features, err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
1. Changes in the `nodes.config.openshift.io` object results in the create/update of `97-{master/worker}-generated-kubelet` machine configs
2. However, these changes are not rendered into the `master/worker` mcps if `98-{master/worker}-generated-kubelet` or `99-{master/worker}-generated-kubelet` machine configs exist due to precedence.
3. Hence, in order to bring in the change caused by nodes.config object's update, the respective sync functions of featuregate controller and the Kubelet config controller need to be called/executed in the syncNodeConfig function.
4. `syncKubeletConfig` function is already getting called and this code change introduces the calling of `syncFeatureHandler` function
5. Also added a minor fix in featuregate controller sync to apply the workerlatencyprofiles change only to the worker mcp

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: https://issues.redhat.com/browse/OCPBUGS-17433 