### PR TITLE
OCPBUGS-22664: Mount /run/nodeip-configuration into coredns containers

### DIFF
--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -23,6 +23,9 @@ spec:
   - name: manifests
     hostPath:
       path: "/opt/openshift/manifests"
+  - name: nodeip-configuration
+    hostPath:
+      path: "/run/nodeip-configuration"
   initContainers:
   - name: render-config
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
@@ -52,6 +55,9 @@ spec:
     - name: manifests
       mountPath: "/opt/openshift/manifests"
       mountPropagation: HostToContainer
+    - name: nodeip-configuration
+      mountPath: "/run/nodeip-configuration"
+      mountPropagation: HostToContainer
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns
@@ -69,6 +75,9 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
+    - name: nodeip-configuration
+      mountPath: "/run/nodeip-configuration"
+      mountPropagation: HostToContainer
     livenessProbe:
       httpGet:
         path: /health

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -25,6 +25,9 @@ contents:
       - name: nm-resolv
         hostPath:
           path: "/var/run/NetworkManager"
+      - name: nodeip-configuration
+        hostPath:
+          path: "/run/nodeip-configuration"
       initContainers:
       - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -55,6 +58,9 @@ contents:
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
           mountPropagation: HostToContainer
+        - name: nodeip-configuration
+          mountPath: "/run/nodeip-configuration"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
       containers:
       - name: coredns
@@ -71,6 +77,9 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
+        - name: nodeip-configuration
+          mountPath: "/run/nodeip-configuration"
+          mountPropagation: HostToContainer
         livenessProbe:
           httpGet:
             path: /health
@@ -98,7 +107,7 @@ contents:
         resources:
           requests:
             cpu: 100m
-            memory: 200Mi          
+            memory: 200Mi
         volumeMounts:
         - name: kubeconfig
           mountPath: "/var/lib/kubelet"
@@ -112,7 +121,10 @@ contents:
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
           mountPropagation: HostToContainer
-        imagePullPolicy: IfNotPresent        
+        - name: nodeip-configuration
+          mountPath: "/run/nodeip-configuration"
+          mountPropagation: HostToContainer
+        imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:
       - operator: Exists


### PR DESCRIPTION
This is required so that coredns can use the IP information written to that directory.

Fixes: OCPBUGS-22664