### PR TITLE
kubevirt: Set transient hostname from metadata

### DIFF
--- a/templates/common/kubevirt/units/afterburn-transient-hostname.service.yaml
+++ b/templates/common/kubevirt/units/afterburn-transient-hostname.service.yaml
@@ -1,0 +1,26 @@
+name: afterburn-transient-hostname.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Set Transient Hostname from KubeVirt meta_data
+
+  # Run afterburn service for collect info from metadata server
+  # see: https://coreos.github.io/afterburn/usage/attributes/
+  Wants=afterburn.service
+  After=afterburn.service
+
+  # Before hostname is received from DHCP
+  Before=network-pre.target
+  Wants=network-pre.target
+
+  # Run before kubelet
+  Before=kubelet.service
+
+  [Service]
+  # Mark afterburn environment file optional, due to it is possible that afterburn service was not executed
+  EnvironmentFile=/run/metadata/afterburn
+  ExecStart=hostnamectl hostname --transient "${AFTERBURN_KUBEVIRT_HOSTNAME}"
+  Type=oneshot
+
+  [Install]
+  WantedBy=network-online.target


### PR DESCRIPTION
"Closes: #xxxx"



**- What I did**
At KubeVirt the hostname is usually set using DHCP on the case of fcos/rhcos but at some use cases this is not the case and at least the transient hostname should be set from the metadata. This change runs the afterburn service that read metadata and dump and env file that can be used later on with hostnamectl to set the transient hostname.

Closes: https://issues.redhat.com/browse/CNV-33668

journal of unit running at an hypershift kubevirt node before and after restart 

```
$ journalctl -u afterburn-transient-hostname
Nov 02 16:11:48 localhost.localdomain systemd[1]: Starting Set Transient Hostname from KubeVirt meta_data...
Nov 02 16:11:48 foo-741a4add-ckjwp systemd[1]: afterburn-transient-hostname.service: Deactivated successfully.
Nov 02 16:11:48 foo-741a4add-ckjwp systemd[1]: Finished Set Transient Hostname from KubeVirt meta_data.
-- Boot f65d0299191c4c76a7db69a6dc97f7c8 --
Nov 02 16:14:13 localhost systemd[1]: Starting Set Transient Hostname from KubeVirt meta_data...
Nov 02 16:14:13 foo-741a4add-ckjwp systemd[1]: afterburn-transient-hostname.service: Deactivated successfully.
Nov 02 16:14:13 foo-741a4add-ckjwp systemd[1]: Finished Set Transient Hostname from KubeVirt meta_data.

```

**- Description for the changelog**
kubevirt: Set transient hostname from metadata