### PR TITLE
OCPCLOUD-2465: Updates GCR CredentialProviderConfig

### DIFF
--- a/templates/common/gcp/files/etc-kubernetes-credential-providers-gcr-credential-provider.yaml
+++ b/templates/common/gcp/files/etc-kubernetes-credential-providers-gcr-credential-provider.yaml
@@ -6,9 +6,13 @@ contents:
     kind: CredentialProviderConfig
     providers:
       - name: gcr-credential-provider
+        apiVersion: credentialprovider.kubelet.k8s.io/v1
         matchImages:
           - "gcr.io"
           - "*.gcr.io"
+          - "*.pkg.dev"
           - "container.cloud.google.com"
-        defaultCacheDuration: "0s"
-        apiVersion: credentialprovider.kubelet.k8s.io/v1
+        defaultCacheDuration: "1m"
+        args:
+          - get-credentials
+          - --v=3


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This change updates the GCR CredentialProviderConfig to pass the 'get-credentials' argument, which is required for the credential plugin to function correctly.

It also adds a matcher for "*.pkg.dev"

**- How to verify it**

- Enable the `DisableKubeletCloudCredentialProviders` feature flag
- Create a deployment that pulls from a private GCR image
- Verify the image does not fail to pull

**- Description for the changelog**

Updates GCR CredentialProviderConfig, passing 'get-credentials' and updating matchers
