### PR TITLE
[release-4.14]OCPBUGS-27178: use *resource.Quantity to not automatically set 0

### DIFF
--- a/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -532,11 +532,11 @@ type ContainerRuntimeConfiguration struct {
 	// logSizeMax specifies the Maximum size allowed for the container log file.
 	// Negative numbers indicate that no size limit is imposed.
 	// If it is positive, it must be >= 8192 to match/exceed conmon's read buffer.
-	LogSizeMax resource.Quantity `json:"logSizeMax,omitempty"`
+	LogSizeMax *resource.Quantity `json:"logSizeMax,omitempty"`
 
 	// overlaySize specifies the maximum size of a container image.
 	// This flag can be used to set quota on the size of container images.
-	OverlaySize resource.Quantity `json:"overlaySize,omitempty"`
+	OverlaySize *resource.Quantity `json:"overlaySize,omitempty"`
 
 	// defaultRuntime is the name of the OCI runtime to be used as the default.
 	DefaultRuntime ContainerRuntimeDefaultRuntime `json:"defaultRuntime,omitempty"`

--- a/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/machineconfiguration.openshift.io/v1/zz_generated.deepcopy.go
@@ -148,8 +148,16 @@ func (in *ContainerRuntimeConfiguration) DeepCopyInto(out *ContainerRuntimeConfi
 		*out = new(int64)
 		**out = **in
 	}
-	out.LogSizeMax = in.LogSizeMax.DeepCopy()
-	out.OverlaySize = in.OverlaySize.DeepCopy()
+	if in.LogSizeMax != nil {
+		in, out := &in.LogSizeMax, &out.LogSizeMax
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.OverlaySize != nil {
+		in, out := &in.OverlaySize, &out.OverlaySize
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
@@ -40,7 +40,7 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 
 			var configFileList []generatedConfigFile
 			ctrcfg := cfg.Spec.ContainerRuntimeConfig
-			if !ctrcfg.OverlaySize.IsZero() {
+			if ctrcfg.OverlaySize != nil && !ctrcfg.OverlaySize.IsZero() {
 				storageTOML, err := mergeConfigChanges(originalStorageIgn, cfg, updateStorageConfig)
 				if err != nil {
 					klog.V(2).Infoln(cfg, err, "error merging user changes to storage.conf: %v", err)
@@ -49,7 +49,7 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 				}
 			}
 			// Create the cri-o drop-in files
-			if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || !ctrcfg.LogSizeMax.IsZero() || ctrcfg.DefaultRuntime != mcfgv1.ContainerRuntimeDefaultRuntimeEmpty {
+			if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || (ctrcfg.LogSizeMax != nil && !ctrcfg.LogSizeMax.IsZero()) || ctrcfg.DefaultRuntime != mcfgv1.ContainerRuntimeDefaultRuntimeEmpty {
 				crioFileConfigs := createCRIODropinFiles(cfg)
 				configFileList = append(configFileList, crioFileConfigs...)
 			}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -610,7 +610,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 
 		var configFileList []generatedConfigFile
 		ctrcfg := cfg.Spec.ContainerRuntimeConfig
-		if !ctrcfg.OverlaySize.IsZero() {
+		if ctrcfg.OverlaySize != nil && !ctrcfg.OverlaySize.IsZero() {
 			storageTOML, err := mergeConfigChanges(originalStorageIgn, cfg, updateStorageConfig)
 			if err != nil {
 				klog.V(2).Infoln(cfg, err, "error merging user changes to storage.conf: %v", err)
@@ -622,7 +622,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		}
 
 		// Create the cri-o drop-in files
-		if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || !ctrcfg.LogSizeMax.IsZero() || ctrcfg.DefaultRuntime != mcfgv1.ContainerRuntimeDefaultRuntimeEmpty {
+		if ctrcfg.LogLevel != "" || ctrcfg.PidsLimit != nil || (ctrcfg.LogSizeMax != nil && !ctrcfg.LogSizeMax.IsZero()) || ctrcfg.DefaultRuntime != mcfgv1.ContainerRuntimeDefaultRuntimeEmpty {
 			crioFileConfigs := createCRIODropinFiles(cfg)
 			configFileList = append(configFileList, crioFileConfigs...)
 		}

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -294,12 +294,14 @@ func updateStorageConfig(data []byte, internal *mcfgv1.ContainerRuntimeConfigura
 		return nil, fmt.Errorf("error decoding crio config: %w", err)
 	}
 
-	if internal.OverlaySize.Value() < 0 {
-		return nil, fmt.Errorf("invalid overlaySize config %q: the overlaySize should be larger than 0", internal.OverlaySize.String())
-	}
+	if internal.OverlaySize != nil {
+		if internal.OverlaySize.Value() < 0 {
+			return nil, fmt.Errorf("invalid overlaySize config %q: the overlaySize should be larger than 0", internal.OverlaySize.String())
+		}
 
-	if internal.OverlaySize.Value() != 0 {
-		tomlConf.Storage.Options.Size = internal.OverlaySize.String()
+		if internal.OverlaySize.Value() != 0 {
+			tomlConf.Storage.Options.Size = internal.OverlaySize.String()
+		}
 	}
 
 	var newData bytes.Buffer
@@ -347,7 +349,7 @@ func createCRIODropinFiles(cfg *mcfgv1.ContainerRuntimeConfig) []generatedConfig
 			klog.V(2).Infoln(cfg, err, "error updating user changes for pids-limit to crio.conf.d: %v", err)
 		}
 	}
-	if ctrcfg.LogSizeMax.Value() != 0 {
+	if ctrcfg.LogSizeMax != nil && ctrcfg.LogSizeMax.Value() != 0 {
 		tomlConf := tomlConfigCRIOLogSizeMax{}
 		tomlConf.Crio.Runtime.LogSizeMax = ctrcfg.LogSizeMax.Value()
 		generatedConfigFileList, err = addTOMLgeneratedConfigFile(generatedConfigFileList, crioDropInFilePathLogSizeMax, tomlConf)
@@ -495,11 +497,11 @@ func validateUserContainerRuntimeConfig(cfg *mcfgv1.ContainerRuntimeConfig) erro
 		return fmt.Errorf("invalid PidsLimit %v", *ctrcfg.PidsLimit)
 	}
 
-	if ctrcfg.LogSizeMax.Value() > 0 && ctrcfg.LogSizeMax.Value() <= minLogSize {
+	if ctrcfg.LogSizeMax != nil && ctrcfg.LogSizeMax.Value() > 0 && ctrcfg.LogSizeMax.Value() <= minLogSize {
 		return fmt.Errorf("invalid LogSizeMax %q, cannot be less than 8kB", ctrcfg.LogSizeMax.String())
 	}
 
-	if ctrcfg.OverlaySize.Value() < 0 {
+	if ctrcfg.OverlaySize != nil && ctrcfg.OverlaySize.Value() < 0 {
 		return fmt.Errorf("invalid overlaySize %q, cannot be less than 0", ctrcfg.OverlaySize.String())
 	}
 

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -12,10 +12,14 @@ import (
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	signature "github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
+	storageconfig "github.com/containers/storage/pkg/config"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -908,5 +912,123 @@ func TestGetValidBlockAndAllowedRegistries(t *testing.T) {
 			require.Equal(t, tt.expectedPolicyBlocked, gotPolicy)
 			require.Equal(t, tt.expectedAllowed, gotAllowed)
 		})
+	}
+}
+
+func TestCreateCRIODropinFiles(t *testing.T) {
+	zeroLogSizeMax := resource.MustParse("0k")
+	validLogSizeMax := resource.MustParse("10G")
+
+	// Test zero value of logSizeMax will not be applied
+	zeroValueTests := []struct {
+		name     string
+		cfg      *mcfgv1.ContainerRuntimeConfiguration
+		filepath string
+	}{
+		{
+			name: "01-ctrcfg-logSizeMax will not be created if logSizeMax is zero",
+			cfg: &mcfgv1.ContainerRuntimeConfiguration{
+				LogSizeMax: &zeroLogSizeMax,
+			},
+			filepath: crioDropInFilePathLogSizeMax,
+		},
+	}
+
+	// Test valid value of logSizeMax will be applied to the drop-in file
+	validValueTests := []struct {
+		name     string
+		cfg      *mcfgv1.ContainerRuntimeConfiguration
+		filepath string
+		want     []byte
+	}{
+		{
+			name: "01-ctrcfg-logSizeMax created for valid logSizeMax",
+			cfg: &mcfgv1.ContainerRuntimeConfiguration{
+				LogSizeMax: &validLogSizeMax,
+			},
+			filepath: crioDropInFilePathLogSizeMax,
+			want: []byte(`[crio]
+  [crio.runtime]
+    log_size_max = 10000000000
+`),
+		},
+	}
+
+	for _, test := range zeroValueTests {
+		ctrcfg := newContainerRuntimeConfig(test.name, test.cfg, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
+		files := createCRIODropinFiles(ctrcfg)
+		for _, file := range files {
+			if file.filePath == test.filepath {
+				t.Errorf("%s: failed. should not have created dropin file", test.name)
+			}
+		}
+	}
+
+	for _, test := range validValueTests {
+		ctrcfg := newContainerRuntimeConfig(test.name, test.cfg, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""))
+		files := createCRIODropinFiles(ctrcfg)
+		for _, file := range files {
+			if file.filePath == test.filepath {
+				require.Equal(t, test.want, file.data, "createCRIODropinFiles() Diff, want %v, got %v", test.want, string(file.data))
+			}
+		}
+	}
+}
+
+func TestUpdateStorageConfig(t *testing.T) {
+	templateStorageConfig := tomlConfigStorage{}
+	buf := bytes.Buffer{}
+	err := toml.NewEncoder(&buf).Encode(templateStorageConfig)
+	require.NoError(t, err)
+	templateBytes := buf.Bytes()
+
+	zeroOverLayerSize := resource.MustParse("0k")
+	validOverLaySize := resource.MustParse("10G")
+
+	tests := []struct {
+		name string
+		cfg  *mcfgv1.ContainerRuntimeConfiguration
+		want tomlConfigStorage
+	}{
+		{
+			name: "not apply zero value of overlaySize",
+			cfg: &mcfgv1.ContainerRuntimeConfiguration{
+				OverlaySize: &zeroOverLayerSize,
+			},
+			want: tomlConfigStorage{},
+		},
+		{
+			name: "apply valid overlaySize",
+			cfg: &mcfgv1.ContainerRuntimeConfiguration{
+				OverlaySize: &validOverLaySize,
+			},
+			want: tomlConfigStorage{
+				Storage: struct {
+					Driver    string                                "toml:\"driver\""
+					RunRoot   string                                "toml:\"runroot\""
+					GraphRoot string                                "toml:\"graphroot\""
+					Options   struct{ storageconfig.OptionsConfig } "toml:\"options\""
+				}{
+					Options: struct{ storageconfig.OptionsConfig }{
+						storageconfig.OptionsConfig{
+							Size: "10G",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got, err := updateStorageConfig(templateBytes, test.cfg)
+		require.NoError(t, err)
+		gotConf := tomlConfigStorage{}
+		if _, err := toml.Decode(string(got), &gotConf); err != nil {
+			t.Errorf("error unmarshalling result: %v", err)
+			return
+		}
+		if !reflect.DeepEqual(gotConf, test.want) {
+			t.Errorf("%s: failed. got %v, want %v", test.name, got, test.want)
+		}
 	}
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Backport API fix https://github.com/openshift/api/pull/1656
**- What I did**
Change the type of OverlaySize and LogSizeMax resource.Quantity to pointer *resource.Quantity.
the struct type will be set as 0 automatically when retrieving the ctrcfg object.
**- How to verify it**
```
# apply the containerruntimeconfig CR
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
 name: pidlimit
spec:
 machineConfigPoolSelector:
   matchLabels:
     pools.operator.machineconfiguration.openshift.io/worker: '' 
 containerRuntimeConfig:
   pidsLimit: 4096 
   logLevel: debug

# current result:
$ oc get containerruntimeconfig  pidlimit -o json | jq '.spec.containerRuntimeConfig'
{
  "logLevel": "debug",
  "logSizeMax": "0",
  "overlaySize": "0",
  "pidsLimit": 4096
}

# after this patch, it will be 
$ oc get containerruntimeconfig  pidlimit -o json | jq '.spec.containerRuntimeConfig'
{
  "logLevel": "debug",
  "pidsLimit": 4096
}
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
