### PR TITLE
OPNET-355: Use NM's dns-change event for resolv.conf

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -23,16 +23,32 @@ contents:
 
     export DHCP6_FQDN_FQDN IP4_DOMAINS IP6_DOMAINS
     export -f resolv_prepender
-    # Given an overall Network Manager dispatcher timeout of 90 seconds, and multiple events which
-    # may occur within this time period, we must enforce a time limit for each event. As some
-    # events cannot happen in the same transaction, we are not simply dividing timeout by their
-    # number (e.g. "up" and "reapply" don't contribute to the same timeout like  "dhcp*-change").
+
+    # For RHEL8 with NetworkManager >= 1.36 and RHEL9 with NetworkManager >=1.42 we can use simplified logic
+    # of observing only a single "dns-change" event. Older version of NetworkManager require however that we
+    # react on a set of multiple events. Once dns-change event is detected we create a flag file to ignore
+    # subsequent up&co. events as undesired.
+    #
+    # Given an overall Network Manager dispatcher timeout of 90 seconds, we are enforcing a slightly shorter
+    # timeout for the observed events.
     case "$STATUS" in
-      up|dhcp4-change|dhcp6-change|reapply)
+      dns-change)
         >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
-        if ! timeout 30s bash -c resolv_prepender; then
+        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
+          touch /run/networkmanager-dns-event-detected
+        fi
+        if ! timeout 60s bash -c resolv_prepender; then
+          >&2 echo "NM resolv-prepender: Timeout occurred"
+          exit 1
+        fi
+      ;;
+      up|dhcp4-change|dhcp6-change|reapply)
+        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
+          >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
+          if ! timeout 30s bash -c resolv_prepender; then
             >&2 echo "NM resolv-prepender: Timeout occurred"
             exit 1
+          fi
         fi
       ;;
       *)


### PR DESCRIPTION
NetworkManager starting from 1.42.2-12.el9_2 and 1.36.0-17.el8_6 adds a new event `dns-change` which is fired whenever a change to the DNS configuration happens. Thanks to this we no longer need to piggyback on other events (like `up` or `dhcp-change`) to detect when we need to potentially fix the content of `/etc/resolv.conf`.

This change will reduce the overall number of calls to `resolv_prepender` as now it will be called only if DNS configuration could have been changed.

We are still keeping the timeout for the `resolv_prepender` function because it is not expected that it would be running for longer than one minute.

Closes: [OPNET-355](https://issues.redhat.com//browse/OPNET-355)