### PR TITLE
[release-4.15] OCPBUGS-27436: Fix mirrorSourcePolicy error prompt imagecontentsourcepolicies

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -749,7 +749,7 @@ func validateRegistriesConfScopes(insecure, blocked, allowed []string, icspRules
 		}
 		if p, ok := sourcePolicy[source]; ok {
 			if policy != p {
-				return fmt.Errorf("conflicting mirrorSourcePolicy is set for the same source %q in imagedigestmirrorsets and/or imagetagmirrorsets", source)
+				return fmt.Errorf("conflicting mirrorSourcePolicy is set for the same source %q in imagedigestmirrorsets, imagetagmirrorsets, or imagecontentsourcepolicies", source)
 			}
 		} else {
 			sourcePolicy[source] = policy

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -662,6 +662,7 @@ func TestValidateRegistriesConfScopes(t *testing.T) {
 		blocked     []string
 		allowed     []string
 		idmsRules   []*apicfgv1.ImageDigestMirrorSet
+		icspRules   []*apioperatorsv1alpha1.ImageContentSourcePolicy
 		expectedErr error
 	}{
 		{
@@ -766,10 +767,33 @@ func TestValidateRegistriesConfScopes(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			icspRules: []*apioperatorsv1alpha1.ImageContentSourcePolicy{
+				{
+					Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+						RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{
+							{Source: "insecure.com/ns-i1", Mirrors: []string{"other.com/ns-o1  "}},
+						},
+					},
+				},
+			},
+			idmsRules: []*apicfgv1.ImageDigestMirrorSet{
+				{
+					Spec: apicfgv1.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []apicfgv1.ImageDigestMirrors{ // other.com is neither insecure nor blocked
+							{Source: "insecure.com/ns-i1", Mirrors: []apicfgv1.ImageMirror{"blocked.com/ns-b1", "other.com/ns-o1"}, MirrorSourcePolicy: apicfgv1.NeverContactSource},
+							{Source: "blocked.com/ns-b/ns2-b", Mirrors: []apicfgv1.ImageMirror{"other.com/ns-o2", "insecure.com/ns-i2"}},
+							{Source: "other.com/ns-o3", Mirrors: []apicfgv1.ImageMirror{"insecure.com/ns-i2", "blocked.com/ns-b/ns3-b", "foo.insecure-example.com/bar"}},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(`conflicting mirrorSourcePolicy is set for the same source "insecure.com/ns-i1" in imagedigestmirrorsets, imagetagmirrorsets, or imagecontentsourcepolicies`),
+		},
 	}
 
 	for _, tc := range tests {
-		res := validateRegistriesConfScopes(tc.insecure, tc.blocked, tc.allowed, nil, tc.idmsRules, nil)
+		res := validateRegistriesConfScopes(tc.insecure, tc.blocked, tc.allowed, tc.icspRules, tc.idmsRules, nil)
 		require.Equal(t, tc.expectedErr, res)
 	}
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
cherry-pick of #4125
This PR replaces https://github.com/openshift/machine-config-operator/pull/4132 due to unit test failure with the auto cherrypick PR.
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
