### PR TITLE
NO-JIRA: clean up node cluster dashboard

### DIFF
--- a/install/0000_90_machine-config_01_node_dashboard.yaml
+++ b/install/0000_90_machine-config_01_node_dashboard.yaml
@@ -2703,9 +2703,7 @@ data:
         ],
         "schemaVersion": 14,
         "style": "dark",
-        "tags": [
-            "node-cluster-mixin"
-        ],
+        "tags": [],
         "templating": {
             "list": [
                 {
@@ -2793,7 +2791,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
-    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/part-of: openshift-machine-config-operator
     console.openshift.io/dashboard: "true"
   name: node-cluster
   namespace: openshift-config-managed


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

The `app.kubernetes.io/part-of` label identifies the "component" in charge of the object. This change also removes the `node-cluster-mixin` tag since the dashboard doesn't come from the node_exporter mixin.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
