### PR TITLE
MCO-1191, MCO-1194: Experiment with creating internal go bindings for bootc , Incorporate support for bootc commands to Machine Config Daemon 

### DIFF
--- a/pkg/daemon/bootc.go
+++ b/pkg/daemon/bootc.go
@@ -1,0 +1,325 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/containers/image/v5/types"
+	"k8s.io/klog/v2"
+)
+
+// rpmOstreeState houses zero or more RpmOstreeDeployments
+// Subset of `bootc status --json`
+// https://github.com/projectatomic/rpm-ostree/blob/bce966a9812df141d38e3290f845171ec745aa4e/src/daemon/rpmostreed-deployment-utils.c#L227
+type rpmOstreeState struct {
+	Deployments []RpmOstreeDeployment
+	Transaction *[]string
+}
+
+// RpmOstreeDeployment represents a single deployment on a node
+type RpmOstreeDeployment struct {
+	ID                      string   `json:"id"`
+	OSName                  string   `json:"osname"`
+	Serial                  int32    `json:"serial"`
+	Checksum                string   `json:"checksum"`
+	BaseChecksum            string   `json:"base-checksum,omitempty"`
+	Version                 string   `json:"version"`
+	Timestamp               uint64   `json:"timestamp"`
+	Booted                  bool     `json:"booted"`
+	Staged                  bool     `json:"staged"`
+	LiveReplaced            string   `json:"live-replaced,omitempty"`
+	Origin                  string   `json:"origin"`
+	CustomOrigin            []string `json:"custom-origin"`
+	ContainerImageReference string   `json:"container-image-reference"`
+}
+
+// NewNodeImageUpdaterClient is an interface describing how to interact with the host
+// around content deployment
+type NodeImageUpdaterClient interface {
+	Initialize() error
+	GetStatus() (string, error)
+	GetBootedOSImageURL() (string, string, string, error)
+	Rebase(string, string) (bool, error)
+	RebaseLayered(string) error
+	IsBootableImage(string) (bool, error)
+	GetBootedAndStagedDeployment() (*RpmOstreeDeployment, *RpmOstreeDeployment, error)
+}
+
+// BootcClient provides all bootc related methods in one structure.
+
+type BootcClient struct{}
+
+// NewNodeUpdaterClient returns a new instance of the default DeploymentClient (BootcClient)
+func NewNodeImageUpdaterClient() NodeImageUpdaterClient {
+	return &BootcClient{}
+}
+
+// Synchronously invoke bootc, writing its stdout to our stdout,
+// and gathering stderr into a buffer which will be returned in err
+// in case of error.
+func runBootc(args ...string) error {
+	return runCmdSync("bootc", args...)
+}
+
+func (r *RpmOstreeClient) loadStatus() (*rpmOstreeState, error) {
+	var rosState rpmOstreeState
+	output, err := runGetOut("rpm-ostree", "status", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(output, &rosState); err != nil {
+		return nil, fmt.Errorf("failed to parse `rpm-ostree status --json` output (%s): %w", truncate(string(output), 30), err)
+	}
+
+	return &rosState, nil
+}
+
+func (r *RpmOstreeClient) Initialize() error {
+	if err := bug2111817Workaround(); err != nil {
+		return err
+	}
+
+	// Commands like update and rebase need the pull secrets to pull images and manifests,
+	// make sure we get access to them when we Initialize
+	err := useKubeletConfigSecrets()
+	if err != nil {
+		return fmt.Errorf("Error while ensuring access to kublet config.json pull secrets: %w", err)
+	}
+
+	return nil
+}
+
+// GetBootedDeployment returns the current deployment found
+func (r *RpmOstreeClient) GetBootedAndStagedDeployment() (booted, staged *RpmOstreeDeployment, err error) {
+	status, err := r.loadStatus()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	booted, err = status.getBootedDeployment()
+	staged = status.getStagedDeployment()
+
+	return
+}
+
+// GetStatus returns multi-line human-readable text describing system status
+// Bootc is working on status update: https://github.com/containers/bootc/issues/408
+func (r *BootcClient) GetStatus() (string, error) {
+	output, err := runGetOut("bootc", "status")
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+// GetBootedOSImageURL returns the image URL as well as the OSTree version(for logging) and the ostree commit (for comparisons)
+// Returns the empty string if the host doesn't have a custom origin that matches pivot://
+// (This could be the case for e.g. FCOS, or a future RHCOS which comes not-pivoted by default)
+func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, string, error) {
+	bootedDeployment, _, err := r.GetBootedAndStagedDeployment()
+	if err != nil {
+		return "", "", "", err
+	}
+
+	// TODO(jkyros): take this out, I just want to see when/why it's empty?
+	j, _ := json.MarshalIndent(bootedDeployment, "", "    ")
+	klog.Infof("%s", j)
+
+	// the canonical image URL is stored in the custom origin field.
+
+	osImageURL := ""
+	if len(bootedDeployment.CustomOrigin) > 0 {
+		if strings.HasPrefix(bootedDeployment.CustomOrigin[0], "pivot://") {
+			osImageURL = bootedDeployment.CustomOrigin[0][len("pivot://"):]
+		}
+	}
+
+	// we have container images now, make sure we can parse those too
+	if bootedDeployment.ContainerImageReference != "" {
+		// right now they start with "ostree-unverified-registry:", so scrape that off
+		tokens := strings.SplitN(bootedDeployment.ContainerImageReference, ":", 2)
+		if len(tokens) > 1 {
+			osImageURL = tokens[1]
+		}
+	}
+
+	// BaseChecksum is populated if the system has been modified in a way that changes the base checksum
+	// (like via an RPM install) so prefer BaseCheksum that if it's present, otherwise just use Checksum.
+	baseChecksum := bootedDeployment.Checksum
+	if bootedDeployment.BaseChecksum != "" {
+		baseChecksum = bootedDeployment.BaseChecksum
+	}
+
+	return osImageURL, bootedDeployment.Version, baseChecksum, nil
+}
+
+// Rebase potentially rebases system if not already rebased.
+func (r *RpmOstreeClient) Rebase(imgURL, osImageContentDir string) (changed bool, err error) {
+	var (
+		ostreeCsum    string
+		ostreeVersion string
+	)
+	defaultDeployment, _, err := r.GetBootedAndStagedDeployment()
+	if err != nil {
+		return
+	}
+
+	previousPivot := ""
+	if len(defaultDeployment.CustomOrigin) > 0 {
+		if strings.HasPrefix(defaultDeployment.CustomOrigin[0], "pivot://") {
+			previousPivot = defaultDeployment.CustomOrigin[0][len("pivot://"):]
+			klog.Infof("Previous pivot: %s", previousPivot)
+		} else {
+			klog.Infof("Previous custom origin: %s", defaultDeployment.CustomOrigin[0])
+		}
+	} else {
+		klog.Info("Current origin is not custom")
+	}
+
+	var imageData *types.ImageInspectInfo
+	if imageData, err = imageInspect(imgURL); err != nil {
+		if err != nil {
+			var podmanImgData *imageInspection
+			klog.Infof("Falling back to using podman inspect")
+			if podmanImgData, err = podmanInspect(imgURL); err != nil {
+				return
+			}
+			ostreeCsum = podmanImgData.Labels["com.coreos.ostree-commit"]
+			ostreeVersion = podmanImgData.Labels["version"]
+		}
+	} else {
+		ostreeCsum = imageData.Labels["com.coreos.ostree-commit"]
+		ostreeVersion = imageData.Labels["version"]
+	}
+	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
+	defer exec.Command("podman", "rmi", imgURL).Run()
+
+	repo := fmt.Sprintf("%s/srv/repo", osImageContentDir)
+
+	// Now we need to figure out the commit to rebase to
+	// Commit label takes priority
+	if ostreeCsum != "" {
+		if ostreeVersion != "" {
+			klog.Infof("Pivoting to: %s (%s)", ostreeVersion, ostreeCsum)
+		} else {
+			klog.Infof("Pivoting to: %s", ostreeCsum)
+		}
+	} else {
+		klog.Infof("No com.coreos.ostree-commit label found in metadata! Inspecting...")
+		var refText []byte
+		refText, err = runGetOut("ostree", "refs", "--repo", repo)
+		if err != nil {
+			return
+		}
+		refs := strings.Split(strings.TrimSpace(string(refText)), "\n")
+		if len(refs) == 1 {
+			klog.Infof("Using ref %s", refs[0])
+			var ostreeCsumBytes []byte
+			ostreeCsumBytes, err = runGetOut("ostree", "rev-parse", "--repo", repo, refs[0])
+			if err != nil {
+				return
+			}
+			ostreeCsum = strings.TrimSpace(string(ostreeCsumBytes))
+		} else if len(refs) > 1 {
+			err = fmt.Errorf("multiple refs found in repo")
+			return
+		} else {
+			// XXX: in the future, possibly scan the repo to find a unique .commit object
+			err = fmt.Errorf("no refs found in repo")
+			return
+		}
+	}
+
+	// This will be what will be displayed in `rpm-ostree status` as the "origin spec"
+	customURL := fmt.Sprintf("pivot://%s", imgURL)
+	klog.Infof("Executing rebase from repo path %s with customImageURL %s and checksum %s", repo, customURL, ostreeCsum)
+
+	args := []string{"rebase", "--experimental", fmt.Sprintf("%s:%s", repo, ostreeCsum),
+		"--custom-origin-url", customURL, "--custom-origin-description", "Managed by machine-config-operator"}
+
+	if err = runRpmOstree(args...); err != nil {
+		return
+	}
+
+	changed = true
+	return
+}
+
+// IsBootableImage determines if the image is a bootable (new container formet) image, or a wrapper (old container format)
+func (r *RpmOstreeClient) IsBootableImage(imgURL string) (bool, error) {
+
+	// TODO(jkyros): This is duplicated-ish from Rebase(), do we still need to carry this around?
+	var isBootableImage string
+	var imageData *types.ImageInspectInfo
+	var err error
+	if imageData, err = imageInspect(imgURL); err != nil {
+		if err != nil {
+			var podmanImgData *imageInspection
+			klog.Infof("Falling back to using podman inspect")
+
+			if podmanImgData, err = podmanInspect(imgURL); err != nil {
+				return false, err
+			}
+			isBootableImage = podmanImgData.Labels["ostree.bootable"]
+		}
+	} else {
+		isBootableImage = imageData.Labels["ostree.bootable"]
+	}
+	// We may have pulled in OSContainer image as fallback during podmanCopy() or podmanInspect()
+	defer exec.Command("podman", "rmi", imgURL).Run()
+
+	return isBootableImage == "true", nil
+}
+
+// RebaseLayered rebases system or errors if already rebased
+func (r *RpmOstreeClient) RebaseLayered(imgURL string) (err error) {
+	klog.Infof("Executing rebase to %s", imgURL)
+	return runRpmOstree("rebase", "--experimental", "ostree-unverified-registry:"+imgURL)
+}
+
+// useKubeletConfigSecrets gives the rpm-ostree client access to secrets in the kubelet config.json by symlinking so that
+// rpm-ostree can use those secrets to pull images. It does this by symlinking the kubelet's config.json into /run/ostree.
+func useKubeletConfigSecrets() error {
+	if _, err := os.Stat("/run/ostree/auth.json"); err != nil {
+
+		if errors.Is(err, os.ErrNotExist) {
+
+			err := os.MkdirAll("/run/ostree", 0o544)
+			if err != nil {
+				return err
+			}
+
+			err = os.Symlink(kubeletAuthFile, "/run/ostree/auth.json")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (state *rpmOstreeState) getBootedDeployment() (*RpmOstreeDeployment, error) {
+	for num := range state.Deployments {
+		deployment := state.Deployments[num]
+		if deployment.Booted {
+			return &deployment, nil
+		}
+	}
+	return &RpmOstreeDeployment{}, fmt.Errorf("not currently booted in a deployment")
+}
+
+func (state *rpmOstreeState) getStagedDeployment() *RpmOstreeDeployment {
+	for num := range state.Deployments {
+		deployment := state.Deployments[num]
+		if deployment.Staged {
+			return &deployment
+		}
+	}
+	return &RpmOstreeDeployment{}
+}

--- a/pkg/daemon/image_manager_helper.go
+++ b/pkg/daemon/image_manager_helper.go
@@ -2,27 +2,36 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/opencontainers/go-digest"
 	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
 const (
+	rpmOstreeSystem imageSystem = "rpm-ostree"
+	bootcSystem     imageSystem = "bootc"
 	// the number of times to retry commands that pull data from the network
 	numRetriesNetCommands = 5
 	// Default ostreeAuthFile location
 	ostreeAuthFile = "/run/ostree/auth.json"
+	// Default bootcAuthFile location
+	bootcAuthFile = "/etc/ostree/auth.json"
 	// Pull secret.  Written by the machine-config-operator
 	kubeletAuthFile = "/var/lib/kubelet/config.json"
 	// Internal Registry Pull secret + Global Pull secret.  Written by the machine-config-operator.
 	imageRegistryAuthFile = "/etc/mco/internal-registry-pull-secret.json"
 )
+
+type imageSystem string
 
 // imageInspection is a public implementation of
 // https://github.com/containers/skopeo/blob/82186b916faa9c8c70cfa922229bafe5ae024dec/cmd/skopeo/inspect.go#L20-L31
@@ -37,6 +46,13 @@ type imageInspection struct {
 	Architecture  string
 	Os            string
 	Layers        []string
+}
+
+// BootedImageInfo stores MCO interested bootec image info
+type BootedImageInfo struct {
+	OSImageURL   string
+	ImageVersion string
+	BaseChecksum string
 }
 
 func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
@@ -98,4 +114,83 @@ func truncate(input string, limit int) string {
 	}
 
 	return fmt.Sprintf("%s [%d more chars]", string(asRunes[:limit]), l-limit)
+}
+
+// useMergedSecrets gives the rpm-ostree / bootc client access to secrets for the internal registry and the global pull
+// secret. It does this by symlinking the merged secrets file into /run/ostree or /etc/ostree. If it fails to find the
+// merged secrets, it will use the default pull secret file instead.
+func useMergedPullSecrets(system imageSystem) error {
+
+	if err := validateImageSystem(system); err != nil {
+		return err
+	}
+
+	// check if merged secret file exists
+	if _, err := os.Stat(imageRegistryAuthFile); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		klog.Errorf("Merged secret file does not exist; defaulting to cluster pull secret")
+		return linkAuthFile(system, kubeletAuthFile)
+	}
+	// Check that merged secret file is valid JSON
+	if file, err := os.ReadFile(imageRegistryAuthFile); err != nil {
+		klog.Errorf("Merged secret file could not be read; defaulting to cluster pull secret %v", err)
+		return linkAuthFile(system, kubeletAuthFile)
+	} else if !json.Valid(file) {
+		klog.Errorf("Merged secret file could not be validated; defaulting to cluster pull secret %v", err)
+		return linkAuthFile(system, kubeletAuthFile)
+	}
+
+	return linkAuthFile(system, imageRegistryAuthFile)
+}
+
+func validateImageSystem(imgSys imageSystem) error {
+	// Sets provided by https://github.com/kubernetes/apimachinery/tree/master/pkg/util/sets
+	// Imported as k8s.io/apimachinery/pkg/util/sets
+	valid := sets.New[imageSystem](rpmOstreeSystem, bootcSystem)
+	if valid.Has(imgSys) {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid system %s! Valid systems are: %v", imgSys, sets.List(valid))
+}
+
+// linkAuthFile gives rpm-ostree / bootc client access to secrets in the file located at `path` by symlinking so that
+// rpm-ostree / bootc can use those secrets to pull images.This can be called multiple times to overwrite an older link.
+
+// Pull secret for 'rpm-ostree' to fetch updates from registry which requires authentication is stored in /run/ostree/auth.json
+// Pull secret for 'bootc' to fetch updates from registry which requires authentication is stored in /etc/ostree/auth.json
+// per https://github.com/containers/bootc/blob/5e9279d6674b28d2c451baeaf981a92a1aa388ff/docs/src/building/secrets.md?plain=1#L4
+func linkAuthFile(system imageSystem, path string) error {
+	if err := validateImageSystem(system); err != nil {
+		return err
+	}
+
+	var authFilePath string
+	switch system {
+	case rpmOstreeSystem:
+		authFilePath = ostreeAuthFile
+	case bootcSystem:
+		authFilePath = bootcAuthFile
+	default:
+		return fmt.Errorf("unknown system value %q", system)
+	}
+
+	if _, err := os.Lstat(authFilePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(authFilePath), 0o544); err != nil {
+			return err
+		}
+	} else {
+		// Remove older symlink if it exists since it needs to be overwritten
+		if err := os.Remove(authFilePath); err != nil {
+			return err
+		}
+	}
+
+	klog.Infof("Linking %s authfile to %s", system, path)
+	return os.Symlink(path, authFilePath)
 }

--- a/pkg/daemon/image_manager_helper.go
+++ b/pkg/daemon/image_manager_helper.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// the number of times to retry commands that pull data from the network
+	numRetriesNetCommands = 5
+	// Default ostreeAuthFile location
+	ostreeAuthFile = "/run/ostree/auth.json"
+	// Pull secret.  Written by the machine-config-operator
+	kubeletAuthFile = "/var/lib/kubelet/config.json"
+	// Internal Registry Pull secret + Global Pull secret.  Written by the machine-config-operator.
+	imageRegistryAuthFile = "/etc/mco/internal-registry-pull-secret.json"
+)
+
+// imageInspection is a public implementation of
+// https://github.com/containers/skopeo/blob/82186b916faa9c8c70cfa922229bafe5ae024dec/cmd/skopeo/inspect.go#L20-L31
+type imageInspection struct {
+	Name          string `json:",omitempty"`
+	Tag           string `json:",omitempty"`
+	Digest        digest.Digest
+	RepoDigests   []string
+	Created       *time.Time
+	DockerVersion string
+	Labels        map[string]string
+	Architecture  string
+	Os            string
+	Layers        []string
+}
+
+func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
+	// Pull the container image if not already available
+	var authArgs []string
+	if _, err := os.Stat(kubeletAuthFile); err == nil {
+		authArgs = append(authArgs, "--authfile", kubeletAuthFile)
+	}
+	args := []string{"pull", "-q"}
+	args = append(args, authArgs...)
+	args = append(args, imgURL)
+	_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
+	if err != nil {
+		return
+	}
+
+	inspectArgs := []string{"inspect", "--type=image"}
+	inspectArgs = append(inspectArgs, fmt.Sprintf("%s", imgURL))
+	var output []byte
+	output, err = runGetOut("podman", inspectArgs...)
+	if err != nil {
+		return
+	}
+	var imagedataArray []imageInspection
+	err = json.Unmarshal(output, &imagedataArray)
+	if err != nil {
+		err = fmt.Errorf("unmarshaling podman inspect: %w", err)
+		return
+	}
+	imgdata = &imagedataArray[0]
+	return
+
+}
+
+// runGetOut executes a command, logging it, and return the stdout output.
+func runGetOut(command string, args ...string) ([]byte, error) {
+	klog.Infof("Running captured: %s %s", command, strings.Join(args, " "))
+	cmd := exec.Command(command, args...)
+	rawOut, err := cmd.Output()
+	if err != nil {
+		errtext := ""
+		if e, ok := err.(*exec.ExitError); ok {
+			// Trim to max of 256 characters
+			errtext = fmt.Sprintf("\n%s", truncate(string(e.Stderr), 256))
+		}
+		return nil, fmt.Errorf("error running %s %s: %s%s", command, strings.Join(args, " "), err, errtext)
+	}
+	return rawOut, nil
+}
+
+// truncate a string using runes/codepoints as limits.
+// This specifically will avoid breaking a UTF-8 value.
+func truncate(input string, limit int) string {
+	asRunes := []rune(input)
+	l := len(asRunes)
+
+	if limit >= l {
+		return input
+	}
+
+	return fmt.Sprintf("%s [%d more chars]", string(asRunes[:limit]), l-limit)
+}

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -5,43 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	rpmostreeclient "github.com/coreos/rpmostree-client-go/pkg/client"
-	"github.com/opencontainers/go-digest"
-	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
 	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
 )
-
-const (
-	// the number of times to retry commands that pull data from the network
-	numRetriesNetCommands = 5
-	// Default ostreeAuthFile location
-	ostreeAuthFile = "/run/ostree/auth.json"
-	// Pull secret.  Written by the machine-config-operator
-	kubeletAuthFile = "/var/lib/kubelet/config.json"
-	// Internal Registry Pull secret + Global Pull secret.  Written by the machine-config-operator.
-	imageRegistryAuthFile = "/etc/mco/internal-registry-pull-secret.json"
-)
-
-// imageInspection is a public implementation of
-// https://github.com/containers/skopeo/blob/82186b916faa9c8c70cfa922229bafe5ae024dec/cmd/skopeo/inspect.go#L20-L31
-type imageInspection struct {
-	Name          string `json:",omitempty"`
-	Tag           string `json:",omitempty"`
-	Digest        digest.Digest
-	RepoDigests   []string
-	Created       *time.Time
-	DockerVersion string
-	Labels        map[string]string
-	Architecture  string
-	Os            string
-	Layers        []string
-}
 
 // RpmOstreeClient provides all RpmOstree related methods in one structure.
 // This structure implements DeploymentClient
@@ -163,38 +133,6 @@ func (r *RpmOstreeClient) GetBootedOSImageURL() (string, string, string, error) 
 	return osImageURL, bootedDeployment.Version, baseChecksum, nil
 }
 
-func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
-	// Pull the container image if not already available
-	var authArgs []string
-	if _, err := os.Stat(ostreeAuthFile); err == nil {
-		authArgs = append(authArgs, "--authfile", ostreeAuthFile)
-	}
-	args := []string{"pull", "-q"}
-	args = append(args, authArgs...)
-	args = append(args, imgURL)
-	_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
-	if err != nil {
-		return
-	}
-
-	inspectArgs := []string{"inspect", "--type=image"}
-	inspectArgs = append(inspectArgs, fmt.Sprintf("%s", imgURL))
-	var output []byte
-	output, err = runGetOut("podman", inspectArgs...)
-	if err != nil {
-		return
-	}
-	var imagedataArray []imageInspection
-	err = json.Unmarshal(output, &imagedataArray)
-	if err != nil {
-		err = fmt.Errorf("unmarshaling podman inspect: %w", err)
-		return
-	}
-	imgdata = &imagedataArray[0]
-	return
-
-}
-
 // RpmOstreeIsNewEnoughForLayering returns true if the version of rpm-ostree on the
 // host system is new enough for layering.
 // VersionData represents the static information about rpm-ostree.
@@ -296,33 +234,4 @@ func useMergedPullSecrets() error {
 
 	// Attempt to link the merged secrets file
 	return linkOstreeAuthFile(imageRegistryAuthFile)
-}
-
-// truncate a string using runes/codepoints as limits.
-// This specifically will avoid breaking a UTF-8 value.
-func truncate(input string, limit int) string {
-	asRunes := []rune(input)
-	l := len(asRunes)
-
-	if limit >= l {
-		return input
-	}
-
-	return fmt.Sprintf("%s [%d more chars]", string(asRunes[:limit]), l-limit)
-}
-
-// runGetOut executes a command, logging it, and return the stdout output.
-func runGetOut(command string, args ...string) ([]byte, error) {
-	klog.Infof("Running captured: %s %s", command, strings.Join(args, " "))
-	cmd := exec.Command(command, args...)
-	rawOut, err := cmd.Output()
-	if err != nil {
-		errtext := ""
-		if e, ok := err.(*exec.ExitError); ok {
-			// Trim to max of 256 characters
-			errtext = fmt.Sprintf("\n%s", truncate(string(e.Stderr), 256))
-		}
-		return nil, fmt.Errorf("error running %s %s: %s%s", command, strings.Join(args, " "), err, errtext)
-	}
-	return rawOut, nil
 }


### PR DESCRIPTION
- Create a bootc.go to store bootc status reading and command line execution
- Create bootc internal go-bindings inside bootc.go. Code designed in the way to be easily separated into a standalone lib: https://github.com/inesqyx/bootc-client-go/tree/bootc-client-go 
- Consolidate functions that rpm-ostree and bootc share in common into one place 
