### PR TITLE
OCPBUGS-17658: Controller pod is spamming unknown field "spec.dns.spec.platform" message

### DIFF
--- a/manifests/controllerconfig.crd.yaml
+++ b/manifests/controllerconfig.crd.yaml
@@ -101,6 +101,47 @@ spec:
                           an API server DNS record may be created for `cluster-api.openshift.example.com`.
                           \n Once set, this field cannot be changed."
                         type: string
+                      platform:
+                        description: platform holds configuration specific to the underlying infrastructure provider for DNS. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
+                        type: object
+                        required:
+                          - type
+                        properties:
+                          aws:
+                            description: aws contains DNS configuration specific to the Amazon Web Services cloud provider.
+                            type: object
+                            properties:
+                              privateZoneIAMRole:
+                                description: privateZoneIAMRole contains the ARN of an IAM role that should be assumed when performing operations on the cluster's private hosted zone specified in the cluster DNS config. When left empty, no role should be assumed.
+                                type: string
+                                pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                          type:
+                            description: "type is the underlying infrastructure provider for the cluster. Allowed values: \"\", \"AWS\". \n Individual components may not support all platforms, and must handle unrecognized platforms with best-effort defaults."
+                            type: string
+                            enum:
+                              - ""
+                              - AWS
+                              - Azure
+                              - BareMetal
+                              - GCP
+                              - Libvirt
+                              - OpenStack
+                              - None
+                              - VSphere
+                              - oVirt
+                              - IBMCloud
+                              - KubeVirt
+                              - EquinixMetal
+                              - PowerVS
+                              - AlibabaCloud
+                              - Nutanix
+                              - External
+                            x-kubernetes-validations:
+                              - rule: self in ['','AWS']
+                                message: allowed values are '' and 'AWS'
+                        x-kubernetes-validations:
+                          - rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws) : !has(self.aws)'
+                            message: aws configuration is required when platform is AWS, and forbidden otherwise
                       privateZone:
                         description: "privateZone is the location where all the DNS
                           records that are only available internally to the cluster


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the platform field under spec in the CRD. Now it matches the 4.16 CRD.

**- How to verify it**
`oc logs <machine-controller-config-pod> | grep unknown `

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
