### PR TITLE
OCPBUGS-26605: use machine client instead of oc for teardown

### DIFF
--- a/test/e2e-layering/onclusterbuild_test.go
+++ b/test/e2e-layering/onclusterbuild_test.go
@@ -100,7 +100,7 @@ func TestOnClusterBuildRollsOutImage(t *testing.T) {
 	cs := framework.NewClientSet("")
 	node := helpers.GetRandomNode(t, cs, "worker")
 	t.Cleanup(makeIdempotentAndRegister(t, func() {
-		helpers.DeleteNodeAndMachine(t, node)
+		helpers.DeleteNodeAndMachine(t, cs, node)
 	}))
 	helpers.LabelNode(t, cs, node, helpers.MCPNameToRole(layeredMCPName))
 	helpers.WaitForNodeImageChange(t, cs, node, imagePullspec)

--- a/test/framework/clientset.go
+++ b/test/framework/clientset.go
@@ -27,6 +27,12 @@ type ClientSet struct {
 	clientbuildv1.BuildV1Interface
 	clientimagev1.ImageV1Interface
 	kubeconfig string
+	config     *rest.Config
+}
+
+// Allows the instantiation of additional clients with the same config.
+func (cs *ClientSet) GetRestConfig() *rest.Config {
+	return cs.config
 }
 
 func (cs *ClientSet) GetKubeconfig() (string, error) {
@@ -59,6 +65,7 @@ func NewClientSet(kubeconfig string) *ClientSet {
 
 	cs := NewClientSetFromConfig(config)
 	cs.kubeconfig = kubeconfig
+	cs.config = config
 	return cs
 }
 
@@ -73,5 +80,6 @@ func NewClientSetFromConfig(config *rest.Config) *ClientSet {
 		OperatorV1alpha1Interface:       clientoperatorsv1alpha1.NewForConfigOrDie(config),
 		BuildV1Interface:                clientbuildv1.NewForConfigOrDie(config),
 		ImageV1Interface:                clientimagev1.NewForConfigOrDie(config),
+		config:                          config,
 	}
 }


### PR DESCRIPTION
**- What I did**

I replaced the calls to oc with native Machine clients for the on-cluster build test.

**- How to verify it**

Run the e2e-gcp-op-layering job. The tests should pass.

**- Description for the changelog**
Fixes e2e-gcp-op-layering job
