### PR TITLE
OCPBUGS-23255: Add FIPS information to oldconfig when checking if reboot is needed

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1086,6 +1086,12 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 		return fmt.Errorf("failed to set kernel arguments from /proc/cmdline: %w", err)
 	}
 
+	// Set the running fips setting to oldConfig in order to correctly include this value
+	// during comparison
+	if err = setNodeFipsIntoMC(oldConfig); err != nil {
+		return fmt.Errorf("failed to set node FIPS into MC: %w", err)
+	}
+
 	// Currently, we generally expect the bootimage to be older, but in the special
 	// case of having bootimage == machine-os-content, and no kernel arguments
 	// specified, then we don't need to do anything here.
@@ -1098,6 +1104,7 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 		if err := os.Remove(constants.MachineConfigEncapsulatedPath); err != nil {
 			return fmt.Errorf("failed to remove %s: %w", constants.MachineConfigEncapsulatedPath, err)
 		}
+		logSystem("skipping reboot since no changes were detected from %s to %s", oldConfig.GetName(), mc.GetName())
 		return nil
 	}
 


### PR DESCRIPTION
When trying to avoid reboot, current FIPS setting needs to be set into the running machine config configuration.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Merged running node FIPS to old configuration

**- How to verify it**
Test installation with assisted installer on top 4.15 with fips enabled.  Reboot should be skipped
**- Description for the changelog**
<!--
Merge running node FIPS into the current configuration when checking if reboot is needed
-->
