### PR TITLE
OCPBUGS-30343: Scope each MCN object to only be accessible from its associated MCD

### DIFF
--- a/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "mcn-guards"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["machineconfiguration.openshift.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE","UPDATE"]
+      resources:   ["machineconfignodes/status","machineconfignodes"]
+  validations:
+    # all requests should have a node-name claim, this prevents impersonation of the machine-config-daemon SA.
+    - expression: "has(request.userInfo.extra) && ('authentication.kubernetes.io/node-name' in request.userInfo.extra)"
+      message: "this user must have a \"authentication.kubernetes.io/node-name\" claim"
+    # all requests should originate from the MCN owner's node
+    - expression: "object.metadata.name == request.userInfo.extra[\"authentication.kubernetes.io/node-name\"][0]"
+      messageExpression: "'updates to MCN ' + string(object.metadata.name) + ' can only be done from the MCN\\'s owner node'"      
+  matchConditions:
+    # Only check requests from machine-config-daemon SA, this allows all other SAs with the correct RBAC to modify MCNs.
+    - name: "check-only-machine-config-daemon-requests"
+      expression: "request.userInfo.username == 'system:serviceaccount:openshift-machine-config-operator:machine-config-daemon'"

--- a/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "mcn-guards-binding"
+spec:
+  policyName: "mcn-guards"
+  validationActions: [Deny]

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -104,18 +104,20 @@ const (
 	mobServiceAccountManifestPath                   = "manifests/machineosbuilder/sa.yaml"
 
 	// Machine Config Daemon manifest paths
-	mcdClusterRoleManifestPath                = "manifests/machineconfigdaemon/clusterrole.yaml"
-	mcdEventsClusterRoleManifestPath          = "manifests/machineconfigdaemon/events-clusterrole.yaml"
-	mcdEventsRoleBindingDefaultManifestPath   = "manifests/machineconfigdaemon/events-rolebinding-default.yaml"
-	mcdEventsRoleBindingTargetManifestPath    = "manifests/machineconfigdaemon/events-rolebinding-target.yaml"
-	mcdClusterRoleBindingManifestPath         = "manifests/machineconfigdaemon/clusterrolebinding.yaml"
-	mcdServiceAccountManifestPath             = "manifests/machineconfigdaemon/sa.yaml"
-	mcdDaemonsetManifestPath                  = "manifests/machineconfigdaemon/daemonset.yaml"
-	mcdKubeRbacProxyConfigMapPath             = "manifests/machineconfigdaemon/kube-rbac-proxy-config.yaml"
-	mcdKubeRbacProxyPrometheusRolePath        = "manifests/machineconfigdaemon/prometheus-rbac.yaml"
-	mcdKubeRbacProxyPrometheusRoleBindingPath = "manifests/machineconfigdaemon/prometheus-rolebinding-target.yaml"
-	mcdRolePath                               = "manifests/machineconfigdaemon/role.yaml"
-	mcdRoleBindingPath                        = "manifests/machineconfigdaemon/rolebinding.yaml"
+	mcdClusterRoleManifestPath                      = "manifests/machineconfigdaemon/clusterrole.yaml"
+	mcdEventsClusterRoleManifestPath                = "manifests/machineconfigdaemon/events-clusterrole.yaml"
+	mcdEventsRoleBindingDefaultManifestPath         = "manifests/machineconfigdaemon/events-rolebinding-default.yaml"
+	mcdEventsRoleBindingTargetManifestPath          = "manifests/machineconfigdaemon/events-rolebinding-target.yaml"
+	mcdClusterRoleBindingManifestPath               = "manifests/machineconfigdaemon/clusterrolebinding.yaml"
+	mcdServiceAccountManifestPath                   = "manifests/machineconfigdaemon/sa.yaml"
+	mcdDaemonsetManifestPath                        = "manifests/machineconfigdaemon/daemonset.yaml"
+	mcdKubeRbacProxyConfigMapPath                   = "manifests/machineconfigdaemon/kube-rbac-proxy-config.yaml"
+	mcdKubeRbacProxyPrometheusRolePath              = "manifests/machineconfigdaemon/prometheus-rbac.yaml"
+	mcdKubeRbacProxyPrometheusRoleBindingPath       = "manifests/machineconfigdaemon/prometheus-rolebinding-target.yaml"
+	mcdRolePath                                     = "manifests/machineconfigdaemon/role.yaml"
+	mcdRoleBindingPath                              = "manifests/machineconfigdaemon/rolebinding.yaml"
+	mcdMCNGuardValidatingAdmissionPolicyPath        = "manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml"
+	mcdMCNGuardValidatingAdmissionPolicyBindingPath = "manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicybinding.yaml"
 
 	// Machine Config Server manifest paths
 	mcsClusterRoleManifestPath                    = "manifests/machineconfigserver/clusterrole.yaml"
@@ -1358,6 +1360,12 @@ func (optr *Operator) syncMachineConfigDaemon(config *renderConfig) error {
 		},
 		configMaps: []string{
 			mcdKubeRbacProxyConfigMapPath,
+		},
+		validatingAdmissionPolicies: []string{
+			mcdMCNGuardValidatingAdmissionPolicyPath,
+		},
+		validatingAdmissionPolicyBindings: []string{
+			mcdMCNGuardValidatingAdmissionPolicyBindingPath,
 		},
 	}
 

--- a/test/e2e-techpreview/main_test.go
+++ b/test/e2e-techpreview/main_test.go
@@ -11,7 +11,7 @@ func TestMain(m *testing.M) {
 
 	// Ensure required feature gates are set.
 	// Add any new feature gates to the test here, and remove them as features are GAed.
-	helpers.MustHaveFeatureGatesEnabled("ManagedBootImages", "OnClusterBuild")
+	helpers.MustHaveFeatureGatesEnabled("ManagedBootImages", "OnClusterBuild", "MachineConfigNodes")
 
 	os.Exit(m.Run())
 }

--- a/test/e2e-techpreview/mcn_test.go
+++ b/test/e2e-techpreview/mcn_test.go
@@ -1,0 +1,55 @@
+package e2e_techpreview_test
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCNScopeSadPath(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab two random nodes from different pools, so we don't end up testing and targetting the same node.
+	nodeUnderTest := helpers.GetRandomNode(t, cs, "worker")
+	targetNode := helpers.GetRandomNode(t, cs, "master")
+
+	// Attempt to patch the MCN owned by targetNode from nodeUnderTest's MCD. This should fail.
+	// This oc command effectively use the service account of the nodeUnderTest's MCD pod, which should only be able to edit nodeUnderTest's MCN.
+	cmdOutput, err := helpers.ExecCmdOnNodeWithError(cs, nodeUnderTest, "chroot", "/rootfs", "oc", "patch", "machineconfignodes", targetNode.Name, "--type=merge", "-p", "{\"spec\":{\"configVersion\":{\"desired\":\"rendered-worker-test\"}}}")
+	require.Error(t, err, "No errors found during failure path :%v", err)
+	require.Contains(t, cmdOutput, "updates to MCN "+targetNode.Name+" can only be done from the MCN's owner node")
+}
+
+func TestMCNScopeImpersonationPath(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab a random node from the worker pool
+	nodeUnderTest := helpers.GetRandomNode(t, cs, "worker")
+
+	var errb bytes.Buffer
+	// Attempt to patch the MCN owned by nodeUnderTest by impersonating the MCD SA. This should fail.
+	cmd := exec.Command("oc", "patch", "machineconfignodes", nodeUnderTest.Name, "--type=merge", "-p", "{\"spec\":{\"configVersion\":{\"desired\":\"rendered-worker-test\"}}}", "--as=system:serviceaccount:openshift-machine-config-operator:machine-config-daemon")
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	require.Error(t, err, "No errors found during impersonation path :%v", err)
+	require.Contains(t, errb.String(), "this user must have a \"authentication.kubernetes.io/node-name\" claim")
+
+}
+
+func TestMCNScopeHappyPath(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab a random node from the worker pool
+	nodeUnderTest := helpers.GetRandomNode(t, cs, "worker")
+
+	// Attempt to patch the MCN owned by nodeUnderTest from nodeUnderTest's MCD. This should succeed.
+	// This oc command effectively use the service account of the nodeUnderTest's MCD pod, which should only be able to edit nodeUnderTest's MCN.
+	helpers.ExecCmdOnNode(t, cs, nodeUnderTest, "chroot", "/rootfs", "oc", "patch", "machineconfignodes", nodeUnderTest.Name, "--type=merge", "-p", "{\"spec\":{\"configVersion\":{\"desired\":\"rendered-worker-test\"}}}")
+}


### PR DESCRIPTION
This PR adds:
- a ValidatingAdmissionPolicy that limits the service account of a node's MCD from editing the MCN associated with another node
- tests in e2e/techpreview to verify this behavior

How to test manually:
- Launch a cluster in TechPreview
- From a random node's MCD pod, attempt to patch the MCN of another node. This should fail.
```
$ oc rsh pod/machine-config-daemon-l2wmr ./rootfs/usr/bin/oc patch  machineconfignodes/djoshy11-gwphs-worker-
b-b5r6s.c.openshift-gce-devel.internal --type=merge -p '{"spec":{"configVersion":{"desired":"rendered-worker-test"}}}'

The machineconfignodes "djoshy11-gwphs-worker-b-b5r6s.c.openshift-gce-devel.internal" is invalid: : ValidatingAdmissionPolicy 'mcn-guards' with binding 'mcn-guards-binding' denied request: MCN update request from node djoshy11-gwphs-master-0.c.openshift-gce-devel.internal rejected, updates to MCN djoshy11-gwphs-worker-b-b5r6s.c.openshift-gce-devel.internal can only be done by the machine-config-daemon running on the MCN's owner node
```

- Attempt to directly patching the MCN by impersonating the machine-config-daemon SA. This should fail.
```
$ oc patch  machineconfignodes/djoshy11-s9km2-master-0.c.openshift-gce-devel.internal --type=merge -p '{"spec":{"configVersion":{"desired":"rendered-worker-test"}}}' --as='system:serviceaccount:openshift-machine-config-operator:machine-config-daemon'

The machineconfignodes "djoshy11-s9km2-master-0.c.openshift-gce-devel.internal" is invalid: : ValidatingAdmissionPolicy 'mcn-guards' with binding 'mcn-guards-binding' denied request: this user must have a "authentication.kubernetes.io/node-name" claim
```
 
- Attempt to patch the MCN from the MCD running on its node. This should succeed, as it is on the correct node and is using the MCD SA.
``` 
$ oc rsh pod/machine-config-daemon-l2wmr ./rootfs/usr/bin/oc patch  machineconfignodes/djoshy11-gwphs-master-0.c.openshift-gce-devel.internal --type=merge -p '{"spec":{"configVersion":{"desired":"rendered-worker-test"}}}'
machineconfignode.machineconfiguration.openshift.io/djoshy11-gwphs-master-0.c.openshift-gce-devel.internal patched
```
- And last but not least, attempt to patch directly from oc using your admin SA. This should still work as normal as the VAP only applies to requests using the MCD SA.
```
$ oc patch  machineconfignodes/djoshy11-s9km2-master-0.c.openshift-gce-devel.internal --type=merge -p '{"spec":{"configVersion":{"desired":"rendered-worker-test"}}}'
machineconfignode.machineconfiguration.openshift.io/djoshy11-s9km2-master-0.c.openshift-gce-devel.internal patched
```