### PR TITLE
OCPBUGS-23418, MCO-1016: Machine-config controller should not log about non-existent pull-secret changes, Remove logs about non-existent changes in the machine-config-controller

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -208,9 +208,11 @@ func (ctrl *Controller) updateMachineConfig(old, cur interface{}) {
 
 	if curControllerRef != nil {
 		if pool := ctrl.resolveControllerRef(curControllerRef); pool != nil {
-			klog.V(4).Infof("MachineConfig %s updated", curMC.Name)
-			ctrl.enqueueMachineConfigPool(pool)
-			return
+			if !reflect.DeepEqual(oldMC.Spec, curMC.Spec) {
+				klog.V(4).Infof("MachineConfig %s updated", curMC.Name)
+				ctrl.enqueueMachineConfigPool(pool)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
This patch is a follow-up on https://github.com/openshift/machine-config-operator/pull/536 
In addition to inaccurate kubelet-config update logging, there exits other circular amount of inaccurate update. The reported bug is one of the examples.
By having this patch, we want to identify all the real updates and eliminate all logs about non-existent changes in the machine-config-controller. 
