### PR TITLE
render: relax VIPs in infra status

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -451,7 +451,10 @@ func onPremPlatformIngressIP(cfg RenderConfig) (interface{}, error) {
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs[0], nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs[0], nil
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs) > 0 {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs[0], nil
+			}
+			return nil, nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
 				if len(cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs) > 0 {
@@ -481,7 +484,10 @@ func onPremPlatformIngressIPs(cfg RenderConfig) (interface{}, error) {
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs, nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs, nil
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs) > 0 {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs, nil
+			}
+			return []string{}, nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
 				return cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs, nil
@@ -511,7 +517,10 @@ func onPremPlatformAPIServerInternalIP(cfg RenderConfig) (interface{}, error) {
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs[0], nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs[0], nil
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs) > 0 {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs[0], nil
+			}
+			return nil, nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
 				if len(cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs) > 0 {
@@ -541,7 +550,10 @@ func onPremPlatformAPIServerInternalIPs(cfg RenderConfig) (interface{}, error) {
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs, nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs, nil
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs) > 0 {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs, nil
+			}
+			return []string{}, nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
 				return cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs, nil

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -275,7 +275,10 @@ func onPremPlatformIngressIP(cfg mcfgv1.ControllerConfigSpec) (interface{}, erro
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs[0], nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs[0], nil
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs) > 0 {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs[0], nil
+			}
+			return nil, nil
 		case configv1.VSpherePlatformType:
 			if len(cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs) > 0 {
 				return cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs[0], nil
@@ -299,7 +302,10 @@ func onPremPlatformIngressIPs(cfg mcfgv1.ControllerConfigSpec) (interface{}, err
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs, nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs, nil
+			if cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs != nil {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs, nil
+			}
+			return []string{}, nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs != nil {
 				return cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs, nil
@@ -326,7 +332,10 @@ func onPremPlatformAPIServerInternalIP(cfg mcfgv1.ControllerConfigSpec) (interfa
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs[0], nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs[0], nil
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs) > 0 {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs[0], nil
+			}
+			return nil, nil
 		case configv1.VSpherePlatformType:
 			if len(cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs) > 0 {
 				return cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs[0], nil
@@ -350,7 +359,10 @@ func onPremPlatformAPIServerInternalIPs(cfg mcfgv1.ControllerConfigSpec) (interf
 		case configv1.OvirtPlatformType:
 			return cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs, nil
 		case configv1.OpenStackPlatformType:
-			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs, nil
+			if cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs != nil {
+				return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs, nil
+			}
+			return []string{}, nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs != nil {
 				return cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs, nil


### PR DESCRIPTION
In the context of Hypershift being deployed on the OpenStack platform,
we have decided that Ingress on the workers would be out of scope in
this release.

For that reason, we would like to relax the Infrastructure object where
IPs don't have to be set for the API & Ingress VIPs.

VMware already allows that for their UPI and we need the same mechanism
for now until we figure out how to handle Ingress VIPs on the workers
and we can deploy Keepalived.
