### PR TITLE
OCPBUGS-18940: Add keepalived healthcheck for machine-config-server

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -36,6 +36,14 @@ contents:
         fall 3
     }
 
+    vrrp_script chk_mcs {
+        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_mcs_script.sh"
+        interval 2
+        weight 3
+        rise 3
+        fall 3
+    }
+
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
@@ -93,6 +101,7 @@ contents:
         track_script {
             chk_ocp_lb
             chk_ocp_both
+            chk_mcs
         }
     }
     {{`{{end}}`}}

--- a/templates/master/00-master/on-prem/files/keepalived-mcs-script.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-mcs-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_mcs_script.sh.tmpl"
+contents:
+  inline: |
+    #!/bin/bash
+    chroot /host /bin/crictl ps --state running | grep -qE '\smachine-config-server\s'


### PR DESCRIPTION
We need to ensure that machine-config-server is available from the API VIP. Up to now we've been relying on the fact that normally MCS is running on all control plane nodes so it doesn't matter which one holds the VIP, but there are circumstances (such as disaster recovery) where not all MCS instances will be running.

Unfortunately, we don't have access to the MCS from deployed nodes for security reasons. Because of this, it's not possible to simply add it to the HAProxy configuration like we would for an external loadbalancer. It's not even possible to call it from the check script and ensure that it's responding. The best we can do is look for the container (similar to what we do for the default ingress pod) and assume that MCO is healthchecking it appropriately and will restart it if it stops working. This shouldn't be _too_ bad since MCS is not called as often as the API so if there's a brief outage it may not even be noticed. Also, we've been getting by with no health check at all for years so this isn't a common failure point.

**- Description for the changelog**
Added keepalived healthcheck for machine-config-server to ensure the API VIP provides access to it.
