### PR TITLE
OCPBUGS-39438: Set ESP offloads off in bonds if slaves don't support them

### DIFF
--- a/templates/common/_base/files/bond-esp-offload.yaml
+++ b/templates/common/_base/files/bond-esp-offload.yaml
@@ -1,0 +1,44 @@
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/99-bond-esp-offload"
+contents:
+    inline: |
+      #!/bin/bash
+
+      # It has been observed that the kernel enables ESP offloads of bond
+      # devices in active/backup mode even if slaves apparently don't support
+      # it. It's unclear if this is expected behavior but we have had problems
+      # with the resulting configuration in vsphere. So set ESP offload features
+      # off in bond devices if they are off in slave devices for the time being.
+      # https://issues.redhat.com/browse/RHEL-58811
+
+      if [[ "$2" != "up" ]]; then
+        exit
+      fi
+
+      driver=$(nmcli -t -m tabular -f general.driver dev show "$DEVICE_IFACE")
+
+      if [[ "$driver" != "bond" ]]; then
+        exit
+      fi
+
+      bond="$DEVICE_IFACE"
+      for feature in tx-esp-segmentation esp-hw-offload esp-tx-csum-hw-offload; do
+
+        if ethtool -k "$bond" | grep -qE "^${feature}: off"; then
+          # already disabled, nothing to do
+          continue
+        fi
+        
+        for slave in $(nmcli -g BOND.SLAVES dev show "$DEVICE_IFACE"); do
+
+          if ! ethtool -k "$slave" | grep -qE "^${feature}: off"; then
+            # enabled in slave, nothing to do
+            continue
+          fi
+
+          logger -t bond-esp-offload -s "Bond link $slave has $feature off, setting master $DEVICE_IFACE $feature off"
+          ethtool -K "$bond" "$feature" off
+
+          break
+        done
+      done

--- a/templates/common/_base/files/vsphere-disable-vmxnet3v4-features.yaml
+++ b/templates/common/_base/files/vsphere-disable-vmxnet3v4-features.yaml
@@ -7,40 +7,12 @@ contents:
       # https://bugzilla.redhat.com/show_bug.cgi?id=1941714
       # https://bugzilla.redhat.com/show_bug.cgi?id=1935539
       # https://bugzilla.redhat.com/show_bug.cgi?id=1987108
-      # https://issues.redhat.com/browse/SPLAT-1409
 
       driver=$(nmcli -t -m tabular -f general.driver dev show "${DEVICE_IFACE}")
 
-      if [[ "$2" != "up" ]]; then
-        exit
-      fi
-      
-      if [[ "${driver}" == "vmxnet3" ]]; then
+      if [[ "$2" == "up" && "${driver}" == "vmxnet3" ]]; then
         logger -s "99-vsphere-disable-tx-udp-tnl triggered by ${2} on device ${DEVICE_IFACE}."
         ethtool -K ${DEVICE_IFACE} tx-udp_tnl-segmentation off
         ethtool -K ${DEVICE_IFACE} tx-udp_tnl-csum-segmentation off
         ethtool -K ${DEVICE_IFACE} tx-checksum-ip-generic off
-        ethtool -K ${DEVICE_IFACE} tx-esp-segmentation off
-        ethtool -K ${DEVICE_IFACE} esp-hw-offload off
-        ethtool -K ${DEVICE_IFACE} esp-tx-csum-hw-offload off
-
-        exit
       fi
-
-      # disable ESP offload also in bonds as they don't seem to honor the slave
-      # configuration
-      if [[ "${driver}" == "bond" ]]; then
-        for slave in $(nmcli -g BOND.SLAVES dev show "${DEVICE_IFACE}"); do
-          driver=$(nmcli -t -m tabular -f general.driver dev show "${slave}")
-          if [[ "${driver}" == "vmxnet3" ]]; then
-            logger -s "99-vsphere-disable-tx-udp-tnl triggered by ${2} on device ${DEVICE_IFACE}."
-            ethtool -K ${DEVICE_IFACE} tx-esp-segmentation off
-            ethtool -K ${DEVICE_IFACE} esp-hw-offload off
-            ethtool -K ${DEVICE_IFACE} esp-tx-csum-hw-offload off
-          
-            exit
-          fi
-        done
-      fi
-
-


### PR DESCRIPTION
We first thought that this issue was specific to vmxnet3 driver but it
looks like it is a widespread issue of bonds: it has been observed that
the kernel enables ESP offloads of bond devices in active/backup mode
even if slaves apparently don't support it. So set ESP offload
features off in bond devices if they are off in slave devices for the
time being.

Sorry for the extra noise but the situation is developing as a PRIO case.
