### PR TITLE
OCPBUGS-39131: fixes node scaledown for e2e tests

### DIFF
--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -896,9 +896,14 @@ func TestFirstBootHasSSHKeys(t *testing.T) {
 
 	// Scale up our MachineSet to add a new node to target for our test.
 	newNodes, cleanupFunc := helpers.ScaleMachineSetAndWaitForNodesToBeReady(t, cs, machineset.Name, *machineset.Spec.Replicas+1)
-	t.Cleanup(cleanupFunc)
-
 	newNode := newNodes[0]
+	t.Cleanup(func() {
+		if t.Failed() {
+			helpers.CollectDebugInfoFromNode(t, cs, newNode)
+		}
+
+		cleanupFunc()
+	})
 
 	sshKeyFile := "/home/core/.ssh/authorized_keys.d/ignition"
 

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -905,17 +905,50 @@ func TestFirstBootHasSSHKeys(t *testing.T) {
 		cleanupFunc()
 	})
 
-	sshKeyFile := "/home/core/.ssh/authorized_keys.d/ignition"
+	sshKeyFileExistsOnNode := func(keyPath string) bool {
+		_, err := helpers.ExecCmdOnNodeWithError(cs, *newNode, "stat", filepath.Join("/rootfs", keyPath))
+		return err == nil
+	}
 
-	// Now that the new node is ready, ensure that the SSH key file is populated.
-	out := helpers.ExecCmdOnNode(t, cs, *newNode, "cat", filepath.Join("/rootfs", sshKeyFile))
-	t.Logf("Got ssh key file data: %s", out)
-	// TODO: Assert that the file contents equals the SSH key field on the
-	// MachineConfig. In theory, this may seem easy to do, but in practice it's a
-	// bit more involved because the SSH key field on MachineConfigs can accept
-	// multiple SSH keys per item with line breaks or single SSH keys
-	// one-per-line. For now, we just assert that the field is not empty.
-	assert.NotEmpty(t, out, "expected SSH key file %s on %s to contain SSH keys, but it was empty", sshKeyFile, newNode.Name)
+	assertSSHKeyContents := func(keyPath string) {
+		// Now that the new node is ready, ensure that the SSH key file is populated.
+		out := helpers.ExecCmdOnNode(t, cs, *newNode, "cat", filepath.Join("/rootfs", keyPath))
+		t.Logf("Got ssh key file data: %s", out)
+		// TODO: Assert that the file contents equals the SSH key field on the
+		// MachineConfig. In theory, this may seem easy to do, but in practice it's a
+		// bit more involved because the SSH key field on MachineConfigs can accept
+		// multiple SSH keys per item with line breaks or single SSH keys
+		// one-per-line. For now, we just assert that the field is not empty.
+		assert.NotEmpty(t, out, "expected SSH key file %s on %s to contain SSH keys, but it was empty", keyPath, newNode.Name)
+	}
+
+	isFound := false
+	isFoundRhcos8KeyPath := false
+	isFoundRhcos9KeyPath := false
+
+	if sshKeyFileExistsOnNode(constants.RHCOS8SSHKeyPath) {
+		assertSSHKeyContents(constants.RHCOS8SSHKeyPath)
+		isFound = true
+		isFoundRhcos8KeyPath = true
+	}
+
+	if sshKeyFileExistsOnNode(constants.RHCOS9SSHKeyPath) {
+		assertSSHKeyContents(constants.RHCOS9SSHKeyPath)
+		isFound = true
+		isFoundRhcos9KeyPath = true
+	}
+
+	if isFound {
+		t.Logf("SSH keys found on node in RHCOS8 location %v / RHCOS9 location %v", isFoundRhcos8KeyPath, isFoundRhcos9KeyPath)
+	} else {
+		t.Logf("Neither %s or %s exists on the node", constants.RHCOS8SSHKeyPath, constants.RHCOS9SSHKeyPath)
+		t.FailNow()
+	}
+}
+
+func sshKeyFileExistsOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
+	_, err := helpers.ExecCmdOnNodeWithError(cs, node, "stat", filepath.Join("/rootfs", path))
+	return err == nil
 }
 
 func createMCToAddFileForRole(name, role, filename, data string) *mcfgv1.MachineConfig {

--- a/test/helpers/archiveartifact.go
+++ b/test/helpers/archiveartifact.go
@@ -1,0 +1,123 @@
+package helpers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Creates and manages a temporary directory for archiving files to the
+// detected build artifact directory.
+type ArtifactArchive struct {
+	t           *testing.T
+	archiveName string
+	artifactDir string
+	stagingDir  string
+}
+
+const (
+	artifactDirEnvVar string = "ARTIFACT_DIR"
+)
+
+// Creates an ArtifactArchive instance for writing archived files to the build
+// artifact directory.
+func NewArtifactArchive(t *testing.T, archiveName string) (*ArtifactArchive, error) {
+	t.Helper()
+
+	_, err := exec.LookPath("tar")
+	if err != nil {
+		return nil, err
+	}
+
+	artifactDir, err := GetBuildArtifactDir(t)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &ArtifactArchive{
+		t:           t,
+		archiveName: filepath.Join(artifactDir, archiveName),
+		artifactDir: artifactDir,
+		stagingDir:  t.TempDir(),
+	}
+
+	// Create the root directory for the staging area.
+	if err := os.MkdirAll(a.StagingDir(), 0o755); err != nil {
+		return nil, err
+	}
+
+	t.Logf("Created archive staging dir: %q. All files written there will be archived to: %q", a.stagingDir, a.archiveName)
+	return a, nil
+}
+
+// Returns the root of the archive. In other words, all files within the
+// archive will be in a folder with this name, which will be a sanitized
+// representation of the test name.
+func (a *ArtifactArchive) ArchiveRoot() string {
+	return SanitizeTestName(a.t)
+}
+
+// Returns the staging directory where files may be written to. The archive
+// root is appended so that all files written to the path returned by this
+// function are under the archive root.
+func (a *ArtifactArchive) StagingDir() string {
+	return filepath.Join(a.stagingDir, a.ArchiveRoot())
+}
+
+// Writes the archive to the build artifact directory using the tar program.
+func (a *ArtifactArchive) WriteArchive() error {
+	cmd := exec.Command("tar", "-cvzf", a.archiveName, "-C", a.stagingDir, ".")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		a.t.Logf(string(output))
+		return err
+	}
+
+	a.t.Logf("Archived files to %q", a.archiveName)
+
+	return nil
+}
+
+// Determines where to write files to. ARTIFACT_DIR is a well-known env var
+// provided by the OpenShift CI system. Writing to the path in this env var
+// will ensure that any files written to that path end up in the OpenShift CI
+// GCP bucket for later viewing.
+//
+// If this env var is not set, these files will be written to the current
+// working directory.
+func GetBuildArtifactDir(t *testing.T) (string, error) {
+	artifactDir, ok := os.LookupEnv(artifactDirEnvVar)
+	if ok && artifactDir != "" {
+		t.Logf("%s set to %q", artifactDirEnvVar, artifactDir)
+		return artifactDir, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	t.Logf("%s not set or empty, using current working directory: %q", artifactDirEnvVar, cwd)
+
+	return cwd, nil
+}
+
+// Makes the test name safe for use as a filename by removing all invalid characters.
+func SanitizeTestName(t *testing.T) string {
+	return sanitizeTestName(t.Name())
+}
+
+func sanitizeTestName(name string) string {
+	invalidChars := []string{
+		"/",
+		"#",
+	}
+
+	for _, char := range invalidChars {
+		name = strings.ReplaceAll(name, char, "_")
+	}
+
+	return name
+}

--- a/test/helpers/archiveartifact_test.go
+++ b/test/helpers/archiveartifact_test.go
@@ -1,0 +1,110 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactArchive(t *testing.T) {
+	artifactDir := t.TempDir()
+	t.Setenv(artifactDirEnvVar, artifactDir)
+
+	archiveName := "test-archive.tar.gz"
+
+	archive, err := NewArtifactArchive(t, archiveName)
+	assert.NoError(t, err)
+
+	contents := []byte("hello world")
+
+	for i := 1; i <= 10; i++ {
+		filename := fmt.Sprintf("file-%d.txt", i)
+		require.NoError(t, os.WriteFile(filepath.Join(archive.StagingDir(), filename), contents, 0o755))
+	}
+
+	assert.NoError(t, archive.WriteArchive())
+	assert.FileExists(t, filepath.Join(artifactDir, archiveName))
+
+	extractDir := t.TempDir()
+	cmd := exec.Command("tar", "-xzvf", filepath.Join(artifactDir, archiveName), "-C", extractDir)
+	require.NoError(t, cmd.Run())
+
+	extractDir = filepath.Join(extractDir, archive.ArchiveRoot())
+
+	for i := 1; i <= 10; i++ {
+		filename := fmt.Sprintf("file-%d.txt", i)
+		assert.FileExists(t, filepath.Join(extractDir, filename))
+	}
+}
+
+func TestGetBuildArtifactDir(t *testing.T) {
+	assertFromEnvVar := func() {
+		val := os.Getenv(artifactDirEnvVar)
+		result, err := GetBuildArtifactDir(t)
+		require.NoError(t, err)
+		assert.Equal(t, val, result)
+	}
+
+	assertFromCwd := func() {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+
+		result, err := GetBuildArtifactDir(t)
+		require.NoError(t, err)
+		assert.Equal(t, cwd, result)
+	}
+
+	val, ok := os.LookupEnv(artifactDirEnvVar)
+	if ok && val != "" {
+		assertFromEnvVar()
+		os.Unsetenv(artifactDirEnvVar)
+	}
+
+	assertFromCwd()
+	t.Setenv(artifactDirEnvVar, "/artifacts")
+	assertFromEnvVar()
+	t.Setenv(artifactDirEnvVar, "")
+	assertFromCwd()
+}
+
+func TestSanitizeTestName(t *testing.T) {
+	tests := []struct {
+		name     string
+		testName string
+		expected string
+	}{
+		{
+			name:     "Simple test name",
+			testName: "TestSomething",
+			expected: "TestSomething",
+		},
+		{
+			name:     "With subtests",
+			testName: "TestSomething/WithSubtest",
+			expected: "TestSomething_WithSubtest",
+		},
+		{
+			name:     "With unique suffix",
+			testName: "TestSomething#01",
+			expected: "TestSomething_01",
+		},
+		{
+			name:     "With unique suffix and subtest",
+			testName: "TestSomething/WithSubtest#01",
+			expected: "TestSomething_WithSubtest_01",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, sanitizeTestName(test.testName))
+		})
+	}
+
+	assert.Equal(t, "TestSanitizeTestName", SanitizeTestName(t))
+}

--- a/test/helpers/nodestate.go
+++ b/test/helpers/nodestate.go
@@ -1,0 +1,76 @@
+package helpers
+
+import (
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TODO: Consider consolidating all of the functions within this file with
+// pkg/controller/common/layered_node_state.go. The only reason why I did not
+// do this is because a larger refactoring of that package is needed and I did
+// not wish to include it at this time.
+
+// Determines whether a node has changed configs.
+func hasNodeConfigChanged(node corev1.Node, mcName string) bool {
+	current := node.Annotations[constants.CurrentMachineConfigAnnotationKey]
+	desired := node.Annotations[constants.DesiredMachineConfigAnnotationKey]
+
+	return current == desired && desired == mcName
+}
+
+// Determines whether a node has changed images.
+func hasNodeImageChanged(node corev1.Node, image string) bool {
+	current := node.Annotations[constants.CurrentImageAnnotationKey]
+	desired := node.Annotations[constants.DesiredImageAnnotationKey]
+
+	return current == desired && desired == image
+}
+
+// Determines whether the MCD on a given node has reached the "Done" state.
+func isMCDDone(node corev1.Node) bool {
+	state := node.Annotations[constants.MachineConfigDaemonStateAnnotationKey]
+	return state == constants.MachineConfigDaemonStateDone
+}
+
+// Determines if a given node is ready.
+func isNodeReady(node corev1.Node) bool {
+	// If the node is cordoned, it is not ready.
+	if node.Spec.Unschedulable {
+		return false
+	}
+
+	// If the nodes' kubelet is not ready, it is not ready.
+	if !isNodeKubeletReady(node) {
+		return false
+	}
+
+	// If the nodes' MCD is not done, it is not ready.
+	if !isMCDDone(node) {
+		return false
+	}
+
+	return true
+}
+
+// Determines if a given node's kubelet is ready.
+func isNodeKubeletReady(node corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Reason == "KubeletReady" && condition.Status == "True" && condition.Type == "Ready" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Determines if all the nodes in a given NodeList are ready. Returns false if
+// any node is not ready.
+func isAllNodesReady(nodes *corev1.NodeList) bool {
+	for _, node := range nodes.Items {
+		if !isNodeReady(node) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
**- What I did**

Fixes: OCPBUGS-39131

Removes the node / Machine deletion call and ensures that the node scaledown function waits for all of the nodes to be ready and prioritizes the nodes it created for deletion. Also modifies `GetRandomNode()` to ensure that the node it returns is actually ready. If not, `GetRandomNode()` will poll for up to 5 minutes for a node to become ready.

**- How to verify it**

Run the e2e test suite. All tests should pass.

**- Description for the changelog**
Fixes node scaledown for e2e tests