### PR TITLE
OCPBUGS-5452: If node is not in pool, error

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -509,6 +509,7 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 		return
 	}
 	if pool == nil {
+		utilruntime.HandleError(fmt.Errorf("all nodes must be in a pool if managed by the MCO. Node %s is not in a pool", curNode.Name))
 		return
 	}
 	klog.V(4).Infof("Node %s updated", curNode.Name)


### PR DESCRIPTION
Currently we allow nodes to exist without being in a pool. If the MCO is managing a node, it needs to be in a pool.
