### PR TITLE
OKD-212: Reference `stream-coreos` instead of `centos-stream-coreos-9`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,z \
     sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for scos
-    sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
+    sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi && \
     dnf --setopt=keepcache=true -y install 'nmstate >= 2.2.10' && \
     if ! rpm -q util-linux; then dnf install --setopt=keepcache=true -y util-linux; fi
 # Copy the binaries *after* we install nmstate so we don't invalidate our cache for local builds.

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,z \
     sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then \
     # rewrite image names for scos
-    sed -i 's/rhel-coreos/centos-stream-coreos-9/g' /manifests/*; fi && \
+    sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi && \
     dnf --setopt=keepcache=true -y install 'nmstate >= 2.2.10' && \
     if ! rpm -q util-linux; then dnf install --setopt=keepcache=true -y util-linux; fi
 # Copy the binaries *after* we install nmstate so we don't invalidate our cache for local builds.

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -121,7 +121,7 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 	if version.IsFCOS() {
 		baseOSContainerImageTag = "fedora-coreos"
 	} else if version.IsSCOS() {
-		baseOSContainerImageTag = "centos-stream-coreos-9"
+		baseOSContainerImageTag = "stream-coreos"
 	}
 
 	if bootstrapOpts.imageReferences != "" {


### PR DESCRIPTION
**- What I did**
Align with the version-less-ness of `rhel-coreos` and `fedora-coreos` and shorten the overall tag.

Both tags are currently aliases, `centos-stream-coreos-9` will be removed in the future.

**- How to verify it**


**- Description for the changelog**
OKD: Reference `stream-coreos` instead of `centos-stream-coreos-9`
