### PR TITLE
[release-4.13] OCPBUGS-19658: After dual-stack conversion reconcile IPFamilies

### DIFF
--- a/lib/resourcemerge/machineconfig.go
+++ b/lib/resourcemerge/machineconfig.go
@@ -82,6 +82,8 @@ func ensureControllerConfigSpec(modified *bool, existing *mcfgv1.ControllerConfi
 	setBytesIfSet(modified, &existing.KubeAPIServerServingCAData, required.KubeAPIServerServingCAData)
 	setBytesIfSet(modified, &existing.CloudProviderCAData, required.CloudProviderCAData)
 
+	setIPFamiliesIfSet(modified, &existing.IPFamilies, required.IPFamilies)
+
 	if required.Infra != nil && !equality.Semantic.DeepEqual(existing.Infra, required.Infra) {
 		*modified = true
 		existing.Infra = required.Infra

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -1,10 +1,24 @@
 package resourcemerge
 
+import (
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
 func setBytesIfSet(modified *bool, existing *[]byte, required []byte) {
 	if len(required) == 0 {
 		return
 	}
 	if string(required) != string(*existing) {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setIPFamiliesIfSet(modified *bool, existing *mcfgv1.IPFamiliesType, required mcfgv1.IPFamiliesType) {
+	if len(required) == 0 {
+		return
+	}
+	if required != *existing {
 		*existing = required
 		*modified = true
 	}


### PR DESCRIPTION
This PR introduces a missing reconciliation of IPFamilies property in the ControllerConfig. A consequence of the reconciliation missing is that after conversion from single-stack to dual-stack the kubelet is still configured as single-stack because the underlying MCO's variable does not change its value.

With this PR, when converting such a cluster, ControllerConfig will update the value and as a consequence reconfigure kubelet (specifically `--node-ip` param).

Please note with this change we are introducing one reboot to the process of cluster conversion.

Fixes: OCPBUGS-15910
Cherry-picks: https://github.com/openshift/machine-config-operator/pull/3909