### PR TITLE
OCPBUGS-22324: Revert "Revert "Merge pull request #4028 from cybertron/wait-for-br-ex""

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -48,6 +48,9 @@ contents:
                   hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
            fi
         fi
+        if [[ "$STATUS" == "up" ]] && [[ $IFACE == "br-ex" ]]; then
+            touch /run/nodeip-configuration/br-ex-up
+        fi
       ;;
       *)
       ;;

--- a/templates/common/on-prem/files/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/files/wait-for-br-ex-up.yaml
@@ -1,0 +1,10 @@
+mode: 0755
+path: "/usr/local/bin/wait-for-br-ex-up.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    until [ -e /run/nodeip-configuration/br-ex-up ]
+    do
+      sleep 1
+    done

--- a/templates/common/on-prem/units/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/units/wait-for-br-ex-up.yaml
@@ -1,5 +1,5 @@
 name: wait-for-br-ex-up.service
-enabled: {{if gt (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
+enabled: {{if and (gt (len (onPremPlatformAPIServerInternalIPs .)) 0) (eq .NetworkType "OVNKubernetes")}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Wait for br-ex up event from NetworkManager

--- a/templates/common/on-prem/units/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/units/wait-for-br-ex-up.yaml
@@ -1,0 +1,15 @@
+name: wait-for-br-ex-up.service
+enabled: {{if gt (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Wait for br-ex up event from NetworkManager
+  Wants=ovs-configuration.service
+  After=ovs-configuration.service
+  Before=node-valid-hostname.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/wait-for-br-ex-up.sh
+
+  [Install]
+  RequiredBy=node-valid-hostname.service


### PR DESCRIPTION
This reverts commit c558cc6bc72d40a243dc22f507decb89b2293bae and adds a commit to fix the problem that prompted the revert in the first place. Now the service will be disabled for all CNI plugins except OVNKubernetes.