### PR TITLE
MCO-1214: Enabled boot images updates for AWS

### DIFF
--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
@@ -18,5 +18,5 @@ spec:
       resources:   ["machineconfigurations"]
       scope: "*"
   validations:
-    - expression: "!has(object.spec.managedBootImages) || (has(object.spec.managedBootImages) && params.status.platformStatus.type in ['GCP'])"
-      message: "This feature is only supported on these platforms: GCP"
+    - expression: "!has(object.spec.managedBootImages) || (has(object.spec.managedBootImages) && params.status.platformStatus.type in ['GCP','AWS'])"
+      message: "This feature is only supported on these platforms: GCP, AWS"


### PR DESCRIPTION
**- What I did**

I enabled the ManagedBootImage feature for the AWS platform as part of managing boot images via the MCO 

**- How to verify it**

See the instructions in this PR for testing GCP for setting up the cluster. 

https://github.com/openshift/machine-config-operator/pull/4083

Please note that with AWS instead of directly using one boot image for each cluster version like GCP does. AWS uses a specific boot image per region for each version and they are stored in the ami field 

You can see each region and the value assigned to that ami in the coreos-bootimages configmap in the machine-config-operator namespace for validation that it's correct. 