### PR TITLE
OCPBUGS-44185: Race in configure-ovs.sh affects bonding interface configuration.

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -573,7 +573,7 @@ contents:
         # But set the entry in master_interfaces to true if this is a slave
         # Also set autoconnect to yes
         local active_state=$(nmcli -g GENERAL.STATE conn show "$conn")
-        if [ "$active_state" == "activated" ] || [ "$active_state" == "activating" ]; then
+        if [ "$active_state" == "activated" ]; then
           echo "Connection $conn already activated"
           if $is_slave; then
             master_interfaces[$master_interface]=true

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -569,6 +569,13 @@ contents:
           fi
         fi
 
+        # slaves should implicitly activate, give them a chance to do so
+        if $is_slave; then
+          if ! timeout 5 bash -c "while ! nmcli -g GENERAL.STATE conn show "$conn" | grep activated; do sleep 1; done"; then
+            echo "WARNING: slave $conn did not implicitly activate in 5s, activating explicitly."
+          fi
+        fi
+
         # Do not activate interfaces that are already active
         # But set the entry in master_interfaces to true if this is a slave
         # Also set autoconnect to yes

--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -573,7 +573,7 @@ contents:
         # But set the entry in master_interfaces to true if this is a slave
         # Also set autoconnect to yes
         local active_state=$(nmcli -g GENERAL.STATE conn show "$conn")
-        if [ "$active_state" == "activated" ]; then
+        if [ "$active_state" == "activated" ] || [ "$active_state" == "activating" ]; then
           echo "Connection $conn already activated"
           if $is_slave; then
             master_interfaces[$master_interface]=true


### PR DESCRIPTION
Bonded network configurations with mode=active-backup and fail_over_mac=follow are not functioning due to a race when activating network profiles. activate_nm_connections() attempts to activate all its generated profiles that are not currently in the "active" state. As autoconnect-slaves is set, once br-ex is activated the bond and all its slaves are automatically activated. Their state is set to "activating" until they become active. The "activating" state is not tested for therefor some of the subordinate profiles maybe activated multiple times causing a race in the bonding driver and incorrectly configuring the bond.

Link: https://github.com/openshift/machine-config-operator/issues/4605
Fixes: #4605 

Please provide the following information:
Please see https://github.com/openshift/machine-config-operator/issues/4605
Testing: verify a 2 slave bond with mode=active-backup and fail_over_mac=follow converts to a working OVS config.
The slaves should not have the same MAC.  Other configs should be tested as well.
pull request for inclusion in the changelog: Fix race in configure-ovs.sh that affects bonding interface configuration.
