### PR TITLE
OCPBUGS-18159: Ensure azure-routes hack for internalLB hairpin traffic works for SGW

### DIFF
--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -119,6 +119,38 @@ contents:
 
     }
 
+    remove_stale_routes() {
+        ## find extra ovn routes
+        local ovnkContainerID=($(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2))
+        echo ${ovnkContainerID}
+        local routeVIPsV4=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip4" | awk '$8{print $8}')
+        echo "Found v4route vips: ${routeVIPsV4}"
+        local host=$(hostname)
+        echo ${host}
+        for route_vip in ${routeVIPsV4}; do
+            if [[ ! -v v4vips[${route_vip}] ]] || [[ "${v4vips[${route_vip}]}" = down ]]; then
+                echo removing stale vip "${route_vip}" for local clients
+                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${route_vip}"
+                crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${route_vip}"
+            fi
+        done
+
+        if [ ! -f /proc/net/if_inet6 ]; then
+            return
+        fi
+
+        local routeVIPsV6=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip6" | awk '$8{print $8}')
+        echo "Found v6route vips: ${routeVIPsV6}"
+        for route_vip in ${routeVIPsV6}; do
+            if [[ ! -v v6vips[${route_vip}] ]] || [[ "${v6vips[${route_vip}]}" = down ]]; then
+                echo removing stale vip "${route_vip}" for local clients
+                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${route_vip}"
+                crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip6.dst == ${route_vip}"
+            fi
+        done
+
+    }
+
     add_rules() {
         for vip in "${!v4vips[@]}"; do
             if [[ "${v4vips[${vip}]}" != down ]]; then
@@ -135,8 +167,60 @@ contents:
         done
     }
 
+    add_routes() {
+        local ovnkContainerID=($(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2))
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        local ovnK8sMp0v4=$(ip -brief address show ovn-k8s-mp0 | awk '{print $3}' | awk -F/ '{print $1}')
+        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v4}"
+        local host=$(hostname)
+        echo ${host}
+        for vip in "${!v4vips[@]}"; do
+            if [[ "${v4vips[${vip}]}" != down ]]; then
+                echo "ensuring route for ${vip} for internal clients"
+                local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v4}")
+                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
+                if [[ "${routes}" == *"${vip}"* ]]; then
+                    echo "Route exists"
+                else
+                    echo "Route does not exist; creating it..."
+                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${vip} reroute ${ovnK8sMp0v4}"
+                    crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${vip}" reroute "${ovnK8sMp0v4}"
+                fi
+            fi
+        done
+
+        if [ ! -f /proc/net/if_inet6 ]; then
+            return
+        fi
+
+        local ovnK8sMp0v6=$(ip -brief address show ovn-k8s-mp0 | awk '{print $4}' | awk -F/ '{print $1}')
+        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v6}"
+
+        for vip in "${!v6vips[@]}"; do
+            if [[ "${v6vips[${vip}]}" != down ]]; then
+                echo "ensuring route for ${vip} for internal clients"
+                local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v6}")
+                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
+                if [[ "${routes}" == *"${vip}"* ]]; then
+                    echo "Route exists"
+                else
+                    echo "Route does not exist; creating it..."
+                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${vip} reroute ${ovnK8sMp0v6}"
+                    crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip6.dst == ${vip}" reroute "${ovnK8sMp0v6}"
+                fi
+            fi
+        done
+    }
+
     clear_rules() {
         iptables -t nat -F "${CHAIN_NAME}" || true
+    }
+
+    clear_routes() {
+        local ovnkContainerID=($(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2))
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        echo "clearing all routes from ovn-cluster-router"
+        crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010
     }
 
     # out paramaters: v4vips v6vips
@@ -172,11 +256,14 @@ contents:
             initialize
             list_lb_ips
             remove_stale
+            remove_stale_routes # needed for sgw mode
             add_rules
+            add_routes # needed for sgw mode
             echo "done applying vip rules"
             ;;
         cleanup)
             clear_rules
+            clear_routes # needed for sgw mode
             ;;
         *)
             echo $"Usage: $0 {start|cleanup}"


### PR DESCRIPTION
We have a watcher that adds iptable rules to redirect traffic destined towards internal azureLB on the master nodes. This is to avoid the hairpin bug where srcIP==dstIP and azure drops the traffic.
However SGW in OVN does not egress via mp0 into the host and traffic leaves directly via br-ex. The ovnk pods on the node will hence have rejections 1/3rd of the time without this fix in case the external azure lb dnats it back to same master node.
Let's add ovnk routes on ovn-cluster-router for sgw that will ensure this traffic is hairpinned within the node.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
(cherry picked from commit 6c3dc5ec2394546527a1e1b7d9ed5d79ea1fad21)

Closes: #OCPBUGS-18159

Clean cherry-pick

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
