### PR TITLE
OCPBUGS-36863: Copy RHEL9 binaries used in HCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ FROM registry.ci.openshift.org/ocp/4.15:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-controller /usr/bin/machine-config-controller.rhel9
 COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-operator /usr/bin/machine-config-operator.rhel9
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-server /usr/bin/machine-config-server.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ]; then \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -19,7 +19,10 @@ FROM registry.ci.openshift.org/ocp/4.15:base
 ARG TAGS=""
 COPY --from=builder /go/src/github.com/openshift/machine-config-operator/instroot.tar /tmp/instroot.tar
 RUN cd / && tar xf /tmp/instroot.tar && rm -f /tmp/instroot.tar
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-controller /usr/bin/machine-config-controller.rhel9
 COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel9
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-operator /usr/bin/machine-config-operator.rhel9
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot/usr/bin/machine-config-server /usr/bin/machine-config-server.rhel9
 COPY install /manifests
 
 RUN if [ "${TAGS}" = "fcos" ]; then \


### PR DESCRIPTION
HyperShift uses some components of MCO in order to generate ignition files. In order to work with FIPS, those binaries need to be built with the same RHEL/openssl version as the HyperShift component that runs them.

This commit makes the dockerfile include those already built binaries so they can be successfully extracted by HyperShift, according to version.

Fixes: #OCPBUGS-36863

**- What I did**
Copy the already built RHEL9 binaries that HyperShift uses

**- How to verify it**
Deploying a FIPS cluster in HyperShift (needs a PR in HyperShift that will choose the right binaries)

**- Description for the changelog**
Ship RHEL9 binaries for machine-config-operator, machine-config-controller and machine-config-server for HyperShift.
