### PR TITLE
OCPBUGS-36850: Port number 22623 exposing weak ciphers to external client from master node IP

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -395,6 +395,12 @@ func cipherOrder() []uint16 {
 		if strings.HasSuffix(c.Name, "CBC_SHA") {
 			return false
 		}
+		if c.Name == "TLS_RSA_WITH_AES_128_GCM_SHA256" {
+			return false
+		}
+		if c.Name == "TLS_RSA_WITH_AES_256_GCM_SHA384" {
+			return false
+		}
 		// 3DES is considered insecure
 		if strings.Contains(c.Name, "3DES") {
 			return false


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Disallowed two insecure ciphers from the MCS server settings:

- TLS_RSA_WITH_AES_128_GCM_SHA256
- TLS_RSA_WITH_AES_256_GCM_SHA384   

**- How to verify it**
With this fix, the server should no longer use the ciphers listed above. This can be tested using the method described [in this comment](https://issues.redhat.com/browse/MCO-850?focusedId=25198979&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25198979).

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
