### PR TITLE
MCO-763 - buildcontroller should set owners for objects it creates

### DIFF
--- a/manifests/machineosbuilder/clusterrole.yaml
+++ b/manifests/machineosbuilder/clusterrole.yaml
@@ -3,64 +3,67 @@ kind: ClusterRole
 metadata:
   name: machine-os-builder
 rules:
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "watch", "patch"]
-- apiGroups: ["machineconfiguration.openshift.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["configmaps", "secrets"]
-  verbs: ["*"]
-- apiGroups: ["config.openshift.io"]
-  resources: ["images", "clusterversions", "featuregates", "nodes", "nodes/status"]
-  verbs: ["*"]
-- apiGroups: ["config.openshift.io"]
-  resources: ["schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["operator.openshift.io"]
-  resources: ["imagecontentsourcepolicies"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["operator.openshift.io"]
-  resources: ["etcds"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["image.openshift.io"]
-  resources: ["images"]
-  verbs: ["get","list","watch","create","update","patch","delete"]
-- apiGroups: ["image.openshift.io"]
-  resources: ["imagestreams"]
-  verbs: ["get","list","watch","create","update","patch","delete"]
-- apiGroups: ["build.openshift.io"]
-  resources: ["builds","buildconfigs","buildconfigs/instantiate"]
-  verbs: ["get","list","watch","create","update","patch","delete"]
-- apiGroups: [""]
-  resources: ["pods/eviction"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "create", "delete", "watch"]
-- apiGroups: ["extensions"]
-  resources: ["daemonsets"]
-  verbs: ["get"]
-- apiGroups: ["apps"]
-  resources: ["daemonsets"]
-  verbs: ["get"]
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - "*"
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["machineconfiguration.openshift.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["*"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["images", "clusterversions", "featuregates", "nodes", "nodes/status"]
+    verbs: ["*"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["operator.openshift.io"]
+    resources: ["imagecontentsourcepolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["image.openshift.io"]
+    resources: ["images"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["image.openshift.io"]
+    resources: ["imagestreams"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["build.openshift.io"]
+    resources: ["builds", "buildconfigs", "buildconfigs/instantiate"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["build.openshift.io"]
+    resources: ["builds/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["pods/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers"]
+    verbs: ["update"]
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - "*"

--- a/pkg/controller/build/assets/buildah-build.sh
+++ b/pkg/controller/build/assets/buildah-build.sh
@@ -14,6 +14,8 @@ mkdir -p "$build_context/machineconfig"
 cp /tmp/dockerfile/Dockerfile "$build_context"
 cp /tmp/machineconfig/machineconfig.json.gz "$build_context/machineconfig/"
 
+digestfile_path="/tmp/done/digestfile"
+
 # Build our image using Buildah.
 buildah bud \
 	--storage-driver vfs \
@@ -25,5 +27,33 @@ buildah bud \
 buildah push \
 	--storage-driver vfs \
 	--authfile="$FINAL_IMAGE_PUSH_CREDS" \
-	--digestfile="/tmp/done/digestfile" \
+	--digestfile="$digestfile_path" \
 	--cert-dir /var/run/secrets/kubernetes.io/serviceaccount "$TAG"
+
+# Write the ConfigMap spec to the shared emptyDir path. This will trigger the
+# wait-for-done container to apply the ConfigMap. We create the ConfigMap this
+# way so that the Build Pod (the pod that this script is running in) will be
+# the owner of the ConfigMap. This simplifies the garbage collection process
+# since the ConfigMap will be deleted when the build pod is. This cannot be
+# templatized with Go templates because the UID of the pod is required and that
+# isn't known until runtime.
+#
+# Also, the YAML below is indented using spaces. Using tabs breaks YAML parsing
+# in this particular situation.
+cat > "$DIGESTFILE_CONFIGMAP_PATH" <<-EOF
+---
+apiVersion: v1
+data:
+  digest: "$(cat "$digestfile_path")"
+kind: ConfigMap
+metadata:
+  name: "$DIGESTFILE_CONFIGMAP_NAME"
+  namespace: "openshift-machine-config-operator"
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Pod
+    name: "$BUILD_POD_NAME"
+    uid: "$BUILD_POD_UID"
+EOF

--- a/pkg/controller/build/assets/wait.sh
+++ b/pkg/controller/build/assets/wait.sh
@@ -4,13 +4,10 @@
 # within the Build Controller binary (see //go:embed) and injected into a
 # custom build pod.
 
-# Wait until the done file appears.
-while [ ! -f "/tmp/done/digestfile" ]
+# Wait until the digestfile ConfigMap file appears.
+while [ ! -f "$DIGESTFILE_CONFIGMAP_PATH" ]
 do
 	sleep 1
 done
 
-oc create configmap \
-	"$DIGEST_CONFIGMAP_NAME" \
-	--namespace openshift-machine-config-operator \
-	--from-file=digest=/tmp/done/digestfile
+oc apply -f "$DIGESTFILE_CONFIGMAP_PATH"

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -19,6 +19,7 @@ import (
 	fakecorev1client "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -319,6 +320,12 @@ func (b *buildControllerTestFixture) setupClients() *Clients {
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "machine-config-operator",
+					Namespace: ctrlcommon.MCONamespace,
+				},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-os-builder",
 					Namespace: ctrlcommon.MCONamespace,
 				},
 			},

--- a/pkg/controller/build/image_build_controller.go
+++ b/pkg/controller/build/image_build_controller.go
@@ -259,7 +259,17 @@ func (ctrl *ImageBuildController) StartBuild(ibr ImageBuildRequest) (*corev1.Obj
 
 	klog.Infof("Build started for pool %s in %s!", ibr.Pool.Name, build.Name)
 
+	if err := setOwnerRefOnConfigMaps(ctrl.kubeclient, ibr, ctrl.getBuildOwnerRefs(build)); err != nil {
+		return nil, err
+	}
+
 	return toObjectRef(build), nil
+}
+
+func (ctrl *ImageBuildController) getBuildOwnerRefs(build *buildv1.Build) []metav1.OwnerReference {
+	buildKind := buildv1.SchemeGroupVersion.WithKind("Build")
+	oref := metav1.NewControllerRef(build, buildKind)
+	return []metav1.OwnerReference{*oref}
 }
 
 // Fires whenever a Build is added.


### PR DESCRIPTION
By setting the OwnerReference fields for the various ephemeral build
objects that are created for each build, BuildController ensures that
those objects are automatically deleted.

**- What I did**

BuildController will now set the OwnersReference fields for the various build objects that it creates. It sets these thusly:
- If a canonical secret is created, it will set the machine-os-builder to be the owner of that secret. By doing this, if the machine-os-builder deployment is deleted, this secret will be deleted as well. It's worth mentioning that BuildController creates this secret only if necessary and ensures that it is up-to-date.
- OpenShift Image Builds and custom pod builds will be owned by the MachineConfigPool that they target. By doing this, if the MachineConfigPool is deleted before the build is completed, the image build pods will also be deleted.
- The ConfigMaps containing the rendered Dockerfile and rendered MachineConfigs are owned by either the custom build pod or the OpenShift Image Build. By doing this, when the build object is deleted, the ConfigMaps will also be deleted.
- For custom build pods, the digestfile ConfigMap that is created as part of the build process will be owned by the custom build pod. This was achieved through injecting the build pod name and UID as environment variables and modifying the ConfigMap creation script to create a ConfigMap with those set as the owner.
- Lastly, the ClusterRole permissions required for the machine-os-builder were pared down to remove unnecessary permissions. There is probably more work that can be done here, but I was being conservative.

**- How to verify it**

Once the e2e-layering test suite lands, it will provide coverage for this scenario although it could be enhanced to assert that the ConfigMaps are deleted.

**- Description for the changelog**
BuildController sets OwnerReference fields for all objects it creates
