### PR TITLE
OCPBUGS-24012: Add templates for gc_thresh sysctls

### DIFF
--- a/templates/common/_base/files/sysctl-gc-thresh.yaml
+++ b/templates/common/_base/files/sysctl-gc-thresh.yaml
@@ -1,0 +1,11 @@
+mode: 0644
+path: "/etc/sysctl.d/gc-thresh.conf"
+contents:
+  inline: |
+    # See: rhbz#1384746, OCPBUGS-24012
+    net.ipv4.neigh.default.gc_thresh1=8192
+    net.ipv4.neigh.default.gc_thresh2=32768
+    net.ipv4.neigh.default.gc_thresh3=65536
+    net.ipv6.neigh.default.gc_thresh1=8192
+    net.ipv6.neigh.default.gc_thresh2=32768
+    net.ipv6.neigh.default.gc_thresh3=65536


### PR DESCRIPTION
**- What I did**

The net.ipv[46].neigh.default.gc_thresh[1-3] have traditionally been set by the Node Tuning Operator.  With OpenShift 4.13, NTO is now an optional operator.  These sysctls tune kernel's ARP cache.  For large scale clusters, the default kernel parameters are too low and result in issues such as rhbz#1384746.  In the absence of NTO and customer clusters getting larger, these sysctls need to be set elsewhere.

Setting these values early on cluster boot (prior to container startups) will also prevent issues such as OCPBUGS-24012.

Fixes: OCPBUGS-24012

**- How to verify it**

Check the file /etc/sysctl.d/gc-thresh.conf exists in a new cluster with:

```
net.ipv4.neigh.default.gc_thresh1=8192
net.ipv4.neigh.default.gc_thresh2=32768
net.ipv4.neigh.default.gc_thresh3=65536
net.ipv6.neigh.default.gc_thresh1=8192
net.ipv6.neigh.default.gc_thresh2=32768
net.ipv6.neigh.default.gc_thresh3=65536
```

**- Description for the changelog**
Add /etc/sysctl.d/gc-thresh.conf file to bump ARP cache limits.
