### PR TITLE
[4.15] OCPBUGS-42110: Do not use 'restart' for 'oneshot' service

### DIFF
--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -9,7 +9,13 @@ contents: |
   StartLimitIntervalSec=0
   [Service]
   Type=oneshot
-  Restart=on-failure
-  RestartSec=10
-  ExecStart=/usr/local/bin/resolv-prepender.sh
+  # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+  # the version of systemd we have right now doesn't support it. It should be
+  # available in systemd v244 and higher.
+  ExecStart=/bin/bash -c " \
+    until \
+    /usr/local/bin/resolv-prepender.sh; \
+    do \
+    sleep 10; \
+    done"
   EnvironmentFile=/run/resolv-prepender/env


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/machine-config-operator/pull/4596
Closes: OCPBUGS-42110