### PR TITLE
OCPBUGS-22910: Remove the condition for checking the multiple ovs-if-br-ex profiles

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -80,7 +80,7 @@ contents:
       fi
     }
 
-    # Used to remove files managed by configure-ovs
+    # Used to remove files managed by configure-ovs and temporary leftover files from network manager
     rm_nm_conn_files() {
       for file in "${MANAGED_NM_CONN_FILES[@]}"; do
         if [ -f "$file" ]; then
@@ -88,6 +88,13 @@ contents:
           echo "Removed nmconnection file $file"
           nm_config_changed=1
         fi
+      done
+      for file in "${MANAGED_NM_CONN_FILES[@]}"; do
+        for temp in $(compgen -G "${file}.*"); do
+          rm -f "$temp"
+          echo "Removed nmconnection temporary file $temp"
+          nm_config_changed=1
+        done
       done
     }
 


### PR DESCRIPTION
Avoid failing the condition if `ovs-if-br-ex.nmconnection.J1K8B2` like file present in the `${NM_CONN_CONF_PATH}` as `${new_conn_files[0]}` from the next step takes only the first file that does not have the extra extension.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**
```
touch /etc/NetworkManager/system-connections/ovs-if-br-ex.nmconnection.J1K8B2
systemctl restart ovs-configuration.service
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
