### PR TITLE
OCPBUGS-27799: Restrict using CoreDNS from outside of the node

### DIFF
--- a/manifests/on-prem/coredns-corefile.tmpl
+++ b/manifests/on-prem/coredns-corefile.tmpl
@@ -6,6 +6,9 @@
     }
     cache 30
     reload
+    allow {
+    	ip {{ .NonVirtualIP }}
+    }
     template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .ControllerConfig.DNS.Spec.BaseDomain }} {
         match .*.apps.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (onPremPlatformIngressIPs .ControllerConfig)) 0 }}{{ index (onPremPlatformIngressIPs .ControllerConfig) 0 }}{{ end }}"

--- a/templates/common/on-prem/files/coredns-corefile.yaml
+++ b/templates/common/on-prem/files/coredns-corefile.yaml
@@ -11,6 +11,9 @@ contents:
         }
         cache 30
         reload
+        allow {
+            ip {{`{{.NonVirtualIP}}`}}
+        }
         template IN {{`{{ .Cluster.IngressVIPRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match .*[.]apps.{{ .DNS.Spec.BaseDomain }}
             answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (onPremPlatformIngressIPs .)) 0 }}{{ index (onPremPlatformIngressIPs .) 0 }}{{ end }}"


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Use allow plugin

Fixes: OCPBUGS-27799

**- How to verify it**

```
nslookup <URL> <node-ip>
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Add allow plugin