### PR TITLE
[OCP-4.13] OCPBUGS-24661: daemon: Add support for new nmstate logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     elif [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for scos
     sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    # XXX: pin nmstate to 2.2.9 until we've replaced `--inspect` (see https://github.com/openshift/machine-config-operator/pull/3706)
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install nmstate-2.2.9-6.rhaos4.13.el8 && dnf clean all && rm -rf /var/cache/dnf/*
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate >= 2.2.10' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -30,8 +30,7 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     elif [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for scos
     sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
-    # XXX: pin nmstate to 2.2.9 until we've replaced `--inspect` (see https://github.com/openshift/machine-config-operator/pull/3706)
-    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install nmstate-2.2.9-6.rhaos4.13.el8 && dnf clean all && rm -rf /var/cache/dnf/*
+    if ! rpm -q util-linux; then dnf install -y util-linux; fi && dnf -y install 'nmstate >= 2.2.10' && dnf clean all && rm -rf /var/cache/dnf/*
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -40,7 +40,7 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 		// If asked, before we try an OS update, persist NIC names (if applicable) so that
 		// we handle the reprovision case with old disk images and Ignition configs
 		// that provide static IP addresses.
-		if err := daemon.MaybePersistNetworkInterfaces("/rootfs"); err != nil {
+		if err := daemon.PersistNetworkInterfaces("/rootfs"); err != nil {
 			return fmt.Errorf("failed to persist network interfaces: %w", err)
 		}
 		return nil


### PR DESCRIPTION
After nmstate 2.2.10, nmstate changed its persistent NIC names logic to:

 1. Before upgrade, `nmstatectl persist-nic-names` will pin ALL ethernet interfaces using its firmware MAC address.
 2. After upgrade, `nmstatectl persist-nic-names --cleanup` will remove systemd .link files which has no effect.

This patch replaced the old nmstate persist-nic-names workflow with above.

Backport of https://github.com/openshift/machine-config-operator/pull/4020
