### PR TITLE
[release-4.16] OCPBUGS-37428: Machine-config operator should not hot loop generating ValidatingAdmissionPolicyUpdated events

### DIFF
--- a/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
@@ -5,11 +5,15 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["operator.openshift.io"]
       apiVersions: ["v1"]
       operations:  ["CREATE","UPDATE"]
       resources:   ["machineconfigurations"]
+      scope: "*"
   validations:
     - expression: "object.metadata.name=='cluster'"
       message: "Only a single object of MachineConfiguration is allowed and it must be named cluster."

--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
@@ -8,11 +8,15 @@ spec:
     apiVersion: config.openshift.io/v1
     kind: Infrastructure
   matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
     resourceRules:
     - apiGroups:   ["operator.openshift.io"]
       apiVersions: ["v1"]
       operations:  ["CREATE","UPDATE"]
       resources:   ["machineconfigurations"]
+      scope: "*"
   validations:
     - expression: "!has(object.spec.managedBootImages) || (has(object.spec.managedBootImages) && params.status.platformStatus.type in ['GCP'])"
       message: "This feature is only supported on these platforms: GCP"


### PR DESCRIPTION
Manual cherry pick of #4460. 4.16 only has 2 of these policies so an auto cherry pick did not work.