### PR TITLE
OCPBUGS-25821: backportable version of api-int cert work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,10 @@ Dockerfile.rhel7: Dockerfile Makefile
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operator
 test-e2e: install-go-junit-report
-	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/ ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 170m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/ ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
 
 test-e2e-techpreview: install-go-junit-report
-	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-techpreview  ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 170m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-techpreview  ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
 
 test-e2e-single-node: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/ | ./hack/test-with-junit.sh $(@)

--- a/install/0000_80_machine-config-operator_00_service.yaml
+++ b/install/0000_80_machine-config-operator_00_service.yaml
@@ -60,3 +60,7 @@ spec:
   - name: metrics
     port: 9001
     protocol: TCP
+  - name: health
+    port: 8798
+    protocol: TCP
+

--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "watch", "patch"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["*"]
   verbs: ["*"]

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -21,6 +21,10 @@ spec:
       containers:
       - name: machine-config-daemon
         image: {{.Images.MachineConfigOperator}}
+        ports:
+        - containerPort: 8798
+          name: health
+          protocol: TCP
         command: ["/usr/bin/machine-config-daemon"]
         args:
           - "start"
@@ -37,6 +41,15 @@ spec:
           - mountPath: /rootfs
             name: rootfs
             mountPropagation: HostToContainer
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          failureThreshold: 3
+          httpGet:
+            host: 127.0.0.1
+            scheme: HTTP
+            port: 8798
+            path: /health
         env:
           - name: NODE_NAME
             valueFrom:

--- a/manifests/machineconfigdaemon/role.yaml
+++ b/manifests/machineconfigdaemon/role.yaml
@@ -10,3 +10,4 @@ rules:
       - configmaps
     verbs:
       - get
+      - patch

--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -13,3 +13,6 @@ rules:
   resourceNames: ["hostnetwork"]
   resources: ["securitycontextconstraints"]
   verbs: ["use"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -73,4 +73,9 @@ const (
 
 	// MCOReleaseImageVersionKey is the key for indexing the MCO release version stored in the bootimages configmap
 	MCOReleaseImageVersionKey = "MCOReleaseImageVersion"
+
+	ServiceCARotateAnnotation = "machineconfiguration.openshift.io/service-ca-rotate"
+
+	ServiceCARotateTrue  = "true"
+	ServiceCARotateFalse = "false"
 )

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -669,7 +669,7 @@ var errConfigNotGzipped = fmt.Errorf("ignition config not gzipped")
 // Decode, decompress, and deserialize an Ignition config file.
 func ParseAndConvertGzippedConfig(rawIgn []byte) (ign3types.Config, error) {
 	// Try to decode and decompress our payload
-	out, err := decodeAndDecompressPayload(bytes.NewReader(rawIgn))
+	out, err := DecodeAndDecompressPayload(bytes.NewReader(rawIgn))
 	if err == nil {
 		// Our payload was decoded and decompressed, so parse it as Ignition.
 		klog.V(2).Info("ignition config was base64-decoded and gunzipped successfully")
@@ -699,7 +699,7 @@ func ParseAndConvertGzippedConfig(rawIgn []byte) (ign3types.Config, error) {
 }
 
 // Attempts to base64-decode and/or decompresses a given byte array.
-func decodeAndDecompressPayload(r io.Reader) ([]byte, error) {
+func DecodeAndDecompressPayload(r io.Reader) ([]byte, error) {
 	// Wrap the io.Reader in a base64 decoder (which implements io.Reader)
 	base64Dec := base64.NewDecoder(base64.StdEncoding, r)
 	out, err := decompressPayload(base64Dec)

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -195,6 +195,7 @@ func newController(
 		UpdateFunc: ctrl.checkMasterNodesOnUpdate,
 		DeleteFunc: ctrl.checkMasterNodesOnDelete,
 	})
+
 	ctrl.syncHandler = ctrl.syncMachineConfigPool
 	ctrl.enqueueMachineConfigPool = ctrl.enqueueDefault
 

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -34,7 +34,8 @@ const (
 	OpenShiftOperatorManagedLabel = "openshift.io/operator-managed"
 	// ControllerConfigResourceVersionKey is used for the certificate writer to indicate the last controllerconfig object it synced upon
 	ControllerConfigResourceVersionKey = "machineconfiguration.openshift.io/lastSyncedControllerConfigResourceVersion"
-
+	// ControllerConfigSyncServerCA is used to determine if we have already synced the server CA for this version of the controller config
+	ControllerConfigSyncServerCA = "machineconfiguration.openshift.io/lastObservedServerCAAnnotation"
 	// GeneratedByVersionAnnotationKey is used to tag the controllerconfig to synchronize the MCO and MCC
 	GeneratedByVersionAnnotationKey = "machineconfiguration.openshift.io/generated-by-version"
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -492,7 +492,7 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 	defer func() {
 		// now that we do rebootless updates, we need to turn off our SIGTERM protection
 		// regardless of how we leave the "update loop"
-		dn.cancelSIGTERM()
+		dn.CancelSIGTERM()
 	}()
 
 	oldConfigName := oldConfig.GetName()
@@ -658,7 +658,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	defer func() {
 		// now that we do rebootless updates, we need to turn off our SIGTERM protection
 		// regardless of how we leave the "update loop"
-		dn.cancelSIGTERM()
+		dn.CancelSIGTERM()
 	}()
 
 	oldConfigName := oldConfig.GetName()
@@ -2364,7 +2364,7 @@ func (dn *Daemon) catchIgnoreSIGTERM() {
 	dn.updateActive = true
 }
 
-func (dn *Daemon) cancelSIGTERM() {
+func (dn *Daemon) CancelSIGTERM() {
 	dn.updateActiveLock.Lock()
 	defer dn.updateActiveLock.Unlock()
 	if dn.updateActive {
@@ -2378,7 +2378,7 @@ func (dn *Daemon) cancelSIGTERM() {
 // on failure to reboot, it throws an error and waits for the operator to try again
 func (dn *Daemon) reboot(rationale string) error {
 	// Now that everything is done, avoid delaying shutdown.
-	dn.cancelSIGTERM()
+	dn.CancelSIGTERM()
 	dn.Close()
 
 	if dn.skipReboot {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/base64"
@@ -926,7 +927,10 @@ func (optr *Operator) safetySyncControllerConfig(config *renderConfig) error {
 // it is meant to be called as part of syncMachineConfigController because it will only succeed if
 // the operator version and controller version match. We can call it from safetySyncControllerConfig
 // because safetySyncControllerConfig ensures that the operator and controller versions match before it syncs.
+//
+//nolint:gocritic
 func (optr *Operator) syncControllerConfig(config *renderConfig) error {
+
 	ccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/controllerconfig.yaml")
 	if err != nil {
 		return err
@@ -936,8 +940,105 @@ func (optr *Operator) syncControllerConfig(config *renderConfig) error {
 	// suppress rendered config generation until a corresponding
 	// new controller can roll out too.
 	// https://bugzilla.redhat.com/show_bug.cgi?id=1879099
-	cc.Annotations[daemonconsts.GeneratedByVersionAnnotationKey] = version.Raw
 
+	editCCAnno := false
+	kubeConfigData, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-apiserver-server-ca")
+	if err != nil {
+		klog.Errorf("Could not get in-cluster server-ca data %v", err)
+	} else {
+		data, err := cmToData(kubeConfigData, "ca-bundle.crt")
+		if err != nil {
+			klog.Errorf("kube-apiserver-server-ca ConfigMap not populated yet. %v", err)
+		} else if data != nil {
+			cmNew := corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubeconfig-data",
+				},
+			}
+			mcoCM, getErr := optr.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), "kubeconfig-data", metav1.GetOptions{})
+			if getErr != nil {
+				klog.Errorf("Issue getting the kubeconfig-data configmap: %v", getErr)
+				if !apierrors.IsNotFound(getErr) && !apierrors.IsTimeout(getErr) && !apierrors.IsServerTimeout(getErr) {
+					return getErr
+				}
+			}
+			dataOld, err := cmToData(mcoCM, "ca-bundle.crt")
+			if err != nil && getErr == nil {
+				klog.Errorf("Could not get ca-bundle.crt from kubeconfig-data cm %v", err)
+			} else if !bytes.Equal(data, dataOld) && getErr == nil {
+				// -1 == mcoCM < kubeCM
+				// 1 == mcoCM > kubeCM
+				klog.Infof("the MCO configmap for the server-ca and the openshift-config-managed one do not match. Diff: (0 means equal -1 means data has been removed 1 means data has been added) %d.", bytes.Compare(dataOld, data))
+				// old mco CM data
+				newData := true
+				for newData {
+					klog.Infof("Polling for new data in kube-apiserver-server-ca")
+					if err := wait.PollUntilContextTimeout(context.TODO(), 15*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+						newData = false
+						// pull off of API not a lister
+						kubeConfigData, err := optr.kubeClient.CoreV1().ConfigMaps("openshift-config-managed").Get(context.TODO(), "kube-apiserver-server-ca", metav1.GetOptions{})
+						if err != nil {
+							klog.Errorf("Could not get in-cluster server-ca data %v", err)
+						} else {
+							newBytes, err := cmToData(kubeConfigData, "ca-bundle.crt")
+							if err != nil {
+								return false, err
+							}
+							if !bytes.Equal(newBytes, data) {
+								klog.Infof("Found new data while polling. Waiting an extra minute to see if there are any more changes.")
+								newData = true
+								data = newBytes
+								return newData, nil
+							}
+						}
+						return false, nil
+					}); err != nil {
+						if !wait.Interrupted(err) {
+							klog.Errorf("Error waiting for kube-apiserver-server-ca to settle: %v", err)
+						}
+					}
+				}
+				binData := make(map[string][]byte)
+				binData["ca-bundle.crt"] = data
+				cmNew.BinaryData = binData
+				cmMarshal, err := json.Marshal(mcoCM)
+				if err != nil {
+					return fmt.Errorf("could not marshal old configmap data. Err: %v ", err)
+				}
+				// new mco CM Data
+				newCMMarshal, err := json.Marshal(cmNew)
+				if err != nil {
+					return fmt.Errorf("could not marshal new configmap data. Data: %s Err: %v ", string(data), err)
+				}
+				// patch mco CM
+				patchBytes, err := jsonmergepatch.CreateThreeWayJSONMergePatch(cmMarshal, newCMMarshal, cmMarshal)
+				if err != nil {
+					return fmt.Errorf("Could not create a three way json merge patch: %w", err)
+				}
+				_, err = optr.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Patch(context.TODO(), "kubeconfig-data", types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				if err != nil {
+					return fmt.Errorf("Could not patch kubeconfig-data with data %s: %w", string(patchBytes), err)
+				}
+				editCCAnno = true
+			} else if getErr != nil {
+				binData := make(map[string][]byte)
+				binData["ca-bundle.crt"] = data
+				cmNew.BinaryData = binData
+				_, err := optr.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Create(context.TODO(), &cmNew, metav1.CreateOptions{})
+				if err != nil {
+					return fmt.Errorf("Could not make kubeconfig-data CM, %v", err)
+				}
+				editCCAnno = true
+			}
+
+		}
+	}
+	cc.Annotations[daemonconsts.GeneratedByVersionAnnotationKey] = version.Raw
+	if editCCAnno {
+		cc.Annotations[ctrlcommon.ServiceCARotateAnnotation] = ctrlcommon.ServiceCARotateTrue
+	} else {
+		cc.Annotations[ctrlcommon.ServiceCARotateAnnotation] = ctrlcommon.ServiceCARotateFalse
+	}
 	// add ocp release version as annotation to controller config, for use when
 	// annotating rendered configs with same.
 	optrVersion, _ := optr.vStore.Get("operator")
@@ -1592,8 +1693,6 @@ func getCAsFromConfigMap(cm *corev1.ConfigMap, key string) ([]byte, error) {
 	} else if d, dok := cm.Data[key]; dok {
 		raw, err := base64.StdEncoding.DecodeString(d)
 		if err != nil {
-			// this is actually the result of a bad assumption.  configmap values are not encoded.
-			// After the installer pull merges, this entire attempt to decode can go away.
 			return []byte(d), nil
 		}
 		return raw, nil
@@ -1813,4 +1912,19 @@ func (optr *Operator) getImageRegistryPullSecrets() ([]byte, error) {
 	}
 
 	return nil, nil
+}
+
+//nolint:unparam
+func cmToData(cm *corev1.ConfigMap, key string) ([]byte, error) {
+	if bd, bdok := cm.BinaryData["ca-bundle.crt"]; bdok {
+		return bd, nil
+	}
+	if d, dok := cm.Data["ca-bundle.crt"]; dok {
+		raw, err := base64.StdEncoding.DecodeString(d)
+		if err != nil {
+			return []byte(d), nil
+		}
+		return raw, nil
+	}
+	return nil, fmt.Errorf("%s not found in %s/%s", key, cm.Namespace, cm.Name)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -139,6 +139,9 @@ func appendInitialMachineConfig(conf *ign3types.Config, mc *mcfgv1.MachineConfig
 }
 
 func appendKubeConfig(conf *ign3types.Config, f kubeconfigFunc) error {
+	if f == nil {
+		return nil
+	}
 	kcData, _, err := f()
 	if err != nil {
 		return err

--- a/test/e2e-shared-tests/mcd_config_drift.go
+++ b/test/e2e-shared-tests/mcd_config_drift.go
@@ -388,7 +388,7 @@ func assertNodeAndMCPIsDegraded(t *testing.T, cs *framework.ClientSet, node core
 	mcdPod, err := helpers.MCDForNode(cs, &node)
 	require.Nil(t, err)
 
-	assertLogsContain(t, cs, mcdPod, logEntry)
+	assertLogsContain(t, cs, mcdPod, &node, logEntry)
 
 	// Assert that the MachineConfigPool eventually reaches a degraded state and has the config mismatch as the reason.
 	t.Log("Verifying MachineConfigPool becomes degraded due to config mismatch")

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -781,6 +781,13 @@ func ExecCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subA
 	cmd.Stderr = os.Stderr
 
 	out, err := cmd.Output()
+	if err != nil {
+		// common err is that the mcd went down mid cmd. Re-try for good measure
+		cmd, err = execCmdOnNode(cs, node, subArgs...)
+		require.Nil(t, err, "could not prepare to exec cmd %v on node %s: %s", subArgs, node.Name, err)
+		out, err = cmd.Output()
+
+	}
 	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
 	return string(out)
 }


### PR DESCRIPTION
this PR is supposed to merge before #4104. This does not follow the MCO's current cert path but does ensure a backport for 4.15/14/13 since we are not bumping the API at all.

when the api-int CA syncs we write to an mco namespaced configmap with the data (this is so the daemon only needs a role for reading MCO configmaps). We also need to add an annotation to the controllerconfig via the operator when this api-int CA rotates. This will trigger the daemons syncControllerConfig loop without actually modifying the controllerconfig API type (we will do this in future ocp versions). We then read from the configmap we just wrote to in the operator if it exists and if the annotation on the controllerconfig is set, and do some kubeconfig related tasks in the daemon's cert writer.


In this PR we also are introducing a livenessProbe for the daemon and some new error handling to catch errors from the reflector. When the reflector fails, the livenessProbe should trigger causing the daemon to get re-deployed. We are unsure why this is necessary. However, deploying new daemons fixes the issue with the listers failing. 