### PR TITLE
NO-ISSUE: pkg/operator/sync: Set ownerReferences on *-user-data-managed Secrets

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -687,6 +687,15 @@ func (optr *Operator) syncMachineConfigPools(config *renderConfig) error {
 			return err
 		}
 		p := resourceread.ReadSecretV1OrDie(userdataBytes)
+
+		p.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: pool.APIVersion,
+				Kind:       pool.Kind,
+				Name:       pool.ObjectMeta.Name,
+				UID:        pool.ObjectMeta.UID,
+			},
+		}
 		_, _, err = resourceapply.ApplySecret(context.TODO(), optr.kubeClient.CoreV1(), optr.libgoRecorder, p)
 		if err != nil {
 			return err

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -688,6 +688,10 @@ func (optr *Operator) syncMachineConfigPools(config *renderConfig) error {
 		}
 		p := resourceread.ReadSecretV1OrDie(userdataBytes)
 
+		// Work around https://github.com/kubernetes/kubernetes/issues/3030 and https://github.com/kubernetes/kubernetes/issues/80609
+		pool.APIVersion = mcfgv1.GroupVersion.String()
+		pool.Kind = "MachineConfigPool"
+
 		p.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 			{
 				APIVersion: pool.APIVersion,


### PR DESCRIPTION
To make it easier for cluster admins to discover the management stack for these Secrets.  This will also enable [garbage-collection][1] of these Secrets if the associated MachineConfigPool is removed.

[1]: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#owners-dependents