### PR TITLE
OCPBUGS-27190: Fix mirrorSourcePolicy error prompt imagecontentsourcepolicies

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -694,7 +694,7 @@ func validateRegistriesConfScopes(insecure, blocked, allowed []string, icspRules
 		}
 		if p, ok := sourcePolicy[source]; ok {
 			if policy != p {
-				return fmt.Errorf("conflicting mirrorSourcePolicy is set for the same source %q in imagedigestmirrorsets and/or imagetagmirrorsets", source)
+				return fmt.Errorf("conflicting mirrorSourcePolicy is set for the same source %q in imagedigestmirrorsets, imagetagmirrorsets, or imagecontentsourcepolicies", source)
 			}
 		} else {
 			sourcePolicy[source] = policy


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fix conflicting mirrorSourcePolicy error prompt to include imagecontentsourcepolicies
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
