### PR TITLE
MCO-1009: MCO-1008: MCO-905: Implement NodeDisruptionPolicy API

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -182,6 +182,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 		ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
 		ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+		ctrlctx.ClientBuilder.OperatorClientOrDie(componentName),
 		startOpts.kubeletHealthzEnabled,
 		startOpts.kubeletHealthzEndpoint,
 		ctrlctx.FeatureGateAccess,
@@ -194,6 +195,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	ctrlctx.KubeInformerFactory.Start(stopCh)
 	ctrlctx.KubeNamespacedInformerFactory.Start(stopCh)
 	ctrlctx.InformerFactory.Start(stopCh)
+	ctrlctx.OperatorInformerFactory.Start(stopCh)
 	close(ctrlctx.InformersStarted)
 
 	select {

--- a/manifests/machineconfigdaemon/clusterrole.yaml
+++ b/manifests/machineconfigdaemon/clusterrole.yaml
@@ -19,6 +19,9 @@ rules:
   resourceNames: ["privileged"]
   resources: ["securitycontextconstraints"]
   verbs: ["use"]
+- apiGroups: ["operator.openshift.io"]
+  resources: ["machineconfigurations"]
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -11,6 +11,8 @@ import (
 	opv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -382,4 +384,15 @@ func convertSpecActiontoStatusAction(action opv1.NodeDisruptionPolicySpecAction)
 		klog.Fatal("Unexpected action type found in Node Disruption Status calculation")
 		return opv1.NodeDisruptionPolicyStatusAction{Type: opv1.RebootStatusAction}
 	}
+}
+
+// Checks if a list of NodeDisruptionActions contain any action from the set of target actions
+func CheckNodeDisruptionActionsForTargetActions(actions []opv1.NodeDisruptionPolicyStatusAction, targetActions ...opv1.NodeDisruptionPolicyStatusActionType) bool {
+
+	currentActions := sets.New[opv1.NodeDisruptionPolicyStatusActionType]()
+	for _, action := range actions {
+		currentActions.Insert(action.Type)
+	}
+
+	return currentActions.HasAny(targetActions...)
 }

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -108,4 +108,7 @@ const (
 
 	// CRIOServiceName is used to specify reloads and restarts of the CRI-O service
 	CRIOServiceName = "crio"
+
+	// DaemonReloadCommand is used to specify reloads and restarts of the systemd manager configuration
+	DaemonReloadCommand = "daemon-reload"
 )

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	kubeinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	mcopfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
@@ -115,6 +117,7 @@ type fixture struct {
 
 	client     *fake.Clientset
 	kubeclient *k8sfake.Clientset
+	oclient    *mcopfake.Clientset
 
 	mcLister   []*mcfgv1.MachineConfig
 	nodeLister []*corev1.Node
@@ -124,6 +127,7 @@ type fixture struct {
 
 	objects     []runtime.Object
 	kubeobjects []runtime.Object
+	oObjects    []runtime.Object
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -142,6 +146,7 @@ var (
 func (f *fixture) newController() *Daemon {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
+	f.oclient = mcopfake.NewSimpleClientset(f.oObjects...)
 
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
@@ -156,6 +161,7 @@ func (f *fixture) newController() *Daemon {
 		i.Machineconfiguration().V1().MachineConfigs(),
 		k8sI.Core().V1().Nodes(),
 		i.Machineconfiguration().V1().ControllerConfigs(),
+		f.oclient,
 		false,
 		"",
 		d.featureGatesAccessor,

--- a/pkg/daemon/upgrade_monitor_test.go
+++ b/pkg/daemon/upgrade_monitor_test.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	mcopfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 )
 
 type upgradeMonitorTestCase struct {
@@ -103,6 +105,8 @@ func (tc upgradeMonitorTestCase) run(t *testing.T) {
 	f.kubeobjects = []runtime.Object{}
 	f.client = fake.NewSimpleClientset(f.objects...)
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
+
+	f.oclient = mcopfake.NewSimpleClientset(f.objects...)
 	fgAccess := featuregates.NewHardcodedFeatureGateAccess(
 		[]apicfgv1.FeatureGateName{
 			apicfgv1.FeatureGateMachineConfigNodes,
@@ -128,6 +132,7 @@ func (tc upgradeMonitorTestCase) run(t *testing.T) {
 		i.Machineconfiguration().V1().MachineConfigs(),
 		k8sI.Core().V1().Nodes(),
 		i.Machineconfiguration().V1().ControllerConfigs(),
+		f.oclient,
 		false,
 		"",
 		fgAccess,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -436,13 +436,13 @@ func (optr *Operator) sync(key string) error {
 		// "RenderConfig" must always run first as it sets the renderConfig in the operator
 		// for the sync funcs below
 		{"RenderConfig", optr.syncRenderConfig},
+		{"MachineConfiguration", optr.syncMachineConfiguration},
 		{"MachineConfigNode", optr.syncMachineConfigNodes},
 		{"MachineConfigPools", optr.syncMachineConfigPools},
 		{"MachineConfigDaemon", optr.syncMachineConfigDaemon},
 		{"MachineConfigController", optr.syncMachineConfigController},
 		{"MachineConfigServer", optr.syncMachineConfigServer},
 		{"MachineOSBuilder", optr.syncMachineOSBuilder},
-		{"MachineConfiguration", optr.syncMachineConfiguration},
 		// this check must always run last since it makes sure the pools are in sync/upgrading correctly
 		{"RequiredPools", optr.syncRequiredMachineConfigPools},
 	}


### PR DESCRIPTION
### This PR does the following:
- The operator now checks the MachineConfiguration global knob for any user provided node disruption policies, merges them with cluster defaults and displays the results in the Status of the MachineConfiguration object. 
- The daemon looks at the status of the MachineConfiguration object during node updates. If the daemon is unable to find the status of MachineConfiguration for more than 2 minutes, it will default to the legacy update path.
- All of this is gated on NodeDisruption feature gate

### How to test:

- Bring up a cluster in TechPreview. If testing on a cluster that was originally having the default FeatureSet and then transitioned to TechPreview, please read this https://github.com/openshift/machine-config-operator/pull/4267#issuecomment-2071154702
- Check the status of the MachineConfiguration object named "cluster"; this should list the cluster default policies.
```
$ oc get MachineConfiguration/cluster -o yaml
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
metadata:
  creationTimestamp: "2024-04-16T15:02:37Z"
  generation: 4
  name: cluster
  resourceVersion: "261205"
  uid: 2c67b155-1898-452f-adbd-ed376afc0ea2
spec:
  logLevel: Normal
  managementState: Managed
  operatorLogLevel: Normal
status:
  nodeDisruptionPolicyStatus:
    clusterPolicies:
      files:
      - actions:
        - type: None
        path: /etc/mco/internal-registry-pull-secret.json
      - actions:
        - type: None
        path: /var/lib/kubelet/config.json
      - actions:
        - reload:
            serviceName: crio.service
          type: Reload
        path: /etc/machine-config-daemon/no-reboot/containers-gpg.pub
      - actions:
        - reload:
            serviceName: crio.service
          type: Reload
        path: /etc/containers/policy.json
      - actions:
        - type: Special
        path: /etc/containers/registries.conf
      sshkey:
        actions:
        - type: None
  readyReplicas: 0

```
- Apply a MachineConfiguration named "cluster" with a valid NodeDisruptionPolicy. More information about the policy and possible actions can be found [here](https://github.com/openshift/enhancements/blob/0264993edbb3ffdb66eada258a77a81f033b7ac1/enhancements/machine-config/admin-defined-node-disruption-policy.md#proposal). Here is a sample policy:
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
metadata:
  name: cluster
  namespace: openshift-machine-config-operator
spec:
  nodeDisruptionPolicy:
    files:
      - path: "/etc/my-file"
        actions:
          - type: None
    units:
      - name: "my.service"
        actions:
          - type: Restart
            restart:
              serviceName: crio.service
      - name: "test.service"
        actions:
          - type: DaemonReload
          - type: Drain
          - type: Reload
            reload:
              serviceName: crio.service
          - type: Restart
            restart:
              serviceName: my.service
    sshkey:
      actions:
      - type: Reboot
```

- Check the status of the MachineConfiguration object; this should now list a merged policy, including the ones specifies by you and the defaults. If there are any conflicts, the user specified ones will override the cluster defaults. 
```

status:
  nodeDisruptionPolicyStatus:
    clusterPolicies:
      files:
      - actions:
        - type: None
        path: /etc/mco/internal-registry-pull-secret.json
      - actions:
        - type: None
        path: /var/lib/kubelet/config.json
      - actions:
        - reload:
            serviceName: crio.service
          type: Reload
        path: /etc/machine-config-daemon/no-reboot/containers-gpg.pub
      - actions:
        - reload:
            serviceName: crio.service
          type: Reload
        path: /etc/containers/policy.json
      - actions:
        - type: Special
        path: /etc/containers/registries.conf
      - actions:
        - type: None
        path: /etc/my-file
      sshkey:
        actions:
        - type: Reboot
      units:
      - actions:
        - restart:
            serviceName: crio.service
          type: Restart
        name: my.service
      - actions:
        - type: DaemonReload
        - type: Drain
        - reload:
            serviceName: crio.service
          type: Reload
        - restart:
            serviceName: my.service
          type: Restart
        name: test.service
```
In this case, the SSHkey section has been overriden. 
- Now, apply a new MachineConfig with a change that would be in effect for the currently defined node disruption policy. In this case, I applied a config which had changes to the `test.service` unit. Observe the daemon logs on the targeted node, and you should see the daemon step through the designated actions. 
```
I0417 18:20:47.614397    2551 update.go:2578] Starting update from rendered-infra-5d1e3cebfddcee59ac7bde56152e0919 to rendered-infra-a17773854499b91cb5cc86087b54cfe8: &{osUpdate:false kargs:false fips:false passwd:false files:false units:true kernelType:false extensions:false}
I0417 18:20:47.624217    2551 update.go:717] Calculating node disruption actions
I0417 18:20:47.624251    2551 update.go:642] NodeDisruptionPolicy found for diff unit test.service!
I0417 18:20:47.624261    2551 update.go:1023] Calculated node disruption actions:
I0417 18:20:47.624271    2551 update.go:1030] DaemonReload
I0417 18:20:47.624284    2551 update.go:1030] Drain
I0417 18:20:47.624298    2551 update.go:1026] Reload - crio.service
I0417 18:20:47.624313    2551 update.go:1028] Restart - my.service
I0417 18:20:47.624320    2551 drain.go:121] Checking drain required for node disruption actions
I0417 18:20:47.624328    2551 update.go:1060] Drain calculated for node disruption: true
...
...
...
I0417 18:21:30.264732    2551 update.go:2578] Executing performPostConfigChangeNodeDisruptionAction(drain already complete/skipped) for config rendered-infra-a17773854499b91cb5cc86087b54cfe8
I0417 18:21:30.266752    2551 update.go:2578] Executing postconfig action: DaemonReload for config rendered-infra-a17773854499b91cb5cc86087b54cfe8
I0417 18:21:30.268793    2551 update.go:2563] Running: systemctl daemon-reload
I0417 18:21:30.645513    2551 update.go:2578] daemon-reload service reloaded successfully!
I0417 18:21:30.647826    2551 update.go:2578] Executing postconfig action: Drain for config rendered-infra-a17773854499b91cb5cc86087b54cfe8
I0417 18:21:30.649623    2551 update.go:2578] Executing postconfig action: Reload for config rendered-infra-a17773854499b91cb5cc86087b54cfe8
I0417 18:21:30.651303    2551 update.go:2563] Running: systemctl reload crio.service
I0417 18:21:30.688445    2551 update.go:2578] crio.service service reloaded successfully!
I0417 18:21:30.690534    2551 update.go:2578] Executing postconfig action: Restart for config rendered-infra-a17773854499b91cb5cc86087b54cfe8
I0417 18:21:30.692379    2551 update.go:2563] Running: systemctl restart my.service
I0417 18:21:30.711817    2551 update.go:2578] my.service service restarted successfully!
I0417 18:21:30.720163    2551 daemon.go:1574] Previous boot ostree-finalize-staged.service appears successful
I0417 18:21:30.720187    2551 daemon.go:1697] Current config: rendered-infra-5d1e3cebfddcee59ac7bde56152e0919
I0417 18:21:30.720192    2551 daemon.go:1698] Desired config: rendered-infra-a17773854499b91cb5cc86087b54cfe8
I0417 18:21:30.720202    2551 daemon.go:1706] state: Done

```

Some things to note
- If any of the changes result in a reboot action, all other policies will be ignored.
- There is no dedup of the final actions list. We don't expect users to do MC changes that causes multiple policies to be in effect for a single update very often, so this didn't seem like a pressing need. 
- There is a special exclusion for files defined in directory `/etc/containers/registries.d/` to account for some recent changes from https://github.com/openshift/machine-config-operator/pull/4160#discussion_r1548669673. In the future, the MCO plans to add directories and wildcard support. With that in place, this exception can be removed and made part of the standard policy. 

