### PR TITLE
OCPBUGS-25406: Azure Run ovs-configuration.service before dnsmasq.service

### DIFF
--- a/templates/common/azure/units/ovs-configuration.service.yaml
+++ b/templates/common/azure/units/ovs-configuration.service.yaml
@@ -1,0 +1,21 @@
+name: ovs-configuration.service
+enabled: {{if eq .NetworkType "OVNKubernetes" "OpenShiftSDN"}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Configures OVS with proper host networking configuration
+  # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
+  Requires=openvswitch.service
+  Wants=NetworkManager-wait-online.service
+  After=firstboot-osupdate.target
+  After=NetworkManager-wait-online.service openvswitch.service network.service nodeip-configuration.service
+  Before=kubelet-dependencies.target node-valid-hostname.service dnsmasq.service
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  ExecStart=/usr/local/bin/configure-ovs.sh {{.NetworkType}}
+  StandardOutput=journal+console
+  StandardError=journal+console
+
+  [Install]
+  RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
ARO's dnsmasq.service, if present, must be run after ovs-configuration. This, could of course be fixed in that service's definition but doing so is not operationally easy to do at this point. There is potential risk that some other dnsmasq.service implementation needs to be run before ovs-configuration and this change would break them. Given the temporal proximity to the breaking change in #3865 lets go ahead and make this.

We should also ensure that ARO makes their service more robust in the future.

Fixes: OCPBUGS-25406

**- What I did**
Added dnsmasq.service to the list of units that ovs-configuration.service should run before.

**- How to verify it**
1) Regression test in normal OCP
2) Confirm in ARO that this addresses OCPBUGS-25406, QE should consult with ARO @rogbas and @bennerv good points of contact.

**- Description for the changelog**
Run ovs-configuration.service before dnsmasq.service
