### PR TITLE
OCPNODE-2438: bump API and update CRD manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/renameio v0.1.0
 	github.com/imdario/mergo v0.3.13
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/openshift/api v0.0.0-20240715101244-b0adfa1f6357
+	github.com/openshift/api v0.0.0-20240722135205-ae4f370f361f
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
 	github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/opencontainers/runc v1.1.12 h1:BOIssBaW1La0/qbNZHXOOa71dZfZEQOzW7dqQf
 github.com/opencontainers/runc v1.1.12/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
 github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/openshift/api v0.0.0-20240715101244-b0adfa1f6357 h1:yp8QH1cSR7zynJlJMdluuD/QEGxY980uV1cooF2snio=
-github.com/openshift/api v0.0.0-20240715101244-b0adfa1f6357/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
+github.com/openshift/api v0.0.0-20240722135205-ae4f370f361f h1:B+uJ4LmjO+qwMTZP2YhlpMziMPD4MD1++WdCAV2y+GI=
+github.com/openshift/api v0.0.0-20240722135205-ae4f370f361f/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
 github.com/openshift/kube-openapi v0.0.0-20230816122517-ffc8f001abb0 h1:GPlAy197Jkr+D0T2FNWanamraTdzS/r9ZkT29lxvHaA=

--- a/install/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
+++ b/install/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
@@ -282,12 +282,16 @@ spec:
                   with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not
                   be used in the middle of the host, i.e.  *.example.com is a valid
-                  case, but example*.*.com is not. Please be aware that the scopes
-                  should not be nested under the repositories of OpenShift Container
-                  Platform images. If configured, the policies for OpenShift Container
-                  Platform repositories will not be in effect. For additional details
-                  about the format, please refer to the document explaining the docker
-                  transport field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                  case, but example*.*.com is not. If multiple scopes match a given
+                  image, only the policy requirements for the most specific scope
+                  apply. The policy requirements for more general scopes are ignored.
+                  In addition to setting a policy appropriate for your own deployed
+                  applications, make sure that a policy on the OpenShift image repositories
+                  quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev
+                  (or on a more general scope) allows deployment of the OpenShift
+                  images required for cluster operation. For additional details about
+                  the format, please refer to the document explaining the docker transport
+                  field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
                 items:
                   maxLength: 512
                   type: string

--- a/install/0000_10_config-operator_01_clusterimagepolicies-DevPreviewNoUpgrade.crd.yaml
+++ b/install/0000_10_config-operator_01_clusterimagepolicies-DevPreviewNoUpgrade.crd.yaml
@@ -282,12 +282,16 @@ spec:
                   with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not
                   be used in the middle of the host, i.e.  *.example.com is a valid
-                  case, but example*.*.com is not. Please be aware that the scopes
-                  should not be nested under the repositories of OpenShift Container
-                  Platform images. If configured, the policies for OpenShift Container
-                  Platform repositories will not be in effect. For additional details
-                  about the format, please refer to the document explaining the docker
-                  transport field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                  case, but example*.*.com is not. If multiple scopes match a given
+                  image, only the policy requirements for the most specific scope
+                  apply. The policy requirements for more general scopes are ignored.
+                  In addition to setting a policy appropriate for your own deployed
+                  applications, make sure that a policy on the OpenShift image repositories
+                  quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev
+                  (or on a more general scope) allows deployment of the OpenShift
+                  images required for cluster operation. For additional details about
+                  the format, please refer to the document explaining the docker transport
+                  field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
                 items:
                   maxLength: 512
                   type: string

--- a/install/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
+++ b/install/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
@@ -282,12 +282,16 @@ spec:
                   with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not
                   be used in the middle of the host, i.e.  *.example.com is a valid
-                  case, but example*.*.com is not. Please be aware that the scopes
-                  should not be nested under the repositories of OpenShift Container
-                  Platform images. If configured, the policies for OpenShift Container
-                  Platform repositories will not be in effect. For additional details
-                  about the format, please refer to the document explaining the docker
-                  transport field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                  case, but example*.*.com is not. If multiple scopes match a given
+                  image, only the policy requirements for the most specific scope
+                  apply. The policy requirements for more general scopes are ignored.
+                  In addition to setting a policy appropriate for your own deployed
+                  applications, make sure that a policy on the OpenShift image repositories
+                  quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev
+                  (or on a more general scope) allows deployment of the OpenShift
+                  images required for cluster operation. For additional details about
+                  the format, please refer to the document explaining the docker transport
+                  field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
                 items:
                   maxLength: 512
                   type: string

--- a/install/0000_80_machine-config_01_kubeletconfigs.crd.yaml
+++ b/install/0000_80_machine-config_01_kubeletconfigs.crd.yaml
@@ -126,6 +126,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       minTLSVersion:
                         description: "minTLSVersion is used to specify the minimal
                           version of the TLS protocol that is negotiated during the

--- a/vendor/github.com/openshift/api/config/v1alpha1/types_cluster_image_policy.go
+++ b/vendor/github.com/openshift/api/config/v1alpha1/types_cluster_image_policy.go
@@ -14,7 +14,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/1457
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
-// +openshift:enable:FeatureGate=ImagePolicy
+// +openshift:enable:FeatureGate=SigstoreImageVerification
 // +openshift:compatibility-gen:level=4
 type ClusterImagePolicy struct {
 	metav1.TypeMeta `json:",inline"`

--- a/vendor/github.com/openshift/api/config/v1alpha1/types_image_policy.go
+++ b/vendor/github.com/openshift/api/config/v1alpha1/types_image_policy.go
@@ -13,7 +13,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/1457
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
-// +openshift:enable:FeatureGate=ImagePolicy
+// +openshift:enable:FeatureGate=SigstoreImageVerification
 // +openshift:compatibility-gen:level=4
 type ImagePolicy struct {
 	metav1.TypeMeta `json:",inline"`

--- a/vendor/github.com/openshift/api/config/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/config/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -28,7 +28,7 @@ clusterimagepolicies.config.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   FilenameOperatorName: config-operator
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_10"
@@ -41,7 +41,7 @@ clusterimagepolicies.config.openshift.io:
   Scope: Cluster
   ShortNames: null
   TopLevelFeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   Version: v1alpha1
 
 imagepolicies.config.openshift.io:
@@ -51,7 +51,7 @@ imagepolicies.config.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   FilenameOperatorName: config-operator
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_10"
@@ -64,7 +64,7 @@ imagepolicies.config.openshift.io:
   Scope: Namespaced
   ShortNames: null
   TopLevelFeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   Version: v1alpha1
 
 insightsdatagathers.config.openshift.io:

--- a/vendor/github.com/openshift/api/features.md
+++ b/vendor/github.com/openshift/api/features.md
@@ -1,7 +1,6 @@
 | FeatureGate | Default on Hypershift | Default on SelfManagedHA | DevPreviewNoUpgrade on Hypershift | DevPreviewNoUpgrade on SelfManagedHA | TechPreviewNoUpgrade on Hypershift | TechPreviewNoUpgrade on SelfManagedHA  |
 | ------ | --- | --- | --- | --- | --- | ---  |
 | ClusterAPIInstall| | | | | |  |
-| ClusterAPIInstallAzure| | | | | |  |
 | ClusterAPIInstallIBMCloud| | | | | |  |
 | EventedPLEG| | | | | |  |
 | MachineAPIMigration| | | | | |  |
@@ -13,6 +12,7 @@
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CSIDriverSharedResource| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ChunkSizeMiB| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ClusterAPIInstallAzure| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClusterAPIInstallGCP| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClusterAPIInstallPowerVS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClusterMonitoringConfig| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
@@ -23,7 +23,6 @@
 | ExternalRouteCertificate| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPLabelsTags| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
-| ImagePolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | IngressControllerLBSubnetsAWS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsConfig| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsConfigAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -447,13 +447,6 @@ var (
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
-	FeatureGateImagePolicy = newFeatureGate("ImagePolicy").
-				reportProblemsToJiraComponent("node").
-				contactPerson("rphillips").
-				productScope(ocpSpecific).
-				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
-				mustRegister()
-
 	FeatureGateNodeDisruptionPolicy = newFeatureGate("NodeDisruptionPolicy").
 					reportProblemsToJiraComponent("MachineConfigOperator").
 					contactPerson("jerzhang").
@@ -486,6 +479,7 @@ var (
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("jhixson74").
 						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateClusterAPIInstallGCP = newFeatureGate("ClusterAPIInstallGCP").
@@ -575,9 +569,9 @@ var (
 					mustRegister()
 
 	FeatureGateIngressControllerLBSubnetsAWS = newFeatureGate("IngressControllerLBSubnetsAWS").
-					reportProblemsToJiraComponent("Routing").
-					contactPerson("miciah").
-					productScope(ocpSpecific).
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
-					mustRegister()
+							reportProblemsToJiraComponent("Routing").
+							contactPerson("miciah").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -962,7 +962,7 @@ github.com/opencontainers/runc/libcontainer/user
 # github.com/opencontainers/runtime-spec v1.1.0
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/openshift/api v0.0.0-20240715101244-b0adfa1f6357
+# github.com/openshift/api v0.0.0-20240722135205-ae4f370f361f
 ## explicit; go 1.22.0
 github.com/openshift/api
 github.com/openshift/api/annotations


### PR DESCRIPTION
Bump API to get the ClusterImagePolicy doc update https://github.com/openshift/api/pull/1927
Run hack/crds-sync.sh to update the manifests

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
