### PR TITLE
OCPBUGS-30136: APIVersion and Kind sometimes are empty when listing objects

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -766,9 +766,9 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig) error {
 				Name: node.Name,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: node.APIVersion,
+						APIVersion: "v1",
 						Name:       node.ObjectMeta.Name,
-						Kind:       node.Kind,
+						Kind:       "Node",
 						UID:        node.ObjectMeta.UID,
 					},
 				},

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -251,9 +251,9 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 	// set the spec config version
 	newMCNode.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		{
-			APIVersion: node.APIVersion,
+			APIVersion: "v1",
 			Name:       node.ObjectMeta.Name,
-			Kind:       node.Kind,
+			Kind:       "Node",
 			UID:        node.ObjectMeta.UID,
 		},
 	}


### PR DESCRIPTION
The same thing happens with MCN objects sometimes. The easiest solution is to hardcode the group and kind (since they don't change)