### PR TITLE
MCO-998: sets up MCO repository for Snyk CI scans

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,21 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    # Ignore vendor/ directory since we're not (yet) concerned with scanning
+    # our dependencies on each CI run.
+    - 'vendor/**'
+    # Ignore _test.go files because they are tests and not exploitable on
+    # running systems.
+    - '**/*_test.go'
+    # Ignoring CWE-295 (Improper Certificate Validation). This is working as
+    # intended.
+    - 'cmd/apiserver-watcher/run.go'
+    # Ignoring CWE-23 (Path Traversal). This does not appear to be exploitable
+    # in this particular context.
+    - 'pkg/daemon/certificate_writer.go'
+    # Ignoring CWE-916 (Use of Password Hash With Insufficient Computational
+    # Effort). We are not hashing passwords with MD5.
+    - 'pkg/controller/render/hash.go'


### PR DESCRIPTION
**- What I did**

In order to get a baseline setup for automated Snyk security scans on each PR, I added a .snyk file to our repository root to ignore certain directories and files.

**- How to verify it**

Once https://github.com/openshift/release/pull/47445 lands, one can run the security job that PR creates. The security job should pass.

**- Description for the changelog**
Enable automated Snyk security scans
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
