### PR TITLE
OCPBUGS-31365: make verify should use MCO's kube version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ ifdef SETUP_ENVTEST
 	@echo "Found setup-envtest"
 else
 	@echo "Installing setup-envtest"
-	go install -mod= sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	go install -mod= sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240315194348-5aaf1190f880
 endif
 
 GO_JUNIT_REPORT := $(shell command -v go-junit-report 2> /dev/null)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Hardcoded setup-envtools to a version right before [the go bump](https://github.com/kubernetes-sigs/controller-runtime/pull/2693) to 1.22. As a result, this will have to manually updated along with a kube bump to keep up as we will no longer be using the @latest tag

**- How to verify it**
`make verify` should pass

