### PR TITLE
OCPBUGS-39226: Enable the use of Linux Bridge as the ovs default port connection

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -280,6 +280,8 @@ contents:
         iface_type=tun
         tun_mode=$(nmcli --get-values tun.mode -e no connection show ${old_conn})
         extra_phys_args+=( tun.mode "${tun_mode}" )
+      elif [ "$(nmcli --get-values connection.type conn show ${old_conn})" == "bridge" ]; then
+        iface_type=bridge
       else
         iface_type=802-3-ethernet
       fi


### PR DESCRIPTION
The linux bridge can be configured to add a virtual switch between one or many ports. This can be done by a simple machine config that adds:
  "bridge=br0:enpf0,enpf2 ip=br0:dhcp"
to the the kernel command line options which will be processed by dracut.

The use case of adding such a virtual bridge for simple IEEE802.1 switching is to support PCIe devices that act as co-processors in a baremetal server. For example:

```
    --------         ---------------------
    | Host |  PCIe   |    Co-processor   |
    |  eth0|<------->|enpf0 <-br0-> enpf2|<---> network
    |      |         |                   |
    --------         ---------------------
```

This co-processor could be a "DPU" network interface card. Thus the co-processor can be part of the same underlay network as the cluster and pods can be scheduled on the Host and the Co-processor. This allows for pods to be offloaded to the co-processor for scaling workloads.
