### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
@@ -9,6 +9,7 @@ contents:
       namespace: openshift-machine-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: etc-kube

--- a/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
@@ -9,6 +9,7 @@ contents:
       namespace: openshift-machine-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: etc-kube


### PR DESCRIPTION
Fixes: [AUTH-482](https://issues.redhat.com/browse/AUTH-482)

**- What I did**
Updated the templates files to pin the required SCCs to workloads in `openshift-machine-config-operator` namespace - added annotations for the `privileged` SCC to the `kube-rbac-proxy-crio` pod.

The SCC chosen is `privileged`, which is already in use by these pods, ensuring no change to the SCC used.

**- How to verify it**
Check that the required SCC annotations are present on the specified pods.

**- Description for the changelog**
Pin required SCCs to `kube-rbac-proxy-crio` pod in `openshift-machine-config-operator` namespace.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
