### PR TITLE
OCPBUGS-18442: MCO is degraded if not install image registry operator

### DIFF
--- a/manifests/machine-os-puller/rolebinding.yaml
+++ b/manifests/machine-os-puller/rolebinding.yaml
@@ -1,4 +1,4 @@
-# Bind system:image-builder role to the image registry service account
+# Bind system:image-puller role to the image registry service account
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1498,16 +1498,16 @@ func (optr *Operator) getImageRegistryPullSecrets() ([]byte, error) {
 	// Check if image registry exists, if it doesn't we no-op
 	co, err := optr.configClient.ConfigV1().ClusterOperators().Get(context.TODO(), "image-registry", metav1.GetOptions{})
 
+	// returning no error in certain cases because image registry may become optional in the future
+	// More info at: https://issues.redhat.com/browse/IR-351
+	if co == nil || apierrors.IsNotFound(err) {
+		klog.Infof("exiting image registry secrets fetch - image registry operator does not exist.")
+		return nil, nil
+	}
+	// for any other error, report it back
 	if err != nil {
 		return nil, err
 	}
-	if co == nil {
-		// returning no error here because image registry may become optional in the future
-		// TODO: add another gate for image registry is "supposed" to be present
-		klog.Errorf("exiting image registry secrets fetch - image registry operator does not exist.")
-		return nil, nil
-	}
-
 	// Image registry exists, so continue to grab the secrets
 
 	// This is for wiring up the default registry route later


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The original check for image registry operator wasn't sufficient. The fetch call can also return an error, so I added a specific carveout so as to not cause a degrade.

(also cleaned up some minor commenting nits I had noticed the other day)

**- How to verify it**
MCO should no longer degrade when launching a cluster with no image registry installed

**- Description for the changelog**
operator: fixed no-op when registry isn't present
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
