### PR TITLE
MCO-707: Strip registry transport from os image URL for comparison

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -151,11 +151,12 @@ func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, string, error) 
 
 	// we have container images now, make sure we can parse those too
 	if bootedDeployment.ContainerImageReference != "" {
-		// right now they start with "ostree-unverified-registry:", so scrape that off
-		tokens := strings.SplitN(bootedDeployment.ContainerImageReference, ":", 2)
-		if len(tokens) > 1 {
-			osImageURL = tokens[1]
+		// right now remove ostree remote, and transport from container image reference
+		ostreeImageReference, err := bootedDeployment.RequireContainerImage()
+		if err != nil {
+			return "", "", "", err
 		}
+		osImageURL = ostreeImageReference.Imgref.Image
 	}
 
 	baseChecksum := bootedDeployment.GetBaseChecksum()


### PR DESCRIPTION
One of the conditions to reboot after firstboot is different os image
URLs.  In order to correctly compare the URLs, the booted OS image URL
has to be stripped from container image reference and transport.
This commit utilizes a recent change in rpm-ostree client to do just
that.
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Strip registry transport from os image URLs before checking if reboot is needed.
**- How to verify it**
1. Regression
2. Verify if URLs are considered equal when booted os URL is with a registry transport, and the required is without.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Strip registry transport from OS Image URLs for comparison
