### PR TITLE
OCPBUGS-28926: [4.15] crio: update pids limit to be -1

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -32,6 +32,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    pids_limit = -1
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -32,6 +32,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    pids_limit = -1
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"


### PR DESCRIPTION
the default in cri-o 1.29 and below is 0, which is interpreted differently by runc and crun. The intended outcome of setting 0 was to set the cgroup limit to "max", so the pids limit is instead set by the kubelet's podPidsLimit.
After crun 1.13, both crun and runc correctly interpret a negative value as "max", so use this value instead to keep consistency.