### PR TITLE
OCPBUGS-38733: Regenerate the rendered MC in use when deleted

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -488,6 +488,15 @@ func (ctrl *Controller) getRenderedMachineConfig(pool *mcfgv1.MachineConfigPool,
 	// The pool has a rendered MachineConfig, so we can do more advanced
 	// reconciliation as we generate it.
 	currentMC, err := ctrl.mcLister.Get(pool.Spec.Configuration.Name)
+
+	// Degenerate case: When the renderedMC that the MCP is currently pointing to is deleted
+	if apierrors.IsNotFound(err) {
+		generated, err := generateRenderedMachineConfig(pool, configs, cc)
+		if err != nil {
+			return nil, err
+		}
+		return generated, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("could not get current MachineConfig %s for MachineConfigPool %s: %w", pool.Spec.Configuration.Name, pool.Name, err)
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: OCPBUGS-38733


**- What I did**
If a renderedMC in use gets deleted, regenerate it without reconciling. The daemon will take care of the reconciling.

**- How to verify it**
1. Create a MC to deploy any file in the worker MCP
2. Get the name of the new rendered MC, like for example "rendered-worker-bf829671270609af06e077311a39363e"
3. When the first node starts updating, delete the new rendered MC
    `oc delete mc rendered-worker-bf829671270609af06e077311a39363e`
4. It should be regenerated and deployed again

**- Description for the changelog**
<!--
If a renderedMC in use gets deleted, regenerate it without reconciling.
-->
