### PR TITLE
NO-JIRA: Fix HasOSImage function

### DIFF
--- a/pkg/controller/common/layered_pool_state.go
+++ b/pkg/controller/common/layered_pool_state.go
@@ -27,10 +27,6 @@ func (l *LayeredPoolState) GetOSImage() string {
 // Determines if a given MachineConfigPool has an available OS image. Returns
 // false if the annotation is missing or set to an empty string.
 func (l *LayeredPoolState) HasOSImage() bool {
-	if l.pool.Labels == nil {
-		return false
-	}
-
 	val, ok := l.pool.Annotations[ExperimentalNewestLayeredImageEquivalentConfigAnnotationKey]
 	return ok && val != ""
 }


### PR DESCRIPTION
Follow up https://github.com/openshift/oc/pull/1834#issuecomment-2260804858

- It should be `l.pool.Annotations` instead.
- No need to do the nil check as "A nil map is equivalent to an empty map except that no elements may be added." [1]

[1] https://go.dev/ref/spec#Map_types

