### PR TITLE
OCPNODE-1877: Delete image openshift/openshift-proxy-pull-test

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,0 @@
-FROM registry.ci.openshift.org/ocp/4.15:base
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-COPY docs/openshift-proxy-pull-test.md .
-LABEL io.openshift.release.operator true

--- a/docs/openshift-proxy-pull-test.md
+++ b/docs/openshift-proxy-pull-test.md
@@ -1,1 +1,0 @@
-The Dockerfile.proxy builds the openshift-proxy-pull-test image.  If the http proxy is set by controller config,  [MCO](https://github.com/openshift/machine-config-operator) will validate the proxy by pulling this image through the proxy.  The proxy is valid if the image can be successfully pulled.


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
openshift-proxy-pull-test image was not used in the code, remove the image openshift-proxy-pull-test-container from the build, so we will not be affected by the possible bugs during the image build.
Created [ART-8371](https://issues.redhat.com/browse/ART-8371) to ask the ART team to remove the image openshift-proxy-pull-test
**- What I did**
revert https://github.com/openshift/machine-config-operator/pull/2602

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
