### PR TITLE
NO-JIRA: Sync CRI-O owners

### DIFF
--- a/pkg/controller/container-runtime-config/OWNERS
+++ b/pkg/controller/container-runtime-config/OWNERS
@@ -1,5 +1,16 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
-reviewers:
+approvers:
+  - giuseppe
+  - haircommander
+  - kolyshkin
+  - mrunalp
+  - nalind
+  - saschagrunert
   - umohnani8
+reviewers:
+  - QiWang19
+  - hasan4791
+  - kwilczynski
   - mtrmac
+  - sohankunkerkar
+  - wgahnagl

--- a/templates/master/01-master-container-runtime/OWNERS
+++ b/templates/master/01-master-container-runtime/OWNERS
@@ -1,5 +1,16 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
-reviewers:
+approvers:
+  - giuseppe
+  - haircommander
+  - kolyshkin
+  - mrunalp
+  - nalind
+  - saschagrunert
   - umohnani8
+reviewers:
+  - QiWang19
+  - hasan4791
+  - kwilczynski
   - mtrmac
+  - sohankunkerkar
+  - wgahnagl

--- a/templates/worker/01-worker-container-runtime/OWNERS
+++ b/templates/worker/01-worker-container-runtime/OWNERS
@@ -1,5 +1,16 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
-reviewers:
+approvers:
+  - giuseppe
+  - haircommander
+  - kolyshkin
+  - mrunalp
+  - nalind
+  - saschagrunert
   - umohnani8
+reviewers:
+  - QiWang19
+  - hasan4791
+  - kwilczynski
   - mtrmac
+  - sohankunkerkar
+  - wgahnagl


### PR DESCRIPTION
Syncing CRI-O config owners defined in:
https://github.com/cri-o/cri-o/blob/main/OWNERS_ALIASES

Leaving out folks which are not associates of Red Hat.

cc @mrunalp @giuseppe @haircommander @kolyshkin @nalind @umohnani8 @mtrmac @QiWang19 @hasan4791 @kwilczynski @sohankunkerkar @wgahnagl 
