### PR TITLE
OCPBUGS-18523: Fix references to coreos-ignition-firstboot-complete service

### DIFF
--- a/templates/common/_base/units/kubelet-auto-node-size.service.yaml
+++ b/templates/common/_base/units/kubelet-auto-node-size.service.yaml
@@ -4,7 +4,7 @@ contents: |
   [Unit]
   Description=Dynamically sets the system reserved for the kubelet
   Wants=network-online.target
-  After=network-online.target ignition-firstboot-complete.service
+  After=network-online.target coreos-ignition-firstboot-complete.service
   Before=kubelet.service crio.service
   [Service]
   # Need oneshot to delay kubelet

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -6,7 +6,7 @@ contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service crio-wipe.service
-  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  After=NetworkManager-wait-online.service coreos-ignition-firstboot-complete.service crio-wipe.service
   Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -7,7 +7,7 @@ contents: |
   # address picking logic is flawed and may end up selecting an address from a
   # different subnet or a deprecated address
   Wants=NetworkManager-wait-online.service crio-wipe.service
-  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  After=NetworkManager-wait-online.service coreos-ignition-firstboot-complete.service crio-wipe.service
   Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -17,7 +17,7 @@ contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service crio-wipe.service
-  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
+  After=NetworkManager-wait-online.service coreos-ignition-firstboot-complete.service crio-wipe.service
   Before=kubelet.service crio.service ovs-configuration.service
 
   [Service]


### PR DESCRIPTION
The ignition-firstboot-complete service was renamed to coreos-ignition-firstboot-complete a while ago, but the references in MCO were not updated. This fixes the name of the service in the dependency lists.

This raises the question of whether the dependency is even necessary since nothing seems to have broken when it was incorrect, but the easiest path is just to fix the reference rather than try to prove it isn't necessary anymore.

**- Description for the changelog**
Fixed reference to coreos-ignition-firstboot-complete service in some dependent service files.