### PR TITLE
CORS-2814: Add support for in-cluster DNS on Cloud Platforms when cloud DNS cannot be used

### DIFF
--- a/install/0000_80_machine-config-operator_00_namespace.yaml
+++ b/install/0000_80_machine-config-operator_00_namespace.yaml
@@ -100,4 +100,21 @@ metadata:
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
     security.openshift.io/scc.podSecurityLabelSync: "false"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cloud-platform-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    name: openshift-cloud-platform-infra
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
 

--- a/manifests/cloud-platform-alt-dns/coredns-corefile.tmpl
+++ b/manifests/cloud-platform-alt-dns/coredns-corefile.tmpl
@@ -1,0 +1,36 @@
+. {
+    errors
+    health :18080
+    forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+        policy sequential
+    }
+    cache 30
+    reload
+    template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformIngressLoadBalancerIPs .ControllerConfig)) 0 }}{{ index (cloudPlatformIngressLoadBalancerIPs .ControllerConfig) 0 }}{{ end }}"
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match ^api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformAPILoadBalancerIPs .ControllerConfig)) 0 }}{{ index (cloudPlatformAPILoadBalancerIPs .ControllerConfig) 0 }}{{ end }}"
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match ^api.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match ^api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformAPIIntLoadBalancerIPs .ControllerConfig)) 0 }}{{ index (cloudPlatformAPIIntLoadBalancerIPs .ControllerConfig) 0 }}{{ end }}"
+        fallthrough
+    }
+    template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
+        match ^api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
+        fallthrough
+    }
+}

--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -1,0 +1,85 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: coredns
+  namespace: openshift-cloud-platform-infra
+  creationTimestamp:
+  deletionGracePeriodSeconds: 65
+  labels:
+    app: cloud-platform-infra-coredns
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  volumes:
+  - name: resource-dir
+    hostPath:
+      path: "/etc/kubernetes/static-pod-resources/coredns"
+  - name: kubeconfig
+    hostPath:
+      path: "/etc/kubernetes/kubeconfig"
+  - name: conf-dir
+    empty-dir: {}
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"
+  initContainers:
+  - name: render-config
+    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    command:
+    - runtimecfg
+    - render
+    - "/etc/kubernetes/kubeconfig"
+    - "--cloud-ext-lb-ips"
+    - "{{- range $index, $ip := cloudPlatformAPILoadBalancerIPs .ControllerConfig }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+    - "--cloud-int-lb-ips"
+    - "{{- range $index, $ip := cloudPlatformAPIIntLoadBalancerIPs .ControllerConfig }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+    - "--cloud-ingress-lb-ips"
+    - "{{- range $index, $ip := cloudPlatformIngressLoadBalancerIPs .ControllerConfig }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+    - "/config"
+    - "--out-dir"
+    - "/etc/coredns"
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
+  resources: {}
+  volumeMounts:
+  - name: kubeconfig
+    mountpath: "/etc/kubernetes/kubeconfig"
+  - name: resource-dir
+    mountpath: "/config"
+  - name: conf-dir
+    mountpath: "/etc/coredns"
+  - name: manifests
+    mountpath: "/opt/openshift/manifests"
+    imagePullPolicy: IfNotPresent
+  containers:
+  - name: coredns
+    securityContext:
+      privileged: true
+      readOnlyRootFilesystem: false
+    image: {{ .Images.CorednsBootstrap }}
+    args:
+    - "--conf"
+    - "/etc/coredns/Corefile"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    volumeMounts:
+    - name: conf-dir
+      mountPath: "/etc/coredns"
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 18080
+        scheme: HTTP
+      initialDelaySeconds: 60
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
+    terminationMessagePolicy: FallbackToLogsOnError
+  hostNetwork: true
+  tolerations:
+  - operator: Exists
+  priorityClassName: system-node-critical
+status: {}

--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -10,6 +10,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: machineconfiguration.openshift.io
@@ -277,12 +278,52 @@ spec:
                                         description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
                                         type: string
                                         pattern: ^https://
+                                  x-kubernetes-list-type: atomic
                             azure:
                               description: Azure contains settings specific to the Azure infrastructure provider.
                               type: object
                             baremetal:
                               description: BareMetal contains settings specific to the BareMetal platform.
                               type: object
+                              properties:
+                                apiServerInternalIPs:
+                                  description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.apiServerInternalIPs will be used. Once set, the list cannot be completely removed (but its second entry can).
+                                  type: array
+                                  maxItems: 2
+                                  items:
+                                    description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - rule: 'size(self) == 2 ? self.exists_one(x, x.contains('':'')) : true'
+                                      message: apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address
+                                ingressIPs:
+                                  description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.ingressIPs will be used. Once set, the list cannot be completely removed (but its second entry can).
+                                  type: array
+                                  maxItems: 2
+                                  items:
+                                    description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - rule: 'size(self) == 2 ? self.exists_one(x, x.contains('':'')) : true'
+                                      message: ingressIPs must contain at most one IPv4 address and at most one IPv6 address
+                                machineNetworks:
+                                  description: machineNetworks are IP networks used to connect all the OpenShift cluster nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)
+                                  x-kubernetes-list-type: set
+                              x-kubernetes-validations:
+                                - rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                                  message: apiServerInternalIPs list is required once set
+                                - rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                                  message: ingressIPs list is required once set
                             equinixMetal:
                               description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
                               type: object
@@ -441,6 +482,45 @@ spec:
                             openstack:
                               description: OpenStack contains settings specific to the OpenStack infrastructure provider.
                               type: object
+                              properties:
+                                apiServerInternalIPs:
+                                  description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.apiServerInternalIPs will be used. Once set, the list cannot be completely removed (but its second entry can).
+                                  type: array
+                                  maxItems: 2
+                                  items:
+                                    description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - rule: 'size(self) == 2 ? self.exists_one(x, x.contains('':'')) : true'
+                                      message: apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address
+                                ingressIPs:
+                                  description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.ingressIPs will be used. Once set, the list cannot be completely removed (but its second entry can).
+                                  type: array
+                                  maxItems: 2
+                                  items:
+                                    description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - rule: 'size(self) == 2 ? self.exists_one(x, x.contains('':'')) : true'
+                                      message: ingressIPs must contain at most one IPv4 address and at most one IPv6 address
+                                machineNetworks:
+                                  description: machineNetworks are IP networks used to connect all the OpenShift cluster nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)
+                                  x-kubernetes-list-type: set
+                              x-kubernetes-validations:
+                                - rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                                  message: apiServerInternalIPs list is required once set
+                                - rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                                  message: ingressIPs list is required once set
                             ovirt:
                               description: Ovirt contains settings specific to the oVirt infrastructure provider.
                               type: object
@@ -495,6 +575,18 @@ spec:
                               description: VSphere contains settings specific to the VSphere infrastructure provider.
                               type: object
                               properties:
+                                apiServerInternalIPs:
+                                  description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.apiServerInternalIPs will be used. Once set, the list cannot be completely removed (but its second entry can).
+                                  type: array
+                                  maxItems: 2
+                                  items:
+                                    description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - rule: 'size(self) == 2 ? self.exists_one(x, x.contains('':'')) : true'
+                                      message: apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address
                                 failureDomains:
                                   description: failureDomains contains the definition of region, zone and the vCenter topology. If this is omitted failure domains (regions and zones) will not be used.
                                   type: array
@@ -558,16 +650,47 @@ spec:
                                             minItems: 1
                                             items:
                                               type: string
+                                            x-kubernetes-list-type: atomic
                                           resourcePool:
                                             description: resourcePool is the absolute path of the resource pool where virtual machines will be created. The absolute path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>. The maximum length of the path is 2048 characters.
                                             type: string
                                             maxLength: 2048
                                             pattern: ^/.*?/host/.*?/Resources.*
+                                          template:
+                                            description: "template is the full inventory path of the virtual machine or template that will be cloned when creating new machines in this failure domain. The maximum length of the path is 2048 characters. \n When omitted, the template will be calculated by the control plane machineset operator based on the region and zone defined in VSpherePlatformFailureDomainSpec. For example, for zone=zonea, region=region1, and infrastructure name=test, the template path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                            type: string
+                                            maxLength: 2048
+                                            minLength: 1
+                                            pattern: ^/.*?/vm/.*?
                                       zone:
                                         description: zone defines the name of a zone tag that will be attached to a vCenter cluster. The tag category in vCenter must be named openshift-zone.
                                         type: string
                                         maxLength: 80
                                         minLength: 1
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                ingressIPs:
+                                  description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.ingressIPs will be used. Once set, the list cannot be completely removed (but its second entry can).
+                                  type: array
+                                  maxItems: 2
+                                  items:
+                                    description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - rule: 'size(self) == 2 ? self.exists_one(x, x.contains('':'')) : true'
+                                      message: ingressIPs must contain at most one IPv4 address and at most one IPv6 address
+                                machineNetworks:
+                                  description: machineNetworks are IP networks used to connect all the OpenShift cluster nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)
+                                  x-kubernetes-list-type: set
                                 nodeNetworking:
                                   description: nodeNetworking contains the definition of internal and external network constraints for assigning the node's networking. If this field is omitted, networking defaults to the legacy address selection behavior which is to only support a single address and return the first one found.
                                   type: object
@@ -581,6 +704,7 @@ spec:
                                           type: array
                                           items:
                                             type: string
+                                          x-kubernetes-list-type: atomic
                                         network:
                                           description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
                                           type: string
@@ -589,6 +713,7 @@ spec:
                                           type: array
                                           items:
                                             type: string
+                                          x-kubernetes-list-type: set
                                     internal:
                                       description: internal represents the network configuration of the node that is routable only within the cluster.
                                       type: object
@@ -598,6 +723,7 @@ spec:
                                           type: array
                                           items:
                                             type: string
+                                          x-kubernetes-list-type: atomic
                                         network:
                                           description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
                                           type: string
@@ -606,6 +732,7 @@ spec:
                                           type: array
                                           items:
                                             type: string
+                                          x-kubernetes-list-type: set
                                 vcenters:
                                   description: vcenters holds the connection details for services to communicate with vCenter. Currently, only a single vCenter is supported. ---
                                   type: array
@@ -624,6 +751,7 @@ spec:
                                         minItems: 1
                                         items:
                                           type: string
+                                        x-kubernetes-list-type: set
                                       port:
                                         description: port is the TCP port that will be used to communicate to the vCenter endpoint. When omitted, this means the user has no opinion and it is up to the platform to choose a sensible default, which is subject to change over time.
                                         type: integer
@@ -634,6 +762,12 @@ spec:
                                         description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
                                         type: string
                                         maxLength: 255
+                                  x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                                - rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                                  message: apiServerInternalIPs list is required once set
+                                - rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                                  message: ingressIPs list is required once set
                     status:
                       description: status holds observed values from the cluster. They may not be overridden.
                       type: object
@@ -765,6 +899,7 @@ spec:
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                  x-kubernetes-list-type: atomic
                                 serviceEndpoints:
                                   description: ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
                                   type: array
@@ -780,6 +915,7 @@ spec:
                                         description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
                                         type: string
                                         pattern: ^https://
+                                  x-kubernetes-list-type: atomic
                             azure:
                               description: Azure contains settings specific to the Azure infrastructure provider.
                               type: object
@@ -826,6 +962,7 @@ spec:
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[0-9A-Za-z_.=+-@]+$
+                                  x-kubernetes-list-type: atomic
                                   x-kubernetes-validations:
                                     - rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
                                       message: resourceTags are immutable and may only be configured during installation
@@ -846,6 +983,7 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
                                 ingressIP:
                                   description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
                                   type: string
@@ -856,6 +994,32 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
+                                loadBalancer:
+                                  description: loadBalancer defines how the load balancer used by the cluster is configured.
+                                  type: object
+                                  default:
+                                    type: OpenShiftManagedDefault
+                                  properties:
+                                    type:
+                                      description: type defines the type of load balancer used by the cluster on BareMetal platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                                      type: string
+                                      default: OpenShiftManagedDefault
+                                      enum:
+                                        - OpenShiftManagedDefault
+                                        - UserManaged
+                                      x-kubernetes-validations:
+                                        - rule: oldSelf == '' || self == oldSelf
+                                          message: type is immutable once set
+                                machineNetworks:
+                                  description: machineNetworks are IP networks used to connect all the OpenShift cluster nodes.
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)
+                                  x-kubernetes-list-type: set
                                 nodeDNSIP:
                                   description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
                                   type: string
@@ -897,12 +1061,139 @@ spec:
                               description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
                               type: object
                               properties:
+                                cloudLoadBalancerConfig:
+                                  description: cloudLoadBalancerConfig is a union that contains the IP addresses of API, API-Int and Ingress Load Balancers created on the cloud platform. These values would not be populated on on-prem platforms. These Load Balancer IPs are used to configure the in-cluster DNS instances for API, API-Int and Ingress services. `dnsType` is expected to be set to `ClusterHosted` when these Load Balancer IP addresses are populated and used.
+                                  type: object
+                                  default:
+                                    dnsType: PlatformDefault
+                                  properties:
+                                    clusterHosted:
+                                      description: clusterHosted holds the IP addresses of API, API-Int and Ingress Load Balancers on Cloud Platforms. The DNS solution hosted within the cluster use these IP addresses to provide resolution for API, API-Int and Ingress services.
+                                      type: object
+                                      properties:
+                                        apiIntLoadBalancerIPs:
+                                          description: apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service. These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses. Entries in the apiIntLoadBalancerIPs must be unique. A maximum of 16 IP addresses are permitted.
+                                          type: array
+                                          format: ip
+                                          maxItems: 16
+                                          items:
+                                            description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                            type: string
+                                            pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                          x-kubernetes-list-type: set
+                                        apiLoadBalancerIPs:
+                                          description: apiLoadBalancerIPs holds Load Balancer IPs for the API service. These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses. Could be empty for private clusters. Entries in the apiLoadBalancerIPs must be unique. A maximum of 16 IP addresses are permitted.
+                                          type: array
+                                          format: ip
+                                          maxItems: 16
+                                          items:
+                                            description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                            type: string
+                                            pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                          x-kubernetes-list-type: set
+                                        ingressLoadBalancerIPs:
+                                          description: ingressLoadBalancerIPs holds IPs for Ingress Load Balancers. These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses. Entries in the ingressLoadBalancerIPs must be unique. A maximum of 16 IP addresses are permitted.
+                                          type: array
+                                          format: ip
+                                          maxItems: 16
+                                          items:
+                                            description: IP is an IP address (for example, "10.0.0.0" or "fd00::").
+                                            type: string
+                                            pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*)
+                                          x-kubernetes-list-type: set
+                                    dnsType:
+                                      description: dnsType indicates the type of DNS solution in use within the cluster. Its default value of `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform. It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode, the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.
+                                      type: string
+                                      default: PlatformDefault
+                                      enum:
+                                        - ClusterHosted
+                                        - PlatformDefault
+                                      x-kubernetes-validations:
+                                        - rule: oldSelf == '' || self == oldSelf
+                                          message: dnsType is immutable
+                                  nullable: true
+                                  x-kubernetes-validations:
+                                    - rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted'' ? !has(self.clusterHosted) : true'
+                                      message: clusterHosted is permitted only when dnsType is ClusterHosted
                                 projectID:
                                   description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
                                   type: string
                                 region:
                                   description: region holds the region for new GCP resources created for the cluster.
                                   type: string
+                                resourceLabels:
+                                  description: resourceLabels is a list of additional labels to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources for information on labeling GCP resources. GCP supports a maximum of 64 labels per resource. OpenShift reserves 32 labels for internal use, allowing 32 labels for user configuration.
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: GCPResourceLabel is a label to apply to GCP resources created for the cluster.
+                                    type: object
+                                    required:
+                                      - key
+                                      - value
+                                    properties:
+                                      key:
+                                        description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
+                                        type: string
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                        x-kubernetes-validations:
+                                          - rule: '!self.startsWith(''openshift-io'') && !self.startsWith(''kubernetes-io'')'
+                                            message: label keys must not start with either `openshift-io` or `kubernetes-io`
+                                      value:
+                                        description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
+                                        type: string
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[0-9a-z_-]{1,63}$
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                  x-kubernetes-validations:
+                                    - rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                                      message: resourceLabels are immutable and may only be configured during installation
+                                resourceTags:
+                                  description: resourceTags is a list of additional tags to apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview for information on tagging GCP resources. GCP supports a maximum of 50 tags per resource.
+                                  type: array
+                                  maxItems: 50
+                                  items:
+                                    description: GCPResourceTag is a tag to apply to GCP resources created for the cluster.
+                                    type: object
+                                    required:
+                                      - key
+                                      - parentID
+                                      - value
+                                    properties:
+                                      key:
+                                        description: key is the key part of the tag. A tag key can have a maximum of 63 characters and cannot be empty. Tag key must begin and end with an alphanumeric character, and must contain only uppercase, lowercase alphanumeric characters, and the following special characters `._-`.
+                                        type: string
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                      parentID:
+                                        description: 'parentID is the ID of the hierarchical resource where the tags are defined, e.g. at the Organization or the Project level. To find the Organization or Project ID refer to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id, https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects. An OrganizationID must consist of decimal numbers, and cannot have leading zeroes. A ProjectID must be 6 to 30 characters in length, can only contain lowercase letters, numbers, and hyphens, and must start with a letter, and cannot end with a hyphen.'
+                                        type: string
+                                        maxLength: 32
+                                        minLength: 1
+                                        pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                      value:
+                                        description: value is the value part of the tag. A tag value can have a maximum of 63 characters and cannot be empty. Tag value must begin and end with an alphanumeric character, and must contain only uppercase, lowercase alphanumeric characters, and the following special characters `_-.@%=+:,*#&(){}[]` and spaces.
+                                        type: string
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                  x-kubernetes-validations:
+                                    - rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                                      message: resourceTags are immutable and may only be configured during installation
+                              x-kubernetes-validations:
+                                - rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels) || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                                  message: resourceLabels may only be configured during installation
+                                - rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                                  message: resourceTags may only be configured during installation
                             ibmcloud:
                               description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
                               type: object
@@ -980,6 +1271,7 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
                                 ingressIP:
                                   description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
                                   type: string
@@ -990,6 +1282,23 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
+                                loadBalancer:
+                                  description: loadBalancer defines how the load balancer used by the cluster is configured.
+                                  type: object
+                                  default:
+                                    type: OpenShiftManagedDefault
+                                  properties:
+                                    type:
+                                      description: type defines the type of load balancer used by the cluster on Nutanix platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                                      type: string
+                                      default: OpenShiftManagedDefault
+                                      enum:
+                                        - OpenShiftManagedDefault
+                                        - UserManaged
+                                      x-kubernetes-validations:
+                                        - rule: oldSelf == '' || self == oldSelf
+                                          message: type is immutable once set
                             openstack:
                               description: OpenStack contains settings specific to the OpenStack infrastructure provider.
                               type: object
@@ -1004,6 +1313,7 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
                                 cloudName:
                                   description: cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).
                                   type: string
@@ -1017,6 +1327,7 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
                                 loadBalancer:
                                   description: loadBalancer defines how the load balancer used by the cluster is configured.
                                   type: object
@@ -1033,6 +1344,15 @@ spec:
                                       x-kubernetes-validations:
                                         - rule: oldSelf == '' || self == oldSelf
                                           message: type is immutable once set
+                                machineNetworks:
+                                  description: machineNetworks are IP networks used to connect all the OpenShift cluster nodes.
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)
+                                  x-kubernetes-list-type: set
                                 nodeDNSIP:
                                   description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
                                   type: string
@@ -1050,6 +1370,7 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
                                 ingressIP:
                                   description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
                                   type: string
@@ -1060,6 +1381,23 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
+                                loadBalancer:
+                                  description: loadBalancer defines how the load balancer used by the cluster is configured.
+                                  type: object
+                                  default:
+                                    type: OpenShiftManagedDefault
+                                  properties:
+                                    type:
+                                      description: type defines the type of load balancer used by the cluster on Ovirt platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                                      type: string
+                                      default: OpenShiftManagedDefault
+                                      enum:
+                                        - OpenShiftManagedDefault
+                                        - UserManaged
+                                      x-kubernetes-validations:
+                                        - rule: oldSelf == '' || self == oldSelf
+                                          message: type is immutable once set
                                 nodeDNSIP:
                                   description: 'deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.'
                                   type: string
@@ -1103,6 +1441,9 @@ spec:
                                         type: string
                                         format: uri
                                         pattern: ^https://
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
                                 zone:
                                   description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
                                   type: string
@@ -1144,6 +1485,7 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
                                 ingressIP:
                                   description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
                                   type: string
@@ -1154,6 +1496,32 @@ spec:
                                   maxItems: 2
                                   items:
                                     type: string
+                                  x-kubernetes-list-type: set
+                                loadBalancer:
+                                  description: loadBalancer defines how the load balancer used by the cluster is configured.
+                                  type: object
+                                  default:
+                                    type: OpenShiftManagedDefault
+                                  properties:
+                                    type:
+                                      description: type defines the type of load balancer used by the cluster on VSphere platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                                      type: string
+                                      default: OpenShiftManagedDefault
+                                      enum:
+                                        - OpenShiftManagedDefault
+                                        - UserManaged
+                                      x-kubernetes-validations:
+                                        - rule: oldSelf == '' || self == oldSelf
+                                          message: type is immutable once set
+                                machineNetworks:
+                                  description: machineNetworks are IP networks used to connect all the OpenShift cluster nodes.
+                                  type: array
+                                  maxItems: 32
+                                  items:
+                                    description: CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                    type: string
+                                    pattern: (^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)
+                                  x-kubernetes-list-type: set
                                 nodeDNSIP:
                                   description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
                                   type: string

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -276,6 +276,16 @@ func appendManifestsByPlatform(manifests []manifest, infra configv1.Infrastructu
 		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.NutanixPlatformType)), lbType)
 	}
 
+	if infra.Status.PlatformStatus.GCP != nil {
+		// Generate just the CoreDNS manifests for the GCP platform only when the DNSType is `ClusterHosted`.
+		if infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig != nil && infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType == configv1.ClusterHostedDNSType {
+			// We do not need the keepalived manifests to be generated because in this case the cloud default Load Balancers are used.
+			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
+			lbType = configv1.LoadBalancerTypeUserManaged
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.GCPPlatformType)), lbType)
+		}
+	}
+
 	return manifests
 }
 

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -84,6 +84,7 @@ func (optr *Operator) syncRelatedObjects() error {
 		{Resource: "namespaces", Name: "openshift-ovirt-infra"},
 		{Resource: "namespaces", Name: "openshift-vsphere-infra"},
 		{Resource: "namespaces", Name: "openshift-nutanix-infra"},
+		{Resource: "namespaces", Name: "openshift-cloud-platform-infra"},
 	}
 
 	if !equality.Semantic.DeepEqual(coCopy.Status.RelatedObjects, co.Status.RelatedObjects) {

--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -1,0 +1,50 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/coredns/Corefile.tmpl"
+contents:
+  inline: |
+    . {
+        errors
+        bufsize 512
+        health :18080
+        forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+            policy sequential
+        }
+        cache 30
+        reload
+        template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match .*[.]apps.{{ .DNS.Spec.BaseDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformIngressLoadBalancerIPs .)) 0 }}{{ index (cloudPlatformIngressLoadBalancerIPs .) 0 }}{{ end }}"
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match .*[.]apps.{{ .DNS.Spec.BaseDomain }}
+            {{ if gt (len (cloudPlatformIngressLoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformIngressLoadBalancerIPs .) 1 }}"{{ end }}
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match ^api.{{ .DNS.Spec.BaseDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 0 }}{{ index (cloudPlatformAPILoadBalancerIPs) 0 }}{{ end }}"
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match ^api.{{ .DNS.Spec.BaseDomain }}
+            {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformAPILoadBalancerIPs) 1 }}"{{ end }}
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match ^api-int.{{ .DNS.Spec.BaseDomain }}
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformAPIIntLoadBalancerIPs .)) 0 }}{{ index (cloudPlatformAPIIntLoadBalancerIPs .) 0 }}{{ end }}"
+            fallthrough
+        }
+        template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
+            match ^api-int.{{ .DNS.Spec.BaseDomain }}
+            {{ if gt (len (cloudPlatformAPIIntLoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformAPIIntLoadBalancerIPs .) 1 }}"{{ end }}
+            fallthrough
+        }
+        hosts {
+            {{`{{- range .Cluster.NodeAddresses }}
+            {{ .Address }} {{ .Name }} {{ .Name }}.{{ $.Cluster.Name }}.{{ $.Cluster.Domain }}
+            {{- end }}`}}
+            fallthrough
+        }
+    }

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -1,0 +1,113 @@
+mode: 0644
+path: {{ if gt (len (cloudPlatformAPIIntLoadBalancerIPs .)) 0 -}} "/etc/kubernetes/manifests/coredns.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/coredns.yaml" {{ end }}
+contents:
+  inline: |
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: coredns
+      namespace: openshift-cloud-platform-infra
+      creationTimestamp:
+      deletionGracePeriodSeconds: 65
+      labels:
+        app: cloud-platform-infra-coredns
+    spec:
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/coredns"
+      - name: kubeconfig
+        hostPath:
+          path: "/var/lib/kubelet"
+      - name: conf-dir
+        hostPath:
+          path: "/etc/coredns"
+      initContainers:
+      - name: render-config-coredns
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - runtimecfg
+        - render
+        - "/var/lib/kubelet/kubeconfig"
+        - "--cloud-ext-lb-ips"
+        - "{{- range $index, $ip := cloudPlatformAPILoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "--cloud-int-lb-ips"
+        - "{{- range $index, $ip := cloudPlatformAPIIntLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "--cloud-ingress-lb-ips"
+        - "{{- range $index, $ip := cloudPlatformIngressLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "/config"
+        - "--out-dir"
+        - "/etc/coredns"
+        resources: {}
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
+        - name: resource-dir
+          mountPath: "/config"
+          mountPropagation: HostToContainer
+        - name: conf-dir
+          mountPath: "/etc/coredns"
+          mountPropagation: HostToContainer
+        imagePullPolicy: IfNotPresent
+      containers:
+      - name: coredns
+        securityContext:
+          privileged: true
+        image: {{.Images.corednsImage}}
+        args:
+        - "--conf"
+        - "/etc/coredns/Corefile"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/coredns"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 18080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      - name: coredns-monitor
+        securityContext:
+          privileged: true
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - corednsmonitor
+        - "/var/lib/kubelet/kubeconfig"
+        - "/config/Corefile.tmpl"
+        - "/etc/coredns/Corefile"
+        - "--cloud-ext-lb-ips"
+        - "{{- range $index, $ip := cloudPlatformAPILoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "--cloud-int-lb-ips"
+        - "{{- range $index, $ip := cloudPlatformAPIIntLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "--cloud-ingress-lb-ips"
+        - "{{- range $index, $ip := cloudPlatformIngressLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi          
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
+        - name: resource-dir
+          mountPath: "/config"
+          mountPropagation: HostToContainer
+        - name: conf-dir
+          mountPath: "/etc/coredns"
+          mountPropagation: HostToContainer
+        imagePullPolicy: IfNotPresent        
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+    status: {}

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -11,6 +11,8 @@ contents:
       deletionGracePeriodSeconds: 65
       labels:
         app: cloud-platform-infra-coredns
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       volumes:
       - name: resource-dir


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Based on enhancement : https://github.com/openshift/enhancements/pull/1468

**- How to verify it**
Verification still in-progress.

**- Description for the changelog**
These changes allow MCO to read an optional configmap containing the LB IPs of the LBs configured on cloud platforms, to be used to generate in-cluster DNS for API and API-Int URLs.

Contains implementation for [CORS-2814](https://issues.redhat.com//browse/CORS-2814), [CORS-2815](https://issues.redhat.com//browse/CORS-2815) and [CORS-3169](https://issues.redhat.com//browse/CORS-3169)
