### PR TITLE
OCPBUGS-17787: Fix sysctl breaking dots in paths

### DIFF
--- a/templates/common/on-prem/files/configure-ip-forwarding.yaml
+++ b/templates/common/on-prem/files/configure-ip-forwarding.yaml
@@ -4,14 +4,14 @@ contents:
   inline: |
     #!/bin/bash
     set -ex
-    
+
     # Used for on-prem deployments to enable ip forwarding as part of nodeip-configuration service.
     # IP forwarding is required on the node IP (k8s API) interface in order for keepalived to function.
-    
+
     echo "Configuring IP Forwarding..."
     ovnk_config_dir='/etc/ovnk'
     ip_hint_file="/run/nodeip-configuration/primary-ip"
-    
+
     get_ip_from_ip_hint_file() {
       local ip_hint_file="$1"
       if [[ ! -f "${ip_hint_file}" ]]; then
@@ -21,7 +21,7 @@ contents:
       ip_hint=$(cat "${ip_hint_file}")
       echo "${ip_hint}"
     }
-    
+
     get_nodeip_hint_interface() {
       local ip_hint=""
       local ip_hint_file="$1"
@@ -40,9 +40,9 @@ contents:
       fi
       echo "${iface}"
     }
-    
+
     iface=$(get_nodeip_hint_interface "${ip_hint_file}")
-    
+
     echo "Node IP interface determined as: ${iface}. Enabling IP forwarding..."
-    sysctl -w net.ipv4.conf.${iface}.forwarding=1
-    sysctl -w net.ipv6.conf.${iface}.forwarding=1
+    echo "1" > /proc/sys/net/ipv4/conf/"${iface}"/forwarding
+    echo "1" > /proc/sys/net/ipv6/conf/"${iface}"/forwarding


### PR DESCRIPTION
Using sysctl to modify paths containing dots is known to cause issues due to the fact that sysctl blindly assumes that dot is always a separator and is changed to `/`.

This is a problem when we want to configure a network interface containing a dot in its name, e.g. `bond0.354`, because `net.ipv4.conf.bond0.354.forwarding=1` expands to
`/proc/sys/net/ipv4/conf/bond0/354/forwarding` when in reality it should be `/proc/sys/net/ipv4/conf/bond0.354/forwarding`.

To remediate this we are changing the call from
`sysctl -w net.ipv4.conf.bond0.354.forwarding=1` to `echo "1" > /proc/sys/net/ipv4/conf/bond0.354/forwarding` as there is no simple way to change the behaviour of sysctl.

In the current form the call is breaking the script as writing a value to a non-existing path returns an error `cannot stat [...] No such file or directory`

Fixes: OCPBUGS-17787