### PR TITLE
OCPBUGS-24019: Add ownership annotations to TLS artifacts

### DIFF
--- a/manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml
+++ b/manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: initial-kube-apiserver-server-ca
   namespace: openshift-config
+  annotations:
+    openshift.io/owning-component: Machine Config Operator
 data:
   ca-bundle.crt: |
 {{.KubeAPIServerServingCA | indent 4}}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Updated annotations in `initial-kube-apiserver-server-ca` configmap so that it can be identified to be created and managed by Machine Config Operator

This adds annotation which identifies the component used to file issues with this certificate. The annotation is verified by [the test](https://github.com/openshift/origin/blob/master/test/extended/operators/certs.go?rgh-link-date=2023-11-21T09%3A53%3A38Z#L130), so that all certificates would be registered and have owners assigned. More metadata would be added later.

See https://github.com/openshift/enhancements/pull/1502 for proposed workflow with TLS registry

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
