### PR TITLE
OCPBUGS-25144: Remove MCN lister and informer from MCO struct

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -97,7 +97,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.ConfigInformerFactory.Config().V1().ClusterOperators(),
-			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1alpha1().MachineConfigNodes(),
 			ctrlctx.FeatureGateAccess,
 		)
 


### PR DESCRIPTION
the MCO logs are spammed regarding an "unknown type" even though the MCN lister isn't added to the `waitForCacheSync` unless the Fg is enabled. Remove it for good measure because this might be causing some upgrade issues. And the lister is unused.
