### PR TITLE
OCPBUGS-29067:  Add HostToContainer propogataion for coreDNS pods on cloud platforms

### DIFF
--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -45,12 +45,15 @@ spec:
   volumeMounts:
   - name: kubeconfig
     mountpath: "/etc/kubernetes/kubeconfig"
+    mountPropagation: HostToContainer
   - name: resource-dir
     mountpath: "/config"
+    mountPropagation: HostToContainer
   - name: conf-dir
     mountpath: "/etc/coredns"
   - name: manifests
     mountpath: "/opt/openshift/manifests"
+    mountPropagation: HostToContainer
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns


### PR DESCRIPTION
Fixes OCPBUGS-29067

Adds HostToContainer mount propogation to hostPath volumeMounts in the CoreDNS pod definition used for cloud platforms.
This fixes the issue where kubeconfig was unavailable to `runtimecfg render` initContainer within the CoreDNS pod running on the bootstrap node for platform GCP.