### PR TITLE
OCPBUGS-38292: controller: default to runc when upgrading clusters from 4.17 to 4.18

### DIFF
--- a/cmd/machine-config-controller/main.go
+++ b/cmd/machine-config-controller/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	componentName = "machine-config-controller"
+	componentName      = "machine-config-controller"
+	componentNamespace = "openshift-machine-config-operator"
 )
 
 var (

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -204,6 +204,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 		),
 		containerruntimeconfig.New(
 			rootOpts.templates,
+			componentNamespace,
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -188,6 +188,12 @@ func (b *Bootstrap) Run(destDir string) error {
 
 	configs = append(configs, rconfigs...)
 
+	defaultRuntimeUseconfigs, err := containerruntimeconfig.RunDefaultContainerRuntimeBootstrap(pools)
+	if err != nil {
+		return err
+	}
+	configs = append(configs, defaultRuntimeUseconfigs...)
+
 	if len(crconfigs) > 0 {
 		containerRuntimeConfigs, err := containerruntimeconfig.RunContainerRuntimeBootstrap(b.templatesDir, crconfigs, cconfig, pools)
 		if err != nil {

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -22,12 +22,14 @@ func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
 				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
 			}
 			// ctrcfg for bootstrap mode
+			cm := newConfigMap("crio-default-container-runtime")
 			ctrcfg := newContainerRuntimeConfig("log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, pools[0])
 			f.mccrLister = append(f.mccrLister, ctrcfg)
 			f.objects = append(f.objects, ctrcfg)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			mcs, err := RunContainerRuntimeBootstrap("../../../templates", []*mcfgv1.ContainerRuntimeConfig{ctrcfg}, cc, pools)
 			require.NoError(t, err)

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -26,6 +26,7 @@ import (
 	operatorlistersv1alpha1 "github.com/openshift/client-go/operator/listers/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +62,9 @@ const (
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
 
-	builtInLabelKey = "machineconfiguration.openshift.io/mco-built-in"
+	builtInLabelKey    = "machineconfiguration.openshift.io/mco-built-in"
+	configMapName      = "crio-default-container-runtime"
+	forceSyncOnUpgrade = "force-sync-on-upgrade"
 )
 
 var (
@@ -78,9 +81,11 @@ var updateBackoff = wait.Backoff{
 // Controller defines the container runtime config controller.
 type Controller struct {
 	templatesDir string
+	namespace    string
 
 	client        mcfgclientset.Interface
 	configClient  configclientset.Interface
+	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
 
 	syncHandler                   func(mcp string) error
@@ -124,7 +129,7 @@ type Controller struct {
 
 // New returns a new container runtime config controller
 func New(
-	templatesDir string,
+	templatesDir, namespace string,
 	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	ccInformer mcfginformersv1.ControllerConfigInformer,
 	mcrInformer mcfginformersv1.ContainerRuntimeConfigInformer,
@@ -145,11 +150,13 @@ func New(
 
 	ctrl := &Controller{
 		templatesDir:  templatesDir,
+		namespace:     namespace,
 		client:        mcfgClient,
 		configClient:  configClient,
 		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-containerruntimeconfigcontroller"})),
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineconfigcontroller-containerruntimeconfigcontroller"),
 		imgQueue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		kubeClient:    kubeClient,
 	}
 
 	mcrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -209,6 +216,7 @@ func New(
 
 	ctrl.clusterVersionLister = clusterVersionInformer.Lister()
 	ctrl.clusterVersionListerSynced = clusterVersionInformer.Informer().HasSynced
+	ctrl.queue.Add(forceSyncOnUpgrade)
 
 	ctrl.featureGateAccess = featureGateAccess
 
@@ -587,6 +595,15 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		klog.V(4).Infof("Finished syncing ContainerRuntimeconfig %q (%v)", key, time.Since(startTime))
 	}()
 
+	// create the MC for the drop in default-container-runtime crio.conf file
+	if err := ctrl.createDefaultContainerRuntimeMC(); err != nil {
+		return fmt.Errorf("failed to create the crio-default-container-runtime MC: %w", err)
+	}
+
+	if key == forceSyncOnUpgrade {
+		return nil
+	}
+
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -651,9 +668,8 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		// If we have seen this generation and the sync didn't fail, then skip
 		if !isNotFound && cfg.Status.ObservedGeneration >= cfg.Generation && cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Type == mcfgv1.ContainerRuntimeConfigSuccess {
 			// But we still need to compare the generated controller version because during an upgrade we need a new one
-			mcCtrlVersion := mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey]
-			if mcCtrlVersion == version.Hash {
-				return nil
+			if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] == version.Hash {
+				continue
 			}
 		}
 		// Generate the original ContainerRuntimeConfig
@@ -740,6 +756,7 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 		klog.Infof("Applied ContainerRuntimeConfig %v on MachineConfigPool %v", key, pool.Name)
 		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync Container Runtime Config", pool.Name)
 	}
+
 	if err := ctrl.cleanUpDuplicatedMC(); err != nil {
 		return err
 	}
@@ -1024,6 +1041,92 @@ func registriesConfigIgnition(templateDir string, controllerConfig *mcfgv1.Contr
 
 	registriesIgn := createNewIgnition(generatedConfigFileList)
 	return &registriesIgn, nil
+}
+
+func (ctrl *Controller) createDefaultContainerRuntimeMC() error {
+	// Check if the crio-default-container-runtime config map exists in the openshift-machine-config-operator namespace
+	defaultContainerRuntimeCM, err := ctrl.kubeClient.CoreV1().ConfigMaps(ctrl.namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error checking for %s config map: %w", configMapName, err)
+	}
+	// If the crio-default-container-runtime config map exists, the MC was already created, so skip creating it again.
+	if defaultContainerRuntimeCM != nil && !errors.IsNotFound(err) {
+		return nil
+	}
+
+	sel, err := metav1.LabelSelectorAsSelector(metav1.AddLabelToSelector(&metav1.LabelSelector{}, builtInLabelKey, ""))
+	if err != nil {
+		return err
+	}
+	// Find all the MachineConfigPools
+	mcpPoolsAll, err := ctrl.mcpLister.List(sel)
+	if err != nil {
+		return err
+	}
+
+	// Create the crio-default-container-runtime MC for all the available pools
+	for _, pool := range mcpPoolsAll {
+		if pool.Name != ctrlcommon.MachineConfigPoolMaster && pool.Name != ctrlcommon.MachineConfigPoolWorker {
+			continue
+		}
+		managedKey := getManagedKeyDefaultContainerRuntime(pool)
+		mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("error checking for %s machine config: %w", managedKey, err)
+		}
+		// continue to the next MC if this already exists
+		if mc != nil && !errors.IsNotFound(err) {
+			continue
+		}
+
+		tempIgnCfg := ctrlcommon.NewIgnConfig()
+		mc, err = ctrlcommon.MachineConfigFromIgnConfig(pool.Name, managedKey, tempIgnCfg)
+		if err != nil {
+			return fmt.Errorf("could not create crio-default-container-runtime MachineConfig from new Ignition config: %w", err)
+		}
+		rawRuntimeIgnition, err := json.Marshal(createNewIgnition(createDefaultContainerRuntimeFile()))
+		if err != nil {
+			return fmt.Errorf("error marshalling crio-default-container-runtime config ignition: %w", err)
+		}
+		mc.Spec.Config.Raw = rawRuntimeIgnition
+		// Create the crio-default-container-runtime MC
+		if err := retry.RetryOnConflict(updateBackoff, func() error {
+			_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
+			return err
+		}); err != nil {
+			return fmt.Errorf("could not create MachineConfig for crio-default-container-runtime: %w", err)
+		}
+		klog.Infof("Applied default runtime MC %v on MachineConfigPool %v", managedKey, pool.Name)
+	}
+
+	// Create the config map for crio-default-container-runtime so we know that the crio-default-container-runtime MC has been created
+	if defaultContainerRuntimeCM == nil {
+		defaultContainerRuntimeCM = &v1.ConfigMap{}
+	}
+
+	defaultContainerRuntimeCM.Name = configMapName
+	defaultContainerRuntimeCM.Namespace = ctrl.namespace
+	if _, err := ctrl.kubeClient.CoreV1().ConfigMaps(ctrl.namespace).Create(context.TODO(), defaultContainerRuntimeCM, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("error creating %s config map: %w", configMapName, err)
+	}
+	return nil
+}
+
+// RunDefaultContainerRuntimeBootstrap creates the crio-default-container-runtime mc on bootstrap
+func RunDefaultContainerRuntimeBootstrap(mcpPools []*mcfgv1.MachineConfigPool) ([]*mcfgv1.MachineConfig, error) {
+	var res []*mcfgv1.MachineConfig
+	for _, pool := range mcpPools {
+		if pool.Name != ctrlcommon.MachineConfigPoolMaster && pool.Name != ctrlcommon.MachineConfigPoolWorker {
+			continue
+		}
+		defaultContainerRuntimeIgn := createNewIgnition(createDefaultContainerRuntimeFile())
+		mc, err := ctrlcommon.MachineConfigFromIgnConfig(pool.Name, getManagedKeyDefaultContainerRuntime(pool), defaultContainerRuntimeIgn)
+		if err != nil {
+			return nil, fmt.Errorf("could not create MachineConfig from new Ignition config: %w", err)
+		}
+		res = append(res, mc)
+	}
+	return res, nil
 }
 
 // getValidScopePolicies returns a map[scope]policyRequirement from ClusterImagePolicy

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/clarketm/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -63,6 +64,7 @@ type fixture struct {
 	client         *fake.Clientset
 	imgClient      *fakeconfigv1client.Clientset
 	operatorClient *fakeoperatorclient.Clientset
+	kubeClient     *k8sfake.Clientset
 
 	ccLister                 []*mcfgv1.ControllerConfig
 	mcpLister                []*mcfgv1.MachineConfigPool
@@ -82,6 +84,7 @@ type fixture struct {
 	objects         []runtime.Object
 	imgObjects      []runtime.Object
 	operatorObjects []runtime.Object
+	k8sObjects      []runtime.Object
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -98,6 +101,15 @@ func newFixture(t *testing.T) *fixture {
 		},
 	)
 	return f
+}
+
+func newConfigMap(name string) *k8sv1.ConfigMap {
+	return &k8sv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-machine-config-operator",
+		},
+	}
 }
 
 func (f *fixture) validateActions() {
@@ -239,11 +251,12 @@ func (f *fixture) newController() *Controller {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	f.imgClient = fakeconfigv1client.NewSimpleClientset(f.imgObjects...)
 	f.operatorClient = fakeoperatorclient.NewSimpleClientset(f.operatorObjects...)
+	f.kubeClient = k8sfake.NewSimpleClientset(f.k8sObjects...)
 
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.imgClient, noResyncPeriodFunc())
 	oi := operatorinformer.NewSharedInformerFactory(f.operatorClient, noResyncPeriodFunc())
-	c := New(templateDir,
+	c := New(templateDir, "openshift-machine-config-operator",
 		i.Machineconfiguration().V1().MachineConfigPools(),
 		i.Machineconfiguration().V1().ControllerConfigs(),
 		i.Machineconfiguration().V1().ContainerRuntimeConfigs(),
@@ -253,7 +266,7 @@ func (f *fixture) newController() *Controller {
 		ci,
 		oi.Operator().V1alpha1().ImageContentSourcePolicies(),
 		ci.Config().V1().ClusterVersions(),
-		k8sfake.NewSimpleClientset(), f.client, f.imgClient,
+		f.kubeClient, f.client, f.imgClient,
 		f.fgAccess,
 	)
 
@@ -575,12 +588,14 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			mcs1 := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcs2 := mcs1.DeepCopy()
 			mcs2.Name = ctrCfgKey
+			cm := newConfigMap("crio-default-container-runtime")
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrcfg1)
 			f.objects = append(f.objects, ctrcfg1)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectGetMachineConfigAction(mcs1)
@@ -615,12 +630,14 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			mcs := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcsUpdate := mcs.DeepCopy()
 			mcsUpdate.Name = keyCtrCfg
+			cm := newConfigMap("crio-default-container-runtime")
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrcfg1)
 			f.objects = append(f.objects, ctrcfg1)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectGetMachineConfigAction(mcs)
@@ -654,6 +671,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrcfgUpdate)
 			f.objects = append(f.objects, mcsUpdate, ctrcfgUpdate)
+			f.k8sObjects = append(f.k8sObjects, cm)
 
 			c = f.newController()
 			stopCh = make(chan struct{})
@@ -713,7 +731,15 @@ func TestImageConfigCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
 
-			f.run("cluster")
+			c := f.newController()
+			stopCh := make(chan struct{})
+			err := c.syncImgHandler("cluster")
+			if err != nil {
+				t.Errorf("syncImgHandler returned %v", err)
+			}
+
+			f.validateActions()
+			close(stopCh)
 
 			for _, mcName := range []string{mcs1.Name, mcs2.Name} {
 				f.verifyRegistriesConfigAndPolicyJSONContents(t, mcName, imgcfg1, nil, nil, nil, nil, cc.Spec.ReleaseImage, true, true, false)
@@ -1512,6 +1538,9 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
 			f.ccLister = append(f.ccLister, cc)
 
+			cm := newConfigMap("crio-default-container-runtime")
+			f.k8sObjects = []runtime.Object{cm}
+
 			ctrcfgCount := 30
 			for i := 0; i < ctrcfgCount; i++ {
 				f.resetActions()
@@ -1528,6 +1557,7 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 				f.mcpLister = append(f.mcpLister, mcp)
 				f.mccrLister = append(f.mccrLister, ccr)
 				f.objects = append(f.objects, ccr)
+				f.k8sObjects = []runtime.Object{cm}
 
 				mcs := helpers.NewMachineConfig(generateManagedKey(ccr, 1), labelSelector.MatchLabels, "dummy://", []ign3types.File{{}})
 				mcsDeprecated := mcs.DeepCopy()
@@ -1559,7 +1589,7 @@ func TestContainerruntimeConfigResync(t *testing.T) {
 			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
 			ccr1 := newContainerRuntimeConfig("log-level-1", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 			ccr2 := newContainerRuntimeConfig("log-level-2", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
-
+			cm := newConfigMap("crio-default-container-runtime")
 			ctrConfigKey, _ := getManagedKeyCtrCfg(mcp, f.client, ccr1)
 			mcs := helpers.NewMachineConfig(ctrConfigKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			mcsDeprecated := mcs.DeepCopy()
@@ -1570,6 +1600,7 @@ func TestContainerruntimeConfigResync(t *testing.T) {
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ccr1)
 			f.objects = append(f.objects, ccr1)
+			f.k8sObjects = []runtime.Object{cm}
 
 			c := f.newController()
 			err := c.syncHandler(getKey(ccr1, t))
@@ -1630,12 +1661,14 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 			ctrc1.SetAnnotations(map[string]string{ctrlcommon.MCNameSuffixAnnotationKey: "1"})
 			ctrc1.Finalizers = []string{ctr1MCKey}
 			ctrcfgMC := helpers.NewMachineConfig(ctrMCKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
+			cm := newConfigMap("crio-default-container-runtime")
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
 			f.mcpLister = append(f.mcpLister, mcp2)
 			f.mccrLister = append(f.mccrLister, ctrc, ctrc1)
 			f.objects = append(f.objects, ctrc, ctrc1, ctrcfgMC)
+			f.k8sObjects = []runtime.Object{cm}
 
 			// ctrc created before ctrc1,
 			// make sure ccr does not have annotation machineconfiguration.openshift.io/mc-name-suffix before sync, ccr1 has annotation machineconfiguration.openshift.io/mc-name-suffix
@@ -1735,9 +1768,12 @@ func TestCleanUpDuplicatedMC(t *testing.T) {
 			// successful test: only custom and upgraded MCs stay
 			mcList, err = ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
 			require.NoError(t, err)
-			assert.Equal(t, 2, len(mcList.Items))
+			assert.Equal(t, 3, len(mcList.Items))
 			actual := make(map[string]mcfgv1.MachineConfig)
 			for _, mc := range mcList.Items {
+				if mc.Name == "99-master-generated-crio-default-container-runtime" {
+					continue
+				}
 				require.GreaterOrEqual(t, len(mc.Annotations), 1)
 				actual[mc.Name] = mc
 			}
@@ -1765,6 +1801,8 @@ func TestClusterImagePolicyCreate(t *testing.T) {
 
 			mcs1 := helpers.NewMachineConfig(keyReg1, map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcs2 := helpers.NewMachineConfig(keyReg2, map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
+			defaultContainermcs1 := helpers.NewMachineConfig("99-master-generated-crio-default-container-runtime", nil, "dummy://", []ign3types.File{{}})
+			defaultContainermcs2 := helpers.NewMachineConfig("99-worker-generated-crio-default-container-runtime", nil, "dummy://", []ign3types.File{{}})
 
 			clusterimgPolicy := newClusterImagePolicyWithPublicKey("image-policy", []string{"example.com"}, []byte("foo bar"))
 			f.ccLister = append(f.ccLister, cc)
@@ -1785,6 +1823,10 @@ func TestClusterImagePolicyCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 
 			f.expectCreateMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(defaultContainermcs1)
+			f.expectCreateMachineConfigAction(defaultContainermcs1)
+			f.expectGetMachineConfigAction(defaultContainermcs2)
+			f.expectCreateMachineConfigAction(defaultContainermcs2)
 
 			f.run("")
 
@@ -1811,6 +1853,8 @@ func TestSigstoreRegistriesConfigIDMSandCIPCreate(t *testing.T) {
 
 			mcs1 := helpers.NewMachineConfig(keyReg1, map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			mcs2 := helpers.NewMachineConfig(keyReg2, map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
+			defaultContainermcs1 := helpers.NewMachineConfig("99-master-generated-crio-default-container-runtime", nil, "dummy://", []ign3types.File{{}})
+			defaultContainermcs2 := helpers.NewMachineConfig("99-worker-generated-crio-default-container-runtime", nil, "dummy://", []ign3types.File{{}})
 
 			// idms source is the same as cip scope
 			idms := newIDMS("built-in", []apicfgv1.ImageDigestMirrors{
@@ -1836,6 +1880,10 @@ func TestSigstoreRegistriesConfigIDMSandCIPCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 
 			f.expectCreateMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(defaultContainermcs1)
+			f.expectCreateMachineConfigAction(defaultContainermcs1)
+			f.expectGetMachineConfigAction(defaultContainermcs2)
+			f.expectCreateMachineConfigAction(defaultContainermcs2)
 
 			f.run("")
 

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_2/types"
 
@@ -46,9 +47,15 @@ import (
 )
 
 const (
-	bootstrapTestName    = "bootstrap-test"
-	templatesDir         = "../../templates"
-	bootstrapTestDataDir = "../../pkg/controller/bootstrap/testdata/bootstrap"
+	bootstrapTestName        = "bootstrap-test"
+	templatesDir             = "../../templates"
+	bootstrapTestDataDir     = "../../pkg/controller/bootstrap/testdata/bootstrap"
+	imagesFile               = "../../install/image-references"
+	componentNamespace       = "openshift-machine-config-operator"
+	pollInterval             = 200 * time.Millisecond
+	pollTimeout              = 30 * time.Second
+	containerRuntimeMCMaster = "99-master-generated-crio-default-container-runtime"
+	containerRuntimeMCWorker = "99-worker-generated-crio-default-container-runtime"
 )
 
 var (
@@ -86,6 +93,13 @@ func TestE2EBootstrap(t *testing.T) {
 
 	_, err = clientSet.Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
+			Name: componentNamespace,
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = clientSet.Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: framework.OpenshiftConfigNamespace,
 		},
 	}, metav1.CreateOptions{})
@@ -106,8 +120,8 @@ func TestE2EBootstrap(t *testing.T) {
 	}{
 		{
 			name:             "With no additional manifests",
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries"},
 		},
 		{
 			name: "With a featuregate manifest",
@@ -119,8 +133,8 @@ metadata:
 spec:
   featureSet: TechPreviewNoUpgrade`),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "98-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "98-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "98-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries", "98-worker-generated-kubelet"},
 		},
 		{
 			name: "With a node config manifest empty spec",
@@ -133,8 +147,8 @@ metadata:
 			// "CgroupMode" field in the nodes.config resource is empty
 			// Internally it gets updated to "v2" explicitly
 			// Hence, 97-{master/worker}-generated-kubelet are expected
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a node config manifest empty \"cgroupMode\"",
@@ -149,8 +163,8 @@ spec:
 			// "CgroupMode" field in the nodes.config resource is empty
 			// Internally it gets updated to "v2" explicitly
 			// Hence, 97-{master/worker}-generated-kubelet are expected
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a featuregate manifest and master kubelet config manifest",
@@ -180,8 +194,8 @@ spec:
       memory: 500Mi
 `),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "99-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries"},
 		},
 		{
 			name: "With a featuregate manifest and a config node manifest",
@@ -245,8 +259,8 @@ spec:
       memory: 500Mi
 `),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-kubelet", "97-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "97-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "99-master-generated-kubelet", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a node config manifest and a worker kubelet config manifest",
@@ -278,8 +292,8 @@ spec:
 			},
 			// 97-{master/worker}-generated-kubelet are expected to be created as the empty "cgroupMode"
 			// internally translates to "v2"
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "97-master-generated-kubelet"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "97-master-generated-kubelet"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries", "99-worker-generated-kubelet", "97-worker-generated-kubelet"},
 		},
 		{
 			name: "With a worker kubelet config manifest",
@@ -321,8 +335,8 @@ spec:
     pidsLimit: 100000
 `),
 			},
-			waitForMasterMCs: []string{"99-master-ssh", "99-master-generated-registries", "99-master-generated-containerruntime"},
-			waitForWorkerMCs: []string{"99-worker-ssh", "99-worker-generated-registries"},
+			waitForMasterMCs: []string{"99-master-ssh", containerRuntimeMCMaster, "99-master-generated-registries", "99-master-generated-containerruntime"},
+			waitForWorkerMCs: []string{"99-worker-ssh", containerRuntimeMCWorker, "99-worker-generated-registries"},
 		},
 	}
 
@@ -330,6 +344,19 @@ spec:
 		t.Run(tc.name, func(t *testing.T) {
 			objs := append([]runtime.Object{}, baseTestManifests...)
 			objs = append(objs, loadRawManifests(t, tc.manifests)...)
+
+			containerRuntimeRawIgnition := []byte(`{"ignition":{"version":"3.2.0"},"storage":{"files":[{"overwrite":true,"path":"/etc/crio/crio.conf.d/01-mc-defaultContainerRuntimeRunc","contents":{"compression":"","source":"data:text/plain;charset=utf-8;base64,W2NyaW9dCiAgW2NyaW8ucnVudGltZV0KICAgIGRlZmF1bHRfcnVudGltZSA9ICJydW5jIgo="},"mode":420}]}}`)
+			masterInheritableMC, err := ctrlcommon.MachineConfigFromRawIgnConfig("master", containerRuntimeMCMaster, containerRuntimeRawIgnition)
+			require.NoError(t, err)
+
+			workerInheritableMC, err := ctrlcommon.MachineConfigFromRawIgnConfig("worker", containerRuntimeMCWorker, containerRuntimeRawIgnition)
+			require.NoError(t, err)
+
+			_, err = clientSet.MachineConfigs().Create(ctx, masterInheritableMC, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			_, err = clientSet.MachineConfigs().Create(ctx, workerInheritableMC, metav1.CreateOptions{})
+			require.NoError(t, err)
 
 			// Only add this node config if one doesn't already exist.
 			// If two are present, the latter one will overwrite the former one.
@@ -488,7 +515,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.FeatureGateAccess,
 		),
 		containerruntimeconfig.New(
-			templatesDir,
+			templatesDir, "openshift-machine-config-operator",
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),

--- a/test/framework/envtest.go
+++ b/test/framework/envtest.go
@@ -156,7 +156,8 @@ func CheckCleanEnvironment(t *testing.T, clientSet *ClientSet) {
 
 	mcList, err := clientSet.MachineConfigs().List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, mcList.Items, 0)
+	// 2 99-poolname-generated-crio-default-container-runtime mc should exist
+	require.Len(t, mcList.Items, 2)
 	// ######################################
 	// END: machineconfiguration.openshift.io
 	// ######################################


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-38292

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This change prevents the automatic switch to crun during the upgrade from version 4.17 to 4.18. Customers can manually opt-in to use crun by deleting the MachineConfig that sets runc as the default runtime.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
