### PR TITLE
OCPBUGS-33671, OCPBUGS-34079: fix secret canonicalization

### DIFF
--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -156,6 +156,72 @@ func TestBuildControllerMultipleOptedInPools(t *testing.T) {
 	})
 }
 
+// Tests that if multiple goroutines attempt to create or update a
+// canonicalized secret that all requests are successful.
+func TestCanonicalizedSecrets(t *testing.T) {
+	t.Parallel()
+
+	clients := getClientsForTest()
+	bc := NewWithCustomPodBuilder(BuildControllerConfig{MaxRetries: 1, UpdateDelay: testUpdateDelay}, clients)
+
+	legacyPullSecretName := "final-image-push-secret"
+
+	assertIsCanonicalSecret := func(t *testing.T, s *corev1.Secret) {
+		// We expect the returned secret to contain the canonical suffix, to have
+		// the canonical labels, and to generally be recognized as a canonical
+		// secret.
+		assert.Contains(t, s.Name, canonicalSecretSuffix)
+		assert.True(t, isCanonicalizedSecret(s))
+		assert.True(t, hasCanonicalizedSecretLabels(s))
+		assert.Equal(t, s.Labels[originalSecretNameLabel], legacyPullSecretName)
+	}
+
+	testFunc := func(t *testing.T) {
+		t.Parallel()
+
+		out, err := bc.validatePullSecret(legacyPullSecretName)
+		assert.NoError(t, err)
+
+		assertIsCanonicalSecret(t, out)
+
+		// Next, we change the original secret to validate that the canonicalized secret also gets the update.
+		secret, err := clients.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), legacyPullSecretName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		secret.Data[corev1.DockerConfigKey] = []byte(`{"updated.hostname.com": {"username": "user", "password": "s3kr1t", "auth": "s00pers3kr1t", "email": "user@hostname.com"}}`)
+
+		_, err = clients.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// We look up the secret by its canonicalized name because once
+		// BuildController canonicalizes a secret, it updates the MachineOSConfig
+		// with the canonicalized name. That means that when it is retrieved again
+		// for the next build, it is retrieved by its canonicalized name.
+		out, err = bc.validatePullSecret(legacyPullSecretName + canonicalSecretSuffix)
+		assert.NoError(t, err)
+
+		assertIsCanonicalSecret(t, out)
+		assert.Contains(t, string(out.Data[corev1.DockerConfigJsonKey]), "updated.hostname.com")
+
+		// We also query the API server for the canonical version of this secret to
+		// ensure that it is actually updated.
+		secret, err = clients.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), legacyPullSecretName+canonicalSecretSuffix, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assertIsCanonicalSecret(t, secret)
+		assert.Contains(t, string(secret.Data[corev1.DockerConfigJsonKey]), "updated.hostname.com")
+	}
+
+	// We run the test function 10 times in parallel against the same
+	// BuildController instance. Doing this simulates BuildController having to
+	// handle multiple secret canonicalization attempts, similar to if someone
+	// were to oc apply a YAML document containing at least two MachineOSConfigs
+	// which reference the same legacy pull secret.
+	for i := 0; i <= 10; i++ {
+		t.Run("", testFunc)
+	}
+}
+
 // Holds a name and function to implement a given BuildController test.
 type buildControllerTestFixture struct {
 	ctx                    context.Context
@@ -193,6 +259,27 @@ func (b *buildControllerTestFixture) runTestFuncs(t *testing.T, tf testFuncs) {
 }
 
 func (b *buildControllerTestFixture) setupClients() *Clients {
+	return getClientsForTest()
+}
+
+func (b *buildControllerTestFixture) getConfig() BuildControllerConfig {
+	return BuildControllerConfig{
+		MaxRetries:  1,
+		UpdateDelay: testUpdateDelay,
+	}
+}
+
+func (b *buildControllerTestFixture) startBuildControllerWithCustomPodBuilder() *Clients {
+	clients := b.setupClients()
+
+	ctrl := NewWithCustomPodBuilder(b.getConfig(), clients)
+
+	go ctrl.Run(b.ctx, 5)
+
+	return clients
+}
+
+func getClientsForTest() *Clients {
 	objects := newMachineConfigPoolAndConfigs("master", "rendered-master-1")
 	objects = append(objects, newMachineConfigPoolAndConfigs("worker", "rendered-worker-1")...)
 	objects = append(objects, &mcfgv1.ControllerConfig{
@@ -250,23 +337,7 @@ func (b *buildControllerTestFixture) setupClients() *Clients {
 		),
 		buildclient: fakeclientbuildv1.NewSimpleClientset(),
 	}
-}
 
-func (b *buildControllerTestFixture) getConfig() BuildControllerConfig {
-	return BuildControllerConfig{
-		MaxRetries:  1,
-		UpdateDelay: testUpdateDelay,
-	}
-}
-
-func (b *buildControllerTestFixture) startBuildControllerWithCustomPodBuilder() *Clients {
-	clients := b.setupClients()
-
-	ctrl := NewWithCustomPodBuilder(b.getConfig(), clients)
-
-	go ctrl.Run(b.ctx, 5)
-
-	return clients
 }
 
 // Helper that determines if the build is a success.

--- a/pkg/controller/build/helpers_test.go
+++ b/pkg/controller/build/helpers_test.go
@@ -160,6 +160,8 @@ func TestCanonicalizePullSecret(t *testing.T) {
 
 			if testCase.expectCanonical {
 				assert.Contains(t, out.Name, "canonical")
+				assert.True(t, isCanonicalizedSecret(out))
+				assert.True(t, hasCanonicalizedSecretLabels(out))
 			}
 
 			for _, val := range out.Data {


### PR DESCRIPTION
**- What I did**

If multiple MachineOSConfigs are created simultaneously (e.g., from multiple
YAML documents in the same file) and each of these MachineOSConfigs references
a legacy pull secret (that is, a pull secret that does not have a top-level
`{"auths": {}}` key), only one of the MachineOSBuilds that gets created will
actually get a status and begin building.

This is because multiple Goroutines will attempt to create a canonicalized
secret and only one will be able to. In the event that this occurs, the best
thing to do is to just fetch the secret and continue.

This PR also includes fixes for updating the canonicalized pull secrets. Basically, if a legacy-style pull secret is supplied and then changed, it would not be kept up-to-date. Instead, we now set a label which contains the name of the original pull secret and read the original pull secret to determine if an update is required.

**- How to verify it**

1. Bring up a 4.16+ cluster.
2. Enable the tech preview no upgrade featuregate.
3. Apply the following MachineConfigs from the same file:
```yaml
---
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
  name: pool-1
spec:
  machineConfigSelector:
    matchExpressions:
      - key: machineconfiguration.openshift.io/role
        operator: In
        values:
        - worker
        - pool-1
  nodeSelector:
    matchLabels:
      node-role.kubernetes.io/pool-1: ""
---
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
  name: pool-2
spec:
  machineConfigSelector:
    matchExpressions:
      - key: machineconfiguration.openshift.io/role
        operator: In
        values:
        - worker
        - pool-2
  nodeSelector:
    matchLabels:
      node-role.kubernetes.io/pool-2: ""
```
4. Wait for them to get a rendered MachineConfig.
5. Apply the following MachineOSConfigs from the same file:
```yaml
---
apiVersion: machineconfiguration.openshift.io/v1alpha1
kind: MachineOSConfig
metadata:
  name: pool-1
spec:
  buildInputs:
    baseImagePullSecret:
      name: global-pull-secret-copy
    containerFile:
    - containerfileArch: noarch
      content: |
        FROM configs AS final
        RUN rpm-ostree install cowsay && \
            ostree container commit
    imageBuilder:
      imageBuilderType: PodImageBuilder
    renderedImagePushSecret:
      name: builder-dockercfg-hknx6-canonical
    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/pool-1:latest
  buildOutputs:
    currentImagePullSecret:
      name: global-pull-secret-copy
  machineConfigPool:
    name: pool-1
---
apiVersion: machineconfiguration.openshift.io/v1alpha1
kind: MachineOSConfig
metadata:
  name: pool-2
spec:
  buildInputs:
    baseImagePullSecret:
      name: global-pull-secret-copy
    containerFile:
    - containerfileArch: noarch
      content: |
        FROM configs AS final
        RUN rpm-ostree install cowsay && \
            ostree container commit
    imageBuilder:
      imageBuilderType: PodImageBuilder
    renderedImagePushSecret:
      name: builder-dockercfg-hknx6-canonical
    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/pool-2:latest
  buildOutputs:
    currentImagePullSecret:
      name: global-pull-secret-copy
  machineConfigPool:
    name: pool-2
```
6. New MachineOSBuilds should be created for each MachineOSConfig and they should begin building.

**- Description for the changelog**
Fix secret canonicalization in on-cluster layering
