### PR TITLE
OCPBUGS-24366: Delete state files on reboot only

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet-cleanup.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet-cleanup.service.yaml
@@ -1,0 +1,14 @@
+name: kubelet-cleanup.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet After Reboot Cleanup
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStart=/bin/rm -f /var/lib/kubelet/memory_manager_state
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,8 +10,6 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -10,8 +10,6 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,8 +10,6 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet-cleanup.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet-cleanup.service.yaml
@@ -1,0 +1,14 @@
+name: kubelet-cleanup.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet After Reboot Cleanup
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStart=/bin/rm -f /var/lib/kubelet/memory_manager_state
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,8 +10,6 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -10,8 +10,6 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- end}}

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,8 +10,6 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
-  ExecStartPre=/bin/rm -f /var/lib/kubelet/memory_manager_state
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

The original kubelet.service definition deletes the cpu and memory manager state files on every kubelet restart. That causes a loss of cpu manager information and new cpu allocations the pods are not expecting.

Splitting the kubelet.service into two parts should fix this.

**- How to verify it**

Make sure the cpu and memory manager state files are not present when kubelet is starting for the first time after a node reboot.

Restarting kubelet should not change cpu affinity of already running pods. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Kubelet systemd service definitions were updated:

- kubelet.service no longer deletes the state files on restart
- kubelet-cleanup.service is an oneshot before=kubelet service that only executes once at boot and performs the state files cleanup after reboot.

Fixes: OCPBUGS-24366
