### PR TITLE
OCPBUGS-32278: Fix configure-ip-forwarding.sh

### DIFF
--- a/templates/common/on-prem/files/configure-ip-forwarding.yaml
+++ b/templates/common/on-prem/files/configure-ip-forwarding.yaml
@@ -44,5 +44,9 @@ contents:
     iface=$(get_nodeip_hint_interface "${ip_hint_file}")
 
     echo "Node IP interface determined as: ${iface}. Enabling IP forwarding..."
-    echo "1" > /proc/sys/net/ipv4/conf/"${iface}"/forwarding
-    echo "1" > /proc/sys/net/ipv6/conf/"${iface}"/forwarding
+    file_paths=("/proc/sys/net/ipv4/conf/${iface}/forwarding" "/proc/sys/net/ipv6/conf/${iface}/forwarding")
+    for file_path in "${file_paths[@]}"; do
+        if [ -f "${file_path}" ]; then
+            echo "1" > "${file_path}"
+        fi
+    done


### PR DESCRIPTION
- Check if the file exists before appending
- In the IPv6-disabled node, the `/proc/sys/net/ipv6` path will not exist.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
