### PR TITLE
Small refactorization of "dynamic_memory_sizing" and "dynamic_cpu_siz…

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -5,73 +5,46 @@ contents:
     #!/bin/bash
     set -e
     NODE_SIZES_ENV=${NODE_SIZES_ENV:-/etc/node-sizing.env}
-    function dynamic_memory_sizing {
-        total_memory=$(free -g|awk '/^Mem:/{print $2}')
-        # total_memory=8 test the recommended values by modifying this value
-        recommended_systemreserved_memory=0
-        if (($total_memory <= 4)); then # 25% of the first 4GB of memory
-            recommended_systemreserved_memory=$(echo $total_memory 0.25 | awk '{print $1 * $2}')
-            total_memory=0
-        else
-            recommended_systemreserved_memory=1
-            total_memory=$((total_memory-4))
-        fi
-        if (($total_memory <= 4)); then # 20% of the next 4GB of memory (up to 8GB)
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.20 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_memory=0
-        else
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 0.80 | awk '{print $1 + $2}')
-            total_memory=$((total_memory-4))
-        fi
-        if (($total_memory <= 8)); then # 10% of the next 8GB of memory (up to 16GB)
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.10 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_memory=0
-        else
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 0.80 | awk '{print $1 + $2}')
-            total_memory=$((total_memory-8))
-        fi
-        if (($total_memory <= 112)); then # 6% of the next 112GB of memory (up to 128GB)
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.06 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_memory=0
-        else
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 6.72 | awk '{print $1 + $2}')
-            total_memory=$((total_memory-112))
-        fi
-        if (($total_memory >= 0)); then # 2% of any memory above 128GB
-            recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.02 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-        fi
-        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory | awk '{printf("%d\n",$1 + 0.5)}') # Round off so we avoid float conversions
-        echo "SYSTEM_RESERVED_MEMORY=${recommended_systemreserved_memory}Gi">> ${NODE_SIZES_ENV}
-    }
-    function dynamic_cpu_sizing {
-        total_cpu=$(getconf _NPROCESSORS_ONLN)
-        recommended_systemreserved_cpu=0
-        if (($total_cpu <= 1)); then # 6% of the first core
-            recommended_systemreserved_cpu=$(echo $total_cpu 0.06 | awk '{print $1 * $2}')
-            total_cpu=0
-        else
-            recommended_systemreserved_cpu=0.06
-            total_cpu=$((total_cpu-1))
-        fi
-        if (($total_cpu <= 1)); then # 1% of the next core (up to 2 cores)
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_cpu=0
-        else
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
-            total_cpu=$((total_cpu-1))
-        fi
-        if (($total_cpu <= 2)); then # 0.5% of the next 2 cores (up to 4 cores)
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.005 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_cpu=0
-        else
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
-            total_cpu=$((total_cpu-2))
-        fi
-        if (($total_cpu >= 0)); then # 0.25% of any cores above 4 cores
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.0025 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-        fi
-        echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}">> ${NODE_SIZES_ENV}
-    }
+    # segment function, given a number it will return the portion specified by the offset and size. 
+    # E.g.: 
+    #  for 18gb of ram, $1=18 -> return the first 4gb -> segment(0,4) = 4 
+    #                         -> return the remaining up to 32gb -> segment(4,32) = 14 
+    awk_segment_function=' 
+        function segment (offset, size) 
+        { 
+            if ($1 - offset >= size) 
+                m=size; 
+            else if ($1 - offset <= 0) 
+                m=0; 
+            else 
+                m=$1 - offset 
+            return m; 
+        }' 
+    function dynamic_memory_sizing { 
+        total_memory=$( free -m | awk '/^Mem:/{print $2/1024}' ) 
+        echo $total_memory | awk "$awk_segment_function"' 
+        { 
+            first_4g = segment(0,4) 
+            next_4g = segment(4,4) 
+            next_8g = segment(8,8) 
+            next_112g = segment(16,112) 
+            remaining = segment(128,100000000) 
+ 
+            printf "SYSTEM_RESERVED_MEMORY=%.0fGi\n", first_4g*0.25 + next_4g*0.2 + next_8g*0.1 + next_112g*0.06 + remaining*0.02 + 0.5  # round up 
+        }' >> ${NODE_SIZES_ENV} 
+    } 
+    function dynamic_cpu_sizing { 
+        total_cpu=$( getconf _NPROCESSORS_ONLN ) 
+        echo $total_cpu | awk "$awk_segment_function"' 
+        { 
+            first_core = segment(0,1) 
+            second_core = segment(1,1) 
+            next_2_cores = segment(2,2) 
+            remaining = segment(4,100000000) 
+ 
+            printf "SYSTEM_RESERVED_CPU=%im\n", (first_core*0.06 + second_core*0.01 + next_2_cores*0.005 + remaining*0.0025)*1000 
+        }' >> ${NODE_SIZES_ENV} 
+    } 
     function dynamic_ephemeral_sizing {
         echo "Not implemented yet"
     }


### PR DESCRIPTION
…ing" functions in a way that is more clear what it does and it can be more maintainable in the future.

Following the recomendations set here https://access.redhat.com/solutions/5843241

It does not solves a bug but it takes into the problem in [OCPBUGS-355](https://issues.redhat.com/browse/OCPBUGS-355)

**- What I did**

Refactor this functions in a way that is more readable, easier to maintain and modify.

**- How to verify it**


```
cat << EOF > test.sh
     #!/bin/bash
     set -e
     total_memory=\$1
     total_cpu=\$2
    # segment function, given a number it will return the portion specified by the offset and size.
    # E.g.:
    #  for 18gb of ram, $1=18 -> return the first 4gb -> segment(0,4) = 4
    #                         -> return the remaining up to 32gb -> segment(4,32) = 14
    awk_segment_function='
        function segment (offset, size)
        {
            if (\$1 - offset >= size)
                m=size;
            else if (\$1 - offset <= 0)
                m=0;
            else
                m=\$1 - offset
            return m; 
        }' 
    function dynamic_memory_sizing { 
        echo \$total_memory | awk "\$awk_segment_function"' 
        {
            first_4g = segment(0,4)
            next_4g = segment(4,4)
            next_8g = segment(8,8)
            next_112g = segment(16,112)
            remaining = segment(128,100000000)
            printf "SYSTEM_RESERVED_MEMORY=%.0fGi\n", first_4g*0.25 + next_4g*0.2 + next_8g*0.1 + next_112g*0.06 + remaining*0.02 + 0.5  # round up
        }'
    } 
    function dynamic_cpu_sizing {
        echo \$total_cpu | awk "\$awk_segment_function"'
        { 
            first_core = segment(0,1)
            second_core = segment(1,1)
            next_2_cores = segment(2,2)
            remaining = segment(4,100000000)
            printf "SYSTEM_RESERVED_CPU=%im\n", (first_core*0.06 + second_core*0.01 + next_2_cores*0.005 + remaining*0.0025)*1000
        }'
    }   
    dynamic_memory_sizing
    dynamic_cpu_sizing
EOF
for i in $(seq -5 5 510); do echo $i; bash test.sh $i.4922 96; done

```


**- Description for the changelog**

I used awk to do the heavy lifting of the calculations and used a self defined function that makes calculations more closer to the algorithm of the documentation
