### PR TITLE
OCPBUGS-24705: consider currentImage and desiredImage annotations

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -709,7 +709,62 @@ func TestGetCandidateMachines(t *testing.T) {
 		otherCandidates: []string{"node-5", "node-6"},
 		capacity:        2,
 		layeredPool:     true,
-	}}
+	}, {
+		// Targets https://issues.redhat.com/browse/OCPBUGS-24705.
+		name:     "Node has received desiredImage annotation but MCD has not yet started working",
+		progress: 1,
+		nodes: []*corev1.Node{
+			// Need to set WithNodeReady() on all nodes to avoid short-circuiting.
+			helpers.NewNodeBuilder("node-0").
+				WithEqualConfigs(machineConfigV1).
+				WithDesiredImage(imageV1).
+				WithNodeReady().
+				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
+				Node(),
+			helpers.NewNodeBuilder("node-1").
+				WithEqualConfigs(machineConfigV1).
+				WithNodeReady().
+				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
+				Node(),
+			helpers.NewNodeBuilder("node-2").
+				WithEqualConfigs(machineConfigV1).
+				WithNodeReady().
+				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
+				Node(),
+		},
+		expected:        nil,
+		otherCandidates: nil,
+		capacity:        0,
+		layeredPool:     true,
+	}, {
+		// Targets https://issues.redhat.com/browse/OCPBUGS-24705.
+		name:     "Node has received desiredImage annotation and the MCD has started working",
+		progress: 1,
+		nodes: []*corev1.Node{
+			// Need to set WithNodeReady() on all nodes to avoid short-circuiting.
+			helpers.NewNodeBuilder("node-0").
+				WithEqualConfigs(machineConfigV1).
+				WithDesiredImage(imageV1).
+				WithNodeReady().
+				WithMCDState(daemonconsts.MachineConfigDaemonStateWorking).
+				Node(),
+			helpers.NewNodeBuilder("node-1").
+				WithEqualConfigs(machineConfigV1).
+				WithNodeReady().
+				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
+				Node(),
+			helpers.NewNodeBuilder("node-2").
+				WithEqualConfigs(machineConfigV1).
+				WithNodeReady().
+				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
+				Node(),
+		},
+		expected:        nil,
+		otherCandidates: nil,
+		capacity:        0,
+		layeredPool:     true,
+	},
+	}
 
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
**- What I did**

The `isNodeUnavailable()` code was not taking the `currentImage` / `desiredImage` annotations into consideration when it determines if the node should be considered unavailable. While opting into on-cluster builds, the following would happen:

1. A node gets updated with the `desiredImage` annotation, indicating that the MCD should transition it to an image.
2. There is a lag between when this annotation is applied and the MCD transitions from "Done" -> "Working".
3. During this lag period, the NodeController may re-enter the sync loop.
4. Because the MCD state has not transitioned yet to "Working" yet and we were not considering the currentImage / desiredImage annotations, the NodeController will apply the `desiredImage` annotation to another node instead.

This adds a check for the presence of the `currentImage` / `desiredImage` annotations. If neither annotation is present, the NodeController will not take these annotations into consideration. However, if either of them is present, it will test their equality before making a determination that a node is "Done". This PR also adds additional test cases in an attempt to verify additional unforeseen edge-cases.

**- How to verify it**

1. Bring up an OpenShift 4.16 cluster.
2. Opt into on-cluster builds using either the docs within this repo or my `onclustertesting` helpers.
3. Opt the `master` pool into on-cluster builds by adding the appropriate label: `$ oc label mcp/master 'machineconfiguration.openshift.io/layering-enabled='`.
4. Only one control plane node should go offline at once.

**- Description for the changelog**
Consider currentImage / desiredImage annotations when determining if a node is unavailable
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
