### PR TITLE
OCPBUGS-35992: disable mglru service

### DIFF
--- a/templates/common/_base/units/disable-mglru.service.yaml
+++ b/templates/common/_base/units/disable-mglru.service.yaml
@@ -1,0 +1,14 @@
+name: disable-mglru.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Disables MGLRU on Openshfit
+  
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=bash -c "echo 0 > /sys/kernel/mm/lru_gen/enabled"
+
+  
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/common/_base/units/kubelet-dependencies.target.yaml
+++ b/templates/common/_base/units/kubelet-dependencies.target.yaml
@@ -4,5 +4,5 @@ contents: |
   Description=Dependencies necessary to run kubelet
   Documentation=https://github.com/openshift/machine-config-operator/
   Requires=basic.target network-online.target
-  Wants=NetworkManager-wait-online.service crio-wipe.service
+  Wants=NetworkManager-wait-online.service crio-wipe.service disable-mglru.service
   Wants=rpc-statd.service


### PR DESCRIPTION
Backports #4425 
Please provide the following information:
**- What I did**
Disable MG LRU via systemd unit

**- How to verify it**
Before the fix,

sh-5.1# cat /sys/kernel/mm/lru_gen/enabled
0x0007
and after the fix is should look like,

sh-5.1# cat /sys/kernel/mm/lru_gen/enabled
0x0000

**- Description for the changelog**
Disable MG LRU via systemd unit