### PR TITLE
OCPNODE-2216: crio: migrate metrics port to localhost only [4.17]

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -70,6 +70,7 @@ contents:
 
     [crio.metrics]
     enable_metrics = true
+    metrics_host = "127.0.0.1"
     metrics_port = 9537
     metrics_collectors = [
       "operations", # DEPRECATED: in favour of "operations_total"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -70,6 +70,7 @@ contents:
 
     [crio.metrics]
     enable_metrics = true
+    metrics_host = "127.0.0.1"
     metrics_port = 9537
     metrics_collectors = [
       "operations", # DEPRECATED: in favour of "operations_total"


### PR DESCRIPTION
Move crio metrics port to localhost only.
