### PR TITLE
OCPCLOUD-2465: Add Image Credential Provider flags for Kubelet on GCP

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -467,6 +467,8 @@ func credentialProviderConfigFlag(cfg RenderConfig) interface{} {
 	switch cfg.Infra.Status.PlatformStatus.Type {
 	case configv1.AWSPlatformType:
 		return fmt.Sprintf("%s %s%s", credentialProviderBinDirFlag, credentialProviderConfigFlag, "ecr-credential-provider.yaml")
+	case configv1.GCPPlatformType:
+		return fmt.Sprintf("%s %s%s", credentialProviderBinDirFlag, credentialProviderConfigFlag, "gcr-credential-provider.yaml")
 	default:
 		return ""
 	}

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -315,7 +315,7 @@ func TestCredentialProviderConfigFlag(t *testing.T) {
 		},
 		{
 			platform: configv1.GCPPlatformType,
-			res:      "",
+			res:      "--image-credential-provider-bin-dir=/usr/libexec/kubelet-image-credential-provider-plugins --image-credential-provider-config=/etc/kubernetes/credential-providers/gcr-credential-provider.yaml",
 		},
 		{
 			platform: configv1.VSpherePlatformType,

--- a/templates/common/gcp/files/etc-kubernetes-credential-providers-gcr-credential-provider.yaml
+++ b/templates/common/gcp/files/etc-kubernetes-credential-providers-gcr-credential-provider.yaml
@@ -1,0 +1,14 @@
+mode: 0644
+path: "/etc/kubernetes/credential-providers/gcr-credential-provider.yaml"
+contents:
+  inline: |
+    apiVersion: kubelet.config.k8s.io/v1
+    kind: CredentialProviderConfig
+    providers:
+      - name: gcr-credential-provider
+        matchImages:
+          - "gcr.io"
+          - "*.gcr.io"
+          - "container.cloud.google.com"
+        defaultCacheDuration: "0s"
+        apiVersion: credentialprovider.kubelet.k8s.io/v1


### PR DESCRIPTION
**- What I did**

Adds configuration for the GCR credential provider to kubelet on GCP
Unit tests show new flags being set correctly.

Builds on  #4103

Depends on the gcr-credential-provider RPM shipping in RHCOS.

**- How to verify it**

Kubelet should be able to pull an image from a private GCR registry.

**- Description for the changelog**

Adds support for GCP gcr credential provider