### PR TITLE
[WIP] TRT-1519: Revert #4129 "OCPBUGS-18940: Add keepalived healthcheck for machine-config-server"

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -36,14 +36,6 @@ contents:
         fall 3
     }
 
-    vrrp_script chk_mcs {
-        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_mcs_script.sh"
-        interval 2
-        weight 3
-        rise 3
-        fall 3
-    }
-
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
     vrrp_script chk_ingress {
@@ -101,7 +93,6 @@ contents:
         track_script {
             chk_ocp_lb
             chk_ocp_both
-            chk_mcs
         }
     }
     {{`{{end}}`}}

--- a/templates/master/00-master/on-prem/files/keepalived-mcs-script.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-mcs-script.yaml
@@ -1,6 +1,0 @@
-mode: 0755
-path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_mcs_script.sh.tmpl"
-contents:
-  inline: |
-    #!/bin/bash
-    chroot /host /bin/crictl ps --state running | grep -qE '\smachine-config-server\s'


### PR DESCRIPTION

Reverts #4129 ; tracked by [TRT-1519](https://issues.redhat.com//browse/TRT-1519)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Around 2/14, metal installs got worse, dropping by about 15%

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Verify metal payload jobs succeed
```

CC: @cybertron

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
