### PR TITLE
MCO-1125: OCPBUGS-35277: Allow paths to be defined for non-disruptive updates

### DIFF
--- a/docs/NodeDisruptionPolicy.md
+++ b/docs/NodeDisruptionPolicy.md
@@ -27,11 +27,11 @@ $ oc get MachineConfiguration/cluster -o yaml
 apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
-  creationTimestamp: "2024-04-16T15:02:37Z"
-  generation: 4
+  creationTimestamp: "2024-07-11T13:44:07Z"
+  generation: 9
   name: cluster
-  resourceVersion: "261205"
-  uid: 2c67b155-1898-452f-adbd-ed376afc0ea2
+  resourceVersion: "239810"
+  uid: 2f31b426-8d50-414a-a46a-463269686b2f
 spec:
   logLevel: Normal
   managementState: Managed
@@ -56,10 +56,27 @@ status:
       - actions:
         - type: Special
         path: /etc/containers/registries.conf
+      - actions:
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        path: /etc/containers/registries.d
+      - actions:
+        - type: None
+        path: /etc/nmstate/openshift
+      - actions:
+        - restart:
+            serviceName: coreos-update-ca-trust.service
+          type: Restart
+        - restart:
+            serviceName: crio.service
+          type: Restart
+        path: /etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt
       sshkey:
         actions:
         - type: None
-  readyReplicas: 0
+  observedGeneration: 9
+
 ```
 Say, for instance the user applied the following MachineConfiguration:
 ```
@@ -81,27 +98,24 @@ $ oc get MachineConfiguration/cluster -o yaml
 apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
-  creationTimestamp: "2024-04-16T15:02:37Z"
-  generation: 4
+  creationTimestamp: "2024-07-11T13:44:07Z"
+  generation: 10
   name: cluster
-  resourceVersion: "261205"
-  uid: 2c67b155-1898-452f-adbd-ed376afc0ea2
+  resourceVersion: "240452"
+  uid: 2f31b426-8d50-414a-a46a-463269686b2f
 spec:
-  nodeDisruptionPolicy:
-    files:
-      - path: /etc/my-file
-        actions:
-          - type: None
   logLevel: Normal
   managementState: Managed
+  nodeDisruptionPolicy:
+    files:
+    - actions:
+      - type: None
+      path: /etc/my-file
   operatorLogLevel: Normal
 status:
   nodeDisruptionPolicyStatus:
     clusterPolicies:
       files:
-      - actions:
-        - type: None
-        path: /etc/my-file
       - actions:
         - type: None
         path: /var/lib/kubelet/config.json
@@ -118,16 +132,35 @@ status:
       - actions:
         - type: Special
         path: /etc/containers/registries.conf
+      - actions:
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        path: /etc/containers/registries.d
+      - actions:
+        - type: None
+        path: /etc/nmstate/openshift
+      - actions:
+        - restart:
+            serviceName: coreos-update-ca-trust.service
+          type: Restart
+        - restart:
+            serviceName: crio.service
+          type: Restart
+        path: /etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt
+      - actions:
+        - type: None
+        path: /etc/my-file
       sshkey:
         actions:
         - type: None
-  readyReplicas: 0
+  observedGeneration: 10
 
 ```
 
 
 For this initial implementation the policy supports MachineConfig changes to the following:
-- Files
+- Files & Directories
 - Units
 - sshKeys
 

--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -9,6 +9,7 @@ import (
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +23,7 @@ var (
 	defaultClusterPolicies = opv1.NodeDisruptionPolicyClusterStatus{
 		Files: []opv1.NodeDisruptionPolicyStatusFile{
 			{
-				Path: "/var/lib/kubelet/config.json",
+				Path: constants.KubeletAuthFile,
 				Actions: []opv1.NodeDisruptionPolicyStatusAction{
 					{
 						Type: opv1.NoneStatusAction,
@@ -30,7 +31,7 @@ var (
 				},
 			},
 			{
-				Path: "/etc/machine-config-daemon/no-reboot/containers-gpg.pub",
+				Path: constants.GPGNoRebootPath,
 				Actions: []opv1.NodeDisruptionPolicyStatusAction{
 					{
 						Type: opv1.ReloadStatusAction,
@@ -41,7 +42,7 @@ var (
 				},
 			},
 			{
-				Path: "/etc/containers/policy.json",
+				Path: constants.ContainerRegistryPolicyPath,
 				Actions: []opv1.NodeDisruptionPolicyStatusAction{
 					{
 						Type: opv1.ReloadStatusAction,
@@ -52,10 +53,46 @@ var (
 				},
 			},
 			{
-				Path: "/etc/containers/registries.conf",
+				Path: constants.ContainerRegistryConfPath,
 				Actions: []opv1.NodeDisruptionPolicyStatusAction{
 					{
 						Type: opv1.SpecialStatusAction,
+					},
+				},
+			},
+			{
+				Path: constants.SigstoreRegistriesConfigDir,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.ReloadStatusAction,
+						Reload: &opv1.ReloadService{
+							ServiceName: "crio.service",
+						},
+					},
+				},
+			},
+			{
+				Path: constants.OpenShiftNMStateConfigDir,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.NoneStatusAction,
+					},
+				},
+			},
+			{
+				Path: constants.UserCABundlePath,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.RestartStatusAction,
+						Restart: &opv1.RestartService{
+							ServiceName: "coreos-update-ca-trust.service",
+						},
+					},
+					{
+						Type: opv1.RestartStatusAction,
+						Restart: &opv1.RestartService{
+							ServiceName: "crio.service",
+						},
 					},
 				},
 			},

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -94,8 +94,14 @@ const (
 	// changes to registries.conf will cause a crio reload and require extra logic about whether to drain
 	ContainerRegistryConfPath = "/etc/containers/registries.conf"
 
+	// changes to registries.conf will cause a crio reload
+	ContainerRegistryPolicyPath = "/etc/containers/policy.json"
+
 	// changes to registries.d will cause a crio reload
 	SigstoreRegistriesConfigDir = "/etc/containers/registries.d"
+
+	// changes to openshift-config-user-ca-bundle.crt will cause an update-ca-trust and crio restart
+	UserCABundlePath = "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt"
 
 	// Changes to this directory should not trigger reboots because they are firstboot-only
 	OpenShiftNMStateConfigDir = "/etc/nmstate/openshift"
@@ -124,4 +130,8 @@ const (
 	// MinFreeStorageAfterPrefetch is the minimum amount of storage
 	// available on the root filesystem after prefetching images.
 	MinFreeStorageAfterPrefetch = "16Gi"
+
+	// GPGNoRebootPath is the path MCO expects will contain GPG key updates. MCO will attempt to only reload crio for
+	// changes to this path. Note that other files added to the parent directory will not be handled specially
+	GPGNoRebootPath = "/etc/machine-config-daemon/no-reboot/containers-gpg.pub"
 )


### PR DESCRIPTION
**- What I did**

- Add support for paths in file based NodeDisruptionPolicies. If multiple policies apply to a file being updated, the closest match will be considered.
- Moved some of the "backdoor" directory based exceptions into the MCO's default policies.
- Added a new default policy for the user CA cert to maintain feature parity until it moves to cert_writer.
- Updated docs to reflect new defaults and path support.

**- How to verify it**
- All previous NodeDisruptionPolicy behavior should still behave the same(node disruption e2e should pass)
- The daemon should now behave correctly for user CA cert changes instead of rebooting.
- To test the multi-path based policies:

1. Define more than one file based policy:
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
metadata:
  name: cluster
  namespace: openshift-machine-config-operator
spec:
  nodeDisruptionPolicy:
    files:
      - path: /etc/example/test
        actions:
          - type: None
      - path: /etc/example/
        actions:
          - reload:
              serviceName: crio.service
            type: Reload
```
2. Create an MC targeting the infra/worker pool that adds a file under /etc/example. Observe the daemon logs, this should cause a CRIO reload.
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: infra
  name:  111-test-file
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:text/plain;charset=utf-8;base64,SSBhbSB2ZXJzaW9uIDEKasas
        path: /etc/example/file
        user:
          name: core
```

3. Now create another MC targeting the same pool that adds a file under /etc/example/test. Observe the daemon logs, this should not cause any action.
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: infra
  name:  112-test-file
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:text/plain;charset=utf-8;base64,SSBhbSB2ZXJzaW9uIDEKasas
        path: /etc/example/test/file
        user:
          name: core
```
**Note: Be sure to add a new MC, and not to overwrite the previous one from step (2). If you overwrite the first test MC, it will cause both policies to be in effect, as you are removing the old test file.**

4. That's it! Nice job! :rocket: 

