### PR TITLE
OCPBUGS-31298: Prevent no-operation patches from overloading the kube-api server with unnecessary calls

### DIFF
--- a/internal/kubeutils.go
+++ b/internal/kubeutils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,13 +27,18 @@ func UpdateNodeRetry(client corev1client.NodeInterface, lister corev1lister.Node
 		if err != nil {
 			return err
 		}
+
+		nodeClone := n.DeepCopy()
+		f(nodeClone)
+
+		if reflect.DeepEqual(n, nodeClone) {
+			return nil
+		}
+
 		oldNode, err := json.Marshal(n)
 		if err != nil {
 			return err
 		}
-
-		nodeClone := n.DeepCopy()
-		f(nodeClone)
 
 		newNode, err := json.Marshal(nodeClone)
 		if err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes OCPBUGS-31298

**- What I did**
When the node status is updated, detect if `reconcileMaster` actually makes any changes to the node config. If empty then prevent making no-op calls

**- How to verify it**
1) #4277 increases the `nodeStatusReportFrequency` to 10s and adds logs when an empty patch is made in function `UpdateNodeRetry`.
  ```
  if bytes.Equal(patchBytes, []byte("{}")) {
      klog.Infof("No change detected in UpdateNodeRetry")
  }
  ```
  These logs will indicate reduction in the empty patch calls made to the api-server

2)  grepping the MCC's node update calls in the kube-api audit logs

**- Description for the changelog**
<!--
Detect empty patches early and prevent them from making unnecessary calls to the kube-api server 
-->
