### PR TITLE
OCPBUGS-29624: Restart resolv-prepender on failure

### DIFF
--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -8,5 +8,8 @@ contents: |
   After=crio-wipe.service
   [Service]
   Type=oneshot
+  Restart=on-failure
+  RestartSec=10
+  StartLimitIntervalSec=0
   ExecStart=/usr/local/bin/resolv-prepender.sh
   EnvironmentFile=/run/resolv-prepender/env


### PR DESCRIPTION
With this PR we are leveraging the systemd `on-failure` restart mode for on-prem-resolv-prepender service to make it more robust for cases when we didn't manage to successfuly configure DNS.

This has been implemented for `oneshot` service types already long time ago via https://github.com/systemd/systemd/pull/13754.

Contributes-to: OCPBUGS-29624