### PR TITLE
MCO-1103: Restore setup-envtest used in the verify test back to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: binaries
 
 .PHONY: clean test test-unit test-e2e verify update install-tools
 
-# Remove build artifaces
+# Remove build artifacts
 # Example:
 #    make clean
 #
@@ -56,6 +56,7 @@ test-unit: install-go-junit-report
 update:
 	hack/update-templates.sh
 	hack/crds-sync.sh
+
 go-deps:
 	go mod tidy
 	go mod vendor
@@ -65,12 +66,13 @@ go-deps:
 	chmod +x ./vendor/k8s.io/code-generator/generate-internal-groups.sh
 
 SETUP_ENVTEST := $(shell command -v setup-envtest 2> /dev/null)
+
 install-setup-envtest:
 ifdef SETUP_ENVTEST
 	@echo "Found setup-envtest"
 else
 	@echo "Installing setup-envtest"
-	go install -mod= sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240315194348-5aaf1190f880
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.17.5
 endif
 
 GO_JUNIT_REPORT := $(shell command -v go-junit-report 2> /dev/null)

--- a/tools.go
+++ b/tools.go
@@ -7,6 +7,7 @@ package tools
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	// Code generators built at runtime.
+	_ "github.com/containers/kubensmnt/utils/systemd"
 	_ "github.com/openshift/api/config/v1alpha1/zz_generated.crd-manifests"
 	_ "github.com/openshift/api/machineconfiguration/v1/zz_generated.crd-manifests"
 	_ "github.com/openshift/api/machineconfiguration/v1alpha1/zz_generated.crd-manifests"
@@ -18,9 +19,6 @@ import (
 	_ "k8s.io/code-generator/cmd/defaulter-gen"
 	_ "k8s.io/code-generator/cmd/informer-gen"
 	_ "k8s.io/code-generator/cmd/lister-gen"
-
-	// TODO: Investigate openapi-gen
-	// _ "k8s.io/code-generator/cmd/openapi-gen"
-
-	_ "github.com/containers/kubensmnt/utils/systemd"
+	_ "k8s.io/code-generator/cmd/openapi-gen"
+	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 )


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
