### PR TITLE
OCPBUGS-27162: Add dependency on crio-wipe to resolv-prepender

### DIFF
--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -4,6 +4,8 @@ enabled: false
 contents: |
   [Unit]
   Description=Populates resolv.conf according to on-prem IPI needs
+  # Per https://issues.redhat.com/browse/OCPBUGS-27162 there is a problem if this is started before crio-wipe
+  After=crio-wipe.service
   [Service]
   Type=oneshot
   ExecStart=/usr/local/bin/resolv-prepender.sh


### PR DESCRIPTION
Because resolv-prepender can run very early in boot and it pulls an image, it can interfere with the functioning of the crio-wipe service after an unclean shutdown (such as a power outage). To avoid this, we can add a dependency to ensure crio-wipe will always complete before we start resolv-prepender.


**- Description for the changelog**
Added dependency on crio-wipe to resolv-prepender.
