### PR TITLE
OCPBUGS-22324: Wait for br-ex up event before node-valid-hostname

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -34,6 +34,9 @@ contents:
             >&2 echo "NM resolv-prepender: Timeout occurred"
             exit 1
         fi
+        if [[ "$STATUS" == "up" ]] && [[ $IFACE == "br-ex" ]]; then
+            touch /run/nodeip-configuration/br-ex-up
+        fi
       ;;
       *)
       ;;

--- a/templates/common/on-prem/files/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/files/wait-for-br-ex-up.yaml
@@ -1,0 +1,10 @@
+mode: 0755
+path: "/usr/local/bin/wait-for-br-ex-up.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    until [ -e /run/nodeip-configuration/br-ex-up ]
+    do
+      sleep 1
+    done

--- a/templates/common/on-prem/units/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/units/wait-for-br-ex-up.yaml
@@ -1,0 +1,15 @@
+name: wait-for-br-ex-up.service
+enabled: {{if gt (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Wait for br-ex up event from NetworkManager
+  Wants=ovs-configuration.service
+  After=ovs-configuration.service
+  Before=node-valid-hostname.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/wait-for-br-ex-up.sh
+
+  [Install]
+  RequiredBy=node-valid-hostname.service


### PR DESCRIPTION
In environments with ipv6 (both single and dual stack) we explicitly set the hostname to the FQDN. However, the recent change to make the current hostname static in the node-valid-hostname service[0] has created a conflict with the resolv-prepender script where we force the FQDN. If node-valid-hostname runs before the "up" event for the interface which provides the hostname, it's possible for it to statically set a short name, which prevents the prepender script from later changing it to an FQDN.

This can happen because the up event is asynchronous. The network is marked up before the event is dispatched, and as a result we currently have a race between the event and the node-valid-hostname service. To ensure proper ordering, this change adds a new dependency to node-valid-hostname which is a service that simply wait for the br-ex up event. Once we've received that, we should have run the prepender script and set the FQDN if necessary.

0: https://github.com/openshift/machine-config-operator/pull/3794

