### PR TITLE
OCPBUGS-35300: Azure: add Azure specific dnsmasq ordering

### DIFF
--- a/templates/common/azure/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/azure/units/machine-config-daemon-pull.service.yaml
@@ -1,0 +1,24 @@
+name: "machine-config-daemon-pull.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Machine Config Daemon Pull
+  # Make sure it runs only on OSTree booted system
+  ConditionPathExists=/run/ostree-booted
+  # This "stamp file" is unlinked when we complete
+  # machine-config-daemon-firstboot.service
+  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
+  # Run after crio-wipe so the pulled MCD image is protected against a corrupted storage from a forced shutdown
+  Wants=crio-wipe.service NetworkManager-wait-online.service
+  After=crio-wipe.service NetworkManager-wait-online.service network.service dnsmasq.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
+  {{if .Proxy -}}
+  EnvironmentFile=/etc/mco/proxy.env
+  {{end -}}
+
+  [Install]
+  RequiredBy=machine-config-daemon-firstboot.service


### PR DESCRIPTION
In 4.14 we slightly tweaked the services such that mcd-pull no longer depends on network-online.target. This broke some ARO disconnected environments that needed dnsmasq to be ready before the MCD-pull runs on firstboot.

Add in a new Azure template for MCD-pull with an additional After=dnsmasq.service so the strict ordering of:

1. ovs-configuration
2. dnsmasq
3. mcd-pull
4. mcd-firstboot

is adhered to.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
