### PR TITLE
MCO-1102: OCPBUGS-32277: Add a ValidatingAdmissionPolicy for the boot images update opt-in API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/openshift/api v0.0.0-20240410141538-3c0461467316
 	github.com/openshift/client-go v0.0.0-20240408153607-64bd6feb83ae
 	github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20231213185242-e4dc676febfe
-	github.com/openshift/library-go v0.0.0-20240312152318-4109a9e7a437
+	github.com/openshift/library-go v0.0.0-20240412173449-eb2f24c36528
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -697,8 +697,8 @@ github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20231213185242-e4d
 github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20231213185242-e4dc676febfe/go.mod h1:SGUtv1pKZSzSVr2YCxXFvhE+LbGfI+vcetEhNicKayw=
 github.com/openshift/kube-openapi v0.0.0-20230816122517-ffc8f001abb0 h1:GPlAy197Jkr+D0T2FNWanamraTdzS/r9ZkT29lxvHaA=
 github.com/openshift/kube-openapi v0.0.0-20230816122517-ffc8f001abb0/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
-github.com/openshift/library-go v0.0.0-20240312152318-4109a9e7a437 h1:xMflL80gT2cXxnmDkR8QLZCbfh/x38jV5XOfLiNlsLE=
-github.com/openshift/library-go v0.0.0-20240312152318-4109a9e7a437/go.mod h1:ePlaOqUiPplRc++6aYdMe+2FmXb2xTNS9Nz5laG2YmI=
+github.com/openshift/library-go v0.0.0-20240412173449-eb2f24c36528 h1:vnLKZUSW1aPv7Pd6+QYjDUU+/8z2MSBacU38cAlNMPA=
+github.com/openshift/library-go v0.0.0-20240412173449-eb2f24c36528/go.mod h1:m/HsttSi90vSixwoy5mPUBHcZid2YRw/QbsLErLxF9s=
 github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b h1:oXzC1N6E9gw76/WH2gEA8GEHvuq09wuVQ9GoCuR8GF4=
 github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/hack/crds-sync.sh
+++ b/hack/crds-sync.sh
@@ -7,14 +7,5 @@ cp vendor/github.com/openshift/api/machineconfiguration/v1/zz_generated.crd-mani
 cp vendor/github.com/openshift/api/machineconfiguration/v1alpha1/zz_generated.crd-manifests/*.crd.yaml install/.
 
 #  These are MCO CRDs that live in other parts of the openshift/api, so the copies need to be more specific
-CRDS_MAPPING=( 
-   "operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-Default.crd.yaml:0000_80_machine-config_01_machineconfigurations-Default.crd.yaml"
-   "operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml:0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml"
-   "config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml:0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml"
-)
-
-for crd in "${CRDS_MAPPING[@]}" ; do
-    SRC="${crd%%:*}"
-    DES="${crd##*:}"
-    cp "vendor/github.com/openshift/api/$SRC" "install/$DES"
-done
+cp vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-*.crd.yaml install/.
+cp vendor/github.com/openshift/api/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-*.crd.yaml install/.

--- a/install/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
+++ b/install/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,398 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: clusterimagepolicies.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ClusterImagePolicy
+    listKind: ClusterImagePolicyList
+    plural: clusterimagepolicies
+    singular: clusterimagepolicy
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterImagePolicy holds cluster-wide configuration for image
+          signature verification \n Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the configuration for the cluster image policy.
+            properties:
+              policy:
+                description: policy contains configuration to allow scopes to be verified,
+                  and defines how images not matching the verification policy will
+                  be treated.
+                properties:
+                  rootOfTrust:
+                    description: rootOfTrust specifies the root of trust for the policy.
+                    properties:
+                      fulcioCAWithRekor:
+                        description: 'fulcioCAWithRekor defines the root of trust
+                          based on the Fulcio certificate and the Rekor public key.
+                          For more information about Fulcio and Rekor, please refer
+                          to the document at: https://github.com/sigstore/fulcio and
+                          https://github.com/sigstore/rekor'
+                        properties:
+                          fulcioCAData:
+                            description: fulcioCAData contains inline base64-encoded
+                              data for the PEM format fulcio CA. fulcioCAData must
+                              be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          fulcioSubject:
+                            description: fulcioSubject specifies OIDC issuer and the
+                              email of the Fulcio authentication configuration.
+                            properties:
+                              oidcIssuer:
+                                description: 'oidcIssuer contains the expected OIDC
+                                  issuer. It will be verified that the Fulcio-issued
+                                  certificate contains a (Fulcio-defined) certificate
+                                  extension pointing at this OIDC issuer URL. When
+                                  Fulcio issues certificates, it includes a value
+                                  based on an URL inside the client-provided ID token.
+                                  Example: "https://expected.OIDC.issuer/"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: oidcIssuer must be a valid URL
+                                  rule: isURL(self)
+                              signedEmail:
+                                description: 'signedEmail holds the email address
+                                  the the Fulcio certificate is issued for. Example:
+                                  "expected-signing-user@example.com"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: invalid email address
+                                  rule: self.matches('^\\S+@\\S+$')
+                            required:
+                            - oidcIssuer
+                            - signedEmail
+                            type: object
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - fulcioCAData
+                        - fulcioSubject
+                        - rekorKeyData
+                        type: object
+                      policyType:
+                        description: policyType serves as the union's discriminator.
+                          Users are required to assign a value to this field, choosing
+                          one of the policy types that define the root of trust. "PublicKey"
+                          indicates that the policy relies on a sigstore publicKey
+                          and may optionally use a Rekor verification. "FulcioCAWithRekor"
+                          indicates that the policy is based on the Fulcio certification
+                          and incorporates a Rekor verification.
+                        enum:
+                        - PublicKey
+                        - FulcioCAWithRekor
+                        type: string
+                      publicKey:
+                        description: publicKey defines the root of trust based on
+                          a sigstore public key.
+                        properties:
+                          keyData:
+                            description: keyData contains inline base64-encoded data
+                              for the PEM format public key. KeyData must be at most
+                              8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - keyData
+                        type: object
+                    required:
+                    - policyType
+                    type: object
+                    x-kubernetes-validations:
+                    - message: publicKey is required when policyType is PublicKey,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''PublicKey''
+                        ? has(self.publicKey) : !has(self.publicKey)'
+                    - message: fulcioCAWithRekor is required when policyType is FulcioCAWithRekor,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
+                        ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
+                  signedIdentity:
+                    description: signedIdentity specifies what image identity the
+                      signature claims about the image. The required matchPolicy field
+                      specifies the approach used in the verification process to verify
+                      the identity in the signature and the actual image identity,
+                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    properties:
+                      exactRepository:
+                        description: exactRepository is required if matchPolicy is
+                          set to "ExactRepository".
+                        properties:
+                          repository:
+                            description: repository is the reference of the image
+                              identity to be matched. The value should be a repository
+                              name (by omitting the tag or digest) in a registry implementing
+                              the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - repository
+                        type: object
+                      matchPolicy:
+                        description: matchPolicy sets the type of matching to be used.
+                          Valid values are "MatchRepoDigestOrExact", "MatchRepository",
+                          "ExactRepository", "RemapIdentity". When omitted, the default
+                          value is "MatchRepoDigestOrExact". If set matchPolicy to
+                          ExactRepository, then the exactRepository must be specified.
+                          If set matchPolicy to RemapIdentity, then the remapIdentity
+                          must be specified. "MatchRepoDigestOrExact" means that the
+                          identity in the signature must be in the same repository
+                          as the image identity if the image identity is referenced
+                          by a digest. Otherwise, the identity in the signature must
+                          be the same as the image identity. "MatchRepository" means
+                          that the identity in the signature must be in the same repository
+                          as the image identity. "ExactRepository" means that the
+                          identity in the signature must be in the same repository
+                          as a specific identity specified by "repository". "RemapIdentity"
+                          means that the signature must be in the same as the remapped
+                          image identity. Remapped image identity is obtained by replacing
+                          the "prefix" with the specified “signedPrefix” if the the
+                          image identity matches the specified remapPrefix.
+                        enum:
+                        - MatchRepoDigestOrExact
+                        - MatchRepository
+                        - ExactRepository
+                        - RemapIdentity
+                        type: string
+                      remapIdentity:
+                        description: remapIdentity is required if matchPolicy is set
+                          to "RemapIdentity".
+                        properties:
+                          prefix:
+                            description: prefix is the prefix of the image identity
+                              to be matched. If the image identity matches the specified
+                              prefix, that prefix is replaced by the specified “signedPrefix”
+                              (otherwise it is used as unchanged and no remapping
+                              takes place). This useful when verifying signatures
+                              for a mirror of some other repository namespace that
+                              preserves the vendor’s repository structure. The prefix
+                              and signedPrefix values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                          signedPrefix:
+                            description: signedPrefix is the prefix of the image identity
+                              to be matched in the signature. The format is the same
+                              as "prefix". The values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - prefix
+                        - signedPrefix
+                        type: object
+                    required:
+                    - matchPolicy
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactRepository is required when matchPolicy is ExactRepository,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''ExactRepository'')
+                        ? has(self.exactRepository) : !has(self.exactRepository)'
+                    - message: remapIdentity is required when matchPolicy is RemapIdentity,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''RemapIdentity'')
+                        ? has(self.remapIdentity) : !has(self.remapIdentity)'
+                required:
+                - rootOfTrust
+                type: object
+              scopes:
+                description: 'scopes defines the list of image identities assigned
+                  to a policy. Each item refers to a scope in a registry implementing
+                  the "Docker Registry HTTP API V2". Scopes matching individual images
+                  are named Docker references in the fully expanded form, either using
+                  a tag or digest. For example, docker.io/library/busybox:latest (not
+                  busybox:latest). More general scopes are prefixes of individual-image
+                  scopes, and specify a repository (by omitting the tag or digest),
+                  a repository namespace, or a registry host (by only specifying the
+                  host name and possibly a port number) or a wildcard expression starting
+                  with `*.`, for matching all subdomains (not including a port number).
+                  Wildcards are only supported for subdomain matching, and may not
+                  be used in the middle of the host, i.e.  *.example.com is a valid
+                  case, but example*.*.com is not. Please be aware that the scopes
+                  should not be nested under the repositories of OpenShift Container
+                  Platform images. If configured, the policies for OpenShift Container
+                  Platform repositories will not be in effect. For additional details
+                  about the format, please refer to the document explaining the docker
+                  transport field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                items:
+                  maxLength: 512
+                  type: string
+                  x-kubernetes-validations:
+                  - message: invalid image scope format, scope must contain a fully
+                      qualified domain name or 'localhost'
+                    rule: 'size(self.split(''/'')[0].split(''.'')) == 1 ? self.split(''/'')[0].split(''.'')[0].split('':'')[0]
+                      == ''localhost'' : true'
+                  - message: invalid image scope with wildcard, a wildcard can only
+                      be at the start of the domain and is only supported for subdomain
+                      matching, not path matching
+                    rule: 'self.contains(''*'') ? self.matches(''^\\*(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$'')
+                      : true'
+                  - message: invalid repository namespace or image specification in
+                      the image scope
+                    rule: '!self.contains(''*'') ? self.matches(''^((((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?)(?::([\\w][\\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$'')
+                      : true'
+                maxItems: 256
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - policy
+            - scopes
+            type: object
+          status:
+            description: status contains the observed state of the resource.
+            properties:
+              conditions:
+                description: conditions provide details on the status of this API
+                  Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/install/0000_80_machine-config_01_machineconfigurations-CustomNoUpgrade.crd.yaml
+++ b/install/0000_80_machine-config_01_machineconfigurations-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,1293 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: machineconfigurations.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: MachineConfiguration
+    listKind: MachineConfigurationList
+    plural: machineconfigurations
+    singular: machineconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfiguration provides information to configure an operator
+          to manage Machine Configuration. \n Compatibility level 1: Stable within
+          a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              Machine Config Operator
+            properties:
+              failedRevisionLimit:
+                description: failedRevisionLimit is the number of failed static pod
+                  installer revisions to keep on disk and in the api -1 = unlimited,
+                  0 or unset = 5 (default)
+                format: int32
+                type: integer
+              forceRedeploymentReason:
+                description: forceRedeploymentReason can be used to force the redeployment
+                  of the operand by providing a unique string. This provides a mechanism
+                  to kick a previously failed deployment and provide a reason why
+                  you think it will work this time instead of failing again on the
+                  same config.
+                type: string
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managedBootImages:
+                description: managedBootImages allows configuration for the management
+                  of boot images for machine resources within the cluster. This configuration
+                  allows users to select resources that should be updated to the latest
+                  boot images during cluster upgrades, ensuring that new machines
+                  always boot with the current cluster version's boot image. When
+                  omitted, no boot images will be updated.
+                properties:
+                  machineManagers:
+                    description: machineManagers can be used to register machine management
+                      resources for boot image updates. The Machine Config Operator
+                      will watch for changes to this list. Only one entry is permitted
+                      per type of machine management resource.
+                    items:
+                      description: MachineManager describes a target machine resource
+                        that is registered for boot image updates. It stores identifying
+                        information such as the resource type and the API Group of
+                        the resource. It also provides granular control via the selection
+                        field.
+                      properties:
+                        apiGroup:
+                          description: apiGroup is name of the APIGroup that the machine
+                            management resource belongs to. The only current valid
+                            value is machine.openshift.io. machine.openshift.io means
+                            that the machine manager will only register resources
+                            that belong to OpenShift machine API group.
+                          enum:
+                          - machine.openshift.io
+                          type: string
+                        resource:
+                          description: resource is the machine management resource's
+                            type. The only current valid value is machinesets. machinesets
+                            means that the machine manager will only register resources
+                            of the kind MachineSet.
+                          enum:
+                          - machinesets
+                          type: string
+                        selection:
+                          description: selection allows granular control of the machine
+                            management resources that will be registered for boot
+                            image updates.
+                          properties:
+                            mode:
+                              description: mode determines how machine managers will
+                                be selected for updates. Valid values are All and
+                                Partial. All means that every resource matched by
+                                the machine manager will be updated. Partial requires
+                                specified selector(s) and allows customisation of
+                                which resources matched by the machine manager will
+                                be updated.
+                              enum:
+                              - All
+                              - Partial
+                              type: string
+                            partial:
+                              description: partial provides label selector(s) that
+                                can be used to match machine management resources.
+                                Only permitted when mode is set to "Partial".
+                              properties:
+                                machineResourceSelector:
+                                  description: machineResourceSelector is a label
+                                    selector that can be used to select machine resources
+                                    like MachineSets.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - machineResourceSelector
+                              type: object
+                          required:
+                          - mode
+                          type: object
+                          x-kubernetes-validations:
+                          - message: Partial is required when type is partial, and
+                              forbidden otherwise
+                            rule: 'has(self.mode) && self.mode == ''Partial'' ?  has(self.partial)
+                              : !has(self.partial)'
+                      required:
+                      - apiGroup
+                      - resource
+                      - selection
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - resource
+                    - apiGroup
+                    x-kubernetes-list-type: map
+                type: object
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              nodeDisruptionPolicy:
+                description: nodeDisruptionPolicy allows an admin to set granular
+                  node disruption actions for MachineConfig-based updates, such as
+                  drains, service reloads, etc. Specifying this will allow for less
+                  downtime when doing small configuration updates to the cluster.
+                  This configuration has no effect on cluster upgrades which will
+                  still incur node disruption where required.
+                properties:
+                  files:
+                    description: files is a list of MachineConfig file definitions
+                      and actions to take to changes on those paths This list supports
+                      a maximum of 50 entries.
+                    items:
+                      description: NodeDisruptionPolicySpecFile is a file entry and
+                        corresponding actions to take and is used in the NodeDisruptionPolicyConfig
+                        object
+                      properties:
+                        actions:
+                          description: actions represents the series of commands to
+                            be executed on changes to the file at the corresponding
+                            file path. Actions will be applied in the order that they
+                            are set in this list. If there are other incoming changes
+                            to other MachineConfig entries in the same update that
+                            require a reboot, the reboot will supercede these actions.
+                            Valid actions are Reboot, Drain, Reload, DaemonReload
+                            and None. The Reboot action and the None action cannot
+                            be used in conjunction with any of the other actions.
+                            This list supports a maximum of 10 entries.
+                          items:
+                            properties:
+                              reload:
+                                description: reload specifies the service to reload,
+                                  only valid if type is reload
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be reloaded
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              restart:
+                                description: restart specifies the service to restart,
+                                  only valid if type is restart
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be restarted
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              type:
+                                description: type represents the commands that will
+                                  be carried out if this NodeDisruptionPolicySpecActionType
+                                  is executed Valid value are Reboot, Drain, Reload,
+                                  Restart, DaemonReload, None and Special reload/restart
+                                  requires a corresponding service target specified
+                                  in the reload/restart field. Other values require
+                                  no further configuration
+                                enum:
+                                - Reboot
+                                - Drain
+                                - Reload
+                                - Restart
+                                - DaemonReload
+                                - None
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: reload is required when type is Reload, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                                : !has(self.reload)'
+                            - message: restart is required when type is Restart, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Restart'' ?
+                                has(self.restart) : !has(self.restart)'
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                          - message: Reboot action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                              == 1 : true'
+                          - message: None action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                              1 : true'
+                        path:
+                          description: path is the location of a file being managed
+                            through a MachineConfig. The Actions in the policy will
+                            apply to changes to the file at this path.
+                          type: string
+                      required:
+                      - actions
+                      - path
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - path
+                    x-kubernetes-list-type: map
+                  sshkey:
+                    description: sshkey maps to the ignition.sshkeys field in the
+                      MachineConfig object, definition an action for this will apply
+                      to all sshkey changes in the cluster
+                    properties:
+                      actions:
+                        description: actions represents the series of commands to
+                          be executed on changes to the file at the corresponding
+                          file path. Actions will be applied in the order that they
+                          are set in this list. If there are other incoming changes
+                          to other MachineConfig entries in the same update that require
+                          a reboot, the reboot will supercede these actions. Valid
+                          actions are Reboot, Drain, Reload, DaemonReload and None.
+                          The Reboot action and the None action cannot be used in
+                          conjunction with any of the other actions. This list supports
+                          a maximum of 10 entries.
+                        items:
+                          properties:
+                            reload:
+                              description: reload specifies the service to reload,
+                                only valid if type is reload
+                              properties:
+                                serviceName:
+                                  description: serviceName is the full name (e.g.
+                                    crio.service) of the service to be reloaded Service
+                                    names should be of the format ${NAME}${SERVICETYPE}
+                                    and can up to 255 characters long. ${NAME} must
+                                    be atleast 1 character long and can only consist
+                                    of alphabets, digits, ":", "-", "_", ".", and
+                                    "\". ${SERVICETYPE} must be one of ".service",
+                                    ".socket", ".device", ".mount", ".automount",
+                                    ".swap", ".target", ".path", ".timer", ".snapshot",
+                                    ".slice" or ".scope".
+                                  maxLength: 255
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: Invalid ${SERVICETYPE} in service name.
+                                      Expected format is ${NAME}${SERVICETYPE}, where
+                                      ${SERVICETYPE} must be one of ".service", ".socket",
+                                      ".device", ".mount", ".automount", ".swap",
+                                      ".target", ".path", ".timer",".snapshot", ".slice"
+                                      or ".scope".
+                                    rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                  - message: Invalid ${NAME} in service name. Expected
+                                      format is ${NAME}${SERVICETYPE}, where {NAME}
+                                      must be atleast 1 character long and can only
+                                      consist of alphabets, digits, ":", "-", "_",
+                                      ".", and "\"
+                                    rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                              required:
+                              - serviceName
+                              type: object
+                            restart:
+                              description: restart specifies the service to restart,
+                                only valid if type is restart
+                              properties:
+                                serviceName:
+                                  description: serviceName is the full name (e.g.
+                                    crio.service) of the service to be restarted Service
+                                    names should be of the format ${NAME}${SERVICETYPE}
+                                    and can up to 255 characters long. ${NAME} must
+                                    be atleast 1 character long and can only consist
+                                    of alphabets, digits, ":", "-", "_", ".", and
+                                    "\". ${SERVICETYPE} must be one of ".service",
+                                    ".socket", ".device", ".mount", ".automount",
+                                    ".swap", ".target", ".path", ".timer", ".snapshot",
+                                    ".slice" or ".scope".
+                                  maxLength: 255
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: Invalid ${SERVICETYPE} in service name.
+                                      Expected format is ${NAME}${SERVICETYPE}, where
+                                      ${SERVICETYPE} must be one of ".service", ".socket",
+                                      ".device", ".mount", ".automount", ".swap",
+                                      ".target", ".path", ".timer",".snapshot", ".slice"
+                                      or ".scope".
+                                    rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                  - message: Invalid ${NAME} in service name. Expected
+                                      format is ${NAME}${SERVICETYPE}, where {NAME}
+                                      must be atleast 1 character long and can only
+                                      consist of alphabets, digits, ":", "-", "_",
+                                      ".", and "\"
+                                    rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                              required:
+                              - serviceName
+                              type: object
+                            type:
+                              description: type represents the commands that will
+                                be carried out if this NodeDisruptionPolicySpecActionType
+                                is executed Valid value are Reboot, Drain, Reload,
+                                Restart, DaemonReload, None and Special reload/restart
+                                requires a corresponding service target specified
+                                in the reload/restart field. Other values require
+                                no further configuration
+                              enum:
+                              - Reboot
+                              - Drain
+                              - Reload
+                              - Restart
+                              - DaemonReload
+                              - None
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: reload is required when type is Reload, and forbidden
+                              otherwise
+                            rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                              : !has(self.reload)'
+                          - message: restart is required when type is Restart, and
+                              forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''Restart'' ? has(self.restart)
+                              : !has(self.restart)'
+                        maxItems: 10
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: Reboot action can only be specified standalone,
+                            as it will override any other actions
+                          rule: 'self.exists(x, x.type==''Reboot'') ? size(self) ==
+                            1 : true'
+                        - message: None action can only be specified standalone, as
+                            it will override any other actions
+                          rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                            1 : true'
+                    required:
+                    - actions
+                    type: object
+                  units:
+                    description: units is a list MachineConfig unit definitions and
+                      actions to take on changes to those services This list supports
+                      a maximum of 50 entries.
+                    items:
+                      description: NodeDisruptionPolicySpecUnit is a systemd unit
+                        name and corresponding actions to take and is used in the
+                        NodeDisruptionPolicyConfig object
+                      properties:
+                        actions:
+                          description: actions represents the series of commands to
+                            be executed on changes to the file at the corresponding
+                            file path. Actions will be applied in the order that they
+                            are set in this list. If there are other incoming changes
+                            to other MachineConfig entries in the same update that
+                            require a reboot, the reboot will supercede these actions.
+                            Valid actions are Reboot, Drain, Reload, DaemonReload
+                            and None. The Reboot action and the None action cannot
+                            be used in conjunction with any of the other actions.
+                            This list supports a maximum of 10 entries.
+                          items:
+                            properties:
+                              reload:
+                                description: reload specifies the service to reload,
+                                  only valid if type is reload
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be reloaded
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              restart:
+                                description: restart specifies the service to restart,
+                                  only valid if type is restart
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be restarted
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              type:
+                                description: type represents the commands that will
+                                  be carried out if this NodeDisruptionPolicySpecActionType
+                                  is executed Valid value are Reboot, Drain, Reload,
+                                  Restart, DaemonReload, None and Special reload/restart
+                                  requires a corresponding service target specified
+                                  in the reload/restart field. Other values require
+                                  no further configuration
+                                enum:
+                                - Reboot
+                                - Drain
+                                - Reload
+                                - Restart
+                                - DaemonReload
+                                - None
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: reload is required when type is Reload, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                                : !has(self.reload)'
+                            - message: restart is required when type is Restart, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Restart'' ?
+                                has(self.restart) : !has(self.restart)'
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                          - message: Reboot action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                              == 1 : true'
+                          - message: None action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                              1 : true'
+                        name:
+                          description: name represents the service name of a systemd
+                            service managed through a MachineConfig Actions specified
+                            will be applied for changes to the named service. Service
+                            names should be of the format ${NAME}${SERVICETYPE} and
+                            can up to 255 characters long. ${NAME} must be atleast
+                            1 character long and can only consist of alphabets, digits,
+                            ":", "-", "_", ".", and "\". ${SERVICETYPE} must be one
+                            of ".service", ".socket", ".device", ".mount", ".automount",
+                            ".swap", ".target", ".path", ".timer", ".snapshot", ".slice"
+                            or ".scope".
+                          maxLength: 255
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Invalid ${SERVICETYPE} in service name. Expected
+                              format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                              must be one of ".service", ".socket", ".device", ".mount",
+                              ".automount", ".swap", ".target", ".path", ".timer",".snapshot",
+                              ".slice" or ".scope".
+                            rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                          - message: Invalid ${NAME} in service name. Expected format
+                              is ${NAME}${SERVICETYPE}, where {NAME} must be atleast
+                              1 character long and can only consist of alphabets,
+                              digits, ":", "-", "_", ".", and "\"
+                            rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                      required:
+                      - actions
+                      - name
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              succeededRevisionLimit:
+                description: succeededRevisionLimit is the number of successful static
+                  pod installer revisions to keep on disk and in the api -1 = unlimited,
+                  0 or unset = 5 (default)
+                format: int32
+                type: integer
+              unsupportedConfigOverrides:
+                description: unsupportedConfigOverrides overrides the final configuration
+                  that was computed by the operator. Red Hat does not support the
+                  use of this field. Misuse of this field could lead to unexpected
+                  behavior or conflict with other configuration options. Seek guidance
+                  from the Red Hat support before using this field. Use of this property
+                  blocks cluster upgrades, it must be removed before upgrading your
+                  cluster.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status is the most recently observed status of the Machine
+              Config Operator
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+              latestAvailableRevisionReason:
+                description: latestAvailableRevisionReason describe the detailed reason
+                  for the most recent deployment
+                type: string
+              nodeDisruptionPolicyStatus:
+                description: nodeDisruptionPolicyStatus status reflects what the latest
+                  cluster-validated policies are, and will be used by the Machine
+                  Config Daemon during future node updates.
+                properties:
+                  clusterPolicies:
+                    description: clusterPolicies is a merge of cluster default and
+                      user provided node disruption policies.
+                    properties:
+                      files:
+                        description: files is a list of MachineConfig file definitions
+                          and actions to take to changes on those paths
+                        items:
+                          description: NodeDisruptionPolicyStatusFile is a file entry
+                            and corresponding actions to take and is used in the NodeDisruptionPolicyClusterStatus
+                            object
+                          properties:
+                            actions:
+                              description: actions represents the series of commands
+                                to be executed on changes to the file at the corresponding
+                                file path. Actions will be applied in the order that
+                                they are set in this list. If there are other incoming
+                                changes to other MachineConfig entries in the same
+                                update that require a reboot, the reboot will supercede
+                                these actions. Valid actions are Reboot, Drain, Reload,
+                                DaemonReload and None. The Reboot action and the None
+                                action cannot be used in conjunction with any of the
+                                other actions. This list supports a maximum of 10
+                                entries.
+                              items:
+                                properties:
+                                  reload:
+                                    description: reload specifies the service to reload,
+                                      only valid if type is reload
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          reloaded Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  restart:
+                                    description: restart specifies the service to
+                                      restart, only valid if type is restart
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          restarted Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  type:
+                                    description: type represents the commands that
+                                      will be carried out if this NodeDisruptionPolicyStatusActionType
+                                      is executed Valid value are Reboot, Drain, Reload,
+                                      Restart, DaemonReload, None and Special reload/restart
+                                      requires a corresponding service target specified
+                                      in the reload/restart field. Other values require
+                                      no further configuration
+                                    enum:
+                                    - Reboot
+                                    - Drain
+                                    - Reload
+                                    - Restart
+                                    - DaemonReload
+                                    - None
+                                    - Special
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: reload is required when type is Reload,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Reload''
+                                    ? has(self.reload) : !has(self.reload)'
+                                - message: restart is required when type is Restart,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Restart''
+                                    ? has(self.restart) : !has(self.restart)'
+                              maxItems: 10
+                              type: array
+                              x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: Reboot action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                  == 1 : true'
+                              - message: None action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                  == 1 : true'
+                            path:
+                              description: path is the location of a file being managed
+                                through a MachineConfig. The Actions in the policy
+                                will apply to changes to the file at this path.
+                              type: string
+                          required:
+                          - actions
+                          - path
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - path
+                        x-kubernetes-list-type: map
+                      sshkey:
+                        description: sshkey is the overall sshkey MachineConfig definition
+                        properties:
+                          actions:
+                            description: actions represents the series of commands
+                              to be executed on changes to the file at the corresponding
+                              file path. Actions will be applied in the order that
+                              they are set in this list. If there are other incoming
+                              changes to other MachineConfig entries in the same update
+                              that require a reboot, the reboot will supercede these
+                              actions. Valid actions are Reboot, Drain, Reload, DaemonReload
+                              and None. The Reboot action and the None action cannot
+                              be used in conjunction with any of the other actions.
+                              This list supports a maximum of 10 entries.
+                            items:
+                              properties:
+                                reload:
+                                  description: reload specifies the service to reload,
+                                    only valid if type is reload
+                                  properties:
+                                    serviceName:
+                                      description: serviceName is the full name (e.g.
+                                        crio.service) of the service to be reloaded
+                                        Service names should be of the format ${NAME}${SERVICETYPE}
+                                        and can up to 255 characters long. ${NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\". ${SERVICETYPE} must be one of
+                                        ".service", ".socket", ".device", ".mount",
+                                        ".automount", ".swap", ".target", ".path",
+                                        ".timer", ".snapshot", ".slice" or ".scope".
+                                      maxLength: 255
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: Invalid ${SERVICETYPE} in service
+                                          name. Expected format is ${NAME}${SERVICETYPE},
+                                          where ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer",".snapshot",
+                                          ".slice" or ".scope".
+                                        rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                      - message: Invalid ${NAME} in service name.
+                                          Expected format is ${NAME}${SERVICETYPE},
+                                          where {NAME} must be atleast 1 character
+                                          long and can only consist of alphabets,
+                                          digits, ":", "-", "_", ".", and "\"
+                                        rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                  required:
+                                  - serviceName
+                                  type: object
+                                restart:
+                                  description: restart specifies the service to restart,
+                                    only valid if type is restart
+                                  properties:
+                                    serviceName:
+                                      description: serviceName is the full name (e.g.
+                                        crio.service) of the service to be restarted
+                                        Service names should be of the format ${NAME}${SERVICETYPE}
+                                        and can up to 255 characters long. ${NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\". ${SERVICETYPE} must be one of
+                                        ".service", ".socket", ".device", ".mount",
+                                        ".automount", ".swap", ".target", ".path",
+                                        ".timer", ".snapshot", ".slice" or ".scope".
+                                      maxLength: 255
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: Invalid ${SERVICETYPE} in service
+                                          name. Expected format is ${NAME}${SERVICETYPE},
+                                          where ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer",".snapshot",
+                                          ".slice" or ".scope".
+                                        rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                      - message: Invalid ${NAME} in service name.
+                                          Expected format is ${NAME}${SERVICETYPE},
+                                          where {NAME} must be atleast 1 character
+                                          long and can only consist of alphabets,
+                                          digits, ":", "-", "_", ".", and "\"
+                                        rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                  required:
+                                  - serviceName
+                                  type: object
+                                type:
+                                  description: type represents the commands that will
+                                    be carried out if this NodeDisruptionPolicyStatusActionType
+                                    is executed Valid value are Reboot, Drain, Reload,
+                                    Restart, DaemonReload, None and Special reload/restart
+                                    requires a corresponding service target specified
+                                    in the reload/restart field. Other values require
+                                    no further configuration
+                                  enum:
+                                  - Reboot
+                                  - Drain
+                                  - Reload
+                                  - Restart
+                                  - DaemonReload
+                                  - None
+                                  - Special
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: reload is required when type is Reload, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Reload'' ?
+                                  has(self.reload) : !has(self.reload)'
+                              - message: restart is required when type is Restart,
+                                  and forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Restart''
+                                  ? has(self.restart) : !has(self.restart)'
+                            maxItems: 10
+                            type: array
+                            x-kubernetes-list-type: atomic
+                            x-kubernetes-validations:
+                            - message: Reboot action can only be specified standalone,
+                                as it will override any other actions
+                              rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                == 1 : true'
+                            - message: None action can only be specified standalone,
+                                as it will override any other actions
+                              rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                == 1 : true'
+                        required:
+                        - actions
+                        type: object
+                      units:
+                        description: units is a list MachineConfig unit definitions
+                          and actions to take on changes to those services
+                        items:
+                          description: NodeDisruptionPolicyStatusUnit is a systemd
+                            unit name and corresponding actions to take and is used
+                            in the NodeDisruptionPolicyClusterStatus object
+                          properties:
+                            actions:
+                              description: actions represents the series of commands
+                                to be executed on changes to the file at the corresponding
+                                file path. Actions will be applied in the order that
+                                they are set in this list. If there are other incoming
+                                changes to other MachineConfig entries in the same
+                                update that require a reboot, the reboot will supercede
+                                these actions. Valid actions are Reboot, Drain, Reload,
+                                DaemonReload and None. The Reboot action and the None
+                                action cannot be used in conjunction with any of the
+                                other actions. This list supports a maximum of 10
+                                entries.
+                              items:
+                                properties:
+                                  reload:
+                                    description: reload specifies the service to reload,
+                                      only valid if type is reload
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          reloaded Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  restart:
+                                    description: restart specifies the service to
+                                      restart, only valid if type is restart
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          restarted Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  type:
+                                    description: type represents the commands that
+                                      will be carried out if this NodeDisruptionPolicyStatusActionType
+                                      is executed Valid value are Reboot, Drain, Reload,
+                                      Restart, DaemonReload, None and Special reload/restart
+                                      requires a corresponding service target specified
+                                      in the reload/restart field. Other values require
+                                      no further configuration
+                                    enum:
+                                    - Reboot
+                                    - Drain
+                                    - Reload
+                                    - Restart
+                                    - DaemonReload
+                                    - None
+                                    - Special
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: reload is required when type is Reload,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Reload''
+                                    ? has(self.reload) : !has(self.reload)'
+                                - message: restart is required when type is Restart,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Restart''
+                                    ? has(self.restart) : !has(self.restart)'
+                              maxItems: 10
+                              type: array
+                              x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: Reboot action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                  == 1 : true'
+                              - message: None action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                  == 1 : true'
+                            name:
+                              description: name represents the service name of a systemd
+                                service managed through a MachineConfig Actions specified
+                                will be applied for changes to the named service.
+                                Service names should be of the format ${NAME}${SERVICETYPE}
+                                and can up to 255 characters long. ${NAME} must be
+                                atleast 1 character long and can only consist of alphabets,
+                                digits, ":", "-", "_", ".", and "\". ${SERVICETYPE}
+                                must be one of ".service", ".socket", ".device", ".mount",
+                                ".automount", ".swap", ".target", ".path", ".timer",
+                                ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - actions
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+              nodeStatuses:
+                description: nodeStatuses track the deployment values and errors across
+                  individual nodes
+                items:
+                  description: NodeStatus provides information about the current state
+                    of a particular node managed by this operator.
+                  properties:
+                    currentRevision:
+                      description: currentRevision is the generation of the most recently
+                        successful deployment
+                      format: int32
+                      type: integer
+                    lastFailedCount:
+                      description: lastFailedCount is how often the installer pod
+                        of the last failed revision failed.
+                      type: integer
+                    lastFailedReason:
+                      description: lastFailedReason is a machine readable failure
+                        reason string.
+                      type: string
+                    lastFailedRevision:
+                      description: lastFailedRevision is the generation of the deployment
+                        we tried and failed to deploy.
+                      format: int32
+                      type: integer
+                    lastFailedRevisionErrors:
+                      description: lastFailedRevisionErrors is a list of human readable
+                        errors during the failed deployment referenced in lastFailedRevision.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    lastFailedTime:
+                      description: lastFailedTime is the time the last failed revision
+                        failed the last time.
+                      format: date-time
+                      type: string
+                    lastFallbackCount:
+                      description: lastFallbackCount is how often a fallback to a
+                        previous revision happened.
+                      type: integer
+                    nodeName:
+                      description: nodeName is the name of the node
+                      type: string
+                    targetRevision:
+                      description: targetRevision is the generation of the deployment
+                        we're trying to apply
+                      format: int32
+                      type: integer
+                  required:
+                  - nodeName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - nodeName
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "managed-bootimages-platform-check"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["operator.openshift.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE","UPDATE"]
+      resources:   ["machineconfigurations"]
+  validations:
+    - expression: "!has(object.spec.managedBootImages) || (has(object.spec.managedBootImages) && params.status.platformStatus.type in ['GCP'])"
+      message: "This feature is only supported on these platforms: GCP"

--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,10 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "managed-bootimages-platform-check-binding"
+spec:
+  policyName: "managed-bootimages-platform-check"
+  validationActions: [Deny]
+  paramRef:
+    name: "cluster"
+    parameterNotFoundAction: "Deny"

--- a/vendor/github.com/openshift/library-go/pkg/certs/pem.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/pem.go
@@ -3,7 +3,6 @@ package certs
 import (
 	"bytes"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -16,7 +15,7 @@ const (
 )
 
 func BlockFromFile(path string, blockType string) (*pem.Block, bool, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, false, err
 	}
@@ -45,7 +44,7 @@ func BlockToFile(path string, block *pem.Block, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, b, mode)
+	return os.WriteFile(path, b, mode)
 }
 
 func BlockToBytes(block *pem.Block) ([]byte, error) {

--- a/vendor/github.com/openshift/library-go/pkg/config/leaderelection/leaderelection.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/leaderelection/leaderelection.go
@@ -2,7 +2,6 @@ package leaderelection
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"strings"
@@ -132,7 +131,7 @@ func LeaderElectionDefaulting(config configv1.LeaderElection, defaultNamespace, 
 			ret.Namespace = defaultNamespace
 		} else {
 			// Fall back to the namespace associated with the service account token, if available
-			if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+			if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 				if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 					ret.Namespace = ns
 				}

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
@@ -96,7 +96,7 @@ func (c syncContext) enqueueKeys(keys ...string) {
 // (or its tombstone) is a namespace  and it matches a name of any namespaces
 // that we are interested in
 func namespaceChecker(interestingNamespaces []string) func(obj interface{}) bool {
-	interestingNamespacesSet := sets.NewString(interestingNamespaces...)
+	interestingNamespacesSet := sets.New(interestingNamespaces...)
 
 	return func(obj interface{}) bool {
 		ns, ok := obj.(*corev1.Namespace)

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/eventfilters.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/eventfilters.go
@@ -15,7 +15,7 @@ func ObjectNameToKey(obj runtime.Object) string {
 }
 
 func NamesFilter(names ...string) EventFilterFunc {
-	nameSet := sets.NewString(names...)
+	nameSet := sets.New(names...)
 	return func(obj interface{}) bool {
 		metaObj, ok := obj.(metav1.ObjectMetaAccessor)
 		if !ok {

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/factory.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/factory.go
@@ -8,7 +8,6 @@ import (
 	"github.com/robfig/cron"
 	"k8s.io/apimachinery/pkg/runtime"
 	errorutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -26,18 +25,17 @@ func DefaultQueueKeysFunc(_ runtime.Object) []string {
 // Factory is generator that generate standard Kubernetes controllers.
 // Factory is really generic and should be only used for simple controllers that does not require special stuff..
 type Factory struct {
-	sync                  SyncFunc
-	syncContext           SyncContext
-	syncDegradedClient    operatorv1helpers.OperatorClient
-	resyncInterval        time.Duration
-	resyncSchedules       []string
-	informers             []filteredInformers
-	informerQueueKeys     []informersWithQueueKey
-	bareInformers         []Informer
-	postStartHooks        []PostStartHook
-	namespaceInformers    []*namespaceInformer
-	cachesToSync          []cache.InformerSynced
-	interestingNamespaces sets.String
+	sync               SyncFunc
+	syncContext        SyncContext
+	syncDegradedClient operatorv1helpers.OperatorClient
+	resyncInterval     time.Duration
+	resyncSchedules    []string
+	informers          []filteredInformers
+	informerQueueKeys  []informersWithQueueKey
+	bareInformers      []Informer
+	postStartHooks     []PostStartHook
+	namespaceInformers []*namespaceInformer
+	cachesToSync       []cache.InformerSynced
 }
 
 // Informer represents any structure that allow to register event handlers and informs if caches are synced.

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -122,7 +122,7 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 }
 
 func (c CertRotationController) SyncWorker(ctx context.Context) error {
-	signingCertKeyPair, err := c.RotatedSigningCASecret.EnsureSigningCertKeyPair(ctx)
+	signingCertKeyPair, _, err := c.RotatedSigningCASecret.EnsureSigningCertKeyPair(ctx)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -52,12 +52,20 @@ type RotatedSigningCASecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT enable, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
-func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
+// EnsureSigningCertKeyPair manages the entire lifecycle of a signer cert as a secret, from creation to continued rotation.
+// It always returns the currently used CA pair, a bool indicating whether it was created/updated within this function call and an error.
+func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, bool, error) {
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
+		return nil, false, err
 	}
 	signingCertKeyPairSecret := originalSigningCertKeyPairSecret.DeepCopy()
 	if apierrors.IsNotFound(err) {
@@ -72,37 +80,44 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
 	}
 
+	signerUpdated := false
 	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Refresh, c.RefreshOnlyWhenExpired); needed {
 		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
 		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
+		signerUpdated = true
 	}
 	// at this point, the secret has the correct signer, so we should read that signer to be able to sign
 	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
 	if err != nil {
-		return nil, err
+		return nil, signerUpdated, err
 	}
 
-	return signingCertKeyPair, nil
+	return signingCertKeyPair, signerUpdated, nil
 }
 
 // ensureOwnerReference adds the owner to the list of owner references in meta, if necessary

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
@@ -2,6 +2,7 @@ package featuregates
 
 import (
 	"fmt"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -39,9 +40,9 @@ func (f *featureGate) Enabled(key configv1.FeatureGateName) bool {
 }
 
 func (f *featureGate) KnownFeatures() []configv1.FeatureGateName {
-	allKnown := sets.NewString()
+	allKnown := sets.New[string]()
 	allKnown.Insert(FeatureGateNamesToStrings(f.enabled.UnsortedList())...)
 	allKnown.Insert(FeatureGateNamesToStrings(f.disabled.UnsortedList())...)
 
-	return StringsToFeatureGateNames(allKnown.List())
+	return StringsToFeatureGateNames(sets.List(allKnown))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -7,10 +7,12 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admissionregistrationclientv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	admissionregistrationclientv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	"k8s.io/klog/v2"
 )
 
@@ -48,13 +50,13 @@ func ApplyMutatingWebhookConfigurationImproved(ctx context.Context, client admis
 	}
 
 	required := requiredOriginal.DeepCopy()
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	copyMutatingWebhookCABundle(existing, required)
 	webhooksEquivalent := equality.Semantic.DeepEqual(existingCopy.Webhooks, required.Webhooks)
-	if webhooksEquivalent && !*modified {
+	if webhooksEquivalent && !modified {
 		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
 		cache.UpdateCachedResourceMetadata(requiredOriginal, existingCopy)
 		return existingCopy, false, nil
@@ -123,13 +125,13 @@ func ApplyValidatingWebhookConfigurationImproved(ctx context.Context, client adm
 	}
 
 	required := requiredOriginal.DeepCopy()
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	copyValidatingWebhookCABundle(existing, required)
 	webhooksEquivalent := equality.Semantic.DeepEqual(existingCopy.Webhooks, required.Webhooks)
-	if webhooksEquivalent && !*modified {
+	if webhooksEquivalent && !modified {
 		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
 		cache.UpdateCachedResourceMetadata(requiredOriginal, existingCopy)
 		return existingCopy, false, nil
@@ -163,4 +165,122 @@ func copyValidatingWebhookCABundle(from, to *admissionregistrationv1.ValidatingW
 			to.Webhooks[i].ClientConfig.CABundle = existing.ClientConfig.CABundle
 		}
 	}
+}
+
+// ApplyValidatingAdmissionPolicyV1beta1 ensures the form of the specified
+// validatingadmissionpolicyconfiguration is present in the API. If it does not exist,
+// it will be created. If it does exist, the metadata of the required
+// validatingadmissionpolicyconfiguration will be merged with the existing validatingadmissionpolicyconfiguration
+// and an update performed if the validatingadmissionpolicyconfiguration spec and metadata differ from
+// the previously required spec and metadata based on generation change.
+func ApplyValidatingAdmissionPolicyV1beta1(ctx context.Context, client admissionregistrationclientv1beta1.ValidatingAdmissionPoliciesGetter, recorder events.Recorder,
+	requiredOriginal *admissionregistrationv1beta1.ValidatingAdmissionPolicy, cache ResourceCache) (*admissionregistrationv1beta1.ValidatingAdmissionPolicy, bool, error) {
+	if requiredOriginal == nil {
+		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
+	}
+
+	existing, err := client.ValidatingAdmissionPolicies().Get(ctx, requiredOriginal.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		required := requiredOriginal.DeepCopy()
+		actual, err := client.ValidatingAdmissionPolicies().Create(
+			ctx, resourcemerge.WithCleanLabelsAndAnnotations(required).(*admissionregistrationv1beta1.ValidatingAdmissionPolicy), metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		if err != nil {
+			return nil, false, err
+		}
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+		return actual, true, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+
+	if cache.SafeToSkipApply(requiredOriginal, existing) {
+		return existing, false, nil
+	}
+
+	required := requiredOriginal.DeepCopy()
+	modified := false
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	specEquivalent := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if specEquivalent && !modified {
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, existingCopy)
+		return existingCopy, false, nil
+	}
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+	toWrite.Spec = required.Spec
+
+	klog.V(2).Infof("ValidatingAdmissionPolicyConfigurationV1beta1 %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
+
+	actual, err := client.ValidatingAdmissionPolicies().Update(ctx, toWrite, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	if err != nil {
+		return nil, false, err
+	}
+	// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+	cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+	return actual, true, nil
+}
+
+// ApplyValidatingAdmissionPolicyBindingV1beta1 ensures the form of the specified
+// validatingadmissionpolicybindingconfiguration is present in the API. If it does not exist,
+// it will be created. If it does exist, the metadata of the required
+// validatingadmissionpolicybindingconfiguration will be merged with the existing validatingadmissionpolicybindingconfiguration
+// and an update performed if the validatingadmissionpolicybindingconfiguration spec and metadata differ from
+// the previously required spec and metadata based on generation change.
+func ApplyValidatingAdmissionPolicyBindingV1beta1(ctx context.Context, client admissionregistrationclientv1beta1.ValidatingAdmissionPolicyBindingsGetter, recorder events.Recorder,
+	requiredOriginal *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, cache ResourceCache) (*admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, bool, error) {
+	if requiredOriginal == nil {
+		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
+	}
+
+	existing, err := client.ValidatingAdmissionPolicyBindings().Get(ctx, requiredOriginal.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		required := requiredOriginal.DeepCopy()
+		actual, err := client.ValidatingAdmissionPolicyBindings().Create(
+			ctx, resourcemerge.WithCleanLabelsAndAnnotations(required).(*admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding), metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		if err != nil {
+			return nil, false, err
+		}
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+		return actual, true, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+
+	if cache.SafeToSkipApply(requiredOriginal, existing) {
+		return existing, false, nil
+	}
+
+	required := requiredOriginal.DeepCopy()
+	modified := false
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	specEquivalent := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if specEquivalent && !modified {
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, existingCopy)
+		return existingCopy, false, nil
+	}
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+	toWrite.Spec = required.Spec
+
+	klog.V(2).Infof("ValidatingAdmissionPolicyBindingConfigurationV1beta1 %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
+
+	actual, err := client.ValidatingAdmissionPolicyBindings().Update(ctx, toWrite, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	if err != nil {
+		return nil, false, err
+	}
+	// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+	cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+	return actual, true, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
@@ -26,10 +26,10 @@ func ApplyCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
-	resourcemerge.EnsureCustomResourceDefinitionV1(modified, existingCopy, *required)
-	if !*modified {
+	resourcemerge.EnsureCustomResourceDefinitionV1(&modified, existingCopy, *required)
+	if !modified {
 		return existing, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiregistration.go
@@ -28,15 +28,15 @@ func ApplyAPIService(ctx context.Context, client apiregistrationv1client.APIServ
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	serviceSame := equality.Semantic.DeepEqual(existingCopy.Spec.Service, required.Spec.Service)
 	prioritySame := existingCopy.Spec.VersionPriority == required.Spec.VersionPriority && existingCopy.Spec.GroupPriorityMinimum == required.Spec.GroupPriorityMinimum
 	insecureSame := existingCopy.Spec.InsecureSkipTLSVerify == required.Spec.InsecureSkipTLSVerify
 	// there was no change to metadata, the service and priorities were right
-	if !*modified && serviceSame && prioritySame && insecureSame {
+	if !modified && serviceSame && prioritySame && insecureSame {
 		return existingCopy, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
@@ -125,12 +125,12 @@ func ApplyDeploymentWithForce(ctx context.Context, client appsclientv1.Deploymen
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	// there was no change to metadata, the generation was right, and we weren't asked for force the deployment
-	if !*modified && existingCopy.ObjectMeta.Generation == expectedGeneration && !forceRollout {
+	if !modified && existingCopy.ObjectMeta.Generation == expectedGeneration && !forceRollout {
 		return existingCopy, false, nil
 	}
 
@@ -212,12 +212,12 @@ func ApplyDaemonSetWithForce(ctx context.Context, client appsclientv1.DaemonSets
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	// there was no change to metadata, the generation was right, and we weren't asked for force the deployment
-	if !*modified && existingCopy.ObjectMeta.Generation == expectedGeneration && !forceRollout {
+	if !modified && existingCopy.ObjectMeta.Generation == expectedGeneration && !forceRollout {
 		return existingCopy, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 // TODO find  way to create a registry of these based on struct mapping or some such that forces users to get this right
@@ -84,7 +85,15 @@ func ApplyConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, r
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
-	return ApplySecretImproved(ctx, client, recorder, required, noCache)
+	return applySecretImproved(ctx, client, recorder, required, noCache, false)
+}
+
+// ApplySecretDoNotUse is depreated and will be removed
+// Deprecated: DO NOT USE, it is intended as a short term hack for a very specific use case,
+// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+// Use ApplySecret instead.
+func ApplySecretDoNotUse(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, required, noCache, true)
 }
 
 // ApplyNamespace merges objectmeta, does not worry about anything else
@@ -106,11 +115,11 @@ func ApplyNamespaceImproved(ctx context.Context, client coreclientv1.NamespacesG
 		return existing, false, nil
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !modified {
 		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
@@ -153,12 +162,12 @@ func ApplyServiceImproved(ctx context.Context, client coreclientv1.ServicesGette
 		return existing, false, nil
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
 	// This will catch also changes between old `required.spec` and current `required.spec`, because
 	// the annotation from SetSpecHashAnnotation will be different.
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	selectorSame := equality.Semantic.DeepEqual(existingCopy.Spec.Selector, required.Spec.Selector)
 
 	typeSame := false
@@ -168,7 +177,7 @@ func ApplyServiceImproved(ctx context.Context, client coreclientv1.ServicesGette
 		typeSame = true
 	}
 
-	if selectorSame && typeSame && !*modified {
+	if selectorSame && typeSame && !modified {
 		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
@@ -205,11 +214,11 @@ func ApplyPodImproved(ctx context.Context, client coreclientv1.PodsGetter, recor
 		return existing, false, nil
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !modified {
 		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
@@ -243,11 +252,11 @@ func ApplyServiceAccountImproved(ctx context.Context, client coreclientv1.Servic
 		return existing, false, nil
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !modified {
 		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
@@ -279,10 +288,10 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 		return existing, false, nil
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
 	// injected by cluster-network-operator: https://github.com/openshift/cluster-network-operator/blob/acc819ee0f3424a341b9ad4e1e83ca0a742c230a/docs/architecture.md?L192#configmap-ca-injector
 	caBundleInjected := required.Labels["config.openshift.io/inject-trusted-cabundle"] == "true"
@@ -325,7 +334,7 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 	}
 
 	dataSame := len(modifiedKeys) == 0
-	if dataSame && !*modified {
+	if dataSame && !modified {
 		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
@@ -356,6 +365,10 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, requiredInput, cache, false)
+}
+
+func applySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache, updateOnly bool) (*corev1.Secret, bool, error) {
 	// copy the stringData to data.  Error on a data content conflict inside required.  This is usually a bug.
 
 	existing, err := client.Secrets(requiredInput.Namespace).Get(ctx, requiredInput.Name, metav1.GetOptions{})
@@ -395,7 +408,7 @@ func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter,
 
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(resourcemerge.BoolPtr(false), &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(ptr.To(false), &existingCopy.ObjectMeta, required.ObjectMeta)
 
 	switch required.Type {
 	case corev1.SecretTypeServiceAccountToken:
@@ -435,6 +448,12 @@ func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter,
 	 * https://github.com/kubernetes/kubernetes/blob/98e65951dccfd40d3b4f31949c2ab8df5912d93e/pkg/apis/core/validation/validation.go#L5048
 	 * We need to explicitly opt for delete+create in that case.
 	 */
+	if updateOnly {
+		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, existingCopy, err)
+		return actual, err == nil, err
+	}
+
 	if existingCopy.Type == existing.Type {
 		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 		reportUpdateEvent(recorder, existingCopy, err)
@@ -466,7 +485,7 @@ func SyncConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, re
 
 // SyncPartialConfigMap does what SyncConfigMap does but it only synchronizes a subset of keys given by `syncedKeys`.
 // SyncPartialConfigMap will delete the target if `syncedKeys` are set but the source does not contain any of these keys.
-func SyncPartialConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.String, ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
+func SyncPartialConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.Set[string], ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
 	source, err := client.ConfigMaps(sourceNamespace).Get(ctx, sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
@@ -527,7 +546,7 @@ func SyncSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder
 
 // SyncPartialSecret does what SyncSecret does but it only synchronizes a subset of keys given by `syncedKeys`.
 // SyncPartialSecret will delete the target if `syncedKeys` are set but the source does not contain any of these keys.
-func SyncPartialSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.String, ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
+func SyncPartialSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.Set[string], ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
 	source, err := client.Secrets(sourceNamespace).Get(ctx, sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -192,6 +193,18 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
 				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
+			}
+		case *admissionregistrationv1beta1.ValidatingAdmissionPolicy:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyValidatingAdmissionPolicyV1beta1(ctx, clients.kubeClient.AdmissionregistrationV1beta1(), recorder, t, cache)
+			}
+		case *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyValidatingAdmissionPolicyBindingV1beta1(ctx, clients.kubeClient.AdmissionregistrationV1beta1(), recorder, t, cache)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/migration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/migration.go
@@ -28,10 +28,10 @@ func ApplyStorageVersionMigration(ctx context.Context, client migrationclientv1a
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified && reflect.DeepEqual(existingCopy.Spec, required.Spec) {
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !modified && reflect.DeepEqual(existingCopy.Spec, required.Spec) {
 		return existingCopy, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/policy.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/policy.go
@@ -27,12 +27,12 @@ func ApplyPodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisr
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	contentSame := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
-	if contentSame && !*modified {
+	if contentSame && !modified {
 		return existingCopy, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
@@ -28,14 +28,14 @@ func ApplyClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGette
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	rulesContentSame := equality.Semantic.DeepEqual(existingCopy.Rules, required.Rules)
 	aggregationRuleContentSame := equality.Semantic.DeepEqual(existingCopy.AggregationRule, required.AggregationRule)
 
-	if aggregationRuleContentSame && rulesContentSame && !*modified {
+	if aggregationRuleContentSame && rulesContentSame && !modified {
 		return existingCopy, false, nil
 	}
 
@@ -74,7 +74,7 @@ func ApplyClusterRoleBinding(ctx context.Context, client rbacclientv1.ClusterRol
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 	requiredCopy := required.DeepCopy()
 
@@ -93,12 +93,12 @@ func ApplyClusterRoleBinding(ctx context.Context, client rbacclientv1.ClusterRol
 		}
 	}
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, requiredCopy.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, requiredCopy.ObjectMeta)
 
 	subjectsAreSame := equality.Semantic.DeepEqual(existingCopy.Subjects, requiredCopy.Subjects)
 	roleRefIsSame := equality.Semantic.DeepEqual(existingCopy.RoleRef, requiredCopy.RoleRef)
 
-	if subjectsAreSame && roleRefIsSame && !*modified {
+	if subjectsAreSame && roleRefIsSame && !modified {
 		return existingCopy, false, nil
 	}
 
@@ -128,12 +128,12 @@ func ApplyRole(ctx context.Context, client rbacclientv1.RolesGetter, recorder ev
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	contentSame := equality.Semantic.DeepEqual(existingCopy.Rules, required.Rules)
-	if contentSame && !*modified {
+	if contentSame && !modified {
 		return existingCopy, false, nil
 	}
 
@@ -162,7 +162,7 @@ func ApplyRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGette
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
 	requiredCopy := required.DeepCopy()
 
@@ -181,12 +181,12 @@ func ApplyRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGette
 		}
 	}
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, requiredCopy.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, requiredCopy.ObjectMeta)
 
 	subjectsAreSame := equality.Semantic.DeepEqual(existingCopy.Subjects, requiredCopy.Subjects)
 	roleRefIsSame := equality.Semantic.DeepEqual(existingCopy.RoleRef, requiredCopy.RoleRef)
 
-	if subjectsAreSame && roleRefIsSame && !*modified {
+	if subjectsAreSame && roleRefIsSame && !modified {
 		return existingCopy, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -61,9 +61,9 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 	}
 
 	// First, let's compare ObjectMeta from both objects
-	modified := resourcemerge.BoolPtr(false)
+	modified := false
 	existingCopy := existing.DeepCopy()
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
 	// Second, let's compare the other fields. StorageClass doesn't have a spec and we don't
 	// want to miss fields, so we have to copy required to get all fields
@@ -73,7 +73,7 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 	requiredCopy.TypeMeta = existingCopy.TypeMeta
 
 	contentSame := equality.Semantic.DeepEqual(existingCopy, requiredCopy)
-	if contentSame && !*modified {
+	if contentSame && !modified {
 		return existing, false, nil
 	}
 
@@ -169,14 +169,14 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 		}
 	}
 
-	metadataModified := resourcemerge.BoolPtr(false)
+	metadataModified := false
 	existingCopy := existing.DeepCopy()
-	resourcemerge.EnsureObjectMeta(metadataModified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(&metadataModified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
 	requiredSpecHash := required.Annotations[specHashAnnotation]
 	existingSpecHash := existing.Annotations[specHashAnnotation]
 	sameSpec := requiredSpecHash == existingSpecHash
-	if sameSpec && !*metadataModified {
+	if sameSpec && !metadataModified {
 		return existing, false, nil
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -6,7 +6,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
@@ -63,6 +63,6 @@ func crd_SetDefaults_CustomResourceDefinitionSpec(obj *apiextensionsv1.CustomRes
 
 func crd_SetDefaults_ServiceReference(obj *apiextensionsv1.ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/object_merger.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/object_merger.go
@@ -36,10 +36,6 @@ func cleanRemovalKeys(required map[string]string) map[string]string {
 	return required
 }
 
-func stringPtr(val string) *string {
-	return &val
-}
-
 func SetString(modified *bool, existing *string, required string) {
 	if required != *existing {
 		*existing = required
@@ -55,15 +51,6 @@ func SetStringIfSet(modified *bool, existing *string, required string) {
 		*existing = required
 		*modified = true
 	}
-}
-
-func setStringPtr(modified *bool, existing **string, required *string) {
-	if *existing == nil || (required == nil && *existing != nil) {
-		*modified = true
-		*existing = required
-		return
-	}
-	SetString(modified, *existing, *required)
 }
 
 func SetStringSlice(modified *bool, existing *[]string, required []string) {
@@ -83,6 +70,7 @@ func SetStringSliceIfSet(modified *bool, existing *[]string, required []string) 
 	}
 }
 
+// Deprecated: Use k8s.io/utils/ptr.To instead.
 func BoolPtr(val bool) *bool {
 	return &val
 }
@@ -92,19 +80,6 @@ func SetBool(modified *bool, existing *bool, required bool) {
 		*existing = required
 		*modified = true
 	}
-}
-
-func setBoolPtr(modified *bool, existing **bool, required *bool) {
-	if *existing == nil || (required == nil && *existing != nil) {
-		*modified = true
-		*existing = required
-		return
-	}
-	SetBool(modified, *existing, *required)
-}
-
-func int64Ptr(val int64) *int64 {
-	return &val
 }
 
 func SetInt32(modified *bool, existing *int32, required int32) {
@@ -127,15 +102,6 @@ func SetInt64(modified *bool, existing *int64, required int64) {
 		*existing = required
 		*modified = true
 	}
-}
-
-func setInt64Ptr(modified *bool, existing **int64, required *int64) {
-	if *existing == nil || (required == nil && *existing != nil) {
-		*modified = true
-		*existing = required
-		return
-	}
-	SetInt64(modified, *existing, *required)
 }
 
 func MergeMap(modified *bool, existing *map[string]string, required map[string]string) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/admission.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/admission.go
@@ -2,6 +2,7 @@ package resourceread
 
 import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -14,6 +15,7 @@ var (
 
 func init() {
 	utilruntime.Must(admissionv1.AddToScheme(admissionScheme))
+	utilruntime.Must(admissionv1beta1.AddToScheme(admissionScheme))
 }
 
 func ReadValidatingWebhookConfigurationV1OrDie(objBytes []byte) *admissionv1.ValidatingWebhookConfiguration {
@@ -32,4 +34,22 @@ func ReadMutatingWebhookConfigurationV1OrDie(objBytes []byte) *admissionv1.Mutat
 	}
 
 	return requiredObj.(*admissionv1.MutatingWebhookConfiguration)
+}
+
+func ReadValidatingAdmissionPolicyV1beta1OrDie(objBytes []byte) *admissionv1beta1.ValidatingAdmissionPolicy {
+	requiredObj, err := runtime.Decode(admissionCodecs.UniversalDecoder(admissionv1beta1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*admissionv1beta1.ValidatingAdmissionPolicy)
+}
+
+func ReadValidatingAdmissionPolicyBindingV1beta1OrDie(objBytes []byte) *admissionv1beta1.ValidatingAdmissionPolicyBinding {
+	requiredObj, err := runtime.Decode(admissionCodecs.UniversalDecoder(admissionv1beta1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*admissionv1beta1.ValidatingAdmissionPolicyBinding)
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -20,7 +20,7 @@ func alwaysFulfilledPreconditions() (bool, error) { return true, nil }
 
 type syncRuleSource struct {
 	ResourceLocation
-	syncedKeys               sets.String            // defines the set of keys to sync from source to dest
+	syncedKeys               sets.Set[string]       // defines the set of keys to sync from source to dest
 	preconditionsFulfilledFn preconditionsFulfilled // preconditions to fulfill before syncing the resource
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -37,7 +37,7 @@ type ResourceSyncController struct {
 	secretSyncRules syncRules
 
 	// knownNamespaces is the list of namespaces we are watching.
-	knownNamespaces sets.String
+	knownNamespaces sets.Set[string]
 
 	configMapGetter            corev1client.ConfigMapsGetter
 	secretGetter               corev1client.SecretsGetter
@@ -125,7 +125,7 @@ func (c *ResourceSyncController) syncConfigMap(destination ResourceLocation, sou
 	defer c.syncRuleLock.Unlock()
 	c.configMapSyncRules[destination] = syncRuleSource{
 		ResourceLocation:         source,
-		syncedKeys:               sets.NewString(keys...),
+		syncedKeys:               sets.New(keys...),
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
 
@@ -160,7 +160,7 @@ func (c *ResourceSyncController) syncSecret(destination, source ResourceLocation
 	defer c.syncRuleLock.Unlock()
 	c.secretSyncRules[destination] = syncRuleSource{
 		ResourceLocation:         source,
-		syncedKeys:               sets.NewString(keys...),
+		syncedKeys:               sets.New(keys...),
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/informers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/informers.go
@@ -16,7 +16,7 @@ import (
 type KubeInformersForNamespaces interface {
 	Start(stopCh <-chan struct{})
 	InformersFor(namespace string) informers.SharedInformerFactory
-	Namespaces() sets.String
+	Namespaces() sets.Set[string]
 
 	ConfigMapLister() corev1listers.ConfigMapLister
 	SecretLister() corev1listers.SecretLister
@@ -48,8 +48,8 @@ func (i kubeInformersForNamespaces) Start(stopCh <-chan struct{}) {
 	}
 }
 
-func (i kubeInformersForNamespaces) Namespaces() sets.String {
-	return sets.StringKeySet(i)
+func (i kubeInformersForNamespaces) Namespaces() sets.Set[string] {
+	return sets.KeySet(i)
 }
 func (i kubeInformersForNamespaces) InformersFor(namespace string) informers.SharedInformerFactory {
 	return i[namespace]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -982,7 +982,7 @@ github.com/openshift/client-go/operator/listers/operator/v1alpha1
 # github.com/openshift/cluster-config-operator v0.0.0-alpha.0.0.20231213185242-e4dc676febfe
 ## explicit; go 1.20
 github.com/openshift/cluster-config-operator/pkg/operator/featuregates
-# github.com/openshift/library-go v0.0.0-20240312152318-4109a9e7a437
+# github.com/openshift/library-go v0.0.0-20240412173449-eb2f24c36528
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/cloudprovider


### PR DESCRIPTION
This PR adds a new validation admission policy that guards the managed boot images configuration field in the MCO API. It only allows updates to the configuration field if the cluster is running on GCP. ValidatingAdmissionPolicy are behind a kube native feature gate, so that is checked before these new manifests are synced.

```
---
apiVersion: admissionregistration.k8s.io/v1beta1
kind: ValidatingAdmissionPolicy
metadata:
  name: "managed-bootimages-platform-check"
spec:
  failurePolicy: Fail
  paramKind:
    apiVersion: config.openshift.io/v1
    kind: Infrastructure
  matchConstraints:
    resourceRules:
    - apiGroups:   ["operator.openshift.io"]
      apiVersions: ["v1"]
      operations:  ["CREATE", "UPDATE"]
      resources:   ["MachineConfiguration"]
  validations:
    - expression: "!has(object.spec.managedBootImages) || (has(object.spec.managedBootImages) && params.status.platformStatus.type in ['GCP'])"
      message: "This feature is only supported on these platforms: GCP"
---
apiVersion: admissionregistration.k8s.io/v1beta1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: "managed-bootimages-platform-check-binding"
spec:
  policyName: "managed-bootimages-platform-check"
  validationActions: [Deny]
  paramRef:
    name: "cluster"     
    parameterNotFoundAction: "Deny"
```