### PR TITLE
MCO-1230: Retry build and push operations multiple times

### DIFF
--- a/pkg/controller/build/assets/wait.sh
+++ b/pkg/controller/build/assets/wait.sh
@@ -4,12 +4,14 @@
 # within the Build Controller binary (see //go:embed) and injected into a
 # custom build pod.
 
-# Wait until the done file appears.
+# Wait until the digestfile file appears. The presence of this file indicates
+# that the build operation is complete.
 while [ ! -f "/tmp/done/digestfile" ]
 do
 	sleep 1
 done
 
+# Inject the contents of the digestfile into a ConfigMap.
 oc create configmap \
 	"$DIGEST_CONFIGMAP_NAME" \
 	--namespace openshift-machine-config-operator \

--- a/pkg/controller/build/image_build_request.go
+++ b/pkg/controller/build/image_build_request.go
@@ -197,6 +197,17 @@ func (i ImageBuildRequest) toBuildPod() *corev1.Pod {
 // nolint:dupl // I don't want to deduplicate this yet since there are still some unknowns.
 func (i ImageBuildRequest) toBuildahPod() *corev1.Pod {
 	env := []corev1.EnvVar{
+		// How many times the build / push steps should be retried. In the future,
+		// this should be wired up to the MachineOSConfig or other higher-level
+		// API. This is useful for retrying builds / pushes when they fail due to a
+		// transient condition such as a temporary network issue. It does *NOT*
+		// handle situations where the build pod is evicted or rescheduled. A
+		// higher-level abstraction will be needed such as a Kubernetes Job
+		// (https://kubernetes.io/docs/concepts/workloads/controllers/job/).
+		{
+			Name:  "MAX_RETRIES",
+			Value: "3",
+		},
 		{
 			Name:  "DIGEST_CONFIGMAP_NAME",
 			Value: i.getDigestConfigMapName(),


### PR DESCRIPTION
**- What I did**

Occasionally, an image build and / or push operation will fail due to a transient network condition. To make this process more robust, we should retry these operations multiple times. This PR implements a simplified approach where the build and push operations themselves are wrapped in a `retry` function. It should be noted that a key limitation of this approach is that it _does not_ account for situations where the build pod is evicted or rescheduled onto a different node. For that, we may want to investigate using a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) which provides additional resilience around evictions and rescheduling.

**- How to verify it**

1. Create a MachineOSConfig with a syntax error in the Containerfile or use an invalid image push secret.
2. Allow the build to run. Eventually, it will fail.
3. Review the logs for the build pod. Statements such as "Retry 3/3 exited 1, no more retries left." should be observed.
 
**- Description for the changelog**
Image builds and pushes should be retried
