### PR TITLE
OCPBUGS-25662: Add Image Credential Provider flags for Kubelet on AWS

### DIFF
--- a/templates/common/aws/files/etc-kubernetes-credential-providers-ecr-credential-provider.yaml
+++ b/templates/common/aws/files/etc-kubernetes-credential-providers-ecr-credential-provider.yaml
@@ -1,0 +1,16 @@
+mode: 0644
+path: "/etc/kubernetes/credential-providers/ecr-credential-provider.yaml"
+contents:
+  inline: |
+    apiVersion: kubelet.config.k8s.io/v1
+    kind: CredentialProviderConfig
+    providers:
+      - name: ecr-credential-provider
+        matchImages:
+          - "*.dkr.ecr.*.amazonaws.com"
+          - "*.dkr.ecr.*.amazonaws.com.cn"
+          - "*.dkr.ecr-fips.*.amazonaws.com"
+          - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+          - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+        defaultCacheDuration: "12h"
+        apiVersion: credentialprovider.kubelet.k8s.io/v1

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -37,6 +37,7 @@ contents: |
         --cloud-provider={{cloudProvider .}} \
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         {{cloudConfigFlag . }} \
+        {{credentialProviderConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -37,6 +37,7 @@ contents: |
         --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
         --cloud-provider={{cloudProvider .}} \
         {{cloudConfigFlag . }} \
+        {{credentialProviderConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
         --pod-infra-container-image={{.Images.infraImageKey}} \


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Adds configuration for the ECR credential provider to kubelet on AWS.

Unit tests show new flags being set correctly.

Depends on the ecr-credential-provider RPM shipping in RHCOS, this is currently a WIP.
/hold

**- How to verify it**
Kubelet should be able to pull an image from a private ECR registry.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
