### PR TITLE
OPNET-604: use Notify instead of Oneshot for on-prem services

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -11,6 +11,10 @@ contents: |
 
   [Service]
   # Need oneshot to delay kubelet
+  # We would use Type=notify so that systemd keeps retrying until we succeed (and makes sure the dependent
+  # services start correctly if we succeeded only after a retry). But this service uses a custom ExecStart
+  # with the infinite until...do loop that reinvents the whole retrying mechanism. For this reason Type=oneshot
+  # and Type=notify do not make difference.
   Type=oneshot
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be

--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -17,7 +17,10 @@ contents: |
 
   [Service]
   # Need oneshot to delay kubelet
-  Type=oneshot
+  # but we use Type=notify so that systemd keeps retrying until we succeed. With
+  # Type=oneshot, it also keeps retrying, but will never start follow-up services
+  # that depend on us if we fail once.
+  Type=notify
   ExecStart=/usr/local/bin/configure-ovs.sh {{.NetworkType}}
   StandardOutput=journal+console
   StandardError=journal+console

--- a/templates/common/_base/units/wait-for-primary-ip.yaml
+++ b/templates/common/_base/units/wait-for-primary-ip.yaml
@@ -8,6 +8,10 @@ contents: |
   Before=kubelet-dependencies.target
 
   [Service]
+  # We would use Type=notify so that systemd keeps retrying until we succeed (and makes sure the dependent
+  # services start correctly if we succeeded only after a retry). But this service uses a custom ExecStart
+  # with the infinite until...do loop that reinvents the whole retrying mechanism. For this reason Type=oneshot
+  # and Type=notify do not make difference.
   Type=oneshot
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be

--- a/templates/common/azure/units/ovs-configuration.service.yaml
+++ b/templates/common/azure/units/ovs-configuration.service.yaml
@@ -17,7 +17,10 @@ contents: |
 
   [Service]
   # Need oneshot to delay kubelet
-  Type=oneshot
+  # but we use Type=notify so that systemd keeps retrying until we succeed. With
+  # Type=oneshot, it also keeps retrying, but will never start follow-up services
+  # that depend on us if we fail once.
+  Type=notify
   ExecStart=/usr/local/bin/configure-ovs.sh {{.NetworkType}}
   StandardOutput=journal+console
   StandardError=journal+console

--- a/templates/common/baremetal/units/nmstate-configuration.service.yaml
+++ b/templates/common/baremetal/units/nmstate-configuration.service.yaml
@@ -9,7 +9,10 @@ contents: |
   Before=nmstate.service kubelet-dependencies.target ovs-configuration.service node-valid-hostname.service
 
   [Service]
-  Type=oneshot
+  # We use Type=notify so that systemd keeps retrying until we succeed. With
+  # Type=oneshot, it also keeps retrying, but will never start follow-up services
+  # that depend on us if we fail once.
+  Type=notify
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be
   # available in systemd v244 and higher.

--- a/templates/common/kubevirt/units/nodeip-configuration.service.yaml
+++ b/templates/common/kubevirt/units/nodeip-configuration.service.yaml
@@ -9,6 +9,10 @@ contents: |
 
   [Service]
   # Need oneshot to delay kubelet
+  # We would use Type=notify so that systemd keeps retrying until we succeed (and makes sure the dependent
+  # services start correctly if we succeeded only after a retry). But this service uses a custom ExecStart
+  # with the infinite until...do loop that reinvents the whole retrying mechanism. For this reason Type=oneshot
+  # and Type=notify do not make difference.
   Type=oneshot
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -12,6 +12,10 @@ contents: |
 
   [Service]
   # Need oneshot to delay kubelet
+  # We would use Type=notify so that systemd keeps retrying until we succeed (and makes sure the dependent
+  # services start correctly if we succeeded only after a retry). But this service uses a custom ExecStart
+  # with the infinite until...do loop that reinvents the whole retrying mechanism. For this reason Type=oneshot
+  # and Type=notify do not make difference.
   Type=oneshot
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be

--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -8,6 +8,10 @@ contents: |
   After=crio-wipe.service
   StartLimitIntervalSec=0
   [Service]
+  # We would use Type=notify so that systemd keeps retrying until we succeed (and makes sure the dependent
+  # services start correctly if we succeeded only after a retry). But this service uses a custom ExecStart
+  # with the infinite until...do loop that reinvents the whole retrying mechanism. For this reason Type=oneshot
+  # and Type=notify do not make difference.
   Type=oneshot
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be

--- a/templates/common/on-prem/units/wait-for-br-ex-up.yaml
+++ b/templates/common/on-prem/units/wait-for-br-ex-up.yaml
@@ -8,7 +8,10 @@ contents: |
   Before=node-valid-hostname.service
 
   [Service]
-  Type=oneshot
+  # We use Type=notify so that systemd keeps retrying until we succeed. With
+  # Type=oneshot, it also keeps retrying, but will never start follow-up services
+  # that depend on us if we fail once.
+  Type=notify
   ExecStart=/usr/local/bin/wait-for-br-ex-up.sh
 
   [Install]

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -22,6 +22,10 @@ contents: |
 
   [Service]
   # Need oneshot to delay kubelet
+  # We would use Type=notify so that systemd keeps retrying until we succeed (and makes sure the dependent
+  # services start correctly if we succeeded only after a retry). But this service uses a custom ExecStart
+  # with the infinite until...do loop that reinvents the whole retrying mechanism. For this reason Type=oneshot
+  # and Type=notify do not make difference.
   Type=oneshot
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be


### PR DESCRIPTION
With this PR we are introducing use of systemd Type=notify so that in
case of failure and retry, dependent services are started.

As we cannot use Type=oneshot together with Restart=on-failure (due to
the fact we need to support systemd older than v244), we want to have
some other mechanism supporting retries that would also keep the
dependency chain healthy.

For services where ExecStart contains the custom `until ... do` logic we
do not necessarily need this change - we expect that it's an infinite
loop so unless there is an implicit timeout on the service itself, the
loop will just keep retrying. But not everywhere this logic is
implemented, thus Type=notify

Closes: [OPNET-604](https://issues.redhat.com//browse/OPNET-604)