### PR TITLE
OCPBUGS-17810: temporarily remove cert observability fields, add storageversionmigration for machineconfigpools,controllerconfig

### DIFF
--- a/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
+++ b/install/0000_80_machine-config-operator_01_machineconfigpool.crd.yaml
@@ -440,6 +440,3 @@ spec:
                     subject:
                       description: the subject of the cert
                       type: string
-                    expiry:
-                      description: the date when the cert expires
-                      type: string 

--- a/install/0000_90_machine-config-operator_01_certificate_observability_storage_migration.yaml
+++ b/install/0000_90_machine-config-operator_01_certificate_observability_storage_migration.yaml
@@ -1,0 +1,27 @@
+apiVersion: migration.k8s.io/v1alpha1
+kind: StorageVersionMigration
+metadata:
+  name: machineconfiguration-controllerconfig-storage-version-migration
+  annotations: 
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  resource:
+    group:  machineconfiguration.openshift.io
+    version: v1
+    resource: controllerconfigs
+---
+apiVersion: migration.k8s.io/v1alpha1
+kind: StorageVersionMigration
+metadata:
+  name: machineconfiguration-machineconfigpool-storage-version-migration
+  annotations: 
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  resource:
+    group:  machineconfiguration.openshift.io
+    version: v1
+    resource: machineconfigpools

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -1883,12 +1883,6 @@ spec:
                     signer:
                       description: signer contains the issuer of the cert
                       type: string
-                    notBefore:
-                      description: lower bound for validity
-                      type: string
-                    notAfter:
-                      description: upper bound for validity
-                      type: string
                     bundleFile:
                       description: the name of the bundle serving this cert.
                       type: string

--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -168,12 +168,6 @@ type ControllerCertificate struct {
 	// signer is the  cert Issuer
 	Signer string `json:"signer"`
 
-	// notBefore is the lower boundary for validity
-	NotBefore string `json:"notBefore"`
-
-	// notAfter is the upper boundary for validity
-	NotAfter string `json:"notAfter"`
-
 	// bundleFile is the larger bundle a cert comes from
 	BundleFile string `json:"bundleFile"`
 }
@@ -349,7 +343,6 @@ type MachineConfigPoolStatus struct {
 type CertExpiry struct {
 	Bundle  string `json:"bundle"`
 	Subject string `json:"subject"`
-	Expiry  string `json:"expiry"`
 }
 
 // MachineConfigPoolStatusConfiguration stores the current configuration for the pool, and

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -1262,7 +1262,6 @@ func TestCertStatus(t *testing.T) {
 
 	cc.Status.ControllerCertificates = append(cc.Status.ControllerCertificates, mcfgv1.ControllerCertificate{
 		BundleFile: "KubeAPIServerServingCAData",
-		NotAfter:   time.Now().String(),
 	})
 
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -51,7 +51,6 @@ func calculateStatus(cconfig *v1.ControllerConfig, pool *mcfgv1.MachineConfigPoo
 				certExpirys = append(certExpirys, v1.CertExpiry{
 					Bundle:  cert.BundleFile,
 					Subject: cert.Subject,
-					Expiry:  cert.NotAfter,
 				},
 				)
 			}

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -504,8 +504,6 @@ func createNewCert(cert []byte, name string) []v1.ControllerCertificate {
 		certs = append(certs, v1.ControllerCertificate{
 			Subject:    c.Subject.String(),
 			Signer:     c.Issuer.String(),
-			NotBefore:  c.NotBefore.String(),
-			NotAfter:   c.NotAfter.String(),
 			BundleFile: name,
 		})
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->


**- What I did**

- Removed certificate observability fields from the MachineConfigPool and ControllerConfig CRDs and types.go, because if they make it in for 4.14 ships, we won't be able to easily change them to the proper `metav1.Time`. 

- Made sure the MCO never sets the cert availability date fields to a value

- This also adds a `StorageVersionMigration` for `ControllerConfig` and `MachineConfigPool` so etcd can clean out anything it has stored for these types (see: https://github.com/openshift/kubernetes-kube-storage-version-migrator/blob/master/USER_GUIDE.md#check-if-migration-has-completed) 

- The certificate cleanup that was using these fields as part of the Image Registry Certificate work  https://github.com/openshift/machine-config-operator/blob/40dfd9b927452690effd3400fbc8f556a2b3ff92/pkg/controller/template/template_controller.go#L480is was always a no-op because it's not running in the daemon, so its functionality is unaffected -- it's deleting certificates from the controller pod that were never there.   

**- How to verify it**
 - Upgrade the MCO from a previous version to this PR, observe `ControllerConfig.status.controllerCertificates` and `MachineConfigPool.status.certExpirys` date fields are removed


**- Description for the changelog**
Temporarily remove certificate observability fields for API migration

Closes: [OCPBUGS-17810](https://issues.redhat.com//browse/OCPBUGS-17810)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
