### PR TITLE
OCPBUGS-33018: pkg/daemon: logSystem the Kube API errors that trigger a re-bootstrap

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1369,6 +1369,7 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error, errCh chan er
 			// we do not want to fail on any .HandleError call. Need to only fail when it is a watcher
 			// we might want to remove this last one. We will see.
 			if dn.deferKubeletRestart && (strings.Contains(strings.ToLower(err.Error()), "failed to watch") || strings.Contains(strings.ToLower(err.Error()), "unknown authority") || strings.Contains(strings.ToLower(err.Error()), "error on the server")) {
+				logSystem("Re-bootstrapping kubelet in response to deferred kubeconfig changes and %v", err)
 				err := dn.kubeletRebootstrap(context.TODO())
 				if err != nil {
 					return err


### PR DESCRIPTION
[OCPBUGS-33018](https://issues.redhat.com/browse/OCPBUGS-33018) is wrestling with some surprise `kubeletRebootstrap` `ErrAuxiliary` 255 exits.  Once the container exits, replacement containers [crash-loop on `content mismatch for file`][2], which means that it's hard to get details about the error condition that triggered the re-bootstrap (and then exited leaving dirty disk state).  By writing the error to the system logs, we're more likely to be able to understand what went wrong, and this will help us maintain the `strings.Contains` filtering going forward.  If we notice re-bootstrap triggers that don't look like things that a re-bootstrap would help resolve, we can drop or adjust that trigger.

[2]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.16-upgrade-from-stable-4.15-e2e-metal-ipi-upgrade-ovn-ipv6/1785416317164064768/artifacts/e2e-metal-ipi-upgrade-ovn-ipv6/gather-extra/artifacts/pods/openshift-machine-config-operator_machine-config-daemon-p79jz_machine-config-daemon_previous.log
