### PR TITLE
Use the bridge interface name for ofport request

### DIFF
--- a/templates/common/_base/files/ofport-request.yaml
+++ b/templates/common/_base/files/ofport-request.yaml
@@ -52,8 +52,14 @@ contents:
         exit 0
     fi
     
-    # Get the port's master = bridge name
-    BRIDGE_NAME=$(nmcli -t -f connection.master conn show "${PORT_CONNECTION_UUID}" | awk -F ':' '{print $NF}')
+    # Get the port's master. If it doesn't have any, assume it's not our bridge
+    BRIDGE_ID=$(nmcli -t -f connection.master conn show "${PORT_CONNECTION_UUID}" | awk -F ':' '{print $NF}')
+    if [ "${BRIDGE_ID}" == "" ]; then
+        exit 0
+    fi
+
+    # Get the bridge name
+    BRIDGE_NAME=$(nmcli -t -f connection.interface-name conn show "${BRIDGE_ID}" | awk -F ':' '{print $NF}')
     # Limit this to br-ex and br-ex1 only. If one wanted to enable this for all OVS bridges,
     # the condition would be: if [ "$BRIDGE_NAME" == "" ]; then
     if [ "${BRIDGE_NAME}" != "br-ex" ] && [ "${BRIDGE_NAME}" != "br-ex1" ]; then


### PR DESCRIPTION
The master of a bridge port can be indicated by UUID or ID. The current implementation assumed it was always ID and that the ID was equal to the interface name. While those assumptions hold true when the configuration is done by configure-ovs, it is not necessarily the case otherwise.