### PR TITLE
OCPCLOUD-1609: Set guestinfo.hostname for CAPI VMs on vSphere

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -11,3 +11,9 @@ contents:
     if vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.hostname'); then
         /usr/bin/hostnamectl set-hostname --static ${vm_name}
     fi
+
+    if [ -z "${vm_name}" ]; then
+      if capi_vm_name=$(bin/vmtoolsd --cmd 'info-get guestinfo.metadata' | base64 -d | grep local-hostname | awk '{ print $2; }' | tr -d '",'; then
+        /usr/bin/hostnamectl set-hostname --static ${capi_vm_name}
+      fi
+    fi


### PR DESCRIPTION
Currently, the virtual machines on vCenter don't have `guestinfo.hostname` when using CAPI on OCP. This PR adds another check to see whether `vm_name` variable is empty, therefore we take the hostname from the metadata.