### PR TITLE
OCPBUGS-42419: kubelet-service: provide path to restorecon command

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}


### PR DESCRIPTION
Fixes: [OCPBUGS-42419](https://issues.redhat.com/browse/OCPBUGS-42419)

**- What I did**

The restorecon command expect a path to be given.
providing a path is mandatory.
see man page: https://linux.die.net/man/8/restorecon

At the moment the command does nothing and the error
is swallowed due to the dash (-) in the beginning
of the command.

**- How to verify it**
check that directories/files selinux labels are matching
the expected labels provided by the container-selinux package 

**- Description for the changelog**
Provide a path to restorecon command
