### PR TITLE
kubevirt: Activate nodeip-configuration.service

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -1,7 +1,7 @@
 # NOTE: When making changes to this service, be sure they are replicated in the
 # VSphere-specific service in templates/common/vsphere/units.
 name: nodeip-configuration.service
-enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{end}}
+enabled: {{if or (eq .Infra.Status.PlatformStatus.Type "None") (eq .Infra.Status.PlatformStatus.Type "kubevirt")}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP


### PR DESCRIPTION
**- What I did**
Enable nodeip-configuration.service at kubevirt platform liks hypershift kubevirt provider.

**- How to verify it**
Following the steps at https://docs.openshift.com/container-platform/4.14/support/troubleshooting/troubleshooting-network-issues.html#overriding-default-node-ip-selection-logic_troubleshooting-network-issues, works as expected

**- Description for the changelog**
kubevirt: Activate nodeip-configuration.service
