### PR TITLE
OCPBUGS-19708: Support to append the duplicate kernel arguments to the rendered MC

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -140,11 +140,7 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.Contro
 
 	kargs := []string{}
 	for _, cfg := range configs {
-		for _, arg := range cfg.Spec.KernelArguments {
-			if !InSlice(arg, kargs) {
-				kargs = append(kargs, arg)
-			}
-		}
+		kargs = append(kargs, cfg.Spec.KernelArguments...)
 	}
 
 	extensions := []string{}

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -99,8 +99,6 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 				Kind:       controllerKind.Kind,
 			}
 			mc.SetOwnerReferences([]metav1.OwnerReference{oref})
-			// updating the machine config resource with the relevant cgroup configuration
-			updateMachineConfigwithCgroup(nodeConfig, mc)
 			res = append(res, mc)
 		}
 	}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-19708

- This code change allows the user to configure duplicate kArgs via MC.
- Also fixes failure of the bootstrap-unit ci job while enabling the above functionality

cc: @sinnykumari 