### PR TITLE
NO-ISSUE: Move ManagedBootImages and NodeDisruptionPolicy to default e2e suite

### DIFF
--- a/test/e2e-techpreview/main_test.go
+++ b/test/e2e-techpreview/main_test.go
@@ -11,7 +11,7 @@ func TestMain(m *testing.M) {
 
 	// Ensure required feature gates are set.
 	// Add any new feature gates to the test here, and remove them as features are GAed.
-	helpers.MustHaveFeatureGatesEnabled("ManagedBootImages", "OnClusterBuild", "MachineConfigNodes", "NodeDisruptionPolicy")
+	helpers.MustHaveFeatureGatesEnabled("OnClusterBuild", "MachineConfigNodes")
 
 	os.Exit(m.Run())
 }

--- a/test/e2e/msbic_test.go
+++ b/test/e2e/msbic_test.go
@@ -1,4 +1,4 @@
-package e2e_techpreview_test
+package e2e_test
 
 import (
 	"context"

--- a/test/e2e/nodedisrupt_test.go
+++ b/test/e2e/nodedisrupt_test.go
@@ -1,4 +1,4 @@
-package e2e_techpreview_test
+package e2e_test
 
 import (
 	"bytes"


### PR DESCRIPTION
This PR moves ManagedBootImages and NodeDisruptionPolicy  e2es to the main test suite, as they have been recently GAed.
