### PR TITLE
OCPBUGS-25725: ManagedBootImages: failed to fetch architecture type of machineset no linked machine found

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -204,7 +204,6 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.ClientBuilder.KubeClientOrDie("machine-set-boot-image-controller"),
 			ctx.ClientBuilder.MachineClientOrDie("machine-set-boot-image-controller"),
 			ctx.KubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
-			ctx.MachineInformerFactory.Machine().V1beta1().Machines(),
 			ctx.MachineInformerFactory.Machine().V1beta1().MachineSets(),
 			ctx.KubeMAOSharedInformer.Core().V1().Secrets(),
 			ctx.ConfigInformerFactory.Config().V1().Infrastructures(),

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -39,9 +39,6 @@ rules:
 - apiGroups: ["machine.openshift.io"]
   resources: ["machinesets"]
   verbs: ["get", "list", "watch", "patch"]
-- apiGroups: ["machine.openshift.io"]
-  resources: ["machines"]
-  verbs: ["list","watch"]
 - apiGroups:
   - authentication.k8s.io
   resources:


### PR DESCRIPTION
Fixes scale-up issue found here: https://github.com/openshift/machine-config-operator/pull/4083#issuecomment-1864268866
This should only merge after #4083 merges.

This PR changes the way the MCO finds the architecture of a machineset to [this method](https://github.com/openshift/enhancements/pull/1496#discussion_r1368704488). Originally, I was mapping the machineset to a node to determine it. However, for machinesets that have no nodes scaled up yet, this would cause an error, and the very first scale-up would take place with the older boot image. This fix only requires a label on the machineset to determine the architecture, if the label is not present the MCO will default to the control plane architecture. 

