### PR TITLE
[release-4.16] OCPBUGS-41806: When newly built images rolled out, the update progress is not displaying correctly (went 0 --> 3)

### DIFF
--- a/pkg/controller/common/layered_node_state.go
+++ b/pkg/controller/common/layered_node_state.go
@@ -59,6 +59,10 @@ func (l *LayeredNodeState) isDesiredImageEqualToBuild(mosc *mcfgv1alpha1.Machine
 	return l.isImageAnnotationEqualToBuild(daemonconsts.DesiredImageAnnotationKey, mosc)
 }
 
+func (l *LayeredNodeState) IsCurrentImageEqualToBuild(mosc *mcfgv1alpha1.MachineOSConfig) bool {
+	return l.isImageAnnotationEqualToBuild(daemonconsts.CurrentImageAnnotationKey, mosc)
+}
+
 func (l *LayeredNodeState) isDesiredMachineConfigEqualToBuild(mosb *mcfgv1alpha1.MachineOSBuild) bool {
 	return l.node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] == mosb.Spec.DesiredConfig.Name
 

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -625,7 +625,7 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 
 	// Specifically log when a node has completed an update so the MCC logs are a useful central aggregate of state changes
 	if oldNode.Annotations[daemonconsts.CurrentMachineConfigAnnotationKey] != oldNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey] &&
-		isNodeDone(curNode) {
+		isNodeDone(curNode, false) {
 		ctrl.logPoolNode(pool, curNode, "Completed update to %s", curNode.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
 		changed = true
 	} else {
@@ -1010,9 +1010,9 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		}
 
 		klog.V(4).Infof("Continuing updates for layered pool %s", pool.Name)
+	} else {
+		klog.V(4).Infof("Pool %s is not layered", pool.Name)
 	}
-
-	klog.V(4).Infof("Pool %s is not layered", pool.Name)
 
 	nodes, err := ctrl.getNodesForPool(pool)
 	if err != nil {
@@ -1166,7 +1166,7 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1alpha1.MachineOSConfig, 
 		if mosb == nil {
 			if lns.IsDesiredEqualToPool(pool, layered) {
 				// If the node's desired annotations match the pool, return directly without updating the node.
-				klog.Infof("no update is needed")
+				klog.V(4).Infof("Pool %s: node %s: no update is needed", pool.Name, nodeName)
 				return nil
 
 			}
@@ -1175,7 +1175,7 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1alpha1.MachineOSConfig, 
 		} else {
 			if lns.IsDesiredEqualToBuild(mosc, mosb) {
 				// If the node's desired annotations match the pool, return directly without updating the node.
-				klog.Infof("no update is needed")
+				klog.V(4).Infof("Pool %s: node %s: no update is needed", pool.Name, nodeName)
 				return nil
 			}
 			// ensure this is happening. it might not be.
@@ -1207,7 +1207,7 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1alpha1.MachineOSConfig, 
 func getAllCandidateMachines(layered bool, config *mcfgv1alpha1.MachineOSConfig, build *mcfgv1alpha1.MachineOSBuild, pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) ([]*corev1.Node, uint) {
 	unavail := getUnavailableMachines(nodesInPool, pool, layered, build)
 	if len(unavail) >= maxUnavailable {
-		klog.Infof("No nodes available for updates")
+		klog.V(4).Infof("Pool %s: No nodes available for updates", pool.Name)
 		return nil, 0
 	}
 	capacity := maxUnavailable - len(unavail)
@@ -1226,7 +1226,7 @@ func getAllCandidateMachines(layered bool, config *mcfgv1alpha1.MachineOSConfig,
 		} else {
 			if lns.IsDesiredEqualToBuild(config, build) {
 				// If the node's desired annotations match the pool, return directly without updating the node.
-				klog.Infof("no update is needed")
+				klog.V(4).Infof("Pool %s: layered node %s: no update is needed", pool.Name, node.Name)
 				continue
 			}
 		}
@@ -1235,6 +1235,7 @@ func getAllCandidateMachines(layered bool, config *mcfgv1alpha1.MachineOSConfig,
 			klog.V(4).Infof("node %s skipped during candidate selection as it is currently unscheduled", node.Name)
 			continue
 		}
+		klog.V(4).Infof("Pool %s: selected candidate node %s", pool.Name, node.Name)
 		nodes = append(nodes, node)
 	}
 	// Nodes which are failing to target this config also count against

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -725,9 +725,9 @@ func TestGetCandidateMachines(t *testing.T) {
 			helpers.NewNodeBuilder("node-7").WithEqualConfigsAndImages(machineConfigV1, imageV1).WithNodeReady().Node(),
 			helpers.NewNodeBuilder("node-8").WithEqualConfigsAndImages(machineConfigV1, imageV1).WithNodeReady().Node(),
 		},
-		expected:        []string{"node-4", "node-5"},
-		otherCandidates: []string{"node-6"},
-		capacity:        2,
+		expected:        []string{"node-4"},
+		otherCandidates: []string{"node-5", "node-6"},
+		capacity:        1,
 		layeredPool:     true,
 	}, {
 		// Targets https://issues.redhat.com/browse/OCPBUGS-24705.
@@ -752,9 +752,9 @@ func TestGetCandidateMachines(t *testing.T) {
 				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
 				Node(),
 		},
-		expected:        nil,
-		otherCandidates: nil,
-		capacity:        0,
+		expected:        []string{"node-1"},
+		otherCandidates: []string{"node-2"},
+		capacity:        1,
 		layeredPool:     true,
 	}, {
 		// Targets https://issues.redhat.com/browse/OCPBUGS-24705.
@@ -799,11 +799,15 @@ func TestGetCandidateMachines(t *testing.T) {
 			pool := pb.MachineConfigPool()
 
 			// TODO: Double check that mosb, mosc should be nil here and layered should be false
+			// NOTE: By doing this, we end up ignoring all the layered checks(only MCs diffs will be done to
+			// determine if a node is available and ready for an update). This will need to reworked.
 			got := getCandidateMachines(pool, nil, nil, test.nodes, test.progress, false)
 			nodeNames := getNamesFromNodes(got)
 			assert.Equal(t, test.expected, nodeNames)
 
 			// TODO: Double check that mosb, mosc should be nil here and layered should be false
+			// NOTE: By doing this, we end up ignoring all the layered checks(only MCs diffs will be done to
+			// determine if a node is available and ready for an update). This will need to reworked.
 			allCandidates, capacity := getAllCandidateMachines(false, nil, nil, pool, test.nodes, test.progress)
 			assert.Equal(t, test.capacity, capacity)
 			var otherCandidates []string

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -145,33 +145,50 @@ func (ctrl *Controller) calculateStatus(fg featuregates.FeatureGate, mcs []*mcfg
 				}
 				continue
 			}
+			/*
+				// TODO: (djoshy) Rework this block to use MCN conditions correctly. See: https://issues.redhat.com/browse/MCO-1228
 
-			if cond.Status == metav1.ConditionUnknown {
-				switch mcfgalphav1.StateProgress(cond.Type) {
-				case mcfgalphav1.MachineConfigNodeUpdatePrepared:
-					updatingMachines = append(updatedMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdateExecuted:
-					updatingMachines = append(updatingMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdatePostActionComplete:
-					updatingMachines = append(updatingMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdateComplete:
-					updatingMachines = append(updatingMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeResumed:
-					updatedMachines = append(updatingMachines, ourNode)
-					readyMachines = append(readyMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdateCompatible:
-					updatedMachines = append(updatingMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdateDrained:
-					unavailableMachines = append(unavailableMachines, ourNode)
-					updatingMachines = append(updatingMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdateCordoned:
-					unavailableMachines = append(unavailableMachines, ourNode)
-					updatingMachines = append(updatingMachines, ourNode)
-				case mcfgalphav1.MachineConfigNodeUpdated:
-					updatedMachines = append(updatedMachines, ourNode)
-					readyMachines = append(readyMachines, ourNode)
+				// Specifically, the main concerns for the following block are:
+				// (i) Why are only unknown conditions being evaluated? Shouldn't True/False conditions be used?
+				// (ii) Multiple conditions can be unknown at the same time, resulting in certain machines being double counted
+
+				// Some background:
+				// The MCN conditions are used to feed MCP statuses if the machine counts add up correctly to the total node count.
+				// If this check fails, node conditions are used to determine machine counts. The MCN counts calculated in this block
+				// seem incorrect most of the time, so the controller almost always defaults to using the node condition based counts.
+				// On occasion, the MCN counts cause a false positive in aformentioned check, resulting in invalid values for the MCP
+				// statuses. Commenting out this block will force the controller to always use node condition based counts to feed the
+				// MCP status.
+
+
+				if cond.Status == metav1.ConditionUnknown {
+					// This switch case will cause a node to be double counted, maybe use a hash for node count
+					switch mcfgalphav1.StateProgress(cond.Type) {
+					case mcfgalphav1.MachineConfigNodeUpdatePrepared:
+						updatingMachines = append(updatedMachines, ourNode) //nolint:gocritic
+					case mcfgalphav1.MachineConfigNodeUpdateExecuted:
+						updatingMachines = append(updatingMachines, ourNode)
+					case mcfgalphav1.MachineConfigNodeUpdatePostActionComplete:
+						updatingMachines = append(updatingMachines, ourNode)
+					case mcfgalphav1.MachineConfigNodeUpdateComplete:
+						updatingMachines = append(updatingMachines, ourNode)
+					case mcfgalphav1.MachineConfigNodeResumed:
+						updatingMachines = append(updatedMachines, ourNode) //nolint:gocritic
+						readyMachines = append(readyMachines, ourNode)
+					case mcfgalphav1.MachineConfigNodeUpdateCompatible:
+						updatingMachines = append(updatedMachines, ourNode) //nolint:gocritic
+					case mcfgalphav1.MachineConfigNodeUpdateDrained:
+						unavailableMachines = append(unavailableMachines, ourNode)
+						updatingMachines = append(updatingMachines, ourNode)
+					case mcfgalphav1.MachineConfigNodeUpdateCordoned:
+						unavailableMachines = append(unavailableMachines, ourNode)
+						updatingMachines = append(updatingMachines, ourNode)
+					case mcfgalphav1.MachineConfigNodeUpdated:
+						updatedMachines = append(updatedMachines, ourNode)
+						readyMachines = append(readyMachines, ourNode)
+					}
 				}
-			}
+			*/
 		}
 	}
 	degradedMachineCount := int32(len(degradedMachines))

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -493,7 +493,7 @@ func TestGetUnavailableMachines(t *testing.T) {
 			helpers.NewNodeBuilder("node-3").WithEqualConfigs(machineConfigV0).WithNodeNotReady().Node(),
 			helpers.NewNodeBuilder("node-4").WithEqualConfigs(machineConfigV0).WithNodeReady().Node(),
 		},
-		unavail:              []string{"node-0", "node-2"},
+		unavail:              []string{"node-0", "node-2", "node-3"},
 		layeredPoolWithImage: true,
 	}, {
 		name: "Mismatched unlayered node and layered pool with image unavailable",
@@ -502,9 +502,9 @@ func TestGetUnavailableMachines(t *testing.T) {
 			helpers.NewNodeBuilder("node-1").WithEqualConfigsAndImages(machineConfigV1, imageV1).Node(),
 			helpers.NewNodeBuilder("node-2").WithEqualConfigsAndImages(machineConfigV1, imageV1).WithNodeNotReady().Node(),
 			helpers.NewNodeBuilder("node-3").WithEqualConfigs(machineConfigV0).WithNodeNotReady().Node(),
-			helpers.NewNodeBuilder("node-4").WithEqualConfigs(machineConfigV0).WithNodeReady().Node(),
+			helpers.NewNodeBuilder("node-4").WithEqualConfigsAndImages(machineConfigV0, imageV1).WithNodeReady().Node(),
 		},
-		unavail:     []string{"node-3"},
+		unavail:     []string{"node-0", "node-2", "node-3"},
 		layeredPool: true,
 	}, {
 		name: "Mismatched layered node and unlayered pool",
@@ -515,7 +515,7 @@ func TestGetUnavailableMachines(t *testing.T) {
 			helpers.NewNodeBuilder("node-3").WithEqualConfigs(machineConfigV0).WithEqualImages(imageV1).WithNodeNotReady().Node(),
 			helpers.NewNodeBuilder("node-4").WithEqualConfigs(machineConfigV0).WithEqualImages(imageV1).WithNodeReady().Node(),
 		},
-		unavail: []string{"node-0"},
+		unavail: []string{"node-0", "node-2", "node-3"},
 	}, {
 		// Targets https://issues.redhat.com/browse/OCPBUGS-24705.
 		name: "nodes working toward layered should not be considered available",
@@ -550,11 +550,13 @@ func TestGetUnavailableMachines(t *testing.T) {
 			// Need to set WithNodeReady() on all nodes to avoid short-circuiting.
 			helpers.NewNodeBuilder("node-0").
 				WithEqualConfigs(machineConfigV0).
+				WithDesiredImage(imageV0).WithCurrentImage(imageV0).
 				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
 				WithNodeReady().
 				Node(),
 			helpers.NewNodeBuilder("node-1").
 				WithEqualConfigs(machineConfigV0).
+				WithDesiredImage(imageV0).WithCurrentImage(imageV0).
 				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
 				WithNodeReady().
 				Node(),
@@ -566,11 +568,12 @@ func TestGetUnavailableMachines(t *testing.T) {
 				Node(),
 			helpers.NewNodeBuilder("node-3").
 				WithEqualConfigs(machineConfigV0).
-				WithDesiredImage(imageV1).WithCurrentImage("").
+				WithDesiredImage(imageV1).WithCurrentImage(imageV0).
 				WithMCDState(daemonconsts.MachineConfigDaemonStateDone).
 				WithNodeReady().
 				Node(),
 		},
+		layeredPool:          true,
 		layeredPoolWithImage: true,
 		unavail:              []string{"node-2", "node-3"},
 	},


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Manual cherry pick of https://github.com/openshift/machine-config-operator/pull/4583

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
