### PR TITLE
OCPBUGS-42546: The MCO does not properly degrade when pools are failing to render a new config

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1569,13 +1569,14 @@ func (optr *Operator) syncRequiredMachineConfigPools(config *renderConfig, co *c
 		// This was needed in-case the cluster is doing a master pool update when a new MachineConfiguration was applied.
 		// This prevents the need to wait for all the master nodes (as the syncAll function of the operator will be
 		// "stuck" here in such a case) to update before the MachineConfiguration status is updated.
-		syncErr := optr.syncMachineConfiguration(config, co)
-		// Update the degrade condition if there was an error reported by syncMachineConfiguration
-		newCO := co.DeepCopy()
-		optr.syncDegradedStatus(newCO, syncError{task: "MachineConfiguration", err: syncErr})
-		co, syncErr = optr.updateClusterOperatorStatus(co, &newCO.Status, lastErr)
-		if syncErr != nil {
-			klog.Errorf("Error updating cluster operator status: %q", syncErr)
+		if syncErr := optr.syncMachineConfiguration(config, co); syncErr != nil {
+			// Update the degrade condition if there was an error reported by syncMachineConfiguration
+			newCO := co.DeepCopy()
+			optr.syncDegradedStatus(newCO, syncError{task: "MachineConfiguration", err: syncErr})
+			co, syncErr = optr.updateClusterOperatorStatus(co, &newCO.Status, lastErr)
+			if syncErr != nil {
+				klog.Errorf("Error updating cluster operator status: %q", syncErr)
+			}
 		}
 
 		pools, err := optr.mcpLister.List(labels.Everything())


### PR DESCRIPTION
Closes: [OCPBUGS-42546](https://issues.redhat.com/browse/OCPBUGS-42546)

**- What I did**
Added a nil check before posting a degrade from `syncMachineConfiguration` within `syncRequiredMachineConfigPools`

**- How to verify it**
Follow repro instructions in bug. 
