### PR TITLE
OCPBUGS-22200: Retry fetching OpenStack hostname if it fails

### DIFF
--- a/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
@@ -5,19 +5,38 @@ contents:
     #!/bin/bash
     set -e -o pipefail
 
-    NODECONF=/etc/systemd/system/kubelet.service.d/20-openstack-node-name.conf
+    NODEENV=/etc/kubernetes/node.env
 
-    if [ -e "${NODECONF}" ]; then
-        echo "Not replacing existing ${NODECONF}"
+    # This can be removed 1 release after it merges because all affected nodes
+    # will have upgraded
+    LEGACY_NODEENV=/etc/systemd/system/kubelet.service.d/20-openstack-node-name.conf
+    if [ -e "${LEGACY_NODEENV}" ]; then
+        # Legacy file was a systemd stanza with KUBELET_NODE_NAME specified in
+        # a directive of the format:
+        #   Environment="KUBELET_NODE_NAME=node.example.com"
+        # New format is an environment file. The following extracts only the
+        # contents of any Environment directives.
+        echo "Migrating ${LEGACY_NODEENV} to ${NODEENV}"
+        awk 'match($0, /^\s*Environment\s*=\s*"(.*)"\s*$/, value) { print value[1] }' < "${LEGACY_NODEENV}" > "${NODEENV}"
+        rm "${LEGACY_NODEENV}"
+        exit 0
+    fi
+
+    if [ -e "${NODEENV}" ]; then
+        echo "Not replacing existing ${NODEENV}"
         exit 0
     fi
 
     # For compatibility with the OpenStack in-tree provider
     # Set node name to be instance name instead of the default FQDN hostname
-    #
-    # https://docs.openstack.org/nova/victoria/user/metadata.html#metadata-openstack-format
-    name=$(curl -s http://169.254.169.254/openstack/2012-08-10/meta_data.json | jq -re .name)
-    cat > "${NODECONF}" <<EOF
-    [Service]
-    Environment="KUBELET_NODE_NAME=${name}"
-    EOF
+    while true; do
+        # https://docs.openstack.org/nova/victoria/user/metadata.html#metadata-openstack-format
+        hostname=$(curl -s http://169.254.169.254/openstack/2012-08-10/meta_data.json | jq -re .name)
+        if [[ -z "${hostname}" ]]; then
+            sleep 5
+            continue
+        fi
+
+        echo "KUBELET_NODE_NAME=${hostname}" > ${NODEENV}
+        break
+    done

--- a/templates/common/openstack/units/kubelet-node-env.dropin.yaml
+++ b/templates/common/openstack/units/kubelet-node-env.dropin.yaml
@@ -1,0 +1,6 @@
+name: kubelet.service
+dropins:
+- name: 20-node-env.conf
+  contents: |
+    [Service]
+    EnvironmentFile=/etc/kubernetes/node.env

--- a/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
+++ b/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
@@ -13,4 +13,4 @@ contents: |
   Type=oneshot
 
   [Install]
-  WantedBy=network-online.target
+  WantedBy=kubelet-dependencies.target


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Common cause with https://github.com/openshift/machine-config-operator/pull/3979

**- What I did**

Firstly, a refactor to use an EnvironmentFile via a dropin on kubelet.service rather than systemd config in kubelet.service.d. This is a slightly nicer way of doing it and is consistent with the approach for AWS in #3979. It requires an upgrade to move any existing file to the new location and format, but this can be removed in a release after all legacy nodes have been upgraded.

Most significantly, updates the generator script to retry indefinitely until it gets a value returned.

**- How to verify it**

* Ensure a newly installed machine gets /etc/kubernetes/node.env correctly populated with instance name.
* Ensure an upgraded machine gets /etc/systemd/system/kubelet.service.d/20-openstack-node-name.conf upgraded to /etc/kubernetes/node.env. The upgrade will be logged in the `openstack-kubelet-nodename` system service on first boot after upgrade.
* Ensure nodename is set to instance name, not hostname, on clouds where these are different. I believe Vexxhost is a candidate.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
