### PR TITLE
OCPBUGS-18955: make sure CO degrades if OCL config is invalid

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1199,7 +1199,10 @@ func (optr *Operator) reconcileMachineOSBuilder(mob *appsv1.Deployment) error {
 		return optr.stopMachineOSBuilderDeployment(mob.Name)
 	}
 
-	// No-op if everything is in the desired state.
+	// if we are in ocb, but for some reason we dont need to do an update to the deployment, we still need to validate config
+	if len(layeredMCPs) != 0 {
+		return build.ValidateOnClusterBuildConfig(optr.kubeClient)
+	}
 	return nil
 }
 


### PR DESCRIPTION
We have handling in the build controller to error if we get invalid settings. However, there is no explicit code in the MCO to degrade if someone gives us bad settings. Something like push or pull secrets might get caught due the the objects not existing, but for some reason image builder type sneaks through.

Add a check at the end of `reconcileMachineOSBuilder` to validate the config.
