### PR TITLE
OCPBUGS-30955: On-Prem resolv prepender to watch for NM changes

### DIFF
--- a/templates/common/on-prem/units/on-prem-resolv-prepender.path.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.path.yaml
@@ -1,0 +1,10 @@
+name: on-prem-resolv-prepender.path
+enabled: true
+contents: |
+  [Unit]
+  Description=Watches for changes in /var/run/NetworkManager/resolv.conf according to on-prem IPI needs
+  [Path]
+  PathModified=/var/run/NetworkManager/resolv.conf
+  Unit=on-prem-resolv-prepender.service
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
Currently the `on-prem-resolv-prepender.service` is triggered only by NetworkManager dispatcher script in case `dns-change` event has happened.

Lately we have noticed that in case there are bugs in NM and the event is not thrown (even though the content of
`/var/run/NetworkManager/resolv.conf` changed), the resolv-prepender will not run and as a result `/etc/resolv.conf` will have incorrect content.

In order to remediate this, we not only rely on NetworkManager sending an event, but also actively monitor for changes in NM and act upon them. Thanks to this, when NM forgets to send an event and start the resolv-prepender, we will anyway notice the change and do what's necessary.

Fixes: OCPBUGS-30955