### PR TITLE
OCPBUGS-31255: Degraded worker pool when applying configs to master and worker pools at the same time

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -1060,6 +1060,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 			}
 		}
 	}
+	time.Sleep(30 * time.Second)
 	candidates, capacity := getAllCandidateMachines(layered, mosc, mosb, pool, nodes, maxunavail)
 	if len(candidates) > 0 {
 		zones := make(map[string]bool)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added sleep interval to delay updates on nodes

**- How to verify it**
Run scripts found in the Jira Bug report and note if a degradation occurs

``` 
./continuous_update.sh                                                                            
MCP master updated.
Creating mc-reproducer-master
machineconfig.machineconfiguration.openshift.io/mc-reproducer-master created
MCP worker updated.
Creating mc-reproducer-worker
machineconfig.machineconfiguration.openshift.io/mc-reproducer-worker created
MCP master updated.
Deleting mc-reproducer-master
machineconfig.machineconfiguration.openshift.io "mc-reproducer-master" deleted
MCP worker updated.
Deleting mc-reproducer-worker
machineconfig.machineconfiguration.openshift.io "mc-reproducer-worker" deleted
MCP master updated.
Creating mc-reproducer-master
machineconfig.machineconfiguration.openshift.io/mc-reproducer-master created
MCP worker updated.
Creating mc-reproducer-worker
machineconfig.machineconfiguration.openshift.io/mc-reproducer-worker created
MCP master updated.
Deleting mc-reproducer-master
machineconfig.machineconfiguration.openshift.io "mc-reproducer-master" deleted
MCP worker updated.
Deleting mc-reproducer-worker
machineconfig.machineconfiguration.openshift.io "mc-reproducer-worker" deleted
...
```

```
MCO/bugs/degraded-worker-pool-loop on ☁️  (us-east-1) on ☁️  aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com 
❯ ./watcher.sh                                                                                      
^C
```

```
❯ oc get mcp -w
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
master   rendered-master-6b6f9caa3a47918196310a162d5e82b2   True      False      False      3              3                   3                     0                      102m
worker   rendered-worker-c61033de989233f93639617ae5e8c42b   True      False      False      3              3                   3                     0                      102m
^C%  
```
no degradation seen

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
