### PR TITLE
OCPBUGS-23484: kubevirt, Activate nodeip-configuration.service

### DIFF
--- a/templates/common/kubevirt/units/nodeip-configuration.service.yaml
+++ b/templates/common/kubevirt/units/nodeip-configuration.service.yaml
@@ -1,7 +1,5 @@
-# NOTE: When making changes to this service, be sure they are replicated in the
-# VSphere-specific service in templates/common/[vsphere|kubevirt]/units
 name: nodeip-configuration.service
-enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{end}}
+enabled: true
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP


### PR DESCRIPTION
**- What I did**
Activate nodeip-configuration for KubeVirt

**- How to verify it**
When creating the node-hint file KubeVirt node select the proper IP for kubelet

**- Description for the changelog**
kubevirt: Activate nodeip-configuration.service
