### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/install/0000_80_machine-config_04_deployment.yaml
+++ b/install/0000_80_machine-config_04_deployment.yaml
@@ -22,6 +22,7 @@ spec:
         k8s-app: machine-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: anyuid
     spec:
       containers:
       - name: machine-config-operator

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         k8s-app: machine-config-controller
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
     spec:
       containers:
       - name: machine-config-controller

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         k8s-app: machine-config-daemon
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       containers:
       - name: machine-config-daemon

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: machine-config-server
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: hostnetwork
     spec:
       containers:
       - name: machine-config-server


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Pinned the required SCC to the following workloads:
- `deployment/machine-config-operator`
- `deployment/machine-config-controller`
- `daemonset/machine-config-daemon`
- `daemonset/machine-config-server`

**- How to verify it**
No effective changes expected; the pinned SCC is the one that the pods are getting admitted with.

**- Description for the changelog**
Pinned the required SCC to prevent custom SCCs from taking precedence.