### PR TITLE
OCPBUGS-29098: Revert "OCPNODE-2024: crio: migrate metrics port to localhost only"

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -70,7 +70,6 @@ contents:
 
     [crio.metrics]
     enable_metrics = true
-    metrics_host = "127.0.0.1"
     metrics_port = 9537
     metrics_collectors = [
       "operations", # DEPRECATED: in favour of "operations_total"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -70,7 +70,6 @@ contents:
 
     [crio.metrics]
     enable_metrics = true
-    metrics_host = "127.0.0.1"
     metrics_port = 9537
     metrics_collectors = [
       "operations", # DEPRECATED: in favour of "operations_total"


### PR DESCRIPTION
Reverts openshift/machine-config-operator#4164