### PR TITLE
OCPBUGS-25245: Add \n in cert_writer for old cert methods and skip cloudCA validation

### DIFF
--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -111,6 +111,10 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		pathToData[cloudCABundleFilePath] = cloudCA
 
 		for bundle, data := range pathToData {
+			if !strings.HasSuffix(string(data), "\n") {
+				bString := string(data) + "\n"
+				data = []byte(bString)
+			}
 			if Finfo, err := os.Stat(bundle); err == nil {
 				var mode os.FileMode
 				Dinfo, err := os.Stat(filepath.Dir(bundle))

--- a/pkg/daemon/on_disk_validation.go
+++ b/pkg/daemon/on_disk_validation.go
@@ -166,7 +166,7 @@ func checkV2Units(units []ign2types.Unit, systemdPath string) error {
 // check for overwrites.
 func checkV3Files(files []ign3types.File) error {
 	for _, f := range files {
-		if f.Path == caBundleFilePath {
+		if f.Path == caBundleFilePath || f.Path == cloudCABundleFilePath {
 			// TODO remove this special case once we have a better way to do this
 			klog.V(4).Infof("Skipping file %s during checkV3Files", caBundleFilePath)
 			continue


### PR DESCRIPTION
it seems the certs prior to 4.14 have a \n at the end. We need to tack one onto the end of the data before writing to disk. Also, skip cloudCA on disk validation similarly to how we do for kubelet to avoid a race.
