### PR TITLE
OCPBUGS-38012: Do not use 'restart' for 'oneshot' service

### DIFF
--- a/templates/common/_base/units/wait-for-primary-ip.yaml
+++ b/templates/common/_base/units/wait-for-primary-ip.yaml
@@ -9,9 +9,15 @@ contents: |
 
   [Service]
   Type=oneshot
-  Restart=on-failure
-  RestartSec=10
-  ExecStart=/usr/local/bin/wait-for-primary-ip.sh
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/local/bin/wait-for-primary-ip.sh; \
+    do \
+    sleep 10; \
+    done"
   StandardOutput=journal+console
   StandardError=journal+console
 

--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -9,7 +9,13 @@ contents: |
   StartLimitIntervalSec=0
   [Service]
   Type=oneshot
-  Restart=on-failure
-  RestartSec=10
-  ExecStart=/usr/local/bin/resolv-prepender.sh
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/local/bin/resolv-prepender.sh; \
+    do \
+    sleep 10; \
+    done"
   EnvironmentFile=/run/resolv-prepender/env


### PR DESCRIPTION
Because of how firstboot works, we should not use features that were added to RHEL (in here, systemd) late in the process, e.g. only in OCP 4.12

`Restart=on-failure` for `Type=oneshot` service is one of them. Albeit very helpful, it does break certain deployments. In order to fix this, we are falling back to an old, ugly but proven `until ... do ... done` bash loop.

Fixes: OCPBUGS-38012