### PR TITLE
[release-4.14] OCPBUGS-23208: workaround nmstate bug by configuring ipv{4,6} addresses

### DIFF
--- a/templates/common/kubevirt/files/002-nmstate-arp-proxy-ipv6-gw.yaml
+++ b/templates/common/kubevirt/files/002-nmstate-arp-proxy-ipv6-gw.yaml
@@ -4,6 +4,11 @@ contents:
     capture:
       ethernet-nics: interfaces.type=="ethernet"
     desiredState:
+      interfaces:
+      - name: "{{`{{ capture.ethernet-nics.interfaces.0.name }}`}}"
+        type: "{{`{{ capture.ethernet-nics.interfaces.0.type }}`}}"
+        ipv4: "{{`{{ capture.ethernet-nics.interfaces.0.ipv4 }}`}}"
+        ipv6: "{{`{{ capture.ethernet-nics.interfaces.0.ipv6 }}`}}"
       routes:
         config:
         - destination: ::/0


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Due to an nmstate bug - [0] - the IPv4 address previously configured from the
DHCP server is being configured as a static address.
    
The same should happen for IPv6 addresses.
    
If we explicitly list the desired IPs on the interfaces for IPv4 and
IPv6, the issue is not triggered.
    
This commit is a workaround, which should be used until the nmstate fix - [1] - is released in a RHEL Z-stream.
    
[0] - https://issues.redhat.com/browse/RHEL-16316
[1] - https://github.com/nmstate/nmstate/pull/2455

**- How to verify it**
1. create an hosted cluster
2. restart a worker node of the hosted cluster
3. the node status should reach `Ready` after a while

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Work-around nmstate bug [RHEL-16316](https://issues.redhat.com//browse/RHEL-16316) by explicitly configuring the IPv{4,6} IP addresses when defining the IPv6 ARP proxy GW.

Fixes: [CNV-35145](https://issues.redhat.com//browse/CNV-35145)