### PR TITLE
OCPBUGS-22412: bootstrap_test: always set APIVersion and Kind for DNS

### DIFF
--- a/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/machineconfigcontroller-controllerconfig.yaml
@@ -33,6 +33,8 @@ spec:
       platformStatus:
         type: None
   dns:
+    apiVersion: config.openshift.io/v1
+    kind: DNS
     spec:
       baseDomain: domain.example.com
   kubeAPIServerServingCAData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCktVQkUgQVBJIFNFUlZFUiBTRVJWSU5HIENBIERBVEEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=


### PR DESCRIPTION
The backporting chain of suppressing warning messages somehow broke this for 4.13, where the test will complain for DNS not setting APIVersion and Kind (but interestingly not for Infra)

So set these explicitly in the object creation loop. This doesn't otherwise affect any cluster functionality and is fine from 4.14 onwards.
