### PR TITLE
disable http2 via flag

### DIFF
--- a/install/0000_80_machine-config-operator_04_deployment.yaml
+++ b/install/0000_80_machine-config-operator_04_deployment.yaml
@@ -48,6 +48,7 @@ spec:
           name: metrics
           protocol: TCP
         args:
+        - --disable-http2
         - --secure-listen-address=0.0.0.0:9001
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -35,6 +35,7 @@ spec:
           name: metrics
           protocol: TCP
         args:
+        - --disable-http2
         - --secure-listen-address=0.0.0.0:9001
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -63,6 +63,7 @@ spec:
           name: metrics
           protocol: TCP
         args:
+        - --disable-http2
         - --secure-listen-address=0.0.0.0:9001
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305


### PR DESCRIPTION
kube-rbac-proxy image just added a disable-http2 flag. Add it in as an extra step to remediate the CVE.
