### PR TITLE
MCO-1276, MCO-1339: Integrate Metric Collection with MCO Daemon and e2e testing automation

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -70,7 +70,7 @@ var (
 			Name: "mcd_local_unsupported_packages",
 			Help: "Total number of locally layered unsupported packages installed on the node",
 		},
-		[]string{"vendor"})
+		[]string{"node"})
 )
 
 // Updates metric with new labels & timestamp, deletes any existing


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
1. Created an e2e test to verify the installation of unsupported RPM packages on nodes using rpm-ostree.
2. Implemented metric collection in the mcd to report unsupported packages by vendor via the mcd_local_unsupported_packages_by_vendor metric.
3. Ensured that the e2e test verifies the installation of the unsupported package, checks that the correct metrics are being reported, and includes cleanup logic to uninstall the package after the test completes.

**- How to verify it**
Run the provided e2e test TestInstallRPMAndCheckMCDMetrics to verify that:
1. The RPM package (aeskeyfind) is successfully installed on the node.
2. The MCD reports the correct metric reflecting the installed package.
**- Description for the changelog**
Added e2e test for verifying unsupported RPM package installation and metric reporting in the mcd.


