### PR TITLE
WIP OCPBUGS-20369: kubelet: set params from afterburn via envvars instead of systemd dropins

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
@@ -5,10 +5,10 @@ contents:
     #!/bin/bash
     set -e -o pipefail
 
-    NODECONF=/etc/systemd/system/kubelet.service.d/20-aws-node-name.conf
+    ENV_FILE=/etc/kubernetes/kubelet-env
 
-    if [ -e "${NODECONF}" ]; then
-        echo "Not replacing existing ${NODECONF}"
+    if ! grep KUBELET_NODE_NAME ${ENV_FILE} > /dev/null; then
+        echo "KUBELET_NODE_NAME already set in ${ENV_FILE}"
         exit 0
     fi
     
@@ -28,7 +28,6 @@ contents:
 
     # For compatibility with the AWS in-tree provider
     # Set node name to be instance name instead of the default FQDN hostname
-    cat > "${NODECONF}" <<EOF
-    [Service]
-    Environment="KUBELET_NODE_NAME=${HOSTNAME}"
+    cat >> "${ENV_FILE}" <<EOF
+    KUBELET_NODE_NAME=${HOSTNAME}"
     EOF

--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-providerid.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-providerid.yaml
@@ -5,10 +5,10 @@ contents:
     #!/bin/bash
     set -e -o pipefail
 
-    NODECONF=/etc/systemd/system/kubelet.service.d/20-aws-providerid.conf
+    ENV_FILE=/etc/kubernetes/kubelet-env
 
-    if [ -e "${NODECONF}" ]; then
-        echo "Not replacing existing ${NODECONF}"
+    if ! grep KUBELET_PROVIDERID ${ENV_FILE} > /dev/null; then
+        echo "KUBELET_PROVIDERID already set in ${ENV_FILE}"
         exit 0
     fi
 
@@ -34,7 +34,6 @@ contents:
     # set KUBELET_PROVIDERID to be a fully qualified AWS instace provider id.
     # This new variable is later used to populate the kubelet's `provider-id` flag, later set on the Node .spec
     # and used by the cloud controller manager's node controller to retrieve the Node's backing instance.
-    cat > "${NODECONF}" <<EOF
-    [Service]
-    Environment="KUBELET_PROVIDERID=aws:///${AVAILABILITY_ZONE}/${INSTANCE_ID}"
+    cat >> "${ENV_FILE}" <<EOF
+    KUBELET_PROVIDERID=aws:///${AVAILABILITY_ZONE}/${INSTANCE_ID}
     EOF

--- a/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
@@ -5,10 +5,10 @@ contents:
     #!/bin/bash
     set -e -o pipefail
 
-    NODECONF=/etc/systemd/system/kubelet.service.d/20-openstack-node-name.conf
+    ENV_FILE=/etc/kubernetes/kubelet-env
 
-    if [ -e "${NODECONF}" ]; then
-        echo "Not replacing existing ${NODECONF}"
+    if ! grep KUBELET_NODE_NAME ${ENV_FILE} > /dev/null; then
+        echo "KUBELET_NODE_NAME already set in ${ENV_FILE}"
         exit 0
     fi
 
@@ -17,7 +17,6 @@ contents:
     #
     # https://docs.openstack.org/nova/victoria/user/metadata.html#metadata-openstack-format
     name=$(curl -s http://169.254.169.254/openstack/2012-08-10/meta_data.json | jq -re .name)
-    cat > "${NODECONF}" <<EOF
-    [Service]
-    Environment="KUBELET_NODE_NAME=${name}"
+    cat >> "${ENV_FILE}" <<EOF
+    KUBELET_NODE_NAME=${name}"
     EOF


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Reworked how AWS/Openstack hostname/providerID being passed to kubelet - via `EnvironmentFile` instead of dropins. Updating dropins requires `systemctl daemon-reload` to take effect

**- How to verify it**
Install latest OKD on AWS (somehow its more prone to this unlike RHCOS)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
