### PR TITLE
MCO-1276: Integrate Metric Collection with MCO Daemon

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -63,6 +63,14 @@ var (
 			Name: "mcd_missing_mc",
 			Help: "total number of times a MC was reported missing",
 		}, []string{"mc"})
+
+	// unsupportedPackages counts the number of unsupported packages installed on the node, categorized by vendor
+	unsupportedPackages = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mcd_local_unsupported_packages",
+			Help: "Total number of locally layered unsupported packages installed on the node",
+		},
+		[]string{"vendor"})
 )
 
 // Updates metric with new labels & timestamp, deletes any existing
@@ -84,6 +92,7 @@ func RegisterMCDMetrics() error {
 		mcdRebootErr,
 		mcdUpdateState,
 		mcdConfigDrift,
+		unsupportedPackages,
 	})
 
 	if err != nil {


### PR DESCRIPTION
- What I did

Implemented metric collection in the mcd to report unsupported packages by vendor via the mcd_local_unsupported_packages_by_vendor metric.

- How to verify it
follow the provided e2e test TestInstallRPMAndCheckMCDMetrics to verify that:

The RPM package (aeskeyfind) is successfully installed on the node.
The MCD reports the correct metric reflecting the installed package.

e2e test found here https://github.com/openshift/machine-config-operator/pull/4614/files#diff-6324e53eb8b87fa591d0dd87722e4dff1200a2bc57d7c83f042a90f4be53f68b

- Description for the changelog
Added metric reporting in the mcd.
