### PR TITLE
OCPNODE-2399: Add a condition in the config node object

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -33,6 +33,9 @@ const (
 	managedFeaturesKeyPrefix      = "98"
 	managedKubeletConfigKeyPrefix = "99"
 	protectKernelDefaultsStr      = "\"protectKernelDefaults\":false"
+	cgroupsV1DeprecationMsg       = "cgroups v1 support will soon be deprecated in Openshift, consider switching to cgroups v2"
+	cgroupModeCondType            = "CGroupMode"
+	cgroupCondReason              = "CGroupModeV1"
 )
 
 func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, userDefinedSystemReserved map[string]string) *ign3types.File {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -10,6 +10,7 @@ import (
 	osev1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +78,12 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		return err
 	}
 
+	if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV1 {
+		klog.Warningf(cgroupsV1DeprecationMsg)
+		if err := ctrl.syncNodeConfigStatus(nodeConfig); err != nil {
+			return err
+		}
+	}
 	// Fetch the controllerconfig
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
@@ -184,6 +191,24 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		}
 	}
 	return nil
+}
+
+func (ctrl *Controller) syncNodeConfigStatus(cfg *osev1.Node) error {
+	statusUpdateErr := retry.RetryOnConflict(updateBackoff, func() error {
+		newStatusCondition := apihelpers.NewCondition(cgroupModeCondType, metav1.ConditionTrue, cgroupCondReason, cgroupsV1DeprecationMsg)
+		if len(cfg.Status.Conditions) == 0 || newStatusCondition.Message != cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Message {
+			cfg.Status.Conditions = append(cfg.Status.Conditions, *newStatusCondition)
+		} else if cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Message == newStatusCondition.Message {
+			cfg.Status.Conditions[len(cfg.Status.Conditions)-1] = *newStatusCondition
+		}
+		_, updateErr := ctrl.configClient.ConfigV1().Nodes().UpdateStatus(context.TODO(), cfg, metav1.UpdateOptions{})
+		return updateErr
+	})
+	// If an error occurred in updating the status, log it
+	if statusUpdateErr != nil {
+		klog.Warningf("Unable to update the node config status: %v", statusUpdateErr)
+	}
+	return statusUpdateErr
 }
 
 func (ctrl *Controller) enqueueNodeConfig(nodeConfig *osev1.Node) {


### PR DESCRIPTION
CGroupsV1 support would be deprecated and hence a warning and a condition status update needs to be present for the clusters that are still on CGroupsV1 mode.