### PR TITLE
OCPBUGS-38632: MCPs with RHEL nodes are degraded when a userCA bundle is added to the cluster

### DIFF
--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -85,7 +85,7 @@ var (
 					{
 						Type: opv1.RestartStatusAction,
 						Restart: &opv1.RestartService{
-							ServiceName: "coreos-update-ca-trust.service",
+							ServiceName: constants.UpdateCATrustServiceName,
 						},
 					},
 					{

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -121,6 +121,13 @@ const (
 	// DaemonReloadCommand is used to specify reloads and restarts of the systemd manager configuration
 	DaemonReloadCommand = "daemon-reload"
 
+	// UpdateCATrustServiceName is a service present on CoresOS nodes that runs the update-ca-trust command
+	UpdateCATrustServiceName = "coreos-update-ca-trust.service"
+
+	// UpdateCATrustCommand will be used to run update-ca-trust directly. This is a fallback for scenarios
+	// where the above service doesn't exist, for example on RHEL nodes.
+	UpdateCATrustCommand = "update-ca-trust"
+
 	// DefaultCRIOSocketPath is the default path to the CRI-O socket
 	DefaultCRIOSocketPath = "/var/run/crio/crio.sock"
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -197,10 +197,26 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 			serviceName := string(action.Restart.ServiceName)
 
 			if err := restartService(serviceName); err != nil {
-				if dn.nodeWriter != nil {
-					dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedServiceRestart", fmt.Sprintf("Restarting %s service failed. Error: %v", serviceName, err))
+				// On RHEL nodes, this service is not available and will error out.
+				// In those cases, directly run the command instead of using the service
+				if serviceName == constants.UpdateCATrustServiceName {
+					logSystem("Error executing %s unit, falling back to command", serviceName)
+					cmd := exec.Command(constants.UpdateCATrustCommand)
+					var stderr bytes.Buffer
+					cmd.Stdout = os.Stdout
+					cmd.Stderr = &stderr
+					if err := cmd.Run(); err != nil {
+						if dn.nodeWriter != nil {
+							dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedServiceRestart", fmt.Sprintf("Restarting %s service failed. Error: %v", serviceName, err))
+						}
+						return fmt.Errorf("error running %s: %s: %w", constants.UpdateCATrustCommand, stderr.String(), err)
+					}
+				} else {
+					if dn.nodeWriter != nil {
+						dn.nodeWriter.Eventf(corev1.EventTypeWarning, "FailedServiceRestart", fmt.Sprintf("Restarting %s service failed. Error: %v", serviceName, err))
+					}
+					return fmt.Errorf("could not apply update: restarting %s service failed. Error: %w", serviceName, err)
 				}
-				return fmt.Errorf("could not apply update: restarting %s service failed. Error: %w", serviceName, err)
 			}
 			// TODO: Add a new MCN Condition to the API for service restarts?
 			if dn.nodeWriter != nil {
@@ -304,12 +320,12 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 	}
 
 	if ctrlcommon.InSlice(postConfigChangeActionRestartCrio, postConfigChangeActions) {
-		cmd := exec.Command("update-ca-trust")
+		cmd := exec.Command(constants.UpdateCATrustCommand)
 		var stderr bytes.Buffer
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("error running update-ca-trust: %s: %w", string(stderr.Bytes()), err)
+			return fmt.Errorf("error running %s: %s: %w", constants.UpdateCATrustCommand, string(stderr.Bytes()), err)
 		}
 
 		serviceName := constants.CRIOServiceName


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
On failure to execute `coreos-update-ca-trust` service, the daemon will attempt to run the `update-ca-trust` command directly. This is needed on RHEL nodes as this service is not included on them by default.

**- How to verify it**
Follow the reproductions steps on the bug. Daemon logs will make note of the MCD falling back to the command:
```
I0827 18:54:36.728842    3232 update.go:2650] Performing post config change action: Restart for config rendered-worker-99a3e7096a7eea7769d164af4b6742fe
I0827 18:54:36.732053    3232 update.go:2635] Running: systemctl restart coreos-update-ca-trust.service
I0827 18:54:36.738163    3232 update.go:2650] Error executing coreos-update-ca-trust.service unit, falling back to command
I0827 18:54:37.595582    3232 update.go:2650] coreos-update-ca-trust.service service restarted successfully!
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
