### PR TITLE
OCPBUGS-35509: In OCB/OCL it takes too much time to apply the new image once it has been build

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -234,7 +234,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
-			ctx.TechPreviewInformerFactory.Machineconfiguration().V1alpha1().MachineOSBuilds(),
+			ctx.TechPreviewInformerFactory.Machineconfiguration().V1alpha1().MachineOSConfigs(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -101,7 +101,7 @@ func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.schedulerClient, noResyncPeriodFunc())
 	c := NewWithCustomUpdateDelay(i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), i.Machineconfiguration().V1().MachineConfigPools(), k8sI.Core().V1().Nodes(),
-		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1alpha1().MachineOSBuilds(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgAccess)
+		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1alpha1().MachineOSConfigs(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgAccess)
 
 	c.ccListerSynced = alwaysReady
 	c.mcpListerSynced = alwaysReady

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -519,7 +519,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
-			ctx.InformerFactory.Machineconfiguration().V1alpha1().MachineOSBuilds(),
+			ctx.InformerFactory.Machineconfiguration().V1alpha1().MachineOSConfigs(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),


### PR DESCRIPTION
**- What I did**
Sync MCP according to MachineOSConfig - CurrentImagePullspec update to capture image built completion to (1) avoid unnecessary syncing (2) make sure that the MCP is notified of a successful image build as soon as possible 

**- How to verify it**

1. Opt a pool in to On Cluster Layering by creating a MachineOSConfig for it
2. Wait for image to be built
3. Watch image building process and time the interval between timestamp1-new image built and timestamp2-newly built image start to roll out 
4. Make sure that it won't take too much time to apply the new image once it has been built. 