### PR TITLE
Improve kubelet error log

### DIFF
--- a/templates/common/on-prem/units/kubelet.service-wait-resolv.yaml
+++ b/templates/common/on-prem/units/kubelet.service-wait-resolv.yaml
@@ -6,5 +6,5 @@ dropins:
       [Service]
       # Wait for resolv-prepender to configure nameservers, exit 255 otherwise
       # to mark the unit as failed and retry later
-      ExecCondition=/bin/bash -c 'test -f /run/resolv-prepender-kni-conf-done || exit 255'
+      ExecCondition=/bin/bash -c '[ -f /run/resolv-prepender-kni-conf-done ] || { echo "NM resolv-prepender failed"; exit 255; }'
       {{end -}}


### PR DESCRIPTION
Fixes: #OCPBUGS-18911

**- What I did**
Added  message before we exit with 255 status

**- How to verify it**
To quickly reproduce just delete  /run/resolv-prepender-kni-conf-done on IPI cluster and restart kubelet. 

**- Description for the changelog**

Improve kubelet error log when there is an issue with resolv-prepender

