### PR TITLE
OCPBUGS-36175: Remove privileged flag from on-prem containers

### DIFF
--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -58,7 +58,6 @@ spec:
   containers:
   - name: coredns
     securityContext:
-      privileged: true
       readOnlyRootFilesystem: false
     image: {{ .Images.CorednsBootstrap }}
     args:

--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -62,7 +62,6 @@ spec:
   containers:
   - name: coredns
     securityContext:
-      privileged: true
       readOnlyRootFilesystem: false
     image: {{ .Images.CorednsBootstrap }}
     args:

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -55,8 +55,6 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
       containers:
       - name: coredns
-        securityContext:
-          privileged: true
         image: {{.Images.corednsImage}}
         args:
         - "--conf"

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -67,8 +67,6 @@ contents:
         imagePullPolicy: IfNotPresent
       containers:
       - name: coredns
-        securityContext:
-          privileged: true
         image: {{.Images.corednsImage}}
         args:
         - "--conf"
@@ -95,8 +93,6 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: coredns-monitor
-        securityContext:
-          privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - corednsmonitor

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -71,7 +71,8 @@ contents:
       containers:
       - name: keepalived
         securityContext:
-          privileged: true
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
         image: {{.Images.keepalivedImage}}
         env:
           - name: NSS_SDB_USE_CACHE
@@ -176,8 +177,6 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: keepalived-monitor
-        securityContext:
-          privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: ENABLE_UNICAST

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -127,7 +127,8 @@ contents:
         imagePullPolicy: IfNotPresent
       - name: haproxy-monitor
         securityContext:
-          privileged: true
+          capabilities:
+            add: ["NET_ADMIN", "SYS_CHROOT"]
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - monitor


### PR DESCRIPTION
It turns out we don't need this in some cases and in others we can get by with specific capabilities instead of a fully privileged container. This is more secure because it means even a compromised container won't have as much ability to cause trouble.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
