### PR TITLE
MCO-1202: MCO-1203: MCO-1204: MCO-1205: MCO-1213: Implementing tlsSecurityProfile for MCO

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -180,6 +180,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
+			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ClientBuilder.KubeClientOrDie("template-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("template-controller"),
 		),

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -103,6 +103,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
 			ctrlctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Nodes(),
+			ctrlctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctrlctx,
 		)
 

--- a/cmd/machine-config-server/main.go
+++ b/cmd/machine-config-server/main.go
@@ -22,10 +22,12 @@ var (
 	}
 
 	rootOpts struct {
-		sport  int
-		isport int
-		cert   string
-		key    string
+		sport           int
+		isport          int
+		cert            string
+		key             string
+		tlsciphersuites []string
+		tlsminversion   string
 	}
 )
 
@@ -34,6 +36,8 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&rootOpts.sport, "secure-port", server.SecurePort, "secure port to serve ignition configs")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.cert, "cert", "/etc/ssl/mcs/tls.crt", "cert file for TLS")
 	rootCmd.PersistentFlags().StringVar(&rootOpts.key, "key", "/etc/ssl/mcs/tls.key", "key file for TLS")
+	rootCmd.PersistentFlags().StringSliceVar(&rootOpts.tlsciphersuites, "tls-cipher-suites", nil, "ciphers suites for TLS")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.tlsminversion, "tls-min-version", "VersionTLS12", "min version for TLS")
 	rootCmd.PersistentFlags().IntVar(&rootOpts.isport, "insecure-port", server.InsecurePort, "insecure port to serve ignition configs")
 	rootCmd.PersistentFlags().StringVar(&version.ReleaseVersion, "payload-version", version.ReleaseVersion, "Version of the openshift release")
 }

--- a/install/0000_80_machine-config_00_clusterreader_clusterrole.yaml
+++ b/install/0000_80_machine-config_00_clusterreader_clusterrole.yaml
@@ -52,6 +52,7 @@ rules:
       - featuregates 
       - nodes
       - nodes/status
+      - apiservers
     verbs:
       - get
       - list

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -38,7 +38,8 @@ spec:
         args:
         - --secure-listen-address=0.0.0.0:9001
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --tls-cipher-suites={{join .TLSCipherSuites ","}} 
+        - --tls-min-version={{.TLSMinVersion}}
         - --upstream=http://127.0.0.1:8797
         - --logtostderr=true
         - --tls-cert-file=/etc/tls/private/tls.crt

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -83,7 +83,8 @@ spec:
         args:
         - --secure-listen-address=0.0.0.0:9001
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --tls-cipher-suites={{join .TLSCipherSuites ","}} 
+        - --tls-min-version={{.TLSMinVersion}}
         - --upstream=http://127.0.0.1:8797
         - --logtostderr=true
         - --tls-cert-file=/etc/tls/private/tls.crt

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
           - "start"
           - "--apiserver-url={{.APIServerURL}}"
           - "--payload-version={{.ReleaseVersion}}"
+          - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
+          - "--tls-min-version={{.TLSMinVersion}}"
         resources:
           requests:
             cpu: 20m

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -277,6 +277,29 @@ func (b *Bootstrap) Run(destDir string) error {
 			return err
 		}
 	}
+
+	// If an apiServer object exists, write it to /etc/mcs/bootstrap/api-server/api-server.yaml
+	// so that bootstrap MCS can consume it
+	if apiServer != nil {
+		buf := bytes.Buffer{}
+		encoder := codecFactory.EncoderForVersion(serializer, apicfgv1.GroupVersion)
+		err = encoder.Encode(apiServer, &buf)
+		if err != nil {
+			return err
+		}
+		apiserverDir := filepath.Join(destDir, "api-server")
+		if err := os.MkdirAll(apiserverDir, 0o764); err != nil {
+			return err
+		}
+		// Disable gosec here to avoid throwing
+		// G306: Expect WriteFile permissions to be 0600 or less
+		// #nosec
+		klog.Infof("writing the following apiserver object to disk: %s", string(buf.Bytes()))
+		if err := os.WriteFile(filepath.Join(apiserverDir, "api-server.yaml"), buf.Bytes(), 0o664); err != nil {
+			return err
+		}
+	}
+
 	buf := bytes.Buffer{}
 	err = encoder.Encode(cconfig, &buf)
 	if err != nil {
@@ -286,6 +309,7 @@ func (b *Bootstrap) Run(destDir string) error {
 	if err := os.MkdirAll(cconfigDir, 0o764); err != nil {
 		return err
 	}
+
 	klog.Infof("writing the following controllerConfig to disk: %s", string(buf.Bytes()))
 	return os.WriteFile(filepath.Join(cconfigDir, "machine-config-controller.yaml"), buf.Bytes(), 0o664)
 

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -90,6 +90,7 @@ func (b *Bootstrap) Run(destDir string) error {
 		itmsRules            []*apicfgv1.ImageTagMirrorSet
 		clusterImagePolicies []*apicfgv1alpha1.ClusterImagePolicy
 		imgCfg               *apicfgv1.Image
+		apiServer            *apicfgv1.APIServer
 	)
 	for _, info := range infos {
 		if info.IsDir() {
@@ -147,6 +148,10 @@ func (b *Bootstrap) Run(destDir string) error {
 				if obj.GetName() == ctrlcommon.ClusterNodeInstanceName {
 					nodeConfig = obj
 				}
+			case *apicfgv1.APIServer:
+				if obj.GetName() == ctrlcommon.APIServerInstanceName {
+					apiServer = obj
+				}
 			default:
 				klog.Infof("skipping %q [%d] manifest because of unhandled %T", file.Name(), idx+1, obji)
 			}
@@ -167,7 +172,7 @@ func (b *Bootstrap) Run(destDir string) error {
 		return fmt.Errorf("error creating feature gate access: %w", err)
 	}
 
-	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig, psraw, nil)
+	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig, psraw, apiServer)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -167,7 +167,7 @@ func (b *Bootstrap) Run(destDir string) error {
 		return fmt.Errorf("error creating feature gate access: %w", err)
 	}
 
-	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig, psraw)
+	iconfigs, err := template.RunBootstrap(b.templatesDir, cconfig, psraw, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -43,6 +43,9 @@ const (
 	// APIServerInstanceName is a singleton name for APIServer configuration
 	APIServerInstanceName = "cluster"
 
+	// APIServerInstanceName is a singleton name for APIServer configuration
+	APIServerBootstrapFileLocation = "/etc/mcs/bootstrap/api-server/api-server.yaml"
+
 	// MachineConfigPoolMaster is the MachineConfigPool name given to the master
 	MachineConfigPoolMaster = "master"
 

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -40,6 +40,9 @@ const (
 	// ClusterNodeInstanceName is a singleton name for node configuration
 	ClusterNodeInstanceName = "cluster"
 
+	// APIServerInstanceName is a singleton name for APIServer configuration
+	APIServerInstanceName = "cluster"
+
 	// MachineConfigPoolMaster is the MachineConfigPool name given to the master
 	MachineConfigPoolMaster = "master"
 

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -51,7 +51,7 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			}
 			if kubeletConfig.Spec.TLSSecurityProfile != nil {
 				// Inject TLS Options from Spec
-				observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(kubeletConfig.Spec.TLSSecurityProfile)
+				observedMinTLSVersion, observedCipherSuites := ctrlcommon.GetSecurityProfileCiphers(kubeletConfig.Spec.TLSSecurityProfile)
 				originalKubeConfig.TLSMinVersion = observedMinTLSVersion
 				originalKubeConfig.TLSCipherSuites = observedCipherSuites
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -71,7 +71,7 @@ func newFixture(t *testing.T) *fixture {
 	f.apiserverLister = []*osev1.APIServer{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: defaultOpenshiftTLSSecurityProfileConfig,
+				Name: ctrlcommon.APIServerInstanceName,
 			},
 		},
 	}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -33,7 +33,9 @@ const (
 // RenderConfig is wrapper around ControllerConfigSpec.
 type RenderConfig struct {
 	*mcfgv1.ControllerConfigSpec
-	PullSecret string
+	PullSecret      string
+	TLSMinVersion   string
+	TLSCipherSuites []string
 
 	// no need to set this, will be automatically configured
 	Constants map[string]string

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -344,6 +344,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
 	funcs["cloudPlatformIngressLoadBalancerIPs"] = cloudPlatformIngressLoadBalancerIPs
+	funcs["join"] = strings.Join
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template %s: %w", path, err)

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -84,7 +84,7 @@ func TestCloudProvider(t *testing.T) {
 				},
 			}
 
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -145,7 +145,7 @@ func TestCredentialProviderConfigFlag(t *testing.T) {
 				},
 			}
 
-			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, name, dummyTemplate)
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, name, dummyTemplate)
 			if err != nil {
 				t.Fatalf("expected nil error %v", err)
 			}
@@ -239,14 +239,14 @@ func TestInvalidPlatform(t *testing.T) {
 
 	// we must treat unrecognized constants as "none"
 	controllerConfig.Spec.Infra.Status.PlatformStatus.Type = "_bad_"
-	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, templateDir)
 	if err != nil {
 		t.Errorf("expect nil error, got: %v", err)
 	}
 
 	// explicitly blocked
 	controllerConfig.Spec.Infra.Status.PlatformStatus.Type = "_base"
-	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
+	_, err = generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, templateDir)
 	expectErr(err, "failed to create MachineConfig for role master: platform _base unsupported")
 }
 
@@ -257,7 +257,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 			t.Fatalf("failed to get controllerconfig config: %v", err)
 		}
 
-		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, nil}, templateDir)
+		cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, templateDir)
 		if err != nil {
 			t.Fatalf("failed to generate machine configs: %v", err)
 		}
@@ -384,7 +384,7 @@ func TestGetPaths(t *testing.T) {
 			}
 			c.res = append(c.res, platformBase)
 
-			got := getPaths(&RenderConfig{&config.Spec, `{"dummy":"dummy"}`, nil}, config.Spec.Platform)
+			got := getPaths(&RenderConfig{&config.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, config.Spec.Platform)
 			if reflect.DeepEqual(got, c.res) {
 				t.Fatalf("mismatch got: %s want: %s", got, c.res)
 			}

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -154,7 +154,7 @@ func RenderBootstrap(
 		templatectrl.KubeRbacProxyKey:       imgs.KubeRbacProxy,
 	}
 
-	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL, nil, []*mcfgv1alpha1.MachineOSConfig{})
+	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL, nil, []*mcfgv1alpha1.MachineOSConfig{}, nil)
 
 	manifests := []manifest{
 		{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -109,6 +109,7 @@ type Operator struct {
 	crcLister             mcfglistersv1.ContainerRuntimeConfigLister
 	nodeClusterLister     configlistersv1.NodeLister
 	moscLister            mcfglistersalphav1.MachineOSConfigLister
+	apiserverLister       configlistersv1.APIServerLister
 
 	crdListerSynced                  cache.InformerSynced
 	deployListerSynced               cache.InformerSynced
@@ -138,6 +139,7 @@ type Operator struct {
 	crcListerSynced                  cache.InformerSynced
 	nodeClusterListerSynced          cache.InformerSynced
 	moscListerSynced                 cache.InformerSynced
+	apiserverListerSynced            cache.InformerSynced
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
@@ -187,6 +189,7 @@ func New(
 	mckInformer mcfginformersv1.KubeletConfigInformer,
 	crcInformer mcfginformersv1.ContainerRuntimeConfigInformer,
 	nodeClusterInformer configinformersv1.NodeInformer,
+	apiserverInformer configinformersv1.APIServerInformer,
 	ctrlctx *ctrlcommon.ControllerContext,
 ) *Operator {
 	eventBroadcaster := record.NewBroadcaster()
@@ -251,8 +254,8 @@ func New(
 		crcInformer.Informer(),
 		nodeClusterInformer.Informer(),
 		clusterOperatorInformer.Informer(),
+		apiserverInformer.Informer(),
 	}
-
 	for _, i := range informers {
 		i.AddEventHandler(optr.eventHandler())
 	}
@@ -310,6 +313,8 @@ func New(
 	optr.mckListerSynced = mckInformer.Informer().HasSynced
 	optr.crcLister = crcInformer.Lister()
 	optr.crcListerSynced = crcInformer.Informer().HasSynced
+	optr.apiserverLister = apiserverInformer.Lister()
+	optr.apiserverListerSynced = apiserverInformer.Informer().HasSynced
 
 	optr.vStore.Set("operator", version.ReleaseVersion)
 

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -43,6 +43,8 @@ type renderConfig struct {
 	Constants              map[string]string
 	PointerConfig          string
 	MachineOSConfigs       []*mcfgv1alpha1.MachineOSConfig
+	TLSMinVersion          string
+	TLSCipherSuites        []string
 }
 
 type assetRenderer struct {

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -80,6 +80,7 @@ func (a *assetRenderer) addTemplateFuncs() {
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
 	funcs["cloudPlatformIngressLoadBalancerIPs"] = cloudPlatformIngressLoadBalancerIPs
+	funcs["join"] = strings.Join
 
 	a.tmpl = a.tmpl.Funcs(funcs)
 }

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -634,7 +634,7 @@ func TestAPIServer(t *testing.T) {
 			ms := &mockServer{
 				GetConfigFn: scenario.serverFunc,
 			}
-			server := NewAPIServer(NewServerAPIHandler(ms), 0, false, "", "")
+			server := NewAPIServer(NewServerAPIHandler(ms), 0, false, "", "", nil)
 			server.handler.ServeHTTP(w, scenario.request)
 
 			resp := w.Result()
@@ -672,6 +672,7 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "Hello, client")
 		}),
+		ctrlcommon.GetGoTLSConfig("", nil),
 	)
 
 	// Configure the TLS testing to allow

--- a/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
@@ -60,7 +60,8 @@ contents:
         - --client-ca-file=/etc/kubernetes/kubelet-ca.crt
         - --logtostderr=true
         - --kubeconfig=/var/lib/kubelet/kubeconfig
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --tls-cipher-suites={{join .TLSCipherSuites ","}} 
+        - --tls-min-version={{.TLSMinVersion}}
         - --upstream=http://127.0.0.1:9537
         - --tls-cert-file=/var/lib/kubelet/pki/kubelet-server-current.pem
         - --tls-private-key-file=/var/lib/kubelet/pki/kubelet-server-current.pem

--- a/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
@@ -60,7 +60,8 @@ contents:
         - --client-ca-file=/etc/kubernetes/kubelet-ca.crt
         - --logtostderr=true
         - --kubeconfig=/var/lib/kubelet/kubeconfig
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --tls-cipher-suites={{join .TLSCipherSuites ","}} 
+        - --tls-min-version={{.TLSMinVersion}}
         - --upstream=http://127.0.0.1:9537
         - --tls-cert-file=/var/lib/kubelet/pki/kubelet-server-current.pem
         - --tls-private-key-file=/var/lib/kubelet/pki/kubelet-server-current.pem

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -469,6 +469,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
+			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ClientBuilder.KubeClientOrDie("template-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("template-controller"),
 		),


### PR DESCRIPTION
**- What I did**

In regular cluster operation:
- The operator and controller will listen on an APIServer object, which contains the [global cluster tls settings](https://docs.openshift.com/container-platform/4.15/security/tls-security-profiles.html#tls-profiles-kubernetes-configuring_tls-security-profiles).
- The operator will now render TLSMinVersion and TLSCiphers to the MCC and MCD kube-rbac-proxy sidecar manifests via templated arguments.
- The template controller will now render TLSMinVersion and TLSCiphers to the kube-rbac-proxy-crio metrics pods via templated arguments. These are per node pods in the MCO namespace, and deployed via MachineConfigs. As a result changing the tls settings will cause a MachineConfig rollout.
- The MCS container now has two new TLS arguments. The operator will render TLSMinVersion and TLSCiphers via these new arguments in the MCS daemonset manifest. The MCS will attempt to create a http server with these new TLS settings while starting up.

During cluster bootstrap:
- The bootstrap MCC will default to the intermediate security profile, unless an install time APIServer manifest is provided. This is necessary during bootstrap, as the kube-rbac-proxy-crio pod manifests show up in rendered MachineConfigs and we need the bootstrap MachineConfigs to match the in cluster MachineConfigs post install. 
- The bootstrap MCC has access to all install time manifests provided to the installer, but the bootstrap MCS does not. When the bootstrap MCC determines that an APIServer manifest has been provided, it will write it to bootstrap MCS's directory.
- The bootstrap MCS will now read in the APIServer manifest and launch its http server with the TLS settings defined in the manifest. If no manifest is provided, it will default to the intermediate security profile. 

**- How to verify it**
1. Bring up a cluster with an install time APIServer manifest named "cluster". To test bootstrap behavior, ensure
environment variable `OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP` is set to true.
3. Once the install is complete, observe the kube rbac proxy manifests in cluster to ensure they have the correct TLS configuration. These can be seen as arguments for the kube rbac proxy sidecards on the MCO deployments, as well as encapsulated in MachineConfigs for the kube-rbac-proxy-crio pods.
4. The MCS daemonset will log the current TLS settings at startup. You can also test the MCS endpoint using the method described in this [comment](https://issues.redhat.com/browse/MCO-1204?focusedId=25007192&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-25007192).
5. You can also log in to the bootstrap node and verify that the MCS bootstrap logs started with the correct TLS settings.
6.  Switch between TLS profiles by [following the documentation](https://docs.openshift.com/container-platform/4.15/security/tls-security-profiles.html#tls-profiles-kubernetes-configuring_tls-security-profiles).
7. This will cause a new MachineConfig rollout and also cause the MCC, MCD and MCS pods to restart. You can verify (2) and (3) is as expected as the update rolls through the cluster.

**Things to note**: 

- It may take a few moments before the operator rolls out the new manifests. If it is done while the MCO is doing a MachineConfig update to the master pool, the manifests won't be updated until the master pool is finished updating. This is because of the way the operator's sync loops are structured.
- The APIServer rejects the Modern profile at the moment, according to the docs.
- If no tlsSecurityProfile is provided, the MCO will default to Intermediate. 
