### PR TITLE
OCPCLOUD-1609: Fix syntax in vsphere-hostname.yaml for CAPI machines

### DIFF
--- a/templates/common/vsphere/files/vsphere-hostname.yaml
+++ b/templates/common/vsphere/files/vsphere-hostname.yaml
@@ -13,7 +13,7 @@ contents:
     fi
 
     if [ -z "${vm_name}" ]; then
-      if capi_vm_name=$(bin/vmtoolsd --cmd 'info-get guestinfo.metadata' | base64 -d | grep local-hostname | awk '{ print $2; }' | tr -d '",'; then
+      if capi_vm_name=$(/bin/vmtoolsd --cmd 'info-get guestinfo.metadata' | base64 -d | grep local-hostname | awk '{ print $2; }' | tr -d '",'); then
         /usr/bin/hostnamectl set-hostname --static ${capi_vm_name}
       fi
     fi


### PR DESCRIPTION
This is a follow up to #3949 as I have introduced bash code that was not syntactically correct.
