### PR TITLE
OCPBUGS-38857:  Add alert for users of deprecating the Image Registry workaround

### DIFF
--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -1,6 +1,31 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  name: machine-config-operator
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: machine-config-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  groups:
+    - name: drain-override-configmap-present
+      rules:
+        - alert: MCODrainOverrideConfigMapAlert
+          expr: |
+            mco_image_registry_drain_override_exists > 0
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "Alerts the user to the presence of a drain override configmap that is being deprecated and removed in a future release."
+            description: "Image Registry Drain Override configmap has been detected. Please use the Node Disruption Policy feature to control the cluster's drain behavior as the configmap method is currently deprecated and will be removed in a future release."
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
   name: machine-config-controller
   namespace: openshift-machine-config-operator
   labels:

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -134,4 +134,8 @@ const (
 	// GPGNoRebootPath is the path MCO expects will contain GPG key updates. MCO will attempt to only reload crio for
 	// changes to this path. Note that other files added to the parent directory will not be handled specially
 	GPGNoRebootPath = "/etc/machine-config-daemon/no-reboot/containers-gpg.pub"
+
+	// ImageRegistryDrainOverrideConfigmap is the name of the Configmap a user can apply to force all
+	// image registry changes to not drain
+	ImageRegistryDrainOverrideConfigmap = "image-registry-override-drain"
 )

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -144,7 +144,7 @@ func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig i
 		// Drain may or may not be necessary in case of container registry config changes.
 		if ctrlcommon.InSlice(constants.ContainerRegistryConfPath, diffFileSet) {
 			if overrideImageRegistryDrain {
-				klog.Warningf("Drain was skipped for this image registry update due to the configmap %s being present. This may not be a safe change", ImageRegistryDrainOverrideConfigmap)
+				klog.Warningf("Drain was skipped for this image registry update due to the configmap %s being present. This may not be a safe change", constants.ImageRegistryDrainOverrideConfigmap)
 				return false, nil
 			}
 			isSafe, err := isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -63,10 +63,6 @@ const (
 	postConfigChangeActionRestartCrio = "restart crio"
 	// Rebooting is still the default scenario for any other change
 	postConfigChangeActionReboot = "reboot"
-
-	// ImageRegistryDrainOverrideConfigmap is the name of the Configmap a user can apply to force all
-	// image registry changes to not drain
-	ImageRegistryDrainOverrideConfigmap = "image-registry-override-drain"
 )
 
 func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
@@ -2813,7 +2809,7 @@ func (dn *Daemon) hasImageRegistryDrainOverrideConfigMap() (bool, error) {
 		return false, nil
 	}
 
-	_, err := dn.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), ImageRegistryDrainOverrideConfigmap, metav1.GetOptions{})
+	_, err := dn.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), constants.ImageRegistryDrainOverrideConfigmap, metav1.GetOptions{})
 	if err == nil {
 		return true, nil
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1056,19 +1056,19 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}
 
 	var drain bool
+	crioOverrideConfigmapExists, err := dn.hasImageRegistryDrainOverrideConfigMap()
+	if err != nil {
+		return err
+	}
 	if fg != nil && fg.Enabled(features.FeatureGateNodeDisruptionPolicy) {
 		// Check actions list and perform node drain if required
-		drain, err = isDrainRequiredForNodeDisruptionActions(nodeDisruptionActions, oldIgnConfig, newIgnConfig)
+		drain, err = isDrainRequiredForNodeDisruptionActions(nodeDisruptionActions, oldIgnConfig, newIgnConfig, crioOverrideConfigmapExists)
 		if err != nil {
 			return err
 		}
 		klog.Infof("Drain calculated for node disruption: %v for config %s", drain, newConfigName)
 	} else {
 		// Check and perform node drain if required
-		crioOverrideConfigmapExists, err := dn.hasImageRegistryDrainOverrideConfigMap()
-		if err != nil {
-			return err
-		}
 		drain, err = isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig, crioOverrideConfigmapExists)
 		if err != nil {
 			return err

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -45,6 +45,13 @@ var (
 			Name: "mco_unavailable_machine_count",
 			Help: "total number of unavailable machines in specified pool",
 		}, []string{"pool"})
+	// mcoImageRegistryDrainOverrideConfigmapExists tracks the presence of the image registry drain override configmap
+	mcoImageRegistryDrainOverrideConfigmapExists = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mco_image_registry_drain_override_exists",
+			Help: "tracks presence of the image registry drain override configmap",
+		},
+	)
 )
 
 func RegisterMCOMetrics() error {
@@ -54,6 +61,7 @@ func RegisterMCOMetrics() error {
 		mcoUpdatedMachineCount,
 		mcoDegradedMachineCount,
 		mcoUnavailableMachineCount,
+		mcoImageRegistryDrainOverrideConfigmapExists,
 	})
 
 	if err != nil {

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -50,6 +50,9 @@ func TestMetrics(t *testing.T) {
 		},
 	})
 
+	configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
+
 	coName := fmt.Sprintf("test-%s", uuid.NewUUID())
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: coName}}
 	optr.name = coName

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	kcc "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
 )
 
@@ -355,6 +356,19 @@ func (optr *Operator) syncMetrics() error {
 		mcoDegradedMachineCount.WithLabelValues(pool.Name).Set(float64(pool.Status.DegradedMachineCount))
 		mcoUnavailableMachineCount.WithLabelValues(pool.Name).Set(float64(pool.Status.UnavailableMachineCount))
 	}
+
+	// Attempt to fetch image-registry-override-drain configmap
+	_, err = optr.mcoCmLister.ConfigMaps(ctrlcommon.MCONamespace).Get(daemonconsts.ImageRegistryDrainOverrideConfigmap)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error fetching configmap %s during metrics sync", daemonconsts.ImageRegistryDrainOverrideConfigmap)
+	}
+	// If the configmap is present, fire an alert warning admin of deprecation
+	if apierrors.IsNotFound(err) {
+		mcoImageRegistryDrainOverrideConfigmapExists.Set(0)
+	} else {
+		mcoImageRegistryDrainOverrideConfigmapExists.Set(1)
+	}
+
 	return nil
 }
 

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -687,6 +687,9 @@ func TestOperatorSyncStatus(t *testing.T) {
 		operatorIndexer.Add(co)
 		operatorIndexer.Add(kasOperator)
 
+		configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
+
 		for j, sync := range testCase.syncs {
 			optr.inClusterBringup = sync.inClusterBringUp
 			if sync.nextVersion != "" {
@@ -763,6 +766,9 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 	operatorIndexer.Add(co)
 	operatorIndexer.Add(kasOperator)
 
+	configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
+
 	fn1 := func(config *renderConfig, co *configv1.ClusterOperator) error {
 		return errors.New("mocked fn1")
 	}
@@ -826,6 +832,9 @@ func TestKubeletSkewUnSupported(t *testing.T) {
 	optr.clusterOperatorLister = configlistersv1.NewClusterOperatorLister(operatorIndexer)
 	operatorIndexer.Add(co)
 	operatorIndexer.Add(kasOperator)
+
+	configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
 
 	fn1 := func(config *renderConfig, co *configv1.ClusterOperator) error {
 		return errors.New("mocked fn1")
@@ -923,6 +932,9 @@ func TestCustomPoolKubeletSkewUnSupported(t *testing.T) {
 	operatorIndexer.Add(co)
 	operatorIndexer.Add(kasOperator)
 
+	configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
+
 	fn1 := func(config *renderConfig, co *configv1.ClusterOperator) error {
 		return errors.New("mocked fn1")
 	}
@@ -1016,6 +1028,9 @@ func TestKubeletSkewSupported(t *testing.T) {
 	optr.clusterOperatorLister = configlistersv1.NewClusterOperatorLister(operatorIndexer)
 	operatorIndexer.Add(co)
 	operatorIndexer.Add(kasOperator)
+
+	configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
 
 	fn1 := func(config *renderConfig, co *configv1.ClusterOperator) error {
 		return errors.New("mocked fn1")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- Added a Prometheus alert if the image registry override `image-registry-override-drain` configmap is detected
- Fixed a bug which was causing the drain skip configmap method to no longer work. We want the workaround to still be functional during deprecation. We plan to remove the configmap workaround completely in 4.19.

**- How to verify it**
1. Create the configmap:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: image-registry-override-drain
  namespace: openshift-machine-config-operator
```
2. You should now seen an alert called `MCODrainOverrideConfigMapAlert` alerting the admin of the workaround deprecation.
3. Ensure that the configmap workaround works as expected to skip the drain.
4. Now, delete the configmap. This should remove the alert.