### PR TITLE
OCPBUGS-28653: userCA and cloudCA certfiicates are not removed from nodes and ignition config

### DIFF
--- a/lib/resourceapply/machineconfig.go
+++ b/lib/resourceapply/machineconfig.go
@@ -13,6 +13,7 @@ import (
 	mcoResourceMerge "github.com/openshift/machine-config-operator/lib/resourcemerge"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 // ApplyMachineConfig applies the required machineconfig to the cluster.
@@ -80,21 +81,32 @@ func ApplyMachineConfigNode(client mcfgclientalphav1.MachineConfigNodesGetter, r
 
 // ApplyControllerConfig applies the required machineconfig to the cluster.
 func ApplyControllerConfig(client mcfgclientv1.ControllerConfigsGetter, required *mcfgv1.ControllerConfig) (*mcfgv1.ControllerConfig, bool, error) {
+	klog.V(4).Infof("Getting existing ControllerConfig with name: %s", required.GetName())
 	existing, err := client.ControllerConfigs().Get(context.TODO(), required.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
+		klog.Info("ControllerConfig not found, creating new one")
 		actual, err := client.ControllerConfigs().Create(context.TODO(), required, metav1.CreateOptions{})
+		if err != nil {
+			klog.Errorf("Failed to create ControllerConfig: %v", err)
+		}
 		return actual, true, err
 	}
 	if err != nil {
+		klog.Errorf("Error fetching ControllerConfig: %v", err)
 		return nil, false, err
 	}
 
 	modified := resourcemerge.BoolPtr(false)
 	mcoResourceMerge.EnsureControllerConfig(modified, existing, *required)
 	if !*modified {
+		klog.V(4).Info("No updates required for the ControllerConfig")
 		return existing, false, nil
 	}
 
+	klog.V(4).Info("Updating existing ControllerConfig")
 	actual, err := client.ControllerConfigs().Update(context.TODO(), existing, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("Failed to update ControllerConfig: %v", err)
+	}
 	return actual, true, err
 }

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -1,15 +1,25 @@
 package resourcemerge
 
 import (
+	"bytes"
+
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 )
 
 func setBytesIfSet(modified *bool, existing *[]byte, required []byte) {
+	// Check if the current required bytes are empty
 	if len(required) == 0 {
+		// If existing is not already empty, update it and set modified to true
+		if len(*existing) != 0 {
+			*existing = nil
+			*modified = true
+		}
 		return
 	}
-	if string(required) != string(*existing) {
-		*existing = required
+	// Update only if there is a change in the content
+	if !bytes.Equal(*existing, required) {
+		*existing = make([]byte, len(required))
+		copy(*existing, required)
 		*modified = true
 	}
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #28653"

Please provide the following information:
-->

**- What I did**
Fixed function setBytesIfSet to correctly remove certificate data from controller config, which now correctly reflects onto node contents

**- How to verify it**
-apply certs
`oc create cm cm-test-cert -n openshift-config --from-file=ca-bundle.crt`

`oc patch proxy/cluster --type merge -p '{"spec": {"trustedCA": {"name": "cm-test-cert"}}}'`

`oc set data -n openshift-config ConfigMap cloud-provider-config  --from-file=ca-bundle.pem=ca-bundle.crt`

-inspect controller config
`oc describe controllerconfig machine-config-controller | head -n 150`

-check node contents
`oc debug -q  node/$(oc get nodes -l node-role.kubernetes.io/worker -ojsonpath="{.items[0].metadata.name}") -- chroot /host cat "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"`

`oc debug -q  node/$(oc get nodes -l node-role.kubernetes.io/worker -ojsonpath="{.items[0].metadata.name}") -- chroot /host cat "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem" `

-remove certs
`oc patch proxy/cluster --type merge -p '{"spec": {"trustedCA": {"name": ""}}}'`

`oc edit  -n openshift-config ConfigMap cloud-provider-config`

-inspect controller config to verify
`oc describe controllerconfig machine-config-controller | head -n 150`

-check node contents to verify 
`oc debug -q  node/$(oc get nodes -l node-role.kubernetes.io/worker -ojsonpath="{.items[0].metadata.name}") -- chroot /host cat "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"`

`oc debug -q  node/$(oc get nodes -l node-role.kubernetes.io/worker -ojsonpath="{.items[0].metadata.name}") -- chroot /host cat "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem" `

*NOTE* apparently the openshift-config-user-ca-bundle.crt was changed to be modified via machine config. This deletion from the node is not produced from altering the config map.

*ALSO* i needed to delete the machine config operator pod every time between adding and removing certs to be reflected. im not sure if this is intended functionality.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
