### PR TITLE
OCPBUGS-32348: Make logging configurable for on-prem components

### DIFF
--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -112,6 +112,8 @@ spec:
         value: "yes"
       - name: IS_BOOTSTRAP
         value: "yes"
+      - name: ENABLE_NODEIP_DEBUG
+        value: "true"
     command:
     - dynkeepalived
     - "/etc/kubernetes/kubeconfig"

--- a/templates/common/on-prem/files/host-networking-rbac.yaml
+++ b/templates/common/on-prem/files/host-networking-rbac.yaml
@@ -1,0 +1,45 @@
+mode: 0644
+path: "/etc/kubernetes/manifests/host-networking-rbac.yaml"
+contents:
+  inline: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: host-networking-services
+      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      annotations:
+        include.release.openshift.io/ibm-cloud-managed: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+    rules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["get", "list", "watch"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: host-networking-services
+      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      annotations:
+        include.release.openshift.io/ibm-cloud-managed: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: host-networking-services
+    subjects:
+      - kind: ServiceAccount
+        namespace: openshift-{{ onPremPlatformShortName . }}-infra
+        name: host-networking-services
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      name: host-networking-services
+      annotations:
+        include.release.openshift.io/ibm-cloud-managed: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
+        include.release.openshift.io/single-node-developer: "true"

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -76,6 +76,12 @@ contents:
         env:
           - name: NSS_SDB_USE_CACHE
             value: "no"
+          - name: DISABLE_KEEPALIVED_LOGS
+            valueFrom:
+              configMapKeyRef:
+                name: logging
+                key: disable-keepalived-logs
+                optional: true
         command:
         - /bin/bash
         - -c
@@ -140,7 +146,11 @@ contents:
 
           trap sigterm_handler SIGTERM
           if [ -s "/etc/keepalived/keepalived.conf" ]; then
-              /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+              if [ "$DISABLE_KEEPALIVED_LOGS" = true ]; then
+                /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp &
+              else
+                /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork --vrrp --log-detail --log-console &
+              fi
           fi
 
           rm -f "$keepalived_sock"
@@ -184,6 +194,12 @@ contents:
             value: "yes"
           - name: IS_BOOTSTRAP
             value: "no"
+          - name: ENABLE_NODEIP_DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: logging
+                key: enable-nodeip-debug
+                optional: true
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
It came to our attention that the default logging configuration for on-prem components is very verbose, causing some customers to overload their log storage infrastructure.

To remediate the issue we have heavily limited what is logged, but without ability to raise a level to DEBUG. With this PR we are allowing to create a ConfigMap `logging` in the respective
`openshift-$PLATFORM-infra` namespace what will accept the following data to configure the levels accordingly

```
disable-keepalived-logs: true
enable-nodeip-debug: true
```

By default no such ConfigMap exists, so that keepalived logs are enabled and Node IP logs are disabled. Creation, as described above, allows to tweak the behaviour.

Fixes: OCPBUGS-32348
Fixes: OCPBUGS-32027