### PR TITLE
parallelize slow running tests

### DIFF
--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestParseManifests(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		raw  string
@@ -145,7 +146,9 @@ spec:
 		}},
 	}}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := parseManifests("dummy-file-name", strings.NewReader(test.raw))
 			if err != nil {
 				t.Fatalf("failed to parse manifest: %v", err)
@@ -158,16 +161,17 @@ spec:
 }
 
 func TestBootstrapRun(t *testing.T) {
-	destDir, err := os.MkdirTemp("", "controller-bootstrap")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
-
-	bootstrap := New("../../../templates", "testdata/bootstrap", "testdata/bootstrap/machineconfigcontroller-pull-secret")
-	err = bootstrap.Run(destDir)
-	require.NoError(t, err)
+	t.Parallel()
 
 	for _, poolName := range []string{"master", "worker"} {
+		poolName := poolName
 		t.Run(poolName, func(t *testing.T) {
+			t.Parallel()
+			destDir := t.TempDir()
+
+			bootstrap := New("../../../templates", "testdata/bootstrap", "testdata/bootstrap/machineconfigcontroller-pull-secret")
+			require.NoError(t, bootstrap.Run(destDir))
+
 			paths, err := filepath.Glob(filepath.Join(destDir, "machine-configs", fmt.Sprintf("rendered-%s-*.yaml", poolName)))
 			require.NoError(t, err)
 			require.Len(t, paths, 1)

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -12,8 +12,11 @@ import (
 )
 
 func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -559,8 +559,11 @@ var ctrcfgPatchBytes = []byte("{\"metadata\":{\"finalizers\":[\"99-master-genera
 // TestContainerRuntimeConfigCreate ensures that a create happens when an existing containerruntime config is created.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestContainerRuntimeConfigCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -599,8 +602,11 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 // TestContainerRuntimeConfigUpdate ensures that an update happens when an existing containerruntime config is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestContainerRuntimeConfigUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -683,8 +689,11 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 // TestImageConfigCreate ensures that a create happens when an image config is created.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestImageConfigCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -725,8 +734,11 @@ func TestImageConfigCreate(t *testing.T) {
 // TestImageConfigUpdate ensures that an update happens when an existing image config is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestImageConfigUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -821,8 +833,11 @@ func TestImageConfigUpdate(t *testing.T) {
 // TestICSPUpdate ensures that an update happens when an existing ICSP is updated.
 // It tests that the necessary get, create, and update steps happen in the correct order.
 func TestICSPUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -924,8 +939,11 @@ func TestICSPUpdate(t *testing.T) {
 }
 
 func TestIDMSUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -1027,8 +1045,11 @@ func TestIDMSUpdate(t *testing.T) {
 }
 
 func TestITMSUpdate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -1130,8 +1151,10 @@ func TestITMSUpdate(t *testing.T) {
 }
 
 func TestRunImageBootstrap(t *testing.T) {
+	t.Parallel()
 	testClusterImagePolicy := clusterImagePolicyTestCRs()["test-cr0"]
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		for _, tc := range []struct {
 			icspRules            []*apioperatorsv1alpha1.ImageContentSourcePolicy
 			idmsRules            []*apicfgv1.ImageDigestMirrorSet
@@ -1169,8 +1192,10 @@ func TestRunImageBootstrap(t *testing.T) {
 				},
 			},
 		} {
+			tc := tc
 
 			t.Run(string(platform), func(t *testing.T) {
+				t.Parallel()
 				cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 				pools := []*mcfgv1.MachineConfigPool{
 					helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
@@ -1206,6 +1231,7 @@ func TestRunImageBootstrap(t *testing.T) {
 // TestRegistriesValidation tests the validity of registries allowed to be listed
 // under blocked registries
 func TestRegistriesValidation(t *testing.T) {
+	t.Parallel()
 	failureTests := []struct {
 		name      string
 		config    *apicfgv1.RegistrySources
@@ -1323,6 +1349,7 @@ func TestRegistriesValidation(t *testing.T) {
 // TestContainerRuntimeConfigOptions tests the validity of allowed and not allowed values
 // for the options in containerruntime config
 func TestContainerRuntimeConfigOptions(t *testing.T) {
+	t.Parallel()
 	var (
 		invalidPidsLimit int64 = 10
 		validPidsLimit   int64 = 2048
@@ -1423,6 +1450,7 @@ func TestContainerRuntimeConfigOptions(t *testing.T) {
 }
 
 func TestMarshalResourceQuantityOptionsJSON(t *testing.T) {
+	t.Parallel()
 	var (
 		validLogSizeMax  = resource.MustParse("10k")
 		validOverlaySize = resource.MustParse("10G")
@@ -1504,8 +1532,11 @@ func generateManagedKey(ctrcfg *mcfgv1.ContainerRuntimeConfig, generation uint64
 }
 
 func TestCtrruntimeConfigMultiCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -1549,8 +1580,11 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 }
 
 func TestContainerruntimeConfigResync(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -1613,8 +1647,11 @@ func TestContainerruntimeConfigResync(t *testing.T) {
 }
 
 func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 
@@ -1672,6 +1709,7 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 // TestCleanUpDuplicatedMC test the function removes the MC from the MC list
 // if the MC is of old GeneratedByControllerVersionAnnotationKey.
 func TestCleanUpDuplicatedMC(t *testing.T) {
+	t.Parallel()
 	v := version.Hash
 	version.Hash = "3.2.0"
 	versionDegrade := "3.1.0"
@@ -1679,7 +1717,9 @@ func TestCleanUpDuplicatedMC(t *testing.T) {
 		version.Hash = v
 	}()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			f.newController()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -1750,8 +1790,11 @@ func TestCleanUpDuplicatedMC(t *testing.T) {
 }
 
 func TestClusterImagePolicyCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
@@ -1796,8 +1839,11 @@ func TestClusterImagePolicyCreate(t *testing.T) {
 }
 
 func TestSigstoreRegistriesConfigIDMSandCIPCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestUpdateRegistriesConfig(t *testing.T) {
+	t.Parallel()
 	templateConfig := sysregistriesv2.V2RegistriesConf{ // This matches templates/*/01-*-container-runtime/_base/files/container-registries.yaml
 		UnqualifiedSearchRegistries: []string{"registry.access.redhat.com", "docker.io"},
 	}
@@ -439,7 +440,9 @@ func TestUpdateRegistriesConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := updateRegistriesConfig(templateBytes, tt.insecure, tt.blocked, tt.icspRules, tt.idmsRules, tt.itmsRules)
 			if err != nil {
 				t.Errorf("updateRegistriesConfig() error = %v", err)
@@ -547,6 +550,7 @@ func clusterImagePolicyTestCRs() map[string]apicfgv1alpha1.ClusterImagePolicy {
 }
 
 func TestUpdatePolicyJSON(t *testing.T) {
+	t.Parallel()
 	testClusterImagePolicyCR := clusterImagePolicyTestCRs()["test-cr0"]
 	expectSigRequirement, policyerr := policyItemFromSpec(testClusterImagePolicyCR.Spec.Policy)
 	require.NoError(t, policyerr)
@@ -738,7 +742,9 @@ func TestUpdatePolicyJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			var (
 				clusterImagePolicies map[string]signature.PolicyRequirements
@@ -777,6 +783,7 @@ func TestUpdatePolicyJSON(t *testing.T) {
 }
 
 func TestValidateRegistriesConfScopes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		insecure    []string
 		blocked     []string
@@ -968,6 +975,7 @@ func TestValidateRegistriesConfScopes(t *testing.T) {
 }
 
 func TestGetValidBlockAndAllowedRegistries(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name, releaseImg                                                  string
 		imgSpec                                                           *apicfgv1.ImageSpec
@@ -1095,7 +1103,9 @@ func TestGetValidBlockAndAllowedRegistries(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotRegistries, gotPolicy, gotAllowed, err := getValidBlockedAndAllowedRegistries(tt.releaseImg, tt.imgSpec, nil, tt.idmsRules)
 			if (err != nil && !tt.expectedErr) || (err == nil && tt.expectedErr) {
 				t.Errorf("getValidBlockedRegistries() error = %v", err)
@@ -1109,6 +1119,7 @@ func TestGetValidBlockAndAllowedRegistries(t *testing.T) {
 }
 
 func TestCreateCRIODropinFiles(t *testing.T) {
+	t.Parallel()
 	zeroLogSizeMax := resource.MustParse("0k")
 	validLogSizeMax := resource.MustParse("10G")
 
@@ -1169,6 +1180,7 @@ func TestCreateCRIODropinFiles(t *testing.T) {
 }
 
 func TestUpdateStorageConfig(t *testing.T) {
+	t.Parallel()
 	templateStorageConfig := tomlConfigStorage{}
 	buf := bytes.Buffer{}
 	err := toml.NewEncoder(&buf).Encode(templateStorageConfig)
@@ -1227,6 +1239,7 @@ func TestUpdateStorageConfig(t *testing.T) {
 }
 
 func TestGetValidScopePolicies(t *testing.T) {
+	t.Parallel()
 	type testcase struct {
 		name                  string
 		clusterImagePolicyCRs []*apicfgv1alpha1.ClusterImagePolicy
@@ -1253,7 +1266,9 @@ func TestGetValidScopePolicies(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			gotScopePolicies, err := getValidScopePolicies(test.clusterImagePolicyCRs)
 			require.Equal(t, test.errorExpected, err != nil)
 			if !test.errorExpected {
@@ -1264,6 +1279,7 @@ func TestGetValidScopePolicies(t *testing.T) {
 }
 
 func TestGenerateSigstoreRegistriesConfig(t *testing.T) {
+	t.Parallel()
 
 	// testcase CIP scopes:
 	// "a.com/a1/a2",
@@ -1390,7 +1406,9 @@ func TestGenerateSigstoreRegistriesConfig(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			registriesTOML, err := updateRegistriesConfig(templateRegistriesConfig, nil, nil, tc.icspRules, tc.idmsRules, tc.itmsRules)
 			require.NoError(t, err)
 			got, err := generateSigstoreRegistriesdConfig(tc.clusterScopePolicies, registriesTOML)
@@ -1405,6 +1423,7 @@ func TestGenerateSigstoreRegistriesConfig(t *testing.T) {
 }
 
 func TestGeneratePolicyJSON(t *testing.T) {
+	t.Parallel()
 
 	testImagePolicyCR0 := clusterImagePolicyTestCRs()["test-cr0"]
 
@@ -1486,6 +1505,7 @@ func TestGeneratePolicyJSON(t *testing.T) {
 }
 
 func TestValidateClusterImagePolicyWithAllowedBlockedRegistries(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                 string
 		allowed              []string
@@ -1548,7 +1568,9 @@ func TestValidateClusterImagePolicyWithAllowedBlockedRegistries(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := validateClusterImagePolicyWithAllowedBlockedRegistries(tt.clusterScopePolicies, tt.allowed, tt.blocked)
 			if err == nil && tt.errorExpected {
 				t.Errorf("validateClusterImagePolicyWithAllowedBlockedRegistries() error = %v", err)

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap_test.go
@@ -18,10 +18,14 @@ import (
 )
 
 func TestRunKubeletBootstrap(t *testing.T) {
+	t.Parallel()
+
 	customSelector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role/custom", "")
 
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			pools := []*mcfgv1.MachineConfigPool{
 				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
@@ -100,6 +104,8 @@ func verifyKubeletConfigYAMLContents(t *testing.T, mc *mcfgv1.MachineConfig, mcN
 }
 
 func TestGenerateDefaultManagedKeyKubelet(t *testing.T) {
+	t.Parallel()
+
 	workerPool := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 	masterPool := helpers.NewMachineConfigPool("master", nil, helpers.WorkerSelector, "v0")
 	kcRaw, err := EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
@@ -199,8 +205,12 @@ func TestGenerateDefaultManagedKeyKubelet(t *testing.T) {
 }
 
 func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
+	t.Parallel()
+
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -416,8 +416,11 @@ func (f *fixture) resetActions() {
 var kcfgPatchBytes = []byte(`{"metadata":{"finalizers":["99-master-generated-kubelet"]}}`)
 
 func TestKubeletConfigCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -451,8 +454,11 @@ func TestKubeletConfigCreate(t *testing.T) {
 }
 
 func TestKubeletConfigMultiCreate(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -501,8 +507,11 @@ func generateManagedKey(kcfg *mcfgv1.KubeletConfig, generation uint64) string {
 }
 
 func TestKubeletConfigAutoSizingReserved(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -545,8 +554,11 @@ func TestKubeletConfigAutoSizingReserved(t *testing.T) {
 }
 
 func TestKubeletConfiglogFile(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -588,8 +600,11 @@ func TestKubeletConfiglogFile(t *testing.T) {
 }
 
 func TestKubeletConfigUpdates(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -675,6 +690,8 @@ func TestKubeletConfigUpdates(t *testing.T) {
 }
 
 func TestKubeletConfigDenylistedOptions(t *testing.T) {
+	t.Parallel()
+
 	failureTests := []struct {
 		name   string
 		config *kubeletconfigv1beta1.KubeletConfiguration
@@ -745,8 +762,11 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 }
 
 func TestKubeletFeatureExists(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "Unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -810,6 +830,7 @@ func getKeyFromConfigNode(node *osev1.Node, t *testing.T) string {
 }
 
 func TestCleanUpStatusConditions(t *testing.T) {
+	t.Parallel()
 	type status struct {
 		curtStatus   []mcfgv1.KubeletConfigCondition
 		newStatus    mcfgv1.KubeletConfigCondition
@@ -889,8 +910,11 @@ func TestCleanUpStatusConditions(t *testing.T) {
 }
 
 func TestKubeletConfigResync(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -954,8 +978,11 @@ func TestKubeletConfigResync(t *testing.T) {
 }
 
 func TestAddAnnotationExistingKubeletConfig(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -1015,6 +1042,7 @@ func TestAddAnnotationExistingKubeletConfig(t *testing.T) {
 // TestCleanUpDuplicatedMC test the function removes the MC from the MC list
 // if the MC is of old GeneratedByControllerVersionAnnotationKey.
 func TestCleanUpDuplicatedMC(t *testing.T) {
+	t.Parallel()
 	v := version.Hash
 	version.Hash = "3.2.0"
 	versionDegrade := "3.1.0"
@@ -1022,7 +1050,9 @@ func TestCleanUpDuplicatedMC(t *testing.T) {
 		version.Hash = v
 	}()
 	for _, platform := range []osev1.PlatformType{osev1.AWSPlatformType, osev1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -21,8 +21,11 @@ import (
 )
 
 func TestFeatureGateDrift(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
@@ -63,8 +66,11 @@ func TestFeatureGateDrift(t *testing.T) {
 }
 
 func TestFeaturesDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"CSIMigration"}, nil)
 			f.newController(fgAccess)
@@ -107,8 +113,11 @@ func TestFeaturesDefault(t *testing.T) {
 }
 
 func TestFeaturesCustomNoUpgrade(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			features := &osev1.FeatureGate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: ctrlcommon.ClusterFeatureInstanceName,
@@ -162,8 +171,11 @@ func TestFeaturesCustomNoUpgrade(t *testing.T) {
 }
 
 func TestBootstrapFeaturesDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
@@ -183,8 +195,11 @@ func TestBootstrapFeaturesDefault(t *testing.T) {
 }
 
 func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
@@ -240,8 +255,11 @@ func TestBootstrapFeaturesCustomNoUpgrade(t *testing.T) {
 }
 
 func TestFeaturesCustomNoUpgradeRemoveUnmanagedMC(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			features := &osev1.FeatureGate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: ctrlcommon.ClusterFeatureInstanceName,

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -20,8 +20,11 @@ import (
 )
 
 func TestOriginalKubeletConfigDefaultNodeConfig(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
@@ -46,8 +49,11 @@ func TestOriginalKubeletConfigDefaultNodeConfig(t *testing.T) {
 }
 
 func TestNodeConfigDefault(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			fgAccess := featuregates.NewHardcodedFeatureGateAccess([]osev1.FeatureGateName{"Example"}, nil)
 			f.newController(fgAccess)
@@ -80,6 +86,7 @@ func TestNodeConfigDefault(t *testing.T) {
 }
 
 func TestBootstrapNodeConfigDefault(t *testing.T) {
+	t.Parallel()
 	configNodeCgroupDefault := createNewDefaultNodeconfig()
 	configNodeCgroupV1 := createNewDefaultNodeconfigWithCgroup(osev1.CgroupModeV1)
 	configNodeCgroupV2 := createNewDefaultNodeconfigWithCgroup(osev1.CgroupModeV2)
@@ -107,7 +114,9 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 	}
 
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
 			mcp1 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
@@ -134,8 +143,11 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 }
 
 func TestBootstrapNoNodeConfig(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			mcp := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			mcps := []*mcfgv1.MachineConfigPool{mcp}
@@ -152,8 +164,11 @@ func TestBootstrapNoNodeConfig(t *testing.T) {
 }
 
 func TestNodeConfigCustom(t *testing.T) {
+	t.Parallel()
 	for _, platform := range []configv1.PlatformType{configv1.AWSPlatformType, configv1.NonePlatformType, "unrecognized"} {
+		platform := platform
 		t.Run(string(platform), func(t *testing.T) {
+			t.Parallel()
 			f := newFixture(t)
 			features := &osev1.FeatureGate{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -1361,6 +1361,7 @@ func TestShouldUpdateStatusOnlyNoProgress(t *testing.T) {
 }
 
 func TestCertStatus(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName, configv1.TopologyMode(""))
 

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestIsNodeReady(t *testing.T) {
+	t.Parallel()
 	nodeList := &corev1.NodeList{
 		Items: []corev1.Node{
 			// node1 considered

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -245,6 +245,7 @@ func newControllerConfig(name string) *mcfgv1.ControllerConfig {
 }
 
 func TestCreatesGeneratedMachineConfig(t *testing.T) {
+
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	files := []ign3types.File{{
@@ -286,6 +287,7 @@ func TestCreatesGeneratedMachineConfig(t *testing.T) {
 // Testing that ignition validation in generateRenderedMachineConfig() correctly finds MCs that contain invalid ignconfigs.
 // generateRenderedMachineConfig should return an error when one of the MCs in configs contains an invalid ignconfig.
 func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
+
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	files := []ign3types.File{{
 		Node: ign3types.Node{
@@ -329,6 +331,7 @@ func TestIgnValidationGenerateRenderedMachineConfig(t *testing.T) {
 }
 
 func TestUpdatesGeneratedMachineConfig(t *testing.T) {
+
 	f := newFixture(t)
 	mcp := helpers.NewMachineConfigPool("test-cluster-master", helpers.MasterSelector, nil, "")
 	files := []ign3types.File{{

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCloudProvider(t *testing.T) {
+	t.Parallel()
 	dummyTemplate := []byte(`{{cloudProvider .}}`)
 
 	cases := []struct {
@@ -68,7 +69,9 @@ func TestCloudProvider(t *testing.T) {
 	}}
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)
+		c := c
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			config := &mcfgv1.ControllerConfig{
 				Spec: mcfgv1.ControllerConfigSpec{
 					Infra: &configv1.Infrastructure{
@@ -95,6 +98,7 @@ func TestCloudProvider(t *testing.T) {
 }
 
 func TestCredentialProviderConfigFlag(t *testing.T) {
+	t.Parallel()
 	dummyTemplate := []byte(`{{credentialProviderConfigFlag .}}`)
 
 	testCases := []struct {
@@ -129,7 +133,9 @@ func TestCredentialProviderConfigFlag(t *testing.T) {
 
 	for idx, c := range testCases {
 		name := fmt.Sprintf("case #%d: %s", idx, c.platform)
+		c := c
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			config := &mcfgv1.ControllerConfig{
 				Spec: mcfgv1.ControllerConfigSpec{
 					Infra: &configv1.Infrastructure{
@@ -156,6 +162,7 @@ func TestCredentialProviderConfigFlag(t *testing.T) {
 }
 
 func TestSkipMissing(t *testing.T) {
+	t.Parallel()
 	dummyTemplate := `{{skip "%s"}}`
 
 	cases := []struct {
@@ -184,6 +191,7 @@ func TestSkipMissing(t *testing.T) {
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			tmpl := []byte(fmt.Sprintf(dummyTemplate, c.key))
 			got, err := renderTemplate(RenderConfig{}, name, tmpl)
 			if err != nil && !c.err {
@@ -219,6 +227,7 @@ var (
 )
 
 func TestInvalidPlatform(t *testing.T) {
+	t.Parallel()
 	controllerConfig, err := controllerConfigFromFile(configs["aws"])
 	if err != nil {
 		t.Fatalf("failed to get controllerconfig config: %v", err)
@@ -248,6 +257,7 @@ func TestInvalidPlatform(t *testing.T) {
 }
 
 func TestGenerateMachineConfigs(t *testing.T) {
+	t.Parallel()
 	for test, config := range configs {
 		controllerConfig, err := controllerConfigFromFile(config)
 		if err != nil {
@@ -346,6 +356,7 @@ func TestGenerateMachineConfigs(t *testing.T) {
 }
 
 func TestGetPaths(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		platform configv1.PlatformType
 		topology configv1.TopologyMode
@@ -365,7 +376,9 @@ func TestGetPaths(t *testing.T) {
 	}}
 	for idx, c := range cases {
 		name := fmt.Sprintf("case #%d", idx)
+		c := c
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			config := &mcfgv1.ControllerConfig{
 				Spec: mcfgv1.ControllerConfigSpec{
 					Infra: &configv1.Infrastructure{

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -280,6 +280,7 @@ func (f *fixture) expectUpdateControllerConfigStatus(status *mcfgv1.ControllerCo
 }
 
 func TestCreatesMachineConfigs(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
@@ -315,6 +316,7 @@ func TestCreatesMachineConfigs(t *testing.T) {
 }
 
 func TestDoNothing(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
@@ -353,6 +355,7 @@ func TestDoNothing(t *testing.T) {
 }
 
 func TestRecreateMachineConfig(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))
@@ -392,6 +395,7 @@ func TestRecreateMachineConfig(t *testing.T) {
 }
 
 func TestUpdateMachineConfig(t *testing.T) {
+	t.Parallel()
 	f := newFixture(t)
 	cc := newControllerConfig("test-cluster")
 	ps := newPullSecret("coreos-pull-secret", []byte(`{"dummy": "dummy"}`))


### PR DESCRIPTION
**- What I did**

Both the `kubelet-config` controller and `container-runtime-config` test suites were taking a very long time to run because all of the tests were running serially. In total, both suites were taking over one minute to run completely. Adding `t.Parallel()` calls to all of the tests and their subtests yielded a substantial improvement in test execution speed. The container-runtime-config test suite now takes approximately 10 seconds to run and the kubelet-config controller tests now take approximately 4 seconds to run.

Some quick testing reveals the following impact:

```console
# Before parallelization
$ time make test-unit
** test output omitted for brevity **
make test-unit  98% cpu  828 KiB  1:06.87 total
```

That's one minute and six seconds.

```console
# After parallelization
$ time make test-unit
** test output omitted for brevity **
make test-unit  458% cpu  826 KiB  15.192 total
```

That's 15 seconds, a 77% decrease in execution time!

Decreasing test execution time like this means that tests will be run more frequently since it takes less time to do so.

**- How to verify it**

Run the unit test suite by running `$ make test-unit`

**- Description for the changelog**
Parallelize unit test execution