### PR TITLE
OCPBUGS-30603: Bootstrap e2e test featuregate setup does not match the actual code

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	features "github.com/openshift/api/features"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -103,7 +102,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				klog.Fatalf("unable to get initial features: %v", err)
 			}
 
-			enabled, disabled := getEnabledDisabledFeatures(fg)
+			enabled, disabled := ctrlcommon.GetEnabledDisabledFeatures(fg)
 			klog.Infof("FeatureGates initialized: enabled=%v  disabled=%v", enabled, disabled)
 			if fg.Enabled(features.FeatureGatePinnedImages) && fg.Enabled(features.FeatureGateMachineConfigNodes) {
 				pinnedImageSet := pinnedimageset.New(
@@ -229,19 +228,4 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 	)
 
 	return controllers
-}
-
-func getEnabledDisabledFeatures(features featuregates.FeatureGate) ([]string, []string) {
-	var enabled []string
-	var disabled []string
-
-	for _, feature := range features.KnownFeatures() {
-		if features.Enabled(feature) {
-			enabled = append(enabled, string(feature))
-		} else {
-			disabled = append(disabled, string(feature))
-		}
-	}
-
-	return enabled, disabled
 }

--- a/pkg/controller/common/featuregates.go
+++ b/pkg/controller/common/featuregates.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"k8s.io/klog/v2"
+)
+
+func WaitForFeatureGatesReady(ctx context.Context, featureGateAccess featuregates.FeatureGateAccess) error {
+	timeout := time.After(1 * time.Minute)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout:
+			return fmt.Errorf("timed out waiting for FeatureGates to be ready")
+		default:
+			features, err := featureGateAccess.CurrentFeatureGates()
+			if err == nil {
+				enabled, disabled := GetEnabledDisabledFeatures(features)
+				klog.Infof("FeatureGates initialized: enabled=%v, disabled=%v", enabled, disabled)
+				return nil
+			}
+			klog.Infof("Waiting for FeatureGates to be ready...")
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+// getEnabledDisabledFeatures extracts enabled and disabled features from the feature gate.
+func GetEnabledDisabledFeatures(features featuregates.FeatureGate) ([]string, []string) {
+	var enabled []string
+	var disabled []string
+
+	for _, feature := range features.KnownFeatures() {
+		if features.Enabled(feature) {
+			enabled = append(enabled, string(feature))
+		} else {
+			disabled = append(disabled, string(feature))
+		}
+	}
+
+	return enabled, disabled
+}

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -444,6 +444,9 @@ func newTestFixture(t *testing.T, cfg *rest.Config, objs []runtime.Object) *fixt
 	ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
 	ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
 
+	err := ctrlcommon.WaitForFeatureGatesReady(ctx, ctrlctx.FeatureGateAccess)
+	require.NoError(t, err, "FeatureGates should be available before proceeding")
+
 	close(ctrlctx.InformersStarted)
 
 	for _, c := range controllers {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
-added a function waitForFeatureGatesReady to handle the initialization and added necessary logging for debugging.
-updated the runStartCmd function to wait for feature gates to be ready before starting controllers.

**- How to verify it**
-run the bootstrap e2e tests located in test/e2e-bootstrap/bootstrap_test.go.
-observe the logs to confirm that feature gates are initialized before controllers are started.

**- Description for the changelog**
 Ensure feature gates are initialized before starting controllers in the bootstrap process for the Machine Config Operator.
