### PR TITLE
OCPBUGS-19352: Fix bootstrap with NTO Operator and duplicate MachineConfigs

### DIFF
--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -155,7 +155,6 @@ spec:
 			}
 		})
 	}
-
 }
 
 func TestBootstrapRun(t *testing.T) {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -120,9 +120,11 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 			}
 		}
 		// The following code updates the MC with the relevant CGroups version
-		err = updateMachineConfigwithCgroup(nodeConfig, mc)
-		if err != nil {
-			return err
+		if role == ctrlcommon.MachineConfigPoolWorker || role == ctrlcommon.MachineConfigPoolMaster {
+			err = updateMachineConfigwithCgroup(nodeConfig, mc)
+			if err != nil {
+				return err
+			}
 		}
 		// Encode the new config into raw JSON
 		cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -76,17 +76,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
 		return err
 	}
-	// explicitly setting the cgroupMode to "v2" and also updating the config node's spec if found empty
-	// This helps in updating the cgroupMode on all the worker nodes if they still have cgroupsv1 (Ex: RHEL8 workers)
-	if nodeConfig.Spec.CgroupMode == osev1.CgroupModeEmpty {
-		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV2
-		ctrl.configClient.ConfigV1().Nodes().Update(context.TODO(), nodeConfig, metav1.UpdateOptions{})
-	}
-	// checking if the Node spec is empty and accordingly returning from here.
-	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
-		klog.V(2).Info("empty Node resource found")
-		return nil
-	}
 
 	// Fetch the controllerconfig
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
@@ -198,7 +187,7 @@ func (ctrl *Controller) enqueueNodeConfig(nodeConfig *osev1.Node) {
 }
 
 func (ctrl *Controller) updateNodeConfig(old, cur interface{}) {
-	var isValidWorkerLatencyProfleTransition = true
+	isValidWorkerLatencyProfleTransition := true
 	oldNode, ok := old.(*osev1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("Couldn't retrieve the old object from the Update Node Config event %#v", old))
@@ -277,16 +266,7 @@ func RunNodeConfigBootstrap(templateDir string, featureGateAccess featuregates.F
 	if nodeConfig == nil {
 		return nil, fmt.Errorf("nodes.config.openshift.io resource not found")
 	}
-	// explicitly setting the cgroupMode to "v2" and also updating the config node's spec if found empty
-	// This helps in updating the cgroupMode on all the worker nodes if they still have cgroupsv1 (Ex: RHEL8 workers)
-	if nodeConfig.Spec.CgroupMode == osev1.CgroupModeEmpty {
-		nodeConfig.Spec.CgroupMode = osev1.CgroupModeV2
-	}
-	// checking if the Node spec is empty and accordingly returning from here.
-	if reflect.DeepEqual(nodeConfig.Spec, osev1.NodeSpec{}) {
-		klog.V(2).Info("empty Node resource found")
-		return nil, nil
-	}
+
 	configs := []*mcfgv1.MachineConfig{}
 
 	for _, pool := range mcpPools {


### PR DESCRIPTION
**- What I did**

NTO is seeing some flakes on rollout of PerformanceProfile custom resources still using cgroupv2 or conflicting kernel arguments.

This PR fixes:

* Node Controller does not update the Node object directly. This causes an additional rollout of the MachineConfig.
* osev1.CgroupModeEmpty did not lay down the default kernel arguments needed by OpenShift. osev1.CgroupModeEmpty is a default and defaults to cgroupv2.
* Fixes bootstrap to lay down the correct kernel arguments without rendering an additional initial MC in the incorrect state.

**- How to verify it**
@yprokule is testing various ZTP scenarios.

**- Description for the changelog**
```
Fix day-0 and day-2 cgroupv2 MC rollout.
```