### PR TITLE
MCO-772: controller: allow custom pool configs to take priority

### DIFF
--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -61,4 +61,7 @@ const (
 	// to be 3.4.0 currently". Ideally if you find an explicit "3.4.0", it's supposed to be "3.4.0" version. If it's this constant,
 	// it's supposed to be the internal default version.
 	InternalMCOIgnitionVersion = "3.4.0"
+
+	// MachineConfigRoleLabel is the role on MachineConfigs, used to select for pools
+	MachineConfigRoleLabel = "machineconfiguration.openshift.io/role"
 )

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -178,6 +178,21 @@ func NewMachineConfigPool(name string, mcSelector, nodeSelector *metav1.LabelSel
 	}
 }
 
+// CreateMachineConfigFromIgnitionWithMetadata returns a MachineConfig object from an Ignition config, name, and role label
+func CreateMachineConfigFromIgnitionWithMetadata(ignCfg interface{}, name, role string) *mcfgv1.MachineConfig {
+	return &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"machineconfiguration.openshift.io/role": role},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: MarshalOrDie(ignCfg),
+			},
+		},
+	}
+}
+
 // CreateMachineConfigFromIgnition returns a MachineConfig object from an Ignition config passed to it
 func CreateMachineConfigFromIgnition(ignCfg interface{}) *mcfgv1.MachineConfig {
 	return &mcfgv1.MachineConfig{


### PR DESCRIPTION
In the MCO today MachineConfiguration merging is purely alphanumerically based, meaning that duplicate entries in higher alphanumerical (e.g. 99>00) MachineConfigs overwrite the lower config.

This is not an issue until you use custom pools, which always need to inherit from worker configs. In an example use case, let's say I have infra and worker pool, and would like to apply a separate kubeconfig to both of them. Both get generated as machineconfig like this:

- 99-infra-generated-kubelet
- 99-worker-generated-kubelet

And since infra pool takes base worker configuration, and i alphanumerically is lower than w, the infra kubeletconfig never can take effect. (The reverse is always fine since worker doesn't contain infra configs)

This means to have a setup where both worker and custom pools have different configs, you would need to name your custom pool starting with x/y/z which is very confusing UX-wise.

With this change, custom pool configs now take priority over worker pool ones. Within worker or custom configs, alphanumeric ordering still takes effect.

This is a behaviour change, but we've never explicitly documented one way or another. I think this change should be safe as a result, since if users specify configuration for a custom pool, they would expect that to take effect over any worker configs.

**- How to verify it**

The unit tests verify the ordering. I've also tested manually like this:
1. spin up cluster
2. create infra pool
3. Apply a kubeletconfig to both infra and worker pool, something like this:

```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: worker-kubeburst
spec:
  machineConfigPoolSelector:
    matchLabels:
      "pools.operator.machineconfiguration.openshift.io/worker": ""
  kubeletConfig:
    kubeAPIBurst: 7000
---
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: infra-kubeburst
spec:
  machineConfigPoolSelector:
    matchLabels:
      "pools.operator.machineconfiguration.openshift.io/infra": ""
  kubeletConfig:
    kubeAPIBurst: 8000
```

Observe that infra rendered config contains 7000

4. Update to this PR
5. Observe new infra rendered config contains 8000 instead
