### PR TITLE
[DO NOT MERGE] adds an onclustertesting binary to help with setup / teardown

### DIFF
--- a/cmd/onclustertesting/clearstatus.go
+++ b/cmd/onclustertesting/clearstatus.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+var (
+	clearStatusCmd = &cobra.Command{
+		Use:   "clear-build-status",
+		Short: "Tears down the pool for on-cluster build testing",
+		Long:  "",
+		Run:   runClearStatusCmd,
+	}
+
+	clearStatusOpts struct {
+		poolName string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(clearStatusCmd)
+	clearStatusCmd.PersistentFlags().StringVar(&clearStatusOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to clear build status on")
+}
+
+func runClearStatusCmd(_ *cobra.Command, _ []string) {
+	common(clearStatusOpts)
+
+	if clearStatusOpts.poolName == "" {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	failOnError(clearBuildStatusesOnPool(framework.NewClientSet(""), clearStatusOpts.poolName))
+}

--- a/cmd/onclustertesting/configmaps.go
+++ b/cmd/onclustertesting/configmaps.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/build"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+)
+
+func createConfigMap(cs *framework.ClientSet, cm *corev1.ConfigMap) error {
+	_, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+	if err == nil {
+		klog.Infof("Created ConfigMap %q in namespace %q", cm.Name, ctrlcommon.MCONamespace)
+		return nil
+	}
+
+	if err != nil && !apierrs.IsAlreadyExists(err) {
+		return err
+	}
+
+	configmap, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), cm.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if !hasOurLabel(configmap.Labels) {
+		klog.Infof("Found preexisting user-supplied ConfigMap %q, using as-is.", cm.Name)
+		return nil
+	}
+
+	// Delete and recreate.
+	klog.Infof("ConfigMap %q was created by us, but could be out of date. Recreating...", cm.Name)
+	err = cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return createConfigMap(cs, cm)
+}
+
+type onClusterBuildConfigMapOpts struct {
+	pushSecretName     string
+	pullSecretName     string
+	pushSecretPath     string
+	pullSecretPath     string
+	finalImagePullspec string
+}
+
+func (o *onClusterBuildConfigMapOpts) shouldCloneGlobalPullSecret() bool {
+	return isNoneSet(o.pullSecretName, o.pullSecretPath)
+}
+
+func (o *onClusterBuildConfigMapOpts) toConfigMap() (*corev1.ConfigMap, error) {
+	pushSecretName, err := o.getPushSecretName()
+	if err != nil {
+		return nil, err
+	}
+
+	pullSecretName, err := o.getPullSecretName()
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      build.OnClusterBuildConfigMapName,
+			Namespace: ctrlcommon.MCONamespace,
+			Labels: map[string]string{
+				createdByOnClusterBuildsHelper: "",
+			},
+		},
+		Data: map[string]string{
+			build.BaseImagePullSecretNameConfigKey:  pullSecretName,
+			build.FinalImagePushSecretNameConfigKey: pushSecretName,
+			build.FinalImagePullspecConfigKey:       o.finalImagePullspec,
+		},
+	}
+
+	return cm, nil
+}
+
+func (o *onClusterBuildConfigMapOpts) getPullSecretName() (string, error) {
+	if o.shouldCloneGlobalPullSecret() {
+		return globalPullSecretCloneName, nil
+	}
+
+	if o.pullSecretName != "" {
+		return o.pullSecretName, nil
+	}
+
+	return getSecretNameFromFile(o.pullSecretPath)
+}
+
+func (o *onClusterBuildConfigMapOpts) getPushSecretName() (string, error) {
+	if o.pushSecretName != "" {
+		return o.pushSecretName, nil
+	}
+
+	return getSecretNameFromFile(o.pushSecretPath)
+}
+
+func (o *onClusterBuildConfigMapOpts) getSecretNameParams() []string {
+	secretNames := []string{}
+
+	if o.pullSecretName != "" {
+		secretNames = append(secretNames, o.pullSecretName)
+	}
+
+	if o.pushSecretName != "" {
+		secretNames = append(secretNames, o.pushSecretName)
+	}
+
+	return secretNames
+}
+
+func createOnClusterBuildConfigMap(cs *framework.ClientSet, opts onClusterBuildConfigMapOpts) error {
+	cm, err := opts.toConfigMap()
+	if err != nil {
+		return err
+	}
+
+	return createConfigMap(cs, cm)
+}
+
+func createCustomDockerfileConfigMap(cs *framework.ClientSet) error {
+	pools, err := cs.MachineconfigurationV1Interface.MachineConfigPools().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "on-cluster-build-custom-dockerfile",
+			Namespace: ctrlcommon.MCONamespace,
+			Labels: map[string]string{
+				createdByOnClusterBuildsHelper: "",
+			},
+		},
+		Data: map[string]string{},
+	}
+
+	for _, pool := range pools.Items {
+		cm.Data[pool.Name] = ""
+	}
+
+	return createConfigMap(cs, cm)
+}
+
+func cleanupConfigMaps(cs *framework.ClientSet) error {
+	configMaps, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).List(context.TODO(), getListOptsForOurLabel())
+
+	if err != nil {
+		return err
+	}
+
+	for _, configMap := range configMaps.Items {
+		if err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		klog.Infof("Deleted ConfigMap %q from namespace %q", configMap.Name, ctrlcommon.MCONamespace)
+	}
+
+	return nil
+}
+
+func forceCleanupConfigMaps(cs *framework.ClientSet) error {
+	configMaps, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).List(context.TODO(), metav1.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	toDelete := sets.NewString("on-cluster-build-config", "on-cluster-build-custom-dockerfile")
+
+	for _, configMap := range configMaps.Items {
+		if toDelete.Has(configMap.Name) {
+			if err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+
+			klog.Infof("Deleted ConfigMap %q from namespace %q", configMap.Name, ctrlcommon.MCONamespace)
+		}
+	}
+
+	return nil
+}

--- a/cmd/onclustertesting/extract.go
+++ b/cmd/onclustertesting/extract.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+var (
+	extractCmd = &cobra.Command{
+		Use:   "extract",
+		Short: "Extracts the Dockerfile and MachineConfig from an on-cluster build",
+		Long:  "",
+		Run:   runExtractCmd,
+	}
+
+	extractOpts struct {
+		poolName      string
+		machineConfig string
+		targetDir     string
+		noConfigMaps  bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(extractCmd)
+	extractCmd.PersistentFlags().StringVar(&extractOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to extract")
+	extractCmd.PersistentFlags().StringVar(&extractOpts.machineConfig, "machineconfig", "", "MachineConfig name to extract")
+	extractCmd.PersistentFlags().StringVar(&extractOpts.targetDir, "dir", "", "Dir to store extract build objects")
+}
+
+func runExtractCmd(_ *cobra.Command, _ []string) {
+	common(extractOpts)
+
+	if extractOpts.poolName == "" && extractOpts.machineConfig == "" {
+		klog.Fatalln("No pool name or MachineConfig name provided!")
+	}
+
+	if extractOpts.poolName != "" && extractOpts.machineConfig != "" {
+		klog.Fatalln("Either pool name or MachineConfig must be provided. Not both!")
+	}
+
+	targetDir := getDir(extractOpts.targetDir)
+
+	cs := framework.NewClientSet("")
+
+	if extractOpts.machineConfig != "" {
+		failOnError(extractBuildObjectsForRenderedMC(cs, extractOpts.machineConfig, targetDir))
+		return
+	}
+
+	if extractOpts.poolName != "" {
+		failOnError(extractBuildObjectsForTargetPool(cs, extractOpts.poolName, targetDir))
+		return
+	}
+}

--- a/cmd/onclustertesting/helpers.go
+++ b/cmd/onclustertesting/helpers.go
@@ -1,0 +1,733 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/pkg/version"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/build"
+)
+
+const (
+	createdByOnClusterBuildsHelper string = "machineconfiguration.openshift.io/createdByOnClusterBuildsHelper"
+	globalPullSecretCloneName      string = "global-pull-secret-copy"
+)
+
+func hasOurLabel(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+
+	_, ok := labels[createdByOnClusterBuildsHelper]
+	return ok
+}
+
+// Compresses and base-64 encodes a given byte array. Ideal for loading an
+// arbitrary byte array into a ConfigMap or Secret.
+func compressAndEncode(payload []byte) (*bytes.Buffer, error) {
+	out := bytes.NewBuffer(nil)
+
+	if len(payload) == 0 {
+		return out, nil
+	}
+
+	// We need to base64-encode our gzipped data so we can marshal it in and out
+	// of a string since ConfigMaps and Secrets expect a textual representation.
+	base64Enc := base64.NewEncoder(base64.StdEncoding, out)
+	defer base64Enc.Close()
+
+	err := compress(bytes.NewBuffer(payload), base64Enc)
+	if err != nil {
+		return nil, fmt.Errorf("could not compress and encode payload: %w", err)
+	}
+
+	err = base64Enc.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not close base64 encoder: %w", err)
+	}
+
+	return out, err
+}
+
+// Compresses a given io.Reader to a given io.Writer
+func compress(r io.Reader, w io.Writer) error {
+	gz, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("could not initialize gzip writer: %w", err)
+	}
+
+	defer gz.Close()
+
+	if _, err := io.Copy(gz, r); err != nil {
+		return fmt.Errorf("could not compress payload: %w", err)
+	}
+
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("could not close gzipwriter: %w", err)
+	}
+
+	return nil
+}
+
+func storeMachineConfigOnDisk(cs *framework.ClientSet, pool *mcfgv1.MachineConfigPool, dir string) error {
+	mc, err := cs.MachineConfigs().Get(context.TODO(), pool.Spec.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	out, err := json.Marshal(mc)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Mkdir(filepath.Join(dir, "machineconfig"), 0o755); err != nil {
+		return err
+	}
+
+	compressed, err := compressAndEncode(out)
+	if err != nil {
+		return err
+	}
+
+	mcPath := filepath.Join(dir, "machineconfig", "machineconfig.json.gz")
+
+	if err := os.WriteFile(mcPath, compressed.Bytes(), 0o755); err != nil {
+		return err
+	}
+
+	klog.Infof("Stored MachineConfig %s on disk at %s", mc.Name, mcPath)
+	return nil
+}
+
+// TODO: Dedupe this with the code from the buildcontroller package.
+func getImageBuildRequest(cs *framework.ClientSet, targetPool string) (*build.ImageBuildRequest, error) {
+	osImageURLConfigMap, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), "machine-config-osimageurl", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	customDockerfile, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), "on-cluster-build-custom-dockerfile", metav1.GetOptions{})
+	if err != nil && !apierrs.IsNotFound(err) {
+		return nil, err
+	}
+
+	var customDockerfileContents string
+	if customDockerfile != nil {
+		customDockerfileContents = customDockerfile.Data[targetPool]
+	}
+
+	mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	buildReq := build.ImageBuildRequest{
+		Pool: mcp,
+		BaseImage: build.ImageInfo{
+			Pullspec: osImageURLConfigMap.Data["baseOSContainerImage"],
+		},
+		ExtensionsImage: build.ImageInfo{
+			Pullspec: osImageURLConfigMap.Data["baseOSExtensionsContainerImage"],
+		},
+		ReleaseVersion:   osImageURLConfigMap.Data["releaseVersion"],
+		CustomDockerfile: customDockerfileContents,
+	}
+
+	return &buildReq, nil
+}
+
+func renderDockerfile(ibr *build.ImageBuildRequest, out io.Writer, copyToStdout bool) error {
+	// TODO: Export the template from the assets package.
+	dockerfileTemplate, err := os.ReadFile("/Users/zzlotnik/go/src/github.com/openshift/machine-config-operator/pkg/controller/build/assets/Dockerfile.on-cluster-build-template")
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("dockerfile").Parse(string(dockerfileTemplate))
+	if err != nil {
+		return err
+	}
+
+	if copyToStdout {
+		out = io.MultiWriter(out, os.Stdout)
+	}
+
+	return tmpl.Execute(out, ibr)
+}
+
+func renderDockerfileToDisk(cs *framework.ClientSet, targetPool, dir string) error {
+	ibr, err := getImageBuildRequest(cs, targetPool)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	dockerfilePath := filepath.Join(dir, "Dockerfile")
+
+	dockerfile, err := os.Create(dockerfilePath)
+	defer func() {
+		failOnError(dockerfile.Close())
+	}()
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Rendered Dockerfile to disk at %s", dockerfilePath)
+	return renderDockerfile(ibr, dockerfile, false)
+}
+
+func createPool(cs *framework.ClientSet, poolName string) (*mcfgv1.MachineConfigPool, error) {
+	pool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: poolName,
+			Labels: map[string]string{
+				createdByOnClusterBuildsHelper: "",
+			},
+		},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      mcfgv1.MachineConfigRoleLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"worker", poolName},
+					},
+				},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-role.kubernetes.io/" + poolName: "",
+				},
+			},
+		},
+	}
+
+	klog.Infof("Creating MachineConfigPool %q", pool.Name)
+
+	_, err := cs.MachineConfigPools().Create(context.TODO(), pool, metav1.CreateOptions{})
+	switch {
+	case apierrs.IsAlreadyExists(err):
+		klog.Infof("Pool %q already exists, will reuse", poolName)
+	case err != nil && !apierrs.IsAlreadyExists(err):
+		return nil, err
+	}
+
+	klog.Infof("Waiting for pool %s to get a rendered MachineConfig", poolName)
+
+	if _, err := waitForRenderedConfigs(cs, poolName, "99-worker-ssh"); err != nil {
+		return nil, err
+	}
+
+	return cs.MachineConfigPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+}
+
+func optInPool(cs *framework.ClientSet, targetPool string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if mcp.Labels == nil {
+			mcp.Labels = map[string]string{}
+		}
+
+		mcp.Labels[ctrlcommon.LayeringEnabledPoolLabel] = ""
+
+		klog.Infof("Opted MachineConfigPool %q into layering", mcp.Name)
+		_, err = cs.MachineConfigPools().Update(context.TODO(), mcp, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func addImageToLayeredPool(cs *framework.ClientSet, pullspec, targetPool string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if mcp.Labels == nil {
+			if err := optInPool(cs, targetPool); err != nil {
+				return err
+			}
+		}
+
+		if mcp.Annotations == nil {
+			mcp.Annotations = map[string]string{}
+		}
+
+		mcp.Annotations[ctrlcommon.ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey] = pullspec
+		mcp, err = cs.MachineConfigPools().Update(context.TODO(), mcp, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		klog.Infof("Applied image %q to MachineConfigPool %s", pullspec, mcp.Name)
+		return clearThenSetStatusOnPool(cs, targetPool, mcfgv1.MachineConfigPoolBuildSuccess, corev1.ConditionTrue)
+	})
+}
+
+func teardownPool(cs *framework.ClientSet, mcp *mcfgv1.MachineConfigPool) error {
+	err := cs.MachineConfigPools().Delete(context.TODO(), mcp.Name, metav1.DeleteOptions{})
+	if apierrs.IsNotFound(err) {
+		klog.Infof("Pool %s not found", mcp.Name)
+		return nil
+	}
+
+	if err != nil && !apierrs.IsNotFound(err) {
+		return err
+	}
+
+	klog.Infof("Deleted pool %s", mcp.Name)
+	return nil
+}
+
+func deleteAllNonStandardPools(cs *framework.ClientSet) error {
+	pools, err := cs.MachineConfigPools().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, pool := range pools.Items {
+		if pool.Name != "master" && pool.Name != "worker" {
+			if err := teardownPool(cs, &pool); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func resetAllNodeAnnotations(cs *framework.ClientSet) error {
+	workerPool, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	nodes, err := cs.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes.Items {
+		if err := resetNodeAnnotationsAndLabels(cs, workerPool, &node); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resetNodeAnnotationsAndLabels(cs *framework.ClientSet, originalPool *mcfgv1.MachineConfigPool, node *corev1.Node) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		expectedNodeRoles := map[string]struct{}{
+			"node-role.kubernetes.io/worker":        {},
+			"node-role.kubernetes.io/master":        {},
+			"node-role.kubernetes.io/control-plane": {},
+		}
+
+		for label := range node.Labels {
+			_, isExpectedNodeRole := expectedNodeRoles[label]
+			if strings.HasPrefix(label, "node-role.kubernetes.io") && !isExpectedNodeRole {
+				delete(node.Labels, label)
+			}
+		}
+
+		if _, ok := node.Labels[helpers.MCPNameToRole(originalPool.Name)]; ok {
+			node.Annotations[constants.CurrentMachineConfigAnnotationKey] = originalPool.Spec.Configuration.Name
+			node.Annotations[constants.DesiredMachineConfigAnnotationKey] = originalPool.Spec.Configuration.Name
+			delete(node.Annotations, constants.CurrentImageAnnotationKey)
+			delete(node.Annotations, constants.DesiredImageAnnotationKey)
+		}
+
+		_, err = cs.CoreV1Interface.Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func deleteAllMachineConfigsForPool(cs *framework.ClientSet, mcp *mcfgv1.MachineConfigPool) error {
+	machineConfigs, err := cs.MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, mc := range machineConfigs.Items {
+		if _, ok := mc.Annotations[helpers.MCPNameToRole(mcp.Name)]; ok && !strings.HasPrefix(mc.Name, "rendered-") {
+			if err := cs.MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func deleteBuildObjects(cs *framework.ClientSet, mcp *mcfgv1.MachineConfigPool) error {
+	selector, err := getSelectorForMCP(mcp)
+	if err != nil {
+		return err
+	}
+
+	return deleteBuildObjectsForSelector(cs, selector)
+}
+
+func getSelectorForMCP(mcp *mcfgv1.MachineConfigPool) (labels.Selector, error) {
+	key := "machineconfiguration.openshift.io/desiredConfig"
+	selector := labels.NewSelector()
+	if mcp == nil {
+		req, err := labels.NewRequirement(key, selection.Exists, []string{})
+		if err != nil {
+			return labels.NewSelector(), err
+		}
+
+		return selector.Add(*req), nil
+	}
+
+	req, err := labels.NewRequirement(key, selection.Equals, []string{mcp.Spec.Configuration.Name})
+	if err != nil {
+		return labels.NewSelector(), err
+	}
+
+	return selector.Add(*req), nil
+}
+
+func deleteBuildObjectsForSelector(cs *framework.ClientSet, selector labels.Selector) error {
+	listOpts := metav1.ListOptions{
+		LabelSelector: selector.String(),
+	}
+
+	configMaps, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).List(context.TODO(), listOpts)
+
+	if err != nil {
+		return err
+	}
+
+	for _, configMap := range configMaps.Items {
+		if err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		klog.Infof("Deleted ConfigMap %s", configMap.Name)
+	}
+
+	pods, err := cs.CoreV1Interface.Pods(ctrlcommon.MCONamespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		if err := cs.CoreV1Interface.Pods(ctrlcommon.MCONamespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		klog.Infof("Deleted Pod %s", pod.Name)
+	}
+
+	builds, err := cs.BuildV1Interface.Builds(ctrlcommon.MCONamespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, build := range builds.Items {
+		if err := cs.BuildV1Interface.Builds(ctrlcommon.MCONamespace).Delete(context.TODO(), build.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		klog.Infof("Deleted Build %s", build.Name)
+	}
+
+	klog.Infof("Cleaned up all build objects for selector %s", selector.String())
+
+	return nil
+}
+
+func waitForRenderedConfigs(cs *framework.ClientSet, pool string, mcNames ...string) (string, error) {
+	var renderedConfig string
+	startTime := time.Now()
+	found := make(map[string]bool)
+
+	ctx := context.Background()
+
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		// Set up the list
+		for _, name := range mcNames {
+			found[name] = false
+		}
+
+		// Update found based on the MCP
+		mcp, err := cs.MachineConfigPools().Get(ctx, pool, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, mc := range mcp.Spec.Configuration.Source {
+			if _, ok := found[mc.Name]; ok {
+				found[mc.Name] = true
+			}
+		}
+
+		// If any are still false, then they weren't included in the MCP
+		for _, nameFound := range found {
+			if !nameFound {
+				return false, nil
+			}
+		}
+
+		// All the required names were found
+		renderedConfig = mcp.Spec.Configuration.Name
+		return true, nil
+	}); err != nil {
+		return "", fmt.Errorf("machine configs %v hasn't been picked by pool %s (waited %s): %w", notFoundNames(found), pool, time.Since(startTime), err)
+	}
+	klog.Infof("Pool %s has rendered configs %v with %s (waited %v)", pool, mcNames, renderedConfig, time.Since(startTime))
+	return renderedConfig, nil
+}
+
+func notFoundNames(foundNames map[string]bool) []string {
+	out := []string{}
+	for name, found := range foundNames {
+		if !found {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func clearBuildStatusesOnPool(cs *framework.ClientSet, targetPool string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		buildConditions := map[mcfgv1.MachineConfigPoolConditionType]struct{}{
+			mcfgv1.MachineConfigPoolBuildSuccess: {},
+			mcfgv1.MachineConfigPoolBuildFailed:  {},
+			mcfgv1.MachineConfigPoolBuildPending: {},
+			mcfgv1.MachineConfigPoolBuilding:     {},
+		}
+
+		filtered := []mcfgv1.MachineConfigPoolCondition{}
+		for _, cond := range mcp.Status.Conditions {
+			if _, ok := buildConditions[cond.Type]; !ok {
+				filtered = append(filtered, cond)
+			}
+		}
+
+		mcp.Status.Conditions = filtered
+		_, err = cs.MachineConfigPools().UpdateStatus(context.TODO(), mcp, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		klog.Infof("Cleared build statuses on MachineConfigPool %s", targetPool)
+		return nil
+	})
+}
+
+func setStatusOnPool(cs *framework.ClientSet, targetPool string, condType mcfgv1.MachineConfigPoolConditionType, status corev1.ConditionStatus) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		newCond := mcfgv1.NewMachineConfigPoolCondition(condType, status, "", "")
+		mcfgv1.SetMachineConfigPoolCondition(&mcp.Status, *newCond)
+
+		_, err = cs.MachineConfigPools().UpdateStatus(context.TODO(), mcp, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		klog.Infof("Set %s / %s on %s", condType, status, targetPool)
+
+		return nil
+	})
+}
+
+func clearThenSetStatusOnPool(cs *framework.ClientSet, targetPool string, condType mcfgv1.MachineConfigPoolConditionType, status corev1.ConditionStatus) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := clearBuildStatusesOnPool(cs, targetPool); err != nil {
+			return err
+		}
+
+		return setStatusOnPool(cs, targetPool, condType, status)
+	})
+}
+
+func extractBuildObjectsForTargetPool(cs *framework.ClientSet, targetPool, targetDir string) error {
+	mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	return extractBuildObjects(cs, mcp, targetDir)
+}
+
+func extractBuildObjects(cs *framework.ClientSet, mcp *mcfgv1.MachineConfigPool, targetDir string) error {
+	return extractBuildObjectsForRenderedMC(cs, mcp.Spec.Configuration.Name, targetDir)
+}
+
+func extractBuildObjectsForRenderedMC(cs *framework.ClientSet, mcName, targetDir string) error {
+	ctx := context.Background()
+
+	dockerfileCM, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, "dockerfile-"+mcName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	mcCM, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, "mc-"+mcName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Extracted Dockerfile from %q", dockerfileCM.Name)
+	klog.Infof("Extracted MachineConfig %s from %q", mcName, mcCM.Name)
+
+	return storeBuildObjectsOnDisk(dockerfileCM.Data["Dockerfile"], mcCM.Data["machineconfig.json.gz"], filepath.Join(targetDir, "build-objects-"+mcName))
+}
+
+func storeBuildObjectsOnDisk(dockerfile, machineConfig, targetDir string) error {
+	mcDirName := filepath.Join(targetDir, "machineconfig")
+	dockerfileName := filepath.Join(targetDir, "Dockerfile")
+	mcFilename := filepath.Join(targetDir, "machineconfig.json.gz")
+
+	if err := os.MkdirAll(mcDirName, 0o755); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(dockerfileName, []byte(dockerfile), 0o755); err != nil {
+		return err
+	}
+
+	klog.Infof("Wrote Dockerfile to %s", dockerfileName)
+
+	if err := os.WriteFile(mcFilename, []byte(machineConfig), 0o755); err != nil {
+		return err
+	}
+
+	klog.Infof("Wrote MachineConfig to %s", mcFilename)
+
+	return nil
+}
+
+func getDir(target string) string {
+	if target != "" {
+		return target
+	}
+
+	cwd, err := os.Getwd()
+	failOnError(err)
+	return cwd
+}
+
+func failOnError(err error) {
+	if err != nil {
+		klog.Fatalln(err)
+	}
+}
+
+func common(opts interface{}) {
+	flag.Set("v", "4")
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	klog.Infof("Options parsed: %+v", opts)
+
+	// To help debugging, immediately log version
+	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+}
+
+func failIfNotSet(in, name string) {
+	if isEmpty(in) {
+		if !strings.HasPrefix(name, "--") {
+			name = "--" + name
+		}
+		klog.Fatalf("Required flag %s not set", name)
+	}
+}
+
+func isNoneSet(in1, in2 string) bool {
+	return isEmpty(in1) && isEmpty(in2)
+}
+
+func isOnlyOneSet(in1, in2 string) bool {
+	if !isEmpty(in1) && !isEmpty(in2) {
+		return false
+	}
+
+	return true
+}
+
+func isEmpty(in string) bool {
+	return in == ""
+}
+
+func dumpYAMLToStdout(in interface{}) error {
+	out, err := yaml.Marshal(in)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stdout.Write(out)
+	return err
+}
+
+func getListOptsForOurLabel() metav1.ListOptions {
+	req, err := labels.NewRequirement(createdByOnClusterBuildsHelper, selection.Exists, []string{})
+	if err != nil {
+		klog.Fatalln(err)
+	}
+
+	return metav1.ListOptions{
+		LabelSelector: req.String(),
+	}
+}
+
+func ignoreIsNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if apierrs.IsNotFound(err) {
+		return nil
+	}
+
+	return err
+}

--- a/cmd/onclustertesting/imagestream.go
+++ b/cmd/onclustertesting/imagestream.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+	imagev1 "github.com/openshift/api/image/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	imagestreamName     string = "os-image"
+	imagestreamPullspec string = "image-registry.openshift-image-registry.svc:5000/" + ctrlcommon.MCONamespace + "/" + imagestreamName + ":latest"
+)
+
+func getImagestreamPullspec(cs *framework.ClientSet, name string) (string, error) {
+	is, err := cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return appendTagToPullspec(is.Status.DockerImageRepository, "latest")
+}
+
+// Not sure if htis is strictly required, but we'll do it anyway.
+func appendTagToPullspec(pullspec, tag string) (string, error) {
+	named, err := reference.ParseNamed(pullspec)
+	if err != nil {
+		return "", fmt.Errorf("could not parse %s: %w", pullspec, err)
+	}
+
+	tagged, err := reference.WithTag(named, tag)
+	if err != nil {
+		return "", fmt.Errorf("could not add tag %s to image pullspec %s: %w", tag, pullspec, err)
+	}
+
+	return tagged.String(), nil
+}
+
+func createImagestream(cs *framework.ClientSet, name string) error {
+	is := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ctrlcommon.MCONamespace,
+			Labels: map[string]string{
+				createdByOnClusterBuildsHelper: "",
+			},
+		},
+	}
+
+	_, err := cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).Create(context.TODO(), is, metav1.CreateOptions{})
+	if err == nil {
+		klog.Infof("Imagestream %q created", name)
+		return nil
+	}
+
+	if apierrs.IsAlreadyExists(err) {
+		klog.Infof("Imagestream %q already exists, will re-use", name)
+		return nil
+	}
+
+	return err
+}
+
+func cleanupImagestreams(cs *framework.ClientSet) error {
+	isList, err := cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).List(context.TODO(), getListOptsForOurLabel())
+	if err != nil {
+		return err
+	}
+
+	for _, is := range isList.Items {
+		if err := deleteImagestream(cs, is.Name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteImagestream(cs *framework.ClientSet, name string) error {
+	err := cs.ImageV1Interface.ImageStreams(ctrlcommon.MCONamespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err == nil {
+		klog.Infof("Imagestream %q deleted", name)
+	}
+
+	if err != nil && apierrs.IsNotFound(err) {
+		klog.Infof("Imagestream %q not found", name)
+		return nil
+	}
+
+	return err
+}

--- a/cmd/onclustertesting/machineconfig.go
+++ b/cmd/onclustertesting/machineconfig.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
+)
+
+var (
+	machineConfigCmd = &cobra.Command{
+		Use:   "machineconfig",
+		Short: "Creates a MachineConfig in a layered MachineConfigPool to cause a build",
+		Long:  "",
+		Run:   runMachineConfigCmd,
+	}
+
+	machineConfigOpts struct {
+		poolName      string
+		machineConfig string
+		sshMC         bool
+		dryRun        bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(machineConfigCmd)
+	machineConfigCmd.PersistentFlags().StringVar(&machineConfigOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to target")
+	machineConfigCmd.PersistentFlags().StringVar(&machineConfigOpts.machineConfig, "machineconfig", "", "MachineConfig name to create")
+	machineConfigCmd.PersistentFlags().BoolVar(&machineConfigOpts.sshMC, "ssh-config", false, "Creates a MachineConfig that adds an SSH key to avoid reboots")
+	machineConfigCmd.PersistentFlags().BoolVar(&machineConfigOpts.dryRun, "dry-run", false, "Dump the MachineConfig to stdout instead of applying it")
+}
+
+func runMachineConfigCmd(_ *cobra.Command, _ []string) {
+	common(machineConfigOpts)
+
+	if extractOpts.poolName == "" {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	cs := framework.NewClientSet("")
+
+	failOnError(createMachineConfig(cs, machineConfigOpts.poolName, machineConfigOpts.machineConfig))
+}
+
+func createMachineConfig(cs *framework.ClientSet, targetPool, name string) error {
+	mc := getMachineConfig(machineConfigOpts.machineConfig, machineConfigOpts.poolName, machineConfigOpts.sshMC)
+	mc.Labels = map[string]string{
+		createdByOnClusterBuildsHelper: "",
+	}
+
+	if machineConfigOpts.dryRun {
+		return dumpYAMLToStdout(mc)
+	}
+
+	_, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, err = cs.MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Created MachineConfig %q targeting pool %q", name, targetPool)
+
+	renderedConfig, err := waitForRenderedConfigs(cs, targetPool, name)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("MachineConfigPool %s got rendered config %q", targetPool, renderedConfig)
+
+	return nil
+}
+
+func getMachineConfig(name, targetPool string, sshMC bool) *mcfgv1.MachineConfig {
+	if name == "" {
+		name = fmt.Sprintf("%s-%s", targetPool, uuid.NewUUID())
+	}
+
+	if !sshMC {
+		return helpers.NewMachineConfig(name, helpers.MCLabelForRole(targetPool), "", []ign3types.File{
+			helpers.CreateEncodedIgn3File(filepath.Join("/etc", name), name, 420),
+		})
+	}
+
+	return getSSHMachineConfig(name, targetPool, string(uuid.NewUUID()))
+}
+
+func getSSHMachineConfig(mcName, mcpName, sshKeyContent string) *mcfgv1.MachineConfig {
+	// Adding authorized key for user core
+	testIgnConfig := ctrlcommon.NewIgnConfig()
+
+	testIgnConfig.Passwd.Users = []ign3types.PasswdUser{
+		{
+			Name:              "core",
+			SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{ign3types.SSHAuthorizedKey(sshKeyContent)},
+		},
+	}
+
+	return &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   mcName,
+			Labels: helpers.MCLabelForRole(mcpName),
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: helpers.MarshalOrDie(testIgnConfig),
+			},
+		},
+	}
+}

--- a/cmd/onclustertesting/main.go
+++ b/cmd/onclustertesting/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/component-base/cli"
+)
+
+const (
+	defaultLayeredPoolName string = "layered"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:   "onclustertesting",
+		Short: "Help with testing on-cluster builds",
+		Long:  "",
+	}
+)
+
+func init() {
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+}
+
+func main() {
+	os.Exit(cli.Run(rootCmd))
+}

--- a/cmd/onclustertesting/optin.go
+++ b/cmd/onclustertesting/optin.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+var (
+	optInCmd = &cobra.Command{
+		Use:   "optin",
+		Short: "Opts a node into on-cluster builds",
+		Long:  "",
+		Run:   runOptInCmd,
+	}
+
+	optInOpts struct {
+		poolName string
+		nodeName string
+		force    bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(optInCmd)
+	optInCmd.PersistentFlags().StringVar(&optInOpts.poolName, "pool", defaultLayeredPoolName, "Pool name")
+	optInCmd.PersistentFlags().StringVar(&optInOpts.nodeName, "node", "", "MachineConfig name")
+}
+
+func runOptInCmd(_ *cobra.Command, _ []string) {
+	common(optInOpts)
+
+	if isEmpty(optInOpts.poolName) {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	if isEmpty(optInOpts.nodeName) {
+		klog.Fatalln("No node name provided!")
+	}
+
+	failOnError(optInNode(framework.NewClientSet(""), optInOpts.nodeName, optInOpts.poolName))
+}
+
+func optInNode(cs *framework.ClientSet, nodeName, targetPool string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		klog.Infof("Found pool %q", targetPool)
+
+		if _, ok := mcp.Labels[ctrlcommon.LayeringEnabledPoolLabel]; !ok {
+			return fmt.Errorf("Pool %q is not opted into layering", mcp.Name)
+		}
+
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		klog.Infof("Found node %q", nodeName)
+
+		invalidNodeRoles := []string{
+			helpers.MCPNameToRole("master"),
+			helpers.MCPNameToRole("control-plane"),
+		}
+
+		for _, invalidNodeRole := range invalidNodeRoles {
+			if _, ok := node.Labels[invalidNodeRole]; ok {
+				return fmt.Errorf("cannot opt node with role %q into layering", invalidNodeRole)
+			}
+		}
+
+		if _, ok := node.Labels[helpers.MCPNameToRole(targetPool)]; ok {
+			return fmt.Errorf("node %q already has label %s", node.Name, helpers.MCPNameToRole(targetPool))
+		}
+
+		node.Labels[helpers.MCPNameToRole(targetPool)] = ""
+
+		_, err = cs.CoreV1Interface.Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		if err == nil {
+			klog.Infof("Node %q opted into layering via pool %q", node.Name, mcp.Name)
+		}
+		return err
+	})
+}

--- a/cmd/onclustertesting/optout.go
+++ b/cmd/onclustertesting/optout.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+var (
+	optOutCmd = &cobra.Command{
+		Use:   "optout",
+		Short: "Opts a node out of on-cluster builds",
+		Long:  "",
+		Run:   runOptOutCmd,
+	}
+
+	optOutOpts struct {
+		poolName string
+		nodeName string
+		force    bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(optOutCmd)
+	optOutCmd.PersistentFlags().StringVar(&optOutOpts.poolName, "pool", defaultLayeredPoolName, "Pool name")
+	optOutCmd.PersistentFlags().StringVar(&optOutOpts.nodeName, "node", "", "MachineConfig name")
+	optOutCmd.PersistentFlags().BoolVar(&optOutOpts.force, "force", false, "Forcefully opt node out")
+}
+
+func runOptOutCmd(_ *cobra.Command, _ []string) {
+	common(optOutOpts)
+
+	if !optOutOpts.force && isEmpty(optOutOpts.poolName) {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	if isEmpty(optOutOpts.nodeName) {
+		klog.Fatalln("No node name provided!")
+	}
+
+	failOnError(optOutNode(framework.NewClientSet(""), optOutOpts.nodeName, optOutOpts.poolName, optOutOpts.force))
+}
+
+func optOutNode(cs *framework.ClientSet, nodeName, poolName string, force bool) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if force {
+			klog.Infof("Forcefully opting node %q out of layering", node.Name)
+			return resetNodeAnnotationsAndLabels(cs, workerMCP, node)
+		}
+
+		role := helpers.MCPNameToRole(poolName)
+
+		if _, ok := node.Labels[role]; !ok {
+			return fmt.Errorf("node %q does not have a label matching %q", node.Name, role)
+		}
+
+		delete(node.Labels, role)
+
+		_, err = cs.CoreV1Interface.Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		if err == nil {
+			klog.Infof("Opted node %q out of on-cluster builds", node.Name)
+		}
+
+		return err
+	})
+}

--- a/cmd/onclustertesting/render.go
+++ b/cmd/onclustertesting/render.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	renderCmd = &cobra.Command{
+		Use:   "render",
+		Short: "Renders the on-cluster build Dockerfile to disk",
+		Long:  "",
+		Run:   runRenderCmd,
+	}
+
+	renderOpts struct {
+		poolName             string
+		includeMachineConfig bool
+		targetDir            string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(renderCmd)
+	renderCmd.PersistentFlags().StringVar(&renderOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to render")
+	renderCmd.PersistentFlags().StringVar(&renderOpts.targetDir, "dir", "", "Dir to store rendered Dockerfile and MachineConfig in")
+}
+
+func runRenderCmd(_ *cobra.Command, _ []string) {
+	common(renderOpts)
+
+	if renderOpts.poolName == "" {
+		failOnError(fmt.Errorf("no pool name provided"))
+	}
+
+	cs := framework.NewClientSet("")
+
+	dir := filepath.Join(getDir(renderOpts.targetDir), renderOpts.poolName)
+
+	failOnError(renderDockerfileToDisk(cs, renderOpts.poolName, dir))
+	mcp, err := cs.MachineConfigPools().Get(context.TODO(), renderOpts.poolName, metav1.GetOptions{})
+	failOnError(err)
+	failOnError(storeMachineConfigOnDisk(cs, mcp, dir))
+}

--- a/cmd/onclustertesting/secrets.go
+++ b/cmd/onclustertesting/secrets.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+)
+
+func createBaseImagePullSecret(cs *framework.ClientSet, path string) error {
+	if path == "" {
+		klog.Infof("No pull secret path provided, will clone global pull secret")
+		return copyGlobalPullSecret(cs)
+	}
+
+	return createSecretFromFile(cs, path)
+}
+
+// Copies the global pull secret from openshift-config/pull-secret into the MCO
+// namespace so that it can be used by the custom build pod.
+func copyGlobalPullSecret(cs *framework.ClientSet) error {
+	globalPullSecret, err := cs.CoreV1Interface.Secrets("openshift-config").Get(context.TODO(), "pull-secret", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	secretCopy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      globalPullSecretCloneName,
+			Namespace: ctrlcommon.MCONamespace,
+			Labels: map[string]string{
+				createdByOnClusterBuildsHelper: "",
+			},
+		},
+		Data: globalPullSecret.Data,
+		Type: globalPullSecret.Type,
+	}
+
+	err = createSecret(cs, secretCopy)
+	if err == nil {
+		klog.Infof("Cloned global pull secret %q into namespace %q as %q", "pull-secret", ctrlcommon.MCONamespace, secretCopy.Name)
+	}
+
+	return nil
+}
+
+func createSecret(cs *framework.ClientSet, s *corev1.Secret) error {
+	_, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Create(context.TODO(), s, metav1.CreateOptions{})
+	if err == nil {
+		klog.Infof("Created secret %q in namespace %q", s.Name, ctrlcommon.MCONamespace)
+		return nil
+	}
+
+	if err != nil && !apierrs.IsAlreadyExists(err) {
+		return err
+	}
+
+	secret, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), s.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if !hasOurLabel(secret.Labels) {
+		klog.Infof("Found preexisting user-supplied secret %q, using as-is.", s.Name)
+		return nil
+	}
+
+	// Delete and recreate.
+	klog.Infof("Secret %q was created by us, but could be out of date. Recreating...", s.Name)
+	err = cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Delete(context.TODO(), s.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return createSecret(cs, s)
+}
+
+func getSecretNameFromFile(path string) (string, error) {
+	secret, err := loadSecretFromFile(path)
+
+	if err != nil {
+		return "", err
+	}
+
+	return secret.Name, nil
+}
+
+func loadSecretFromFile(pushSecretPath string) (*corev1.Secret, error) {
+	pushSecretBytes, err := os.ReadFile(pushSecretPath)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := &corev1.Secret{}
+	if err := yaml.Unmarshal(pushSecretBytes, &secret); err != nil {
+		return nil, err
+	}
+
+	secret.Labels = map[string]string{
+		createdByOnClusterBuildsHelper: "",
+	}
+
+	secret.Namespace = ctrlcommon.MCONamespace
+
+	return secret, nil
+}
+
+func createSecretFromFile(cs *framework.ClientSet, path string) error {
+	secret, err := loadSecretFromFile(path)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Loaded secret %q from %s", secret.Name, path)
+
+	return createSecret(cs, secret)
+}
+
+func cleanupSecrets(cs *framework.ClientSet) error {
+	secrets, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).List(context.TODO(), getListOptsForOurLabel())
+
+	if err != nil {
+		return err
+	}
+
+	for _, secret := range secrets.Items {
+		if err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		klog.Infof("Deleted secret %q from namespace %q", secret.Name, ctrlcommon.MCONamespace)
+	}
+
+	return nil
+}
+
+func forceCleanupSecrets(cs *framework.ClientSet) error {
+	secrets, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).List(context.TODO(), metav1.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	toDelete := sets.NewString("global-pull-secret-copy")
+
+	for _, secret := range secrets.Items {
+		if strings.HasSuffix(secret.Name, "-canonical") {
+			toDelete.Insert(secret.Name)
+		}
+	}
+
+	for _, secret := range secrets.Items {
+		if toDelete.Has(secret.Name) {
+			if err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+			klog.Infof("Deleted secret %q from namespace %q", secret.Name, ctrlcommon.MCONamespace)
+		}
+	}
+
+	return nil
+
+}
+
+func getBuilderPushSecretName(cs *framework.ClientSet) (string, error) {
+	secrets, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, secret := range secrets.Items {
+		if strings.HasPrefix(secret.Name, "builder-dockercfg") {
+			klog.Infof("Will use builder secret %q in namespace %q", secret.Name, ctrlcommon.MCONamespace)
+			return secret.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find matching secret name in namespace %s", ctrlcommon.MCONamespace)
+}
+
+// TODO: Dedupe these funcs from BuildController helpers.
+func validateSecret(cs *framework.ClientSet, secretName string) error {
+	// Here we just validate the presence of the secret, and not its content
+	secret, err := cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil && apierrs.IsNotFound(err) {
+		return fmt.Errorf("secret %q not found in namespace %q. Did you use the right secret name?", secretName, ctrlcommon.MCONamespace)
+	}
+
+	if err != nil {
+		return fmt.Errorf("could not get secret %s: %w", secretName, err)
+	}
+
+	if _, err := getPullSecretKey(secret); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Looks up a given secret key for a given secret type and validates that the
+// key is present and the secret is a non-zero length. Returns an error if it
+// is the incorrect secret type, missing the appropriate key, or the secret is
+// a zero-length.
+func getPullSecretKey(secret *corev1.Secret) (string, error) {
+	if secret.Type != corev1.SecretTypeDockerConfigJson && secret.Type != corev1.SecretTypeDockercfg {
+		return "", fmt.Errorf("unknown secret type %s", secret.Type)
+	}
+
+	secretTypes := map[corev1.SecretType]string{
+		corev1.SecretTypeDockercfg:        corev1.DockerConfigKey,
+		corev1.SecretTypeDockerConfigJson: corev1.DockerConfigJsonKey,
+	}
+
+	key := secretTypes[secret.Type]
+
+	val, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("missing %q in %s", key, secret.Name)
+	}
+
+	if len(val) == 0 {
+		return "", fmt.Errorf("empty value %q in %s", key, secret.Name)
+	}
+
+	return key, nil
+}
+
+func validateSecretsExist(cs *framework.ClientSet, names []string) error {
+	for _, name := range names {
+		if err := validateSecret(cs, name); err != nil {
+			return err
+		}
+		klog.Infof("Secret %q exists in namespace %q", name, ctrlcommon.MCONamespace)
+	}
+
+	return nil
+}

--- a/cmd/onclustertesting/setimage.go
+++ b/cmd/onclustertesting/setimage.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+var (
+	setImageCmd = &cobra.Command{
+		Use:   "set-image",
+		Short: "Sets an image pullspec on a MachineConfigPool",
+		Long:  "",
+		Run:   runSetImageCmd,
+	}
+
+	setImageOpts struct {
+		poolName  string
+		imageName string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(setImageCmd)
+	setImageCmd.PersistentFlags().StringVar(&setImageOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to set build status on")
+	setImageCmd.PersistentFlags().StringVar(&setImageOpts.imageName, "image", "", "The image pullspec to set")
+}
+
+func runSetImageCmd(_ *cobra.Command, _ []string) {
+	common(setImageOpts)
+
+	if setImageOpts.poolName == "" {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	if setImageOpts.imageName == "" {
+		klog.Fatalln("No image name provided!")
+	}
+
+	cs := framework.NewClientSet("")
+	failOnError(setImageOnPool(cs, setImageOpts.poolName, setImageOpts.imageName))
+}
+
+func setImageOnPool(cs *framework.ClientSet, targetPool, pullspec string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := optInPool(cs, targetPool); err != nil {
+			return err
+		}
+
+		return addImageToLayeredPool(cs, pullspec, targetPool)
+	})
+}

--- a/cmd/onclustertesting/setstatus.go
+++ b/cmd/onclustertesting/setstatus.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+var (
+	setStatusCmd = &cobra.Command{
+		Use:   "set-build-status",
+		Short: "Sets the build status on a given MachineConfigPool",
+		Long:  "",
+		Run:   runSetStatusCmd,
+	}
+
+	setStatusOpts struct {
+		poolName string
+		condType string
+		status   bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(setStatusCmd)
+	setStatusCmd.PersistentFlags().StringVar(&setStatusOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to set build status on")
+	setStatusCmd.PersistentFlags().StringVar(&setStatusOpts.condType, "type", "", "The condition type to set")
+	setStatusCmd.PersistentFlags().BoolVar(&setStatusOpts.status, "status", false, "Condition true or false")
+}
+
+func runSetStatusCmd(_ *cobra.Command, _ []string) {
+	common(setStatusOpts)
+
+	if setStatusOpts.poolName == "" {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	validCondTypes := []mcfgv1.MachineConfigPoolConditionType{
+		mcfgv1.MachineConfigPoolUpdated,
+		mcfgv1.MachineConfigPoolUpdating,
+		mcfgv1.MachineConfigPoolNodeDegraded,
+		mcfgv1.MachineConfigPoolRenderDegraded,
+		mcfgv1.MachineConfigPoolDegraded,
+		mcfgv1.MachineConfigPoolBuildPending,
+		mcfgv1.MachineConfigPoolBuilding,
+		mcfgv1.MachineConfigPoolBuildSuccess,
+		mcfgv1.MachineConfigPoolBuildFailed,
+	}
+
+	var condTypeToSet mcfgv1.MachineConfigPoolConditionType
+	for _, condType := range validCondTypes {
+		if string(condType) == setStatusOpts.condType {
+			condTypeToSet = mcfgv1.MachineConfigPoolConditionType(setStatusOpts.condType)
+			break
+		}
+	}
+
+	if condTypeToSet == "" {
+		klog.Fatalf("unknown condition type %q, valid options: %v", setStatusOpts.condType, validCondTypes)
+	}
+
+	status := map[bool]corev1.ConditionStatus{
+		true:  corev1.ConditionTrue,
+		false: corev1.ConditionFalse,
+	}
+
+	if err := setStatusOnPool(framework.NewClientSet(""), setStatusOpts.poolName, condTypeToSet, status[setStatusOpts.status]); err != nil {
+		klog.Fatal(err)
+	}
+}

--- a/cmd/onclustertesting/setup.go
+++ b/cmd/onclustertesting/setup.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+var (
+	setupCmd = &cobra.Command{
+		Use:   "setup",
+		Short: "Sets up pool for on-cluster build testing",
+		Long:  "",
+		Run:   runSetupCmd,
+	}
+
+	inClusterRegistryCmd = &cobra.Command{
+		Use:   "in-cluster-registry",
+		Short: "Sets up pool for on-cluster build testing using an ImageStream",
+		Long:  "",
+		Run:   runInClusterRegistrySetupCmd,
+	}
+
+	setupOpts struct {
+		pullSecretPath     string
+		pushSecretPath     string
+		pullSecretName     string
+		pushSecretName     string
+		finalImagePullspec string
+		poolName           string
+		waitForBuildInfo   bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+	setupCmd.AddCommand(inClusterRegistryCmd)
+	setupCmd.PersistentFlags().StringVar(&setupOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to setup")
+	setupCmd.PersistentFlags().BoolVar(&setupOpts.waitForBuildInfo, "wait-for-build", false, "Wait for build info")
+	setupCmd.PersistentFlags().StringVar(&setupOpts.pullSecretName, "pull-secret-name", "", "The name of a preexisting secret to use as the pull secret. If absent, will clone global pull secret.")
+	setupCmd.PersistentFlags().StringVar(&setupOpts.pushSecretName, "push-secret-name", "", "The name of a preexisting secret to use as the push secret.")
+	setupCmd.PersistentFlags().StringVar(&setupOpts.pullSecretPath, "pull-secret-path", "", "Path to a pull secret YAML to use. If absent, will clone global pull secret.")
+	setupCmd.PersistentFlags().StringVar(&setupOpts.pushSecretPath, "push-secret-path", "", "Path to a pull secret YAML to use.")
+	setupCmd.PersistentFlags().StringVar(&setupOpts.finalImagePullspec, "final-pullspec", "", "The final image pushspec to use for testing")
+}
+
+func runSetupCmd(_ *cobra.Command, _ []string) {
+	common(setupOpts)
+
+	failIfNotSet(setupOpts.poolName, "pool")
+	failIfNotSet(setupOpts.finalImagePullspec, "final-pullspec")
+
+	if isNoneSet(setupOpts.pushSecretPath, setupOpts.pushSecretName) {
+		klog.Fatalln("Either --push-secret-name or --push-secret-path must be provided!")
+	}
+
+	if !isOnlyOneSet(setupOpts.pushSecretPath, setupOpts.pushSecretName) {
+		klog.Fatalln("--pull-secret-name and --pull-secret-path cannot be combined!")
+	}
+
+	if !isOnlyOneSet(setupOpts.pullSecretPath, setupOpts.pullSecretName) {
+		klog.Fatalln("--push-secret-name and --push-secret-path cannot be combined!")
+	}
+
+	if err := mobSetup(framework.NewClientSet(""), setupOpts.poolName, setupOpts.waitForBuildInfo); err != nil {
+		klog.Fatal(err)
+	}
+}
+
+func runInClusterRegistrySetupCmd(_ *cobra.Command, _ []string) {
+	common(setupOpts)
+
+	failIfNotSet(setupOpts.poolName, "pool")
+
+	cs := framework.NewClientSet("")
+
+	failOnError(inClusterMobSetup(cs, setupOpts.poolName, setupOpts.waitForBuildInfo))
+}
+
+func inClusterMobSetup(cs *framework.ClientSet, targetPool string, getBuildInfo bool) error {
+	pushSecretName, err := getBuilderPushSecretName(cs)
+	if err != nil {
+		return err
+	}
+
+	imagestreamName := "os-image"
+	if err := createImagestream(cs, imagestreamName); err != nil {
+		return err
+	}
+
+	pullspec, err := getImagestreamPullspec(cs, imagestreamName)
+	if err != nil {
+		return err
+	}
+
+	if _, err := createPool(cs, targetPool); err != nil {
+		return err
+	}
+
+	opts := onClusterBuildConfigMapOpts{
+		pushSecretName:     pushSecretName,
+		finalImagePullspec: pullspec,
+	}
+
+	if err := createConfigMapsAndSecrets(cs, opts); err != nil {
+		return err
+	}
+
+	if err := optInPool(cs, targetPool); err != nil {
+		return err
+	}
+
+	if !getBuildInfo {
+		return nil
+	}
+
+	return waitForBuildInfo(cs, targetPool)
+}
+
+func mobSetup(cs *framework.ClientSet, targetPool string, getBuildInfo bool) error {
+	if _, err := createPool(cs, targetPool); err != nil {
+		return err
+	}
+
+	opts := onClusterBuildConfigMapOpts{
+		pushSecretName:     setupOpts.pushSecretName,
+		pullSecretName:     setupOpts.pullSecretName,
+		pushSecretPath:     setupOpts.pushSecretPath,
+		pullSecretPath:     setupOpts.pullSecretPath,
+		finalImagePullspec: setupOpts.finalImagePullspec,
+	}
+
+	if err := createConfigMapsAndSecrets(cs, opts); err != nil {
+		return err
+	}
+
+	if err := optInPool(cs, targetPool); err != nil {
+		return err
+	}
+
+	if !getBuildInfo {
+		return nil
+	}
+
+	return waitForBuildInfo(cs, targetPool)
+}
+
+func createConfigMapsAndSecrets(cs *framework.ClientSet, opts onClusterBuildConfigMapOpts) error {
+	if opts.shouldCloneGlobalPullSecret() {
+		if err := copyGlobalPullSecret(cs); err != nil {
+			return nil
+		}
+	}
+
+	if opts.pushSecretPath != "" {
+		if err := createSecretFromFile(cs, opts.pushSecretPath); err != nil {
+			return err
+		}
+	}
+
+	if opts.pullSecretPath != "" {
+		if err := createSecretFromFile(cs, opts.pullSecretPath); err != nil {
+			return err
+		}
+	}
+
+	secretNames := opts.getSecretNameParams()
+	if err := validateSecretsExist(cs, secretNames); err != nil {
+		return err
+	}
+
+	if err := createOnClusterBuildConfigMap(cs, opts); err != nil {
+		return err
+	}
+
+	return createCustomDockerfileConfigMap(cs)
+}
+
+func waitForBuildInfo(_ *framework.ClientSet, _ string) error {
+	klog.Infof("no-op for now")
+	return nil
+}

--- a/cmd/onclustertesting/teardown.go
+++ b/cmd/onclustertesting/teardown.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/spf13/cobra"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+var (
+	teardownCmd = &cobra.Command{
+		Use:   "teardown",
+		Short: "Tears down the pool for on-cluster build testing",
+		Long:  "",
+		Run:   runTeardownCmd,
+	}
+
+	teardownOpts struct {
+		poolName string
+		extract  bool
+		dir      string
+		force    bool
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(teardownCmd)
+	teardownCmd.PersistentFlags().StringVar(&teardownOpts.poolName, "pool", defaultLayeredPoolName, "Pool name to teardown")
+	teardownCmd.PersistentFlags().BoolVar(&teardownOpts.extract, "extract-objects", false, "Extract and store build objects on disk before teardown")
+	teardownCmd.PersistentFlags().StringVar(&teardownOpts.dir, "dir", "", "Dir to store extract build objects")
+	teardownCmd.PersistentFlags().BoolVar(&teardownOpts.force, "force", false, "Removes all on-cluster build related objects even if not created by this CLI tool")
+}
+
+func runTeardownCmd(_ *cobra.Command, _ []string) {
+	common(teardownOpts)
+
+	if teardownOpts.poolName == "" {
+		klog.Fatalln("No pool name provided!")
+	}
+
+	targetDir := getDir(teardownOpts.dir)
+
+	failOnError(mobTeardown(framework.NewClientSet(""), teardownOpts.poolName, targetDir, teardownOpts.extract))
+}
+
+func mobTeardown(cs *framework.ClientSet, targetPool, targetDir string, extractObjects bool) error {
+	mcp, err := cs.MachineConfigPools().Get(context.TODO(), targetPool, metav1.GetOptions{})
+	if err != nil && !apierrs.IsNotFound(err) {
+		return err
+	}
+
+	if apierrs.IsNotFound(err) {
+		klog.Infof("Pool %s not found", targetPool)
+		mcp = nil
+	}
+
+	if extractObjects {
+		klog.Infof("Extracting build objects (if they exist) to %s", targetDir)
+		if err := extractBuildObjects(cs, mcp, targetDir); err != nil {
+			if errors.Is(err, fs.ErrNotExist) || apierrs.IsNotFound(err) {
+				klog.Warningf("Recovered from: %s", err)
+			} else {
+				return err
+			}
+		}
+	} else {
+		klog.Infof("Skipping build object extraction")
+	}
+
+	if err := deleteBuildObjects(cs, mcp); err != nil {
+		return err
+	}
+
+	if mcp != nil {
+		if err := teardownPool(cs, mcp); err != nil {
+			return err
+		}
+	}
+
+	if err := deleteAllNonStandardPools(cs); err != nil {
+		return err
+	}
+
+	if mcp != nil {
+		if err := deleteAllMachineConfigsForPool(cs, mcp); err != nil {
+			return err
+		}
+	}
+
+	if teardownOpts.force {
+		return forceCleanup(cs)
+	}
+
+	return normalCleanup(cs)
+}
+
+func normalCleanup(cs *framework.ClientSet) error {
+	if err := cleanupConfigMaps(cs); err != nil {
+		return err
+	}
+
+	if err := cleanupSecrets(cs); err != nil {
+		return err
+	}
+
+	return cleanupImagestreams(cs)
+}
+
+func forceCleanup(cs *framework.ClientSet) error {
+	if err := forceCleanupConfigMaps(cs); err != nil {
+		klog.Errorf("could not force clean ConfigMaps")
+		return err
+	}
+
+	if err := forceCleanupSecrets(cs); err != nil {
+		klog.Errorf("could not force clean Secrets")
+		return err
+	}
+
+	if err := deleteImagestream(cs, "os-image"); err != nil {
+		klog.Errorf("could not force clean ImageStream 'os-image'")
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
**- What I did**

Provides a very simple binary for setting up / tearing down on-cluster builds to make testing / development go faster. This is mostly intended to be left here for posterity and I have no plans for this PR to be merged. Some of the code written here was later repurposed for writing the e2e-layering test suite in https://github.com/openshift/machine-config-operator/pull/3807. 

**- How to verify it**

## Prerequisites
- An OpenShift 4.14 cluster
- Kubeconfig for the aforementioned cluster.
- Go toolchain
- Git
- _(optional, but recommended)_ [Official GitHub CLI](https://cli.github.com/)
- _(optional, but recommended)_ [K9s](https://k9scli.io/)

## To use
1. Check out this PR locally. The [official GitHub CLI](https://cli.github.com/) makes this very easy if you have a local clone of this repo: `$ gh pr checkout 3852`.
1. Change to the binary directory: `$ cd cmd/onclustertesting`
1. Build the binary: `$ go build .`
1. Place the built binary somewhere in your `PATH` or run it directly from the directory you built it in.

You can now set up a very simple on-cluster build testing situation which makes use of some handy defaults such as using the global pull secret and an in-cluster OpenShift ImageStream for pushing the built image to.

To do this, run:
`$ ./onclustertesting setup in-cluster-registry`

You can then tear down everything created for this test by running:
`$ ./onclustertesting teardown`

## Known Limitations
- I did my best to fill in the CLI options for help, but I recognize that there will be gaps.
- There are places where I hard-coded paths on my system. You may need to adjust those for your system and rebuild the binary.
- This cannot work around the rollback problem identified in https://issues.redhat.com/browse/MCO-694.

**- Description for the changelog**
This is not intended to be merged.