### PR TITLE
OCPNODE-1943: crio: add crun handler to template

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,13 @@ contents:
     ]
     drop_infra_ctr = true
 
+    [crio.runtime.runtimes.crun]
+    runtime_root = "/run/crun"
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
+    ]
+
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,13 @@ contents:
     ]
     drop_infra_ctr = true
 
+    [crio.runtime.runtimes.crun]
+    runtime_root = "/run/crun"
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
+    ]
+
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [


### PR DESCRIPTION
as well as allow /dev/fuse device access to the runtime class. After this merges, we will stop shipping a crio.conf in the crio rpm

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
