### PR TITLE
OCPBUGS-32922: [release-4.15] add cluster fleet evaluation support to mco

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -99,6 +99,9 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.ConfigInformerFactory.Config().V1().ClusterOperators(),
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1alpha1().MachineConfigNodes(),
 			ctrlctx.FeatureGateAccess,
+			ctrlctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
+			ctrlctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+			ctrlctx.ConfigInformerFactory.Config().V1().Nodes(),
 		)
 
 		ctrlctx.InformerFactory.Start(ctrlctx.Stop)

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -380,7 +380,7 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 	if cfg.Spec.KubeletConfig == nil || cfg.Spec.KubeletConfig.Raw == nil {
 		return nil
 	}
-	kcDecoded, err := decodeKubeletConfig(cfg.Spec.KubeletConfig.Raw)
+	kcDecoded, err := DecodeKubeletConfig(cfg.Spec.KubeletConfig.Raw)
 	if err != nil {
 		return fmt.Errorf("KubeletConfig could not be unmarshalled, err: %w", err)
 	}
@@ -436,7 +436,7 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.KubeletConfig
 	return *condition
 }
 
-func decodeKubeletConfig(data []byte) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+func DecodeKubeletConfig(data []byte) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 	config := &kubeletconfigv1beta1.KubeletConfiguration{}
 	d := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), len(data))
 	if err := d.Decode(config); err != nil {
@@ -488,7 +488,7 @@ func generateKubeletIgnFiles(kubeletConfig *mcfgv1.KubeletConfig, originalKubeCo
 	userDefinedSystemReserved := make(map[string]string)
 
 	if kubeletConfig.Spec.KubeletConfig != nil && kubeletConfig.Spec.KubeletConfig.Raw != nil {
-		specKubeletConfig, err := decodeKubeletConfig(kubeletConfig.Spec.KubeletConfig.Raw)
+		specKubeletConfig, err := DecodeKubeletConfig(kubeletConfig.Spec.KubeletConfig.Raw)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not deserialize the new Kubelet config: %w", err)
 		}

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -60,10 +60,8 @@ const (
 	defaultOpenshiftTLSSecurityProfileConfig = "apiserver.v1.config.openshift.io"
 )
 
-var (
-	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = mcfgv1.SchemeGroupVersion.WithKind("KubeletConfig")
-)
+// controllerKind contains the schema.GroupVersionKind for this controller type.
+var controllerKind = mcfgv1.SchemeGroupVersion.WithKind("KubeletConfig")
 
 var updateBackoff = wait.Backoff{
 	Steps:    5,
@@ -205,7 +203,6 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(ctrl.nodeConfigWorker, time.Second, stopCh)
-
 	}
 
 	<-stopCh
@@ -372,7 +369,7 @@ func generateOriginalKubeletConfigWithFeatureGates(cc *mcfgv1.ControllerConfig, 
 	if err != nil {
 		return nil, fmt.Errorf("could not decode the original Kubelet source string: %w", err)
 	}
-	originalKubeConfig, err := decodeKubeletConfig(contents)
+	originalKubeConfig, err := DecodeKubeletConfig(contents)
 	if err != nil {
 		return nil, fmt.Errorf("could not deserialize the Kubelet source: %w", err)
 	}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -37,9 +37,7 @@ import (
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
 
-var (
-	alwaysReady = func() bool { return true }
-)
+var alwaysReady = func() bool { return true }
 
 const (
 	templateDir = "../../../templates"
@@ -632,7 +630,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 
 			// Modify config
 			kcUpdate := kc1.DeepCopy()
-			kcDecoded, err := decodeKubeletConfig(kcUpdate.Spec.KubeletConfig.Raw)
+			kcDecoded, err := DecodeKubeletConfig(kcUpdate.Spec.KubeletConfig.Raw)
 			if err != nil {
 				t.Errorf("KubeletConfig could not be unmarshalled")
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -34,7 +34,7 @@ func TestFeatureGateDrift(t *testing.T) {
 			}
 			contents, err := ctrlcommon.DecodeIgnitionFileContents(kubeletConfig.Contents.Source, kubeletConfig.Contents.Compression)
 			require.NoError(t, err)
-			originalKubeConfig, err := decodeKubeletConfig(contents)
+			originalKubeConfig, err := DecodeKubeletConfig(contents)
 			require.NoError(t, err)
 
 			defaultFeatureGates, err := generateFeatureMap(fgAccess)
@@ -42,7 +42,7 @@ func TestFeatureGateDrift(t *testing.T) {
 				t.Errorf("could not generate defaultFeatureGates: %v", err)
 			}
 			if !reflect.DeepEqual(originalKubeConfig.FeatureGates, *defaultFeatureGates) {
-				var found = map[string]bool{}
+				found := map[string]bool{}
 				for featureGate := range originalKubeConfig.FeatureGates {
 					for apiGate := range *defaultFeatureGates {
 						if featureGate == apiGate {
@@ -168,7 +168,6 @@ func TestFeaturesCustomNoUpgrade(t *testing.T) {
 func TestBootstrapFeaturesDefault(t *testing.T) {
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
 		t.Run(string(platform), func(t *testing.T) {
-
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
@@ -190,7 +189,6 @@ func TestBootstrapFeaturesDefault(t *testing.T) {
 func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
 		t.Run(string(platform), func(t *testing.T) {
-
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
@@ -212,7 +210,7 @@ func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
 				conf, err := ctrlcommon.DecodeIgnitionFileContents(regfile.Contents.Source, regfile.Contents.Compression)
 				require.NoError(t, err)
 
-				originalKubeConfig, err := decodeKubeletConfig(conf)
+				originalKubeConfig, err := DecodeKubeletConfig(conf)
 				require.NoError(t, err)
 
 				fgAccess := createNewDefaultFeatureGateAccess()

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -33,7 +33,7 @@ func TestOriginalKubeletConfigDefaultNodeConfig(t *testing.T) {
 			}
 			contents, err := ctrlcommon.DecodeIgnitionFileContents(kubeletConfig.Contents.Source, kubeletConfig.Contents.Compression)
 			require.NoError(t, err)
-			originalKubeConfig, err := decodeKubeletConfig(contents)
+			originalKubeConfig, err := DecodeKubeletConfig(contents)
 			require.NoError(t, err)
 
 			if reflect.DeepEqual(originalKubeConfig.NodeStatusReportFrequency, metav1.Duration{osev1.DefaultNodeStatusUpdateFrequency}) {

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +24,7 @@ import (
 	v1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	kcc "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
 )
 
@@ -392,6 +394,135 @@ func (optr *Operator) syncMetrics() error {
 	return nil
 }
 
+func (optr *Operator) syncClusterFleetEvaluation() error {
+	co, err := optr.fetchClusterOperator()
+	if err != nil {
+		return err
+	}
+	if co == nil {
+		return nil
+	}
+
+	unexpectedEvaluations, err := optr.generateClusterFleetEvaluations()
+	if err != nil {
+		return err
+	}
+
+	status := configv1.ConditionFalse
+	reason := asExpectedReason
+	if len(unexpectedEvaluations) > 0 {
+		status = configv1.ConditionTrue
+		reason = evaluationToString(unexpectedEvaluations)
+	}
+
+	return optr.updateStatus(co, configv1.ClusterOperatorStatusCondition{
+		Type:   configv1.EvaluationConditionsDetected,
+		Status: status,
+		Reason: reason,
+	})
+}
+
+func evaluationToString(e []string) string {
+	if len(e) == 0 {
+		return ""
+	}
+	return strings.Join(e, "::")
+}
+
+// generateClusterFleetEvaluations is used to flag items where we may consider setting upgradeable=false
+// on the operator. We are also able to query telemetry for information on percentage of clusters migrated.
+func (optr *Operator) generateClusterFleetEvaluations() ([]string, error) {
+	evaluations := []string{}
+
+	enabled, err := optr.cfeEvalFailSwapOn()
+	if err != nil {
+		return evaluations, err
+	}
+	if enabled {
+		evaluations = append(evaluations, "failswapon: KubeletConfig setting is currently unsupported by OpenShift")
+	}
+
+	enabled, err = optr.cfeEvalRunc()
+	if err != nil {
+		return evaluations, err
+	}
+	if enabled {
+		evaluations = append(evaluations, "runc: transition to default crun")
+	}
+
+	enabled, err = optr.cfeEvalCgroupsV1()
+	if err != nil {
+		return evaluations, err
+	}
+	if enabled {
+		evaluations = append(evaluations, "cgroupsv1: support has been deprecated in favor of cgroupsv2")
+	}
+
+	sort.Strings(evaluations)
+
+	return evaluations, nil
+}
+
+func (optr *Operator) cfeEvalFailSwapOn() (bool, error) {
+	// check for nil so we do not have to mock within tests
+	if optr.mckLister == nil {
+		return false, nil
+	}
+	kubeletConfigs, err := optr.mckLister.List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+	for _, kubeletConfig := range kubeletConfigs {
+		if kubeletConfig.Spec.KubeletConfig == nil || kubeletConfig.Spec.KubeletConfig.Raw == nil {
+			continue
+		}
+		decodedKC, err := kcc.DecodeKubeletConfig(kubeletConfig.Spec.KubeletConfig.Raw)
+		if err != nil {
+			klog.V(2).Infof("could not decode KubeletConfig: %v", err)
+			continue
+		}
+		if decodedKC.FailSwapOn != nil && !*decodedKC.FailSwapOn {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (optr *Operator) cfeEvalRunc() (bool, error) {
+	// check for nil so we do not have to mock within tests
+	if optr.crcLister == nil {
+		return false, nil
+	}
+	containerConfigs, err := optr.crcLister.List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+	for _, containerConfig := range containerConfigs {
+		if containerConfig.Spec.ContainerRuntimeConfig == nil {
+			continue
+		}
+		if containerConfig.Spec.ContainerRuntimeConfig.DefaultRuntime == mcfgv1.ContainerRuntimeDefaultRuntimeRunc {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (optr *Operator) cfeEvalCgroupsV1() (bool, error) {
+	// check for nil so we do not have to mock within tests
+	if optr.nodeClusterLister == nil {
+		return false, nil
+	}
+	nodeClusterConfig, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return nodeClusterConfig.Spec.CgroupMode == configv1.CgroupModeV1, nil
+}
+
 // isKubeletSkewSupported checks the version skew of kube-apiserver and node kubelet version.
 // Returns the skew status. version skew > 2 is not supported.
 func (optr *Operator) isKubeletSkewSupported(pools []*v1.MachineConfigPool) (skewStatus string, coStatus configv1.ClusterOperatorStatusCondition, err error) {
@@ -548,13 +679,20 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 		return nil, err
 	}
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
-		Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
+		Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse,
+	})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
-		Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
+		Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse,
+	})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
-		Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
+		Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse,
+	})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
-		Type: configv1.OperatorUpgradeable, Status: configv1.ConditionUnknown, Reason: "NoData"})
+		Type: configv1.OperatorUpgradeable, Status: configv1.ConditionUnknown, Reason: "NoData",
+	})
+	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
+		Type: configv1.EvaluationConditionsDetected, Status: configv1.ConditionFalse, Reason: asExpectedReason,
+	})
 
 	// RelatedObjects are consumed by https://github.com/openshift/must-gather
 	co.Status.RelatedObjects = []configv1.ObjectReference{

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -191,6 +191,10 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		return fmt.Errorf("error syncing metrics: %w", err)
 	}
 
+	if err := optr.syncClusterFleetEvaluation(); err != nil {
+		return fmt.Errorf("error running cluster fleet evaluation: %w", err)
+	}
+
 	if optr.inClusterBringup && syncErr.err == nil {
 		klog.Infof("Initialization complete")
 		optr.inClusterBringup = false


### PR DESCRIPTION
Backports https://github.com/openshift/machine-config-operator/pull/4316 to 4.15.