### PR TITLE
OCPBUGS-36289: e2e test should wait for MCD pod to be running

### DIFF
--- a/test/e2e-techpreview/helpers_test.go
+++ b/test/e2e-techpreview/helpers_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -110,7 +109,7 @@ func createConfigMap(t *testing.T, cs *framework.ClientSet, cm *corev1.ConfigMap
 
 	return makeIdempotentAndRegister(t, func() {
 		require.NoError(t, cs.CoreV1Interface.ConfigMaps(ctrlcommon.MCONamespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{}))
-		klog.Infof("Deleted ConfigMap %q", cm.Name)
+		t.Logf("Deleted ConfigMap %q", cm.Name)
 	})
 }
 


### PR DESCRIPTION
**- What I did**

The `TestMCDGetsMachineOSConfigSecrets` e2e test was failing frequently during a backport to 4.16 in this PR: https://github.com/openshift/machine-config-operator/pull/4430. Basically, `helpers.ExecCmdOnNode()` was unable to get the current credentials on the node because that particular function uses the MCD pod as a bridge to execute a command on a given node. The reason why is because the MCD pod restarted to get the new secret volumes required by the MachineOSConfig. However, the MCD pod containers were not in a running / ready state.

This PR introduces a check to ensure that the MCD pods are in a running / ready state before moving onto the final phase of the test. This PR also includes minor cleanups such as only fetching the expected registry hostnames from the ControllerConfig once before beginning the MCD check.

Note: This change is already included in https://github.com/openshift/machine-config-operator/pull/4430 and was cherry-picked into this PR.

**- How to verify it**

Run the `e2e-gcp-op-techpreview` job and ensure that the `TestMCDGetsMachineOSConfigSecrets` test passes consistently.

**- Description for the changelog**
e2e test should ensure MCD pod is ready
