### PR TITLE
OCPBUGS-24416: Sync MCN with node creation and deletion

### DIFF
--- a/install/0000_80_machine-config-operator_00_clusterreader_clusterrole.yaml
+++ b/install/0000_80_machine-config-operator_00_clusterreader_clusterrole.yaml
@@ -34,6 +34,17 @@ rules:
       - list
       - watch
   - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfignodes
+      - machineconfignodes/status
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - create
+  - apiGroups:
       - config.openshift.io
     resources: 
       - images 


### PR DESCRIPTION
the MCN object was not reacting to node deletions. the MCO was also creating these objects too early in their lifecycle. We should only create an MCN  once the node is out of the Provisioning and Pending Status.