### PR TITLE
OCPNODE-1799: support icsp and idms objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3
 	github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20230516205036-088c6d48cc1a
 	github.com/openshift/library-go v0.0.0-20230614142803-865e70cc6b32
-	github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f
+	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/prometheus/client_golang v1.15.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20230516205036-088
 github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20230516205036-088c6d48cc1a/go.mod h1:O4TuBlo2A+kZiykV1LxUSdEjx6zNqgCKf05+lkTDVZc=
 github.com/openshift/library-go v0.0.0-20230614142803-865e70cc6b32 h1:4fniM/5gS16UJ79sC3whgqufsfg7+Rj6ySMLb2GJvAY=
 github.com/openshift/library-go v0.0.0-20230614142803-865e70cc6b32/go.mod h1:PegtilvJPBJXjJG3AV8uL1a0SAnBr6K67ShNiWVb40M=
-github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f h1:ubRzazPtplWWNWWX07v4ww74S9QL+B2RAxHJ8O00m7o=
-github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
+github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b h1:oXzC1N6E9gw76/WH2gEA8GEHvuq09wuVQ9GoCuR8GF4=
+github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -18,7 +18,6 @@ import (
 	operatorinformersv1alpha1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1"
 	operatorlistersv1alpha1 "github.com/openshift/client-go/operator/listers/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	runtimeutils "github.com/openshift/runtime-utils/pkg/registries"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -789,10 +788,6 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 		return err
 	}
 
-	if err := runtimeutils.RejectMultiUpdateMirrorSetObjs(icspRules, idmsRules, itmsRules); err != nil {
-		return err
-	}
-
 	var (
 		registriesBlocked, policyBlocked, allowedRegs []string
 		releaseImage                                  string
@@ -960,10 +955,6 @@ func RunImageBootstrap(templateDir string, controllerConfig *mcfgv1.ControllerCo
 		insecureRegs, registriesBlocked, policyBlocked, allowedRegs, searchRegs []string
 		err                                                                     error
 	)
-
-	if err := runtimeutils.RejectMultiUpdateMirrorSetObjs(icspRules, idmsRules, itmsRules); err != nil {
-		return nil, err
-	}
 
 	// Read the search, insecure, blocked, and allowed registries from the cluster-wide Image CR if it is not nil
 	if imgCfg != nil {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -1061,6 +1061,11 @@ func TestRunImageBootstrap(t *testing.T) {
 			itmsRules []*apicfgv1.ImageTagMirrorSet
 		}{
 			{
+				idmsRules: []*apicfgv1.ImageDigestMirrorSet{
+					newIDMS("idms-1", []apicfgv1.ImageDigestMirrors{
+						{Source: "source.example.com", Mirrors: []apicfgv1.ImageMirror{"mirror.example.com"}},
+					}),
+				},
 				icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
 					newICSP("built-in", []apioperatorsv1alpha1.RepositoryDigestMirrors{
 						{Source: "built-in-source.example.com", Mirrors: []string{"built-in-mirror.example.com"}},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -948,7 +948,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers
-# github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f
+# github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 ## explicit; go 1.18
 github.com/openshift/runtime-utils/pkg/registries
 # github.com/pelletier/go-toml/v2 v2.0.8


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
remove the check that prevents ICSP and IDMS/ITMS from coexisting.
vendor in https://github.com/openshift/runtime-utils/pull/18 to support both ICSP and IDMS objects writing to registries.conf
**- How to verify it**
on the cluster launched with https://github.com/openshift/kubernetes/pull/1685, and this patch:
`launch https://github.com/openshift/kubernetes/pull/1685,https://github.com/openshift/machine-config-operator/pull/3898`
1. create icsp objects
2. create idms objects that has same source, mirror configurations as icsp
3. delete icsp objects and registries.conf stays  the same. No reboots after the icsp deletion.

```yaml
apiVersion: config.openshift.io/v1
kind: ImageDigestMirrorSet
metadata:
  name: ubi8repo
spec:
  imageDigestMirrors:
  - mirrors:
    - icsp-example.io/example/ubi-minimal-dup-v1alpha1
    - icsp.example.mirror
    source: registry.access.redhat.com/ubi8/ubi-minimal-1
```

```yaml
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  name: ubi8repo
spec:
  repositoryDigestMirrors:
  - mirrors:
    - icsp-example.io/example/ubi-minimal-dup-v1alpha1 
    - icsp.example.mirror
    source: registry.access.redhat.com/ubi8/ubi-minimal-1
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow icsp, idms ,itms objects to exist.