### PR TITLE
MCO-694: Reverting from layered to non-layered MachineConfigPools does not work

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -388,7 +388,7 @@ func calculatePostConfigChangeAction(diff *machineConfigDiff, diffFileSet []stri
 	return calculatePostConfigChangeActionFromFileDiffs(diffFileSet), nil
 }
 
-func (dn *Daemon) updateImage(newConfig *mcfgv1.MachineConfig, oldImage, newImage string) error {
+func (dn *Daemon) updateImage(newConfig *mcfgv1.MachineConfig, oldImage, newImage string, writeNewImageToOnDiskConfig bool) error {
 	if dn.nodeWriter != nil {
 		state, err := getNodeAnnotationExt(dn.node, constants.MachineConfigDaemonStateAnnotationKey, true)
 		if err != nil {
@@ -416,8 +416,11 @@ func (dn *Daemon) updateImage(newConfig *mcfgv1.MachineConfig, oldImage, newImag
 	}
 
 	odc := &onDiskConfig{
-		currentImage:  newImage,
 		currentConfig: newConfig,
+	}
+
+	if writeNewImageToOnDiskConfig {
+		odc.currentImage = newImage
 	}
 
 	if err := dn.storeCurrentConfigOnDisk(odc); err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
