### PR TITLE
OCPBUGS-36654: Machine-config operator should not hot loop generating ValidatingAdmissionPolicyUpdated events

### DIFF
--- a/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
@@ -5,11 +5,15 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["operator.openshift.io"]
       apiVersions: ["v1"]
       operations:  ["CREATE","UPDATE"]
       resources:   ["machineconfigurations"]
+      scope: "*"
   validations:
     - expression: "object.metadata.name=='cluster'"
       message: "Only a single object of MachineConfiguration is allowed and it must be named cluster."

--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
@@ -8,11 +8,15 @@ spec:
     apiVersion: config.openshift.io/v1
     kind: Infrastructure
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["operator.openshift.io"]
       apiVersions: ["v1"]
       operations:  ["CREATE","UPDATE"]
       resources:   ["machineconfigurations"]
+      scope: "*"
   validations:
     - expression: "!has(object.spec.managedBootImages) || (has(object.spec.managedBootImages) && params.status.platformStatus.type in ['GCP'])"
       message: "This feature is only supported on these platforms: GCP"

--- a/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml
@@ -5,11 +5,15 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}    
     resourceRules:
     - apiGroups:   ["machineconfiguration.openshift.io"]
       apiVersions: ["v1alpha1"]
       operations:  ["CREATE","UPDATE"]
       resources:   ["machineconfignodes/status","machineconfignodes"]
+      scope: "*"
   validations:
     # all requests should have a node-name claim, this prevents impersonation of the machine-config-daemon SA.
     - expression: "has(request.userInfo.extra) && ('authentication.kubernetes.io/node-name' in request.userInfo.extra)"


### PR DESCRIPTION
**- What I did**
This adds a few defaults to the existing VAP manifests, so that the library-go reconciler doesn't attempt to update the VAP when the defaults aren't provided.

**- How to verify it**
- VAP policies should be still in effect, so all the existing rules can be verified.
- You should not see any ValidatingAdmissionPolicy update events when running:
``` 
oc -n openshift-machine-config-operator get -o json events | jq -r '.items[] | select(.reason == "ValidatingAdmissionPolicyUpdated")'
```
