### PR TITLE
[release-4.13] OCPBUGS-19414: The kubeconfig copied on to each node has 644 permissions

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeErrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -545,6 +546,11 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			}
 		}
 	}()
+
+	// update file permissions
+	if err := dn.updateKubeConfigPermission(); err != nil {
+		return err
+	}
 
 	if err := dn.updateSSHKeys(newIgnConfig.Passwd.Users); err != nil {
 		return err
@@ -1648,6 +1654,23 @@ func (dn *Daemon) SetPasswordHash(newUsers []ign3types.PasswdUser) error {
 		glog.Info("Password has been configured")
 	}
 
+	return nil
+}
+
+// Update the permission of the kubeconfig file located in /etc/kubenetes/kubeconfig
+// Requested in https://issues.redhat.com/browse/OCPBUGS-15367
+func (dn *Daemon) updateKubeConfigPermission() error {
+	klog.Info("updating the permission of the kubeconfig to: 0o600")
+
+	kubeConfigPath := "/etc/kubernetes/kubeconfig"
+	// Checking if kubeconfig is existed in the expected path:
+	if _, err := os.Stat(kubeConfigPath); err == nil {
+		if err := os.Chmod(kubeConfigPath, 0o600); err != nil {
+			return fmt.Errorf("Failed to reset permission for %s:%w", kubeConfigPath, err)
+		}
+	} else {
+		return fmt.Errorf("Cannot stat %s: %w", kubeConfigPath, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/3808
/assign yuqi-zhang