### PR TITLE
MCO-564: Make MCD aware of on-cluster builds

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -28,10 +28,18 @@ func (dn *Daemon) loadNodeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 	}
 	if os.IsNotExist(err) {
 		// try currentConfig if, for whatever reason we lost annotations? this is super best effort.
-		currentOnDisk, err := dn.getCurrentConfigOnDisk()
+		odc, err := dn.getCurrentConfigOnDisk()
 		if err == nil {
-			klog.Infof("Setting initial node config based on current configuration on disk: %s", currentOnDisk.GetName())
-			return dn.nodeWriter.SetAnnotations(map[string]string{constants.CurrentMachineConfigAnnotationKey: currentOnDisk.GetName()})
+			klog.Infof("Setting initial node config based on current configuration on disk: %s", odc.currentConfig.GetName())
+			annos := map[string]string{
+				constants.CurrentMachineConfigAnnotationKey: odc.currentConfig.GetName(),
+			}
+
+			if odc.currentImage != "" {
+				annos[constants.CurrentImageAnnotationKey] = odc.currentImage
+			}
+
+			return dn.nodeWriter.SetAnnotations(annos)
 		}
 		return nil, err
 	}

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -217,7 +217,7 @@ func rpmOstreeVersion() (*VersionData, error) {
 	return &q.Root, nil
 }
 
-func RpmOstreeIsNewEnoughForLayering() (bool, error) {
+func (r *RpmOstreeClient) IsNewEnoughForLayering() (bool, error) {
 	verdata, err := rpmOstreeVersion()
 	if err != nil {
 		return false, err

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -809,6 +810,10 @@ func TestRunGetOut(t *testing.T) {
 // TestOriginalFileBackupRestore tests backikg up and restoring original files (files that are present in the base image and
 // get overwritten by a machine configuration)
 func TestOriginalFileBackupRestore(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("Non-Linux OS %q detected, skipping test", runtime.GOOS)
+	}
+
 	testDir, cleanup := setupTempDirWithEtc(t)
 	defer cleanup()
 

--- a/test/e2e-shared-tests/mcd_config_drift.go
+++ b/test/e2e-shared-tests/mcd_config_drift.go
@@ -264,7 +264,7 @@ func (c configDriftTest) Run(t *testing.T) {
 				mutateFileOnNode(t, c.ClientSet, c.node, configDriftFilename, "not-the-data")
 				assertNodeAndMCPIsDegraded(t, c.ClientSet, c.node, c.mcp, configDriftFilename)
 
-				expectedReason := "content mismatch for file \"/etc/etc-file\""
+				expectedReason := fmt.Sprintf("content mismatch for file %q", configDriftFilename)
 
 				mutateFileOnNode(t, c.ClientSet, c.node, configDriftFilename, configDriftFileContents)
 				assertNodeAndMCPIsRecovered(t, c.ClientSet, c.node, c.mcp)
@@ -277,7 +277,7 @@ func (c configDriftTest) Run(t *testing.T) {
 				node, err := c.ClientSet.CoreV1Interface.Nodes().Get(ctx, c.node.Name, metav1.GetOptions{})
 				require.Nil(t, err)
 
-				assert.Equal(t, node.Annotations[constants.MachineConfigDaemonReasonAnnotationKey], expectedReason)
+				assert.Contains(t, node.Annotations[constants.MachineConfigDaemonReasonAnnotationKey], expectedReason)
 
 				assertPoolReachesState(t, c.ClientSet, c.mcp, isPoolDegraded)
 
@@ -372,7 +372,7 @@ func mutateFileOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, f
 func assertNodeAndMCPIsDegraded(t *testing.T, cs *framework.ClientSet, node corev1.Node, mcp mcfgv1.MachineConfigPool, filename string) {
 	t.Helper()
 
-	logEntry := fmt.Sprintf("content mismatch for file \"%s\"", filename)
+	logEntry := fmt.Sprintf("content mismatch for file %q", filename)
 
 	// Assert that the node eventually reaches a Degraded state and has the
 	// config mismatch as the reason


### PR DESCRIPTION
**- What I did**

The MCD needs to be aware of the new layered image annotations so that it can apply layered OS updates as well as traditional MachineConfig updates.

**- How to verify it**

**- Description for the changelog**
