### PR TITLE
OCPBUGS-18771: Add escape hatch for remote-worker feature

### DIFF
--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -27,7 +27,7 @@ contents: |
     {{ .Images.baremetalRuntimeCfgImage }} \
     node-ip \
     set \
-    --platform {{ .Infra.Status.PlatformStatus.Type }} \
+    --platform ${REMOTE_WORKER_OVERRIDE:-{{ .Infra.Status.PlatformStatus.Type }}} \
     {{if not (isOpenShiftManagedDefaultLB .) -}}
     --user-managed-lb \
     {{end -}}


### PR DESCRIPTION
This feature has turned out to be problematic in quite a few environments, including some that we unfortunately didn't know about prior to shipping it. Because of that, we have deployments that are blocked from upgrading to 4.13 because this breaks their LB setup.

Unfortunately, fixing this properly is non-trivial and probably not a good idea to backport. Instead, this patch provides a mechanism to disable the feature where it is not desired. This should unblock existing deployments and give us time to support their scenarios properly.

The simplest way to disable this is to tell runtimecfg that the platform is something other than baremetal since we already disable it everywhere else. This patch adds an environment variable to the nodeip-configuration service that can be set to do so. Users will set this by creating a file such as
/etc/systemd/system/nodeip-configuration.service.d/11-override.conf with the contents:
[Service]
Environment="REMOTE_WORKER_OVERRIDE=true"

The specific value does not matter as long as it is not any variation of "baremetal", but I think setting it to true best indicates the intent of the variable.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Provide a way to disable the remote-worker logic in nodeip-configuration.
