### PR TITLE
OCPBUGS-19628: Log network service output to console

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -37,6 +37,8 @@ contents: |
     done"
   ExecStart=/bin/systemctl daemon-reload
   ExecStartPre=/bin/mkdir -p /run/nodeip-configuration
+  StandardOutput=journal+console
+  StandardError=journal+console
 
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -45,6 +45,8 @@ contents: |
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}
   ExecStartPost=+/usr/local/bin/configure-ip-forwarding.sh
+  StandardOutput=journal+console
+  StandardError=journal+console
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -47,6 +47,8 @@ contents: |
     done"
   ExecStart=/bin/systemctl daemon-reload
   ExecStartPre=/bin/mkdir -p /run/nodeip-configuration
+  StandardOutput=journal+console
+  StandardError=journal+console
 
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env


### PR DESCRIPTION
When early boot network services get stuck, in some circumstances it can make debugging difficult because it prevents ssh login. This change adds configuration to log their output to the console so it is at least possible to see where the node is stuck when something fails repeatedly.

This is already being done in ovs-configuration, and it makes sense to do it for nodeip-configuration too.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Log nodeip-configuration output to the console for debugging in cases where networking is broken.
