### PR TITLE
OCPBUGS-33891: Avoid degrading a node over a brief apiserver disruption

### DIFF
--- a/internal/kubeutils.go
+++ b/internal/kubeutils.go
@@ -54,7 +54,7 @@ func UpdateNodeRetry(client corev1client.NodeInterface, lister corev1lister.Node
 		return err
 	}); err != nil {
 		// may be conflict if max retries were hit
-		return nil, fmt.Errorf("unable to update node %q: %w", node, err)
+		return nil, fmt.Errorf("unable to update node %q: %w", nodeName, err)
 	}
 	return node, nil
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Simplified the error message by replacing the full node struct with just the node name in the logs when an update fails. This makes the logs clearer and easier to read.

**- How to verify it**
Upgrade the cluster and monitor the logs. The logs should be cleaner without the full struct dumps.

**- Description for the changelog**
Improved log readability by replacing full node struct dumps with just the node name in error messages.

