### PR TITLE
[WIP] OCPNODE-1211: Enable priority based Graceful Node Shutdown support

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -23,6 +23,15 @@ contents:
     protectKernelDefaults: true
     rotateCertificates: true
     serializeImagePulls: false
+    shutdownGracePeriodByPodPriority:
+      - priority: 0
+        shutdownGracePeriodSeconds: 3900
+      - priority: 10000
+        shutdownGracePeriodSeconds: 3900
+      - priority: 2000000000
+        shutdownGracePeriodSeconds: 2100
+      - priority: 2000001000
+        shutdownGracePeriodSeconds: 2100
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
     nodeStatusUpdateFrequency: 10s

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -23,6 +23,15 @@ contents:
     protectKernelDefaults: true
     rotateCertificates: true
     serializeImagePulls: false
+    shutdownGracePeriodByPodPriority:
+      - priority: 0
+        shutdownGracePeriodSeconds: 3900
+      - priority: 10000
+        shutdownGracePeriodSeconds: 3900
+      - priority: 2000000000
+        shutdownGracePeriodSeconds: 2100
+      - priority: 2000001000
+        shutdownGracePeriodSeconds: 2100
     staticPodPath: /etc/kubernetes/manifests
     systemCgroups: /system.slice
     nodeStatusUpdateFrequency: 10s


### PR DESCRIPTION
**- What I did**

Enable priority based Graceful Node Shutdown support in OpenShift as default.

_(taken from the linked blog post)_

> What is a graceful node shutdown? 
>
> The kubelet's handling for a [graceful node shutdown](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown) allows the kubelet to detect a node shutdown event, properly terminate the pods on that node, and release resources before the actual shutdown. [Critical pods](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical) are terminated after all the regular pods are terminated, to ensure that the essential functions of an application can continue to work as long as possible.

Related:

- [KEP-2000: Graceful Node Shutdown](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2000-graceful-node-shutdown/README.md)
- [KEP-2712: Pod Priority Based Graceful Node Shutdown
](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown/README.md)
- [Kubernetes 1.26: Non-Graceful Node Shutdown Moves to Beta
](https://kubernetes.io/blog/2022/12/16/kubernetes-1-26-non-graceful-node-shutdown-beta)

**- How to verify it**

N/A

**- Description for the changelog**

None