### PR TITLE
Revert "fix nodeStatusUpdateFrequency"

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -25,7 +25,6 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
-    nodeStatusUpdateFrequency: 10s
     featureGates:
       AlibabaPlatform: true
       OpenShiftPodSecurityAdmission: true

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -25,7 +25,6 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
-    nodeStatusUpdateFrequency: 10s
     featureGates:
       AlibabaPlatform: true
       OpenShiftPodSecurityAdmission: true


### PR DESCRIPTION
This reverts commit 3c70c4bb9b4da7127ff848c0deb696a72a6b456b.

TRT is observing failures starting in payload [4.14.0-0.nightly-2023-08-24-021808](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2023-08-24-021808) we started seeing failures in [periodic-ci-openshift-release-master-ci-4.14-upgrade-from-stable-4.13-e2e-gcp-ovn-rt-upgrade](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-gcp-ovn-rt-upgrade-4.14-minor-release-openshift-release-analysis-aggregator/1694535327638622208) job tests for `Nodes should reach OSUpdateStaged in a timely fashion`

We have opened [OCPBUGS-18090](https://issues.redhat.com/browse/OCPBUGS-18090) to track the issue and identified https://github.com/openshift/machine-config-operator/pull/3784 as a recent change the *may* have impacted the test.

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), and given the time constraints as we look to get successful payload we are opening this revert to attempt to run payload jobs against it to see if we can observe the issue or not with this code reverted.

Running the payload-aggregate command
/payload-aggregate periodic-ci-openshift-release-master-ci-4.14-upgrade-from-stable-4.13-e2e-gcp-ovn-rt-upgrade 10

Against this revert did not produce the failures we are seeing in the last two payloads

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run periodic-ci-openshift-release-master-ci-4.14-upgrade-from-stable-4.13-e2e-gcp-ovn-rt-upgrade jobs on the unrevert:

/payload-aggregate periodic-ci-openshift-release-master-ci-4.14-upgrade-from-stable-4.13-e2e-gcp-ovn-rt-upgrade 10
