### PR TITLE
NO-ISSUE: pkg: Deduplicate api/machineconfiguration/v1 imports

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -11,7 +11,6 @@ import (
 	helpers "github.com/openshift/machine-config-operator/pkg/helpers"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
-	v1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -73,12 +72,12 @@ func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
 }
 
 //nolint:gocyclo
-func calculateStatus(mcs []*mcfgalphav1.MachineConfigNode, cconfig *v1.ControllerConfig, pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv1.MachineConfigPoolStatus {
-	certExpirys := []v1.CertExpiry{}
+func calculateStatus(mcs []*mcfgalphav1.MachineConfigNode, cconfig *mcfgv1.ControllerConfig, pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node) mcfgv1.MachineConfigPoolStatus {
+	certExpirys := []mcfgv1.CertExpiry{}
 	if cconfig != nil {
 		for _, cert := range cconfig.Status.ControllerCertificates {
 			if cert.BundleFile == "KubeAPIServerServingCAData" {
-				certExpirys = append(certExpirys, v1.CertExpiry{
+				certExpirys = append(certExpirys, mcfgv1.CertExpiry{
 					Bundle:  cert.BundleFile,
 					Subject: cert.Subject,
 					Expiry:  cert.NotAfter,

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -15,7 +15,6 @@ import (
 
 	osev1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
-	v1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	"github.com/openshift/client-go/machineconfiguration/clientset/versioned/scheme"
 	mcfginformersv1 "github.com/openshift/client-go/machineconfiguration/informers/externalversions/machineconfiguration/v1"
@@ -437,8 +436,8 @@ func updateControllerConfigCerts(config *mcfgv1.ControllerConfig) bool {
 		config.Spec.RootCAData,
 		config.Spec.AdditionalTrustBundle,
 	}
-	newImgCerts := []v1.ControllerCertificate{}
-	newCtrlCerts := []v1.ControllerCertificate{}
+	newImgCerts := []mcfgv1.ControllerCertificate{}
+	newCtrlCerts := []mcfgv1.ControllerCertificate{}
 	for i, cert := range certs {
 		certs := createNewCert(cert, names[i])
 		if len(certs) > 0 {
@@ -486,8 +485,8 @@ func updateControllerConfigCerts(config *mcfgv1.ControllerConfig) bool {
 	return modified
 }
 
-func createNewCert(cert []byte, name string) []v1.ControllerCertificate {
-	certs := []v1.ControllerCertificate{}
+func createNewCert(cert []byte, name string) []mcfgv1.ControllerCertificate {
+	certs := []mcfgv1.ControllerCertificate{}
 	for len(cert) > 0 {
 		b, next := pem.Decode(cert)
 		if b == nil {
@@ -500,7 +499,7 @@ func createNewCert(cert []byte, name string) []v1.ControllerCertificate {
 			continue
 		}
 		cert = next
-		certs = append(certs, v1.ControllerCertificate{
+		certs = append(certs, mcfgv1.ControllerCertificate{
 			Subject:    c.Subject.String(),
 			Signer:     c.Issuer.String(),
 			BundleFile: name,

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
-	v1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
@@ -370,7 +369,7 @@ func (optr *Operator) syncMetrics() error {
 	// set metrics per pool, we need to get the latest condition to log for the state
 	var latestTime metav1.Time
 	latestTime.Time = time.Time{}
-	var cond v1.MachineConfigPoolCondition
+	var cond mcfgv1.MachineConfigPoolCondition
 	for _, pool := range pools {
 		for _, condition := range pool.Status.Conditions {
 			if condition.Status == corev1.ConditionTrue && condition.LastTransitionTime.After(latestTime.Time) {
@@ -393,7 +392,7 @@ func (optr *Operator) syncMetrics() error {
 
 // isKubeletSkewSupported checks the version skew of kube-apiserver and node kubelet version.
 // Returns the skew status. version skew > 2 is not supported.
-func (optr *Operator) isKubeletSkewSupported(pools []*v1.MachineConfigPool) (skewStatus string, coStatus configv1.ClusterOperatorStatusCondition, err error) {
+func (optr *Operator) isKubeletSkewSupported(pools []*mcfgv1.MachineConfigPool) (skewStatus string, coStatus configv1.ClusterOperatorStatusCondition, err error) {
 	coStatus = configv1.ClusterOperatorStatusCondition{}
 	kubeAPIServerStatus, err := optr.configClient.ConfigV1().ClusterOperators().Get(context.TODO(), "kube-apiserver", metav1.GetOptions{})
 	if err != nil {
@@ -471,7 +470,7 @@ func (optr *Operator) isKubeletSkewSupported(pools []*v1.MachineConfigPool) (ske
 }
 
 // GetAllManagedNodes returns the nodes managed by MCO
-func (optr *Operator) GetAllManagedNodes(pools []*v1.MachineConfigPool) ([]*corev1.Node, error) {
+func (optr *Operator) GetAllManagedNodes(pools []*mcfgv1.MachineConfigPool) ([]*corev1.Node, error) {
 	nodes := []*corev1.Node{}
 	for _, pool := range pools {
 		selector, err := metav1.LabelSelectorAsSelector(pool.Spec.NodeSelector)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -34,7 +34,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
-	v1 "github.com/openshift/api/machineconfiguration/v1"
 	v1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -281,7 +280,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 	if err != nil {
 		return err
 	}
-	imgRegistryUsrData := []v1.ImageRegistryBundle{}
+	imgRegistryUsrData := []mcfgv1.ImageRegistryBundle{}
 	if cfg.Spec.AdditionalTrustedCA.Name != "" {
 		cm, err := optr.clusterCmLister.ConfigMaps("openshift-config").Get(cfg.Spec.AdditionalTrustedCA.Name)
 		if err != nil {
@@ -292,19 +291,19 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 			for _, key := range newKeys {
 				raw, err := base64.StdEncoding.DecodeString(cm.Data[key])
 				if err != nil {
-					imgRegistryUsrData = append(imgRegistryUsrData, v1.ImageRegistryBundle{
+					imgRegistryUsrData = append(imgRegistryUsrData, mcfgv1.ImageRegistryBundle{
 						File: key,
 						Data: []byte(cm.Data[key]),
 					})
 				} else {
-					imgRegistryUsrData = append(imgRegistryUsrData, v1.ImageRegistryBundle{
+					imgRegistryUsrData = append(imgRegistryUsrData, mcfgv1.ImageRegistryBundle{
 						File: key,
 						Data: raw,
 					})
 				}
 			}
 			for _, key := range newBinaryKeys {
-				imgRegistryUsrData = append(imgRegistryUsrData, v1.ImageRegistryBundle{
+				imgRegistryUsrData = append(imgRegistryUsrData, mcfgv1.ImageRegistryBundle{
 					File: key,
 					Data: cm.BinaryData[key],
 				})
@@ -312,7 +311,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		}
 	}
 
-	imgRegistryData := []v1.ImageRegistryBundle{}
+	imgRegistryData := []mcfgv1.ImageRegistryBundle{}
 	cm, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("image-registry-ca")
 	if err == nil {
 		newKeys := sets.StringKeySet(cm.Data).List()
@@ -320,19 +319,19 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig) error {
 		for _, key := range newKeys {
 			raw, err := base64.StdEncoding.DecodeString(cm.Data[key])
 			if err != nil {
-				imgRegistryData = append(imgRegistryData, v1.ImageRegistryBundle{
+				imgRegistryData = append(imgRegistryData, mcfgv1.ImageRegistryBundle{
 					File: key,
 					Data: []byte(cm.Data[key]),
 				})
 			} else {
-				imgRegistryData = append(imgRegistryData, v1.ImageRegistryBundle{
+				imgRegistryData = append(imgRegistryData, mcfgv1.ImageRegistryBundle{
 					File: key,
 					Data: raw,
 				})
 			}
 		}
 		for _, key := range newBinaryKeys {
-			imgRegistryData = append(imgRegistryData, v1.ImageRegistryBundle{
+			imgRegistryData = append(imgRegistryData, mcfgv1.ImageRegistryBundle{
 				File: key,
 				Data: cm.BinaryData[key],
 			})


### PR DESCRIPTION
These had snuck in back in 80e7b4dbdb (#3756), 81136ed1ae (#3770), and similar.  Having the same package imported under multiple names doesn't have any functional impact, but it's less confusing to read if the package is refered to with a consistent prefix.  This commit addresses all the duplicates turned up with:

```console
$ git grep -c '"github.com/openshift/api/machineconfiguration/v1"'  | grep '[.]go:' | grep -v 'vendor/\|:1$'
```
