### PR TITLE
TRT-1519: Revert #4133 "OPNET-355: Use NM's dns-change event for resolv.conf"

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -27,32 +27,16 @@ contents:
 
     export IP4_DOMAINS IP6_DOMAINS
     export -f resolv_prepender
-
-    # For RHEL8 with NetworkManager >= 1.36 and RHEL9 with NetworkManager >=1.42 we can use simplified logic
-    # of observing only a single "dns-change" event. Older version of NetworkManager require however that we
-    # react on a set of multiple events. Once dns-change event is detected we create a flag file to ignore
-    # subsequent up&co. events as undesired.
-    #
-    # Given an overall Network Manager dispatcher timeout of 90 seconds, we are enforcing a slightly shorter
-    # timeout for the observed events.
+    # Given an overall Network Manager dispatcher timeout of 90 seconds, and multiple events which
+    # may occur within this time period, we must enforce a time limit for each event. As some
+    # events cannot happen in the same transaction, we are not simply dividing timeout by their
+    # number (e.g. "up" and "reapply" don't contribute to the same timeout like  "dhcp*-change").
     case "$STATUS" in
-      dns-change)
-        >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
-        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
-          touch /run/networkmanager-dns-event-detected
-        fi
-        if ! timeout 60s bash -c resolv_prepender; then
-          >&2 echo "NM resolv-prepender: Timeout occurred"
-          exit 1
-        fi
-      ;;
       up|dhcp4-change|dhcp6-change|reapply)
-        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
-          >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
-          if ! timeout 30s bash -c resolv_prepender; then
+        >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
+        if ! timeout 30s bash -c resolv_prepender; then
             >&2 echo "NM resolv-prepender: Timeout occurred"
             exit 1
-          fi
         fi
         # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain and static hostname was not already set
         if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] ; then


### PR DESCRIPTION

Reverts #4133 ; tracked by TRT-1519

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Around 2/14, metal installs got worse, dropping by about 15%

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Verify metal payload jobs succeed
```

CC: @mkowalski

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
