### PR TITLE
OCPBUGS-33784: Guard MachineOSBuild informers with feature gates

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -137,6 +137,10 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
 			}
 
+			if fg.Enabled(features.FeatureGateOnClusterBuild) {
+				ctrlctx.TechPreviewInformerFactory.Start(ctrlctx.Stop)
+			}
+
 		case <-time.After(1 * time.Minute):
 			klog.Errorf("timed out waiting for FeatureGate detection")
 			os.Exit(1)
@@ -230,7 +234,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
-			ctx.InformerFactory.Machineconfiguration().V1alpha1().MachineOSBuilds(),
+			ctx.TechPreviewInformerFactory.Machineconfiguration().V1alpha1().MachineOSBuilds(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -49,6 +49,7 @@ type ControllerContext struct {
 
 	NamespacedInformerFactory                           mcfginformers.SharedInformerFactory
 	InformerFactory                                     mcfginformers.SharedInformerFactory
+	TechPreviewInformerFactory                          mcfginformers.SharedInformerFactory
 	KubeInformerFactory                                 informers.SharedInformerFactory
 	KubeNamespacedInformerFactory                       informers.SharedInformerFactory
 	OpenShiftConfigKubeNamespacedInformerFactory        informers.SharedInformerFactory
@@ -79,6 +80,7 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder) *Controll
 	operatorClient := cb.OperatorClientOrDie("operator-shared-informer")
 	machineClient := cb.MachineClientOrDie("machine-shared-informer")
 	sharedInformers := mcfginformers.NewSharedInformerFactory(client, resyncPeriod()())
+	sharedTechPreviewInformers := mcfginformers.NewSharedInformerFactory(client, resyncPeriod()())
 	sharedNamespacedInformers := mcfginformers.NewFilteredSharedInformerFactory(client, resyncPeriod()(), MCONamespace, nil)
 	kubeSharedInformer := informers.NewSharedInformerFactory(kubeClient, resyncPeriod()())
 	kubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), MCONamespace, nil)
@@ -131,6 +133,7 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder) *Controll
 		ClientBuilder:                                       cb,
 		NamespacedInformerFactory:                           sharedNamespacedInformers,
 		InformerFactory:                                     sharedInformers,
+		TechPreviewInformerFactory:                          sharedTechPreviewInformers,
 		KubeInformerFactory:                                 kubeSharedInformer,
 		KubeNamespacedInformerFactory:                       kubeNamespacedSharedInformer,
 		OpenShiftConfigKubeNamespacedInformerFactory:        openShiftConfigKubeNamespacedSharedInformer,

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -404,7 +404,7 @@ func (ctrl *Controller) addMachineOSBuild(obj interface{}) {
 func (ctrl *Controller) updateMachineOSBuild(old, cur interface{}) {
 	oldMOSB := old.(*mcfgv1alpha1.MachineOSBuild)
 	curMOSB := cur.(*mcfgv1alpha1.MachineOSBuild)
-	if equality.Semantic.DeepEqual(oldMOSB.Status, oldMOSB.Status) {
+	if equality.Semantic.DeepEqual(oldMOSB.Status, curMOSB.Status) {
 		// we do not want to trigger an update func just for MOSB spec, we dont act on the spec
 		return
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a tech preview specific InformerFactory that is only started if the OCL feature gate is enabled.
I also noticed a minor bug within the informer callback which I fixed.

**- How to verify it**

- There should no longer be logs like the following in the controller while in the default featureset:

```
W0515 10:38:17.921662       1 reflector.go:539] github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125: failed to list *v1alpha1.MachineOSBuild: the server could not find the requested resource (get machineosbuilds.machineconfiguration.openshift.io)
E0515 10:38:17.921703       1 reflector.go:147] github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125: Failed to watch *v1alpha1.MachineOSBuild: failed to list *v1alpha1.MachineOSBuild: the server could not find the requested resource (get machineosbuilds.machineconfiguration.openshift.io)
```

- OCL features should still work as intended(tech preview e2es should pass).

