### PR TITLE
OCPNODE-2357: templates/master/cri-o: make crun as the default container runtime

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -30,6 +30,7 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
+    default_runtime = "crun"
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -30,6 +30,7 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
+    default_runtime = "crun"
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This commit sets `crun` as the default container runtime in OCP for 4.17

**- How to verify it**
I'm in the process of adding test coverage for this behavior.

**- Description for the changelog**
Make crun the default container runtime
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
