### PR TITLE
OCPBUGS-38809: Update machine-config-daemon-pull.service to use custom policy for Podman < 4.4.1

### DIFF
--- a/templates/common/_base/files/podman-policy-args.yaml
+++ b/templates/common/_base/files/podman-policy-args.yaml
@@ -1,0 +1,23 @@
+mode: 0755
+path: "/etc/machine-config-daemon/generate_podman_policy_args.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    
+    # Extract Podman version and determine the signature policy
+    /usr/bin/podman -v | /bin/awk '{
+        split($3, version, "-");
+        clean_version = version[1];
+    
+        split(clean_version, current, /\./);
+        split("4.4.1", target, /\./);
+    
+        for (i = 1; i <= 3; i++) {
+            if ((current[i] + 0) < (target[i] + 0)) {
+                print "--signature-policy /etc/machine-config-daemon/policy-for-old-podman.json";
+                exit;
+            } else if ((current[i] + 0) > (target[i] + 0)) {
+                exit;
+            }
+        }
+    }' > /tmp/podman_policy_args

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -15,7 +15,9 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
+  ExecStartPre=/etc/machine-config-daemon/generate_podman_policy_args.sh
+  ExecStart=/bin/sh -c "while ! /usr/bin/podman pull $(cat /tmp/podman_policy_args) --authfile=/var/lib/kubelet/config.json '{{ .Images.machineConfigOperator }}'; do sleep 1; done"
+  
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}

--- a/templates/master/01-master-container-runtime/_base/files/policy-no-sigstoresigned.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/policy-no-sigstoresigned.yaml
@@ -1,0 +1,18 @@
+mode: 0644
+path: "/etc/machine-config-daemon/policy-for-old-podman.json"
+contents:
+  inline: |
+    {
+        "default": [
+            {
+                "type": "insecureAcceptAnything"
+            }
+        ],
+        "transports":
+            {
+                "docker-daemon":
+                    {
+                        "": [{"type":"insecureAcceptAnything"}]
+                    }
+            }
+    }

--- a/templates/worker/01-worker-container-runtime/_base/files/policy-no-sigstoresigned.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/policy-no-sigstoresigned.yaml
@@ -1,0 +1,18 @@
+mode: 0644
+path: "/etc/machine-config-daemon/policy-for-old-podman.json"
+contents:
+  inline: |
+    {
+        "default": [
+            {
+                "type": "insecureAcceptAnything"
+            }
+        ],
+        "transports":
+            {
+                "docker-daemon":
+                    {
+                        "": [{"type":"insecureAcceptAnything"}]
+                    }
+            }
+    }


### PR DESCRIPTION


<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Update machine-config-daemon-pull.service.yaml to not use sigstore policy.json if pdman version is less than 4.4.1. it will use `/etc/machine-config-daemon/policy-for-old-podman.json` to skip the default `openshift` clusterimagepolicy verifications.

**- How to verify it**
Using reproduce steps in the bug description
copied-machineset-modified-flgjt running using 4.5 base image
```
$ oc get machines.machine.openshift.io    -n openshift-machine-api
NAME                                                PHASE     TYPE         REGION      ZONE         AGE
ci-ln-cihng1k-76ef8-zm6hv-master-0                  Running   m6a.xlarge   us-east-1   us-east-1d   97m
ci-ln-cihng1k-76ef8-zm6hv-master-1                  Running   m6a.xlarge   us-east-1   us-east-1f   97m
ci-ln-cihng1k-76ef8-zm6hv-master-2                  Running   m6a.xlarge   us-east-1   us-east-1d   97m
ci-ln-cihng1k-76ef8-zm6hv-worker-us-east-1d-cvlhk   Running   m6a.xlarge   us-east-1   us-east-1d   93m
ci-ln-cihng1k-76ef8-zm6hv-worker-us-east-1d-m8rwb   Running   m6a.xlarge   us-east-1   us-east-1d   93m
ci-ln-cihng1k-76ef8-zm6hv-worker-us-east-1f-hfr6n   Running   m6a.xlarge   us-east-1   us-east-1f   93m
copied-machineset-modified-flgjt                    Running   m6a.xlarge   us-east-1   us-east-1f   23m

$  oc describe machines.machine.openshift.io copied-machineset-modified-flgjt   -n openshift-machine-api | grep Address 
  Addresses:
    Address:  10.0.80.21
    Address:  ip-10-0-80-21.ec2.internal
    Address:  ip-10-0-80-21.ec2.internal


$ oc get nodes
NAME                           STATUS   ROLES                  AGE   VERSION
ip-10-0-110-241.ec2.internal   Ready    control-plane,master   98m   v1.31.3
ip-10-0-36-200.ec2.internal    Ready    control-plane,master   97m   v1.31.3
ip-10-0-40-0.ec2.internal      Ready    worker                 89m   v1.31.3
ip-10-0-61-193.ec2.internal    Ready    control-plane,master   97m   v1.31.3
ip-10-0-7-226.ec2.internal     Ready    worker                 90m   v1.31.3
ip-10-0-75-34.ec2.internal     Ready    worker                 90m   v1.31.3
ip-10-0-80-21.ec2.internal     Ready    worker                 18m   v1.31.3
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
