### PR TITLE
Add missing Devices annotation to CRI-O configuration

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -35,12 +35,15 @@ contents:
     [crio.runtime.runtimes.runc]
     allowed_annotations = [
         "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
         "io.kubernetes.cri-o.LinkLogs",
     ]
 
     [crio.runtime.runtimes.crun]
+    runtime_root = "/run/crun"
     allowed_annotations = [
         "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
         "io.kubernetes.cri-o.LinkLogs",
     ]
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -35,12 +35,15 @@ contents:
     [crio.runtime.runtimes.runc]
     allowed_annotations = [
         "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
         "io.kubernetes.cri-o.LinkLogs",
     ]
 
     [crio.runtime.runtimes.crun]
+    runtime_root = "/run/crun"
     allowed_annotations = [
         "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
         "io.kubernetes.cri-o.LinkLogs",
     ]
 


### PR DESCRIPTION
**- What I did**

Add the missing `io.kubernetes.cri-o.Devices` annotating to CRI-O configuration. Thus, allow for devices, such as the `/dev/fuse` to be correctly created.

**- How to verify it**

Deploy corrected configuration using either the Machine Config Operator or manually. Add support for `/dev/fuse` via an annotation to a simple Pod deployment. Observe the device file added and accessible.

**- Description for the changelog**

```release-note
None
```