### PR TITLE
OCPBUGS-29067: GCP Custom-DNS: Update services that run on control plane nodes

### DIFF
--- a/templates/common/gcp/files/usr-local-bin-update-dns-server.yaml
+++ b/templates/common/gcp/files/usr-local-bin-update-dns-server.yaml
@@ -1,0 +1,25 @@
+mode: 0755
+path: "/usr/local/bin/update-dns-server"
+contents:
+  inline: |
+    #!/bin/bash
+    # For GCP, updating the NetworkManager configuration file to
+    # include the IP address of the local node as the default DNS
+    # resolver when UserProvisionedDNS is enabled.
+    # A CoreDNS static pod running on the node is responsible for
+    # resolving the api, api-int and *.apps URLs.
+
+    mkdir -p /etc/NetworkManager/conf.d
+
+    cat <<EOF | tee /etc/NetworkManager/conf.d/dns-servers.conf
+    # Added by OpenShift
+    [global-dns-domain-*]
+    servers=$(ip --json route get 8.8.8.8 | jq -r ".[0].prefsrc"),169.254.169.254
+    EOF
+
+    # network manager may already be running at this point.
+    # reload to update /etc/resolv.conf with this configuration
+    nmcli general reload conf
+    nmcli general reload dns-rc
+
+    echo "Done updating dns-server.conf"

--- a/templates/common/gcp/units/gcp-update-dns.service.yaml
+++ b/templates/common/gcp/units/gcp-update-dns.service.yaml
@@ -1,0 +1,19 @@
+name: gcp-update-dns.service
+enabled: {{if and (eq .Infra.Status.PlatformStatus.Type "GCP") (.Infra.Status.PlatformStatus.GCP) (.Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig) (eq .Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType "ClusterHosted") }}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Update Default GCP Resolver
+  # We don't need to do this on the firstboot
+  After=firstboot-osupdate.target
+  # Wait for NetworkManager to report it's online
+  After=NetworkManager-wait-online.service
+  # Run before kubelet
+  Before=kubelet-dependencies.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/usr/local/bin/update-dns-server
+
+  [Install]
+  RequiredBy=kubelet-dependencies.target

--- a/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
+++ b/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
@@ -1,5 +1,5 @@
 name: openshift-gcp-routes.service
-enabled: true
+enabled: {{if and (eq .Infra.Status.PlatformStatus.Type "GCP") (.Infra.Status.PlatformStatus.GCP) (.Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig) (eq .Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType "ClusterHosted") }}false{{else}}true{{end}}
 contents: |
   [Unit]
   Description=Update GCP routes for forwarded IPs.


### PR DESCRIPTION
<!--
Fixes OCPBUGS-29067

Please provide the following information:
-->

**- What I did**
1. Added a update-dns-server script that adds DNS servers to /etc/NetworkManager/conf.d/dns-servers.conf. This script is run as part of gcp-update-dns.service which is also added as part of this PR. This service should run when the DNSType on the GCP platform is set to "ClusterHosted".
2. The `openshift-gcp-routes` service does not need to run when DNSType is "ClusterHosted". So, enable it conditionally

**- How to verify it**
Start an IPI Install on GCP with userProvisionedDNS=true

**- Description for the changelog**
Creates a gcp-update-dns.service that updates DNS configuration when GCP's DNSType is "ClusterHosted"
Conditionally runs the `openshift-gcp-routes` service