### PR TITLE
MCO-681, OCPBUGS-20427: Add Key State Metrics, No datapoint found when querying up certain registered metrics

### DIFF
--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -38,6 +38,12 @@ var (
 			Name: "mcc_pool_alert",
 			Help: "pool status alert",
 		}, []string{"node"})
+	// MCCSubControllerState logs the state of the subcontrollers of the MCC
+	MCCSubControllerState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mcc_sub_controller_state",
+			Help: "state of sub-controllers in the MCC",
+		}, []string{"subcontroller", "state", "object"})
 )
 
 func RegisterMCCMetrics() error {
@@ -45,15 +51,25 @@ func RegisterMCCMetrics() error {
 		OSImageURLOverride,
 		MCCDrainErr,
 		MCCPoolAlert,
+		MCCSubControllerState,
 	})
 
 	if err != nil {
 		return fmt.Errorf("could not register machine-config-controller metrics: %w", err)
 	}
 
-	MCCDrainErr.Reset()
+	// Initilize GuageVecs to ensure that metrics of type GuageVec are accessible from the dashboard even if without a logged value
+	// Solution to OCPBUGS-20427: https://issues.redhat.com/browse/OCPBUGS-20427
+	OSImageURLOverride.WithLabelValues("initialize").Set(0)
+	MCCDrainErr.WithLabelValues("initialize").Set(0)
+	MCCPoolAlert.WithLabelValues("initialize").Set(0)
+	MCCSubControllerState.WithLabelValues("initialize", "initialize", "initialize").Set(0)
 
 	return nil
+}
+
+func UpdateStateMetric(metric *prometheus.GaugeVec, labels ...string) {
+	metric.WithLabelValues(labels...).SetToCurrentTime()
 }
 
 func RegisterMetrics(metrics []prometheus.Collector) error {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -684,11 +684,11 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 			return ctrl.syncStatusOnly(cfg, err, "could not add finalizers to ContainerRuntimeConfig: %v", err)
 		}
 		klog.Infof("Applied ContainerRuntimeConfig %v on MachineConfigPool %v", key, pool.Name)
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync Container Runtime Config", pool.Name)
 	}
 	if err := ctrl.cleanUpDuplicatedMC(); err != nil {
 		return err
 	}
-
 	return ctrl.syncStatusOnly(cfg, nil)
 }
 
@@ -887,9 +887,9 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 		}
 		if applied {
 			klog.Infof("Applied ImageConfig cluster on MachineConfigPool %v", pool.Name)
+			ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync Image Config", pool.Name)
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -327,7 +327,7 @@ func (ctrl *Controller) syncNode(key string) error {
 	if err := ctrl.setNodeAnnotations(node.Name, annotations); err != nil {
 		return fmt.Errorf("node %s: failed to set node uncordoned annotation: %w", node.Name, err)
 	}
-
+	ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-drain", desiredVerb, node.Name)
 	return nil
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -658,6 +658,7 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 			return ctrl.syncStatusOnly(cfg, err, "could not add finalizers to KubeletConfig: %v", err)
 		}
 		klog.Infof("Applied KubeletConfig %v on MachineConfigPool %v", key, pool.Name)
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync Kubelet Config", pool.Name)
 	}
 	if err := ctrl.cleanUpDuplicatedMC(managedKubeletConfigKeyPrefix); err != nil {
 		return err

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -118,6 +118,7 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 			return fmt.Errorf("could not Create/Update MachineConfig: %w", err)
 		}
 		klog.Infof("Applied FeatureSet %v on MachineConfigPool %v", key, pool.Name)
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync FeatureSet", pool.Name)
 	}
 	return ctrl.cleanUpDuplicatedMC(managedFeaturesKeyPrefix)
 

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -163,6 +163,7 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 			return fmt.Errorf("Could not Create/Update MachineConfig, error: %w", err)
 		}
 		klog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync NodeConfig", pool.Name)
 	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -987,6 +987,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 			}
 			return err
 		}
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-node", "Sync Machine Config Pool", pool.Name)
 	}
 	return ctrl.syncStatusOnly(pool)
 }

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -438,7 +438,6 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	if err := ctrl.syncGeneratedMachineConfig(pool, mcs); err != nil {
 		return ctrl.syncFailingStatus(pool, err)
 	}
-
 	return ctrl.syncAvailableStatus(pool)
 }
 
@@ -535,7 +534,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		return err
 	}
 	klog.V(2).Infof("Pool %s: now targeting: %s", pool.Name, pool.Spec.Configuration.Name)
-
+	ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-render", "Sync Machine Config Pool with new MC", pool.Name)
 	return ctrl.garbageCollectRenderedConfigs(pool)
 }
 

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -578,6 +578,7 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		if updated {
 			klog.V(4).Infof("Machineconfig %s was updated", mc.Name)
 		}
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-template", "Sync Controller Config", mc.Name)
 	}
 
 	return ctrl.syncCompletedStatus(cfg)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1190,6 +1190,7 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 
 // Called whenever the on-disk config has drifted from the current machineconfig.
 func (dn *Daemon) onConfigDrift(err error) {
+	mcdConfigDrift.SetToCurrentTime()
 	dn.nodeWriter.Eventf(corev1.EventTypeWarning, "ConfigDriftDetected", err.Error())
 	klog.Error(err)
 	if err := dn.updateErrorState(err); err != nil {
@@ -1212,6 +1213,7 @@ func (dn *Daemon) getCurrentConfigFromNode() (*onDiskConfig, error) {
 }
 
 func (dn *Daemon) startConfigDriftMonitor() {
+	mcdConfigDrift.Set(0)
 	// Even though the Config Drift Monitor object ensures that only a single
 	// Config Drift Watcher is running at any given time, other things, such as
 	// emitting Kube events on startup, should only occur if we weren't

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -17,11 +17,11 @@ var (
 		}, []string{"os", "version"})
 
 	// mcdPivotErr flags error encountered during pivot
-	mcdPivotErr = prometheus.NewGauge(
+	mcdPivotErr = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "mcd_pivot_errors_total",
 			Help: "Total number of errors encountered during pivot.",
-		})
+		}, []string{"total"})
 
 	// mcdState is state of mcd for indicated node (ex: degraded)
 	mcdState = prometheus.NewGaugeVec(
@@ -50,6 +50,13 @@ var (
 			Name: "mcd_update_state",
 			Help: "completed update config or error",
 		}, []string{"config", "err"})
+
+	// mcdConfigDrift logs a config drift
+	mcdConfigDrift = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mcd_config_drift",
+			Help: "timestamp for configt drift",
+		})
 )
 
 // Updates metric with new labels & timestamp, deletes any existing
@@ -70,11 +77,15 @@ func RegisterMCDMetrics() error {
 		kubeletHealthState,
 		mcdRebootErr,
 		mcdUpdateState,
+		mcdConfigDrift,
 	})
 
 	if err != nil {
 		return fmt.Errorf("could not register machine-config-daemon metrics: %w", err)
 	}
+
+	// Initilize GuageVecs:
+	mcdPivotErr.WithLabelValues("initialize").Set(0)
 
 	kubeletHealthState.Set(0)
 

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"fmt"
+
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,5 +48,17 @@ var (
 )
 
 func RegisterMCOMetrics() error {
-	return ctrlcommon.RegisterMetrics([]prometheus.Collector{mcoState, mcoMachineCount, mcoUpdatedMachineCount, mcoDegradedMachineCount, mcoUnavailableMachineCount})
+	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
+		mcoState,
+		mcoMachineCount,
+		mcoUpdatedMachineCount,
+		mcoDegradedMachineCount,
+		mcoUnavailableMachineCount,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not register machine-config-operator metrics: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
In this PR, I have enabled several metrics to report key state of the MCC & MCD

- Metrics for MCC sub-controllers
  - Introduced state metric: `MCCSubControllerState`, which has label `"subcontroller, state object`, to record the action of the subcontroller on certain object e.g. `machine-config-controller-render Sync Machine Config Pool master timestampA` --> the render controller has synced the master pool at timestamp A. 
- Timestamps for MCD config drifts
- Timestamps for pivot error 

I have also fixed the bug reported in https://issues.redhat.com/browse/OCPBUGS-20427:

Before: when query for `mcc_drain_err`, it returns `no datapoint found`
Now: when query for `mcc_drain_err`, it returns the initial value set until change happened