### PR TITLE
OCPBUGS-30239: Prevent OVS-configuration to run before kdump

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -2,6 +2,11 @@ name: ovs-configuration.service
 enabled: {{if eq .NetworkType "OVNKubernetes" "OpenShiftSDN"}}true{{else}}false{{end}}
 contents: |
   [Unit]
+  # Kdump will generate it's initramfs based on the running state when kdump.service run
+  # If OVS has already run, the kdump fails to gather a working network config,
+  # which prevent network log exports, sush as SSH.
+  # See https://issues.redhat.com/browse/OCPBUGS-28239
+  After=kdump.service
   Description=Configures OVS with proper host networking configuration
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service

--- a/templates/common/azure/units/ovs-configuration.service.yaml
+++ b/templates/common/azure/units/ovs-configuration.service.yaml
@@ -2,6 +2,11 @@ name: ovs-configuration.service
 enabled: {{if eq .NetworkType "OVNKubernetes" "OpenShiftSDN"}}true{{else}}false{{end}}
 contents: |
   [Unit]
+  # Kdump will generate it's initramfs based on the running state when kdump.service run
+  # If OVS has already run, the kdump fails to gather a working network config,
+  # which prevent network log exports, sush as SSH.
+  # See https://issues.redhat.com/browse/OCPBUGS-28239
+  After=kdump.service
   Description=Configures OVS with proper host networking configuration
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service


### PR DESCRIPTION
Kdump will generate it's initramfs based on the running state when kdump.service run If OVS has already run, the kdump fails to gather a working network config, which prevent network log exports, sush as SSH.

See https://issues.redhat.com/browse/OCPBUGS-28239

Ideally we would need that to be backported to 4.14, otherwise I will add a systemd drop-in as a workaround in RHCOS 
