### PR TITLE
OCPBUGS-38490: Increase connection limit for cluster loadbalancer

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -5,7 +5,7 @@ contents:
     global
       stats socket /var/lib/haproxy/run/haproxy.sock  mode 600 level admin expose-fd listeners
     defaults
-      maxconn 20000
+      maxconn 40000
       mode    tcp
       log     /var/run/haproxy/haproxy-log.sock local0 notice alert
       log-format "%ci:%cp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"


### PR DESCRIPTION
It has been reported that for certain deployments in hub-spoke topology (a single metal cluster with 3500+ managed clusters attached), during upgrades the current limit of 20k connections to the loadbalancer is not big enough and clusters are reporting connection timeouts.

As the current limit of 20k is an arbitrary selected number and the tests report that increasing it to 40k does help for the scenario described above, we should increase the current default limit.

This PR does not change the overall recommendation to use external enterprise-grade loadbalancer for such a resource-consuming workload.