### PR TITLE
OCPBUGS-26951: annotate on-prem static pods for workload partitioning

### DIFF
--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -11,6 +11,8 @@ contents:
       deletionGracePeriodSeconds: 65
       labels:
         app: {{ onPremPlatformShortName . }}-infra-coredns
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       volumes:
       - name: resource-dir

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -11,6 +11,8 @@ contents:
       deletionGracePeriodSeconds: 65
       labels:
         app: {{ onPremPlatformShortName . }}-infra-vrrp
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       volumes:
       - name: resource-dir

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -11,6 +11,8 @@ contents:
       deletionGracePeriodSeconds: 65
       labels:
         app: {{ onPremPlatformShortName . }}-infra-api-lb
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       volumes:
       - name: resource-dir
@@ -136,7 +138,7 @@ contents:
         resources:
           requests:
             cpu: 100m
-            memory: 200Mi          
+            memory: 200Mi
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/haproxy"


### PR DESCRIPTION
In order for static pods to use reserved CPUs according to the workload partitioning, we are adding a `PreferredDuringScheduling` annotation.

Closes: OCPBUGS-26951