### PR TITLE
OCPBUGS-24035: execute cert related processes to ensure proper rotation

### DIFF
--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -107,10 +107,8 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 
 		kubeAPIServerServingCABytes := controllerConfig.Spec.KubeAPIServerServingCAData
 		cloudCA := controllerConfig.Spec.CloudProviderCAData
-		userCA := controllerConfig.Spec.AdditionalTrustBundle
 		pathToData[caBundleFilePath] = kubeAPIServerServingCABytes
 		pathToData[cloudCABundleFilePath] = cloudCA
-		pathToData[userCABundleFilePath] = userCA
 
 		for bundle, data := range pathToData {
 			if Finfo, err := os.Stat(bundle); err == nil {
@@ -183,6 +181,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			return fmt.Errorf("failed to set ControllerConfigResourceVersion annotation on node: %w", err)
 		}
 		klog.Infof("Certificate was synced from controllerconfig resourceVersion %s", controllerConfig.ObjectMeta.ResourceVersion)
+
 	}
 
 	return nil

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -101,4 +101,7 @@ const (
 
 	// SSH keys in RHCOS 9 / FCOS / SCOS will be written to /home/core/.ssh/authorized_keys.d/ignition
 	RHCOS9SSHKeyPath = CoreUserSSHPath + "/authorized_keys.d/ignition"
+
+	// CRIOServiceName is used to specify reloads and restarts of the CRI-O service
+	CRIOServiceName = "crio"
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1074,7 +1074,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 	}
 
 	if ctrlcommon.InSlice(postConfigChangeActionReloadCrio, actions) {
-		serviceName := "crio"
+		serviceName := constants.CRIOServiceName
 		if err := reloadService(serviceName); err != nil {
 			return fmt.Errorf("could not apply update: reloading %s configuration failed. Error: %w", serviceName, err)
 		}

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -119,7 +119,7 @@ func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig i
 	if ctrlcommon.InSlice(postConfigChangeActionReboot, actions) {
 		// Node is going to reboot, we definitely want to perform drain
 		return true, nil
-	} else if ctrlcommon.InSlice(postConfigChangeActionReloadCrio, actions) {
+	} else if ctrlcommon.InSlice(postConfigChangeActionReloadCrio, actions) || ctrlcommon.InSlice(postConfigChangeActionRestartCrio, actions) {
 		// Drain may or may not be necessary in case of container registry config changes.
 		if ctrlcommon.InSlice(constants.ContainerRegistryConfPath, diffFileSet) {
 			isSafe, err := isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig)

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -132,7 +132,6 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 
 	addDataAndMaybeAppendToIgnition(caBundleFilePath, cc.Spec.KubeAPIServerServingCAData, &ignConf)
 	addDataAndMaybeAppendToIgnition(cloudProviderCAPath, cc.Spec.CloudProviderCAData, &ignConf)
-	addDataAndMaybeAppendToIgnition(additionalCAPath, cc.Spec.AdditionalTrustBundle, &ignConf)
 	appenders := getAppenders(currConf, nil, bsc.kubeconfigFunc, bsc.certs, bsc.serverBaseDir)
 	for _, a := range appenders {
 		if err := a(&ignConf, mc); err != nil {

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -136,7 +136,6 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 
 	addDataAndMaybeAppendToIgnition(caBundleFilePath, cc.Spec.KubeAPIServerServingCAData, &ignConf)
 	addDataAndMaybeAppendToIgnition(cloudProviderCAPath, cc.Spec.CloudProviderCAData, &ignConf)
-	addDataAndMaybeAppendToIgnition(additionalCAPath, cc.Spec.AdditionalTrustBundle, &ignConf)
 	appenders := getAppenders(currConf, cr.version, cs.kubeconfigFunc, []string{}, "")
 	for _, a := range appenders {
 		if err := a(&ignConf, mc); err != nil {

--- a/templates/common/_base/files/additional-trust-bundle.yaml
+++ b/templates/common/_base/files/additional-trust-bundle.yaml
@@ -1,0 +1,7 @@
+mode: 0600
+path: "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
+contents:
+  inline: |
+{{if .AdditionalTrustBundle -}}
+{{.AdditionalTrustBundle | toString | indent 4}}
+{{end -}}

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -400,7 +400,6 @@ func compareRenderedConfigPool(t *testing.T, clientSet *framework.ClientSet, des
 	for _, file := range outIgn.Storage.Files {
 		require.False(t, file.Path == "/etc/kubernetes/kubelet-ca.crt")
 		require.False(t, file.Path == "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem")
-		require.False(t, file.Path == "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt")
 	}
 	if controllerRenderedConfigName != bootstrapRenderedConfigName {
 		t.Errorf("Expected rendered %s configurations to match: got bootstrap config %q, got controller config %q", poolName, bootstrapRenderedConfigName, controllerRenderedConfigName)

--- a/test/e2e/mco_test.go
+++ b/test/e2e/mco_test.go
@@ -248,7 +248,13 @@ func TestImageRegistryMergedCM(t *testing.T) {
 	//mcd, err := helpers.MCDForNode(cs, &nodes[0])
 
 	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		out := helpers.ExecCmdOnNode(t, cs, nodes[0], "ls", "/rootfs/etc/docker/certs.d")
+		out, err := helpers.ExecCmdOnNodeWithError(cs, nodes[0], "ls", "/rootfs/etc/docker/certs.d")
+		if err != nil {
+			t.Logf("Error while exec'ing on node. Probably transient due to commands being executed: %s", err.Error())
+			nodes, err = helpers.GetNodesByRole(cs, "worker")
+			require.Nil(t, err)
+			return false, nil
+		}
 		t.Logf("OUTPUT: %s", out)
 		return strings.Contains(out, "foo"), nil
 	})


### PR DESCRIPTION
in order to update the system with new cert info, execute update-ca-trust and crio restart when the userCA changes

also add it back to MachineConfig in order to avoid the kubelet going down and the node becoming unreachable. So now, changing this cert causes an update with a new post config action