### PR TITLE
OCPBUGS-11936: Wait for OpenStack Metadata service

### DIFF
--- a/templates/common/openstack/units/afterburn-hostname.service.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.service.yaml
@@ -3,16 +3,25 @@ enabled: true
 contents: |
   [Unit]
   Description=Afterburn Hostname
-  # Block services relying on Networking being up.
+  # Block services relying on Networking being up
   Before=network-online.target
   # Wait for NetworkManager to report its online
   After=NetworkManager-wait-online.service
   # Run before hostname checks
   Before=node-valid-hostname.service
+  # Allow 120 retries (10 minutes at 5 seconds per retry)
+  StartLimitIntervalSec=infinity
+  StartLimitBurst=120
 
   [Service]
   ExecStart=/usr/local/bin/openstack-afterburn-hostname
   Type=oneshot
+  # Show as active after exit since we change state
+  RemainAfterExit=true
+  # Retry every 5 seconds on failure without marking the service as failed
+  Restart=on-failure
+  RestartMode=direct
+  RestartSec=5
 
   [Install]
   WantedBy=network-online.target


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

When deploying a cluster on OpenStack using OVN-Kubernetes, there can be a delay before the metadata service is available. Afterburn [1] does not provide a mechanism to configure the timeouts and the network-online target merely indicates that we *a* configured, routable IP address, not necessarily that we can access the metadata service yet. Work around by restarting the service on failure. This is possible since systemd v244.1 [2].
    
[1] https://github.com/coreos/afterburn
[2] https://github.com/systemd/systemd/pull/13754

**- How to verify it**

Working on this with QE now.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

The `afterburn-hostname.service` systemd service deployed on the OpenStack will now retry in the event of the metadata service taking longer than expected to come up.
