### PR TITLE
OCPBUGS-20338: dashboard should detect unknown and not ready for not ready dashboard

### DIFF
--- a/install/0000_90_machine-config-operator_01_node_dashboard.yaml
+++ b/install/0000_90_machine-config-operator_01_node_dashboard.yaml
@@ -87,7 +87,7 @@ data:
                         },
                         "targets": [
                             {
-                                "expr": "sum(kube_node_status_condition{condition=\"Ready\", status=\"false\"})",
+                                "expr": "sum(kube_node_status_condition{condition=\"Ready\", status=~\"unknown|false\"})",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
                                 "metric": "kube_node_status_condition",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: https://issues.redhat.com/browse/OCPBUGS-20338

**- What I did**
This dashboard is used to report the number of not ready nodes.  If a node stops reporting its status, it is possible to have a condition status that says `unknown` rather than `false`.  We should check for both unknown and false.

**- How to verify it**
I applied this yaml to an existing 4.14 cluster and verified that the query works.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
NodeNotReady should report both unknown and false for reporting unhealthy nodes.