### PR TITLE
OCPBUGS-42987: Disable ESP offload for OVS attached interfaces

### DIFF
--- a/templates/common/_base/files/bond-esp-offload.yaml
+++ b/templates/common/_base/files/bond-esp-offload.yaml
@@ -1,44 +1,32 @@
 mode: 0744
-path: "/etc/NetworkManager/dispatcher.d/99-bond-esp-offload"
+path: "/etc/NetworkManager/dispatcher.d/99-esp-offload"
 contents:
     inline: |
       #!/bin/bash
 
-      # It has been observed that the kernel enables ESP offloads of bond
-      # devices in active/backup mode even if slaves apparently don't support
-      # it. It's unclear if this is expected behavior but we have had problems
-      # with the resulting configuration in vsphere. So set ESP offload features
-      # off in bond devices if they are off in slave devices for the time being.
+      # ESP offload, either in actual hardware or as part as GRO (generic
+      # recieve offload) does not work for interfaces attached to an OVS bridge
+      # so turn it off for the time being.
       # https://issues.redhat.com/browse/RHEL-58811
+      
+      # Depends on ipsec service drop-in to start it after configure-ovs to make
+      # sure offloads are disabled before ipsec starts.
 
       if [[ "$2" != "up" ]]; then
         exit
       fi
 
-      driver=$(nmcli -t -m tabular -f general.driver dev show "$DEVICE_IFACE")
+      device=$DEVICE_IFACE
+      kind_slave=$(ip -j -d link show "$device" | jq -r '.[0] | .linkinfo.info_slave_kind // empty')
 
-      if [[ "$driver" != "bond" ]]; then
-        exit
-      fi
-
-      bond="$DEVICE_IFACE"
-      for feature in tx-esp-segmentation esp-hw-offload esp-tx-csum-hw-offload; do
-
-        if ethtool -k "$bond" | grep -qE "^${feature}: off"; then
-          # already disabled, nothing to do
-          continue
-        fi
-        
-        for slave in $(nmcli -g BOND.SLAVES dev show "$DEVICE_IFACE"); do
-
-          if ! ethtool -k "$slave" | grep -qE "^${feature}: off"; then
-            # enabled in slave, nothing to do
+      if [ "$kind_slave" = "openvswitch" ]; then
+        for feature in tx-esp-segmentation esp-hw-offload esp-tx-csum-hw-offload; do
+          if ethtool -k "$device" | grep -qE "^${feature}: off"; then
+            # already disabled, nothing to do
             continue
           fi
-
-          logger -t bond-esp-offload -s "Bond link $slave has $feature off, setting master $DEVICE_IFACE $feature off"
-          ethtool -K "$bond" "$feature" off
-
-          break
+          
+          logger -t 99-esp-offload -s "Setting $feature off for $device: unsupported when attached to Open vSwitch bridge"
+          ethtool -K "$device" "$feature" off
         done
-      done
+      fi

--- a/templates/common/_base/units/ipsec.service.yaml
+++ b/templates/common/_base/units/ipsec.service.yaml
@@ -1,0 +1,6 @@
+name: ipsec.service
+dropins:
+  - name: 01-after-configure-ovs.conf
+    contents: |
+      [Unit]
+      After=ovs-configuration.service


### PR DESCRIPTION
We learnt a bit more about the ESP offload problem with bonds (part 3).

Actually it is OVS which does not support ESP offload, neither in hardware 
nor as part of GRO (generic receive offload). The fact that esp_offload kernel
module plays a role if both scenarios without OVS supporting either, combined
with the bond device reporting that ESP offload was supported when it really wasn't,
threw us us in all kind of directions. That's like three potential kernel issues to be
tracked from https://issues.redhat.com/browse/RHEL-58811

Reworked dispatcher script to disable ESP offload if interface is in OVS
bridge.

Delay ipsec service after configure-ovs so that we have a chance to
disable ESP offloads before it starts. Otherwise libreswan can be
tricked into thinking ESP offload is supported and might try to enable
it anyway.