### PR TITLE
OCPBUGS-41956: crio: force runc by default

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -17,6 +17,7 @@ contents:
     default_env = [
         "NSS_SDB_USE_CACHE=no",
     ]
+    default_runtime = "runc"
     log_level = "info"
     cgroup_manager = "systemd"
     default_sysctls = [

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -22,6 +22,7 @@ contents:
     default_sysctls = [
         "net.ipv4.ping_group_range=0 2147483647",
     ]
+    default_runtime = "runc"
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
         "/run/containers/oci/hooks.d",


### PR DESCRIPTION
upstream moved to crun, but there's still an outstanding bug in crun that's breaking graceful shutdowns. Force runc until we identify the bug

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
