### PR TITLE
MCO-1248: port {azure,gcp}-routes.sh from iptables to nftables

### DIFF
--- a/cmd/apiserver-watcher/README.md
+++ b/cmd/apiserver-watcher/README.md
@@ -21,7 +21,7 @@ plane is hosted as part of the cluster, we rely on hairpin extensively.
  +---------------+
 ```
 
-We have iptables workarounds to fix these scenarios, but they need to know when
+We have nftables workarounds to fix these scenarios, but they need to know when
 the local apiserver is up or down. Hence, the apiserver-watcher.
 
 ### GCP
@@ -29,7 +29,7 @@ the local apiserver is up or down. Hence, the apiserver-watcher.
 Google cloud load balancer is a L3LB that is special. It doesn't do DNAT; instead, it
 just redirects traffic to backends and preserves the VIP as the destination IP.
 
-So, an agent exists on the node. It programs the node (either via iptables or routing tables) to
+So, an agent exists on the node. It programs the node (either via nftables or routing tables) to
 accept traffic destined for the VIP. However, this has a problem: all hairpin traffic
 to the balanced servce is *always* handled by that backend, even if it is down
 or otherwise out of rotation.
@@ -69,7 +69,7 @@ The apiserver-watcher is installed on all the masters and monitors the
 apiserver process /readyz.
 
 When /readyz fails,  write `/run/cloud-routes/$VIP.down`, which tells the
-provider-specific service to update iptables rules. When it is up, write `$VIP.up`.
+provider-specific service to update nftables rules. When it is up, write `$VIP.up`.
 
 Separately, a provider-specific process watches that directory and, as necessary,
-updates iptables rules accordingly.
+updates nftables rules accordingly.

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -132,7 +132,6 @@ contents:
         ## find extra ovn routes
         local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
         if [ -z "${ovnkContainerID}" ]; then
-            echo "Plugin is SDN, nothing to do.. exiting"
             return
         fi
         echo "Found ovnkube-controller pod... ${ovnkContainerID}"
@@ -183,7 +182,7 @@ contents:
     add_routes() {
         local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
         if [ -z "${ovnkContainerID}" ]; then
-            echo "Plugin is SDN, nothing to do.. exiting"
+            echo "OVN-Kubernetes is not running; no routes to add."
             return
         fi
         echo "Found ovnkube-controller pod... ${ovnkContainerID}"
@@ -237,7 +236,7 @@ contents:
     clear_routes() {
         local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
         if [ -z "${ovnkContainerID}" ]; then
-            echo "Plugin is SDN, nothing to do.. exiting"
+            echo "OVN-Kubernetes is not running; no routes to remove."
             return
         fi
         echo "Found ovnkube-controller pod... ${ovnkContainerID}"

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -97,13 +97,6 @@ contents:
 
         ensure_rule4 nat OUTPUT -m comment --comment 'azure LB vip overriding for local clients' -j ${CHAIN_NAME}
         ensure_rule6 nat OUTPUT -m comment --comment 'azure LB vip overriding for local clients' -j ${CHAIN_NAME}
-
-        # Need this so that existing flows (with an entry in conntrack) continue,
-        # even if the iptables rule is removed
-        ensure_rule4 filter FORWARD -m comment --comment 'azure LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
-        ensure_rule6 filter FORWARD -m comment --comment 'azure LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
-        ensure_rule4 filter OUTPUT -m comment --comment 'azure LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
-        ensure_rule6 filter OUTPUT -m comment --comment 'azure LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
     }
 
     remove_stale() {

--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -18,7 +18,7 @@ contents:
     # The solution is to redirect traffic destined to the lb vip back to ourselves.
     #
     # We check /run/cloud-routes/ for files $VIP.up and $VIP.down. If the .up file
-    # exists, then we redirect traffic destined for that vip to ourselves via iptables.
+    # exists, then we redirect traffic destined for that vip to ourselves via nftables.
     # A systemd unit watches the directory for changes.
     #
     # TODO: Address the potential issue where apiserver-watcher could create multiple files
@@ -32,93 +32,23 @@ contents:
     declare -A v4vips
     declare -A v6vips
 
-    CHAIN_NAME="azure-vips"
+    TABLE_NAME="azure-vips"
+    VIPS_CHAIN="redirect-vips"
     RUN_DIR="/run/cloud-routes"
 
-    # Create a chan if it doesn't exist
-    ensure_chain4() {
-        local table="${1}"
-        local chain="${2}"
-
-        if ! iptables -w -t "${table}" -S "${chain}" &> /dev/null ; then
-            echo "creating ${chain} chain in ${table} table"
-            iptables -w -t "${table}" -N "${chain}";
-        fi;
-    }
-
-    # Create a chain if it doesn't exist
-    ensure_chain6() {
-        if [ ! -f /proc/net/if_inet6 ]; then
-            return
-        fi
-        local table="${1}"
-        local chain="${2}"
-
-        if ! ip6tables -w -t "${table}" -S "${chain}" &> /dev/null ; then
-            echo "creating ${chain} chain in ${table} table"
-            ip6tables -w -t "${table}" -N "${chain}";
-        fi;
-    }
-
-
-    ensure_rule4() {
-        local table="${1}"
-        local chain="${2}"
-        shift 2
-
-        if ! iptables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
-            echo "adding \"$@\" to ${chain} chain in ${table} table"
-            iptables -w -t "${table}" -A "${chain}" "$@"
-        fi
-    }
-
-    ensure_rule6() {
-        if [ ! -f /proc/net/if_inet6 ]; then
-            return
-        fi
-
-        local table="${1}"
-        local chain="${2}"
-        shift 2
-
-        if ! ip6tables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
-            echo "adding \"$@\" to ${chain} chain in ${table} table"
-            ip6tables -w -t "${table}" -A "${chain}" "$@"
-        fi
-    }
-
-    # set the chain, ensure entry rules, ensure ESTABLISHED rule
     initialize() {
-        ensure_chain4 nat "${CHAIN_NAME}"
-        ensure_chain6 nat "${CHAIN_NAME}"
+        nft -f - <<EOF
+            add table inet ${TABLE_NAME} { comment "azure LB vip overriding"; }
+            add chain inet ${TABLE_NAME} ${VIPS_CHAIN}
 
-        ensure_rule4 nat PREROUTING -m comment --comment 'azure LB vip overriding for pods' -j ${CHAIN_NAME}
-        ensure_rule6 nat PREROUTING -m comment --comment 'azure LB vip overriding for pods' -j ${CHAIN_NAME}
+            add chain inet ${TABLE_NAME} prerouting { type nat hook prerouting priority dstnat; }
+            flush chain inet ${TABLE_NAME} prerouting
+            add rule inet ${TABLE_NAME} prerouting goto ${VIPS_CHAIN}
 
-        ensure_rule4 nat OUTPUT -m comment --comment 'azure LB vip overriding for local clients' -j ${CHAIN_NAME}
-        ensure_rule6 nat OUTPUT -m comment --comment 'azure LB vip overriding for local clients' -j ${CHAIN_NAME}
-    }
-
-    remove_stale() {
-        ## find extra iptables rules
-        for ipt_vip in $(iptables -w -t nat -S "${CHAIN_NAME}" | awk '$4{print $4}' | awk -F/ '{print $1}'); do
-            if [[ ! -v v4vips[${ipt_vip}] ]] || [[ "${v4vips[${ipt_vip}]}" = down ]]; then
-                echo removing stale vip "${ipt_vip}" for local clients
-                iptables -w -t nat -D "${CHAIN_NAME}" --dst "${ipt_vip}" -j REDIRECT
-            fi
-        done
-
-        if [ ! -f /proc/net/if_inet6 ]; then
-            return
-        fi
-
-        for ipt_vip in $(ip6tables -w -t nat -S "${CHAIN_NAME}" | awk '$4{print $4}' | awk -F/ '{print $1}'); do
-            if [[ ! -v v6vips[${ipt_vip}] ]] || [[ "${v6vips[${ipt_vip}]}" = down ]]; then
-                echo removing stale vip "${ipt_vip}" for local clients
-                ip6tables -w -t nat -D "${CHAIN_NAME}" --dst "${ipt_vip}" -j REDIRECT
-            fi
-        done
-
+            add chain inet ${TABLE_NAME} output { type nat hook output priority dstnat; }
+            flush chain inet ${TABLE_NAME} output
+            add rule inet ${TABLE_NAME} output goto ${VIPS_CHAIN}
+    EOF
     }
 
     remove_stale_routes() {
@@ -156,20 +86,31 @@ contents:
 
     }
 
-    add_rules() {
+    sync_rules() {
+        # Construct the VIP lists. (The nftables syntax allows a trailing comma.)
+        v4vipset=""
+        v6vipset=""
         for vip in "${!v4vips[@]}"; do
             if [[ "${v4vips[${vip}]}" != down ]]; then
-                echo "ensuring rule for ${vip} for internal clients"
-                ensure_rule4 nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
+                v4vipset="${vip}, ${v4vipset}"
+            fi
+        done
+        for vip in "${!v6vips[@]}"; do
+            if [[ "${v6vips[${vip}]}" != down ]]; then
+                v6vipset="${vip}, ${v6vipset}"
             fi
         done
 
-        for vip in "${!v6vips[@]}"; do
-            if [[ "${v6vips[${vip}]}" != down ]]; then
-                echo "ensuring rule for ${vip} for internal clients"
-                ensure_rule6 nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
+        echo "synchronizing IPv4 VIPs to (${v4vipset}), IPv6 VIPS to (${v6vipset})"
+        {
+            echo "flush chain inet ${TABLE_NAME} ${VIPS_CHAIN}"
+            if [[ -n "${v4vipset}" ]]; then
+                echo "add rule inet ${TABLE_NAME} ${VIPS_CHAIN} ip daddr { ${v4vipset} } redirect"
             fi
-        done
+            if [[ -n "${v6vipset}" ]]; then
+                echo "add rule inet ${TABLE_NAME} ${VIPS_CHAIN} ip6 daddr { ${v6vipset} } redirect"
+            fi
+        } | nft -f -
     }
 
     add_routes() {
@@ -222,8 +163,8 @@ contents:
     }
 
     clear_rules() {
-        echo "clearing rules from ${CHAIN_NAME} chain in nat table"
-        iptables -t nat -F "${CHAIN_NAME}" || true
+        echo "clearing rules from ${TABLE_NAME}"
+        nft delete table inet "${TABLE_NAME}" || true
     }
 
     clear_routes() {
@@ -237,7 +178,7 @@ contents:
         crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010
     }
 
-    # out paramaters: v4vips v6vips
+    # out parameters: v4vips v6vips
     list_lb_ips() {
         for k in "${!v4vips[@]}"; do
             unset v4vips["${k}"]
@@ -269,9 +210,8 @@ contents:
         start)
             initialize
             list_lb_ips
-            remove_stale
+            sync_rules
             remove_stale_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
-            add_rules
             add_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
             echo "done applying vip rules"
             ;;

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -74,10 +74,6 @@ contents:
         ensure_rule nat PREROUTING -m comment --comment 'gcp LB vip DNAT' -j ${CHAIN_NAME}
         ensure_rule nat OUTPUT -m comment --comment 'gcp LB vip DNAT for local clients' -j ${CHAIN_NAME}-local
 
-        # Need this so that existing flows (with an entry in conntrack) continue to be
-        # balanced, even if the DNAT entry is removed
-        ensure_rule filter INPUT -m comment --comment 'gcp LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
-
         # If a connection for a VIP comes in while we have no rewrite rule for that VIP,
         # we would think the VIP is an external host and so forward the connection back
         # off the node. In the specific case of connections from the GCP LB health

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -4,7 +4,7 @@ contents:
   inline: |
     #!/bin/bash
 
-    # Update iptables rules based on google cloud load balancer VIPS
+    # Update nftables rules based on google cloud load balancer VIPS
     #
     # This is needed because the GCP L3 load balancer doesn't actually do DNAT;
     # the destination IP address is still the VIP. Normally, there is an agent that
@@ -18,8 +18,6 @@ contents:
     #
     # Additionally, clients can write a file to /run/cloud-routes/$IP.down to force
     # a VIP as down. This is useful for graceful shutdown / upgrade.
-    #
-    # ~cdc~
 
     set -e
 
@@ -44,71 +42,39 @@ contents:
         fi
     }
 
-    CHAIN_NAME="gcp-vips"
+    TABLE_NAME="gcp-vips"
+    EXTERNAL_VIPS_CHAIN="external-vips"
+    LOCAL_VIPS_CHAIN="local-vips"
     RUN_DIR="/run/cloud-routes"
 
-    # Create a chan if it doesn't exist
-    ensure_chain() {
-        local table="${1}"
-        local chain="${2}"
-
-        if ! iptables -w -t "${table}" -S "${chain}" &> /dev/null ; then
-            iptables -w -t "${table}" -N "${chain}";
-        fi;
-    }
-
-    ensure_rule() {
-        local table="${1}"
-        local chain="${2}"
-        shift 2
-
-        if ! iptables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
-            iptables -w -t "${table}" -A "${chain}" "$@"
-        fi
-    }
-
-    # set the chain, ensure entry rules, ensure ESTABLISHED rule
+    # Set up base table and rules
     initialize() {
-        ensure_chain nat "${CHAIN_NAME}"
-        ensure_chain nat "${CHAIN_NAME}-local"
-        ensure_rule nat PREROUTING -m comment --comment 'gcp LB vip DNAT' -j ${CHAIN_NAME}
-        ensure_rule nat OUTPUT -m comment --comment 'gcp LB vip DNAT for local clients' -j ${CHAIN_NAME}-local
+        nft -f - <<EOF
+            add table ip ${TABLE_NAME} { comment "apiserver loadbalancer routing helper"; }
+            add chain ip ${TABLE_NAME} ${EXTERNAL_VIPS_CHAIN} { type nat hook prerouting priority dstnat; comment "gcp LB vip DNAT for external clients"; }
+            add chain ip ${TABLE_NAME} ${LOCAL_VIPS_CHAIN} { type nat hook output priority dstnat; comment "gcp LB vip DNAT for local clients"; }
 
-        # If a connection for a VIP comes in while we have no rewrite rule for that VIP,
-        # we would think the VIP is an external host and so forward the connection back
-        # off the node. In the specific case of connections from the GCP LB health
-        # checkers to the VIP, this would result in a bad conntrack entry being created
-        # and then never deleted even after the VIP rule was installed, because the health
-        # checker only uses a small range of source ports, so newer health checks would
-        # keep refreshing the bad conntrack entry created by the first failed health
-        # check. As a result, we would end up persistently failing some percentage of
-        # health checks. See https://bugzilla.redhat.com/show_bug.cgi?id=1925698,
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1930457.
-        #
-        # The fix here is a rule that drops health check probes if we notice that we're
-        # about to forward them off-node, which then prevents the bad conntrack entries
-        # from being created. The HealthCheck origin ip-ranges are documented:
-        # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
-        ensure_rule filter FORWARD -m comment --comment 'gcp HealthCheck traffic' -s 35.191.0.0/16 -j DROP
-        ensure_rule filter FORWARD -m comment --comment 'gcp HealthCheck traffic' -s 130.211.0.0/22 -j DROP
+            # If a connection for a VIP comes in while we have no rewrite rule for that VIP,
+            # we would think the VIP is an external host and so forward the connection back
+            # off the node. In the specific case of connections from the GCP LB health
+            # checkers to the VIP, this would result in a bad conntrack entry being created
+            # and then never deleted even after the VIP rule was installed, because the health
+            # checker only uses a small range of source ports, so newer health checks would
+            # keep refreshing the bad conntrack entry created by the first failed health
+            # check. As a result, we would end up persistently failing some percentage of
+            # health checks. See https://bugzilla.redhat.com/show_bug.cgi?id=1925698,
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1930457.
+            #
+            # The fix here is a rule that drops health check probes if we notice that we're
+            # about to forward them off-node, which then prevents the bad conntrack entries
+            # from being created. The HealthCheck origin ip-ranges are documented:
+            # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+            add chain ip ${TABLE_NAME} forward { type filter hook forward priority filter; comment "gcp HealthCheck traffic"; }
+            add rule ip ${TABLE_NAME} forward ip saddr 35.191.0.0/16 drop
+            add rule ip ${TABLE_NAME} forward ip saddr 130.211.0.0/22 drop
+    EOF
 
         mkdir -p "${RUN_DIR}"
-    }
-
-    remove_stale() {
-        ## find extra iptables rules
-        for ipt_vip in $(iptables -w -t nat -S "${CHAIN_NAME}" | awk '$4{print $4}' | awk -F/ '{print $1}'); do
-            if [[ -z "${vips[${ipt_vip}]}" ]]; then
-                echo removing stale vip "${ipt_vip}" for external clients
-                iptables -w -t nat -D "${CHAIN_NAME}" --dst "${ipt_vip}" -j REDIRECT
-            fi
-        done
-        for ipt_vip in $(iptables -w -t nat -S "${CHAIN_NAME}-local" | awk '$4{print $4}' | awk -F/ '{print $1}'); do
-            if [[ -z "${vips[${ipt_vip}]}" ]] || [[ "${vips[${ipt_vip}]}" = down ]]; then
-                echo removing stale vip "${ipt_vip}" for local clients
-                iptables -w -t nat -D "${CHAIN_NAME}-local" --dst "${ipt_vip}" -j REDIRECT
-            fi
-        done
     }
 
     remove_stale_routes() {
@@ -131,16 +97,28 @@ contents:
         done
     }
 
-    add_rules() {
+    sync_rules() {
+        # Construct the VIP lists. (The nftables syntax allows a trailing comma.)
+        external_vips=""
+        local_vips=""
         for vip in "${!vips[@]}"; do
-            echo "ensuring rule for ${vip} for external clients"
-            ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
-
+            external_vips="${vip}, ${external_vips}"
             if [[ "${vips[${vip}]}" != down ]]; then
-                echo "ensuring rule for ${vip} for internal clients"
-                ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
+                local_vips="${vip}, ${local_vips}"
             fi
         done
+
+        echo "synchronizing external VIPs to (${external_vips}), local VIPs to (${local_vips})"
+        {
+            echo "flush chain ip ${TABLE_NAME} ${EXTERNAL_VIPS_CHAIN}"
+            if [[ -n "${external_vips}" ]]; then
+                echo "add rule ip ${TABLE_NAME} ${EXTERNAL_VIPS_CHAIN} ip daddr { ${external_vips} } redirect"
+            fi
+            echo "flush chain ip ${TABLE_NAME} ${LOCAL_VIPS_CHAIN}"
+            if [[ -n "${local_vips}" ]]; then
+                echo "add rule ip ${TABLE_NAME} ${LOCAL_VIPS_CHAIN} ip daddr { ${local_vips} } redirect"
+            fi
+        } | nft -f -
     }
 
     add_routes() {
@@ -171,8 +149,7 @@ contents:
     }
 
     clear_rules() {
-        iptables -t nat -F "${CHAIN_NAME}" || true
-        iptables -t nat -F "${CHAIN_NAME}-local" || true
+        nft delete table ip "${TABLE_NAME}" || true
     }
 
     clear_routes() {
@@ -186,7 +163,7 @@ contents:
         crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 || true
     }
 
-    # out paramater: vips
+    # out parameter: vips
     list_lb_ips() {
         for k in "${!vips[@]}"; do
             unset vips["${k}"]
@@ -235,9 +212,8 @@ contents:
         initialize
         while :; do
           list_lb_ips
-          remove_stale
+          sync_rules
           remove_stale_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
-          add_rules
           add_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
           echo "done applying vip rules"
           sleep_or_watch

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -119,7 +119,6 @@ contents:
         ## find extra ovn routes
         local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
         if [ -z "${ovnkContainerID}" ]; then
-            echo "Plugin is SDN, nothing to do.. exiting"
             return
         fi
         echo "Found ovnkube-controller pod... ${ovnkContainerID}"
@@ -151,7 +150,7 @@ contents:
     add_routes() {
         local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
         if [ -z "${ovnkContainerID}" ]; then
-            echo "Plugin is SDN, nothing to do.. exiting"
+            echo "OVN-Kubernetes is not running; no routes to add."
             return
         fi
         echo "Found ovnkube-controller pod... ${ovnkContainerID}"
@@ -183,7 +182,7 @@ contents:
     clear_routes() {
         local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
         if [ -z "${ovnkContainerID}" ]; then
-            echo "Plugin is SDN, nothing to do.. exiting"
+            echo "OVN-Kubernetes is not running; no routes to remove."
             return
         fi
         echo "Found ovnkube-controller pod... ${ovnkContainerID}"

--- a/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/master/00-master/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -78,18 +78,21 @@ contents:
         # balanced, even if the DNAT entry is removed
         ensure_rule filter INPUT -m comment --comment 'gcp LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
 
-        # bz1925698: GCP LBs can create stale entries causing apiservers disruption
-        # The GCP LB Health Check polls continuously the LB VIP assigned to the VM
-        # but, if the LB VIP is down, we are not handling the VIP traffic and
-        # the traffic can hairpin, leaving stale conntrack entries on the host.
-        # xref: https://bugzilla.redhat.com/show_bug.cgi?id=1925698#c29
-        # Deleting conntrack entries solves the problem, but it also affects other connections
-        # directed to the LB vips, causing unexpected networks disruptions.
-        # The solution is to not FORWARD GCP HealthCheckers traffic, because that traffic 
-        # is only directed to the host, and it must go to the INPUT chain.
-        # xref: https://bugzilla.redhat.com/show_bug.cgi?id=1930457#c8
-        # The HealthCheck origin ip-ranges are documented: 130.211.0.0/22 and 35.191.0.0/16
-        # xref: https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+        # If a connection for a VIP comes in while we have no rewrite rule for that VIP,
+        # we would think the VIP is an external host and so forward the connection back
+        # off the node. In the specific case of connections from the GCP LB health
+        # checkers to the VIP, this would result in a bad conntrack entry being created
+        # and then never deleted even after the VIP rule was installed, because the health
+        # checker only uses a small range of source ports, so newer health checks would
+        # keep refreshing the bad conntrack entry created by the first failed health
+        # check. As a result, we would end up persistently failing some percentage of
+        # health checks. See https://bugzilla.redhat.com/show_bug.cgi?id=1925698,
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1930457.
+        #
+        # The fix here is a rule that drops health check probes if we notice that we're
+        # about to forward them off-node, which then prevents the bad conntrack entries
+        # from being created. The HealthCheck origin ip-ranges are documented:
+        # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
         ensure_rule filter FORWARD -m comment --comment 'gcp HealthCheck traffic' -s 35.191.0.0/16 -j DROP
         ensure_rule filter FORWARD -m comment --comment 'gcp HealthCheck traffic' -s 130.211.0.0/22 -j DROP
 


### PR DESCRIPTION
iptables is going away in RHEL10; this PR ports {azure,gcp}-routes.sh from iptables to nftables.

What's different:
- The old azure script created separate iptables and ip6tables rules, but the nftables version just uses the `inet` family so we can put both sets of rules together (and we don't need to check if IPv6 is enabled or not; the IPv6 rule will just never match anything if IPv6 is disabled.)
- The old version used an iptables rule per VIP, the new version uses a single nftables rule that does a set match against all the VIPs at once.
- The old version did "figure out which rules don't belong, then remove then, then add new rules", while the new version does "atomically overwrite the old rules with the new rules".

Other than that (and the commit that removes an unnecessary ACCEPT rule), there are no changes in functionality; I had previously started an attempt to refactor them first (#3619, #3673, #3674, #3675) but wasn't having much luck with that, and we need to get rid of iptables, so...