### PR TITLE
OCPBUGS-43893: Pinned images not working

### DIFF
--- a/pkg/daemon/cri/cri.go
+++ b/pkg/daemon/cri/cri.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -141,6 +142,7 @@ func newClientConn(_ context.Context, target string) (conn *grpc.ClientConn, err
 		grpc.WithConnectParams(connParams),
 		grpc.WithContextDialer(dialerFn),
 	)
+	resolver.SetDefaultScheme("passthrough")
 
 	return grpc.NewClient(target, dialOpts...)
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Explicitly set the pinned image set dialer to use passthrough.

**- How to verify it**
In tech preview, apply a pinned image set object, and ensure that the images are being pinned as expected. See attached bug for more details.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1alpha1
kind: PinnedImageSet
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: tc-73623-worker-pinned-images
spec:
  pinnedImages:
  - name: "quay.io/openshifttest/busybox@sha256:0415f56ccc05526f2af5a7ae8654baec97d4a614f24736e8eef41a4591f08019"
  - name: quay.io/openshifttest/alpine@sha256:be92b18a369e989a6e86ac840b7f23ce0052467de551b064796d67280dfa06d5
EOF
```
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
