### PR TITLE
OCPBUGS-19537: OCB should fail if node is not coreos based

### DIFF
--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -23,6 +23,13 @@ const (
 	scos   string = "scos"
 )
 
+// OS Pretty Names
+const (
+	RHCOS string = "Red Hat Enterprise Linux CoreOS"
+	FCOS  string = "Fedora Linux"
+	SCOS  string = "CentOS Stream CoreOS"
+)
+
 // OperatingSystem is a wrapper around a subset of the os-release fields
 // and also tracks whether ostree is in use.
 type OperatingSystem struct {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -50,6 +50,7 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	templatectrl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/pkg/helpers"
 	"github.com/openshift/machine-config-operator/pkg/server"
 	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -1240,6 +1241,14 @@ func (optr *Operator) reconcileMachineOSBuilder(mob *appsv1.Deployment) error {
 		return fmt.Errorf("could not get layered MachineConfigPools: %w", err)
 	}
 
+	// If layeredMCP is found, verify that the node is coreos based as non coreos OS images
+	// cannot handle layered builds
+	if len(layeredMCPs) > 0 {
+		if err := optr.validateLayeredPoolNodes(layeredMCPs); err != nil {
+			return err
+		}
+	}
+
 	isRunning, err := optr.isMachineOSBuilderRunning(mob)
 	// An unknown error occurred. Bail out here.
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -1268,6 +1277,31 @@ func (optr *Operator) reconcileMachineOSBuilder(mob *appsv1.Deployment) error {
 	// if we are in ocb, but for some reason we dont need to do an update to the deployment, we still need to validate config
 	if len(layeredMCPs) != 0 {
 		return build.ValidateOnClusterBuildConfig(optr.kubeClient, optr.client, layeredMCPs)
+	}
+	return nil
+}
+
+// Validate that the nodes part of layered pools are coreos based
+func (optr *Operator) validateLayeredPoolNodes(layeredMCPs []*mcfgv1.MachineConfigPool) error {
+	nodes, err := optr.GetAllManagedNodes(layeredMCPs)
+	if err != nil {
+		return fmt.Errorf("could not get nodes in layered MachineConfigPools: %w", err)
+	}
+	// Error out if any of the nodes in the pool where OCL is enabled is a non-coreos node
+	errNodes := []error{}
+	for _, node := range nodes {
+		if !helpers.IsCoreOSNode(node) {
+			poolNames, err := helpers.GetPoolNamesForNode(optr.mcpLister, node)
+			if err != nil {
+				return err
+			}
+			err = fmt.Errorf("non-CoreOS OS %q detected on node %q in MachineConfigPool(s) %q", node.Status.NodeInfo.OSImage, node.Name, poolNames)
+			errNodes = append(errNodes, err)
+		}
+	}
+
+	if len(errNodes) > 0 {
+		return fmt.Errorf("on-cluster layering is only supported on CoreOS-based nodes: %w", kubeErrs.NewAggregate(errNodes))
 	}
 	return nil
 }

--- a/test/e2e/node_os_test.go
+++ b/test/e2e/node_os_test.go
@@ -5,18 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	rhcos string = "Red Hat Enterprise Linux CoreOS"
-	scos  string = "CentOS Stream CoreOS"
-	fcos  string = "Fedora Linux"
 )
 
 // Verifies that the OS on each node is identifiable using the mechanism the
@@ -39,11 +34,11 @@ func TestOSDetection(t *testing.T) {
 			assert.False(t, nodeOSRelease.OS.IsLikeTraditionalRHEL7(), "expected IsLikeTraditionalRHEL7() to be false: %s", nodeOSRelease.EtcContent)
 
 			switch {
-			case strings.Contains(nodeOSRelease.EtcContent, rhcos):
+			case strings.Contains(nodeOSRelease.EtcContent, osrelease.RHCOS):
 				assertRHCOS(t, nodeOSRelease, node)
-			case strings.Contains(nodeOSRelease.EtcContent, scos):
+			case strings.Contains(nodeOSRelease.EtcContent, osrelease.SCOS):
 				assertSCOS(t, nodeOSRelease, node)
-			case strings.Contains(nodeOSRelease.EtcContent, fcos):
+			case strings.Contains(nodeOSRelease.EtcContent, osrelease.FCOS):
 				assertFCOS(t, nodeOSRelease, node)
 			default:
 				t.Fatalf("unknown OS on node %s detected: %s", node.Name, nodeOSRelease.EtcContent)
@@ -60,25 +55,25 @@ func assertRHCOS(t *testing.T, nodeOSRelease helpers.NodeOSRelease, node corev1.
 	rhelVersion := nodeOSRelease.OS.OSRelease().ADDITIONAL_FIELDS["RHEL_VERSION"]
 
 	if strings.Contains(nodeOSRelease.EtcContent, "RHEL_VERSION=\"8.") { // This pattern intentionally unterminated so it matches all RHCOS 8 versions
-		t.Logf("Identified %s %s on node %s", rhcos, rhelVersion, node.Name)
+		t.Logf("Identified %s %s on node %s", osrelease.RHCOS, rhelVersion, node.Name)
 		assert.False(t, nodeOSRelease.OS.IsEL9(), "expected < RHCOS 9.0: %s", nodeOSRelease.EtcContent)
 	}
 
 	if strings.Contains(nodeOSRelease.EtcContent, "RHEL_VERSION=\"9.") { // This pattern intentionally unterminated so it matches all RHCOS 9 versions
-		t.Logf("Identified %s %s on node %s", rhcos, rhelVersion, node.Name)
+		t.Logf("Identified %s %s on node %s", osrelease.RHCOS, rhelVersion, node.Name)
 		assert.True(t, nodeOSRelease.OS.IsEL9(), "expected >= RHCOS 9.0+: %s", nodeOSRelease.EtcContent)
 	}
 }
 
 func assertSCOS(t *testing.T, nodeOSRelease helpers.NodeOSRelease, node corev1.Node) {
-	t.Logf("Identified %s on node %s", scos, node.Name)
+	t.Logf("Identified %s on node %s", osrelease.SCOS, node.Name)
 	assert.True(t, nodeOSRelease.OS.IsEL(), "expected IsEL() to be true: %s", nodeOSRelease.EtcContent)
 	assert.True(t, nodeOSRelease.OS.IsEL9(), "expected IsEL9() to be true: %s", nodeOSRelease.EtcContent)
 	assert.False(t, nodeOSRelease.OS.IsFCOS(), "expected IsFCOS() to be false: %s", nodeOSRelease.EtcContent)
 }
 
 func assertFCOS(t *testing.T, nodeOSRelease helpers.NodeOSRelease, node corev1.Node) {
-	t.Logf("Identified OS %s on node %s", fcos, node.Name)
+	t.Logf("Identified OS %s on node %s", osrelease.FCOS, node.Name)
 	assert.False(t, nodeOSRelease.OS.IsEL(), "expected IsEL() to be false: %s", nodeOSRelease.EtcContent)
 	assert.False(t, nodeOSRelease.OS.IsEL9(), "expected IsEL9() to be false: %s", nodeOSRelease.EtcContent)
 	assert.False(t, nodeOSRelease.OS.IsSCOS(), "expected IsSCOS() to be false: %s", nodeOSRelease.EtcContent)


### PR DESCRIPTION
If a non-coreos based node, such as RHEL8, is added to a cluster and the user tries to enable on cluster builds, throw an error as that is not supported on non-coreos based nodes.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-19537

**- What I did**
Added a check for when OCB is enabled to verify which OS the nodes have and to fail if they are non-coreos based.

**- How to verify it**
Start a cluster, add a RHEL node to it and then try enabling OCB

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Throw an error if cluster has non-coreos node when trying to enable OCB
