### PR TITLE
MCO-898: OCPBUGS-29857: OCPBUGS-29819: Implement an alerting mechanism for boot image update failures

### DIFF
--- a/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config-operator_01_prometheus-rules.yaml
@@ -37,6 +37,18 @@ spec:
           annotations:
             summary: "Triggers when nodes in a pool have overlapping labels such as master, worker, and a custom label therefore a choice must be made as to which is honored."
             description: "Node {{ $labels.exported_node }} has triggered a pool alert due to a label change. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
+    - name: mcc-boot-image-update-error
+      rules:
+        - alert: MCCBootImageUpdateError
+          expr: |
+            mcc_bootimage_update_error > 0
+          for: 30m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "Triggers when machineset boot images could not be updated"
+            description: "The boot images of Machineset {{ $labels.machineset }} could not be updated. For more details check MachineConfigController pod logs: oc logs -n {{ $labels.namespace }} -f $(oc get pod -o name -l='k8s-app=machine-config-controller' -n openshift-machine-config-operator) | grep machine_set"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -44,6 +44,12 @@ var (
 			Name: "mcc_sub_controller_state",
 			Help: "state of sub-controllers in the MCC",
 		}, []string{"subcontroller", "state", "object"})
+	// MCCBootImageUpdateErr logs when the bootimage reconciliation of a MachineSet fails.
+	MCCBootImageUpdateErr = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mcc_bootimage_update_error",
+			Help: "boot image reconciliation failed",
+		}, []string{"machineset"})
 )
 
 func RegisterMCCMetrics() error {
@@ -52,6 +58,7 @@ func RegisterMCCMetrics() error {
 		MCCDrainErr,
 		MCCPoolAlert,
 		MCCSubControllerState,
+		MCCBootImageUpdateErr,
 	})
 
 	if err != nil {
@@ -64,6 +71,7 @@ func RegisterMCCMetrics() error {
 	MCCDrainErr.WithLabelValues("initialize").Set(0)
 	MCCPoolAlert.WithLabelValues("initialize").Set(0)
 	MCCSubControllerState.WithLabelValues("initialize", "initialize", "initialize").Set(0)
+	MCCBootImageUpdateErr.WithLabelValues("initialize").Set(0)
 
 	return nil
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a new prometheus metric that counts MSBIC failures to update boot images per machineset. 
- Added a new prometheus rule that creates an alert if there are sustained failures on a machineset for longer than 30 minutes

Open to changing the alerting expression/time interval, this is just a starting point (: 

**- How to verify it**
Break anything that is necessary for machineset reconciliation. I tested this via removing patch powers for the MCC in RBAC, breaking JSON marshalling for the `coreos-bootimages` configmap.(Both require scaling down the CVO) There are probably simpler ways I hadn't thought of! 

