### PR TITLE
Get the nmstate pinned package from kojihub when building on top of a CentOS base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,16 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     elif [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for scos
     sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    # pin nmstate to 2.2.9 until we update to https://github.com/openshift/machine-config-operator/pull/3720
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install nmstate-2.2.9-6.rhaos4.14.el8 && dnf clean all && rm -rf /var/cache/dnf/*
+    # pin nmstate to 2.2.9 until we update to https://github.com/openshift/machine-config-operator/pull/3720 \
+    . /etc/os-release; \
+    NMSTATE_PKG=nmstate-2.2.9-6.rhaos4.14.el8; \
+    if [ "${ID}" == "centos" ]; then \
+        GNU_ARCH=$(uname -m); \
+        NMSTATE_PKG="https://kojihub.stream.centos.org/kojifiles/packages/nmstate/2.2.9/1.el9/${GNU_ARCH}/nmstate-2.2.9-1.el9.${GNU_ARCH}.rpm"; \
+    fi && \
+    dnf -y install ${NMSTATE_PKG} && \
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && \
+    dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -32,8 +32,16 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     elif [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for scos
     sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    # pin nmstate to 2.2.9 until we update to https://github.com/openshift/machine-config-operator/pull/3720
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install nmstate-2.2.9-6.rhaos4.14.el8 && dnf clean all && rm -rf /var/cache/dnf/*
+    # pin nmstate to 2.2.9 until we update to https://github.com/openshift/machine-config-operator/pull/3720 \
+    . /etc/os-release; \
+    NMSTATE_PKG=nmstate-2.2.9-6.rhaos4.14.el8; \
+    if [ "${ID}" == "centos" ]; then \
+        GNU_ARCH=$(uname -m); \
+        NMSTATE_PKG="https://kojihub.stream.centos.org/kojifiles/packages/nmstate/2.2.9/1.el9/${GNU_ARCH}/nmstate-2.2.9-1.el9.${GNU_ARCH}.rpm"; \
+    fi && \
+    dnf -y install ${NMSTATE_PKG} && \
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && \
+    dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
openshift/machine-config-operator#3769 pinned the nmstate package to version 2.2.9 until the breaking changes of the newer versions are addressed in the code base of the MCO. 

The changes in this PR allow to build the image on top of CS9 base images that do not have nmstate-2.2.9 in the current repositories by retrieving it from kojihub. This is useful when building the entire OKD payload on top of CS9 base images
