### PR TITLE
DO NOT MERGE: Revert "Merge pull request #3789 from sairameshv/cgroupsv2-default"

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -76,12 +76,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
 		return err
 	}
-	// explicitly setting the cgroupMode to "v2" and also updating the config node's spec if found empty
-	// This helps in updating the cgroupMode on all the worker nodes if they still have cgroupsv1 (Ex: RHEL8 workers)
-	if nodeConfig.Spec.CgroupMode == osev1.CgroupModeEmpty {
-		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV2
-		ctrl.configClient.ConfigV1().Nodes().Update(context.TODO(), nodeConfig, metav1.UpdateOptions{})
-	}
 	// checking if the Node spec is empty and accordingly returning from here.
 	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
 		klog.V(2).Info("empty Node resource found")
@@ -276,11 +270,6 @@ func (ctrl *Controller) deleteNodeConfig(obj interface{}) {
 func RunNodeConfigBootstrap(templateDir string, featureGateAccess featuregates.FeatureGateAccess, cconfig *mcfgv1.ControllerConfig, nodeConfig *osev1.Node, mcpPools []*mcfgv1.MachineConfigPool) ([]*mcfgv1.MachineConfig, error) {
 	if nodeConfig == nil {
 		return nil, fmt.Errorf("nodes.config.openshift.io resource not found")
-	}
-	// explicitly setting the cgroupMode to "v2" and also updating the config node's spec if found empty
-	// This helps in updating the cgroupMode on all the worker nodes if they still have cgroupsv1 (Ex: RHEL8 workers)
-	if nodeConfig.Spec.CgroupMode == osev1.CgroupModeEmpty {
-		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV2
 	}
 	// checking if the Node spec is empty and accordingly returning from here.
 	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -94,8 +94,8 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 			if err != nil {
 				t.Errorf("could not run node config bootstrap: %v", err)
 			}
-			if len(mcs) != 2 {
-				t.Errorf("expected %v machine configs generated with the default node config, got 0 machine configs", len(mcs))
+			if len(mcs) != 0 {
+				t.Errorf("expected no machine configs generated with the default node config, got %v machine configs", len(mcs))
 			}
 		})
 	}

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -124,11 +124,8 @@ kind: Node
 metadata:
   name: cluster`),
 			},
-			// "CgroupMode" field in the nodes.config resource is empty
-			// Internally it gets updated to "v2" explicitly
-			// Hence, 97-{master/worker}-generated-kubelet are expected
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
+			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
 		},
 		{
 			name: "With a node config manifest empty \"cgroupMode\"",
@@ -140,10 +137,8 @@ metadata:
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction`),
 			},
-			// "CgroupMode" field in the nodes.config resource is empty
-			// Internally it gets updated to "v2" explicitly
-			// Hence, 97-{master/worker}-generated-kubelet are expected
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
+
+			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
@@ -270,8 +265,6 @@ spec:
       memory: 500Mi
 `),
 			},
-			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
-			// internally translates to "v2"
 			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
 			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},


### PR DESCRIPTION
This reverts commit ddea245222e437e2259bb56f559a2b36fa7eaea0, reversing changes made to 312e16d6da6f40d58ac06defb4f94398cae7b417.

This PR attempts reverting the change to make cgroups v2 default in OCP after it was flagged in https://issues.redhat.com/browse/OCPBUGS-19388 as a potential cause for CPU utilization increase.

This PR will only be used for investigation purposes.