### PR TITLE
OCPBUGS-22721: Don't retry node-ip show in resolv-prepender

### DIFF
--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -68,7 +68,6 @@ contents:
                 {{if not (isOpenShiftManagedDefaultLB .) -}}
                 --user-managed-lb \
                 {{end -}}
-                --retry-on-failure \
                 {{range onPremPlatformAPIServerInternalIPs . }}"{{.}}" {{end}} \
                 {{range onPremPlatformIngressIPs . }}"{{.}}" {{end}})"
             DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"


### PR DESCRIPTION
The retry time in runtimecfg is 5 minutes and the dispatcher script is only allowed to run for 30 seconds so this is never going to be effective anyway. Usually if we don't find the IP in the prepender script it means we're reconfiguring the network in configure-ovs anyway so even if it could run long enough to retry it still wouldn't find the IP.

Note that this doesn't happen in vanilla deployments with just a single NIC or bond being bridged. However, if there are VLANs on the primary interface each one of them will trigger the script and if the primary IP isn't configured yet they will all fail. With enough VLANs this can have a significant impact on boot time.


**- Description for the changelog**
Remove retry from resolv-prepender since the retry interval is longer than the timeout of the script.