### PR TITLE
[WIP] reformat cert observability

### DIFF
--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -504,8 +504,8 @@ func createNewCert(cert []byte, name string) []v1.ControllerCertificate {
 		certs = append(certs, v1.ControllerCertificate{
 			Subject:    c.Subject.String(),
 			Signer:     c.Issuer.String(),
-			NotBefore:  c.NotBefore.String(),
-			NotAfter:   c.NotAfter.String(),
+			NotBefore:  c.NotBefore.Format(time.RFC3339),
+			NotAfter:   c.NotAfter.Format(time.RFC3339),
 			BundleFile: name,
 		})
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- make sure cert observability strings outputs as RFC3339 so they can be parsed later as a metav1.Time

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
