### PR TITLE
OCPBUGS-30139: [release-4.15] Use NM's dns-change event for resolv.conf

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -27,16 +27,32 @@ contents:
 
     export IP4_DOMAINS IP6_DOMAINS
     export -f resolv_prepender
-    # Given an overall Network Manager dispatcher timeout of 90 seconds, and multiple events which
-    # may occur within this time period, we must enforce a time limit for each event. As some
-    # events cannot happen in the same transaction, we are not simply dividing timeout by their
-    # number (e.g. "up" and "reapply" don't contribute to the same timeout like  "dhcp*-change").
+
+    # For RHEL8 with NetworkManager >= 1.36 and RHEL9 with NetworkManager >=1.42 we can use simplified logic
+    # of observing only a single "dns-change" event. Older version of NetworkManager require however that we
+    # react on a set of multiple events. Once dns-change event is detected we create a flag file to ignore
+    # subsequent up&co. events as undesired.
+    #
+    # Given an overall Network Manager dispatcher timeout of 90 seconds, we are enforcing a slightly shorter
+    # timeout for the observed events.
     case "$STATUS" in
-      up|dhcp4-change|dhcp6-change|reapply)
+      dns-change)
         >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
-        if ! timeout 30s bash -c resolv_prepender; then
+        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
+          touch /run/networkmanager-dns-event-detected
+        fi
+        if ! timeout 60s bash -c resolv_prepender; then
+          >&2 echo "NM resolv-prepender: Timeout occurred"
+          exit 1
+        fi
+      ;;
+      up|dhcp4-change|dhcp6-change|reapply)
+        if [ ! -f "/run/networkmanager-dns-event-detected" ]; then
+          >&2 echo "NM resolv-prepender triggered by ${IFACE} ${STATUS}."
+          if ! timeout 30s bash -c resolv_prepender; then
             >&2 echo "NM resolv-prepender: Timeout occurred"
             exit 1
+          fi
         fi
         # If $DHCP6_FQDN_FQDN is not empty and is not localhost.localdomain and static hostname was not already set
         if [[ -n "$DHCP6_FQDN_FQDN" && "$DHCP6_FQDN_FQDN" != "localhost.localdomain" && "$DHCP6_FQDN_FQDN" =~ "." ]] ; then

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -64,6 +64,9 @@ contents:
                   hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN
            fi
         fi
+        if [[ "$STATUS" == "up" ]] && [[ $IFACE == "br-ex" ]]; then
+            touch /run/nodeip-configuration/br-ex-up
+        fi
       ;;
       *)
       ;;

--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -116,8 +116,8 @@ contents:
                       # re-run the lookup of the hostname now that we know we have DNS
                       # servers configured correctly in resolv.conf.
                       nmcli general reload dns-rc
-                      touch "${KNICONFDONEPATH}"
                     fi
+                    touch "${KNICONFDONEPATH}"
                 fi
             fi
     }

--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -108,13 +108,16 @@ contents:
                     fi
                     # Only leave the first 3 nameservers in /etc/resolv.conf
                     sed -i ':a $!{N; ba}; s/\(^\|\n\)nameserver/\n# nameserver/4g' "${RESOLVCONFTMPPATH}"
-                    chmod 644 "${RESOLVCONFTMPPATH}"
-                    mv -Zf "${RESOLVCONFTMPPATH}" /etc/resolv.conf
-                    # Workaround for bz 1929160. Reload NetworkManager to force it to
-                    # re-run the lookup of the hostname now that we know we have DNS
-                    # servers configured correctly in resolv.conf.
-                    nmcli general reload dns-rc
-                    touch "${KNICONFDONEPATH}"
+                    # Only touch existing resolv.conf if files actually differ
+                    if ! cmp -s "${RESOLVCONFTMPPATH}" /etc/resolv.conf; then
+                      chmod 644 "${RESOLVCONFTMPPATH}"
+                      mv -Zf "${RESOLVCONFTMPPATH}" /etc/resolv.conf
+                      # Workaround for bz 1929160. Reload NetworkManager to force it to
+                      # re-run the lookup of the hostname now that we know we have DNS
+                      # servers configured correctly in resolv.conf.
+                      nmcli general reload dns-rc
+                      touch "${KNICONFDONEPATH}"
+                    fi
                 fi
             fi
     }

--- a/templates/common/on-prem/files/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/files/wait-for-br-ex-up.yaml
@@ -1,0 +1,10 @@
+mode: 0755
+path: "/usr/local/bin/wait-for-br-ex-up.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    until [ -e /run/nodeip-configuration/br-ex-up ]
+    do
+      sleep 1
+    done

--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -6,5 +6,8 @@ contents: |
   Description=Populates resolv.conf according to on-prem IPI needs
   [Service]
   Type=oneshot
+  Restart=on-failure
+  RestartSec=10
+  StartLimitIntervalSec=0
   ExecStart=/usr/local/bin/resolv-prepender.sh
   EnvironmentFile=/run/resolv-prepender/env

--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -4,6 +4,8 @@ enabled: false
 contents: |
   [Unit]
   Description=Populates resolv.conf according to on-prem IPI needs
+  # Per https://issues.redhat.com/browse/OCPBUGS-27162 there is a problem if this is started before crio-wipe
+  After=crio-wipe.service
   [Service]
   Type=oneshot
   Restart=on-failure

--- a/templates/common/on-prem/units/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/units/wait-for-br-ex-up.yaml
@@ -1,5 +1,5 @@
 name: wait-for-br-ex-up.service
-enabled: {{if gt (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
+enabled: {{if and (gt (len (onPremPlatformAPIServerInternalIPs .)) 0) (eq .NetworkType "OVNKubernetes")}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Wait for br-ex up event from NetworkManager

--- a/templates/common/on-prem/units/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/units/wait-for-br-ex-up.yaml
@@ -1,0 +1,15 @@
+name: wait-for-br-ex-up.service
+enabled: {{if gt (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Wait for br-ex up event from NetworkManager
+  Wants=ovs-configuration.service
+  After=ovs-configuration.service
+  Before=node-valid-hostname.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/wait-for-br-ex-up.sh
+
+  [Install]
+  RequiredBy=node-valid-hostname.service


### PR DESCRIPTION
This is a manual cherry-pick for commits implementing OPNET-355. Initially discovered as bug RHEL-2184.