### PR TITLE
OSDOCS-7297: Include ordering considerations

### DIFF
--- a/docs/custom-pools.md
+++ b/docs/custom-pools.md
@@ -66,6 +66,10 @@ worker   rendered-worker-6db67f47c0b205c26561b1c5ab74d79b   True      False     
 
 The example above makes an `infra` pool that contains all of the MachineConfigs used by the `worker` pool.
 
+### Ordering the custom pool and resulting MachineConfigs
+
+The MachineConfigPool will generate MachineConfigs based on it's `Name`. The render controller sorts all the other MachineConfigs based on the lexicographically increasing order of their `Name`. It uses the first MachineConfig in the list as the base and appends the rest to the base MachineConfig. As a result, in order to successfully override MachineConfigs applied by the `worker` MachineConfigPool, the custom MachineConfigPool should have a name with a lexicographic value greater than `worker`. The simplest way is to make the custom MachineConfigPool name start with a `x`, `y`, or `z`.
+
 ## Deploy changes to a custom pool (optional)
 
 Deploying changes to a custom pool is just a matter of creating a MachineConfig that uses the custom pool name as the label (`infra` in the example):


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Closes: [OSDOCS-7297](https://issues.redhat.com//browse/OSDOCS-7297)

**- What I did**

Update documentation of custom pools with information about the ordering considerations of the resulting MachineConfigs. Some of the language used was taken from here: https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigController.md#ordering-the-machineconfigs

Ultimately, we would like this change to also be applied to https://access.redhat.com/solutions/5688941. I can make this happen once the doc change is approved.

For background, please refer to the RCA linked in [OSDOCS-7297](https://issues.redhat.com//browse/OSDOCS-7297)

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
