### PR TITLE
OCPBUGS-16035: daemon: create /etc/systemd/network directory on node

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1617,6 +1617,13 @@ func PersistNetworkInterfaces(osRoot string) error {
 	if hostos.IsEL8() {
 		logSystem("Persisting NIC names for RHEL8 host system")
 
+		// Workaround for https://issues.redhat.com/browse/OCPBUGS-16035 .
+		// Create /etc/systemd/network directory if it doesn't exist.
+		dirPath := filepath.Join(osRoot, systemdNetworkDir)
+		if err := os.MkdirAll(dirPath, defaultDirectoryPermissions); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
+		}
+
 		// nmstate always logs to stderr, so we need to capture/forward that too
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
OCPBUGS-16035: On some system, nmstatectl fails to persists nic due to missing /etc/systemd/network. Until we use fixed version of nmstate in MCO, this workaround will ensure that the process happens successfully.