### PR TITLE
OCPBUGS-34959: ensure event handlers are registered after queue is configured

### DIFF
--- a/pkg/controller/pinnedimageset/pinned_image_set.go
+++ b/pkg/controller/pinnedimageset/pinned_image_set.go
@@ -78,19 +78,22 @@ func New(
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigcontroller-pinnedimagesetcontroller"),
 	}
 
+	ctrl.syncHandler = ctrl.syncMachineConfigPool
+	ctrl.enqueueMachineConfigPool = ctrl.enqueueDefault
+
+	// this must be done after the enqueueMachineConfigPool is configured to
+	// avoid panics when the event handler is called.
 	mcpInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ctrl.addMachineConfigPool,
 		UpdateFunc: ctrl.updateMachineConfigPool,
 		DeleteFunc: ctrl.deleteMachineConfigPool,
 	})
+
 	imageSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ctrl.addPinnedImageSet,
 		UpdateFunc: ctrl.updatePinnedImageSet,
 		DeleteFunc: ctrl.deletePinnedImageSet,
 	})
-
-	ctrl.syncHandler = ctrl.syncMachineConfigPool
-	ctrl.enqueueMachineConfigPool = ctrl.enqueueDefault
 
 	ctrl.mcpLister = mcpInformer.Lister()
 	ctrl.mcpListerSynced = mcpInformer.Informer().HasSynced

--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -166,12 +166,11 @@ func NewPinnedImageSetManager(
 		},
 	}
 
-	imageSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    p.addPinnedImageSet,
-		UpdateFunc: p.updatePinnedImageSet,
-		DeleteFunc: p.deletePinnedImageSet,
-	})
+	p.syncHandler = p.sync
+	p.enqueueMachineConfigPool = p.enqueue
 
+	// this must be done after the enqueueMachineConfigPool is configured to
+	// avoid panics when the event handler is called.
 	mcpInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    p.addMachineConfigPool,
 		UpdateFunc: p.updateMachineConfigPool,
@@ -183,8 +182,11 @@ func NewPinnedImageSetManager(
 		UpdateFunc: func(oldObj, newObj interface{}) { p.handleNodeEvent(newObj) },
 	})
 
-	p.syncHandler = p.sync
-	p.enqueueMachineConfigPool = p.enqueue
+	imageSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    p.addPinnedImageSet,
+		UpdateFunc: p.updatePinnedImageSet,
+		DeleteFunc: p.deletePinnedImageSet,
+	})
 
 	p.imageSetLister = imageSetInformer.Lister()
 	p.imageSetSynced = imageSetInformer.Informer().HasSynced


### PR DESCRIPTION
This PR addresses a race with the ordering of event handlers and queue which can result in a panic.

tests:
clusterbot: 1
e2e-vsphere-ovn-techpreview: 1
