### PR TITLE
MCO-746: make buildcontroller tests less flaky

### DIFF
--- a/pkg/controller/build/image_build_request.go
+++ b/pkg/controller/build/image_build_request.go
@@ -201,7 +201,9 @@ func (i ImageBuildRequest) toBuild() *buildv1.Build {
 	dockerfile := "FROM scratch"
 
 	return &buildv1.Build{
-		TypeMeta:   metav1.TypeMeta{},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Build",
+		},
 		ObjectMeta: i.getObjectMeta(i.getBuildName()),
 		Spec: buildv1.BuildSpec{
 			CommonSpec: buildv1.CommonSpec{

--- a/pkg/controller/build/pool_state.go
+++ b/pkg/controller/build/pool_state.go
@@ -1,0 +1,242 @@
+package build
+
+import (
+	"fmt"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type poolState struct {
+	*ctrlcommon.LayeredPoolState
+	pool *mcfgv1.MachineConfigPool
+}
+
+func newPoolState(pool *mcfgv1.MachineConfigPool) *poolState {
+	copied := pool.DeepCopy()
+	return &poolState{
+		LayeredPoolState: ctrlcommon.NewLayeredPoolState(copied),
+		pool:             copied,
+	}
+}
+
+// Returns the name of the MachineConfigPool.
+func (p *poolState) Name() string {
+	return p.pool.GetName()
+}
+
+// Returns the name of the current MachineConfig.
+func (p *poolState) CurrentMachineConfig() string {
+	return p.pool.Spec.Configuration.Name
+}
+
+// Returns a deep-copy of the MachineConfigPool with any changes made,
+// propagating spec.Configurtion to status.Configuration in the process.
+func (p *poolState) MachineConfigPool() *mcfgv1.MachineConfigPool {
+	out := p.pool.DeepCopy()
+	out.Spec.Configuration.DeepCopyInto(&out.Status.Configuration)
+	return out
+}
+
+// Sets the image pullspec annotation.
+func (p *poolState) SetImagePullspec(pullspec string) {
+	if p.pool.Annotations == nil {
+		p.pool.Annotations = map[string]string{}
+	}
+
+	p.pool.Annotations[ctrlcommon.ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey] = pullspec
+}
+
+// Clears the image pullspec annotation.
+func (p *poolState) ClearImagePullspec() {
+	if p.pool.Annotations == nil {
+		return
+	}
+
+	delete(p.pool.Annotations, ctrlcommon.ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey)
+}
+
+// Deletes a given build object reference by its name.
+func (p *poolState) DeleteBuildRefByName(name string) {
+	p.pool.Spec.Configuration.Source = p.getFilteredObjectRefs(func(objRef corev1.ObjectReference) bool {
+		return objRef.Name != name && !p.isBuildObjectRef(objRef)
+	})
+}
+
+// Determines if a MachineConfigPool contains a reference to a Build or custom
+// build pod for its current rendered MachineConfig.
+func (p *poolState) HasBuildObjectForCurrentMachineConfig() bool {
+	return p.HasBuildObjectRefName(newImageBuildRequest(p.pool).getBuildName())
+}
+
+// Determines if a MachineConfigPool has a build object reference given its
+// name.
+func (p *poolState) HasBuildObjectRefName(name string) bool {
+	for _, src := range p.pool.Spec.Configuration.Source {
+		if src.Name == name && p.isBuildObjectRef(src) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Searches for any object reference.
+func (p *poolState) HasObjectRef(objRef corev1.ObjectReference) bool {
+	for _, src := range p.pool.Spec.Configuration.Source {
+		if src == objRef {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Searches only for build object references.
+func (p *poolState) HasBuildObjectRef(objRef corev1.ObjectReference) bool {
+	for _, src := range p.pool.Spec.Configuration.Source {
+		if src == objRef && p.isBuildObjectRef(src) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Deletes the build object reference for the build belonging to the current MachineConfig.
+func (p *poolState) DeleteBuildRefForCurrentMachineConfig() {
+	p.DeleteBuildRefByName(newImageBuildRequest(p.pool).getBuildName())
+}
+
+// Deletes all build object references.
+func (p *poolState) DeleteAllBuildRefs() {
+	p.pool.Spec.Configuration.Source = p.getFilteredObjectRefs(func(objRef corev1.ObjectReference) bool {
+		return objRef.Kind == "MachineConfig"
+	})
+}
+
+// Deletes a given object reference.
+func (p *poolState) DeleteObjectRef(toDelete corev1.ObjectReference) {
+	p.pool.Spec.Configuration.Source = p.getFilteredObjectRefs(func(objRef corev1.ObjectReference) bool {
+		return objRef != toDelete
+	})
+}
+
+// Gets all build object references.
+func (p *poolState) GetBuildObjectRefs() []corev1.ObjectReference {
+	return p.getFilteredObjectRefs(func(objRef corev1.ObjectReference) bool {
+		return p.isBuildObjectRef(objRef)
+	})
+}
+
+// Adds a build object reference. Returns an error if a build object reference
+// already exists.
+func (p *poolState) AddBuildObjectRef(objRef corev1.ObjectReference) error {
+	if !p.isBuildObjectRef(objRef) {
+		return fmt.Errorf("%s not a valid build object kind", objRef.Kind)
+	}
+
+	buildRefs := p.GetBuildObjectRefs()
+	if len(buildRefs) != 0 {
+		return fmt.Errorf("cannot add build ObjectReference, found: %v", buildRefs)
+	}
+
+	p.pool.Spec.Configuration.Source = append(p.pool.Spec.Configuration.Source, objRef)
+	return nil
+}
+
+// Clears all build object conditions.
+func (p *poolState) ClearAllBuildConditions() {
+	p.pool.Status.Conditions = clearAllBuildConditions(p.pool.Status.Conditions)
+}
+
+// Idempotently sets the supplied build conditions.
+func (p *poolState) SetBuildConditions(conditions []mcfgv1.MachineConfigPoolCondition) {
+	for _, condition := range conditions {
+		condition := condition
+		currentCondition := mcfgv1.GetMachineConfigPoolCondition(p.pool.Status, condition.Type)
+		if currentCondition != nil && isConditionEqual(*currentCondition, condition) {
+			continue
+		}
+
+		mcpCondition := mcfgv1.NewMachineConfigPoolCondition(condition.Type, condition.Status, condition.Reason, condition.Message)
+		mcfgv1.SetMachineConfigPoolCondition(&p.pool.Status, *mcpCondition)
+	}
+}
+
+// Gets all build conditions.
+func (p *poolState) GetAllBuildConditions() []mcfgv1.MachineConfigPoolCondition {
+	buildConditions := []mcfgv1.MachineConfigPoolCondition{}
+
+	for _, condition := range p.pool.Status.Conditions {
+		if p.isBuildCondition(condition) {
+			buildConditions = append(buildConditions, condition)
+		}
+	}
+
+	return buildConditions
+}
+
+func (p *poolState) isBuildCondition(cond mcfgv1.MachineConfigPoolCondition) bool {
+	for _, condType := range getMachineConfigPoolBuildConditions() {
+		if cond.Type == condType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *poolState) isBuildObjectRef(objRef corev1.ObjectReference) bool {
+	if objRef.Kind == "Pod" {
+		return true
+	}
+
+	if objRef.Kind == "Build" {
+		return true
+	}
+
+	return false
+}
+
+func (p *poolState) getFilteredObjectRefs(filterFunc func(objRef corev1.ObjectReference) bool) []corev1.ObjectReference {
+	refs := []corev1.ObjectReference{}
+
+	for _, src := range p.pool.Spec.Configuration.Source {
+		if filterFunc(src) {
+			refs = append(refs, src)
+		}
+	}
+
+	return refs
+}
+
+// Determines if two conditions are equal. Note: I purposely do not include the
+// timestamp in the equality test, since we do not directly set it.
+func isConditionEqual(cond1, cond2 mcfgv1.MachineConfigPoolCondition) bool {
+	return cond1.Type == cond2.Type &&
+		cond1.Status == cond2.Status &&
+		cond1.Message == cond2.Message &&
+		cond1.Reason == cond2.Reason
+}
+
+func clearAllBuildConditions(inConditions []mcfgv1.MachineConfigPoolCondition) []mcfgv1.MachineConfigPoolCondition {
+	conditions := []mcfgv1.MachineConfigPoolCondition{}
+
+	for _, condition := range inConditions {
+		buildConditionFound := false
+		for _, buildConditionType := range getMachineConfigPoolBuildConditions() {
+			if condition.Type == buildConditionType {
+				buildConditionFound = true
+				break
+			}
+		}
+
+		if !buildConditionFound {
+			conditions = append(conditions, condition)
+		}
+	}
+
+	return conditions
+}

--- a/pkg/controller/build/pool_state_test.go
+++ b/pkg/controller/build/pool_state_test.go
@@ -1,0 +1,188 @@
+package build
+
+import (
+	"testing"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPoolState(t *testing.T) {
+	t.Parallel()
+
+	mcp := helpers.NewMachineConfigPoolBuilder("worker").WithMachineConfig("rendered-worker-1").MachineConfigPool()
+	mcp.Spec.Configuration.Source = []corev1.ObjectReference{
+		{
+			Name: "mc-1",
+			Kind: "MachineConfig",
+		},
+		{
+			Name: "mc-2",
+			Kind: "MachineConfig",
+		},
+	}
+
+	assert.NotEqual(t, mcp.Spec.Configuration, mcp.Status.Configuration)
+
+	ps := newPoolState(mcp)
+
+	ps.SetImagePullspec("registry.host.com/org/repo:tag")
+	assert.True(t, ps.HasOSImage())
+	assert.Equal(t, "registry.host.com/org/repo:tag", ps.GetOSImage())
+}
+
+func TestPoolStateBuildRefs(t *testing.T) {
+	t.Parallel()
+
+	mcRefs := []corev1.ObjectReference{
+		{
+			Name: "mc-1",
+			Kind: "MachineConfig",
+		},
+		{
+			Name: "mc-2",
+			Kind: "MachineConfig",
+		},
+	}
+
+	mcp := helpers.NewMachineConfigPoolBuilder("worker").WithMachineConfig("rendered-worker-1").MachineConfigPool()
+	mcp.Spec.Configuration.Source = append(mcp.Spec.Configuration.Source, mcRefs...)
+
+	assert.NotEqual(t, mcp.Spec.Configuration, mcp.Status.Configuration)
+
+	buildPodRef := corev1.ObjectReference{
+		Kind: "Pod",
+		Name: "build-pod",
+	}
+
+	buildRef := corev1.ObjectReference{
+		Kind: "Build",
+		Name: "build",
+	}
+
+	buildRefTests := []struct {
+		buildRef    corev1.ObjectReference
+		errExpected bool
+	}{
+		{
+			buildRef: buildPodRef,
+		},
+		{
+			buildRef: buildRef,
+		},
+		{
+			buildRef: corev1.ObjectReference{
+				Kind: "MachineConfig",
+				Name: "mc-1",
+			},
+			errExpected: true,
+		},
+	}
+
+	for _, buildRefTest := range buildRefTests {
+		t.Run("BuildRefTest", func(t *testing.T) {
+			ps := newPoolState(mcp)
+			if buildRefTest.errExpected {
+				assert.Error(t, ps.AddBuildObjectRef(buildRefTest.buildRef))
+				return
+			}
+
+			assert.NoError(t, ps.AddBuildObjectRef(buildRefTest.buildRef), "initial insertion should not error")
+			assert.Equal(t, append(mcp.Spec.Configuration.Source, buildRefTest.buildRef), ps.MachineConfigPool().Spec.Configuration.Source)
+			assert.Equal(t, append(mcp.Spec.Configuration.Source, buildRefTest.buildRef), ps.MachineConfigPool().Status.Configuration.Source)
+
+			assert.NotEqual(t, mcp.Spec.Configuration.Source, ps.MachineConfigPool().Spec.Configuration.Source, "should not mutate the underlying MCP")
+			assert.NotEqual(t, mcp.Status.Configuration.Source, ps.MachineConfigPool().Status.Configuration.Source, "should not mutate the underlying MCP")
+
+			assert.Equal(t, []corev1.ObjectReference{buildRefTest.buildRef}, ps.GetBuildObjectRefs(), "expected build refs to include the inserted ref")
+
+			assert.True(t, ps.HasBuildObjectRef(buildRefTest.buildRef))
+			assert.True(t, ps.HasBuildObjectRefName(buildRefTest.buildRef.Name))
+			assert.False(t, ps.HasBuildObjectRef(mcRefs[0]), "MachineConfigs should not match build objects")
+			assert.False(t, ps.HasBuildObjectRefName(mcRefs[0].Name), "MachineConfigs should not match build objects")
+
+			assert.Error(t, ps.AddBuildObjectRef(buildPodRef), "should not be able to insert more than one build ref")
+			assert.Error(t, ps.AddBuildObjectRef(buildRef), "should not be able to insert more than one build ref")
+			ps.DeleteObjectRef(buildRefTest.buildRef)
+			assert.Equal(t, mcp.Spec.Configuration.Source, ps.pool.Spec.Configuration.Source)
+
+			assert.NoError(t, ps.AddBuildObjectRef(buildRefTest.buildRef))
+			ps.DeleteBuildRefByName(buildRefTest.buildRef.Name)
+			assert.False(t, ps.HasBuildObjectRef(buildRefTest.buildRef))
+			assert.False(t, ps.HasBuildObjectRefName(buildRefTest.buildRef.Name))
+			assert.Equal(t, mcp.Spec.Configuration.Source, ps.pool.Spec.Configuration.Source)
+
+			assert.NoError(t, ps.AddBuildObjectRef(buildRefTest.buildRef))
+			ps.DeleteAllBuildRefs()
+			assert.False(t, ps.HasBuildObjectRef(buildRefTest.buildRef))
+			assert.False(t, ps.HasBuildObjectRefName(buildRefTest.buildRef.Name))
+			assert.Equal(t, mcp.Spec.Configuration.Source, ps.pool.Spec.Configuration.Source)
+
+			outMCP := ps.MachineConfigPool()
+			assert.Equal(t, outMCP.Spec.Configuration, outMCP.Status.Configuration)
+		})
+	}
+}
+
+func TestPoolStateConditions(t *testing.T) {
+	t.Parallel()
+
+	mcp := helpers.NewMachineConfigPoolBuilder("worker").WithMachineConfig("rendered-worker-1").MachineConfigPool()
+	ps := newPoolState(mcp)
+
+	conditionTests := []struct {
+		condType  mcfgv1.MachineConfigPoolConditionType
+		checkFunc func() bool
+	}{
+		{
+			condType:  mcfgv1.MachineConfigPoolBuildFailed,
+			checkFunc: ps.IsBuildFailure,
+		},
+		{
+			condType:  mcfgv1.MachineConfigPoolBuildPending,
+			checkFunc: ps.IsBuildPending,
+		},
+		{
+			condType:  mcfgv1.MachineConfigPoolBuildSuccess,
+			checkFunc: ps.IsBuildSuccess,
+		},
+		{
+			condType:  mcfgv1.MachineConfigPoolBuilding,
+			checkFunc: ps.IsBuilding,
+		},
+	}
+
+	for _, condTest := range conditionTests {
+		t.Run(string(condTest.condType), func(t *testing.T) {
+			ps.SetBuildConditions([]mcfgv1.MachineConfigPoolCondition{
+				{
+					Status: corev1.ConditionTrue,
+					Type:   condTest.condType,
+				},
+			})
+
+			assert.True(t, condTest.checkFunc())
+
+			ps.SetBuildConditions([]mcfgv1.MachineConfigPoolCondition{
+				{
+					Status: corev1.ConditionFalse,
+					Type:   condTest.condType,
+				},
+			})
+
+			assert.False(t, condTest.checkFunc())
+		})
+	}
+
+	ps.ClearAllBuildConditions()
+	buildConditionTypes := getMachineConfigPoolBuildConditions()
+	for _, condition := range mcp.Status.Conditions {
+		for _, conditionType := range buildConditionTypes {
+			if conditionType == condition.Type {
+				t.Fatalf("expected not to find any build conditions, found: %v", conditionType)
+			}
+		}
+	}
+}

--- a/pkg/controller/common/layered_pool_state.go
+++ b/pkg/controller/common/layered_pool_state.go
@@ -67,3 +67,31 @@ func (l *LayeredPoolState) IsBuilding() bool {
 func (l *LayeredPoolState) IsBuildFailure() bool {
 	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolBuildFailed)
 }
+
+func (l *LayeredPoolState) IsAnyDegraded() bool {
+	condTypes := []mcfgv1.MachineConfigPoolConditionType{
+		mcfgv1.MachineConfigPoolDegraded,
+		mcfgv1.MachineConfigPoolNodeDegraded,
+		mcfgv1.MachineConfigPoolRenderDegraded,
+	}
+
+	for _, condType := range condTypes {
+		if mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, condType) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *LayeredPoolState) IsDegraded() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolDegraded)
+}
+
+func (l *LayeredPoolState) IsNodeDegraded() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolNodeDegraded)
+}
+
+func (l *LayeredPoolState) IsRenderDegraded() bool {
+	return mcfgv1.IsMachineConfigPoolConditionTrue(l.pool.Status.Conditions, mcfgv1.MachineConfigPoolRenderDegraded)
+}


### PR DESCRIPTION
**- What I did**

This makes the BuildController unit tests less flaky in a couple of ways:
1. Consolidates all MachineConfigPool object interrogation / mutation into a single place.
2. Ensures that MachineConfigPool object updates are retried in the event of a conflict. This work was imported from https://github.com/openshift/machine-config-operator/pull/3894 and should be merged as part of this PR.

**- How to verify it**

To verify this, the unit test suite must be run exhaustively. To reproduce this locally, one can clone this PR and run: `$ go test -count=100 -failfast ./pkg/controller/build` This will effectively run the unit test suite 100 times. While I cannot completely guarantee that it will never fail, the likelihood that it will is substantially reduced.

**- Description for the changelog**
Stabilizes BuildController unit test suite