### PR TITLE
OCPBUGS-17788: Improved error handling for missing MC

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -160,3 +160,16 @@ spec:
               Moreover, OOM kill is expected which negatively influences the pod scheduling.
               If this happens on container level, the descheduler will not be able to detect it, as it works on the pod level.
               To fix this, increase memory of the affected node of control plane nodes.
+    - name: mcd-missing-mc
+      rules:
+        - alert: MissingMachineConfig
+          expr: |
+            mcd_missing_mc > 0
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "This keeps track of Machine Config failures. Specifically a common failure on install when a rendered Machine Config is missing. Triggered when this error happens once."
+            description: >-
+              Could not find config {{ $labels.mc }} in-cluster, this likely indicates the MachineConfigs in-cluster has changed during the install process. 
+              If you are seeing this when installing the cluster, please compare the in-cluster rendered machineconfigs to /etc/mcs-machine-config-content.json

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -57,6 +57,12 @@ var (
 			Name: "mcd_config_drift",
 			Help: "timestamp for config drift",
 		})
+	// mcdMissingMC tracks the missing machine config error
+	mcdMissingMC = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mcd_missing_mc",
+			Help: "total number of times a MC was reported missing",
+		}, []string{"mc"})
 )
 
 // Updates metric with new labels & timestamp, deletes any existing


### PR DESCRIPTION
the error for when a MachineConfig is missing is very vague. Usually the error has little to do with the cause. Specify steps users can take to alleviate the situations.
