### PR TITLE
OCPBUGS-26489: feat: enable nodeip service for single node

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -1,7 +1,7 @@
 # NOTE: When making changes to this service, be sure they are replicated in the
 # VSphere-specific service in templates/common/[vsphere|kubevirt]/units
 name: nodeip-configuration.service
-enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{end}}
+enabled: {{if or (eq .Infra.Status.PlatformStatus.Type "None") (and (eq .Infra.Status.ControlPlaneTopology "SingleReplica") (eq (cloudProvider .) "external")) }}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -12,7 +12,7 @@
 # code. Instead, we create this duplicate version of the service that will
 # only be enabled for VSphere UPI deployments.
 name: nodeip-configuration-vsphere-upi.service
-enabled: {{if eq (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
+enabled: {{if or (eq (len (onPremPlatformAPIServerInternalIPs .)) 0) (and (eq .Infra.Status.ControlPlaneTopology "SingleReplica") (eq (cloudProvider .) "external"))}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP


### PR DESCRIPTION
An upstream change to kubelet removed the guess that kubelet was doing to discover the node ip when the cloud-provider was set to external.

The cloud provider is expected to update the node object on boot up, unfortunatly on single node deployments a reboot causes a failure to the control plane because kubelet can not provide the ip address to etcd and everything cascades from there.

With this change we are enabling the nodeip-configuraton.service for SNO control plane topology.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Enabled the `nodeip-configuration.service` for all single node deployments with external cloud providers.

**- How to verify it**

Once a cluster has come up, running `systemctl status nodeip-configuration.service` should display that it ran.

**- Description for the changelog**

For single node deployments we enabled the `nodeip-configuration.service` to discover the nodes IP at start up and set that information as a `--node-ip` argument to kubelet to be used for external cloud providers.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
