### PR TITLE
OCL test must write secrets to the node for now

### DIFF
--- a/test/e2e-techpreview/helpers_test.go
+++ b/test/e2e-techpreview/helpers_test.go
@@ -640,3 +640,16 @@ func cloneSecret(t *testing.T, cs *framework.ClientSet, srcName, srcNamespace, d
 		t.Logf("Deleted cloned secret \"%s/%s\"", dstNamespace, dstName)
 	})
 }
+
+// Extracts the internal registry pull secret from the ControllerConfig and
+// writes it to the designated place on the nodes' filesystem. This is
+// needed to work around https://issues.redhat.com/browse/OCPBUGS-33803
+// until this bug can be resolved.
+func writeInternalRegistryPullSecretToNode(t *testing.T, cs *framework.ClientSet, node corev1.Node) func() {
+	cc, err := cs.ControllerConfigs().Get(context.TODO(), "machine-config-controller", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	path := "/etc/mco/internal-registry-pull-secret.json"
+
+	return helpers.WriteFileToNode(t, cs, node, path, string(cc.Spec.InternalRegistryPullSecret))
+}

--- a/test/e2e-techpreview/onclusterbuild_test.go
+++ b/test/e2e-techpreview/onclusterbuild_test.go
@@ -118,9 +118,14 @@ func TestOnClusterBuildRollsOutImage(t *testing.T) {
 
 	cs := framework.NewClientSet("")
 	node := helpers.GetRandomNode(t, cs, "worker")
+
 	t.Cleanup(makeIdempotentAndRegister(t, func() {
 		helpers.DeleteNodeAndMachine(t, cs, node)
 	}))
+
+	// This is needed to work around https://issues.redhat.com/browse/OCPBUGS-33803.
+	t.Cleanup(writeInternalRegistryPullSecretToNode(t, cs, node))
+
 	helpers.LabelNode(t, cs, node, helpers.MCPNameToRole(layeredMCPName))
 	helpers.WaitForNodeImageChange(t, cs, node, imagePullspec)
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -1180,3 +1180,22 @@ func validateFeatureGatesEnabled(cs *framework.ClientSet, requiredFeatureGates .
 	disabledRequiredFeatures := requiredFeatures.Difference(enabledFeatures)
 	return fmt.Errorf("missing required FeatureGate(s): %v, have: %v", sets.List(disabledRequiredFeatures), sets.List(enabledFeatures))
 }
+
+// Writes a file to a given node. Returns an idempotent cleanup function.
+func WriteFileToNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, filename, contents string) func() {
+	t.Helper()
+
+	if !strings.HasPrefix(filename, "/rootfs") {
+		filename = filepath.Join("/rootfs", filename)
+	}
+
+	bashCmd := fmt.Sprintf("printf '%s' > %s", contents, filename)
+	t.Logf("Writing file %s to node %s", filename, node.Name)
+
+	ExecCmdOnNode(t, cs, node, "/bin/bash", "-c", bashCmd)
+
+	return MakeIdempotent(func() {
+		t.Logf("Removing file %s from node %s", filename, node.Name)
+		ExecCmdOnNode(t, cs, node, "rm", filename)
+	})
+}


### PR DESCRIPTION
**- What I did**

This is a temporary workaround until https://issues.redhat.com/browse/OCPBUGS-33803 can be resolved.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
