### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -52,6 +52,7 @@ contents:
           mountPath: "/etc/coredns"
           mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
       containers:
       - name: coredns
         securityContext:
@@ -97,6 +98,7 @@ contents:
           requests:
             cpu: 100m
             memory: 200Mi          
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: kubeconfig
           mountPath: "/var/lib/kubelet"

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -47,6 +47,7 @@ contents:
         - "--resolvconf-path"
         - "/var/run/NetworkManager/resolv.conf"
         resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: kubeconfig
           mountPath: "/var/lib/kubelet"
@@ -110,6 +111,7 @@ contents:
           requests:
             cpu: 100m
             memory: 200Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: kubeconfig
           mountPath: "/var/lib/kubelet"

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -53,6 +53,7 @@ contents:
         - "--out-dir"
         - "/etc/keepalived"
         resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: kubeconfig
           mountPath: "/etc/kubernetes"
@@ -218,6 +219,7 @@ contents:
         - name: nodeip-configuration
           mountPath: "/run/nodeip-configuration"
           mountPropagation: HostToContainer
+        terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -38,6 +38,7 @@ contents:
         - |
           /usr/bin/curl -o /dev/null -kLfs https://api-int.{{ .DNS.Spec.BaseDomain }}:6443/healthz
         resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: chroot-host
           mountPath: "/host"

--- a/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
@@ -68,6 +68,7 @@ contents:
           requests:
             cpu: 20m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: etc-kube
           mountPath: "/etc/kubernetes"

--- a/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
@@ -68,6 +68,7 @@ contents:
           requests:
             cpu: 20m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: etc-kube
           mountPath: "/etc/kubernetes"


### PR DESCRIPTION
These appear to be static pods, but they're missing the termination failure policy, so I've updated them too.  I think I see these active on openstack.