### PR TITLE
Fix openstack-kubelet-nodename service

### DIFF
--- a/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
+++ b/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
@@ -3,8 +3,9 @@ enabled: true
 contents: |
   [Unit]
   Description=Fetch kubelet node name from OpenStack metadata
-  # Wait for NetworkManager to report it's online
-  After=NetworkManager-wait-online.service
+  # Wait for NetworkManager and wait-for-br-ex-up to report it's online
+  Wants=wait-for-br-ex-up.service
+  After=NetworkManager-wait-online.service wait-for-br-ex-up.service
   # Run before kubelet
   Before=kubelet-dependencies.target
 


### PR DESCRIPTION
Make openstack-kubelet-nodename.service depend on
wait-for-br-ex-up.service.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
