### PR TITLE
Tighten the permissions on kubelet.conf

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -1,4 +1,4 @@
-mode: 0644
+mode: 0600
 path: "/etc/kubernetes/kubelet.conf"
 contents:
   inline: |

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -1,4 +1,4 @@
-mode: 0644
+mode: 0600
 path: "/etc/kubernetes/kubelet.conf"
 contents:
   inline: |


### PR DESCRIPTION
According to CIS benchmark guidance 4.1.9, kubelet.conf should only be read/writeable to the owner (600).

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Changed permission of /etc/kubernetes/kubelet.conf to 0600.

**- How to verify it**
`# ls -l /etc/kubernetes/kubelet.conf 
-rw-------. 1 root root 2001 Feb 28 04:54 /etc/kubernetes/kubelet.conf`


**- Description for the changelog**
Tighten the permissions on kubelet.conf. 
According to CIS benchmark guidance 4.1.9, kubelet.conf should only be read/writeable to the owner (600).


