### PR TITLE
CRI-O: Use `127.0.0.1` for stream server with random port

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -7,8 +7,8 @@ contents:
     version_file_persist = "/var/lib/crio/version"
 
     [crio.api]
-    stream_address = ""
-    stream_port = "10010"
+    stream_address = "127.0.0.1"
+    stream_port = "0"
 
     [crio.runtime]
     selinux = true

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -7,8 +7,8 @@ contents:
     version_file_persist = "/var/lib/crio/version"
 
     [crio.api]
-    stream_address = ""
-    stream_port = "10010"
+    stream_address = "127.0.0.1"
+    stream_port = "0"
 
     [crio.runtime]
     selinux = true


### PR DESCRIPTION
This should work since it's the default in CRI-O with the merge of https://github.com/cri-o/cri-o/pull/1714. It slightly increases security of the default configuration.

**- Description for the changelog**

Updated CRI-O streaming server configuration to use 127.0.0.1 and a random port.
