### PR TITLE
NO-JIRA: nmstate, configure nmstate to keep service yamls

### DIFF
--- a/templates/common/_base/files/nmstate-service-keep-state-file-after-apply.yaml
+++ b/templates/common/_base/files/nmstate-service-keep-state-file-after-apply.yaml
@@ -1,0 +1,6 @@
+mode: 0644
+path: "/etc/nmstate/nmstate.conf"
+contents:
+  inline: |
+    [service]
+    keep_state_file_after_apply = true


### PR DESCRIPTION
When https://github.com/nmstate/nmstate/pull/2546 land to RHCOS the nmstate service will go back to previous behaviour, the /etc/nmstate/*.yml files are moved to .applied files, so we need to configure nmstate to keep the those files, if we don't do so MCO complains at in place upgrades since the file system has change.

The original in place problem is described at https://github.com/nmstate/nmstate/pull/2499:

```
At some envs like openshift machine-config-operator moving configuration files can break in place upgrades. This change use symlinks instead of rename to mark a .yml file as applied so the original file is preserved.
```

And the original issue was:
https://issues.redhat.com/browse/RHEL-19680