### PR TITLE
[Don't merge] Revert "APIVersion and Kind sometimes are empty when listing objects"

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -766,9 +766,9 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig) error {
 				Name: node.Name,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1",
+						APIVersion: node.APIVersion,
 						Name:       node.ObjectMeta.Name,
-						Kind:       "Node",
+						Kind:       node.Kind,
 						UID:        node.ObjectMeta.UID,
 					},
 				},

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -251,9 +251,9 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 	// set the spec config version
 	newMCNode.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		{
-			APIVersion: "v1",
+			APIVersion: node.APIVersion,
 			Name:       node.ObjectMeta.Name,
-			Kind:       "Node",
+			Kind:       node.Kind,
 			UID:        node.ObjectMeta.UID,
 		},
 	}


### PR DESCRIPTION
This reverts commit 43ada4455a9289c3ead2d08e6abf0baa681f0312.

Mostly it shouldn't be the case but testing if recent failure in https://issues.redhat.com/browse/OCPBUGS-30149 is related to this change in anyway.