### PR TITLE
NO-JIRA: crio: set min memory for crun

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -46,6 +46,8 @@ contents:
         "io.kubernetes.cri-o.Devices",
         "io.kubernetes.cri-o.LinkLogs",
     ]
+    # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
+    container_min_memory = "512KiB"
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -46,6 +46,8 @@ contents:
         "io.kubernetes.cri-o.Devices",
         "io.kubernetes.cri-o.LinkLogs",
     ]
+    # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
+    container_min_memory = "512KiB"
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
as of cri-o 1.30 (available in 4.17), it now supports a per runtime minimum memory, which allows us to customize the minimum allowed memory for a container. Now, we can utilize the fact crun can run with as low as 512 kb to allow users to specify tighter memory limits for their containers
**- How to verify it**

**- Description for the changelog**
CRI-O: set a customized minimum memory limit for containers run by crun, as its memory footprint is much lower. Now, if using the crun OCI runtime, a container can have a memory limit as low as 512 KB
