### PR TITLE
OCPBUGS-33694: daemon/update: disable systemd unit before overwriting

### DIFF
--- a/pkg/daemon/file_writers.go
+++ b/pkg/daemon/file_writers.go
@@ -297,6 +297,18 @@ func writeUnit(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error
 				return err
 			}
 		}
+		// If the unit is currently enabled, disable it before overwriting since we might be
+		// changing its WantedBy= or RequiredBy= directive (see OCPBUGS-33694). Later code will
+		// re-enable the new unit as directed by the MachineConfig.
+		cmd := exec.Command("systemctl", "is-enabled", u.Name)
+		out, _ := cmd.CombinedOutput()
+		if cmd.ProcessState.ExitCode() == 0 && strings.TrimSpace(string(out)) == "enabled" {
+			klog.Infof("Disabling systemd unit %s before re-writing it", u.Name)
+			disableOut, err := exec.Command("systemctl", "disable", u.Name).CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("disabling %s failed: %w (output: %s)", u.Name, err, string(disableOut))
+			}
+		}
 		if err := writeFileAtomicallyWithDefaults(fpath, []byte(*u.Contents)); err != nil {
 			return fmt.Errorf("failed to write systemd unit %q: %w", u.Name, err)
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2042,6 +2042,29 @@ func (dn *Daemon) deleteStaleData(oldIgnConfig, newIgnConfig ign3types.Config) e
 		}
 	}
 
+	// nolint:revive // because i disagree that returning this directly would be cleaner
+	if err := dn.workaroundOcpBugs33694(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Previous versions of the MCD leaked some enablement symlinks. We clean a
+// known problematic subset of those here. See also:
+// https://issues.redhat.com/browse/OCPBUGS-33694?focusedId=24917003#comment-24917003
+func (dn *Daemon) workaroundOcpBugs33694() error {
+	stalePaths := []string{
+		"/etc/systemd/system/network-online.target.requires/node-valid-hostname.service",
+		"/etc/systemd/system/network-online.target.wants/ovs-configuration.service",
+	}
+	for _, path := range stalePaths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("error deleting %s: %w", path, err)
+		} else if err == nil {
+			klog.Infof("Removed stale symlink %q", path)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
When overwriting a systemd unit with new content, we need to account for
the case where the new unit content has a different `[Install]` section.
If it does, then simply overwriting will leak the previous enablement
symlinks and become node state. That's OK most of the time, but this can
cause real issues as we've seen with the combination of #3967 which does
exactly that (changing `[Install]` sections) and #4213 which assumed
that those symlinks were cleaned up. More details on that cocktail in:

https://issues.redhat.com/browse/OCPBUGS-33694?focusedId=24917003#comment-24917003

Fix this by always checking if the unit is currently enabled, and if so,
running `systemctl disable` *before* overwriting its contents. The unit
will then be re-enabled (or not) based on the MachineConfig.

Fixes: https://issues.redhat.com/browse/OCPBUGS-33694

---

daemon/update: add workaround for OCPBUGS-33694

Due to the bug detailed in the previous commit, we now have nodes out
there that have stale enablement symlinks on-disk. It would be too risky
to try to catch them all and clean them up, but at least let's clean up
the ones that are known to be problematic.

---

**- What I did**

See commit messages above.

**- How to verify it**

To verify the bug fix (first commit):

- Boot to an OCP version that doesn't have https://github.com/openshift/machine-config-operator/pull/3967.
- Upgrade to an OCP version that has the bug fix (and implicitly also has https://github.com/openshift/machine-config-operator/pull/3967).
- Verify that there are no stale enablement symlinks.

To verify the workaround (second commit):

- Boot to an OCP version that doesn't have https://github.com/openshift/machine-config-operator/pull/3967.
- Upgrade to an OCP version that does have https://github.com/openshift/machine-config-operator/pull/3967.
- Upgrade to an OCP version that has the workaround.
- Verify that the stale enablement symlinks are removed.

**- Description for the changelog**

Stop leaking enablement symlinks when writing systemd units.