### PR TITLE
OCPBUGS-9178: Track ssh authorized files

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1478,7 +1478,7 @@ func (dn *Daemon) startConfigDriftMonitor() {
 
 	opts := ConfigDriftMonitorOpts{
 		OnDrift:       dn.onConfigDrift,
-		SystemdPath:   pathSystemd,
+		RootPath:      "/",
 		ErrChan:       dn.exitCh,
 		MachineConfig: odc.currentConfig,
 	}
@@ -2294,7 +2294,7 @@ func (dn *Daemon) runOnceFromIgnition(ignConfig ign3types.Config) error {
 	if err := dn.writeFiles(ignConfig.Storage.Files, false); err != nil {
 		return err
 	}
-	if err := dn.writeUnits(ignConfig.Systemd.Units); err != nil {
+	if err := dn.writeUnits(ignConfig.Systemd.Units, "/"); err != nil {
 		return err
 	}
 	// Unconditionally remove this file in the once-from (classic RHEL)
@@ -2556,7 +2556,7 @@ func (dn *Daemon) validateOnDiskStateImpl(currentConfig *mcfgv1.MachineConfig, i
 		}
 	}
 
-	return validateOnDiskState(currentConfig, pathSystemd)
+	return validateOnDiskState(currentConfig, "/")
 }
 
 // validateOnDiskState compares the on-disk state against what a configuration

--- a/pkg/daemon/file_writers.go
+++ b/pkg/daemon/file_writers.go
@@ -187,9 +187,10 @@ func writeFileAtomically(fpath string, b []byte, dirMode, fileMode os.FileMode, 
 }
 
 // write dropins to disk
-func writeDropins(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error {
+func writeDropins(u ign3types.Unit, rootPath string, isCoreOSVariant bool) error {
+	systemdPath := getSystemdPath(rootPath)
 	for i := range u.Dropins {
-		dpath := filepath.Join(systemdRoot, u.Name+".d", u.Dropins[i].Name)
+		dpath := filepath.Join(systemdPath, u.Name+".d", u.Dropins[i].Name)
 		if u.Dropins[i].Contents == nil || *u.Dropins[i].Contents == "" {
 			klog.Infof("Dropin for %s has no content, skipping write", u.Dropins[i].Name)
 			if _, err := os.Stat(dpath); err != nil {
@@ -265,13 +266,14 @@ func writeFiles(files []ign3types.File, skipCertificateWrite bool) error {
 }
 
 // writeUnit writes a systemd unit and its dropins to disk
-func writeUnit(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error {
-	if err := writeDropins(u, systemdRoot, isCoreOSVariant); err != nil {
+func writeUnit(u ign3types.Unit, rootPath string, isCoreOSVariant bool) error {
+	if err := writeDropins(u, rootPath, isCoreOSVariant); err != nil {
 		return err
 	}
 
 	// write (or cleanup) path in /etc/systemd/system
-	fpath := filepath.Join(systemdRoot, u.Name)
+	systemdPath := getSystemdPath(rootPath)
+	fpath := filepath.Join(systemdPath, u.Name)
 	if u.Mask != nil && *u.Mask {
 		// if the unit is masked, symlink fpath to /dev/null and return early.
 
@@ -331,9 +333,9 @@ func writeUnit(u ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error
 }
 
 // writeUnits writes systemd units and their dropins to disk
-func writeUnits(units []ign3types.Unit, systemdRoot string, isCoreOSVariant bool) error {
+func writeUnits(units []ign3types.Unit, rootPath string, isCoreOSVariant bool) error {
 	for _, u := range units {
-		if err := writeUnit(u, systemdRoot, isCoreOSVariant); err != nil {
+		if err := writeUnit(u, rootPath, isCoreOSVariant); err != nil {
 			return err
 		}
 	}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1802,7 +1802,7 @@ func (dn *Daemon) updateFiles(oldIgnConfig, newIgnConfig ign3types.Config, skipC
 	if err := dn.writeFiles(newIgnConfig.Storage.Files, skipCertificateWrite); err != nil {
 		return err
 	}
-	if err := dn.writeUnits(newIgnConfig.Systemd.Units); err != nil {
+	if err := dn.writeUnits(newIgnConfig.Systemd.Units, "/"); err != nil {
 		return err
 	}
 	return dn.deleteStaleData(oldIgnConfig, newIgnConfig)
@@ -2121,14 +2121,14 @@ func (dn *Daemon) presetUnit(unit ign3types.Unit) error {
 }
 
 // writeUnits writes the systemd units to disk
-func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
+func (dn *Daemon) writeUnits(units []ign3types.Unit, rootPath string) error {
 	var enabledUnits []string
 	var disabledUnits []string
 
 	isCoreOSVariant := dn.os.IsCoreOSVariant()
 
 	for _, u := range units {
-		if err := writeUnit(u, pathSystemd, isCoreOSVariant); err != nil {
+		if err := writeUnit(u, rootPath, isCoreOSVariant); err != nil {
 			return fmt.Errorf("daemon could not write systemd unit: %w", err)
 		}
 		// if the unit doesn't note if it should be enabled or disabled then
@@ -2335,7 +2335,7 @@ func (dn *Daemon) updateSSHKeys(newUsers, oldUsers []ign3types.PasswdUser) error
 	var concatSSHKeys string
 	for _, u := range newUsers {
 		for _, k := range u.SSHAuthorizedKeys {
-			concatSSHKeys = concatSSHKeys + string(k) + "\n"
+			concatSSHKeys = concatSSHKeys + strings.TrimSpace(string(k)) + "\n"
 		}
 	}
 

--- a/test/e2e-single-node/sno_mcd_test.go
+++ b/test/e2e-single-node/sno_mcd_test.go
@@ -276,10 +276,7 @@ func TestNoReboot(t *testing.T) {
 		helpers.ExecCmdOnNode(t, cs, node, "/bin/bash", "-c", bashCmd)
 	}
 
-	// Delete the expected SSH keys directory to ensure that the directories are
-	// (re)created correctly by the MCD. This targets the upgrade case where that
-	// directory may not previously exist.
-	helpers.ExecCmdOnNode(t, cs, node, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+	require.Equal(t, sshPaths.Expected, constants.RHCOS9SSHKeyPath)
 
 	// Adding authorized key for user core
 	testIgnConfig := ctrlcommon.NewIgnConfig()

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -462,11 +462,7 @@ func TestNoReboot(t *testing.T) {
 		helpers.ExecCmdOnNode(t, cs, infraNode, "/bin/bash", "-c", bashCmd)
 	}
 
-	// Delete the expected SSH keys directory to ensure that the directories are
-	// (re)created correctly by the MCD. This targets the upgrade case where that
-	// directory may not previously exist. Note: This will need to be revisited
-	// once Config Drift Monitor is aware of SSH keys.
-	helpers.ExecCmdOnNode(t, cs, infraNode, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+	require.Equal(t, sshPaths.Expected, constants.RHCOS9SSHKeyPath)
 
 	output := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
 	oldTime := strings.Split(output, " ")[0]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Fixes: OCPBUGS-9178

**- What I did**

The Config Drift Monitor currently runs [`validateOnDiskState`](https://github.com/openshift/machine-config-operator/blob/d1a18e7a6f605263835cea5b90be2a2a1a216480/pkg/daemon/config_drift_monitor.go#L284) every time there’s a change in any tracked file. This triggers a check of all files and units for possible drift, even if only one file changed.
Hence this change, efficiently only checks the specific file or path for config drift where the change happened using `validateOnDiskStateForEvent`. Only when the Config Drift Monitor detects a disk state mismatch due to the event that occurred, an update is scheduled and then the complete `validateOnDiskState` is run. This reduces the overhead every loop of the config drift monitor. 

The SSH authorized paths have also been added.

**- How to verify it**

Any file event logged by fsnotify only triggers a check to the corresponding MC field

Verify SSH file content drifts by the test cases
`go test -v ./pkg/daemon/ -run ConfigDriftMonitor/ssh_file_content_drift`
`go test -v ./pkg/daemon/ -run ConfigDriftMonitor/ssh_file_touch`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
