### PR TITLE
OCPNODE-2633: templates/*: make crun as the default container runtime

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -17,7 +17,7 @@ contents:
     default_env = [
         "NSS_SDB_USE_CACHE=no",
     ]
-    default_runtime = "runc"
+    default_runtime = "crun"
     log_level = "info"
     cgroup_manager = "systemd"
     default_sysctls = [

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -22,7 +22,7 @@ contents:
     default_sysctls = [
         "net.ipv4.ping_group_range=0 2147483647",
     ]
-    default_runtime = "runc"
+    default_runtime = "crun"
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
         "/run/containers/oci/hooks.d",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This commit sets `crun` as the default container runtime in OCP for 4.18

**- How to verify it**
I'm in the process of adding test coverage for this behavior.

**- Description for the changelog**
Make crun the default container runtime
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
