### PR TITLE
OCPBUGS-42018: on-prem/resolv-prepender: stop leaking tmp files

### DIFF
--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -81,7 +81,6 @@ contents:
                         rm -f "${KNICONFDONEPATH}"
                         # Copy tmp file contents to preserve permissions and SELinux label
                         cat "${KNICONFTMPPATH}" > "${KNICONFPATH}"
-                        rm -rf "${KNICONFTMPPATH}"
                     fi
 
                     if [[ ! -f "${KNICONFDONEPATH}" ]]; then
@@ -91,6 +90,7 @@ contents:
                         fi
                         touch "${KNICONFDONEPATH}"
                     fi
+                    rm -rf "${KNICONFTMPPATH}"
                 else
                     >&2 echo "NM resolv-prepender: Prepending 'nameserver $NAMESERVER_IP' to /etc/resolv.conf (other nameservers from /var/run/NetworkManager/resolv.conf)"
                     RESOLVCONFTMPPATH="$(mktemp)"
@@ -118,6 +118,7 @@ contents:
                       nmcli general reload dns-rc
                     fi
                     touch "${KNICONFDONEPATH}"
+                    rm -rf "${RESOLVCONFTMPPATH}"
                 fi
             fi
     }


### PR DESCRIPTION
**- What I did**

In some cases, the tmp files were not removed.
This patch fixes that.

**- How to verify it**

When deploying Shift On Stack, check in /tmp and we should not see any tmp.XXX files anymore.

**- Description for the changelog**

Temporary files created to populate resolv.conf are now removed when the script has run.
