### PR TITLE
OCPBUGS-19722: Informers are setup with incorrect namespace

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -66,7 +66,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	run := func(ctx context.Context) {
 		go common.SignalHandler(runCancel)
 
-		ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb, componentName)
+		ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 
 		// Start the metrics handler
 		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctrlctx.Stop, ctrlcommon.RegisterMCCMetrics)

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -142,7 +142,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 	if startOpts.hypershiftDesiredConfigMap != "" {
 		// This is a hypershift-mode daemon
-		ctx := ctrlcommon.CreateControllerContext(ctx, cb, componentName)
+		ctx := ctrlcommon.CreateControllerContext(ctx, cb)
 		err := dn.HypershiftConnect(
 			startOpts.nodeName,
 			kubeClient,
@@ -165,7 +165,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	// Start local metrics listener
 	go ctrlcommon.StartMetricsListener(startOpts.promMetricsURL, stopCh, daemon.RegisterMCDMetrics)
 
-	ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb, componentName)
+	ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 	// create the daemon instance. this also initializes kube client items
 	// which need to come from the container and not the chroot.
 	err = dn.ClusterConnect(

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -66,7 +66,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	run := func(ctx context.Context) {
 		go common.SignalHandler(runCancel)
 
-		ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb, ctrlcommon.MCONamespace)
+		ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 		controller := operator.New(
 			ctrlcommon.MCONamespace, componentName,
 			startOpts.imagesFile,

--- a/cmd/machine-os-builder/start.go
+++ b/cmd/machine-os-builder/start.go
@@ -66,7 +66,7 @@ func getBuildController(ctx context.Context, cb *clients.Builder) (*build.Contro
 		return nil, err
 	}
 
-	ctrlCtx := ctrlcommon.CreateControllerContext(ctx, cb, componentName)
+	ctrlCtx := ctrlcommon.CreateControllerContext(ctx, cb)
 	buildClients := build.NewClientsFromControllerContext(ctrlCtx)
 	cfg := build.DefaultBuildControllerConfig()
 

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -68,16 +68,16 @@ type ControllerContext struct {
 }
 
 // CreateControllerContext creates the ControllerContext with the ClientBuilder.
-func CreateControllerContext(ctx context.Context, cb *clients.Builder, targetNamespace string) *ControllerContext {
+func CreateControllerContext(ctx context.Context, cb *clients.Builder) *ControllerContext {
 	client := cb.MachineConfigClientOrDie("machine-config-shared-informer")
 	kubeClient := cb.KubeClientOrDie("kube-shared-informer")
 	apiExtClient := cb.APIExtClientOrDie("apiext-shared-informer")
 	configClient := cb.ConfigClientOrDie("config-shared-informer")
 	operatorClient := cb.OperatorClientOrDie("operator-shared-informer")
 	sharedInformers := mcfginformers.NewSharedInformerFactory(client, resyncPeriod()())
-	sharedNamespacedInformers := mcfginformers.NewFilteredSharedInformerFactory(client, resyncPeriod()(), targetNamespace, nil)
+	sharedNamespacedInformers := mcfginformers.NewFilteredSharedInformerFactory(client, resyncPeriod()(), MCONamespace, nil)
 	kubeSharedInformer := informers.NewSharedInformerFactory(kubeClient, resyncPeriod()())
-	kubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), targetNamespace, nil)
+	kubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), MCONamespace, nil)
 	openShiftConfigKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), "openshift-config", nil)
 	openShiftKubeAPIServerKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient,
 		resyncPeriod()(),
@@ -99,19 +99,19 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder, targetNam
 		opts.LabelSelector = labels.Merge(labelsMap, map[string]string{daemonconsts.OpenShiftOperatorManagedLabel: ""}).String()
 	}
 	apiExtSharedInformer := apiextinformers.NewSharedInformerFactoryWithOptions(apiExtClient, resyncPeriod()(),
-		apiextinformers.WithNamespace(targetNamespace), apiextinformers.WithTweakListOptions(assignFilterLabels))
+		apiextinformers.WithNamespace(MCONamespace), apiextinformers.WithTweakListOptions(assignFilterLabels))
 	configSharedInformer := configinformers.NewSharedInformerFactory(configClient, resyncPeriod()())
 	operatorSharedInformer := operatorinformers.NewSharedInformerFactory(operatorClient, resyncPeriod()())
 
 	desiredVersion := version.ReleaseVersion
 	missingVersion := "0.0.1-snapshot"
 
-	controllerRef, err := events.GetControllerReferenceForCurrentPod(ctx, kubeClient, targetNamespace, nil)
+	controllerRef, err := events.GetControllerReferenceForCurrentPod(ctx, kubeClient, MCONamespace, nil)
 	if err != nil {
 		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 	}
 
-	recorder := events.NewKubeRecorder(kubeClient.CoreV1().Events(targetNamespace), "cloud-controller-manager-operator", controllerRef)
+	recorder := events.NewKubeRecorder(kubeClient.CoreV1().Events(MCONamespace), "cloud-controller-manager-operator", controllerRef)
 
 	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
 	featureGateAccessor := featuregates.NewFeatureGateAccess(

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -420,7 +420,7 @@ func compareRenderedConfigPool(t *testing.T, clientSet *framework.ClientSet, des
 func newTestFixture(t *testing.T, cfg *rest.Config, objs []runtime.Object) *fixture {
 	ctx, stop := context.WithCancel(context.Background())
 	cb := clients.BuilderFromConfig(cfg)
-	ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb, bootstrapTestName)
+	ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 
 	clientSet := framework.NewClientSetFromConfig(cfg)
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the namspace argument in CreateControllerContext, since this seems like it should be a constant for all pods. Sending a wrong namespace argument(we were sending in the componentName in most cases, except the operator)  would break the informer - we didn't run into this before because we were luckily not using namespace based informers in these pods. Let's see if removing this argument breaks anything. 


**- Description for the changelog**
controller: remove namespace arg in context create
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
