### PR TITLE
OCPNODE-2482: Enable CRI-O internal repair feature as the default

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -4,6 +4,7 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
+    internal_repair = true
 
     [crio.api]
     stream_address = "127.0.0.1"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -4,6 +4,7 @@ contents:
   inline: |
     [crio]
     internal_wipe = true
+    internal_repair = true
 
     [crio.api]
     stream_address = "127.0.0.1"


### PR DESCRIPTION
**- What I did**

For a while now, CRI-O can attempt to repair the storage directory on start-up following an unclean shutdown, such as a node crash or unexpected restart. This allows CRI-O to recover from a storage directory corruption, alleviating potential crashes or termination with a fatal error once it's started back up.

However, this internal repair feature has to be enabled to take effect, so it's currently an opt-in solution. This feature has matured and can be turned on as the new default when deploying OpenShift clusters. As a result, our customers will benefit from improved cluster resilience.

Thus, turn the internal feature on as the new default.

Related:

- https://github.com/cri-o/cri-o/pull/8417
- https://github.com/cri-o/cri-o/issues/7177

**- How to verify it**

Deploy updated configuration manually or using either the Machine Config Operator. 

Then, to verify the internal repair feature working, proceed using the following steps:

_(assuming that the test will be performed using an OpenShift cluster with privileged access available)_

1. Stop kubelet and CRI-O services
1. Navigate to the `/var/lib/containers` directory
1. Remove a random layer from any of the available container images (to corrupt the storage directory)
1. Remove the `/var/lib/crio/clean.shutdown` file to simulate CRI-O unclean shutdown
1. Start CRI-O and kubelet services
1. Verify that both services are working correctly
1. Verify that CRI-O run the check and repair to fix the corrupted storage directory on start-up (see service logs)

**- Description for the changelog**

```release-note
Change the internal repair option to be enabled by default.
```
