### PR TITLE
OCPBUGS-25412: APIServer URL env should exist on all nodes

### DIFF
--- a/templates/common/_base/files/apiserver-url-env.yaml
+++ b/templates/common/_base/files/apiserver-url-env.yaml
@@ -1,6 +1,6 @@
 mode: 0644
 path: "{{.Constants.APIServerURLFile}}"
-# used by the cluster network operator to learn the URL to the internal apiserver load balancer
+# used by the cluster network operator and cloud controller manager to learn the URL to the internal apiserver load balancer
 contents:
  inline: |
    KUBERNETES_SERVICE_HOST='{{urlHost .Infra.Status.APIServerInternalURL}}'


### PR DESCRIPTION
**- What I did**

This moves the `apiserv-url-env.yaml` file from the master base files to the common base files. The intention is that rather than applying this file to just the master nodes, that it is present on all nodes.

This is required since the Azure cloud node manager runs on all nodes and relies on the file to understand how to talk to KAS without routing through the CNI. Up until now, a bug in Kubelet has meant that on workers, an IP address was set, allowing CNI to schedule correctly without the CNM initialising the IP addresses on the node. This bug has now been fixed in 1.29 which means the CNM is now a dependency of CNI, meaning it cannot use the cluster network to talk to KAS anymore.

There is code in place already such that this works on master, but it does not work on workers currently because of the absence of this file.

**- How to verify it**

`oc debug node/<worker node>`
`chroot /host`
`ls /etc/kubernetes`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
