### PR TITLE
[release-4.13] OCPBUGS-37783: Openshift uncordoned compute-node that was intentionally cordoned

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -955,6 +955,11 @@ func getAllCandidateMachines(pool *mcfgv1.MachineConfigPool, nodesInPool []*core
 			}
 			continue
 		}
+		// Ignore nodes that are currently mid-update or unscheduled
+		if !isNodeReady(node) {
+			glog.V(4).Infof("node %s skipped during candidate selection as it is currently unscheduled", node.Name)
+			continue
+		}
 		nodes = append(nodes, node)
 	}
 	// Nodes which are failing to target this config also count against

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -560,6 +560,17 @@ func TestGetCandidateMachines(t *testing.T) {
 		otherCandidates: nil,
 		capacity:        0,
 	}, {
+		// node-0 is unavailable and should be skipped over
+		progress: 2,
+		nodes: []*corev1.Node{
+			newNodeWithReady("node-0", "v0", "v0", corev1.ConditionFalse),
+			newNodeWithReady("node-1", "v0", "v0", corev1.ConditionTrue),
+			newNodeWithReady("node-2", "v0", "v0", corev1.ConditionTrue),
+		},
+		expected:        []string{"node-1"},
+		otherCandidates: []string{"node-2"},
+		capacity:        1,
+	}, {
 		// node-2 is going to change config, so we can only progress one more
 		progress: 3,
 		nodes: []*corev1.Node{


### PR DESCRIPTION
Manual cherry pick of #4502 
