### PR TITLE
OCPBUGS-32138: add cluster fleet evaluation support to mco

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -100,6 +100,9 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.ClientBuilder.OperatorClientOrDie(componentName),
 			ctrlctx.OperatorInformerFactory.Operator().V1().MachineConfigurations(),
 			ctrlctx.FeatureGateAccess,
+			ctrlctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
+			ctrlctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+			ctrlctx.ConfigInformerFactory.Config().V1().Nodes(),
 		)
 
 		ctrlctx.InformerFactory.Start(ctrlctx.Stop)

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -362,7 +362,7 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 	if cfg.Spec.KubeletConfig == nil || cfg.Spec.KubeletConfig.Raw == nil {
 		return nil
 	}
-	kcDecoded, err := decodeKubeletConfig(cfg.Spec.KubeletConfig.Raw)
+	kcDecoded, err := DecodeKubeletConfig(cfg.Spec.KubeletConfig.Raw)
 	if err != nil {
 		return fmt.Errorf("KubeletConfig could not be unmarshalled, err: %w", err)
 	}
@@ -418,7 +418,7 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.KubeletConfig
 	return *condition
 }
 
-func decodeKubeletConfig(data []byte) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+func DecodeKubeletConfig(data []byte) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 	config := &kubeletconfigv1beta1.KubeletConfiguration{}
 	d := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), len(data))
 	if err := d.Decode(config); err != nil {
@@ -470,7 +470,7 @@ func generateKubeletIgnFiles(kubeletConfig *mcfgv1.KubeletConfig, originalKubeCo
 	userDefinedSystemReserved := make(map[string]string)
 
 	if kubeletConfig.Spec.KubeletConfig != nil && kubeletConfig.Spec.KubeletConfig.Raw != nil {
-		specKubeletConfig, err := decodeKubeletConfig(kubeletConfig.Spec.KubeletConfig.Raw)
+		specKubeletConfig, err := DecodeKubeletConfig(kubeletConfig.Spec.KubeletConfig.Raw)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not deserialize the new Kubelet config: %w", err)
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -60,10 +60,8 @@ const (
 	defaultOpenshiftTLSSecurityProfileConfig = "apiserver.v1.config.openshift.io"
 )
 
-var (
-	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = mcfgv1.SchemeGroupVersion.WithKind("KubeletConfig")
-)
+// controllerKind contains the schema.GroupVersionKind for this controller type.
+var controllerKind = mcfgv1.SchemeGroupVersion.WithKind("KubeletConfig")
 
 var updateBackoff = wait.Backoff{
 	Steps:    5,
@@ -205,7 +203,6 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(ctrl.nodeConfigWorker, time.Second, stopCh)
-
 	}
 
 	<-stopCh
@@ -372,7 +369,7 @@ func generateOriginalKubeletConfigWithFeatureGates(cc *mcfgv1.ControllerConfig, 
 	if err != nil {
 		return nil, fmt.Errorf("could not decode the original Kubelet source string: %w", err)
 	}
-	originalKubeConfig, err := decodeKubeletConfig(contents)
+	originalKubeConfig, err := DecodeKubeletConfig(contents)
 	if err != nil {
 		return nil, fmt.Errorf("could not deserialize the Kubelet source: %w", err)
 	}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -37,9 +37,7 @@ import (
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
-var (
-	alwaysReady = func() bool { return true }
-)
+var alwaysReady = func() bool { return true }
 
 const (
 	templateDir = "../../../templates"
@@ -634,7 +632,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 
 			// Modify config
 			kcUpdate := kc1.DeepCopy()
-			kcDecoded, err := decodeKubeletConfig(kcUpdate.Spec.KubeletConfig.Raw)
+			kcDecoded, err := DecodeKubeletConfig(kcUpdate.Spec.KubeletConfig.Raw)
 			if err != nil {
 				t.Errorf("KubeletConfig could not be unmarshalled")
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -183,7 +183,6 @@ func TestBootstrapFeaturesDefault(t *testing.T) {
 func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
 		t.Run(string(platform), func(t *testing.T) {
-
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
@@ -205,7 +204,7 @@ func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
 				conf, err := ctrlcommon.DecodeIgnitionFileContents(regfile.Contents.Source, regfile.Contents.Compression)
 				require.NoError(t, err)
 
-				originalKubeConfig, err := decodeKubeletConfig(conf)
+				originalKubeConfig, err := DecodeKubeletConfig(conf)
 				require.NoError(t, err)
 
 				features := &osev1.FeatureGate{

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -34,7 +34,7 @@ func TestOriginalKubeletConfigDefaultNodeConfig(t *testing.T) {
 			}
 			contents, err := ctrlcommon.DecodeIgnitionFileContents(kubeletConfig.Contents.Source, kubeletConfig.Contents.Compression)
 			require.NoError(t, err)
-			originalKubeConfig, err := decodeKubeletConfig(contents)
+			originalKubeConfig, err := DecodeKubeletConfig(contents)
 			require.NoError(t, err)
 
 			if reflect.DeepEqual(originalKubeConfig.NodeStatusReportFrequency, metav1.Duration{osev1.DefaultNodeStatusUpdateFrequency}) {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -194,6 +194,10 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		return fmt.Errorf("error syncing metrics: %w", err)
 	}
 
+	if err := optr.syncClusterFleetEvaluation(); err != nil {
+		return fmt.Errorf("error running cluster fleet evaluation: %w", err)
+	}
+
 	if optr.inClusterBringup && syncErr.err == nil {
 		klog.Infof("Initialization complete")
 		optr.inClusterBringup = false
@@ -774,6 +778,7 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig) error {
 	}
 	return nil
 }
+
 func isApplyManifestErrorRetriable(err error) bool {
 	// Retry on brief rpc errors
 	// See https://issues.redhat.com/browse/OCPBUGS-24228 for more information.
@@ -881,7 +886,6 @@ func (optr *Operator) applyManifests(config *renderConfig, paths manifestPaths) 
 			}
 		}
 		fg, err := optr.fgAccessor.CurrentFeatureGates()
-
 		if err != nil {
 			return fmt.Errorf("could not get feature gates: %w", err)
 		}
@@ -921,7 +925,6 @@ func (optr *Operator) applyManifests(config *renderConfig, paths manifestPaths) 
 		}
 		return nil
 	})
-
 }
 
 // safetySyncControllerConfig is a special case render of the controllerconfig that we run when
@@ -954,7 +957,6 @@ func (optr *Operator) safetySyncControllerConfig(config *renderConfig) error {
 //
 //nolint:gocritic
 func (optr *Operator) syncControllerConfig(config *renderConfig) error {
-
 	ccBytes, err := renderAsset(config, "manifests/machineconfigcontroller/controllerconfig.yaml")
 	if err != nil {
 		return err


### PR DESCRIPTION
Enables ClusterFleetEvaluation logic within MCO. This PR adds flags for `failswapon`, `cgroupsv1`, and `runc`.

```
❯ oc get clusteroperators.config.openshift.io machine-config -o yaml | grep EvaluationConditionsDetected -B 3
  - lastTransitionTime: "2024-04-12T13:03:04Z"
    reason: AsExpected
    status: "False"
    type: EvaluationConditionsDetected
❯ cat worker-kube-config.yaml 
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: set-worker-kube-config
spec:
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
  kubeletConfig:
    failSwapOn: false
❯ oc create -f worker-kube-config.yaml 
❯ oc get clusteroperators.config.openshift.io machine-config -o yaml | grep EvaluationConditionsDetected -B 3
  - lastTransitionTime: "2024-04-12T13:30:03Z"
    reason: failswapon: KubeletConfig setting is currently unsupported by OpenShift
    status: "True"
    type: EvaluationConditionsDetected
❯ # Applying the cgroupsv1 Node object to the cluster results in
❯ oc get clusteroperators.config.openshift.io machine-config -o yaml | grep EvaluationConditionsDetected -B 3
  - lastTransitionTime: "2024-04-12T13:30:03Z"
    reason: cgroupsv1: support has been deprecated in favor of cgroupsv2::failswapon: KubeletConfig setting is currently unsupported by OpenShift
    status: "True"
    type: EvaluationConditionsDetected
```