### PR TITLE
OCPBUGS-7638: typo s/iface_default_hint_file/default_bridge_file/

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -691,7 +691,7 @@ contents:
 
       # try to use user specified file first
       if [ -f "$default_bridge_file" ]; then
-        iface=$(cat "${iface_default_hint_file}")
+        iface=$(cat "${default_bridge_file}")
         if [ -z "$iface" ]; then
           echo "ERROR: User specified bridge file detected without any data"
           exit 1


### PR DESCRIPTION
typo s/iface_default_hint_file/default_bridge_file/

We are reading the wrong file.

This is why `[ -f ]` checks are bad, they aren't atomic.  Actually reading the file is the only true test.

```
configure-ovs.sh[8910]: ++ get_default_bridge_interface /var/lib/ovnk/iface_default_hint /etc/ovnk/extra_bridge /run/nodeip-configuration/primary-ip /etc/ovnk/default_bridge
configure-ovs.sh[8910]: ++ local iface=
configure-ovs.sh[8910]: ++ local counter=0
configure-ovs.sh[8910]: ++ local iface_default_hint_file=/var/lib/ovnk/iface_default_hint
configure-ovs.sh[8910]: ++ local extra_bridge_file=/etc/ovnk/extra_bridge
configure-ovs.sh[8910]: ++ local ip_hint_file=/run/nodeip-configuration/primary-ip
configure-ovs.sh[8910]: ++ local default_bridge_file=/etc/ovnk/default_bridge
configure-ovs.sh[8910]: ++ local extra_bridge=
configure-ovs.sh[8910]: ++ '[' -f /etc/ovnk/extra_bridge ']'
configure-ovs.sh[8910]: ++ '[' -f /etc/ovnk/default_bridge ']'
configure-ovs.sh[8911]: +++ cat /var/lib/ovnk/iface_default_hint
configure-ovs.sh[8911]: cat: /var/lib/ovnk/iface_default_hint: No such file or directory
configure-ovs.sh[8910]: ++ iface=
configure-ovs.sh[8910]: ++ '[' -z '' ']'
configure-ovs.sh[8910]: ++ echo 'ERROR: User specified bridge file detected without any data'
configure-ovs.sh[8910]: ++ exit 1
configure-ovs.sh[8883]: + iface='ERROR: User specified bridge file detected without any data'
configure-ovs.sh[8883]: ++ handle_exit
configure-ovs.sh[8883]: ++ e=1
```
