### PR TITLE
OCPBUGS-33357: Check both ready and health ingress endpoints

### DIFF
--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -46,8 +46,16 @@ contents:
 
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
-    vrrp_script chk_ingress {
+    vrrp_script chk_ingress_ready {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        interval 1
+        weight 10
+        rise 3
+        fall 2
+    }
+
+    vrrp_script chk_ingress {
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz"
         interval 1
         rise 3
         fall 2
@@ -140,6 +148,7 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_ingress_ready
             chk_default_ingress
         }
     }

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -11,8 +11,16 @@ contents:
 
     # TODO: Improve this check. The port is assumed to be alive.
     # Need to assess what is the ramification if the port is not there.
-    vrrp_script chk_ingress {
+    vrrp_script chk_ingress_ready {
         script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        interval 1
+        weight 10
+        rise 3
+        fall 2
+    }
+
+    vrrp_script chk_ingress {
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz"
         interval 1
         rise 3
         fall 2
@@ -64,6 +72,7 @@ contents:
         }
         track_script {
             chk_ingress
+            chk_ingress_ready
             chk_default_ingress
         }
     }


### PR DESCRIPTION
Previously we were only checking the ready endpoint, which means the check script will start failing as soon as the ingress service indicates it is gracefully stopping. In some upgrade scenarios that seems to be resulting in a 30-ish second outage because we now remove the VIP from nodes without a healthy ingress. I don't fully understand how all the ingress endpoints could be down at the same time in a rolling update, but that seems to be the most likely explanation

With this change, we still have no weight set for the healthz endpoint, which means failure of that script will still cause removal of the VIP. However, a weight is included for the ready endpoint so if a node starts to gracefully shut down ingress and there are no other nodes to take the VIP, we'll leave it in place until the healthz check is also failing (at which point the ingress is no longer functional so there's nothing we can do anyway). This should minimize the outage time as much as possible.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
