### PR TITLE
OCPBUGS-27508: daemon: allow the user to override drains on IR changes

### DIFF
--- a/manifests/machineconfigdaemon/role.yaml
+++ b/manifests/machineconfigdaemon/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: machine-config-daemon
+  namespace: {{.TargetNamespace}}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get

--- a/manifests/machineconfigdaemon/rolebinding.yaml
+++ b/manifests/machineconfigdaemon/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-daemon
+  namespace: {{.TargetNamespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: machine-config-daemon
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-daemon

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1027,7 +1027,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 	}
 
 	// Check and perform node drain if required
-	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig)
+	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -115,13 +115,17 @@ func (dn *Daemon) performDrain() error {
 }
 
 // isDrainRequired determines whether node drain is required or not to apply config changes.
-func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig ign3types.Config) (bool, error) {
+func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig ign3types.Config, overrideImageRegistryDrain bool) (bool, error) {
 	if ctrlcommon.InSlice(postConfigChangeActionReboot, actions) {
 		// Node is going to reboot, we definitely want to perform drain
 		return true, nil
 	} else if ctrlcommon.InSlice(postConfigChangeActionReloadCrio, actions) || ctrlcommon.InSlice(postConfigChangeActionRestartCrio, actions) {
 		// Drain may or may not be necessary in case of container registry config changes.
 		if ctrlcommon.InSlice(constants.ContainerRegistryConfPath, diffFileSet) {
+			if overrideImageRegistryDrain {
+				klog.Warningf("Drain was skipped for this image registry update due to the configmap %s being present. This may not be a safe change", ImageRegistryDrainOverrideConfigmap)
+				return false, nil
+			}
 			isSafe, err := isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig)
 			if err != nil {
 				return false, err

--- a/pkg/daemon/drain_test.go
+++ b/pkg/daemon/drain_test.go
@@ -468,7 +468,7 @@ location = "mirror.com/repo/test-img-14"
 				t.Errorf("parsing new Ignition config failed: %v", err)
 			}
 			diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
-			drain, err := isDrainRequired(test.actions, diffFileSet, oldIgnConfig, newIgnConfig)
+			drain, err := isDrainRequired(test.actions, diffFileSet, oldIgnConfig, newIgnConfig, false)
 			if !reflect.DeepEqual(test.expectedAction, drain) {
 				t.Errorf("Failed determining drain behavior: expected: %v but result is: %v. Error: %v", test.expectedAction, drain, err)
 			}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clarketm/json"
 	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeErrs "k8s.io/apimachinery/pkg/util/errors"
@@ -60,6 +61,10 @@ const (
 	// GPGNoRebootPath is the path MCO expects will contain GPG key updates. MCO will attempt to only reload crio for
 	// changes to this path. Note that other files added to the parent directory will not be handled specially
 	GPGNoRebootPath = "/etc/machine-config-daemon/no-reboot/containers-gpg.pub"
+
+	// ImageRegistryDrainOverrideConfigmap is the name of the Configmap a user can apply to force all
+	// image registry changes to not drain
+	ImageRegistryDrainOverrideConfigmap = "image-registry-override-drain"
 )
 
 func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
@@ -715,7 +720,12 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}
 
 	// Check and perform node drain if required
-	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig)
+	crioOverrideConfigmapExists, err := dn.hasImageRegistryDrainOverrideConfigMap()
+	if err != nil {
+		return err
+	}
+
+	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig, crioOverrideConfigmapExists)
 	if err != nil {
 		return err
 	}
@@ -2501,4 +2511,21 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	// Apply extensions
 	return dn.applyExtensions(oldConfig, newConfig)
+}
+
+func (dn *Daemon) hasImageRegistryDrainOverrideConfigMap() (bool, error) {
+	if dn.kubeClient == nil {
+		return false, nil
+	}
+
+	_, err := dn.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), ImageRegistryDrainOverrideConfigmap, metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("Error fetching image registry drain override configmap: %w", err)
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -108,6 +108,8 @@ const (
 	mcdKubeRbacProxyConfigMapPath             = "manifests/machineconfigdaemon/kube-rbac-proxy-config.yaml"
 	mcdKubeRbacProxyPrometheusRolePath        = "manifests/machineconfigdaemon/prometheus-rbac.yaml"
 	mcdKubeRbacProxyPrometheusRoleBindingPath = "manifests/machineconfigdaemon/prometheus-rolebinding-target.yaml"
+	mcdRolePath                               = "manifests/machineconfigdaemon/role.yaml"
+	mcdRoleBindingPath                        = "manifests/machineconfigdaemon/rolebinding.yaml"
 
 	// Machine Config Server manifest paths
 	mcsClusterRoleManifestPath                    = "manifests/machineconfigserver/clusterrole.yaml"
@@ -1182,11 +1184,13 @@ func (optr *Operator) syncMachineConfigDaemon(config *renderConfig) error {
 		},
 		roles: []string{
 			mcdKubeRbacProxyPrometheusRolePath,
+			mcdRolePath,
 		},
 		roleBindings: []string{
 			mcdEventsRoleBindingDefaultManifestPath,
 			mcdEventsRoleBindingTargetManifestPath,
 			mcdKubeRbacProxyPrometheusRoleBindingPath,
+			mcdRoleBindingPath,
 		},
 		clusterRoleBindings: []string{
 			mcdClusterRoleBindingManifestPath,


### PR DESCRIPTION
The MCO logic today allows users to not reboot when changing the registries.conf file (through ICSP/IDMS/ITMS objects), but the MCO will sometimes drain the node if the change is deemed "unsafe" (deleting a mirror, for example).

This behaviour is very disruptive for some customers who with to make all image registries changes non-disruptive. With this PR they can create a ConfigMap and override the drain check.

Also add rbac for MCD to only read MCO-namespaced ConfigMaps.

To be used with support exception only.

Testing steps:

create ICSP/IDMS/ITMS, e.g.
```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  name: quay-mirror
spec:
  repositoryDigestMirrors:
  - mirrors:
    - my-quay.io.mirror
    source: quay.io
```
apply the configmap
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: image-registry-override-drain
  namespace: openshift-machine-config-operator
```
delete the ICSP object and observe that no drain happens