### PR TITLE
OCPBUGS-29659: Apply new DNS configuration only if changed

### DIFF
--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -108,13 +108,16 @@ contents:
                     fi
                     # Only leave the first 3 nameservers in /etc/resolv.conf
                     sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' "${RESOLVCONFTMPPATH}"
-                    chmod 644 "${RESOLVCONFTMPPATH}"
-                    mv -Zf "${RESOLVCONFTMPPATH}" /etc/resolv.conf
-                    # Workaround for bz 1929160. Reload NetworkManager to force it to
-                    # re-run the lookup of the hostname now that we know we have DNS
-                    # servers configured correctly in resolv.conf.
-                    nmcli general reload dns-rc
-                    touch "${KNICONFDONEPATH}"
+                    # Only touch existing resolv.conf if files actually differ
+                    if ! cmp -s "${RESOLVCONFTMPPATH}" /etc/resolv.conf; then
+                      chmod 644 "${RESOLVCONFTMPPATH}"
+                      mv -Zf "${RESOLVCONFTMPPATH}" /etc/resolv.conf
+                      # Workaround for bz 1929160. Reload NetworkManager to force it to
+                      # re-run the lookup of the hostname now that we know we have DNS
+                      # servers configured correctly in resolv.conf.
+                      nmcli general reload dns-rc
+                      touch "${KNICONFDONEPATH}"
+                    fi
                 fi
             fi
     }


### PR DESCRIPTION
With this change the resolv-prepender script will apply DNS changes only when DNS servers actually changed. This will significantly reduce the number of `nmcli` calls and remove scenarios in which we can end up in the infinite loop of resolv-prepender calls.

Fixes: [OPNET-469](https://issues.redhat.com//browse/OPNET-469)
Relates-to: OCPBUGS-29624