### PR TITLE
MCO-1324: Remove injection of managed secret by boot image controller

### DIFF
--- a/pkg/controller/machine-set-boot-image/platform_helpers.go
+++ b/pkg/controller/machine-set-boot-image/platform_helpers.go
@@ -48,13 +48,6 @@ func reconcileGCP(machineSet *machinev1beta1.MachineSet, configMap *corev1.Confi
 		}
 	}
 
-	// For now, hardcode to the managed worker secret, until Custom Pool Booting is implemented. When that happens, this will have to
-	// respect the pool this machineset is targeted for.
-	if newProviderSpec.UserDataSecret.Name != ManagedWorkerSecretName {
-		newProviderSpec.UserDataSecret.Name = ManagedWorkerSecretName
-		patchRequired = true
-	}
-
 	// If patch is required, marshal the new providerspec into the machineset
 	if patchRequired {
 		newMachineSet = machineSet.DeepCopy()
@@ -140,11 +133,6 @@ func reconcileAWS(machineSet *machinev1beta1.MachineSet, configMap *corev1.Confi
 		klog.Infof("Current image: %s: %s", region, currentAMI)
 		patchRequired = true
 		newProviderSpec.AMI.ID = &newami
-	}
-
-	if newProviderSpec.UserDataSecret.Name != ManagedWorkerSecretName {
-		newProviderSpec.UserDataSecret.Name = ManagedWorkerSecretName
-		patchRequired = true
 	}
 
 	if patchRequired {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the msbic's capability to inject the managed stub secret during boot image updates. As part of the work for managing the MCS CA and TLS cert in https://issues.redhat.com/browse/MCO-1208, we will be updating both versions of the secret(managed and unmanaged) and as a result, updating the field in the machineset will no longer be necessary.

**- How to verify it**
Enroll a cluster's machinesets for boot image updates. The `providerSpec.managedSecret` field will no longer be updated to the managed stub secret.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
