### PR TITLE
OCPBUGS-17701: daemon: igmore mounting MCD pod content when target is "/"

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -384,6 +384,13 @@ func (dn *Daemon) HypershiftConnect(
 
 // PrepareNamespace is invoked before chrooting into the target root
 func PrepareNamespace(target string) error {
+	// With ReexecuteForTargetRoot, we have already chroot into rootfs.
+	// So, we should already have necessary MCD pod content mounted inside the host.
+	// This also avoids overriding previously mounted content.
+	if target == "/" {
+		return nil
+	}
+
 	// This contains the /run/secrets/kubernetes.io service account tokens that we still need
 	secretsMount := "/run/secrets"
 	targetSecrets := filepath.Join(target, secretsMount)


### PR DESCRIPTION
With ReexecuteForTargetRoot, we have already chroot into rootfs. So, we should already have necessary MCD pod content mounted inside the host. This also avoids overriding previously mounted content.

We saw this issue in 4.13 https://github.com/openshift/machine-config-operator/pull/3812#issuecomment-1645446448 . We don't see this issue in usual upgrade case in ci because we upgrade from 4.13 to 4.14 , where both have RHEL 9 baseOS. But I forgot that in EUS upgrade with paused pool, it is likely that OS upgrade will happen from 4.12 (RHEL 8) to 4.14 .

This was anyway I had in mind to cherry-pick to 4.14 but somehow went off the radar.