### PR TITLE
OCPBUGS-33129: Panic when we remove an OCB infra MCP and we try to create new ones with different names

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -402,6 +402,9 @@ func (ctrl *Controller) customBuildPodUpdater(pod *corev1.Pod) error {
 	if err != nil {
 		return err
 	}
+	if mosc == nil || mosb == nil {
+		return fmt.Errorf("Missing MOSC/MOSB for pool %s", pool.Name)
+	}
 
 	// We cannot solely rely upon the pod phase to determine whether the build
 	// pod is in an error state. This is because it is possible for the build


### PR DESCRIPTION
Avoid non-existing MOSC de-reference.