### PR TITLE
OCPBUGS-29459: if a malformed cert, make sure to set cert = next

### DIFF
--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -487,12 +487,12 @@ func createNewCert(cert []byte, name string) []mcfgv1.ControllerCertificate {
 			klog.Infof("Unable to decode cert %s into a pem block. Cert is either empty or invalid.", string(cert))
 			break
 		}
+		cert = next
 		c, err := x509.ParseCertificate(b.Bytes)
 		if err != nil {
 			klog.Infof("Malformed Cert, not syncing")
 			continue
 		}
-		cert = next
 		certs = append(certs, mcfgv1.ControllerCertificate{
 			Subject:    c.Subject.String(),
 			Signer:     c.Issuer.String(),


### PR DESCRIPTION
currently cert = next is set after the continue block. 

This causes an infinite loop. Move this `cert = next` to above this check.
