### PR TITLE
Revert "[release-4.14] OCPBUGS-28379: fix nodeStatusUpdateFrequency"

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -25,7 +25,6 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
-    nodeStatusUpdateFrequency: 10s
     featureGates:
       AlibabaPlatform: true
       OpenShiftPodSecurityAdmission: true

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -25,7 +25,6 @@ contents:
     serializeImagePulls: false
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
-    nodeStatusUpdateFrequency: 10s
     featureGates:
       AlibabaPlatform: true
       OpenShiftPodSecurityAdmission: true


### PR DESCRIPTION
Reverts openshift/machine-config-operator#4149

for testing whether this caused the CPU increase that's been observed in https://issues.redhat.com/browse/OCPBUGS-29424
