### PR TITLE
OCPBUGS-34050: Default ipv4 NODE_IP to 0.0.0.0

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -13,6 +13,8 @@ contents: |
   ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
+{{- else}}
+  Environment="KUBELET_NODE_IP=0.0.0.0"
 {{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -11,6 +11,11 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- else}}
+  Environment="KUBELET_NODE_IP=0.0.0.0"
+{{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -13,6 +13,8 @@ contents: |
   ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
+{{- else}}
+  Environment="KUBELET_NODE_IP=0.0.0.0"
 {{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -11,6 +11,11 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- else}}
+  Environment="KUBELET_NODE_IP=0.0.0.0"
+{{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env


### PR DESCRIPTION
**- What I did**

This ensures that the `--node-ip` flag is defaulted to `0.0.0.0` on IPv4 clusters when otherwise not overridden by the kubelet-env file.

This we believe should Kubelet to start pods, that require the host IP to be set via the downwards API, prior to the kubelet accessing the kube API. This is helpful in hibernation recovery scenarios.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

/hold for manual testing of the above theory