### PR TITLE
OCPSTRAT-1062: [4.15] crio: enable log linking by default in 4.15

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,18 @@ contents:
     ]
     drop_infra_ctr = true
 
+    [crio.runtime.runtimes.runc]
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.LinkLogs",
+    ]
+
+    [crio.runtime.runtimes.crun]
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.LinkLogs",
+    ]
+
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,18 @@ contents:
     ]
     drop_infra_ctr = true
 
+    [crio.runtime.runtimes.runc]
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.LinkLogs",
+    ]
+
+    [crio.runtime.runtimes.crun]
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.LinkLogs",
+    ]
+
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/machine-config-operator/pull/4116

related to https://issues.redhat.com/browse/SUPPORTEX-17246