### PR TITLE
MCO-1273: OCB respects proxy configuration in Controller Config

### DIFF
--- a/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
+++ b/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
@@ -29,6 +29,9 @@ COPY --from=extract /etc/machine-config-daemon/currentconfig /etc/machine-config
 RUN container="oci" exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported <(cat /etc/machine-config-daemon/currentconfig | jq '.spec.config') && \
 	ostree container commit
 
+COPY ./openshift-config-user-ca-bundle.crt /etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt
+RUN update-ca-trust
+
 LABEL machineconfig={{.MachineOSBuild.Spec.DesiredConfig.Name}}
 LABEL machineconfigpool={{.MachineOSConfig.Spec.MachineConfigPool.Name}}
 LABEL releaseversion={{.ReleaseVersion}}

--- a/pkg/controller/build/utils/helpers.go
+++ b/pkg/controller/build/utils/helpers.go
@@ -53,6 +53,11 @@ func parseImagePullspecWithDigest(pullspec string, imageDigest digest.Digest) (s
 	return canonical.String(), nil
 }
 
+// Computes the AdditionalTrustBundle ConfigMap name based upon the MachineConfigPool name.
+func GetAdditionalTrustBundleConfigMapName(mosb *mcfgv1alpha1.MachineOSBuild) string {
+	return fmt.Sprintf("additionaltrustbundle-%s", getFieldFromMachineOSBuild(mosb))
+}
+
 // Computes the Containerfile ConfigMap name.
 func GetContainerfileConfigMapName(mosb *mcfgv1alpha1.MachineOSBuild) string {
 	return fmt.Sprintf("containerfile-%s", getFieldFromMachineOSBuild(mosb))


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Closes: [MCO-1273](https://issues.redhat.com//browse/MCO-1273)

**- What I did**
Added support for proxy configuration specified in the Controller Config to the buildah-build scripts 

**- How to verify it**
1) Add a cluster wide proxy like
```
oc get proxy/cluster -o yaml | yq
apiVersion: config.openshift.io/v1
kind: Proxy
metadata:
  creationTimestamp: "2024-09-19T13:45:39Z"
  generation: 1
  name: cluster
  resourceVersion: "546"
  uid: b9890313-569c-4083-8f1d-a97eb4bb42e3
spec:
  httpProxy: http://username:passwd@ip:port/
  httpsProxy: http://username:passwd@ip:port/
  trustedCA:
    name: ""
status:
  httpProxy: http://username:passwd@ip:port/
  httpsProxy: http://username:passwd@ip:port/
  noProxy: .cluster.local,localhost
```
2) Add a network policy to only allow egress through the proxy

3) Trigger a build by creating a MOSC (Containerfile can contain `rpm-ostree install cowsay`)

4) MOSB succeeds  

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
OCB respects proxy configuration in Controller Config