### PR TITLE
OCPBUGS-32348: Make logging configurable for on-prem components

### DIFF
--- a/install/0000_80_machine-config_03_rbac.yaml
+++ b/install/0000_80_machine-config_03_rbac.yaml
@@ -71,3 +71,84 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
   namespace: openshift-monitoring
+---
+# Role host-networking-services lets system:node read config maps. This is needed in order to allow
+# configuring log level (and in the future more parameters) of static pods deployed in the
+# openshift-*-infra namespace.
+# Because host networking components right now only run on on-prem platforms, we create RoleBinding
+# explicitly only in namespaces for OpenStack, BareMetal, vSphere and Nutanix.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: host-networking-services
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: host-networking-system-node
+  namespace: openshift-openstack-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:nodes
+roleRef:
+  kind: ClusterRole
+  name: host-networking-services
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: host-networking-system-node
+  namespace: openshift-kni-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:nodes
+roleRef:
+  kind: ClusterRole
+  name: host-networking-services
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: host-networking-system-node
+  namespace: openshift-vsphere-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:nodes
+roleRef:
+  kind: ClusterRole
+  name: host-networking-services
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: host-networking-system-node
+  namespace: openshift-nutanix-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:nodes
+roleRef:
+  kind: ClusterRole
+  name: host-networking-services

--- a/install/0000_80_machine-config_03_rbac.yaml
+++ b/install/0000_80_machine-config_03_rbac.yaml
@@ -78,9 +78,49 @@ subjects:
 # Because host networking components right now only run on on-prem platforms, we create RoleBinding
 # explicitly only in namespaces for OpenStack, BareMetal, vSphere and Nutanix.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: host-networking-services
+  namespace: openshift-openstack-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: host-networking-services
+  namespace: openshift-kni-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: host-networking-services
+  namespace: openshift-vsphere-infra
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: host-networking-services
+  namespace: openshift-nutanix-infra
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -102,7 +142,7 @@ subjects:
     kind: Group
     name: system:nodes
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: host-networking-services
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -118,7 +158,7 @@ subjects:
     kind: Group
     name: system:nodes
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: host-networking-services
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -134,7 +174,7 @@ subjects:
     kind: Group
     name: system:nodes
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: host-networking-services
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,5 +190,5 @@ subjects:
     kind: Group
     name: system:nodes
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: host-networking-services

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -112,6 +112,10 @@ spec:
         value: "yes"
       - name: IS_BOOTSTRAP
         value: "yes"
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     command:
     - dynkeepalived
     - "/etc/kubernetes/kubeconfig"

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -184,6 +184,10 @@ contents:
             value: "yes"
           - name: IS_BOOTSTRAP
             value: "no"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
This PR consists of 2 commits that together are allowing to configure logging for on-prem components (as for today, the log level of the node IP selection logic)

* OCPBUGS-32348: Mount pod namespace for on-prem components
* OCPBUGS-32348: Allow system:node read config maps in infra namespaces

The first one is self-explanatory. The second one is explained in its commit message (for ease of access, pasted below)

```
Host networking services running in on-prem platforms require access to
the config map so that their configuration can be parametrized. As those
services run as static pods, it is not possible to simply mount the
config map from the Pod yaml definition. In order to overcome this, the
respecive applications use k8s API calls to retrieve the config map at
runtime.

Credentials used by those components are `system:node` and by default
they do not have access to required config map. In order to overcome
this, we are allowing `system:node` to read config maps in the
`openshift-*-infra` namespaces.
```