### PR TITLE
MCO 566: MCO 662 Wire up productionalized BuildController in Machine OS Builder binary and choosing backend image builder

### DIFF
--- a/cmd/machine-os-builder/main.go
+++ b/cmd/machine-os-builder/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"time"
+	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/component-base/cli"
 )
 
 const componentName = "machine-os-builder"
@@ -23,6 +23,5 @@ func init() {
 }
 
 func main() {
-	fmt.Println("Hello, World!")
-	<-time.After(876000 * time.Hour)
+	os.Exit(cli.Run(rootCmd))
 }

--- a/cmd/machine-os-builder/start.go
+++ b/cmd/machine-os-builder/start.go
@@ -1,7 +1,16 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
+
+	"github.com/openshift/machine-config-operator/internal/clients"
+	"github.com/openshift/machine-config-operator/pkg/controller/build"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
@@ -26,7 +35,50 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 }
 
+// Checks if the on-cluster-build-config ConfigMap exists. If it exists, return the ConfigMap.
+// If not, return an error.
+func getBuildControllerConfigMap(ctx context.Context, cb *clients.Builder) (*corev1.ConfigMap, error) {
+	kubeclient := cb.KubeClientOrDie(componentName)
+	cmName := build.OnClusterBuildConfigMapName
+	cm, err := kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, cmName, metav1.GetOptions{})
+
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("configmap %s does not exist. Please create it before opting into on-cluster builds", cmName)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}
+
+// Creates a new BuildController configured for a certain image builder based
+// upon the imageBuilderType key in the on-cluster-build-config ConfigMap.
+func getBuildController(ctx context.Context, cb *clients.Builder) (*build.Controller, error) {
+	onClusterBuildConfigMap, err := getBuildControllerConfigMap(ctx, cb)
+	if err != nil {
+		return nil, err
+	}
+
+	imageBuilderType, err := build.GetImageBuilderType(onClusterBuildConfigMap)
+	if err != nil {
+		return nil, err
+	}
+
+	ctrlCtx := ctrlcommon.CreateControllerContext(ctx, cb, componentName)
+	buildClients := build.NewClientsFromControllerContext(ctrlCtx)
+	cfg := build.DefaultBuildControllerConfig()
+
+	if imageBuilderType == build.OpenshiftImageBuilder {
+		return build.NewWithImageBuilder(cfg, buildClients), nil
+	}
+
+	return build.NewWithCustomPodBuilder(cfg, buildClients), nil
+}
+
 func runStartCmd(_ *cobra.Command, _ []string) {
+	flag.Set("v", "4")
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
@@ -35,4 +87,19 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cb, err := clients.NewBuilder("")
+	if err != nil {
+		klog.Fatalln(err)
+	}
+
+	ctrl, err := getBuildController(ctx, cb)
+	if err != nil {
+		klog.Fatalln(err)
+	}
+
+	go ctrl.Run(ctx, 5)
+	<-ctx.Done()
 }

--- a/manifests/machineosbuilder/clusterrole.yaml
+++ b/manifests/machineosbuilder/clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
   verbs: ["create"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "create", "delete"]
+  verbs: ["get", "list", "create", "delete", "watch"]
 - apiGroups: ["extensions"]
   resources: ["daemonsets"]
   verbs: ["get"]

--- a/pkg/controller/build/fixtures_test.go
+++ b/pkg/controller/build/fixtures_test.go
@@ -53,13 +53,13 @@ func getOSImageURLConfigMap() *corev1.ConfigMap {
 func getOnClusterBuildConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      onClusterBuildConfigMapName,
+			Name:      OnClusterBuildConfigMapName,
 			Namespace: ctrlcommon.MCONamespace,
 		},
 		Data: map[string]string{
-			baseImagePullSecretNameConfigKey:  "base-image-pull-secret",
-			finalImagePushSecretNameConfigKey: "final-image-push-secret",
-			finalImagePullspecConfigKey:       expectedImagePullspecWithTag,
+			BaseImagePullSecretNameConfigKey:  "base-image-pull-secret",
+			FinalImagePushSecretNameConfigKey: "final-image-push-secret",
+			FinalImagePullspecConfigKey:       expectedImagePullspecWithTag,
 		},
 	}
 }

--- a/pkg/controller/build/helpers.go
+++ b/pkg/controller/build/helpers.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,11 +12,15 @@ import (
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/opencontainers/go-digest"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -235,4 +240,102 @@ func ignoreIsNotFoundErr(err error) error {
 	}
 
 	return nil
+}
+
+// ValidateOnClusterBuildConfig validates the existence of the on-cluster-build-config ConfigMap and the presence of the secrets it refers to.
+func ValidateOnClusterBuildConfig(kubeclient clientset.Interface) error {
+	// Validate the presence of the on-cluster-build-config ConfigMap
+	cm, err := kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), OnClusterBuildConfigMapName, metav1.GetOptions{})
+	if err != nil && k8serrors.IsNotFound(err) {
+		return fmt.Errorf("%s ConfigMap missing, did you create it?", OnClusterBuildConfigMapName)
+	}
+
+	if err != nil {
+		return fmt.Errorf("could not get ConfigMap %s: %w", OnClusterBuildConfigMapName, err)
+	}
+
+	secretNames := []string{BaseImagePullSecretNameConfigKey, FinalImagePushSecretNameConfigKey}
+	imagePullspecs := []string{FinalImagePullspecConfigKey}
+
+	// Validate the presence of secrets it refers to
+	for _, key := range secretNames {
+		val, ok := cm.Data[key]
+		if !ok {
+			return fmt.Errorf("missing required key %q in configmap %s", key, OnClusterBuildConfigMapName)
+		}
+
+		if val == "" {
+			return fmt.Errorf("key %q in configmap %s has an empty value", key, OnClusterBuildConfigMapName)
+		}
+
+		if err := validateSecret(kubeclient, val); err != nil {
+			return err
+		}
+	}
+
+	// Validate the image pullspec(s) it referes to.
+	for _, key := range imagePullspecs {
+		val, ok := cm.Data[key]
+		if !ok {
+			return fmt.Errorf("missing required key %q in configmap %s", key, OnClusterBuildConfigMapName)
+		}
+
+		if val == "" {
+			return fmt.Errorf("key %q in configmap %s has an empty value", key, OnClusterBuildConfigMapName)
+		}
+
+		if _, err := reference.ParseNamed(val); err != nil {
+			return fmt.Errorf("could not parse %s with %q: %w", key, val, err)
+		}
+	}
+
+	// Validate the image builder type from the ConfigMap
+	if _, err := GetImageBuilderType(cm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateSecret(kubeclient clientset.Interface, secretName string) error {
+	// Here we just validate the presence of the secret, and not its content
+	secret, err := kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil && k8serrors.IsNotFound(err) {
+		return fmt.Errorf("secret %s from %s is not found. Did you use the right secret name?", secretName, OnClusterBuildConfigMapName)
+	}
+
+	if err != nil {
+		return fmt.Errorf("could not get secret %s: %w", secretName, err)
+	}
+
+	if _, err := getPullSecretKey(secret); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Determines which image builder to start based upon the imageBuilderType key
+// in the on-cluster-build-config ConfigMap. Defaults to custom-pod-builder.
+func GetImageBuilderType(cm *corev1.ConfigMap) (string, error) {
+	configMapImageBuilder, ok := cm.Data[ImageBuilderTypeConfigMapKey]
+	defaultBuilder := OpenshiftImageBuilder
+
+	if !ok {
+		klog.Infof("%s not set, defaulting to %q", ImageBuilderTypeConfigMapKey, defaultBuilder)
+		return defaultBuilder, nil
+	}
+
+	if ok && configMapImageBuilder == "" {
+		klog.Infof("%s empty, defaulting to %q", ImageBuilderTypeConfigMapKey, defaultBuilder)
+		return defaultBuilder, nil
+	}
+
+	validImageBuilderTypes := sets.NewString(OpenshiftImageBuilder, CustomPodImageBuilder)
+	if !validImageBuilderTypes.Has(configMapImageBuilder) {
+		return "", fmt.Errorf("invalid image builder type %q, valid types: %v", configMapImageBuilder, validImageBuilderTypes.List())
+	}
+
+	klog.Infof("%s set to %q", ImageBuilderTypeConfigMapKey, configMapImageBuilder)
+	return configMapImageBuilder, nil
 }

--- a/pkg/controller/build/image_build_request.go
+++ b/pkg/controller/build/image_build_request.go
@@ -75,9 +75,9 @@ func newImageBuildRequest(pool *mcfgv1.MachineConfigPool) ImageBuildRequest {
 // Populates the final image info from the on-cluster-build-config ConfigMap.
 func newFinalImageInfo(inputs *buildInputs) ImageInfo {
 	return ImageInfo{
-		Pullspec: inputs.onClusterBuildConfig.Data[finalImagePullspecConfigKey],
+		Pullspec: inputs.onClusterBuildConfig.Data[FinalImagePullspecConfigKey],
 		PullSecret: corev1.LocalObjectReference{
-			Name: inputs.onClusterBuildConfig.Data[finalImagePushSecretNameConfigKey],
+			Name: inputs.onClusterBuildConfig.Data[FinalImagePushSecretNameConfigKey],
 		},
 	}
 }
@@ -88,7 +88,7 @@ func newBaseImageInfo(inputs *buildInputs) ImageInfo {
 	return ImageInfo{
 		Pullspec: inputs.osImageURL.Data[baseOSContainerImageConfigKey],
 		PullSecret: corev1.LocalObjectReference{
-			Name: inputs.onClusterBuildConfig.Data[baseImagePullSecretNameConfigKey],
+			Name: inputs.onClusterBuildConfig.Data[BaseImagePullSecretNameConfigKey],
 		},
 	}
 }
@@ -99,7 +99,7 @@ func newExtensionsImageInfo(inputs *buildInputs) ImageInfo {
 	return ImageInfo{
 		Pullspec: inputs.osImageURL.Data[baseOSExtensionsContainerImageConfigKey],
 		PullSecret: corev1.LocalObjectReference{
-			Name: inputs.onClusterBuildConfig.Data[baseImagePullSecretNameConfigKey],
+			Name: inputs.onClusterBuildConfig.Data[BaseImagePullSecretNameConfigKey],
 		},
 	}
 }

--- a/pkg/controller/build/image_build_request_test.go
+++ b/pkg/controller/build/image_build_request_test.go
@@ -47,12 +47,12 @@ func TestImageBuildRequest(t *testing.T) {
 	assert.Equal(t, osImageURLConfigMap.Data[baseOSContainerImageConfigKey], ibr.BaseImage.Pullspec)
 	assert.Equal(t, osImageURLConfigMap.Data[baseOSExtensionsContainerImageConfigKey], ibr.ExtensionsImage.Pullspec)
 
-	assert.Equal(t, onClusterBuildConfigMap.Data[baseImagePullSecretNameConfigKey], ibr.BaseImage.PullSecret.Name)
-	assert.Equal(t, onClusterBuildConfigMap.Data[baseImagePullSecretNameConfigKey], ibr.ExtensionsImage.PullSecret.Name)
+	assert.Equal(t, onClusterBuildConfigMap.Data[BaseImagePullSecretNameConfigKey], ibr.BaseImage.PullSecret.Name)
+	assert.Equal(t, onClusterBuildConfigMap.Data[BaseImagePullSecretNameConfigKey], ibr.ExtensionsImage.PullSecret.Name)
 
-	assert.Equal(t, onClusterBuildConfigMap.Data[finalImagePullspecConfigKey], ibr.FinalImage.Pullspec)
+	assert.Equal(t, onClusterBuildConfigMap.Data[FinalImagePullspecConfigKey], ibr.FinalImage.Pullspec)
 
-	assert.Equal(t, onClusterBuildConfigMap.Data[finalImagePushSecretNameConfigKey], ibr.FinalImage.PullSecret.Name)
+	assert.Equal(t, onClusterBuildConfigMap.Data[FinalImagePushSecretNameConfigKey], ibr.FinalImage.PullSecret.Name)
 
 	assert.Equal(t, "dockerfile-rendered-worker-1", ibr.getDockerfileConfigMapName())
 	assert.Equal(t, "build-rendered-worker-1", ibr.getBuildName())

--- a/pkg/controller/build/pod_build_controller.go
+++ b/pkg/controller/build/pod_build_controller.go
@@ -189,7 +189,7 @@ func (ctrl *PodBuildController) Run(ctx context.Context, workers int) {
 // Gets the final image pullspec by retrieving the ConfigMap that the build pod
 // creates from the Buildah digestfile.
 func (ctrl *PodBuildController) FinalPullspec(pool *mcfgv1.MachineConfigPool) (string, error) {
-	onClusterBuildConfigMap, err := ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), onClusterBuildConfigMapName, metav1.GetOptions{})
+	onClusterBuildConfigMap, err := ctrl.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), OnClusterBuildConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openshift/machine-config-operator/manifests"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	v1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/pkg/controller/build"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	templatectrl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -902,6 +903,10 @@ func (optr *Operator) hasCorrectReplicaCount(mob *appsv1.Deployment) bool {
 }
 
 func (optr *Operator) updateMachineOSBuilderDeployment(mob *appsv1.Deployment, replicas int32) error {
+	if err := build.ValidateOnClusterBuildConfig(optr.kubeClient); err != nil {
+		return fmt.Errorf("could not update Machine OS Builder deployment: %w", err)
+	}
+
 	_, updated, err := mcoResourceApply.ApplyDeployment(optr.kubeClient.AppsV1(), mob)
 	if err != nil {
 		return fmt.Errorf("could not apply Machine OS Builder deployment: %w", err)
@@ -943,6 +948,10 @@ func (optr *Operator) isMachineOSBuilderRunning(mob *appsv1.Deployment) (bool, e
 
 // Updates the Machine OS Builder Deployment, creating it if it does not exist.
 func (optr *Operator) startMachineOSBuilderDeployment(mob *appsv1.Deployment) error {
+	if err := build.ValidateOnClusterBuildConfig(optr.kubeClient); err != nil {
+		return fmt.Errorf("could not start Machine OS Builder: %w", err)
+	}
+
 	// start machine os builder deployment
 	_, updated, err := mcoResourceApply.ApplyDeployment(optr.kubeClient.AppsV1(), mob)
 	if err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Wire up productionalized BuildController in Machine OS Builder binary and added choice for backend image builder. The productionalized BuildController is started by the binary and it is able to create and monitor builds. The Machine OS Builder startup process reads the on-cluster-build-config ConfigMap at startup and uses the desired imageBuilder.

**- How to verify it**

**For [MCO-566](https://issues.redhat.com//browse/MCO-566): Wiring up Productionalized Build Controller**
1. create a machine config pool and apply it
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
  name: on-cluster-build
spec:
  machineConfigSelector:
    matchExpressions:
      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,on-cluster-build]}
  nodeSelector:
    matchLabels:
      node-role.kubernetes.io/on-cluster-build: ""
```
2. apply the `layering-enabled` label
`oc label mcp/on-cluster-build 'machineconfiguration.openshift.io/layering-enabled='`

- when configmap doesnt exist, this is expected behavior
```
~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com 
❯ oc get pods | grep "machine-os-builder"                                
machine-os-builder-67f76d7f49-8592l                                0/1     Error       3 (31s ago)   50s

~/MCO/on-cluster-build on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com 
❯ oc logs machine-os-builder-67f76d7f49-8592l                            
I0815 18:56:31.208127       1 start.go:126] Options parsed: {kubeconfig: createDefaults:false copyGlobalPullSecret:false}
I0815 18:56:31.208198       1 start.go:129] Version: 1d0466de-dirty (1d0466de5b742638df6de4acb2b7b725771db03d)
I0815 18:56:31.208204       1 builder.go:87] Using in-cluster kube client config
F0815 18:56:31.223404       1 start.go:150] configmap on-cluster-build-config does not exist. Please create it before opting into on-cluster builds
```

- when configmap exists but `imageBuilderType` is empty
```
❯ oc logs machine-os-builder-67f76d7f49-s25gr | grep "empty"
I0815 19:04:00.195303       1 start.go:74] imageBuilderType empty, defaulting to "openshift-image-builder"
```
3. create a configmap called `on-cluster-build-config` and add/populate `baseImagePullSecretName`, `finalImagePushSecretName`, and `finalImagePullspec` fields
```
apiVersion: v1
data:
  baseImagePullSecretName: global-pull-secret-copy
  finalImagePushSecretName: dkhater-dkhater-test-ocb-pull-secret
  finalImagePullspec: "quay.io/repository/dkhater/on-cluster-build"
kind: ConfigMap
metadata:
  name: on-cluster-build-config
  namespace: openshift-machine-config-operator
  ```
  
4. delete the machine-os-builder pod
5. monitor the logs 
```
❯ oc logs machine-os-builder-67f76d7f49-j64qs 
I0815 18:58:57.933796       1 start.go:69] imageBuilderType not set, defaulting to "openshift-image-builder"
...
I0815 18:58:57.945082       1 build_controller.go:779] Adding MachineConfigPool master
I0815 18:58:57.945186       1 build_controller.go:779] Adding MachineConfigPool on-cluster-build
I0815 18:58:57.945246       1 build_controller.go:779] Adding MachineConfigPool worker
I0815 18:58:58.041285       1 shared_informer.go:341] caches populated
I0815 18:58:58.041558       1 reflector.go:287] Starting reflector *v1.Build (0s) from github.com/openshift/client-go/build/informers/externalversions/factory.go:101
I0815 18:58:58.041573       1 reflector.go:323] Listing and watching *v1.Build from github.com/openshift/client-go/build/informers/externalversions/factory.go:101
I0815 18:58:58.048368       1 image_build_controller.go:268] Adding Build mco-image-build. Is OS image build? false
I0815 18:58:58.141788       1 shared_informer.go:341] caches populated
I0815 18:58:58.141809       1 image_build_controller.go:175] Starting MachineOSBuilder-ImageBuildController
I0815 18:59:02.945814       1 build_controller.go:461] Started syncing machineconfigpool "worker" (2023-08-15 18:59:02.945802827 +0000 UTC m=+5.048948212)
I0815 18:59:02.945813       1 build_controller.go:461] Started syncing machineconfigpool "master" (2023-08-15 18:59:02.945805976 +0000 UTC m=+5.048951332)
I0815 18:59:02.945820       1 build_controller.go:461] Started syncing machineconfigpool "on-cluster-build" (2023-08-15 18:59:02.945805952 +0000 UTC m=+5.048951341)
I0815 18:59:02.951019       1 build_controller.go:490] MachineConfigPool worker is not opted-in for layering, ignoring
I0815 18:59:02.951027       1 build_controller.go:507] MachineConfigPool on-cluster-build is building
I0815 18:59:02.951031       1 build_controller.go:463] Finished syncing machineconfigpool "worker" (5.226901ms)
I0815 18:59:02.951036       1 build_controller.go:463] Finished syncing machineconfigpool "on-cluster-build" (5.228176ms)
I0815 18:59:02.952052       1 build_controller.go:490] MachineConfigPool master is not opted-in for layering, ignoring
I0815 18:59:02.952077       1 build_controller.go:463] Finished syncing machineconfigpool "master" (6.269098ms)
```
**For [MCO-662](https://issues.redhat.com/browse/MCO-662): Ability to choose backend image builder**
1. recreate and apply the `on-cluster-build-config` configmap with the `imageBuilder` field
```
apiVersion: v1
data:
  baseImagePullSecretName: global-pull-secret-copy
  finalImagePushSecretName: dkhater-dkhater-test-ocb-pull-secret
  finalImagePullspec: "quay.io/repository/dkhater/on-cluster-build"
  imageBuilderType: openshift-image-builder
kind: ConfigMap
metadata:
  name: on-cluster-build-config
  namespace: openshift-machine-config-operator
```
2. delete the machine-os-builder pod
3. inspect the logs of machine-os-builder
```
❯ oc logs machine-os-builder-67f76d7f49-zg2pb | grep "set to" 
I0815 18:02:12.343325       1 start.go:61] imageBuilderType set to "openshift-image-builder"
```