### PR TITLE
ensure that object kind is set in ObjectReferences

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -370,7 +370,7 @@ func (ctrl *Controller) imageBuildUpdater(build *buildv1.Build) error {
 
 	klog.Infof("Build (%s) is %s", build.Name, build.Status.Phase)
 
-	objRef := toObjectRef(build)
+	objRef := toBuildObjectRef(build)
 
 	ps := newPoolState(pool)
 
@@ -418,7 +418,7 @@ func (ctrl *Controller) customBuildPodUpdater(pod *corev1.Pod) error {
 	switch pod.Status.Phase {
 	case corev1.PodPending:
 		if !ps.IsBuildPending() {
-			objRef := toObjectRef(pod)
+			objRef := toPodObjectRef(pod)
 			err = ctrl.markBuildPendingWithObjectRef(ps, *objRef)
 		}
 	case corev1.PodRunning:

--- a/pkg/controller/build/helpers.go
+++ b/pkg/controller/build/helpers.go
@@ -12,12 +12,11 @@ import (
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/opencontainers/go-digest"
+	buildv1 "github.com/openshift/api/build/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -218,18 +217,21 @@ func getPullSecretKey(secret *corev1.Secret) (string, error) {
 	return key, nil
 }
 
-// Converts a given Kube object into an object reference.
-func toObjectRef(obj interface {
-	GetName() string
-	GetNamespace() string
-	GetUID() k8stypes.UID
-	GetObjectKind() schema.ObjectKind
-}) *corev1.ObjectReference {
+func toBuildObjectRef(build *buildv1.Build) *corev1.ObjectReference {
 	return &corev1.ObjectReference{
-		Kind:      obj.GetObjectKind().GroupVersionKind().Kind,
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		UID:       obj.GetUID(),
+		Kind:      "Build",
+		Name:      build.GetName(),
+		Namespace: build.GetNamespace(),
+		UID:       build.GetUID(),
+	}
+}
+
+func toPodObjectRef(pod *corev1.Pod) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:      "Pod",
+		Name:      pod.GetName(),
+		Namespace: pod.GetNamespace(),
+		UID:       pod.GetUID(),
 	}
 }
 

--- a/pkg/controller/build/image_build_controller.go
+++ b/pkg/controller/build/image_build_controller.go
@@ -245,7 +245,7 @@ func (ctrl *ImageBuildController) StartBuild(ibr ImageBuildRequest) (*corev1.Obj
 	// This means we found a preexisting build build.
 	if build != nil && err == nil && hasAllRequiredOSBuildLabels(build.Labels) {
 		klog.Infof("Found preexisting OS image build (%s) for pool %s", build.Name, ibr.Pool.Name)
-		return toObjectRef(build), nil
+		return toBuildObjectRef(build), nil
 	}
 
 	klog.Infof("Starting build for pool %s", ibr.Pool.Name)
@@ -259,7 +259,7 @@ func (ctrl *ImageBuildController) StartBuild(ibr ImageBuildRequest) (*corev1.Obj
 
 	klog.Infof("Build started for pool %s in %s!", ibr.Pool.Name, build.Name)
 
-	return toObjectRef(build), nil
+	return toBuildObjectRef(build), nil
 }
 
 // Fires whenever a Build is added.

--- a/pkg/controller/build/pod_build_controller.go
+++ b/pkg/controller/build/pod_build_controller.go
@@ -256,7 +256,7 @@ func (ctrl *PodBuildController) StartBuild(ibr ImageBuildRequest) (*corev1.Objec
 	// This means we found a preexisting build pod.
 	if pod != nil && err == nil && hasAllRequiredOSBuildLabels(pod.Labels) {
 		klog.Infof("Found preexisting build pod (%s) for pool %s", pod.Name, ibr.Pool.Name)
-		return toObjectRef(pod), nil
+		return toPodObjectRef(pod), nil
 	}
 
 	klog.Infof("Starting build for pool %s", ibr.Pool.Name)
@@ -270,7 +270,7 @@ func (ctrl *PodBuildController) StartBuild(ibr ImageBuildRequest) (*corev1.Objec
 
 	klog.Infof("Build started for pool %s in %s!", ibr.Pool.Name, pod.Name)
 
-	return toObjectRef(pod), nil
+	return toPodObjectRef(pod), nil
 }
 
 // Fires whenever a new pod is started.


### PR DESCRIPTION
**- What I did**

Rather than infer the Kind from the Build and Pod objects, we should explicitly
set them. Whenever these objects are returned from the API server, the Kind
field is not populated. Because we expect it to be populated, this causes
errors within the rest of the BuildController state machine. 

**- How to verify it**

Run the unit test suite and the e2e test suite

**- Description for the changelog**
Explicitly set Kind for ObjectReferences
