### PR TITLE
MCO-760: add rebuild mechanism to ocb

### DIFF
--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -49,6 +49,8 @@ const (
 	// LayeringEnabledPoolLabel is the label that enables the "layered" workflow path for a pool.
 	LayeringEnabledPoolLabel = "machineconfiguration.openshift.io/layering-enabled"
 
+	RebuildPoolLabel = "machineconfiguration.openshift.io/rebuildImage"
+
 	// ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey is the annotation that signifies which rendered config
 	// TODO(zzlotnik): Determine if we should use this still.
 	ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey = "machineconfiguration.openshift.io/newestImageEquivalentConfig"

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -1175,6 +1175,12 @@ func IsLayeredPool(pool *mcfgv1.MachineConfigPool) bool {
 	return false
 }
 
+func DoARebuild(pool *mcfgv1.MachineConfigPool) bool {
+	_, ok := pool.Labels[RebuildPoolLabel]
+	return ok
+
+}
+
 // DockerConfigJSON represents ~/.docker/config.json file info
 type DockerConfigJSON struct {
 	Auths DockerConfig `json:"auths"`


### PR DESCRIPTION
trigger a rebuild by adding the machineconfiguration.openshift.io/rebuildImage label to the specified pool this will delete any existing build objects for an MCP and start a new one in the traditional manner.
