### PR TITLE
MCO-1100: enable RHEL entitlements in on-cluster layering

### DIFF
--- a/pkg/controller/build/assets/buildah-build.sh
+++ b/pkg/controller/build/assets/buildah-build.sh
@@ -5,6 +5,10 @@
 # custom build pod.
 set -xeuo
 
+ETC_PKI_ENTITLEMENT_MOUNTPOINT="${ETC_PKI_ENTITLEMENT_MOUNTPOINT:-}"
+ETC_PKI_RPM_GPG_MOUNTPOINT="${ETC_PKI_RPM_GPG_MOUNTPOINT:-}"
+ETC_YUM_REPOS_D_MOUNTPOINT="${ETC_YUM_REPOS_D_MOUNTPOINT:-}"
+
 build_context="$HOME/context"
 
 # Create a directory to hold our build context.
@@ -14,12 +18,58 @@ mkdir -p "$build_context/machineconfig"
 cp /tmp/dockerfile/Dockerfile "$build_context"
 cp /tmp/machineconfig/machineconfig.json.gz "$build_context/machineconfig/"
 
-# Build our image using Buildah.
-buildah bud \
-	--storage-driver vfs \
-	--authfile="$BASE_IMAGE_PULL_CREDS" \
-	--tag "$TAG" \
-	--file="$build_context/Dockerfile" "$build_context"
+build_args=(
+	--log-level=DEBUG
+	--storage-driver vfs
+	--authfile="$BASE_IMAGE_PULL_CREDS"
+	--tag "$TAG"
+	--file="$build_context/Dockerfile"
+)
+
+mount_opts="z,rw"
+
+# If we have RHSM certs, copy them into a tempdir to avoid SELinux issues, and
+# tell Buildah about them.
+rhsm_path="/var/run/secrets/rhsm"
+if [[ -d "$rhsm_path" ]]; then
+	rhsm_certs="$(mktemp -d)"
+	cp -r -v "$rhsm_path/." "$rhsm_certs"
+	chmod -R 0755 "$rhsm_certs"
+	build_args+=("--volume=$rhsm_certs:/run/secrets/rhsm:$mount_opts")
+fi
+
+# If we have /etc/pki/entitlement certificates, commonly used with RHEL
+# entitlements, copy them into a tempdir to avoid SELinux issues, and tell
+# Buildah about them.
+if [[ -n "$ETC_PKI_ENTITLEMENT_MOUNTPOINT" ]] && [[ -d "$ETC_PKI_ENTITLEMENT_MOUNTPOINT" ]]; then
+	configs="$(mktemp -d)"
+	cp -r -v "$ETC_PKI_ENTITLEMENT_MOUNTPOINT/." "$configs"
+	chmod -R 0755 "$configs"
+	build_args+=("--volume=$configs:$ETC_PKI_ENTITLEMENT_MOUNTPOINT:$mount_opts")
+fi
+
+# If we have /etc/yum.repos.d configs, commonly used with Red Hat Satellite
+# subscriptions, copy them into a tempdir to avoid SELinux issues, and tell
+# Buildah about them.
+if [[ -n "$ETC_YUM_REPOS_D_MOUNTPOINT" ]] && [[ -d "$ETC_YUM_REPOS_D_MOUNTPOINT" ]]; then
+	configs="$(mktemp -d)"
+	cp -r -v "$ETC_YUM_REPOS_D_MOUNTPOINT/." "$configs"
+	chmod -R 0755 "$configs"
+	build_args+=("--volume=$configs:$ETC_YUM_REPOS_D_MOUNTPOINT:$mount_opts")
+fi
+
+# If we have /etc/pki/rpm-gpg configs, commonly used with Red Hat Satellite
+# subscriptions, copy them into a tempdir to avoid SELinux issues, and tell
+# Buildah about them.
+if [[ -n "$ETC_PKI_RPM_GPG_MOUNTPOINT" ]] && [[ -d "$ETC_PKI_RPM_GPG_MOUNTPOINT" ]]; then
+	configs="$(mktemp -d)"
+	cp -r -v "$ETC_PKI_RPM_GPG_MOUNTPOINT/." "$configs"
+	chmod -R 0755 "$configs"
+	build_args+=("--volume=$configs:$ETC_PKI_RPM_GPG_MOUNTPOINT:$mount_opts")
+fi
+
+# Build our image.
+buildah bud "${build_args[@]}" "$build_context"
 
 # Push our built image.
 buildah push \

--- a/test/e2e-techpreview/Containerfile.cowsay
+++ b/test/e2e-techpreview/Containerfile.cowsay
@@ -1,0 +1,9 @@
+FROM quay.io/centos/centos:stream9 AS centos
+RUN dnf install -y epel-release
+
+FROM configs AS final
+COPY --from=centos /etc/yum.repos.d /etc/yum.repos.d
+COPY --from=centos /etc/pki/rpm-gpg/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
+RUN sed -i 's/\$stream/9-stream/g' /etc/yum.repos.d/centos*.repo && \
+    rpm-ostree install cowsay && \
+		ostree container commit

--- a/test/e2e-techpreview/Containerfile.entitled
+++ b/test/e2e-techpreview/Containerfile.entitled
@@ -1,0 +1,6 @@
+FROM configs AS final
+
+RUN rm -rf /etc/rhsm-host && \
+  rpm-ostree install buildah && \
+  ln -s /run/secrets/rhsm /etc/rhsm-host && \
+  ostree container commit

--- a/test/e2e-techpreview/Containerfile.yum-repos-d
+++ b/test/e2e-techpreview/Containerfile.yum-repos-d
@@ -1,0 +1,3 @@
+FROM configs AS final
+RUN rpm-ostree install buildah && \
+	ostree container commit

--- a/test/e2e-techpreview/helpers_test.go
+++ b/test/e2e-techpreview/helpers_test.go
@@ -1,8 +1,14 @@
 package e2e_techpreview_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,10 +19,13 @@ import (
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 // Identifies a secret in the MCO namespace that has permissions to push to the ImageStream used for the test.
@@ -106,24 +115,96 @@ func createSecret(t *testing.T, cs *framework.ClientSet, secret *corev1.Secret) 
 // Copies the global pull secret from openshift-config/pull-secret into the MCO
 // namespace so that it can be used by the build processes.
 func copyGlobalPullSecret(t *testing.T, cs *framework.ClientSet) func() {
-	globalPullSecret, err := cs.CoreV1Interface.Secrets("openshift-config").Get(context.TODO(), "pull-secret", metav1.GetOptions{})
+	return cloneSecret(t, cs, "pull-secret", "openshift-config", globalPullSecretCloneName, ctrlcommon.MCONamespace)
+}
+
+// Copy the entitlement certificates into the MCO namespace. If the secrets
+// cannot be found, calls t.Skip() to skip the test.
+//
+// Registers and returns a cleanup function to remove the certificate(s) after test completion.
+func copyEntitlementCerts(t *testing.T, cs *framework.ClientSet) func() {
+	namespace := "openshift-config-managed"
+	name := "etc-pki-entitlement"
+
+	_, err := cs.CoreV1Interface.Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		return cloneSecret(t, cs, name, namespace, name, ctrlcommon.MCONamespace)
+	}
+
+	if apierrs.IsNotFound(err) {
+		t.Logf("Secret %q not found in %q, skipping test", name, namespace)
+		t.Skip()
+		return func() {}
+	}
+
+	t.Fatalf("could not get %q from %q: %s", name, namespace, err)
+	return func() {}
+}
+
+// Uses the centos stream 9 container and extracts the contents of both the
+// /etc/yum.repos.d and /etc/pki/rpm-gpg directories and injects those into a
+// ConfigMap and Secret, respectively. This is so that the build process will
+// consume those objects as part of the build process, injecting them into the
+// build context.
+func injectYumRepos(t *testing.T, cs *framework.ClientSet) func() {
+	tempDir := t.TempDir()
+
+	yumReposPath := filepath.Join(tempDir, "yum-repos-d")
+	require.NoError(t, os.MkdirAll(yumReposPath, 0o755))
+
+	centosPullspec := "quay.io/centos/centos:stream9"
+	yumReposContents := convertFilesFromContainerImageToBytesMap(t, centosPullspec, "/etc/yum.repos.d/")
+	rpmGpgContents := convertFilesFromContainerImageToBytesMap(t, centosPullspec, "/etc/pki/rpm-gpg/")
+
+	configMapCleanupFunc := createConfigMap(t, cs, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etc-yum-repos-d",
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		// Note: Even though the BuildController retrieves this ConfigMap, it only
+		// does so to determine whether or not it is present. It does not look at
+		// its contents. For that reason, we can use the BinaryData field here
+		// because the Build Pod will use its contents the same regardless of
+		// whether its string data or binary data.
+		BinaryData: yumReposContents,
+	})
+
+	secretCleanupFunc := createSecret(t, cs, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etc-pki-rpm-gpg",
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		Data: rpmGpgContents,
+	})
+
+	return makeIdempotentAndRegister(t, func() {
+		configMapCleanupFunc()
+		secretCleanupFunc()
+	})
+}
+
+// Clones a given secret from a given namespace into the MCO namespace.
+// Registers and returns a cleanup function to delete the secret upon test
+// completion.
+func cloneSecret(t *testing.T, cs *framework.ClientSet, srcName, srcNamespace, dstName, dstNamespace string) func() {
+	secret, err := cs.CoreV1Interface.Secrets(srcNamespace).Get(context.TODO(), srcName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	secretCopy := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      globalPullSecretCloneName,
-			Namespace: ctrlcommon.MCONamespace,
+			Name:      dstName,
+			Namespace: dstNamespace,
 		},
-		Data: globalPullSecret.Data,
-		Type: globalPullSecret.Type,
+		Data: secret.Data,
+		Type: secret.Type,
 	}
 
 	cleanup := createSecret(t, cs, secretCopy)
-	t.Logf("Cloned global pull secret %q into namespace %q as %q", "pull-secret", ctrlcommon.MCONamespace, secretCopy.Name)
+	t.Logf("Cloned \"%s/%s\" to \"%s/%s\"", srcNamespace, srcName, dstNamespace, dstName)
 
 	return makeIdempotentAndRegister(t, func() {
 		cleanup()
-		t.Logf("Deleted global pull secret copy %q", secretCopy.Name)
+		t.Logf("Deleted cloned secret \"%s/%s\"", dstNamespace, dstName)
 	})
 }
 
@@ -138,7 +219,9 @@ func waitForPoolToReachState(t *testing.T, cs *framework.ClientSet, poolName str
 		return condFunc(mcp), nil
 	})
 
-	require.NoError(t, err, "MachineConfigPool %q did not reach desired state", poolName)
+	if err != nil {
+		t.Fatalf("MachineConfigPool %q did not reach desired state", poolName)
+	}
 }
 
 // Registers a cleanup function, making it idempotent, and wiring up the
@@ -150,5 +233,197 @@ func makeIdempotentAndRegister(t *testing.T, cleanupFunc func()) func() {
 		}
 	})
 	t.Cleanup(out)
+	return out
+}
+
+// Determines where to write the build logs in the event of a failure.
+// ARTIFACT_DIR is a well-known env var provided by the OpenShift CI system.
+// Writing to the path in this env var will ensure that any files written to
+// that path end up in the OpenShift CI GCP bucket for later viewing.
+//
+// If this env var is not set, these files will be written to the current
+// working directory.
+func getBuildArtifactDir(t *testing.T) string {
+	artifactDir := os.Getenv("ARTIFACT_DIR")
+	if artifactDir != "" {
+		return artifactDir
+	}
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	return cwd
+}
+
+// Writes any ephemeral ConfigMaps that got created as part of the build
+// process to a file. Also writes the build pod spec.
+func writeBuildArtifactsToFiles(t *testing.T, cs *framework.ClientSet, pool *mcfgv1.MachineConfigPool) error {
+	dirPath := getBuildArtifactDir(t)
+
+	configmaps := []string{
+		"on-cluster-build-config",
+		"on-cluster-build-custom-dockerfile",
+		fmt.Sprintf("dockerfile-%s", pool.Spec.Configuration.Name),
+		fmt.Sprintf("mc-%s", pool.Spec.Configuration.Name),
+	}
+
+	for _, configmap := range configmaps {
+		if err := writeConfigMapToFile(t, cs, configmap, dirPath); err != nil {
+			return err
+		}
+	}
+
+	return writePodSpecToFile(t, cs, pool, dirPath)
+}
+
+// Writes a given ConfigMap to a file.
+func writeConfigMapToFile(t *testing.T, cs *framework.ClientSet, configmapName, dirPath string) error {
+	cm, err := cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), configmapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("could not get configmap %s: %w", configmapName, err)
+	}
+
+	out, err := yaml.Marshal(cm)
+	if err != nil {
+		return fmt.Errorf("could not marshal configmap %s to YAML: %w", configmapName, err)
+	}
+
+	filename := filepath.Join(dirPath, fmt.Sprintf("%s-%s-configmap.yaml", t.Name(), configmapName))
+	t.Logf("Writing configmap (%s) contents to %s", configmapName, filename)
+	return os.WriteFile(filename, out, 0o755)
+}
+
+// Wrttes a build pod spec to a file.
+func writePodSpecToFile(t *testing.T, cs *framework.ClientSet, pool *mcfgv1.MachineConfigPool, dirPath string) error {
+	podName := fmt.Sprintf("build-%s", pool.Spec.Configuration.Name)
+
+	pod, err := cs.CoreV1Interface.Pods(ctrlcommon.MCONamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("could not get pod %s: %w", podName, err)
+	}
+
+	out, err := yaml.Marshal(pod)
+	if err != nil {
+		return err
+	}
+
+	podFilename := filepath.Join(dirPath, fmt.Sprintf("%s-%s-pod.yaml", t.Name(), pod.Name))
+	t.Logf("Writing spec for pod %s to %s", pod.Name, podFilename)
+	return os.WriteFile(podFilename, out, 0o755)
+}
+
+// Streams the logs for all of the containers running in the build pod. The pod
+// logs can provide a valuable window into how / why a given build failed.
+func streamBuildPodLogsToFile(ctx context.Context, t *testing.T, cs *framework.ClientSet, pool *mcfgv1.MachineConfigPool) error {
+	podName := fmt.Sprintf("build-%s", pool.Spec.Configuration.Name)
+
+	pod, err := cs.CoreV1Interface.Pods(ctrlcommon.MCONamespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("could not get pod %s: %w", podName, err)
+	}
+
+	errGroup, egCtx := errgroup.WithContext(ctx)
+
+	for _, container := range pod.Spec.Containers {
+		container := container
+		pod := pod.DeepCopy()
+
+		// Because we follow the logs for each container in a build pod, this
+		// blocks the current Goroutine. So we run each log stream operation in a
+		// separate Goroutine to avoid blocking the main Goroutine.
+		errGroup.Go(func() error {
+			return streamContainerLogToFile(egCtx, t, cs, pod, container)
+		})
+	}
+
+	return errGroup.Wait()
+}
+
+// Streams the logs for a given container to a file.
+func streamContainerLogToFile(ctx context.Context, t *testing.T, cs *framework.ClientSet, pod *corev1.Pod, container corev1.Container) error {
+	dirPath := getBuildArtifactDir(t)
+
+	logger, err := cs.CoreV1Interface.Pods(ctrlcommon.MCONamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: container.Name,
+		Follow:    true,
+	}).Stream(ctx)
+
+	defer logger.Close()
+
+	if err != nil {
+		return fmt.Errorf("could not get logs for container %s in pod %s: %w", container.Name, pod.Name, err)
+	}
+
+	filename := filepath.Join(dirPath, fmt.Sprintf("%s-%s-%s.log", t.Name(), pod.Name, container.Name))
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	t.Logf("Streaming pod (%s) container (%s) logs to %s", pod.Name, container.Name, filename)
+	if _, err := io.Copy(file, logger); err != nil {
+		return fmt.Errorf("could not write pod logs to %s: %w", filename, err)
+	}
+
+	return nil
+}
+
+// Skips a given test if it is detected that the cluster is running OKD. We
+// skip these tests because they're either irrelevant for OKD or would fail.
+func skipOnOKD(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	isOKD, err := helpers.IsOKDCluster(cs)
+	require.NoError(t, err)
+
+	if isOKD {
+		t.Logf("OKD detected, skipping test %s", t.Name())
+		t.Skip()
+	}
+}
+
+// Extracts the contents of a directory within a given container to a temporary
+// directory. Next, it loads them into a bytes map keyed by filename. It does
+// not handle nested directories, so use with caution.
+func convertFilesFromContainerImageToBytesMap(t *testing.T, pullspec, containerFilepath string) map[string][]byte {
+	tempDir := t.TempDir()
+
+	path := fmt.Sprintf("%s:%s", containerFilepath, tempDir)
+	cmd := exec.Command("oc", "image", "extract", pullspec, "--path", path)
+	t.Logf("Extracting files under %q from %q to %q; running %s", containerFilepath, pullspec, tempDir, cmd.String())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	out := map[string][]byte{}
+
+	isCentosImage := strings.Contains(pullspec, "centos")
+
+	err := filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if isCentosImage {
+			contents = bytes.ReplaceAll(contents, []byte("$stream"), []byte("9-stream"))
+		}
+
+		// Replace $stream with 9-stream in any of the Centos repo content we pulled.
+		out[filepath.Base(path)] = contents
+		return nil
+	})
+
+	require.NoError(t, err)
+
 	return out
 }


### PR DESCRIPTION
**- What I did**

This adds the capability for BuildController to use the RHEL entitlement secrets to allow cluster admins to inject RHEL content into their builds that they are entitled to receive. This also allows the injection / consumption of content into `/etc/yum.repos.d` as well as `/etc/pki/rpm-gpg`. There are a few notes about the implementation that I would like to have at a higher level:

- Because we run rootless Buildah, we're more prone to running into SELinux complications. This makes it more difficult  to directly mount the contents of `/etc/yum.repos.d`, `/etc/pki/entitlement`, and `/etc/pki/rpm-gpg` directly into the build context. With that in mind, we copy everything into a series of temp directories first, and then mount those temp directories into the build context as a volume.
- We also create an `emptyDir` which is mounted into the build pod at `/home/build/.local/share/containers`. It is unclear why this is necessary, but as mentioned before, I suspect that this is due to SELinux issues.
- The e2e test suite now has the capability to stream the container logs from the build pod to the filesystem as there is useful information contained within those logs if the e2e test fails. In OpenShift CI, this location will be determined by the `ARTIFACT_DIR` env var. If this env var is not present, it will default the current directory.

**- How to verify it**

Automated verification:

1. Bring up a cluster where the secret `etc-pki-entitlement` exists in the `openshift-config-managed` namespace. If this secret is not present, `TestEntitledBuilds` and `TestEntitledBuildsRollsOutImage` will be skipped.
2. Ensure that the OnClusterBuild feature-gate is enabled. The test suite will fail immediately if the feature-gate is not enabled.
3. Run the tech preview e2e test suite: `$ go test -count=1 -v ./test/e2e-techpreview/...`

(Note: Because we have not landed https://github.com/openshift/machine-config-operator/pull/4284, the cleanup / teardown will delete the node and its underlying machine, causing the Machine API to provision a replacement node.)

Semi-manual verification:

1. Download / install [v0.0.14](https://github.com/cheesesashimi/zacks-openshift-helpers/releases/tag/v0.0.14) (or newer) of my OpenShift helpers on your local machine.
2. Bring up a cluster where the secret `etc-pki-entitlement` exists in the `openshift-config-managed` namespace.
3. Create a Dockerfile on your local machine that contains the following content:
```Dockerfile
FROM configs AS final

RUN rm -rf /etc/rhsm-host && \
  rpm-ostree install buildah && \
  ln -s /run/secrets/rhsm /etc/rhsm-host && \
  ostree container commit
```
5. With my `onclustertesting` helper in your `$PATH`, run the following: `$ onclustertesting setup in-cluster-registry --enable-featuregate --pool=layered --custom-dockerfile=./path/to/the/Dockerfile`
6. If you have not previously enabled the featuregate, my helper will enable it for you. It will cause a new MachineConfig to be created and rolled out to all of the nodes, so the build might not begin immediately. Using this flag is idempotent.
7. Watch for the `machine-os-builder` pod to start. Shortly afterward, the build pod should start. It should complete without any errors.

**- Description for the changelog**
Enables RHEL entitlements in on-cluster layering