### PR TITLE
Add kernel-64k kernelType

### DIFF
--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -180,7 +180,7 @@ When a machine boots with `nosmt` Kernel Argument, it disables multi-threading o
 ### KernelType
 
 This feature is available with OCP 4.4 and onward releases as both `day 1` and `day 2` operation. It allows to choose between traditional and Real Time (RT) kernel on an RHCOS node. Supported values are
-`""` or `default` for traditional kernel and `realtime` for RT kernel.
+`""` or `default` for traditional kernel, `realtime` for RT kernel and `64k-pages` for 64k memory pages on aarch64.
 
 To set kernelType field during cluster install, see the [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Switching-RHCOS-host-kernel-using-KernelType).
 
@@ -201,7 +201,13 @@ spec:
 **Note:** The RT kernel lowers throughput (performance) in return for improved worst-case latency bounds. This feature is intended only for use cases that require consistent low latency. For more information, see the [Linux Foundation wiki](https://wiki.linuxfoundation.org/realtime/start) and the [RHEL RT portal](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/).
 
 ### RHCOS Extensions
-RHCOS is a minimal OCP focused OS which provides capabilities common across all the platforms. With extensions support, OCP 4.6 and onward users can enable a limited set of additional functionality on the RHCOS nodes. In OCP 4.6 the supported extensions is `usbguard`. In OCP 4.8 the supported extensions are `usbguard` and `sandboxed-containers`.  In OCP 4.11 the supported extensions are `usbguard`, `sandboxed-containers`, and `kerberos`. In OCP 4.14 the supported extensions are `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec` and `wasm`.
+RHCOS is a minimal OCP focused OS which provides capabilities common across all the platforms. With extensions support, OCP 4.6 and onward users can enable a limited set of additional functionality on the RHCOS nodes.
+| OCP version   |     Supported extensions     |
+| ------------- | ---------------------------- |
+| 4.6           |  `usbguard`                  |
+| 4.8           |  `usbguard`, `sandboxed-containers`    |
+| 4.11          |  `usbguard`, `sandboxed-containers`, `kerberos`   |
+| 4.14          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm`   |
 
 Extensions can be installed by creating a MachineConfig object. Extensions can be enabled as both day1 and day2. Check [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Enabling-RHCOS-Extensions) to enable extensions during cluster install.
 

--- a/docs/MachineConfiguration.md
+++ b/docs/MachineConfiguration.md
@@ -181,6 +181,7 @@ When a machine boots with `nosmt` Kernel Argument, it disables multi-threading o
 
 This feature is available with OCP 4.4 and onward releases as both `day 1` and `day 2` operation. It allows to choose between traditional and Real Time (RT) kernel on an RHCOS node. Supported values are
 `""` or `default` for traditional kernel, `realtime` for RT kernel and `64k-pages` for 64k memory pages on aarch64.
+Note that `64k-pages` and `realtime` cannot be selected at the same time. Also, 64k pages support is limited to aarch64 architecture.
 
 To set kernelType field during cluster install, see the [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Switching-RHCOS-host-kernel-using-KernelType).
 

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -22,6 +22,9 @@ const (
 	// KernelTypeRealtime denominates the realtime kernel type
 	KernelTypeRealtime = "realtime"
 
+	// KernelType64kPages denominates the 64k pages kernel
+	KernelType64kPages = "64k-pages"
+
 	// MasterLabel defines the label associated with master node. The master taint uses the same label as taint's key
 	MasterLabel = "node-role.kubernetes.io/master"
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -120,17 +120,17 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.Contro
 		return nil, err
 	}
 
-	// Setting FIPS to true or kerneType to realtime in any MachineConfig takes priority in setting that field
+	// Setting FIPS to true or kernelType to a non-default value in any MachineConfig takes priority in setting that field
 	for _, cfg := range configs {
 		if cfg.Spec.FIPS {
 			fips = true
 		}
-		if cfg.Spec.KernelType == KernelTypeRealtime {
+		if cfg.Spec.KernelType == KernelTypeRealtime || cfg.Spec.KernelType == KernelType64kPages {
 			kernelType = cfg.Spec.KernelType
 		}
 	}
 
-	// If no MC sets kerneType, then set it to 'default' since that's what it is using
+	// If no MC sets kernelType, then set it to 'default' since that's what it is using
 	if kernelType == "" {
 		kernelType = KernelTypeDefault
 	}
@@ -569,7 +569,7 @@ func InSlice(elem string, slice []string) bool {
 
 // ValidateMachineConfig validates that given MachineConfig Spec is valid.
 func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
-	if !(cfg.KernelType == "" || cfg.KernelType == KernelTypeDefault || cfg.KernelType == KernelTypeRealtime) {
+	if !(cfg.KernelType == "" || cfg.KernelType == KernelTypeDefault || cfg.KernelType == KernelTypeRealtime || cfg.KernelType == KernelType64kPages) {
 		return fmt.Errorf("kernelType=%s is invalid", cfg.KernelType)
 	}
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"reflect"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1146,6 +1147,11 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 	// is also default (i.e. throughput) then we have nothing to do.
 	if newKtype == ctrlcommon.KernelTypeDefault {
 		return nil
+	}
+
+	// 64K memory pages kernel is only supported for aarch64
+	if newKtype == ctrlcommon.KernelType64kPages && goruntime.GOARCH != "arm64" {
+		return fmt.Errorf("64k-pages is only supported for aarch64 architecture")
 	}
 
 	// TODO: Drop this code and use https://github.com/coreos/rpm-ostree/issues/2542 instead


### PR DESCRIPTION
Since RHEL 9 reverted to 4K memory pages for aarch64, add a way to
switch to a hugepage kernel.
The MachineConfig should contain the following to trigger the kernel
switch:
spec:
  kernelType: 64k-pages

This is exclusive with the `realtime` kernel option.

xref https://issues.redhat.com/browse/COS-2402
This requires https://github.com/openshift/os/pull/1351
