### PR TITLE
OCPBUGS-19352: Restrict cgroup version updates to master and worker pools only

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -131,9 +131,11 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 			}
 		}
 		// The following code updates the MC with the relevant CGroups version
-		err = updateMachineConfigwithCgroup(nodeConfig, mc)
-		if err != nil {
-			return err
+		if role == ctrlcommon.MachineConfigPoolWorker || role == ctrlcommon.MachineConfigPoolMaster {
+			err = updateMachineConfigwithCgroup(nodeConfig, mc)
+			if err != nil {
+				return err
+			}
 		}
 		// Encode the new config into raw JSON
 		cfgIgn, err := kubeletConfigToIgnFile(originalKubeConfig)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Restrict the rollout of cgroup version related to kernel args only to worker and master pools

**- How to verify it**
After changing the cgroup version, the worker and master nodes boot with appropriate cgroup version.  

**- Description for the changelog**
Restrict cgroup version updates to master and worker pools only
<!--
Restrict the rollout of cgroup version related to kernel args only to worker and master pools
-->
