### PR TITLE
TRT-1375: Revert #3965 "MCO-681, OCPBUGS-20427: Add Key State Metrics, No datapoint found when querying up certain registered metrics"

### DIFF
--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -38,12 +38,6 @@ var (
 			Name: "mcc_pool_alert",
 			Help: "pool status alert",
 		}, []string{"node"})
-	// MCCSubControllerState logs the state of the subcontrollers of the MCC
-	MCCSubControllerState = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "mcc_sub_controller_state",
-			Help: "state of sub-controllers in the MCC",
-		}, []string{"subcontroller", "state", "object"})
 )
 
 func RegisterMCCMetrics() error {
@@ -51,25 +45,15 @@ func RegisterMCCMetrics() error {
 		OSImageURLOverride,
 		MCCDrainErr,
 		MCCPoolAlert,
-		MCCSubControllerState,
 	})
 
 	if err != nil {
 		return fmt.Errorf("could not register machine-config-controller metrics: %w", err)
 	}
 
-	// Initilize GuageVecs to ensure that metrics of type GuageVec are accessible from the dashboard even if without a logged value
-	// Solution to OCPBUGS-20427: https://issues.redhat.com/browse/OCPBUGS-20427
-	OSImageURLOverride.WithLabelValues("initialize").Set(0)
-	MCCDrainErr.WithLabelValues("initialize").Set(0)
-	MCCPoolAlert.WithLabelValues("initialize").Set(0)
-	MCCSubControllerState.WithLabelValues("initialize", "initialize", "initialize").Set(0)
+	MCCDrainErr.Reset()
 
 	return nil
-}
-
-func UpdateStateMetric(metric *prometheus.GaugeVec, labels ...string) {
-	metric.WithLabelValues(labels...).SetToCurrentTime()
 }
 
 func RegisterMetrics(metrics []prometheus.Collector) error {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -684,11 +684,11 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 			return ctrl.syncStatusOnly(cfg, err, "could not add finalizers to ContainerRuntimeConfig: %v", err)
 		}
 		klog.Infof("Applied ContainerRuntimeConfig %v on MachineConfigPool %v", key, pool.Name)
-		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync Container Runtime Config", pool.Name)
 	}
 	if err := ctrl.cleanUpDuplicatedMC(); err != nil {
 		return err
 	}
+
 	return ctrl.syncStatusOnly(cfg, nil)
 }
 
@@ -887,9 +887,9 @@ func (ctrl *Controller) syncImageConfig(key string) error {
 		}
 		if applied {
 			klog.Infof("Applied ImageConfig cluster on MachineConfigPool %v", pool.Name)
-			ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync Image Config", pool.Name)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -361,7 +361,7 @@ func (ctrl *Controller) syncNode(key string) error {
 	if err := ctrl.setNodeAnnotations(node.Name, annotations); err != nil {
 		return fmt.Errorf("node %s: failed to set node uncordoned annotation: %w", node.Name, err)
 	}
-	ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-drain", desiredVerb, node.Name)
+
 	return nil
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -660,7 +660,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 			return ctrl.syncStatusOnly(cfg, err, "could not add finalizers to KubeletConfig: %v", err)
 		}
 		klog.Infof("Applied KubeletConfig %v on MachineConfigPool %v", key, pool.Name)
-		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync Kubelet Config", pool.Name)
 	}
 	if err := ctrl.cleanUpDuplicatedMC(managedKubeletConfigKeyPrefix); err != nil {
 		return err

--- a/pkg/controller/kubelet-config/kubelet_config_features.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features.go
@@ -118,7 +118,6 @@ func (ctrl *Controller) syncFeatureHandler(key string) error {
 			return fmt.Errorf("could not Create/Update MachineConfig: %w", err)
 		}
 		klog.Infof("Applied FeatureSet %v on MachineConfigPool %v", key, pool.Name)
-		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync FeatureSet", pool.Name)
 	}
 	return ctrl.cleanUpDuplicatedMC(managedFeaturesKeyPrefix)
 

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -163,7 +163,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 			return fmt.Errorf("Could not Create/Update MachineConfig, error: %w", err)
 		}
 		klog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
-		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync NodeConfig", pool.Name)
 	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -999,7 +999,6 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 			}
 			return err
 		}
-		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-node", "Sync Machine Config Pool", pool.Name)
 	}
 	return ctrl.syncStatusOnly(pool)
 }

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -439,6 +439,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		klog.Errorf("Error syncing Generated MCFG: %w", err)
 		return ctrl.syncFailingStatus(pool, err)
 	}
+
 	return ctrl.syncAvailableStatus(pool)
 }
 
@@ -535,7 +536,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		return err
 	}
 	klog.V(2).Infof("Pool %s: now targeting: %s", pool.Name, pool.Spec.Configuration.Name)
-	ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-render", "Sync Machine Config Pool with new MC", pool.Name)
+
 	return ctrl.garbageCollectRenderedConfigs(pool)
 }
 

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -577,7 +577,6 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		if updated {
 			klog.V(4).Infof("Machineconfig %s was updated", mc.Name)
 		}
-		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-template", "Sync Controller Config", mc.Name)
 	}
 
 	return ctrl.syncCompletedStatus(cfg)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1277,7 +1277,6 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 
 // Called whenever the on-disk config has drifted from the current machineconfig.
 func (dn *Daemon) onConfigDrift(err error) {
-	mcdConfigDrift.SetToCurrentTime()
 	dn.nodeWriter.Eventf(corev1.EventTypeWarning, "ConfigDriftDetected", err.Error())
 	klog.Error(err)
 	if err := dn.updateErrorState(err); err != nil {
@@ -1300,7 +1299,6 @@ func (dn *Daemon) getCurrentConfigFromNode() (*onDiskConfig, error) {
 }
 
 func (dn *Daemon) startConfigDriftMonitor() {
-	mcdConfigDrift.Set(0)
 	// Even though the Config Drift Monitor object ensures that only a single
 	// Config Drift Watcher is running at any given time, other things, such as
 	// emitting Kube events on startup, should only occur if we weren't

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -17,11 +17,11 @@ var (
 		}, []string{"os", "version"})
 
 	// mcdPivotErr flags error encountered during pivot
-	mcdPivotErr = prometheus.NewGaugeVec(
+	mcdPivotErr = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "mcd_pivot_errors_total",
 			Help: "Total number of errors encountered during pivot.",
-		}, []string{"total"})
+		})
 
 	// mcdState is state of mcd for indicated node (ex: degraded)
 	mcdState = prometheus.NewGaugeVec(
@@ -50,13 +50,6 @@ var (
 			Name: "mcd_update_state",
 			Help: "completed update config or error",
 		}, []string{"config", "err"})
-
-	// mcdConfigDrift logs a config drift
-	mcdConfigDrift = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "mcd_config_drift",
-			Help: "timestamp for configt drift",
-		})
 )
 
 // Updates metric with new labels & timestamp, deletes any existing
@@ -77,15 +70,11 @@ func RegisterMCDMetrics() error {
 		kubeletHealthState,
 		mcdRebootErr,
 		mcdUpdateState,
-		mcdConfigDrift,
 	})
 
 	if err != nil {
 		return fmt.Errorf("could not register machine-config-daemon metrics: %w", err)
 	}
-
-	// Initilize GuageVecs:
-	mcdPivotErr.WithLabelValues("initialize").Set(0)
 
 	kubeletHealthState.Set(0)
 

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -1,8 +1,6 @@
 package operator
 
 import (
-	"fmt"
-
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,17 +46,5 @@ var (
 )
 
 func RegisterMCOMetrics() error {
-	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
-		mcoState,
-		mcoMachineCount,
-		mcoUpdatedMachineCount,
-		mcoDegradedMachineCount,
-		mcoUnavailableMachineCount,
-	})
-
-	if err != nil {
-		return fmt.Errorf("could not register machine-config-operator metrics: %w", err)
-	}
-
-	return nil
+	return ctrlcommon.RegisterMetrics([]prometheus.Collector{mcoState, mcoMachineCount, mcoUpdatedMachineCount, mcoDegradedMachineCount, mcoUnavailableMachineCount})
 }


### PR DESCRIPTION

Reverts #3965 ; tracked by [TRT-1375](https://issues.redhat.com//browse/TRT-1375)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

10/10 GCP upgrades failed on MCDPivotError firing on the last payload, https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-gcp-ovn-rt-upgrade-4.15-minor-release-openshift-release-analysis-aggregator/1730187997023834112

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Please test payload blocking jobs, /payload 4.15 nightly blocking
```

CC: @inesqyx

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
