### PR TITLE
OCPBUGS-18076: daemon: create /etc/systemd/network directory on node

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1695,6 +1695,13 @@ func MaybePersistNetworkInterfaces(osRoot string) error {
 		cmd.Args = append(cmd.Args, "--inspect")
 	}
 
+	// Workaround for https://issues.redhat.com/browse/OCPBUGS-16035 .
+	// Create /etc/systemd/network directory if it doesn't exist.
+	dirPath := filepath.Join(osRoot, "etc/systemd/network")
+	if err := os.MkdirAll(dirPath, defaultDirectoryPermissions); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
+	}
+
 	// nmstate always logs to stderr, so we need to capture/forward that too
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/3883

In 4.13, for safer side creating the /etc/systemd/network/ directory on both both RHEL 8 and RHEL 9 based nodes. This is because we are invoking `nmstatectl persist-nic-names ----inspect` on RHEL 9 nodes. 