### PR TITLE
MCO-708: Extract and merge kernel arguments from /proc/cmdline

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1054,6 +1054,13 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	// it, reflecting the current machine state.
 	oldConfig := canonicalizeEmptyMC(nil)
 	oldConfig.Spec.OSImageURL = dn.bootedOSImageURL
+
+	// Setting the Kernel Arguments is for comparison only with the desired MachineConfig.
+	// The resulting MC should not be for updating node configuration.
+	if err = setRunningKargs(oldConfig, mc.Spec.KernelArguments); err != nil {
+		return fmt.Errorf("failed to set kernel arguments from /proc/cmdline: %w", err)
+	}
+
 	// Currently, we generally expect the bootimage to be older, but in the special
 	// case of having bootimage == machine-os-content, and no kernel arguments
 	// specified, then we don't need to do anything here.

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -122,6 +122,29 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 	return dn.triggerUpdateWithMachineConfig(state.currentConfig, state.desiredConfig, true)
 }
 
+func setRunningKargsWithCmdline(config *mcfgv1.MachineConfig, requestedKargs []string, cmdline []byte) error {
+	splits := splitKernelArguments(strings.TrimSpace(string(cmdline)))
+	config.Spec.KernelArguments = nil
+	for _, split := range splits {
+		for _, reqKarg := range requestedKargs {
+			if reqKarg == split {
+				config.Spec.KernelArguments = append(config.Spec.KernelArguments, reqKarg)
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func setRunningKargs(config *mcfgv1.MachineConfig, requestedKargs []string) error {
+	rpmostreeKargsBytes, err := runGetOut("rpm-ostree", "kargs")
+	if err != nil {
+		return err
+	}
+
+	return setRunningKargsWithCmdline(config, requestedKargs, rpmostreeKargsBytes)
+}
+
 func canonicalizeEmptyMC(config *mcfgv1.MachineConfig) *mcfgv1.MachineConfig {
 	if config != nil {
 		return config


### PR DESCRIPTION
In firstboot MCO checks if reboot can be skipped.  In order for reboot to be skipped, the kernel arguments of the current (booted) system and the expected system need to match.
Currently, in firstboot the list of the current kargs is assumed to be empty.  To reflect the actual list of arguments the system was booted with, this change extracts the set of booted kargs from /proc/cmdline to be used for comparison.
Only kargs that appear both in the requested kargs and /proc/cmdline are used for comparison.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Extracted the kernel arguments from /proc/cmdline to be used for comparison with the expected kernel arguments
**- How to verify it**
1. regression
2. With assisted installed with other changes in the epic, verify that reboot is skipped and installation is successful.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Extract and merge kernel arguments from /proc/cmdline
