### PR TITLE
OCPBUGS-37984: Give keepalived-monitor necessary capabilities

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -177,6 +177,9 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: keepalived-monitor
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "SYS_CHROOT"]
         image: {{ .Images.baremetalRuntimeCfgImage }}
         env:
           - name: ENABLE_UNICAST


### PR DESCRIPTION
When we dropped the privileged flag from the on-prem containers we missed that the keepalived-monitor container needs access to iptables in order to signal to keepalived whether the HAProxy redirect rule is in place. This change gives it the necessary caps to do that.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
