### PR TITLE
OCPBUGS-23085: MCO duplicates kernel arguments during firstboot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1112,7 +1112,7 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig() error {
 	// This "false" is a compatibility for IBM's use case, where they are using the MCD to write the full configuration instead of just
 	// the encapsulated config. This shouldn't affect normal OCP operations, but will allow anyone using this code to write configs to
 	// still get the kubelet cert
-	err = dn.update(nil, &mc, false)
+	err = dn.update(oldConfig, &mc, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
During firstboot, if a kernel argument appears both in the boot command line and in the encapsulated machine config, this kernel argument is duplicated.
The reason for that is that current running configuration is not taken into account when updating the configuration before reboot. The solution is to use the current running configuration when updating during firstboot.
Fixes: OCPBUGS-23085

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Use the current running configuration when updating in firstboot.
**- How to verify it**
Add a kernel argument that appears also in the machine-config to firstboot, and see that it is not duplicated after reboot.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Do not duplicate kernel arguments if they are present during firstboot

/cc @sinnykumari 