### PR TITLE
OCPBUGS-10498: If multiple hostnames are returned, use the first one for the Node name

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
@@ -44,5 +44,5 @@ contents:
     # For compatibility with the AWS in-tree provider
     # Set node name to be instance FQDN instead of the default hostname
     cat > "${NODEENV}" <<EOF
-    KUBELET_NODE_NAME=${HOSTNAME}
+    KUBELET_NODE_NAME=${HOSTNAME%% *}
     EOF


### PR DESCRIPTION
It is possible in AWS to specify multiple hostnames as part of the VPC DHCP options. Machine API will pick both of these up and set them in the Machine status:
```
  - address: ip-10-0-91-2.huliu.test
    type: InternalDNS
  - address: ip-10-0-91-2.testa.com
    type: InternalDNS
```
CSR approval needs to match one of these against the provided hostname, and it doesn't matter which.

We will use the first of the names in the list always, so that we have a simple and consistent approach.

Tested manually, this patch trims everything after and including the first space character, eg
```
$ hostname="foo bar baz"
$ echo ${hostname}
foo bar baz
$ echo ${hostname%% *}
foo
```
