### PR TITLE
OCPBUGS-18086: Quiet controller noisiness

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -561,8 +561,6 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 
 	if cconfig.Spec.BaseOSContainerImage == "" {
 		klog.Warningf("No BaseOSContainerImage set")
-	} else {
-		klog.Infof("BaseOSContainerImage=%s", cconfig.Spec.BaseOSContainerImage)
 	}
 
 	// Before merging all MCs for a specific pool, let's make sure MachineConfigs are valid

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -545,7 +545,6 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 	modified := updateControllerConfigCerts(cfg)
 
 	if modified {
-		klog.Info("Detecting cert modification, syncing these changes to the true controllerConfig.")
 		if err := ctrl.syncCertificateStatus(cfg); err != nil {
 			return err
 		}


### PR DESCRIPTION
controller: Drop noisy log message about certificates

I often turn to the controller pod logs to debug issues, and
this log message is repeated very often.  While it was
probably useful at the time the feature was being developed/tested
I doubt it will be necessary in the future.

In the end, the status really *is* the debugging frontend I believe.

---

controller: Drop noisy BaseOSContainerImage log message

In general we should avoid logging unless something changed.
I don't believe we need this log message, we can detect OS
changes from e.g. the MCD logs.

---

