### PR TITLE
OCPBUGS-38320: Revert "templates/master/cri-o: make crun as the default container runtime"

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -30,7 +30,6 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
-    default_runtime = "crun"
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -30,7 +30,6 @@ contents:
     absent_mount_sources_to_reject = [
         "/etc/hostname",
     ]
-    default_runtime = "crun"
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]


### PR DESCRIPTION
Reverts openshift/machine-config-operator#4437; tracked by https://issues.redhat.com/browse/OCPBUGS-38320

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

4.18/4.17 Disruption failures

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-ci-4.18-e2e-aws-ovn-upgrade-out-of-change
```
```
/payload-job periodic-ci-openshift-release-master-nightly-4.18-e2e-aws-ovn-serial
```

CC: @sohankunkerkar 

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>