### PR TITLE
OCPCLOUD-2462: Add Image Credential Provider flags for Kubelet on Azure

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -469,6 +469,8 @@ func credentialProviderConfigFlag(cfg RenderConfig) interface{} {
 		return fmt.Sprintf("%s %s%s", credentialProviderBinDirFlag, credentialProviderConfigFlag, "ecr-credential-provider.yaml")
 	case configv1.GCPPlatformType:
 		return fmt.Sprintf("%s %s%s", credentialProviderBinDirFlag, credentialProviderConfigFlag, "gcr-credential-provider.yaml")
+	case configv1.AzurePlatformType:
+		return fmt.Sprintf("%s %s%s", credentialProviderBinDirFlag, credentialProviderConfigFlag, "acr-credential-provider.yaml")
 	default:
 		return ""
 	}

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -311,7 +311,7 @@ func TestCredentialProviderConfigFlag(t *testing.T) {
 		},
 		{
 			platform: configv1.AzurePlatformType,
-			res:      "",
+			res:      "--image-credential-provider-bin-dir=/usr/libexec/kubelet-image-credential-provider-plugins --image-credential-provider-config=/etc/kubernetes/credential-providers/acr-credential-provider.yaml",
 		},
 		{
 			platform: configv1.GCPPlatformType,

--- a/templates/common/azure/files/etc-kubernetes-credential-providers-acr-credential-provider.yaml
+++ b/templates/common/azure/files/etc-kubernetes-credential-providers-acr-credential-provider.yaml
@@ -1,0 +1,18 @@
+mode: 0644
+path: "/etc/kubernetes/credential-providers/acr-credential-provider.yaml"
+contents:
+  inline: |
+    apiVersion: kubelet.config.k8s.io/v1
+    kind: CredentialProviderConfig
+    providers:
+      - name: acr-credential-provider
+        apiVersion: credentialprovider.kubelet.k8s.io/v1
+        defaultCacheDuration: "10m"
+        matchImages:
+          - "*.azurecr.io"
+          - "*.azurecr.cn"
+          - "*.azurecr.de"
+          - "*.azurecr.us"
+        args:
+          - /etc/kubernetes/cloud.conf
+


### PR DESCRIPTION
**- What I did**

Adds configuration for the ACR credential provider to kubelet on Azure
Unit tests show new flags being set correctly.

Builds on  #4103

Depends on the acr-credential-provider RPM shipping in RHCOS.

**- How to verify it**

Kubelet should be able to pull an image from a private ACR registry.

**- Description for the changelog**

Adds support for azure acr credential provider