### PR TITLE
OCPBUGS-43328: remove dra manager state

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet-cleanup.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet-cleanup.service.yaml
@@ -9,6 +9,7 @@ contents: |
   Type=oneshot
   ExecStart=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   ExecStart=/bin/rm -f /var/lib/kubelet/memory_manager_state
+  ExecStart=-/bin/rm -f /var/lib/kubelet/dra_manager_state
 
   [Install]
   WantedBy=multi-user.target

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet-cleanup.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet-cleanup.service.yaml
@@ -9,6 +9,7 @@ contents: |
   Type=oneshot
   ExecStart=/bin/rm -f /var/lib/kubelet/cpu_manager_state
   ExecStart=/bin/rm -f /var/lib/kubelet/memory_manager_state
+  ExecStart=-/bin/rm -f /var/lib/kubelet/dra_manager_state
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
This only impacts TechPreview or DevPreview jobs right now, since DRA is still in Alpha. We remove the dra_manager_state like we do with the cpu and memory manager state files.

Clusters on TechPreview or DevPreview will exhibit on upgrade:

```
failed to run Kubelet: failed to create claimInfo cache: error calling GetOrCreate() on checkpoint state: failed to get checkpoint dra_manager_state: checkpoint is corrupted"
```