### PR TITLE
[release-4.15] OCPBUGS-20152: Don't error if the certs.d dir doesn't exist yet

### DIFF
--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -137,7 +137,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		mergedData := append(controllerConfig.Spec.ImageRegistryBundleData, controllerConfig.Spec.ImageRegistryBundleUserData...)
 
 		entries, err := os.ReadDir("/etc/docker/certs.d")
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
 


### PR DESCRIPTION
When trying to read the /etc/docker/certs.d directory don't return an error if the error is that it doesn't exist. It is possible that the direcotry hasn't been created yet and that is okay.

Fixes the cert issue described in https://issues.redhat.com/browse/OCPBUGS-20152 but not the timing issue around controller config.

This issue was already fixed in 4.16 and master in this PR https://github.com/openshift/machine-config-operator/pull/4106. However, that PR consist of other major cert changes that cannot be backported at this time. So only picking the patch that fixes the certs.d not found issue.

This will need to be backported to 4.14 as well.
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a check to not error on dir doesn't exist for the /etc/docker/certs.d directory.

**- How to verify it**
This issue is reproducible on 4.15. When creating a cluster, add this to the install-config.yaml
```
capabilities:
  additionalEnabledCapabilities:
  - MachineAPI
  - CloudCredential
  baselineCapabilitySet: None
```
Once the cluster is up, check the MCD logs for this `Marking Degraded due to: open /etc/docker/certs.d: no such file or directory`. There should be none with this patch.  Example:
```
oc logs machine-config-daemon-l9hdk machine-config-daemon | grep "Marking Degraded due to: open /etc/docker/certs.d: no such file or directory"  | wc -l
0
```

If this patch is not applied, there should be many in the logs.

**- Description for the changelog**
Add a check to not error on dir doesn't exist for the /etc/docker/certs.d directory
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
