### PR TITLE
OCPNODE-2226: Introduce versioning in auto-node-sizing feature

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -5,6 +5,8 @@ contents:
     #!/bin/bash
     set -e
     NODE_SIZES_ENV=${NODE_SIZES_ENV:-/etc/node-sizing.env}
+    NODE_AUTO_SIZING_VERSION=${NODE_AUTO_SIZING_VERSION:-1}
+    NODE_AUTO_SIZING_VERSION_FILE=${NODE_AUTO_SIZING_VERSION_FILE:-/etc/node-sizing-version.json}
     function dynamic_memory_sizing {
         total_memory=$(free -g|awk '/^Mem:/{print $2}')
         # total_memory=8 test the recommended values by modifying this value
@@ -113,6 +115,9 @@ contents:
         set_cpu $2
         set_es $3
     }
+    function create_version_file {
+        echo "{\"version\": $1}" > $2
+    }
 
     if [ $1 == "true" ]; then
         dynamic_node_sizing $4
@@ -121,4 +126,4 @@ contents:
     else
         echo "Unrecognized command line option. Valid options are \"true\" or \"false\""
     fi
-
+    create_version_file $NODE_AUTO_SIZING_VERSION $NODE_AUTO_SIZING_VERSION_FILE

--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -5,7 +5,9 @@ contents:
     #!/bin/bash
     set -e
     NODE_SIZES_ENV=${NODE_SIZES_ENV:-/etc/node-sizing.env}
-    NODE_AUTO_SIZING_VERSION=${NODE_AUTO_SIZING_VERSION:-1}
+    VERSION_1=1
+    VERSION_2=2
+    NODE_AUTO_SIZING_VERSION=${NODE_AUTO_SIZING_VERSION:-$VERSION_2}
     NODE_AUTO_SIZING_VERSION_FILE=${NODE_AUTO_SIZING_VERSION_FILE:-/etc/node-sizing-version.json}
     function dynamic_memory_sizing {
         total_memory=$(free -g|awk '/^Mem:/{print $2}')
@@ -47,30 +49,45 @@ contents:
     }
     function dynamic_cpu_sizing {
         total_cpu=$(getconf _NPROCESSORS_ONLN)
-        recommended_systemreserved_cpu=0
-        if (($total_cpu <= 1)); then # 6% of the first core
-            recommended_systemreserved_cpu=$(echo $total_cpu 0.06 | awk '{print $1 * $2}')
-            total_cpu=0
+        if [ "$1" -eq "$VERSION_1" ]; then
+            recommended_systemreserved_cpu=0
+            if (($total_cpu <= 1)); then # 6% of the first core
+                recommended_systemreserved_cpu=$(echo $total_cpu 0.06 | awk '{print $1 * $2}')
+                total_cpu=0
+            else
+                recommended_systemreserved_cpu=0.06
+                total_cpu=$((total_cpu-1))
+            fi
+            if (($total_cpu <= 1)); then # 1% of the next core (up to 2 cores)
+                recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+                total_cpu=0
+            else
+                recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
+                total_cpu=$((total_cpu-1))
+            fi
+            if (($total_cpu <= 2)); then # 0.5% of the next 2 cores (up to 4 cores)
+                recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.005 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+                total_cpu=0
+            else
+                recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
+                total_cpu=$((total_cpu-2))
+            fi
+            if (($total_cpu >= 0)); then # 0.25% of any cores above 4 cores
+                recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.0025 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+            fi
         else
-            recommended_systemreserved_cpu=0.06
-            total_cpu=$((total_cpu-1))
-        fi
-        if (($total_cpu <= 1)); then # 1% of the next core (up to 2 cores)
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_cpu=0
-        else
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
-            total_cpu=$((total_cpu-1))
-        fi
-        if (($total_cpu <= 2)); then # 0.5% of the next 2 cores (up to 4 cores)
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.005 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-            total_cpu=0
-        else
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu 0.01 | awk '{print $1 + $2}')
-            total_cpu=$((total_cpu-2))
-        fi
-        if (($total_cpu >= 0)); then # 0.25% of any cores above 4 cores
-            recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.0025 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+            # Base allocation for 1 CPU in fractions of a core (60 millicores = 0.06 CPU core)
+            base_allocation_fraction=0.06
+            # Increment per additional CPU in fractions of a core (12 millicores = 0.012 CPU core)
+            increment_per_cpu_fraction=0.012
+            if ((total_cpu > 1)); then
+                # Calculate the total system-reserved CPU in fractions, starting with the base allocation
+                # and adding the incremental fraction for each additional CPU
+                recommended_systemreserved_cpu=$(awk -v base="$base_allocation_fraction" -v increment="$increment_per_cpu_fraction" -v cpus="$total_cpu" 'BEGIN {printf "%.2f\n", base + increment * (cpus - 1)}')
+            else
+                # For a single CPU, use the base allocation
+                recommended_systemreserved_cpu=$base_allocation_fraction
+            fi
         fi
         echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}">> ${NODE_SIZES_ENV}
     }
@@ -104,7 +121,7 @@ contents:
     function dynamic_node_sizing {
         rm -f ${NODE_SIZES_ENV}
         dynamic_memory_sizing
-        dynamic_cpu_sizing
+        dynamic_cpu_sizing $2
         set_es $1
         #dynamic_ephemeral_sizing
         #dynamic_pid_sizing
@@ -118,12 +135,14 @@ contents:
     function create_version_file {
         echo "{\"version\": $1}" > $2
     }
-
+    if ! [ -f $NODE_AUTO_SIZING_VERSION_FILE ]; then
+        create_version_file $NODE_AUTO_SIZING_VERSION $NODE_AUTO_SIZING_VERSION_FILE
+    fi
+    new_version=$(jq .version $NODE_AUTO_SIZING_VERSION_FILE)
     if [ $1 == "true" ]; then
-        dynamic_node_sizing $4
+        dynamic_node_sizing $4 $new_version
     elif [ $1 == "false" ]; then
         static_node_sizing $2 $3 $4
     else
         echo "Unrecognized command line option. Valid options are \"true\" or \"false\""
     fi
-    create_version_file $NODE_AUTO_SIZING_VERSION $NODE_AUTO_SIZING_VERSION_FILE


### PR DESCRIPTION
**- What I did**
Introducing versioning for the auto-node-sizing feature
**- How to verify it**
The presence of `/etc/node-sizing-version.json` file on a node indicates the introduction of versioning in the auto node sizing feature
**- Description for the changelog**
Auto node sizing feature gives recommendations about the `kube reserved`, `system reserved` memory and cpus as described in this [enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/kubelet/kubelet-node-sizing.md)
These recommendations tend to change on a requirement basis i.e. based on the resource utilizations of system and kube, new features etc.
Hence, introduction of the versioning for this feature helps in modifying the memory, cpu values and also ease the upgrades without breaking the clusters.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
