### PR TITLE
OCPBUGS-16871: MCO - currentConfig missing on the filesystem

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -110,9 +110,15 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 	}
 
 	var inDesiredConfig bool
-	if inDesiredConfig, err = dn.updateConfigAndState(state); err != nil {
+	var missingODC bool
+	if missingODC, inDesiredConfig, err = dn.updateConfigAndState(state); err != nil {
 		return fmt.Errorf("could not apply update: setting node's state to Done failed. Error: %w", err)
 	}
+
+	if missingODC {
+		return fmt.Errorf("error updating state.currentconfig from on-disk currentconfig")
+	}
+
 	if inDesiredConfig {
 		// (re)start the config drift monitor since rebooting isn't needed.
 		dn.startConfigDriftMonitor()


### PR DESCRIPTION
**- What I did**
Set up a backup plan for on-disk current config reading, so that the call will reads the current config from the node annotation when the currentConfig is missing on the filesystem 

**- How to verify it**
Before:

1. remove the currentConfig (/etc/machine-config-daemon/currentConfig)  from the node 
2. apply an update 
3. check the status of the MCO 
RESULT: DEGRADED

After:

1. remove the currentConfig (/etc/machine-config-daemon/currentConfig) from the node
2. apply an update
3. check the status of the MCO
RESULT: update went through; the mcp did not get degraded; currentConfig got written back to the disk at some point
