### PR TITLE
NO-JIRA: remove kube-rbac-proxy for crio port

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -79,30 +79,6 @@ spec:
           name: proxy-tls
         - mountPath: /etc/kube-rbac-proxy
           name: mcd-auth-proxy-config
-      - name: crio-kube-rbac-proxy
-        image: {{.Images.KubeRbacProxy}}
-        ports:
-        - containerPort: 9637
-          name: metrics
-          protocol: TCP
-        args:
-        - --secure-listen-address=0.0.0.0:9637
-        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        - --upstream=http://127.0.0.1:9537
-        - --logtostderr=true
-        - --tls-cert-file=/etc/tls/private/tls.crt
-        - --tls-private-key-file=/etc/tls/private/tls.key
-        resources:
-          requests:
-            cpu: 20m
-            memory: 50Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: proxy-tls
-        - mountPath: /etc/kube-rbac-proxy
-          name: mcd-auth-proxy-config
       hostNetwork: true
       hostPID: true
       serviceAccountName: machine-config-daemon


### PR DESCRIPTION
Removes the kube-rbac-proxy for the crio port from the MCD.

#4175 will likely supersede with a static pod solution.