### PR TITLE
OCPBUGS-18772: resolv-prepender: avoid pulling baremetalRuntimeCfgImage again 

### DIFF
--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -18,6 +18,9 @@ contents:
     {{end -}}
 
     function pull_baremetal_runtime_cfg_image {
+        if [[ "$(/usr/bin/podman images  --quiet {{ .Images.baremetalRuntimeCfgImage }} | wc -l)" == "1" ]]; then
+            return 0
+        fi
         >&2 echo "NM resolv-prepender: Starting download of baremetal runtime cfg image"
         while ! /usr/bin/podman pull --authfile /var/lib/kubelet/config.json {{ .Images.baremetalRuntimeCfgImage }}; do sleep 1; done
         >&2 echo "NM resolv-prepender: Download of baremetal runtime cfg image completed"


### PR DESCRIPTION
Avoid pulling baremetalRuntimeCfgImage again if it already exists on the node

`pull_baremetal_runtime_cfg_image` function should avoid  pull attempt if this image already present on the node. This ensures DNS prepender can work when mirror/quay image is temporarily unreachable

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Updated resolv-prepender.sh to make sure that pull is not running if the image already exists on the node 

**- How to verify it**
Check networkmanager logs - it should have `NM resolv-prepender: Starting download of baremetal runtime cfg image` just once (in upgrade case you may see it twice) for on-premise jobs, i.e.:
```
wget -O - https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/3907/pull-ci-openshift-machine-config-operator-master-e2e-vsphere/1701162972396654592/artifacts/e2e-vsphere/gather-extra/artifacts/nodes/ci-op-8s25i4px-6b38f-9262w-master-0/journal | zgrep "Starting download"    
--2023-09-11 13:27:38--  https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/3907/pull-ci-openshift-machine-config-operator-master-e2e-vsphere/1701162972396654592/artifacts/e2e-vsphere/gather-extra/artifacts/nodes/ci-op-8s25i4px-6b38f-9262w-master-0/journal
Resolving gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com (gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com)... 52.205.222.12, 52.23.49.187
Connecting to gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com (gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com)|52.205.222.12|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/gzip]
Saving to: ‘STDOUT’

-                                                   [  <=>                                                                                                  ] 243.70K   589KB/s               Sep 11 09:35:54.580706 ci-op-8s25i4px-6b38f-9262w-master-0 resolv-prepender.sh[2139]: NM resolv-prepender: Starting download of baremetal runtime cfg image
-                                                   [   <=>                                                                                                 ] 712.49K  1.26MB/s    in 0.6s    

2023-09-11 13:27:39 (1.26 MB/s) - written to stdout [729591]
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
resolve-prepender no longer needs reachable image source
