### PR TITLE
OCPBUGS-24356: ovs-configure: fix `vlan_parent` calculation

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -227,10 +227,10 @@ contents:
           exit 1
         fi
 
-        if nmcli connection show "$vlan_parent" &> /dev/null; then
+        if nmcli connection show uuid "$vlan_parent" &> /dev/null; then
           # if the VLAN connection is configured with a connection UUID as parent, we need to find the underlying device
           # and create the bridge against it, as the parent connection can be replaced by another bridge.
-          vlan_parent=$(nmcli --get-values GENERAL.DEVICES conn show ${vlan_parent})
+          vlan_parent=$(nmcli --get-values GENERAL.DEVICES conn show uuid ${vlan_parent})
         fi
 
         extra_phys_args=( dev "${vlan_parent}" id "${vlan_id}" )


### PR DESCRIPTION
When converting a VLAN connection to a bridge, the case when the target connection `vlan.parent` has been configured with a connection UUID needs to be managed as a special case, as the bridge connection has to target the underlying device instead of a connection UUID.

Use `nmcli connection show uuid <X>` to verify X is a connection UUID.

Previous condition `nmcli connection show <X>` evaluates to true if X is either a connection name, a UUID or a connection path. This happens to break when there are two connections with the same name, e.g.:

```
NAME        UUID                                  TYPE      DEVICE
bond0.3810  5960c784-fe08-45ec-ab4d-7c68edb4c0bc  vlan      bond0.3810
bond0       313f4e8e-f950-4a59-8015-0359675758d6  bond      bond0
bond0       c9ca866f-9211-498d-8ba5-ad7c182ce14d  bond      --
bond0.3810  cefa1736-7d08-41b6-96b0-7dbbf7bcbbb6  vlan      --
```
which outputs
```
++ nmcli --get-values vlan.parent conn show 5960c784-fe08-45ec-ab4d-7c68edb4c0bc
+ vlan_parent=bond0
+ '[' -z bond0 ']'
+ nmcli connection show bond0
++ nmcli --get-values GENERAL.DEVICES conn show bond0
+ vlan_parent='
bond0'
+ extra_phys_args=(dev "${vlan_parent}" id "${vlan_id}")
+ '[' '!' '' = 0 ']'
+ extra_phys_args+=(802-3-ethernet.cloned-mac-address "${iface_mac}")
+ nmcli connection show ovs-if-phys0
+ ovs-vsctl --timeout=30 --if-exists destroy interface bond0.3810
+ add_nm_conn type vlan conn.interface bond0.3810 ... 1500 dev '
bond0' id 3810 802-3-ethernet.cloned-mac-address e4:3d:1a:1b:26:1c
+ nmcli c add type vlan conn.interface bond0.3810 ... 1500 dev '
bond0' id 3810 802-3-ethernet.cloned-mac-address e4:3d:1a:1b:26:1c connection.autoconnect no
Error: Failed to add 'ovs-if-phys0' connection: vlan.parent: '
bond0' is neither an UUID nor an interface name
```

Note `vlan_parent` contains a new line character, as `nmcli conn show` targets two connections.

cc @tssurya 