### PR TITLE
NO-ISSUE: pkg/operator/status: Block ClusterVersion updates until multi-arch transitions complete

### DIFF
--- a/cmd/machine-config-operator/main.go
+++ b/cmd/machine-config-operator/main.go
@@ -22,6 +22,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	rootCmd.PersistentFlags().StringVar(&version.ReleaseVersion, "payload-version", version.ReleaseVersion, "Version of the openshift release")
+	rootCmd.PersistentFlags().StringVar(&version.OperatorImage, "operator-image", version.OperatorImage, "Image pullspec for the current machine-config operator")
 }
 
 func main() {

--- a/install/0000_80_machine-config_04_deployment.yaml
+++ b/install/0000_80_machine-config_04_deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - "start"
         - "--images-json=/etc/mco/images/images.json"
         - "--payload-version=0.0.1-snapshot"
+        - "--operator-image=placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator"
         resources:
           requests:
             cpu: 20m

--- a/install/0000_80_machine-config_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config_06_clusteroperator.yaml
@@ -11,6 +11,8 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+    - name: operator-image
+      version: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
   relatedObjects:
     - group: ""
       name: openshift-machine-config-operator

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -314,6 +314,7 @@ func New(
 	optr.apiserverListerSynced = apiserverInformer.Informer().HasSynced
 
 	optr.vStore.Set("operator", version.ReleaseVersion)
+	optr.vStore.Set("operator-image", version.OperatorImage)
 
 	return optr
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,6 +14,10 @@ var (
 	// This will be injected by the payload build process.
 	ReleaseVersion = "0.0.1-snapshot"
 
+	// OperatorImage is the image pullspec for the current machine-config operator.
+	// This will be injected by the payload build process.
+	OperatorImage = "placeholder.url.oc.will.replace.this.org/placeholdernamespace:was-not-built-properly"
+
 	// Raw is the string representation of the version. This will be replaced
 	// with the calculated version at build time.
 	Raw = "v0.0.0-was-not-built-properly"


### PR DESCRIPTION
By setting a new `operator-image` entry in the ClusterOperator `status.versions` manifest, so [the cluster-version operator will wait for the in-cluster status][1] to have both:

* The `operator` value we already declare, so the CVO waits for us to hit the target version.
* The `operator-image` value I'm adding in this commit, to help distinguish between single-arch and multi-arch targets which share the same version string (but have unique release and MCO pullspecs).

Without this change, the CVO immediately thinks the MCO has completed its update ("`operator` matches 4.13.0, and that's all I've been asked to match!") while the MCO is still working to pivot to the new, multi-arch component.  Folks who try to take advantage of the new multi-arch functionality at this point might be surprised to have ClusterVersion claiming the update to multi-arch is complete, even though the MCO is still only part way through that transition, and has not yet positioned itself to point at the multi-arch RHCOS image when new Machines try to come up ([OCPBUGS-10300][2]).

[1]: https://github.com/openshift/cluster-version-operator/blob/e546515213c8681ca44c52f178401cd47ad07d11/pkg/cvo/internal/operatorstatus.go#L174-L176
[2]: https://issues.redhat.com/browse/OCPBUGS-10300
