### PR TITLE
OCPBUGS-42392: openstack: relax openstack-kubelet-nodename systemd dependency

### DIFF
--- a/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
@@ -66,7 +66,19 @@ contents:
         while true; do
             if [ "$SINGLE_STACK_IPV6" = true ]
             then
-                hostname=$(curl http://[fe80::a9fe:a9fe%25br-ex]:80/openstack/2012-08-10/meta_data.json | jq -re .name)
+                metadata_ip6="fe80::a9fe:a9fe"
+                # `ip route show to match` returns this:
+                # <subnet or name> via <gateway ip> dev <nic> proto dhcp src <ip> metric <metric>
+                # so the nic name is the first item after "dev"
+                while read nic; do
+                    # "curl" will return a non-zero exit code if the metadata is not reachable which would stop the script too soon.
+                    # We also want to give a change (5 seconds) to reach the metadata before we consider that the given URL is not usable.
+                    # Once hostname was found with a given nic, we just move on.
+                    set +e
+                    hostname=$(curl --connect-timeout 5 -s http://[${metadata_ip6}%25${nic}]:80/openstack/2012-08-10/meta_data.json | jq -re .name)
+                    set -e
+                    [ ! -z "${hostname}" ] && break
+                done < <(ip -6 route show to match ${metadata_ip6} | awk '{for(i=1;i<NF;i++) if ($i == "dev") print $(i+1)}')
             else
                 # https://docs.openstack.org/nova/victoria/user/metadata.html#metadata-openstack-format
                 hostname=$(curl -s http://169.254.169.254/openstack/2012-08-10/meta_data.json | jq -re .name)

--- a/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
+++ b/templates/common/openstack/units/openstack-kubelet-nodename.service.yaml
@@ -3,9 +3,8 @@ enabled: true
 contents: |
   [Unit]
   Description=Fetch kubelet node name from OpenStack metadata
-  # Wait for NetworkManager and wait-for-br-ex-up to report it's online
-  Wants=wait-for-br-ex-up.service
-  After=NetworkManager-wait-online.service wait-for-br-ex-up.service
+  # Wait for NetworkManager to report it's online
+  After=NetworkManager-wait-online.service
   # Run before kubelet
   Before=kubelet-dependencies.target
 
@@ -15,8 +14,17 @@ contents: |
 {{- else}}
   Environment="SINGLE_STACK_IPV6=false"
 {{- end}}
-  ExecStart=/usr/local/bin/openstack-kubelet-nodename
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+  until \
+  /usr/local/bin/openstack-kubelet-nodename; \
+  do \
+  sleep 10; \
+  done"
   Type=oneshot
+  TimeoutSec=600
 
   [Install]
   WantedBy=kubelet-dependencies.target


### PR DESCRIPTION
**- What I did**

In https://github.com/openshift/machine-config-operator/pull/4570, we
added a dependency on a service that in certain cases (Hypershift) will
never run. That makes Kubelet never starting.

We initially relied on br-ex because we thought it was the simplest way
to use a predictable interface name to reach the metadata via curl.

In fact, it's not reliable because we rely on br-ex being actually a
thing (OVN k8s CNI uses it but some other CNIs don't). And also because
br-ex might come online later. We don't really need it to be online as
we already have an interface connected to the network and able to reach
the metadata.

Let's use `ip` command to find how which interface can reach the
metadata over ipv6 and use it.

**- How to verify it**

* Hypershift jobs for OpenStack will be tested.
* Regular OpenStack job for single-stack IPv6 will be run as well to make sure there is no regression.

**- Description for the changelog**

We don't rely anymore on br-ex to reach the Metadata over IPv6. We use `ip` command to find out
via which NIC we can reach it and use it when doing curl.
