### PR TITLE
OCPBUGS-29732: Always touch resolv-prepender file at end of script

### DIFF
--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -116,8 +116,8 @@ contents:
                       # re-run the lookup of the hostname now that we know we have DNS
                       # servers configured correctly in resolv.conf.
                       nmcli general reload dns-rc
-                      touch "${KNICONFDONEPATH}"
                     fi
+                    touch "${KNICONFDONEPATH}"
                 fi
             fi
     }


### PR DESCRIPTION
PR #4196 made this conditional based on whether changes were actually made to resolv.conf. Unfortunately, because resolv.conf is persistent over reboots this means that we never touch it after the initial deployment and as a result on subsequent boots kubelet will never start because the file is never created.

Because we don't care whether changes were actually made, only that resolv.conf is correctly generated, we can move this file creation out of the if block and always do it to fix the problem.

Note that this probably does not happen with OVNKubernetes because the creation of br-ex triggers DNS changes (it gets cleared and then re-populated) so this is only relevant for OpenShiftSDN-based envs.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
