### PR TITLE
OCPBUGS-39222: Do not enable on-prem-resolv-prepender.path for UPI

### DIFF
--- a/templates/common/on-prem/units/on-prem-resolv-prepender.path.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.path.yaml
@@ -1,5 +1,5 @@
 name: on-prem-resolv-prepender.path
-enabled: true
+enabled: {{if gt (len (onPremPlatformAPIServerInternalIPs .)) 0}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Watches for changes in /var/run/NetworkManager/resolv.conf according to on-prem IPI needs


### PR DESCRIPTION
Closes: OCPBUGS-39222