### PR TITLE
OCPBUGS-32367: The MCD can override a restart crio action with a reload crio action

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -591,12 +591,13 @@ func calculatePostConfigChangeActionFromMCDiffs(diffFileSet []string) (actions [
 	for _, path := range diffFileSet {
 		if ctrlcommon.InSlice(path, filesPostConfigChangeActionNone) {
 			continue
-		} else if ctrlcommon.InSlice(path, filesPostConfigChangeActionReloadCrio) {
-			actions = []string{postConfigChangeActionReloadCrio}
+		} else if ctrlcommon.InSlice(path, filesPostConfigChangeActionReloadCrio) || ctrlcommon.InSlice(filepath.Dir(path), dirsPostConfigChangeActionReloadCrio) {
+			// Don't override a restart CRIO action
+			if !ctrlcommon.InSlice(postConfigChangeActionRestartCrio, actions) {
+				actions = []string{postConfigChangeActionReloadCrio}
+			}
 		} else if ctrlcommon.InSlice(path, filesPostConfigChangeActionRestartCrio) {
 			actions = []string{postConfigChangeActionRestartCrio}
-		} else if ctrlcommon.InSlice(filepath.Dir(path), dirsPostConfigChangeActionReloadCrio) {
-			actions = []string{postConfigChangeActionReloadCrio}
 		} else if ctrlcommon.InSlice(filepath.Dir(path), directoriesPostConfigChangeActionNone) {
 			continue
 		} else {


### PR DESCRIPTION
**- What I did**
Added an additional check in  `calculatePostConfigChangeActionFromMCDiffs` within the daemon so that a crio reload would not override a crio restart action that was already queued. Also added a couple of unit tests that verified this behavior.

**- How to verify it**
On a cluster without these patch, apply a MachineConfig with changes that would cause both these actions, with the crio reload file later in the new config. Here is a sample:
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: infra
  name:  109-test-file
spec:
  config:
    ignition:
      version: 3.4.0
    storage:
      files:
      - contents:
          source: data:,MCO%20test%20file%20permissions%0A
        path: /etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt
      - contents:
          source: data:,MCO%20test%20file%20permissions%0A
        path: /etc/machine-config-daemon/no-reboot/containers-gpg.pub
```

A crio reload will take place, you can verify by looking at daemon logs:
```
I0520 20:38:19.236636    2631 update.go:2595] Running: systemctl reload crio
I0520 20:38:19.255181    2631 update.go:2610] crio config reloaded successfully! Desired config rendered-infra-file-205a40f349dfd056969c64f53dff95d4 has been applied, skipping reboot
```
Now attempt the same MachineConfig on a cluster with this patch. This should result in a crio restart:
```
I0521 13:52:17.076919    2328 update.go:2596] Running: systemctl restart crio
I0521 13:52:17.783622    2328 update.go:2611] crio config restarted successfully! Desired config rendered-infra-file-0beaebbfc1f673abb97d95464cfdc32a has been applied, skipping reboot
```

 

