### PR TITLE
crio: update pids limit to be -1

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -31,6 +31,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    pids_limit = -1
 
     [crio.runtime.runtimes.crun]
     runtime_root = "/run/crun"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -31,6 +31,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    pids_limit = -1
 
     [crio.runtime.runtimes.crun]
     runtime_root = "/run/crun"


### PR DESCRIPTION
the default in cri-o 1.29 and below is 0, which is interpreted differently by runc and crun. The intended outcome of setting 0 was to set the cgroup limit to "max", so the pids limit is instead set by the kubelet's podPidsLimit.
After crun 1.13, both crun and runc correctly interpret a negative value as "max", so use this value instead to keep consistency.

Note: this has no effect in 4.16, as the default in cri-o has been changed to -1. I am picking it here just to keep future cherry-picks easier