### PR TITLE
OCPBUGS-24743: crio: drop automatic image cleanup on upgrades

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -4,7 +4,6 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
-    version_file_persist = "/var/lib/crio/version"
 
     [crio.api]
     stream_address = "127.0.0.1"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -4,7 +4,6 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
-    version_file_persist = "/var/lib/crio/version"
 
     [crio.api]
     stream_address = "127.0.0.1"


### PR DESCRIPTION
as it causes us to redundently pull images, and the kubelet should protect us from old images taking up too much disk space

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
