### PR TITLE
switch cert times to metav1.Time

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
@@ -442,4 +442,5 @@ spec:
                       type: string
                     expiry:
                       description: the date when the cert expires
-                      type: string 
+                      type: string
+                      format: date-time

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -1881,9 +1881,11 @@ spec:
                     notBefore:
                       description: lower bound for validity
                       type: string
+                      format: date-time
                     notAfter:
                       description: upper bound for validity
                       type: string
+                      format: date-time
                     bundleFile:
                       description: the name of the bundle serving this cert.
                       type: string

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -165,10 +165,10 @@ type ControllerCertificate struct {
 	Signer string `json:"signer"`
 
 	// notBefore is the lower boundary for validity
-	NotBefore string `json:"notBefore"`
+	NotBefore metav1.Time `json:"notBefore"`
 
 	// notAfter is the upper boundary for validity
-	NotAfter string `json:"notAfter"`
+	NotAfter metav1.Time `json:"notAfter"`
 
 	// bundleFile is the larger bundle a cert comes from
 	BundleFile string `json:"bundleFile"`
@@ -343,9 +343,9 @@ type MachineConfigPoolStatus struct {
 
 // ceryExpiry contains the bundle name and the expiry date
 type CertExpiry struct {
-	Bundle  string `json:"bundle"`
-	Subject string `json:"subject"`
-	Expiry  string `json:"expiry"`
+	Bundle  string      `json:"bundle"`
+	Subject string      `json:"subject"`
+	Expiry  metav1.Time `json:"expiry"`
 }
 
 // MachineConfigPoolStatusConfiguration stores the current configuration for the pool, and

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -1018,7 +1018,7 @@ func TestCertStatus(t *testing.T) {
 
 	cc.Status.ControllerCertificates = append(cc.Status.ControllerCertificates, mcfgv1.ControllerCertificate{
 		BundleFile: "KubeAPIServerServingCAData",
-		NotAfter:   time.Now().String(),
+		NotAfter:   metav1.Now(),
 	})
 
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -504,8 +504,8 @@ func createNewCert(cert []byte, name string) []v1.ControllerCertificate {
 		certs = append(certs, v1.ControllerCertificate{
 			Subject:    c.Subject.String(),
 			Signer:     c.Issuer.String(),
-			NotBefore:  c.NotBefore.String(),
-			NotAfter:   c.NotAfter.String(),
+			NotBefore:  metav1.NewTime(c.NotBefore),
+			NotAfter:   metav1.NewTime(c.NotAfter),
 			BundleFile: name,
 		})
 	}


### PR DESCRIPTION
title says it all, switched the CRD to format date-time and switched the structs from string to metav1.Time.

This is because when merging the MCO API into openshift/API, using metav1.time is more correct and up to standards.
