### PR TITLE
OCPBUGS-18771: Consider ingress VIPs when selecting node IP

### DIFF
--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -35,7 +35,8 @@ contents: |
     --prefer-ipv6 \
     {{end -}}
     --retry-on-failure \
-    {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}}; \
+    {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}} \
+    {{ range onPremPlatformIngressIPs . }}{{.}} {{end}}; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
We never intended to support ingress and API VIPs on different subnets, but it turns out we didn't prevent it either and it was working up until 4.13 so we have clusters deployed in production that use such an architecture. In 4.13 this was broken by the automatic remote worker functionality because we only look at the API VIPs when selecting the node IP, and as a result the nodes on the ingress VIP subnet looked like remote workers and would not start keepalived or schedule ingress router pods.

To restore the previous behavior we can just include the ingress VIPs in the call to node-ip set so nodes on the ingress VIP subnet will also be seen as non-remote.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
Also use ingress VIPs when searching for node IP.
