### PR TITLE
OCPBUGS-27261: Fix typo in AWS node env unit

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
@@ -22,8 +22,8 @@ contents:
         exit 0
     fi
 
-    if [ -e "${NODENV}" ]; then
-        echo "Not replacing existing ${NODENV}"
+    if [ -e "${NODEENV}" ]; then
+        echo "Not replacing existing ${NODEENV}"
         exit 0
     fi
     


### PR DESCRIPTION
This typo means that the hostname env var is being overwritten on every reboot, which is not the desired behaviour. The intention is that the file is written once, before Kubelet starts up for the first time, and never modified.
