### PR TITLE
OCPBUGS-41631: Panic seen in CI job for MCC pod

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -582,7 +582,7 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 
 	// Let's be verbose when a node changes pool
 	oldPool, err := ctrl.getPrimaryPoolForNode(oldNode)
-	if err == nil && oldPool.Name != pool.Name {
+	if err == nil && oldPool != nil && oldPool.Name != pool.Name {
 		ctrl.logPoolNode(pool, curNode, "changed from pool %s", oldPool.Name)
 		// Let's also make sure the old pool node counts/status get updated
 		ctrl.enqueueMachineConfigPool(oldPool)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a nil check for the oldPool field before using it.

**- How to verify it**
The periodic test listed in bug should no longer have an undiagnosed panic.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
