### PR TITLE
NO-ISSUE: add e2e-techpreview-shared, remove layering test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,10 @@ Dockerfile.rhel7: Dockerfile Makefile
 
 # This was copied from https://github.com/openshift/cluster-image-registry-operator
 test-e2e: install-go-junit-report
-	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/ | ./hack/test-with-junit.sh $(@)
-
-test-e2e-layering: install-go-junit-report
-	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-techpreview | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/ ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
 
 test-e2e-techpreview: install-go-junit-report
-	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-techpreview | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-techpreview  ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
 
 test-e2e-single-node: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-single-node/ | ./hack/test-with-junit.sh $(@)

--- a/test/e2e-techpreview-shared/README.md
+++ b/test/e2e-techpreview-shared/README.md
@@ -1,0 +1,5 @@
+This test package should be used for e2e tests that need to be tested under the default featureset and the techpreview featureset. This would mean that your test 
+has two paths, one when the feature gate is enabled and one when the feature gate is disabled. Tests added here will run under the test-e2e and test-e2e-techpreview
+Makefile targets, which is used by ci/prow/e2e-gcp-op and ci/prow/e2e-gcp-op-techpreview test suites respectively.
+
+Please remember to remove your test from this package when your feature is GA-ed(General Availability) and no longer behind the feature gate.

--- a/test/e2e-techpreview-shared/noop_test.go
+++ b/test/e2e-techpreview-shared/noop_test.go
@@ -1,0 +1,7 @@
+package e2e_techpreview_shared_test
+
+import "testing"
+
+func TestNoop(t *testing.T) {
+	t.Logf("In TestNoop - Please remove me when you add tests in this package")
+}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This PR adds a new test package, `e2e-techpreview-shared`. This test package should be used for e2e tests that need to be tested under the default featureset and the techpreview featureset. This would mean that your test 
has two paths, one when the feature gate is enabled and one when the feature gate is disabled. Tests added here will run under the test-e2e and test-e2e-techpreview Makefile targets, which is used by ci/prow/e2e-gcp-op and ci/prow/e2e-gcp-op-techpreview test suites respectively.

This PR also removes the old makefile target for e2e-gcp-op-layering which has now been repurposed into e2e-gcp-op-techpreview. 

This should merge after https://github.com/openshift/release/pull/48618 merges.

**- How to verify it**
- tests, including the new `e2e-gcp-op-techpreview` should succeed
- both `e2e-gcp-op` and `e2e-gcp-op-techpreview` should run `TestNoop`. 

