### PR TITLE
OCPBUGS-37840: [release-4.16] Introduce versioning for Auto Node Sizing feature

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -5,6 +5,8 @@ contents:
     #!/bin/bash
     set -e
     NODE_SIZES_ENV=${NODE_SIZES_ENV:-/etc/node-sizing.env}
+    NODE_AUTO_SIZING_VERSION=${NODE_AUTO_SIZING_VERSION:-1}
+    NODE_AUTO_SIZING_VERSION_FILE=${NODE_AUTO_SIZING_VERSION_FILE:-/etc/node-sizing-version.json}
     function dynamic_memory_sizing {
         total_memory=$(free -g|awk '/^Mem:/{print $2}')
         # total_memory=8 test the recommended values by modifying this value
@@ -113,6 +115,9 @@ contents:
         set_cpu $2
         set_es $3
     }
+    function create_version_file {
+        echo "{\"version\": $1}" > $2
+    }
 
     if [ $1 == "true" ]; then
         dynamic_node_sizing $4
@@ -121,4 +126,4 @@ contents:
     else
         echo "Unrecognized command line option. Valid options are \"true\" or \"false\""
     fi
-
+    create_version_file $NODE_AUTO_SIZING_VERSION $NODE_AUTO_SIZING_VERSION_FILE


### PR DESCRIPTION
- What I did
Introducing versioning for the auto-node-sizing feature
- How to verify it
The presence of /etc/node-sizing-version.json file on a node indicates the introduction of versioning in the auto node sizing feature
- Description for the changelog
Auto node sizing feature gives recommendations about the kube reserved, system reserved memory and cpus as described in this [enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/kubelet/kubelet-node-sizing.md)
These recommendations tend to change on a requirement basis i.e. based on the resource utilizations of system and kube, new features etc.
Hence, introduction of the versioning for this feature helps in modifying the memory, cpu values and also ease the upgrades without breaking the clusters.