### PR TITLE
[release-4.12] OPNET-355: Use NM's dns-change event for resolv.conf

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -23,10 +23,12 @@ contents:
 
     export DHCP6_FQDN_FQDN IP4_DOMAINS IP6_DOMAINS
     export -f resolv_prepender
-    # Given an overall Network Manager dispatcher timeout of 90 seconds, and 3 events which may occur within
-    # this time period (up, dhcp4, dhcp6), we must enforce a time limit for each event.
+    # Given an overall Network Manager dispatcher timeout of 90 seconds, and multiple events which
+    # may occur within this time period, we must enforce a time limit for each event. As some
+    # events cannot happen in the same transaction, we are not simply dividing timeout by their
+    # number (e.g. "up" and "reapply" don't contribute to the same timeout like  "dhcp*-change").
     case "$STATUS" in
-      up|dhcp4-change|dhcp6-change)
+      up|dhcp4-change|dhcp6-change|reapply)
         >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
         if ! timeout 30s bash -c resolv_prepender; then
             >&2 echo "NM resolv-prepender: Timeout occurred"

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -23,16 +23,32 @@ contents:
 
     export DHCP6_FQDN_FQDN IP4_DOMAINS IP6_DOMAINS
     export -f resolv_prepender
-    # Given an overall Network Manager dispatcher timeout of 90 seconds, and multiple events which
-    # may occur within this time period, we must enforce a time limit for each event. As some
-    # events cannot happen in the same transaction, we are not simply dividing timeout by their
-    # number (e.g. "up" and "reapply" don't contribute to the same timeout like  "dhcp*-change").
+
+    # For RHEL8 with NetworkManager >= 1.36 and RHEL9 with NetworkManager >=1.42 we can use simplified logic
+    # of observing only a single "dns-change" event. Older version of NetworkManager require however that we
+    # react on a set of multiple events. Once dns-change event is detected we create a flag file to ignore
+    # subsequent up&co. events as undesired.
+    #
+    # Given an overall Network Manager dispatcher timeout of 90 seconds, we are enforcing a slightly shorter
+    # timeout for the observed events.
     case "$STATUS" in
-      up|dhcp4-change|dhcp6-change|reapply)
+      dns-change)
         >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
-        if ! timeout 30s bash -c resolv_prepender; then
+        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
+          touch /run/networkmanager-dns-event-detected
+        fi
+        if ! timeout 60s bash -c resolv_prepender; then
+          >&2 echo "NM resolv-prepender: Timeout occurred"
+          exit 1
+        fi
+      ;;
+      up|dhcp4-change|dhcp6-change|reapply)
+        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
+          >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
+          if ! timeout 30s bash -c resolv_prepender; then
             >&2 echo "NM resolv-prepender: Timeout occurred"
             exit 1
+          fi
         fi
       ;;
       *)


### PR DESCRIPTION
This is manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/4133 because it also picks the 5a2f3698ba5fb8511db9af3b69754998c4cadb1d commit