### PR TITLE
MCO-817: API Migration Cleanup: Populate kubelet.yaml template feature gates from featureGateAccessor

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -27,21 +27,6 @@ contents:
     systemCgroups: /system.slice
     nodeStatusUpdateFrequency: 10s
     nodeStatusReportFrequency: 5m
-    featureGates:
-      AlibabaPlatform: true
-      AzureWorkloadIdentity: true
-      BuildCSIVolumes: true
-      CloudDualStackNodeIPs: true
-      DisableKubeletCloudCredentialProviders: false
-      ExternalCloudProvider: true
-      ExternalCloudProviderAzure: true
-      ExternalCloudProviderGCP: true
-      ExternalCloudProviderExternal: true
-      KMSv1: true
-      NetworkLiveMigration: true
-      OpenShiftPodSecurityAdmission: true
-      PrivateHostedZoneAWS: true
-      VSphereControlPlaneMachineSet: true
     serverTLSBootstrap: true
     tlsMinVersion: VersionTLS12
     tlsCipherSuites:

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -27,21 +27,6 @@ contents:
     systemCgroups: /system.slice
     nodeStatusUpdateFrequency: 10s
     nodeStatusReportFrequency: 5m
-    featureGates:
-      AlibabaPlatform: true
-      AzureWorkloadIdentity: true
-      BuildCSIVolumes: true
-      CloudDualStackNodeIPs: true
-      DisableKubeletCloudCredentialProviders: false
-      ExternalCloudProvider: true
-      ExternalCloudProviderAzure: true
-      ExternalCloudProviderGCP: true
-      ExternalCloudProviderExternal: true
-      KMSv1: true
-      NetworkLiveMigration: true
-      OpenShiftPodSecurityAdmission: true
-      PrivateHostedZoneAWS: true
-      VSphereControlPlaneMachineSet: true
     serverTLSBootstrap: true
     tlsMinVersion: VersionTLS12
     tlsCipherSuites:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
removed the hardcoded values from the kubelet template. Cross verified by looking on the node to see if the featuregates matched.

**- How to verify it**
oc get featuregate cluster -o yaml

and 

❯ oc debug node/ip-10-0-46-151.ec2.internal
sh-4.4# chroot /host
sh-5.1# cat etc/kubernetes/kubelet.conf 

verify the feature gates are correctly enabled/disabled on the cluster

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
