### PR TITLE
OCPBUGS-33397: Openshift uncordoned compute-node that was intentionally cordoned

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -1230,6 +1230,11 @@ func getAllCandidateMachines(layered bool, config *mcfgv1alpha1.MachineOSConfig,
 				continue
 			}
 		}
+		// Ignore nodes that are currently mid-update or unscheduled
+		if !isNodeReady(node) {
+			klog.V(4).Infof("node %s skipped during candidate selection as it is currently unscheduled", node.Name)
+			continue
+		}
 		nodes = append(nodes, node)
 	}
 	// Nodes which are failing to target this config also count against

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -613,6 +613,17 @@ func TestGetCandidateMachines(t *testing.T) {
 		otherCandidates: nil,
 		capacity:        0,
 	}, {
+		name:     "node-0 is unavailable and should be skipped over",
+		progress: 2,
+		nodes: []*corev1.Node{
+			newNodeWithReady("node-0", machineConfigV0, machineConfigV0, corev1.ConditionFalse),
+			newNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			newNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		expected:        []string{"node-1"},
+		otherCandidates: []string{"node-2"},
+		capacity:        1,
+	}, {
 		name:     "node-2 is going to change config, so we can only progress one more",
 		progress: 3,
 		nodes: []*corev1.Node{
@@ -708,14 +719,14 @@ func TestGetCandidateMachines(t *testing.T) {
 			helpers.NewNodeBuilder("node-1").WithEqualConfigsAndImages(machineConfigV1, imageV1).WithNodeNotReady().Node(),
 			helpers.NewNodeBuilder("node-2").WithConfigs(machineConfigV0, machineConfigV1).WithImages(imageV0, imageV1).WithNodeReady().Node(),
 			helpers.NewNodeBuilder("node-3").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeNotReady().Node(),
-			helpers.NewNodeBuilder("node-4").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeNotReady().Node(),
-			helpers.NewNodeBuilder("node-5").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeNotReady().Node(),
-			helpers.NewNodeBuilder("node-6").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeNotReady().Node(),
+			helpers.NewNodeBuilder("node-4").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeReady().Node(),
+			helpers.NewNodeBuilder("node-5").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeReady().Node(),
+			helpers.NewNodeBuilder("node-6").WithEqualConfigsAndImages(machineConfigV0, imageV0).WithNodeReady().Node(),
 			helpers.NewNodeBuilder("node-7").WithEqualConfigsAndImages(machineConfigV1, imageV1).WithNodeReady().Node(),
 			helpers.NewNodeBuilder("node-8").WithEqualConfigsAndImages(machineConfigV1, imageV1).WithNodeReady().Node(),
 		},
-		expected:        []string{"node-3", "node-4"},
-		otherCandidates: []string{"node-5", "node-6"},
+		expected:        []string{"node-4", "node-5"},
+		otherCandidates: []string{"node-6"},
 		capacity:        2,
 		layeredPool:     true,
 	}, {


### PR DESCRIPTION

**- What I did**
This PR adds a node readiness check in the node controller before a selection of update candidate nodes are made. Prior to this, the MCO used a count of target nodes, but did not specifically exclude a node that was already unscheduled or mid update. This would only happen in clusters where maxUnavailable > currently unscheduled nodes, as there was an earlier check that blocked the pool from updating in that case.

It also adds a new unit test for this particular case.

**- How to verify it**

On a cluster without this fix, set the maxUnavailable on the worker pool to 2, and cordon one of the nodes. Attempt an MC update to the worker pool. You should notice that the node controller will queue all the nodes for updates, and eventually uncordon all of the nodes. 

Now, on a cluster with this fix, follow the same steps. The node that was manually cordoned should remain so after the pool gets updated and should not get updated with the rest of the pool.

In addition, all existing e2es should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
