### PR TITLE
OPNET-508: Remove ovsdb before applying nmstate configuration

### DIFF
--- a/templates/common/baremetal/files/nmstate-configuration.yaml
+++ b/templates/common/baremetal/files/nmstate-configuration.yaml
@@ -37,4 +37,5 @@ contents:
     fi
 
     cp "$src_path/$config_file" /etc/nmstate
+    rm /etc/openvswitch/conf.db
     touch /etc/nmstate/openshift/applied


### PR DESCRIPTION
This is a gross hack to make migration from configure-ovs work. I doubt we actually want to do this, but I'm writing the patch to start a conversation about the proper way to do it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
