### PR TITLE
OCPBUGS-33913: Move internal registry pull secret file management to certificatewriter

### DIFF
--- a/docs/NodeDisruptionPolicy.md
+++ b/docs/NodeDisruptionPolicy.md
@@ -42,9 +42,6 @@ status:
       files:
       - actions:
         - type: None
-        path: /etc/mco/internal-registry-pull-secret.json
-      - actions:
-        - type: None
         path: /var/lib/kubelet/config.json
       - actions:
         - reload:
@@ -105,9 +102,6 @@ status:
       - actions:
         - type: None
         path: /etc/my-file
-      - actions:
-        - type: None
-        path: /etc/mco/internal-registry-pull-secret.json
       - actions:
         - type: None
         path: /var/lib/kubelet/config.json

--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -22,14 +22,6 @@ var (
 	defaultClusterPolicies = opv1.NodeDisruptionPolicyClusterStatus{
 		Files: []opv1.NodeDisruptionPolicyStatusFile{
 			{
-				Path: "/etc/mco/internal-registry-pull-secret.json",
-				Actions: []opv1.NodeDisruptionPolicyStatusAction{
-					{
-						Type: opv1.NoneStatusAction,
-					},
-				},
-			},
-			{
 				Path: "/var/lib/kubelet/config.json",
 				Actions: []opv1.NodeDisruptionPolicyStatusAction{
 					{

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -33,8 +33,7 @@ const (
 // RenderConfig is wrapper around ControllerConfigSpec.
 type RenderConfig struct {
 	*mcfgv1.ControllerConfigSpec
-	PullSecret                 string
-	InternalRegistryPullSecret string
+	PullSecret string
 
 	// no need to set this, will be automatically configured
 	Constants map[string]string

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -84,7 +84,7 @@ func TestCloudProvider(t *testing.T) {
 				},
 			}
 
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -145,7 +145,7 @@ func TestCredentialProviderConfigFlag(t *testing.T) {
 				},
 			}
 
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -239,14 +239,14 @@ func TestInvalidPlatform(t *testing.T) {
 
 	// we must treat unrecognized constants as "none"
 	controllerConfig.Spec.Infra.Status.PlatformStatus.Type = "_bad_"
-	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, `{"dummy":"dummy"}`, nil}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
 	if err != nil {
 		t.Errorf("expect nil error, got: %v", err)
 	}
 
 	// explicitly blocked
 	controllerConfig.Spec.Infra.Status.PlatformStatus.Type = "_base"
-	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, `{"dummy":"dummy"}`, nil}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
 	expectErr(err, "failed to create MachineConfig for role master: platform _base unsupported")
 }
 
@@ -257,7 +257,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 			t.Fatalf("failed to get controllerconfig config: %v", err)
 		}
 
-		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, `{"dummy":"dummy"}`, nil}, templateDir)
+		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
 		if err != nil {
 			t.Fatalf("failed to generate machine configs: %v", err)
 		}
@@ -384,7 +384,7 @@ func TestGetPaths(t *testing.T) {
 			}
 			c.res = append(c.res, platformBase)
 
-			got := getPaths(&RenderConfig{&config.Spec, `{"dummy":"dummy"}`, `{"dummy":"dummy"}`, nil}, config.Spec.Platform)
+			got := getPaths(&RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, config.Spec.Platform)
 			if reflect.DeepEqual(got, c.res) {
 				t.Fatalf("mismatch got: %s want: %s", got, c.res)
 			}

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -557,7 +557,7 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		clusterPullSecretRaw = clusterPullSecret.Data[corev1.DockerConfigJsonKey]
 	}
 
-	mcs, err := getMachineConfigsForControllerConfig(ctrl.templatesDir, cfg, clusterPullSecretRaw, cfg.Spec.InternalRegistryPullSecret)
+	mcs, err := getMachineConfigsForControllerConfig(ctrl.templatesDir, cfg, clusterPullSecretRaw)
 	if err != nil {
 		return ctrl.syncFailingStatus(cfg, err)
 	}
@@ -576,15 +576,14 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 	return ctrl.syncCompletedStatus(cfg)
 }
 
-func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.ControllerConfig, clusterPullSecretRaw, internalRegistryPullSecretRaw []byte) ([]*mcfgv1.MachineConfig, error) {
+func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.ControllerConfig, clusterPullSecretRaw []byte) ([]*mcfgv1.MachineConfig, error) {
 	buf := &bytes.Buffer{}
 	if err := json.Compact(buf, clusterPullSecretRaw); err != nil {
 		return nil, fmt.Errorf("couldn't compact pullsecret %q: %w", string(clusterPullSecretRaw), err)
 	}
 	rc := &RenderConfig{
-		ControllerConfigSpec:       &config.Spec,
-		PullSecret:                 string(buf.Bytes()),
-		InternalRegistryPullSecret: string(internalRegistryPullSecretRaw),
+		ControllerConfigSpec: &config.Spec,
+		PullSecret:           string(buf.Bytes()),
 	}
 	mcs, err := generateTemplateMachineConfigs(rc, templatesDir)
 	if err != nil {
@@ -602,5 +601,5 @@ func getMachineConfigsForControllerConfig(templatesDir string, config *mcfgv1.Co
 
 // RunBootstrap runs the tempate controller in boostrap mode.
 func RunBootstrap(templatesDir string, config *mcfgv1.ControllerConfig, pullSecretRaw []byte) ([]*mcfgv1.MachineConfig, error) {
-	return getMachineConfigsForControllerConfig(templatesDir, config, pullSecretRaw, nil)
+	return getMachineConfigsForControllerConfig(templatesDir, config, pullSecretRaw)
 }

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -279,7 +279,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 	f.objects = append(f.objects, cc)
 	f.kubeobjects = append(f.kubeobjects, ps)
 
-	expMCs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`), nil)
+	expMCs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestDoNothing(t *testing.T) {
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
 
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`), nil)
+	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +348,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
 
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`), nil)
+	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
 
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`), nil)
+	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +407,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 		f.objects = append(f.objects, mcs[idx])
 	}
 
-	expmcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`), []byte(`{"dummy": "dummy"}`))
+	expmcs, err := getMachineConfigsForControllerConfig(templateDir, cc, []byte(`{"dummy": "dummy"}`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -122,6 +122,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		cloudCA := controllerConfig.Spec.CloudProviderCAData
 		pathToData[caBundleFilePath] = kubeAPIServerServingCABytes
 		pathToData[cloudCABundleFilePath] = cloudCA
+		pathToData[imageRegistryAuthFile] = controllerConfig.Spec.InternalRegistryPullSecret
 		var err error
 		var cm *corev1.ConfigMap
 		var fullCA []string

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -569,7 +569,6 @@ func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newC
 func calculatePostConfigChangeActionFromMCDiffs(diffFileSet []string) (actions []string) {
 	filesPostConfigChangeActionNone := []string{
 		caBundleFilePath,
-		imageRegistryAuthFile,
 		"/var/lib/kubelet/config.json",
 	}
 	directoriesPostConfigChangeActionNone := []string{

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1932,7 +1932,9 @@ func (optr *Operator) getImageRegistryPullSecrets() ([]byte, error) {
 			return nil, fmt.Errorf("failed to retrieve image pull secret %s: %w", imagePullSecret.Name, err)
 		}
 		// merge the secret into the JSON map
-		ctrlcommon.MergeDockerConfigstoJSONMap(secret.Data[corev1.DockerConfigKey], dockerConfigJSON.Auths)
+		if err := ctrlcommon.MergeDockerConfigstoJSONMap(secret.Data[corev1.DockerConfigKey], dockerConfigJSON.Auths); err != nil {
+			return nil, fmt.Errorf("could not merge auths from secret %s: %w", imagePullSecret.Name, err)
+		}
 	}
 
 	// Fetch the cluster pull secret

--- a/test/e2e-techpreview/helpers_test.go
+++ b/test/e2e-techpreview/helpers_test.go
@@ -640,16 +640,3 @@ func cloneSecret(t *testing.T, cs *framework.ClientSet, srcName, srcNamespace, d
 		t.Logf("Deleted cloned secret \"%s/%s\"", dstNamespace, dstName)
 	})
 }
-
-// Extracts the internal registry pull secret from the ControllerConfig and
-// writes it to the designated place on the nodes' filesystem. This is
-// needed to work around https://issues.redhat.com/browse/OCPBUGS-33803
-// until this bug can be resolved.
-func writeInternalRegistryPullSecretToNode(t *testing.T, cs *framework.ClientSet, node corev1.Node) func() {
-	cc, err := cs.ControllerConfigs().Get(context.TODO(), "machine-config-controller", metav1.GetOptions{})
-	require.NoError(t, err)
-
-	path := "/etc/mco/internal-registry-pull-secret.json"
-
-	return helpers.WriteFileToNode(t, cs, node, path, string(cc.Spec.InternalRegistryPullSecret))
-}

--- a/test/e2e-techpreview/onclusterbuild_test.go
+++ b/test/e2e-techpreview/onclusterbuild_test.go
@@ -123,9 +123,6 @@ func TestOnClusterBuildRollsOutImage(t *testing.T) {
 		helpers.DeleteNodeAndMachine(t, cs, node)
 	}))
 
-	// This is needed to work around https://issues.redhat.com/browse/OCPBUGS-33803.
-	t.Cleanup(writeInternalRegistryPullSecretToNode(t, cs, node))
-
 	helpers.LabelNode(t, cs, node, helpers.MCPNameToRole(layeredMCPName))
 	helpers.WaitForNodeImageChange(t, cs, node, imagePullspec)
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -1199,3 +1199,60 @@ func WriteFileToNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, fi
 		ExecCmdOnNode(t, cs, node, "rm", filename)
 	})
 }
+
+// Polls the ControllerConfig and calls the provided condition function with
+// the ControllerConfig to determine if the ControllerConfig has reached the
+// expected state.
+func AssertControllerConfigReachesExpectedState(t *testing.T, cs *framework.ClientSet, condFunc func(*mcfgv1.ControllerConfig) bool) {
+	t.Helper()
+
+	start := time.Now()
+	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 5*time.Minute, true, func(pCtx context.Context) (bool, error) {
+		cc, err := cs.ControllerConfigs().Get(pCtx, "machine-config-controller", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		return condFunc(cc), nil
+	})
+
+	require.NoError(t, err, "ControllerConfig failed to reach expected state")
+	t.Logf("ControllerConfig reached expected state in %v", time.Since(start))
+}
+
+// Polls all of the nodes and calls the provided condition function with each
+// node to determine if the ControllerConfig has reached the expected state.
+// Once the node has reached the expected state, it is skipped over for future
+// iterations.
+func AssertAllNodesReachExpectedState(t *testing.T, cs *framework.ClientSet, condFunc func(corev1.Node) bool) {
+	t.Helper()
+
+	nodeList, err := cs.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	nodes := sets.New[string]()
+	for _, node := range nodeList.Items {
+		nodes.Insert(node.Name)
+	}
+
+	nodesWithDesiredConfig := sets.New[string]()
+
+	start := time.Now()
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 5*time.Minute, true, func(_ context.Context) (bool, error) {
+		for _, node := range nodeList.Items {
+			if nodesWithDesiredConfig.Has(node.Name) {
+				continue
+			}
+
+			if condFunc(node) {
+				nodesWithDesiredConfig.Insert(node.Name)
+				t.Logf("Node %s reached desired state in %v", node.Name, time.Since(start))
+			}
+		}
+
+		return nodes.Equal(nodesWithDesiredConfig), nil
+	})
+
+	require.NoError(t, err, "%d nodes %v failed to reach desired state", nodes.Len()-nodesWithDesiredConfig.Len(), nodes.Difference(nodesWithDesiredConfig).UnsortedList())
+
+	t.Logf("All nodes reached desired state in %v", time.Since(start))
+}


### PR DESCRIPTION
**- What I did**

This moves management of the `/etc/mco/internal-registry-pull-secret.json` file
from MachineConfigs to the certificatewriter mechanism. The reason for this is
because it seems that the `machine-os-puller` serviceaccount rotates its pull
secret every ~60 minutes or so. If this is handled via MachineConfigs, it can
be a disruptive update. Instead, we already have the certificatewriter
mechanism which writes certain files on the node in response to changes to the
ControllerConfig object. 

**- How to verify it**

1. Bring up a cluster.
2. There should be no `/etc/mco/internal-registry-pull-secret.json` file present in any of the rendered MachineConfigs.
3. The `/etc/mco/internal-registry-pull-secret.json` file should be present on each node and its contents should match the `.spec.internalRegistryPullSecret` field on the ControllerConfig.
4. Run the e2e-techpreview test suite to ensure that on-cluster layering is still able to roll out new images.

**- Description for the changelog**
Move internal registry pull secret file management to certificatewriter
