### PR TITLE
OCPBUGS-31630: fix: resources were in the wrong indentation level

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
@@ -43,10 +43,10 @@ contents:
           done
         securityContext:
           privileged: true
-      resources:
-        requests:
-          memory: 50Mi
-          cpu: 5m
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 5m
       containers:
       - name: kube-rbac-proxy-crio
         image: {{.Images.kubeRbacProxyImage}}

--- a/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
@@ -43,10 +43,10 @@ contents:
           done
         securityContext:
           privileged: true
-      resources:
-        requests:
-          memory: 50Mi
-          cpu: 5m
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 5m
       containers:
       - name: kube-rbac-proxy-crio
         image: {{.Images.kubeRbacProxyImage}}


### PR DESCRIPTION
workload partitioning ignores the init container setup, because it does not contain resources.requests due to them being in the wrong indentation level

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Correct indentation level for resources

**- How to verify it**

init container `setup` should have correct resource requests applied

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed incorrect indentation for `setup` container in pod `kube-rbac-proxy-crio` template.
