### PR TITLE
OCPBUGS-35300: MCD-pull: run after network-online.target in Azure

### DIFF
--- a/templates/common/azure/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/azure/units/machine-config-daemon-pull.service.yaml
@@ -1,0 +1,24 @@
+name: "machine-config-daemon-pull.service"
+enabled: true
+contents: |
+  [Unit]
+  Description=Machine Config Daemon Pull
+  # Make sure it runs only on OSTree booted system
+  ConditionPathExists=/run/ostree-booted
+  # This "stamp file" is unlinked when we complete
+  # machine-config-daemon-firstboot.service
+  ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
+  # Run after crio-wipe so the pulled MCD image is protected against a corrupted storage from a forced shutdown
+  Wants=crio-wipe.service network-online.target
+  After=crio-wipe.service network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
+  {{if .Proxy -}}
+  EnvironmentFile=/etc/mco/proxy.env
+  {{end -}}
+
+  [Install]
+  RequiredBy=machine-config-daemon-firstboot.service


### PR DESCRIPTION
This was originally reordered such that ovs-configuration was able to run when the reboot was skipped. See: https://github.com/openshift/machine-config-operator/pull/3858

This broke ARO since they require the network to be ready for the pull to happen (and generally, probably best for the network to be ready before attempting to pull the new OS image).

This fix aims to apply just to Azure, which is not ideal since it drifts the service definition, but if don't-reboot-on-metal and ARO have different dependency chains, this is the easiest middle ground.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
