### PR TITLE
OCPBUGS-34647 : Check for kernel arg diff in updateOnClusterBuild

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -921,6 +921,14 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 		}
 	}()
 
+	// Update the kernal args if there is a difference
+	if diff.kargs && dn.os.IsCoreOSVariant() {
+		coreOSDaemon := CoreOSDaemon{dn}
+		if err := coreOSDaemon.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {
+			return err
+		}
+	}
+
 	// Ideally we would want to update kernelArguments only via MachineConfigs.
 	// We are keeping this to maintain compatibility and OKD requirement.
 	if err := UpdateTuningArgs(KernelTuningFile, CmdLineFile); err != nil {


### PR DESCRIPTION
For the OCL case, check to see if there is a difference in the kernel args between the old and new MCs and update accordingly.

Closes: OCPBUGS-34647 

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add a kernel arg check in `updateOnClusterBuild` for the OCL case. Without this we were not updating the kernel args correctly causing the node to go unready due to a state mismatch.

**- How to verify it**
- Enable OCL in cluster
- Create a MachineOSConfig and let new build roll out
- Create a MC with `enforcing=0` and wait for build to trigger and roll out

**- Description for the changelog**
Add a kernel arg check in `updateOnClusterBuild` for the OCL case.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
