### PR TITLE
OCPBUGS-36711: templates: run disable-mglru conditionally

### DIFF
--- a/templates/common/_base/units/disable-mglru.service.yaml
+++ b/templates/common/_base/units/disable-mglru.service.yaml
@@ -7,7 +7,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=bash -c "echo 0 > /sys/kernel/mm/lru_gen/enabled"
+  ExecStart=/bin/bash -c "if [ -f "/sys/kernel/mm/lru_gen/enabled" ]; then echo 0 > /sys/kernel/mm/lru_gen/enabled; fi"
 
   
   [Install]


### PR DESCRIPTION
RHEL worker nodes may not have lru_gen, so adding a condition so it doesn't fail