### PR TITLE
OCPBUGS-32739: MachineConfigurations is only effective with name <cluster>

### DIFF
--- a/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "machine-configuration-guards"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["operator.openshift.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE","UPDATE"]
+      resources:   ["machineconfigurations"]
+  validations:
+    - expression: "object.metadata.name=='cluster'"
+      message: "Only a single object of MachineConfiguration is allowed and it must be named cluster."

--- a/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "machine-configuration-guards-binding"
+spec:
+  policyName: "machine-configuration-guards"
+  validationActions: [Deny]

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -77,17 +77,19 @@ type manifestPaths struct {
 
 const (
 	// Machine Config Controller manifest paths
-	mccClusterRoleManifestPath                              = "manifests/machineconfigcontroller/clusterrole.yaml"
-	mccEventsClusterRoleManifestPath                        = "manifests/machineconfigcontroller/events-clusterrole.yaml"
-	mccEventsRoleBindingDefaultManifestPath                 = "manifests/machineconfigcontroller/events-rolebinding-default.yaml"
-	mccEventsRoleBindingTargetManifestPath                  = "manifests/machineconfigcontroller/events-rolebinding-target.yaml"
-	mccClusterRoleBindingManifestPath                       = "manifests/machineconfigcontroller/clusterrolebinding.yaml"
-	mccServiceAccountManifestPath                           = "manifests/machineconfigcontroller/sa.yaml"
-	mccKubeRbacProxyConfigMapPath                           = "manifests/machineconfigcontroller/kube-rbac-proxy-config.yaml"
-	mccKubeRbacProxyPrometheusRolePath                      = "manifests/machineconfigcontroller/prometheus-rbac.yaml"
-	mccKubeRbacProxyPrometheusRoleBindingPath               = "manifests/machineconfigcontroller/prometheus-rolebinding-target.yaml"
-	mccUpdateBootImagesValidatingAdmissionPolicyPath        = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml"
-	mccUpdateBootImagesValidatingAdmissionPolicyBindingPath = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml"
+	mccClusterRoleManifestPath                                        = "manifests/machineconfigcontroller/clusterrole.yaml"
+	mccEventsClusterRoleManifestPath                                  = "manifests/machineconfigcontroller/events-clusterrole.yaml"
+	mccEventsRoleBindingDefaultManifestPath                           = "manifests/machineconfigcontroller/events-rolebinding-default.yaml"
+	mccEventsRoleBindingTargetManifestPath                            = "manifests/machineconfigcontroller/events-rolebinding-target.yaml"
+	mccClusterRoleBindingManifestPath                                 = "manifests/machineconfigcontroller/clusterrolebinding.yaml"
+	mccServiceAccountManifestPath                                     = "manifests/machineconfigcontroller/sa.yaml"
+	mccKubeRbacProxyConfigMapPath                                     = "manifests/machineconfigcontroller/kube-rbac-proxy-config.yaml"
+	mccKubeRbacProxyPrometheusRolePath                                = "manifests/machineconfigcontroller/prometheus-rbac.yaml"
+	mccKubeRbacProxyPrometheusRoleBindingPath                         = "manifests/machineconfigcontroller/prometheus-rolebinding-target.yaml"
+	mccMachineConfigurationGuardsValidatingAdmissionPolicyPath        = "manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml"
+	mccMachineConfigurationGuardsValidatingAdmissionPolicyBindingPath = "manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml"
+	mccUpdateBootImagesValidatingAdmissionPolicyPath                  = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml"
+	mccUpdateBootImagesValidatingAdmissionPolicyBindingPath           = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml"
 
 	// Machine OS Builder manifest paths
 	mobClusterRoleManifestPath                      = "manifests/machineosbuilder/clusterrole.yaml"
@@ -1101,9 +1103,11 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig) error {
 			mopServiceAccountManifestPath,
 		},
 		validatingAdmissionPolicies: []string{
+			mccMachineConfigurationGuardsValidatingAdmissionPolicyPath,
 			mccUpdateBootImagesValidatingAdmissionPolicyPath,
 		},
 		validatingAdmissionPolicyBindings: []string{
+			mccMachineConfigurationGuardsValidatingAdmissionPolicyBindingPath,
 			mccUpdateBootImagesValidatingAdmissionPolicyBindingPath,
 		},
 	}


### PR DESCRIPTION
This adds a new ValidatingAdmissionPolicy which rejects all MachineConfiguration objects not named "cluster".

How to test:
- Launch a cluster in TechPreview. Handy cluster bot command:
```
launch 4.16,openshift/machine-config-operator#4332 gcp,techpreview
```
If starting from default and transitioning to TechPreview, wait for the `kube-apiserver` operator to settle as this indicates that all the feature gates have been setup correctly. This can take up to 20 minutes, so I recommend the above method.
- Attempt to create a new CR of the type MachineConfiguration not named "cluster". Here is a sample object.
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
metadata:
  name: example-file
  namespace: openshift-machine-config-operator
spec:
  nodeDisruptionPolicy:
    files:
      - path: "/etc/example.sh"
        actions:
          - type: None
```
This should fail, with a message like this:
```
The machineconfigurations "example-file" is invalid: : ValidatingAdmissionPolicy 'machine-configuration-guards' with binding 'machine-configuration-guards-binding' denied request: Only a single object of MachineConfiguration is allowed and it must be named cluster.
```
This should be true for any object not named "cluster", regardless of the content.
- Now, rename the object you were trying to apply to "cluster", and try to apply it. 
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
metadata:
  name: cluster
  namespace: openshift-machine-config-operator
spec:
  nodeDisruptionPolicy:
    files:
      - path: "/etc/example.sh"
        actions:
          - type: None
```
It should succeed:
```
machineconfiguration.operator.openshift.io/cluster configured
```
