### PR TITLE
OCPBUGS-30192: Move StartLimitIntervalSec to Unit section

### DIFF
--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -6,10 +6,10 @@ contents: |
   Description=Populates resolv.conf according to on-prem IPI needs
   # Per https://issues.redhat.com/browse/OCPBUGS-27162 there is a problem if this is started before crio-wipe
   After=crio-wipe.service
+  StartLimitIntervalSec=0
   [Service]
   Type=oneshot
   Restart=on-failure
   RestartSec=10
-  StartLimitIntervalSec=0
   ExecStart=/usr/local/bin/resolv-prepender.sh
   EnvironmentFile=/run/resolv-prepender/env


### PR DESCRIPTION
This was the correct key in the wrong section. Moving it to Unit fixes the warning at start and also will hopefully fix the upgrade issue we're hitting where resolv-prepender restarts too quickly and gets stopped permanently by systemd.