### PR TITLE
MCO-694: revert from layered pool to non-layered pool

### DIFF
--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+
 	daemon "github.com/openshift/machine-config-operator/pkg/daemon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -21,11 +23,14 @@ var firstbootCompleteMachineconfig = &cobra.Command{
 
 var persistNics bool
 
+var machineConfigFile string
+
 // init executes upon import
 func init() {
 	rootCmd.AddCommand(firstbootCompleteMachineconfig)
 	firstbootCompleteMachineconfig.PersistentFlags().StringVar(&startOpts.rootMount, "root-mount", "/rootfs", "where the nodes root filesystem is mounted for chroot and file manipulation.")
 	firstbootCompleteMachineconfig.PersistentFlags().BoolVar(&persistNics, "persist-nics", false, "Run nmstatectl persist-nic-names")
+	firstbootCompleteMachineconfig.PersistentFlags().StringVar(&machineConfigFile, "machineconfig-file", daemonconsts.MachineConfigEncapsulatedPath, "The MachineConfig file on-disk to use as the source of truth.")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 
@@ -55,7 +60,7 @@ func runFirstBootCompleteMachineConfig(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return dn.RunFirstbootCompleteMachineconfig()
+	return dn.RunFirstbootCompleteMachineconfig(machineConfigFile)
 }
 
 func executeFirstbootCompleteMachineConfig(cmd *cobra.Command, args []string) {

--- a/pkg/daemon/runtimeassets/README.md
+++ b/pkg/daemon/runtimeassets/README.md
@@ -1,0 +1,25 @@
+# runtimeassets
+
+The intent behind this package is to provide a place for assets that the MCD
+must render at runtime. Generally speaking, these are used to work around edge
+cases where it may not be desirable to have a config file or systemd unit
+rendered as part of the normal MachineConfig flow.
+
+These could be static files or they could be runtime-rendered templates based
+upon the status of the MCD and/or objects the MCD can access, such as
+ControllerConfig.
+
+The RuntimeAsset interface specifies that any additional types or files added
+to this package should be rendered as Ignition. This will allow the MCD to
+write the files to the nodes' filesystem using the standard Ignition file
+writing paths that currently exist.
+
+In the future, items in this package could be expanded and used in the
+certificate-writer path as well as other similar paths.
+
+## RevertService
+
+This is used for reverting from a layeed MachineConfigPool to a non-layered
+MachineConfigPool. This is because the systemd unit that performs this function
+should not be part of the default MachineConfig. Instead, it should be rendered
+and applied on an as-needed basis.

--- a/pkg/daemon/runtimeassets/machine-config-daemon-revert.service.yaml
+++ b/pkg/daemon/runtimeassets/machine-config-daemon-revert.service.yaml
@@ -1,0 +1,29 @@
+# This systemd unit is intended to help revert from a layered state to a
+# non-layered state. It is heavily based upon the
+# machine-config-daemon-firstboot.service.yaml found in:
+# templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+name: {{ .ServiceName }}
+enabled: true
+contents: |
+  [Unit]
+  Description=Machine Config Daemon Revert
+  # Make sure it runs only on OSTree booted system
+  ConditionPathExists=/run/ostree-booted
+  # Removal of this file signals firstboot completion
+  ConditionPathExists={{ .RevertServiceMachineConfigFile }}
+  After=network.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
+  ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
+  # Run this via podman because we want to use the nmstatectl binary in our container
+  ExecStart=/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .MCOImage }}' firstboot-complete-machineconfig --persist-nics --machineconfig-file {{ .RevertServiceMachineConfigFile }}
+  ExecStart=/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .MCOImage }}' firstboot-complete-machineconfig --machineconfig-file {{ .RevertServiceMachineConfigFile }}
+  {{if .Proxy -}}
+  EnvironmentFile=/etc/mco/proxy.env
+  {{end -}}
+
+  [Install]
+  RequiredBy=multi-user.target

--- a/pkg/daemon/runtimeassets/revertservice.go
+++ b/pkg/daemon/runtimeassets/revertservice.go
@@ -1,0 +1,112 @@
+package runtimeassets
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"html/template"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"sigs.k8s.io/yaml"
+)
+
+var _ RuntimeAsset = &revertService{}
+
+const (
+	RevertServiceName              string = "machine-config-daemon-revert.service"
+	RevertServiceMachineConfigFile string = "/etc/mco/machineconfig-revert.json"
+)
+
+//go:embed machine-config-daemon-revert.service.yaml
+var mcdRevertServiceIgnYAML string
+
+type revertService struct {
+	// The MCO image pullspec that should be used.
+	MCOImage string
+	// Whether the proxy file exists and should be considered.
+	Proxy bool
+}
+
+// Constructs a revertService instance from a ControllerConfig. Returns an
+// error if the provided ControllerConfig cannot be used.
+func NewRevertService(ctrlcfg *mcfgv1.ControllerConfig) (RuntimeAsset, error) {
+	mcoImage, ok := ctrlcfg.Spec.Images["machineConfigOperator"]
+	if !ok {
+		return nil, fmt.Errorf("controllerconfig Images does not have machineConfigOperator image")
+	}
+
+	if mcoImage == "" {
+		return nil, fmt.Errorf("controllerconfig Images has machineConfigOperator but it is empty")
+	}
+
+	hasProxy := false
+	if ctrlcfg.Spec.Proxy != nil {
+		hasProxy = true
+	}
+
+	return &revertService{
+		MCOImage: mcoImage,
+		Proxy:    hasProxy,
+	}, nil
+}
+
+// Returns an Ignition config containing the
+// machine-config-daemon-revert.service systemd unit.
+func (r *revertService) Ignition() (*ign3types.Config, error) {
+	rendered, err := r.render()
+	if err != nil {
+		return nil, err
+	}
+
+	out := &ign3types.Unit{}
+
+	if err := yaml.Unmarshal(rendered, out); err != nil {
+		return nil, err
+	}
+
+	ignConfig := ctrlcommon.NewIgnConfig()
+	ignConfig.Systemd = ign3types.Systemd{
+		Units: []ign3types.Unit{
+			*out,
+		},
+	}
+
+	return &ignConfig, nil
+}
+
+// Renders the embedded template with the provided values.
+func (r *revertService) render() ([]byte, error) {
+	if r.MCOImage == "" {
+		return nil, fmt.Errorf("MCOImage field must be provided")
+	}
+
+	tmpl := template.New(RevertServiceName)
+
+	tmpl, err := tmpl.Parse(mcdRevertServiceIgnYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	// Golang templates must be rendered using exported fields. However, we want
+	// to manage the exported field for this service, so we create an anonymous
+	// struct which embeds RevertService and the ServiceName before we render
+	// the template.
+	data := struct {
+		ServiceName                    string
+		RevertServiceMachineConfigFile string
+		revertService
+	}{
+		ServiceName:                    RevertServiceName,
+		RevertServiceMachineConfigFile: RevertServiceMachineConfigFile,
+		revertService:                  *r,
+	}
+
+	buf := bytes.NewBuffer([]byte{})
+	if err := tmpl.Execute(buf, data); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/daemon/runtimeassets/revertservice_test.go
+++ b/pkg/daemon/runtimeassets/revertservice_test.go
@@ -1,0 +1,96 @@
+package runtimeassets
+
+import (
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRevertService(t *testing.T) {
+	mcoImagePullspec := "mco.image.pullspec"
+
+	proxyContents := "EnvironmentFile=/etc/mco/proxy.env"
+
+	alwaysExpectedContents := []string{
+		fmt.Sprintf("ConditionPathExists=%s", RevertServiceMachineConfigFile),
+		fmt.Sprintf("podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '%s' firstboot-complete-machineconfig --persist-nics --machineconfig-file %s", mcoImagePullspec, RevertServiceMachineConfigFile),
+		fmt.Sprintf("podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '%s' firstboot-complete-machineconfig --machineconfig-file %s", mcoImagePullspec, RevertServiceMachineConfigFile),
+	}
+
+	testCases := []struct {
+		name               string
+		ctrlcfg            *mcfgv1.ControllerConfig
+		expectedContents   []string
+		unexpectedContents []string
+		errExpected        bool
+	}{
+		{
+			name: "no proxy",
+			ctrlcfg: &mcfgv1.ControllerConfig{
+				Spec: mcfgv1.ControllerConfigSpec{
+					Images: map[string]string{
+						"machineConfigOperator": mcoImagePullspec,
+					},
+				},
+			},
+			expectedContents: alwaysExpectedContents,
+			unexpectedContents: []string{
+				proxyContents,
+			},
+		},
+		{
+			name: "with proxy",
+			ctrlcfg: &mcfgv1.ControllerConfig{
+				Spec: mcfgv1.ControllerConfigSpec{
+					Proxy: &configv1.ProxyStatus{},
+					Images: map[string]string{
+						"machineConfigOperator": mcoImagePullspec,
+					},
+				},
+			},
+			expectedContents: append(alwaysExpectedContents, proxyContents),
+		},
+		{
+			name:        "no mco image found",
+			ctrlcfg:     &mcfgv1.ControllerConfig{},
+			errExpected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			rs, err := NewRevertService(testCase.ctrlcfg)
+			if testCase.errExpected {
+				assert.Error(t, err)
+				assert.Nil(t, rs)
+				return
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, rs)
+			}
+
+			ign, err := rs.Ignition()
+			assert.NoError(t, err)
+			assert.NotNil(t, ign)
+
+			unit := ign.Systemd.Units[0]
+
+			for _, item := range testCase.expectedContents {
+				assert.Contains(t, *unit.Contents, item)
+			}
+
+			for _, item := range testCase.unexpectedContents {
+				assert.NotContains(t, *unit.Contents, item)
+			}
+
+			assert.Equal(t, unit.Name, RevertServiceName)
+			assert.True(t, *unit.Enabled)
+		})
+	}
+}

--- a/pkg/daemon/runtimeassets/runtimeassets.go
+++ b/pkg/daemon/runtimeassets/runtimeassets.go
@@ -1,0 +1,9 @@
+package runtimeassets
+
+import (
+	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
+)
+
+type RuntimeAsset interface {
+	Ignition() (*ign3types.Config, error)
+}

--- a/test/e2e-techpreview/onclusterlayering_test.go
+++ b/test/e2e-techpreview/onclusterlayering_test.go
@@ -15,6 +15,7 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
 
+	"github.com/openshift/machine-config-operator/pkg/daemon/runtimeassets"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
@@ -119,14 +120,31 @@ func TestOnClusterBuildRollsOutImage(t *testing.T) {
 	cs := framework.NewClientSet("")
 	node := helpers.GetRandomNode(t, cs, "worker")
 
-	t.Cleanup(makeIdempotentAndRegister(t, func() {
-		helpers.DeleteNodeAndMachine(t, cs, node)
-	}))
-
-	helpers.LabelNode(t, cs, node, helpers.MCPNameToRole(layeredMCPName))
+	unlabelFunc := makeIdempotentAndRegister(t, helpers.LabelNode(t, cs, node, helpers.MCPNameToRole(layeredMCPName)))
 	helpers.WaitForNodeImageChange(t, cs, node, imagePullspec)
 
+	helpers.AssertNodeBootedIntoImage(t, cs, node, imagePullspec)
+	t.Logf("Node %s is booted into image %q", node.Name, imagePullspec)
+
 	t.Log(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "cowsay", "Moo!"))
+
+	unlabelFunc()
+
+	assertNodeRevertsToNonLayered(t, cs, node)
+}
+
+func assertNodeRevertsToNonLayered(t *testing.T, cs *framework.ClientSet, node corev1.Node) {
+	workerMCName := helpers.GetMcName(t, cs, "worker")
+	workerMC, err := cs.MachineConfigs().Get(context.TODO(), workerMCName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	helpers.WaitForNodeConfigAndImageChange(t, cs, node, workerMCName, "")
+
+	helpers.AssertNodeBootedIntoImage(t, cs, node, workerMC.Spec.OSImageURL)
+	t.Logf("Node %s has reverted to OS image %q", node.Name, workerMC.Spec.OSImageURL)
+
+	helpers.AssertFileNotOnNode(t, cs, node, filepath.Join("/etc/systemd/system", runtimeassets.RevertServiceName))
+	helpers.AssertFileNotOnNode(t, cs, node, runtimeassets.RevertServiceMachineConfigFile)
 }
 
 // This test extracts the /etc/yum.repos.d and /etc/pki/rpm-gpg content from a

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	rpmostreeclient "github.com/coreos/rpmostree-client-go/pkg/client"
 	opv1 "github.com/openshift/api/operator/v1"
 	mcoac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 )
@@ -829,6 +831,72 @@ func ExecCmdOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, subA
 	}
 	require.Nil(t, err, "failed to exec cmd %v on node %s: %s", subArgs, node.Name, string(out))
 	return string(out)
+}
+
+// Gets the rpm-ostree status for a given node.
+func GetRPMOStreeStatusForNode(t *testing.T, cs *framework.ClientSet, node corev1.Node) *rpmostreeclient.Status {
+	status, err := getRPMOStreeStatusForNode(cs, node)
+	require.NoError(t, err)
+
+	return status
+}
+
+// Internal-only version of GetRPMOStreeStatusForNode()
+func getRPMOStreeStatusForNode(cs *framework.ClientSet, node corev1.Node) (*rpmostreeclient.Status, error) {
+	cmd, err := execCmdOnNode(cs, node, "chroot", "/rootfs", "rpm-ostree", "status", "--json")
+	if err != nil {
+		return nil, fmt.Errorf("could not construct command: %w", err)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("could not execute command %s on node %s: %w", cmd.String(), node.Name, err)
+	}
+
+	status := &rpmostreeclient.Status{}
+
+	if err := json.Unmarshal(output, status); err != nil {
+		return nil, fmt.Errorf("could not parse rpm-ostree status for node %s: %w", node.Name, err)
+	}
+
+	return status, nil
+}
+
+// Gets the currently booted rpmostree deployment for a given node.
+func getBootedRPMOstreeDeployment(cs *framework.ClientSet, node corev1.Node) (*rpmostreeclient.Deployment, error) {
+	status, err := getRPMOStreeStatusForNode(cs, node)
+	if err != nil {
+		return nil, fmt.Errorf("could not get rpm-ostree status for node %s: %w", node.Name, err)
+	}
+
+	for _, deployment := range status.Deployments {
+		deployment := deployment
+		if deployment.Booted {
+			return &deployment, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no booted deployments found on node %s", node.Name)
+}
+
+// Asserts that a given node is booted into a specific image. This works by
+// examining the rpm-ostree status and determining if the currently booted
+// deployment is the expected image.
+func AssertNodeBootedIntoImage(t *testing.T, cs *framework.ClientSet, node corev1.Node, expectedImagePullspec string) bool {
+	deployment, err := getBootedRPMOstreeDeployment(cs, node)
+	require.NoError(t, err)
+
+	return assert.Contains(t, deployment.ContainerImageReference, expectedImagePullspec, "expected node %q to be booted into image %q, got %q", node.Name, expectedImagePullspec, deployment.ContainerImageReference)
+}
+
+// Asserts that a given node is not booted into a specific image. This works by
+// examining the rpm-ostree status and determining if the currently booted
+// deployment is the expected image.
+func AssertNodeNotBootedIntoImage(t *testing.T, cs *framework.ClientSet, node corev1.Node, unexpectedImagePullspec string) bool {
+	deployment, err := getBootedRPMOstreeDeployment(cs, node)
+	require.NoError(t, err)
+
+	return assert.NotContains(t, deployment.ContainerImageReference, unexpectedImagePullspec, "expected node %q not to be booted into %q", node.Name, unexpectedImagePullspec)
 }
 
 // ExecCmdOnNodeWithError behaves like ExecCmdOnNode, with the exception that


### PR DESCRIPTION
**- What I did**

This adds code that reverts from a layered MachineConfigPool to a non-layered MachineConfigPool.

Why this was so troublesome is:
- When a MachineConfig is written to the node, it is placed in the portions of the filesystem that are mutable according to ostree.
- When a container image containing those MachineConfigs is written onto the node using rpm-ostree, it technically overwrites those preexisting MachineConfigs. In doing so, the container is now claiming (for lack of a better term) ownership of those files.
- The "factory" OS image does not contain these MachineConfigs.
- So when we roll back from the customized image to the "factory" image, because the MachineConfig files on disk are now owned by the customized container, they are removed when the factory OS image is rebased.

If an ad-hoc file is written to a mutable part of the filesystem after the container has been applied, provided that the container does not claim ownership of a file with the same name, the ad-hoc file will persist after a reboot. To take full advantage of this fact, this PR does the following:

1. Introduces a new subpackage called `pkg/daemon/runtimeassets`. The purpose of this package is to house any configs or templates that need to be applied to a node during runtime but should not be part of the clusters MachineConfig. There is the potential for this to be used by the certificate writer path in the future.
2. Introduces a `machine-config-daemon-revert.service` systemd service which is only rendered, written to the node , and enabled whenever a revert operation is being done.
3. After the file is written to the nodes' filesystem, the node reboots.
4. During the bootup, the new service detects the presence of `/etc/mco/machineconfig-revert.json` and runs the MCD in bootstrap mode to rewrite all of the configs to disk. This (unfortunately) requires a second node reboot.
5. Following the second node reboot, the node should be in the reverted configuration.

**- How to verify it**

1. Bring up an OpenShift cluster for this PR.
2. Opt into on-cluster builds. My [onclustertesting](https://github.com/cheesesashimi/zacks-openshift-helpers/tree/main/cmd/onclustertesting) helper can be used to assist with that; just run `$ onclustertesting setup --enable-feature-gate --pool=layered in-cluster-registry`.
3. Wait for the image to finish building.
5. Add a node to the layered MachineConfigPool: `$ oc label node/<nodename> 'node-role.kubernetes.io/layered='`
6. Wait for the node to deploy the built image.
7. Remove the label from the layered MachineConfigPool: `$ oc label node/<nodename> 'node-role.kubernetes.io/layered-'`
8. Wait for the node to revert back to the worker MachineConfigPool.

**- Description for the changelog**
Allows reverting from layered MachineConfigPool to non-layered MachineConfigPool
