### PR TITLE
[release-4.15] OCPBUGS-30217: Fix cloud platform bootstrap coredns.yaml

### DIFF
--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -41,16 +41,19 @@ spec:
     - "/etc/coredns"
     - "--cluster-config"
     - "/opt/openshift/manifests/cluster-config.yaml"
-  resources: {}
-  volumeMounts:
-  - name: kubeconfig
-    mountpath: "/etc/kubernetes/kubeconfig"
-  - name: resource-dir
-    mountpath: "/config"
-  - name: conf-dir
-    mountpath: "/etc/coredns"
-  - name: manifests
-    mountpath: "/opt/openshift/manifests"
+    resources: {}
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
+      mountPropagation: HostToContainer
+    - name: resource-dir
+      mountPath: "/config"
+      mountPropagation: HostToContainer
+    - name: conf-dir
+      mountPath: "/etc/coredns"
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
+      mountPropagation: HostToContainer
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns


### PR DESCRIPTION
Fixes OCPBUGS-30217. This is a manual backport of https://github.com/openshift/machine-config-operator/pull/4218 and https://github.com/openshift/machine-config-operator/pull/4238. 
This fix replaces https://github.com/openshift/machine-config-operator/pull/4237.

Can be verified by enabling `userProvisionedDNS` on GCP.