### PR TITLE
OCPBUGS-31777: Updates message verbs to use %q where appropriate

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1099,7 +1099,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 		return nil
 	}
 
-	klog.Infof("Update is reconcilable. Diff: %v", mcDiff)
+	klog.Infof("Update is reconcilable. Diff: %+v", mcDiff)
 
 	// This should be eventually de-duplicated with the update() function.
 	oldIgnConfig, err := ctrlcommon.ParseAndConvertConfig(currentConfig.Spec.Config.Raw)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2180,7 +2180,7 @@ func (dn *Daemon) writeFiles(files []ign3types.File, skipCertificateWrite bool) 
 // Ensures that both the SSH root directory (/home/core/.ssh) as well as any
 // subdirectories are created with the correct (0700) permissions.
 func createSSHKeyDir(authKeyDir string) error {
-	klog.Infof("Creating missing SSH key dir at %s", authKeyDir)
+	klog.Infof("Creating missing SSH key dir at %q", authKeyDir)
 
 	mkdir := func(dir string) error {
 		return exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", dir).Run()
@@ -2631,6 +2631,7 @@ func runCmdSync(cmdName string, args ...string) error {
 // Log a message to the systemd journal as well as our stdout
 func logSystem(format string, a ...interface{}) {
 	message := fmt.Sprintf(format, a...)
+	message = fmt.Sprintf("%q", message)
 	klog.Info(message)
 	// Since we're chrooted into the host rootfs with /run mounted,
 	// we can just talk to the journald socket.  Doing this as a

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -115,13 +115,13 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	poolName := path.Base(r.URL.Path)
 	useragent := r.Header.Get("User-Agent")
 	acceptHeader := r.Header.Get("Accept")
-	klog.Infof("Pool %s requested by address:%q User-Agent:%q Accept-Header: %q", poolName, r.RemoteAddr, useragent, acceptHeader)
+	klog.Infof("Pool %q requested by address:%q User-Agent:%q Accept-Header: %q", poolName, r.RemoteAddr, useragent, acceptHeader)
 
 	reqConfigVer, err := detectSpecVersionFromAcceptHeader(acceptHeader)
 	if err != nil {
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusBadRequest)
-		klog.Error(err)
+		klog.Error(err.Error())
 		return
 	}
 
@@ -134,7 +134,7 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusInternalServerError)
-		klog.Errorf("couldn't get config for req: %v, error: %v", cr, err)
+		klog.Errorf("couldn't get config for req: %+v, error: %v", cr, err)
 		return
 	}
 	if conf == nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This change updates the message verbs to use %q instead of %s, where appropriate, to properly escape output. This is to ensure potentially malicious input will be properly escaped.

**- How to verify it**

Read the code

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updates verbs to use %q where appropriate 

