### PR TITLE
OCPBUGS-25821,OCPBUGS-31381: certificate_writer: clean up disk-write logic

### DIFF
--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -193,7 +193,8 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							}
 							logSystem("Cert not found in kubeconfig. This means we need to write to disk. Subject is: %s", c.Subject.CommonName)
 							// these rotate randomly during upgrades. need to ignore. DO NOT restart kubelet until we error.
-							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") {
+							// TODO(jerzhang): handle this better
+							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") && !strings.Contains(c.Subject.CommonName, "kube-apiserver-lb-signer") {
 								logSystem("Need to restart kubelet")
 								dn.deferKubeletRestart = false
 							} else {


### PR DESCRIPTION
Presently it seems that the daemon sometimes doesn't react to the configmap changes, possibly due to the lexicographical comparison (which probably should have been a size?)

Change the logic a bit such that it:
1. checks for all the cert changes (adds/updates)
2. always write in from the configmap
3. still defer kubelet restarts/MCD restarts for some cases
4. do not write back to the configmap as that shouldn't be necessary