### PR TITLE
MCO-729: BuildController should allow cluster admins to provide a custom Dockerfile

### DIFF
--- a/pkg/controller/build/assets/Dockerfile.on-cluster-build-template
+++ b/pkg/controller/build/assets/Dockerfile.on-cluster-build-template
@@ -20,14 +20,20 @@ FROM {{.ExtensionsImage.Pullspec}} AS extensions
 {{end}}
 
 
-FROM {{.BaseImage.Pullspec}} AS final
+FROM {{.BaseImage.Pullspec}} AS configs
 # Copy the extracted MachineConfig into the expected place in the image.
 COPY --from=extract /etc/machine-config-daemon/currentconfig /etc/machine-config-daemon/currentconfig
 # Do the ignition live-apply, extracting the Ignition config from the MachineConfig.
-RUN exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported <(cat /etc/machine-config-daemon/currentconfig | jq '.spec.config') && \
+# Not sure why Ignition explicitly requires the container env var to be set
+# since it should be set by the container runtime / builder.
+RUN container="oci" exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported <(cat /etc/machine-config-daemon/currentconfig | jq '.spec.config') && \
 	ostree container commit
 
 LABEL machineconfig={{.Pool.Spec.Configuration.Name}}
 LABEL machineconfigpool={{.Pool.Name}}
 LABEL releaseversion={{.ReleaseVersion}}
 LABEL baseOSContainerImage={{.BaseImage.Pullspec}}
+
+{{if .CustomDockerfile}}
+{{.CustomDockerfile}}
+{{end}}

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -51,6 +51,11 @@ const (
 	desiredConfigLabel = "machineconfiguration.openshift.io/desiredConfig"
 )
 
+// on-cluster-build-custom-dockerfile ConfigMap name.
+const (
+	customDockerfileConfigMapName = "on-cluster-build-custom-dockerfile"
+)
+
 // on-cluster-build-config ConfigMap keys.
 const (
 	// Name of ConfigMap which contains knobs for configuring the build controller.
@@ -598,7 +603,7 @@ func (ctrl *Controller) postBuildCleanup(pool *mcfgv1.MachineConfigPool, ignoreM
 		return err
 	}
 
-	// Delete the ConfigMap containing the Dockerfile.
+	// Delete the ConfigMap containing the rendered Dockerfile.
 	deleteDockerfileConfigMap := func() error {
 		ibr := newImageBuildRequest(pool)
 
@@ -768,57 +773,90 @@ func (ctrl *Controller) addMachineConfigPool(obj interface{}) {
 	ctrl.enqueueMachineConfigPool(pool)
 }
 
-// Prepares all of the objects needed to perform an image build.
-func (ctrl *Controller) prepareMachineConfigForPool(ibr ImageBuildRequest) error {
-	mc, err := ctrl.mcfgclient.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), ibr.Pool.Spec.Configuration.Name, metav1.GetOptions{})
+func (ctrl *Controller) getBuildInputs(pool *mcfgv1.MachineConfigPool) (*buildInputs, error) {
+	osImageURL, err := ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), machineConfigOSImageURLConfigMapName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("could not get MachineConfig %s: %w", ibr.Pool.Spec.Configuration.Name, err)
+		return nil, fmt.Errorf("could not get OS image URL: %w", err)
 	}
 
-	mcConfigMap, err := ibr.toConfigMap(mc)
+	onClusterBuildConfig, err := ctrl.getOnClusterBuildConfig(pool)
 	if err != nil {
-		return fmt.Errorf("could not convert MachineConfig %s into ConfigMap: %w", mc.Name, err)
+		return nil, fmt.Errorf("could not get configmap %q: %w", onClusterBuildConfigMapName, err)
+	}
+
+	customDockerfiles, err := ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), customDockerfileConfigMapName, metav1.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve %s ConfigMap: %w", customDockerfileConfigMapName, err)
+	}
+
+	mc, err := ctrl.mcfgclient.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), pool.Spec.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get MachineConfig %s: %w", pool.Spec.Configuration.Name, err)
+	}
+
+	inputs := &buildInputs{
+		onClusterBuildConfig: onClusterBuildConfig,
+		osImageURL:           osImageURL,
+		customDockerfiles:    customDockerfiles,
+		pool:                 pool,
+		machineConfig:        mc,
+	}
+
+	return inputs, nil
+}
+
+// Prepares all of the objects needed to perform an image build.
+func (ctrl *Controller) prepareForBuild(inputs *buildInputs) (ImageBuildRequest, error) {
+	ibr := newImageBuildRequestFromBuildInputs(inputs)
+
+	mcConfigMap, err := ibr.toConfigMap(inputs.machineConfig)
+	if err != nil {
+		return ImageBuildRequest{}, fmt.Errorf("could not convert MachineConfig %s into ConfigMap: %w", inputs.machineConfig.Name, err)
 	}
 
 	_, err = ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Create(context.TODO(), mcConfigMap, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("could not load rendered MachineConfig %s into configmap: %w", mcConfigMap.Name, err)
+		return ImageBuildRequest{}, fmt.Errorf("could not load rendered MachineConfig %s into configmap: %w", mcConfigMap.Name, err)
 	}
 
-	klog.Infof("Stored MachineConfig %s in ConfigMap %s for build", mc.Name, mcConfigMap.Name)
+	klog.Infof("Stored MachineConfig %s in ConfigMap %s for build", inputs.machineConfig.Name, mcConfigMap.Name)
 
 	dockerfileConfigMap, err := ibr.dockerfileToConfigMap()
 	if err != nil {
-		return fmt.Errorf("could not generate Dockerfile ConfigMap: %w", err)
+		return ImageBuildRequest{}, fmt.Errorf("could not generate Dockerfile ConfigMap: %w", err)
 	}
 
 	_, err = ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Create(context.TODO(), dockerfileConfigMap, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("could not load rendered Dockerfile %s into configmap: %w", dockerfileConfigMap.Name, err)
+		return ImageBuildRequest{}, fmt.Errorf("could not load rendered Dockerfile %s into configmap: %w", dockerfileConfigMap.Name, err)
 	}
 
 	klog.Infof("Stored Dockerfile for build %s in ConfigMap %s for build", ibr.getBuildName(), dockerfileConfigMap.Name)
 
-	return nil
+	return ibr, nil
 }
 
 // Determines if we should run a build, then starts a build pod to perform the
 // build, and updates the MachineConfigPool with an object reference for the
 // build pod.
 func (ctrl *Controller) startBuildForMachineConfigPool(pool *mcfgv1.MachineConfigPool) error {
-	osImageURLConfigMap, err := ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), machineConfigOSImageURLConfigMapName, metav1.GetOptions{})
+	inputs, err := ctrl.getBuildInputs(pool)
 	if err != nil {
-		return fmt.Errorf("could not get OS image URL: %w", err)
+		return fmt.Errorf("could not fetch build inputs: %w", err)
 	}
 
-	onClusterBuildConfigMap, err := ctrl.getOnClusterBuildConfig(pool)
+	ibr, err := ctrl.prepareForBuild(inputs)
 	if err != nil {
-		return fmt.Errorf("could not get configmap %q: %w", onClusterBuildConfigMapName, err)
+		return fmt.Errorf("could not start build for MachineConfigPool %s: %w", pool.Name, err)
 	}
 
-	ibr := newImageBuildRequestWithConfigMap(pool, osImageURLConfigMap, onClusterBuildConfigMap)
+	objRef, err := ctrl.imageBuilder.StartBuild(ibr)
 
-	return ctrl.handleImageBuildRequest(ibr)
+	if err != nil {
+		return err
+	}
+
+	return ctrl.markBuildPendingWithObjectRef(ibr.Pool, *objRef)
 }
 
 // Gets the ConfigMap which specifies the name of the base image pull secret, final image pull secret, and final image pullspec.
@@ -863,7 +901,7 @@ func (ctrl *Controller) getOnClusterBuildConfig(pool *mcfgv1.MachineConfigPool) 
 			// perform a build.
 			named, err := reference.ParseNamed(val)
 			if err != nil {
-				return nil, fmt.Errorf("could not parse %s with %q: %w", finalImagePullspecConfigKey, val, err)
+				return nil, fmt.Errorf("could not parse %s with %q: %w", key, val, err)
 			}
 
 			tagged, err := reference.WithTag(named, pool.Spec.Configuration.Name)
@@ -958,22 +996,6 @@ func (ctrl *Controller) handleCanonicalizedPullSecret(secret *corev1.Secret) (*c
 	klog.Infof("Updated canonical secret %s", secret.Name)
 
 	return out, nil
-}
-
-// Starts a build for a given Image Build Request.
-func (ctrl *Controller) handleImageBuildRequest(ibr ImageBuildRequest) error {
-	err := ctrl.prepareMachineConfigForPool(ibr)
-	if err != nil {
-		return fmt.Errorf("could not start build for MachineConfigPool %s: %w", ibr.Pool.Name, err)
-	}
-
-	objRef, err := ctrl.imageBuilder.StartBuild(ibr)
-
-	if err != nil {
-		return err
-	}
-
-	return ctrl.markBuildPendingWithObjectRef(ibr.Pool, *objRef)
 }
 
 // If one wants to opt out, this removes all of the statuses and object

--- a/pkg/controller/build/fixtures_test.go
+++ b/pkg/controller/build/fixtures_test.go
@@ -23,6 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+func getCustomDockerfileConfigMap(poolToDockerfile map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      customDockerfileConfigMapName,
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		Data: poolToDockerfile,
+	}
+}
+
 // Gets an example machine-config-osimageurl ConfigMap.
 func getOSImageURLConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{

--- a/pkg/controller/build/helpers_test.go
+++ b/pkg/controller/build/helpers_test.go
@@ -8,6 +8,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestValidateImagePullspecHasDigest(t *testing.T) {
+	cm := getOSImageURLConfigMap()
+
+	validPullspecs := []string{
+		cm.Data[baseOSContainerImageConfigKey],
+		cm.Data[baseOSExtensionsContainerImageConfigKey],
+		cm.Data[osImageURLConfigKey],
+	}
+
+	for _, pullspec := range validPullspecs {
+		assert.NoError(t, validateImageHasDigestedPullspec(pullspec))
+	}
+
+	invalidPullspecs := []string{
+		expectedImagePullspecWithTag,
+	}
+
+	for _, pullspec := range invalidPullspecs {
+		assert.Error(t, validateImageHasDigestedPullspec(pullspec))
+	}
+}
+
 // Tests that a given image pullspec with a tag and SHA is correctly substituted.
 func TestParseImagePullspec(t *testing.T) {
 	t.Parallel()

--- a/pkg/controller/build/pod_build_controller.go
+++ b/pkg/controller/build/pod_build_controller.go
@@ -194,7 +194,9 @@ func (ctrl *PodBuildController) FinalPullspec(pool *mcfgv1.MachineConfigPool) (s
 		return "", err
 	}
 
-	finalImageInfo := newFinalImageInfo(onClusterBuildConfigMap)
+	finalImageInfo := newFinalImageInfo(&buildInputs{
+		onClusterBuildConfig: onClusterBuildConfigMap,
+	})
 	ibr := newImageBuildRequest(pool)
 
 	digestConfigMap, err := ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), ibr.getDigestConfigMapName(), metav1.GetOptions{})


### PR DESCRIPTION
**- What I did**

BuildController now allows a cluster admin to provide an optional ConfigMap containing a custom Dockerfile. This Dockerfile is provided on a per-pool basis, meaning that different pools can have different Dockerfiles, if desired. A admin-supplied Dockerfile will be injected into the Dockerfile that we render prior to beginning a build. The custom Dockerfile is located in a ConfigMap with 1:1 mapping of pool -> Dockerfile content. In other words, it will look like this:
```yaml
---
apiVersion: v1
data:
  layering: |-
    FROM configs AS final
    echo 'custom file' > /etc/custom-file
  master: ""
  worker: ""
kind: ConfigMap
metadata:
  name: on-cluster-build-custom-dockerfile
  namespace: openshift-machine-config-operator
``` 

This ConfigMap is optional as are the individual Dockerfiles contained therein. If they are absent, no content will be injected into the Dockerfile generated by BuildController.

**- How to verify it**

Test cases have been added to the provided unit test suite to validate that this is possible. A more complete way of testing this once https://github.com/openshift/machine-config-operator/pull/3861 lands is to create a ConfigMap containing a custom Dockerfile like this:




**- Description for the changelog**
BuildController should allow cluster admins to provide a custom Dockerfile