### PR TITLE
[release-4.12] OCPBUGS-30823: Introduce kubelet-dependencies.target and firstboot-osupdate.target

### DIFF
--- a/templates/common/_base/units/crio.service.yaml
+++ b/templates/common/_base/units/crio.service.yaml
@@ -1,5 +1,10 @@
 name: crio.service
 dropins:
+  - name: 05-mco-ordering.conf
+    contents: |
+      [Unit]
+      After=kubelet-dependencies.target
+      Requires=kubelet-dependencies.target
   - name: 10-mco-default-madv.conf
     contents: |
       [Service]

--- a/templates/common/_base/units/firstboot-osupdate.target
+++ b/templates/common/_base/units/firstboot-osupdate.target
@@ -1,0 +1,11 @@
+name: firstboot-osupdate.target
+enabled: true
+contents: |
+  [Unit]
+  Description=The firstboot OS update has completed
+  Documentation=https://github.com/openshift/machine-config-operator/
+  Requires=basic.target
+
+  [Install]
+  WantedBy=default.target
+

--- a/templates/common/_base/units/kubelet-auto-node-size.service.yaml
+++ b/templates/common/_base/units/kubelet-auto-node-size.service.yaml
@@ -4,8 +4,9 @@ contents: |
   [Unit]
   Description=Dynamically sets the system reserved for the kubelet
   Wants=network-online.target
-  After=network-online.target ignition-firstboot-complete.service
-  Before=kubelet.service crio.service
+  After=network-online.target firstboot-osupdate.target
+  Before=kubelet-dependencies.target
+  
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
@@ -13,4 +14,4 @@ contents: |
   EnvironmentFile=/etc/node-sizing-enabled.env
   ExecStart=/bin/bash /usr/local/sbin/dynamic-system-reserved-calc.sh ${NODE_SIZING_ENABLED} ${SYSTEM_RESERVED_MEMORY} ${SYSTEM_RESERVED_CPU} ${SYSTEM_RESERVED_ES}
   [Install]
-  RequiredBy=kubelet.service
+  RequiredBy=kubelet-dependencies.target

--- a/templates/common/_base/units/kubelet-dependencies.target.yaml
+++ b/templates/common/_base/units/kubelet-dependencies.target.yaml
@@ -1,0 +1,8 @@
+name: kubelet-dependencies.target
+contents: |
+  [Unit]
+  Description=Dependencies necessary to run kubelet
+  Documentation=https://github.com/openshift/machine-config-operator/
+  Requires=basic.target network-online.target
+  Wants=NetworkManager-wait-online.service crio-wipe.service
+  Wants=rpc-statd.service

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -8,7 +8,7 @@ contents: |
   # Removal of this file signals firstboot completion
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
   After=machine-config-daemon-pull.service
-  Before=crio.service kubelet.service
+  Before=kubelet-dependencies.target
 
   [Service]
   Type=oneshot
@@ -21,5 +21,4 @@ contents: |
   {{end -}}
 
   [Install]
-  WantedBy=multi-user.target
-  RequiredBy=crio.service kubelet.service
+  RequiredBy=firstboot-osupdate.target

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -9,8 +9,8 @@ contents: |
   # machine-config-daemon-firstboot.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
   # Run after crio-wipe so the pulled MCD image is protected against a corrupted storage from a forced shutdown
-  Wants=network-online.target crio-wipe.service
-  After=network-online.target crio-wipe.service
+  Wants=crio-wipe.service NetworkManager-wait-online.service
+  After=crio-wipe.service NetworkManager-wait-online.service network.service
 
   [Service]
   Type=oneshot

--- a/templates/common/_base/units/mtu-migration.service.yaml
+++ b/templates/common/_base/units/mtu-migration.service.yaml
@@ -7,7 +7,7 @@ contents: |
   Requires=openvswitch.service ovs-configuration.service
   Wants=NetworkManager-wait-online.service
   After=NetworkManager-wait-online.service openvswitch.service network.service ovs-configuration.service
-  Before=network-online.target kubelet.service crio.service node-valid-hostname.service
+  Before=kubelet-dependencies.target node-valid-hostname.service
 
   [Service]
   # Need oneshot to delay kubelet
@@ -27,6 +27,6 @@ contents: |
   StandardError=journal+console
 
   [Install]
-  WantedBy=network-online.target
+  WantedBy=kubelet-dependencies.target
 
 {{ end }}{{ end }}

--- a/templates/common/_base/units/node-valid-hostname.service.yaml
+++ b/templates/common/_base/units/node-valid-hostname.service.yaml
@@ -3,7 +3,7 @@ enabled: true
 contents: |
   [Unit]
   Description=Wait for a non-localhost hostname
-  Before=network-online.target
+  Before=kubelet-dependencies.target
 
   [Service]
   Type=oneshot
@@ -15,7 +15,6 @@ contents: |
   TimeoutSec=300
 
   [Install]
-  WantedBy=multi-user.target
-  # Ensure that network-online.target will not complete until the node has a non-localhost hostname.
-  RequiredBy=network-online.target
+  # TODO: Change this to RequiredBy after we fix https://github.com/openshift/machine-config-operator/pull/3865#issuecomment-1746963115
+  WantedBy=kubelet-dependencies.target
 

--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -3,9 +3,9 @@ enabled: {{if eq .Infra.Status.PlatformStatus.Type "None"}}true{{else}}false{{en
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
-  Wants=NetworkManager-wait-online.service crio-wipe.service
-  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
-  Before=kubelet.service crio.service ovs-configuration.service
+  Wants=NetworkManager-wait-online.service
+  After=NetworkManager-wait-online.service firstboot-osupdate.target
+  Before=kubelet-dependencies.target ovs-configuration.service
 
   [Service]
   # Need oneshot to delay kubelet
@@ -41,4 +41,4 @@ contents: |
   EnvironmentFile=-/etc/default/nodeip-configuration
 
   [Install]
-  RequiredBy=kubelet.service
+  RequiredBy=kubelet-dependencies.target

--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -3,13 +3,12 @@ enabled: {{if eq .NetworkType "OVNKubernetes" "OpenShiftSDN"}}true{{else}}false{
 contents: |
   [Unit]
   Description=Configures OVS with proper host networking configuration
-  # Removal of this file signals firstboot completion
-  ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service
   Wants=NetworkManager-wait-online.service
+  After=firstboot-osupdate.target
   After=NetworkManager-wait-online.service openvswitch.service network.service nodeip-configuration.service
-  Before=network-online.target kubelet.service crio.service node-valid-hostname.service
+  Before=kubelet-dependencies.target node-valid-hostname.service
 
   [Service]
   # Need oneshot to delay kubelet
@@ -19,4 +18,4 @@ contents: |
   StandardError=journal+console
 
   [Install]
-  WantedBy=network-online.target
+  RequiredBy=kubelet-dependencies.target

--- a/templates/common/alibabacloud/units/alibaba-kubelet-nodename.service.yaml
+++ b/templates/common/alibabacloud/units/alibaba-kubelet-nodename.service.yaml
@@ -5,8 +5,7 @@ contents: |
   Description=Fetch the region and isntance id from Alibaba Metadata
   # Wait for NetworkManager to report it's online
   After=NetworkManager-wait-online.service
-  # Run before kubelet
-  Before=kubelet.service
+  Before=kubelet-dependencies.target
 
   [Service]
   ExecStart=/usr/local/bin/alibaba-kubelet-nodename

--- a/templates/common/aws/units/aws-kubelet-nodename.service.yaml
+++ b/templates/common/aws/units/aws-kubelet-nodename.service.yaml
@@ -14,7 +14,7 @@ contents: |
   # Wait for NetworkManager to report it's online
   After=NetworkManager-wait-online.service
   # Run before kubelet
-  Before=kubelet.service
+  Before=kubelet-dependencies.target
 
   [Service]
   # Mark afterburn environment file optional, due to it is possible that afterburn service was not executed

--- a/templates/common/aws/units/aws-kubelet-providerid.service.yaml
+++ b/templates/common/aws/units/aws-kubelet-providerid.service.yaml
@@ -14,7 +14,7 @@ contents: |
   # Wait for NetworkManager to report it's online
   After=NetworkManager-wait-online.service
   # Run before kubelet
-  Before=kubelet.service
+  Before=kubelet-dependencies.target
 
   [Service]
   # Mark afterburn environment file optional, due to it is possible that afterburn service was not executed

--- a/templates/common/azure/units/ovs-configuration.service.yaml
+++ b/templates/common/azure/units/ovs-configuration.service.yaml
@@ -1,0 +1,21 @@
+name: ovs-configuration.service
+enabled: {{if eq .NetworkType "OVNKubernetes" "OpenShiftSDN"}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Configures OVS with proper host networking configuration
+  # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
+  Requires=openvswitch.service
+  Wants=NetworkManager-wait-online.service
+  After=firstboot-osupdate.target
+  After=NetworkManager-wait-online.service openvswitch.service network.service nodeip-configuration.service
+  Before=kubelet-dependencies.target node-valid-hostname.service dnsmasq.service
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  ExecStart=/usr/local/bin/configure-ovs.sh {{.NetworkType}}
+  StandardOutput=journal+console
+  StandardError=journal+console
+
+  [Install]
+  RequiredBy=kubelet-dependencies.target

--- a/templates/common/gcp/units/gcp-hostname.service.yaml
+++ b/templates/common/gcp/units/gcp-hostname.service.yaml
@@ -3,10 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Set GCP Transient Hostname
-  # Removal of this file signals firstboot completion
-  ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
-  # Block services relying on networking being up.
-  Before=network-online.target
+  # We don't need to do this on the firstboot
+  After=firstboot-osupdate.target
   # Wait for NetworkManager to report it's online
   After=NetworkManager-wait-online.service
   # Run before hostname checks
@@ -18,5 +16,4 @@ contents: |
   ExecStart=/usr/local/bin/mco-hostname --gcp
 
   [Install]
-  WantedBy=multi-user.target
-  WantedBy=network-online.target
+  RequiredBy=kubelet-dependencies.target

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -6,9 +6,9 @@ contents: |
   # This only applies to VIP managing environments where the kubelet and crio IP
   # address picking logic is flawed and may end up selecting an address from a
   # different subnet or a deprecated address
-  Wants=NetworkManager-wait-online.service crio-wipe.service
-  After=NetworkManager-wait-online.service ignition-firstboot-complete.service crio-wipe.service
-  Before=kubelet.service crio.service ovs-configuration.service
+  Wants=NetworkManager-wait-online.service
+  After=NetworkManager-wait-online.service firstboot-osupdate.target
+  Before=kubelet-dependencies.target ovs-configuration.service
 
   [Service]
   # Need oneshot to delay kubelet
@@ -38,4 +38,4 @@ contents: |
   {{end -}}
 
   [Install]
-  WantedBy=multi-user.target
+  RequiredBy=kubelet-dependencies.target

--- a/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
+++ b/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
@@ -6,7 +6,7 @@ contents: |
   # Wait for NetworkManager to report it's online
   After=NetworkManager-wait-online.service
   # Run before kubelet
-  Before=kubelet.service
+  Before=kubelet-dependencies.target
 
   [Service]
   ExecStart=/usr/local/bin/openstack-kubelet-nodename

--- a/templates/common/vsphere/units/vsphere-hostname.service.yaml
+++ b/templates/common/vsphere/units/vsphere-hostname.service.yaml
@@ -8,7 +8,7 @@ contents: |
 
   ConditionVirtualization=vmware
   
-  Before=kubelet.service
+  Before=kubelet-dependencies.target
   Before=node-valid-hostname.service
   Before=NetworkManager.service
 

--- a/templates/master/00-master/alibabacloud/units/openshift-alibabacloud-routes.path.yaml
+++ b/templates/master/00-master/alibabacloud/units/openshift-alibabacloud-routes.path.yaml
@@ -3,8 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Watch for downfile changes
-  Before=kubelet.service
-  ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
+  Before=kubelet-dependencies.service
+  After=firstboot-osupdate.target
 
   [Path]
   PathExistsGlob=/run/cloud-routes/*
@@ -12,4 +12,4 @@ contents: |
   MakeDirectory=true
 
   [Install]
-  RequiredBy=kubelet.service
+  RequiredBy=kubelet-dependencies.service

--- a/templates/master/00-master/azure/units/openshift-azure-routes.path.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes.path.yaml
@@ -3,8 +3,7 @@ enabled: true
 contents: |
   [Unit]
   Description=Watch for downfile changes
-  Before=kubelet.service
-  ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
+  Before=kubelet-dependencies.target
 
   [Path]
   PathExistsGlob=/run/cloud-routes/*
@@ -12,4 +11,4 @@ contents: |
   MakeDirectory=true
 
   [Install]
-  RequiredBy=kubelet.service
+  RequiredBy=kubelet-dependencies.target

--- a/templates/master/00-master/azure/units/openshift-azure-routes.service.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes.service.yaml
@@ -3,7 +3,9 @@ enabled: false
 contents: |
   [Unit]
   Description=Work around Azure load balancer hairpin
-
+  # We don't need to do this on the firstboot
+  After=firstboot-osupdate.target
+  
   [Service]
   Type=simple
   ExecStart=/bin/bash /opt/libexec/openshift-azure-routes.sh start

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service network-online.target
-  Requires=crio.service kubelet-auto-node-size.service
-  After=network-online.target crio.service kubelet-auto-node-size.service
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
   After=ostree-finalize-staged.service
 
   [Service]

--- a/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service network-online.target
-  Requires=crio.service kubelet-auto-node-size.service
-  After=network-online.target crio.service kubelet-auto-node-size.service
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
   After=ostree-finalize-staged.service
 
   [Service]

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service network-online.target
-  Requires=crio.service kubelet-auto-node-size.service
-  After=network-online.target crio.service kubelet-auto-node-size.service
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
   After=ostree-finalize-staged.service
 
   [Service]

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service network-online.target
-  Requires=crio.service kubelet-auto-node-size.service
-  After=network-online.target crio.service kubelet-auto-node-size.service
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
   After=ostree-finalize-staged.service
 
   [Service]

--- a/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/alibabacloud/units/kubelet.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service network-online.target
-  Requires=crio.service kubelet-auto-node-size.service
-  After=network-online.target crio.service kubelet-auto-node-size.service
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
   After=ostree-finalize-staged.service
 
   [Service]

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Kubernetes Kubelet
-  Wants=rpc-statd.service network-online.target
-  Requires=crio.service kubelet-auto-node-size.service
-  After=network-online.target crio.service kubelet-auto-node-size.service
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
   After=ostree-finalize-staged.service
 
   [Service]


### PR DESCRIPTION
Manual backport of https://github.com/openshift/machine-config-operator/pull/4043 and https://github.com/openshift/machine-config-operator/pull/4115 (needed to avoid [regression](https://issues.redhat.com/browse/OCPBUGS-26240) on Azure).