### PR TITLE
OCPBUGS-39438: Persist ethtool hw offload setting for br-ex

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -284,6 +284,12 @@ contents:
         iface_type=802-3-ethernet
       fi
 
+      # TODO: Should this persist all ethtool options?
+      ethtool_offload_opts=$(nmcli --get-values ethtool.feature-esp-tx-csum-hw-offload conn show ${old_conn})
+      if [ -n "$ethtool_offload_opts" ]; then
+        extra_phys_args+=( ethtool.feature-esp-tx-csum-hw-offload "${ethtool_offload_opts}" )
+      fi
+
       if [ ! "${clone_mac:-}" = "0" ]; then
         # In active-backup link aggregation, with fail_over_mac mode enabled,
         # cloning the mac address is not supported. It is possible then that


### PR DESCRIPTION
In some circumstances it is necessary to disable the ethtool setting feature-esp-tx-csum-hw-offload. Previously if this was disabled on the underlying interface, that setting would be lost when br-ex was created. This patch adds it to the list of configuration values to maintain from the underlying interface.

For the time being I am only persisting the specific value needed to fix the referenced bug. We may want to consider persisting all ethtool configuration as a followup, but I'm unsure of the implications of that right now so I'd like to get this specific problem fixed before worrying about more general cases.
