### PR TITLE
OCPBUGS-31710: Unify machineconfig file format for kubeletconfig to use YAML encoding instead of JSON encoding

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
@@ -28,7 +28,7 @@ func TestRunKubeletBootstrap(t *testing.T) {
 				helpers.NewMachineConfigPool("custom", nil, customSelector, "v0"),
 			}
 
-			kcRaw, err := EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion)
+			kcRaw, err := EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
 			if err != nil {
 				panic(err)
 			}
@@ -83,25 +83,25 @@ func TestRunKubeletBootstrap(t *testing.T) {
 
 			for i := range mcs {
 				require.Equal(t, expectedMCNames[i], mcs[i].Name)
-				verifyKubeletConfigJSONContents(t, mcs[i], mcs[i].Name, cc.Spec.ReleaseImage)
+				verifyKubeletConfigYAMLContents(t, mcs[i], mcs[i].Name, cc.Spec.ReleaseImage)
 			}
 		})
 	}
 }
 
-func verifyKubeletConfigJSONContents(t *testing.T, mc *mcfgv1.MachineConfig, mcName string, releaseImageReg string) {
+func verifyKubeletConfigYAMLContents(t *testing.T, mc *mcfgv1.MachineConfig, mcName string, releaseImageReg string) {
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	require.NoError(t, err)
 	regfile := ignCfg.Storage.Files[0]
 	conf, err := ctrlcommon.DecodeIgnitionFileContents(regfile.Contents.Source, regfile.Contents.Compression)
 	require.NoError(t, err)
-	require.Contains(t, string(conf), `"maxPods": 100`)
+	require.Contains(t, string(conf), `maxPods: 100`)
 }
 
 func TestGenerateDefaultManagedKeyKubelet(t *testing.T) {
 	workerPool := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 	masterPool := helpers.NewMachineConfigPool("master", nil, helpers.WorkerSelector, "v0")
-	kcRaw, err := EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion)
+	kcRaw, err := EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -164,7 +164,7 @@ func newControllerConfig(name string, platform osev1.PlatformType) *mcfgv1.Contr
 }
 
 func newKubeletConfig(name string, kubeconf *kubeletconfigv1beta1.KubeletConfiguration, selector *metav1.LabelSelector) *mcfgv1.KubeletConfig {
-	kcRaw, err := EncodeKubeletConfig(kubeconf, kubeletconfigv1beta1.SchemeGroupVersion)
+	kcRaw, err := EncodeKubeletConfig(kubeconf, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
 	if err != nil {
 		panic(err)
 	}
@@ -637,7 +637,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 				t.Errorf("KubeletConfig could not be unmarshalled")
 			}
 			kcDecoded.MaxPods = 101
-			kcRaw, err := EncodeKubeletConfig(kcDecoded, kubeletconfigv1beta1.SchemeGroupVersion)
+			kcRaw, err := EncodeKubeletConfig(kcDecoded, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
 			if err != nil {
 				t.Errorf("KubeletConfig could not be marshalled")
 			}


### PR DESCRIPTION
…se YAML encoding instead of JSON encoding
From doc: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/controller-revision-v1/#ControllerRevision about `RawExtension`, this field holds the unpacked data in json format. So keep using json encoding for kubeletconfig for unit/e2e testing.
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
close: https://issues.redhat.com/browse/OCPBUGS-31710
**- How to verify it**
apply a kubelet config sets maxPods
```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: max-pods-worker
spec:
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
  kubeletConfig:
    maxPods: 107
```

```bash
sh-5.1# cat /etc/kubernetes/kubelet.conf
apiVersion: kubelet.config.k8s.io/v1beta1
authentication:
  anonymous:
    enabled: false
  webhook:
    cacheTTL: 0s
  x509:
    clientCAFile: /etc/kubernetes/kubelet-ca.crt
authorization:
  webhook:
    cacheAuthorizedTTL: 0s
    cacheUnauthorizedTTL: 0s
cgroupDriver: systemd
cgroupRoot: /
clusterDNS:
- 172.30.0.10
clusterDomain: cluster.local
containerLogMaxSize: 50Mi
containerRuntimeEndpoint: ""
cpuManagerReconcilePeriod: 0s
enableSystemLogQuery: true
evictionPressureTransitionPeriod: 0s
featureGates:
  AdminNetworkPolicy: true
  AlibabaPlatform: true
  AutomatedEtcdBackup: false
  AzureWorkloadIdentity: true
  BareMetalLoadBalancer: true
  BuildCSIVolumes: true
  CSIDriverSharedResource: false
  ChunkSizeMiB: false
  CloudDualStackNodeIPs: true
  ClusterAPIInstall: false
  ClusterAPIInstallAWS: true
  ClusterAPIInstallAzure: false
  ClusterAPIInstallGCP: false
  ClusterAPIInstallIBMCloud: false
  ClusterAPIInstallNutanix: true
  ClusterAPIInstallOpenStack: true
  ClusterAPIInstallPowerVS: false
  ClusterAPIInstallVSphere: true
  DNSNameResolver: false
  DisableKubeletCloudCredentialProviders: true
  DynamicResourceAllocation: false
  EtcdBackendQuota: false
  EventedPLEG: false
  Example: false
  ExternalCloudProvider: true
  ExternalCloudProviderAzure: true
  ExternalCloudProviderExternal: true
  ExternalCloudProviderGCP: true
  ExternalOIDC: false
  ExternalRouteCertificate: false
  GCPClusterHostedDNS: false
  GCPLabelsTags: false
  GatewayAPI: false
  HardwareSpeed: false
  ImagePolicy: false
  InsightsConfig: false
  InsightsConfigAPI: false
  InsightsOnDemandDataGather: false
  InstallAlternateInfrastructureAWS: false
  KMSv1: true
  MachineAPIOperatorDisableMachineHealthCheckController: false
  MachineAPIProviderOpenStack: false
  MachineConfigNodes: false
  ManagedBootImages: false
  MaxUnavailableStatefulSet: false
  MetricsCollectionProfiles: false
  MetricsServer: true
  MixedCPUsAllocation: false
  NetworkDiagnosticsConfig: true
  NetworkLiveMigration: true
  NewOLM: false
  NodeDisruptionPolicy: false
  NodeSwap: false
  OnClusterBuild: false
  OpenShiftPodSecurityAdmission: true
  PinnedImages: false
  PlatformOperators: false
  PrivateHostedZoneAWS: true
  RouteExternalCertificate: false
  ServiceAccountTokenNodeBinding: false
  ServiceAccountTokenNodeBindingValidation: false
  ServiceAccountTokenPodNodeInfo: false
  SignatureStores: false
  SigstoreImageVerification: false
  TranslateStreamCloseWebsocketRequests: false
  UpgradeStatus: false
  VSphereControlPlaneMachineSet: true
  VSphereDriverConfiguration: false
  VSphereMultiVCenters: false
  VSphereStaticIPs: true
  ValidatingAdmissionPolicy: false
  VolumeGroupSnapshot: false
fileCheckFrequency: 0s
httpCheckFrequency: 0s
imageMaximumGCAge: 0s
imageMinimumGCAge: 0s
kind: KubeletConfiguration
kubeAPIBurst: 100
kubeAPIQPS: 50
logging:
  flushFrequency: 0
  options:
    json:
      infoBufferSize: "0"
  verbosity: 0
maxPods: 107
memorySwap: {}
nodeStatusReportFrequency: 5m0s
nodeStatusUpdateFrequency: 10s
podPidsLimit: 4096
protectKernelDefaults: true
rotateCertificates: true
runtimeRequestTimeout: 0s
serializeImagePulls: false
serverTLSBootstrap: true
shutdownGracePeriod: 0s
shutdownGracePeriodCriticalPods: 0s
staticPodPath: /etc/kubernetes/manifests
streamingConnectionIdleTimeout: 0s
syncFrequency: 0s
systemCgroups: /system.slice
tlsCipherSuites:
- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
tlsMinVersion: VersionTLS12
volumeStatsAggPeriod: 0s
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
