### PR TITLE
OCPBUGS-6508: keepalived: disable Unicast if InfrastructureTopology is SingleReplica

### DIFF
--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -109,7 +109,7 @@ spec:
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
     env:
       - name: ENABLE_UNICAST
-        value: "yes"
+        value: {{ if isSingleReplicaTopology .ControllerConfig }}"no"{{ else }}"yes"{{ end }}
       - name: IS_BOOTSTRAP
         value: "yes"
     command:

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -343,6 +343,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
 	funcs["cloudPlatformIngressLoadBalancerIPs"] = cloudPlatformIngressLoadBalancerIPs
+	funcs["isSingleReplicaTopology"] = isSingleReplicaTopology
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template %s: %w", path, err)
@@ -758,4 +759,8 @@ func cloudPlatformLoadBalancerIPState(cfg RenderConfig) LoadBalancerIPState {
 		}
 	}
 	return lbIPState
+}
+
+func isSingleReplicaTopology(cfg RenderConfig) bool {
+	return cfg.Infra.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode
 }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -77,6 +77,7 @@ func (a *assetRenderer) addTemplateFuncs() {
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
 	funcs["cloudPlatformIngressLoadBalancerIPs"] = cloudPlatformIngressLoadBalancerIPs
+	funcs["isSingleReplicaTopology"] = isSingleReplicaTopology
 
 	a.tmpl = a.tmpl.Funcs(funcs)
 }
@@ -447,4 +448,8 @@ func cloudPlatformLoadBalancerIPState(cfg mcfgv1.ControllerConfigSpec) LoadBalan
 		}
 	}
 	return lbIPState
+}
+
+func isSingleReplicaTopology(cfg mcfgv1.ControllerConfigSpec) bool {
+	return cfg.Infra.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode
 }

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -181,7 +181,7 @@ contents:
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: ENABLE_UNICAST
-            value: "yes"
+            value: {{ if isSingleReplicaTopology . }}"no"{{ else }}"yes"{{ end }}
           - name: IS_BOOTSTRAP
             value: "no"
         command:


### PR DESCRIPTION
If we find that the `InfrastructureTopology` is `SingleReplica`, we will
not configure Keepalived in Unicast mode, since you need at least 2
nodes for VRRP peering via Unicast.

This patch will enable on-prem platforms using Keepalived to serve VIPs for a single node OpenShift.