### PR TITLE
MCO-1323:  Stop writing root-ca to disk

### DIFF
--- a/templates/common/_base/files/root-ca.yaml
+++ b/templates/common/_base/files/root-ca.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/kubernetes/ca.crt"
-contents:
-  inline: |
-{{.RootCAData | toString | indent 4}}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removing writing this CA to disk as nothing we know of uses it. Read [MCO-1323](https://issues.redhat.com/browse/MCO-1323) for more details.

**- How to verify it**
No functional changes are expected, existing e2es & paayloads should pass.

