### PR TITLE
OCPBUGS-28577: MCO-1030, MCO-910: Updating MCO base image to RHEL9

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.16

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,5 @@
-# THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
-# TODO switch the default image to rhel9 and drop the rhel8 one in 4.15 because
-# we can require by the time we get to 4.14 that we don't have any rhel8 hosts left
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+# Use RHEL 9 as the primary builder base for the Machine Config Operator
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
@@ -9,17 +7,20 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 RUN make install DESTDIR=./instroot && tar -C instroot -cf instroot.tar .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS rhel9-builder
+# Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS rhel8-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-RUN make install DESTDIR=./instroot
+RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+# Base image is RHEL 9. Only machine-config-daemon.rhel8 is from RHEL 8; all other binaries are RHEL 9.
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
-COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
+# Copy the RHEL 8 machine-config-daemon binary and rename
+COPY --from=rhel8-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel8/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel8
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ]; then \

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -500,24 +500,11 @@ func ReexecuteForTargetRoot(target string) error {
 	if sourceOsVersion.IsLikeRHEL() && targetOsVersion.IsLikeRHEL() {
 		sourceMajor := sourceOsVersion.BaseVersionMajor()
 		targetMajor := targetOsVersion.BaseVersionMajor()
-		if sourceMajor == "8" && targetMajor == "9" {
-			sourceBinarySuffix = ".rhel9"
-			klog.Info("container is rhel8, target is rhel9")
-		} else if sourceMajor == "9" && targetMajor == "8" {
-			// This code path shouldn't be hit right now because our container image
-			// is built from rhel8, but let's handle it for consistency in the future
-			// when we're likely to switch the container image to RHEL9.  Then
-			// it will be needed for both scaleup from old rhel8 bootimages as well
-			// as the case where a cluster is upgraded from
-			// 4.12 -> 4.14 or beyond and we have a stray worker node still on
-			// 4.12 (rhel8).
+		if sourceMajor == "9" && targetMajor == "8" {
 			sourceBinarySuffix = ".rhel8"
 			klog.Info("container is rhel9, target is rhel8")
 		} else {
-			// Otherwise, we assume that there's no suffixing needed.  Hopefully
-			// by RHEL10 the MCD will have fundamentally changed and we won't be doing the
-			// chroot() thing anymore.
-			klog.Infof("not chrooting for source=rhel-%s target=rhel-%s", sourceMajor, targetMajor)
+			klog.Infof("using appropriate binary for source=rhel-%s target=rhel-%s", sourceMajor, targetMajor)
 		}
 	} else {
 		klog.Info("assuming we can use container binary chroot() to host")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
I updated the Dockerfile to use RHEL 9 as the primary base image for building the Machine Config Operator (MCO) components, ensuring compatibility with RHEL 9 environments. Additionally, I modified the ReexecuteForTargetRoot function within the MCO to correctly identify and use the corresponding MCO daemon binaries based on the underlying OS version, addressing the transition between RHEL 8 and RHEL 9 nodes. Lastly, I modified and updated the go dependencies.

**- How to verify it**
1. Build the MCO container image using the updated Dockerfile and verify that it successfully creates images with the correct RHEL 9 base and includes RHEL 8 MCO daemon binaries.
2. Deploy the updated MCO on a mixed environment (with both RHEL 8 and RHEL 9 nodes) and validate that it can correctly identify the OS version and execute the appropriate daemon binary for each node, ensuring seamless operation across versions.

**- Description for the changelog**
<!--
Updated the MCO Dockerfile to use RHEL 9 as the base image and modified the ReexecuteForTargetRoot function to support dynamic selection and execution of the appropriate MCO daemon binary based on the node's OS version, enhancing compatibility and support for RHEL 9 nodes.
-->
