### PR TITLE
[release-4.15] OCPBUGS-38712: SCC-pinning for openshift workloads

### DIFF
--- a/manifests/on-prem/coredns.yaml
+++ b/manifests/on-prem/coredns.yaml
@@ -10,6 +10,7 @@ metadata:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-coredns
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: privileged
 spec:
   volumes:
   - name: resource-dir

--- a/manifests/on-prem/keepalived.yaml
+++ b/manifests/on-prem/keepalived.yaml
@@ -10,6 +10,7 @@ metadata:
     app: {{ onPremPlatformShortName .ControllerConfig }}-infra-vrrp
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: privileged
 spec:
   volumes:
   - name: resource-dir

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -13,6 +13,7 @@ contents:
         app: {{ onPremPlatformShortName . }}-infra-coredns
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: resource-dir

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -13,6 +13,7 @@ contents:
         app: {{ onPremPlatformShortName . }}-infra-vrrp
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: resource-dir

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -13,6 +13,7 @@ contents:
         app: {{ onPremPlatformShortName . }}-infra-api-lb
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: resource-dir


### PR DESCRIPTION
Fixes: [OCPBUGS-38712](https://issues.redhat.com/browse/OCPBUGS-38712)
Cherry-pick of #4504 

**- What I did**
Updated the templates and manifest files to pin the required SCCs to workloads in platform namespaces (`openshift-kni-infra`,  `openshift-openstack-infra`, `openshift-vsphere-infra`, `openshift-nutanix-infra`) - added annotations for the `privileged` SCC to the following pods:

- `coredns` on both master and worker nodes
- `haproxy` on master nodes
- `keepalived` on both master and worker nodes

The SCC chosen is `privileged`, which is already in use by these pods, ensuring no change to the SCC used.

**- How to verify it**
Check that the required SCC annotations are present on the specified pods.

**- Description for the changelog**
Pin required SCCs to platform namespace workloads, including `coredns`, `haproxy`, and `keepalived` pods in `openshift-kni-infra`, `openshift-openstack-infra`, `openshift-vsphere-infra`, and `openshift-nutanix-infra`.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->