### PR TITLE
Fixes NodeController issues

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -235,6 +235,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.TechPreviewInformerFactory.Machineconfiguration().V1alpha1().MachineOSConfigs(),
+			ctx.TechPreviewInformerFactory.Machineconfiguration().V1alpha1().MachineOSBuilds(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -67,6 +67,8 @@ type fixture struct {
 	ccLister   []*mcfgv1.ControllerConfig
 	mcpLister  []*mcfgv1.MachineConfigPool
 	nodeLister []*corev1.Node
+	// moscLister []*mcfgv1alpha1.MachineOSConfig
+	// mosbLister []*mcfgv1alpha1.MachineOSBuild
 
 	kubeactions []core.Action
 	actions     []core.Action
@@ -101,7 +103,7 @@ func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.schedulerClient, noResyncPeriodFunc())
 	c := NewWithCustomUpdateDelay(i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), i.Machineconfiguration().V1().MachineConfigPools(), k8sI.Core().V1().Nodes(),
-		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1alpha1().MachineOSConfigs(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgAccess)
+		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1alpha1().MachineOSConfigs(), i.Machineconfiguration().V1alpha1().MachineOSBuilds(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgAccess)
 
 	c.ccListerSynced = alwaysReady
 	c.mcpListerSynced = alwaysReady

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -520,6 +520,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.InformerFactory.Machineconfiguration().V1alpha1().MachineOSConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1alpha1().MachineOSBuilds(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),


### PR DESCRIPTION
**- What I did**

This is a brief attempt to fix https://issues.redhat.com/browse/OCPBUGS-43382. In the process, I also ran into https://issues.redhat.com/browse/OCPBUGS-43552. I was going to include fixes as part of https://github.com/openshift/machine-config-operator/pull/4624, but ultimately, I decided not to do so and put them into a separate PR (this one). https://github.com/openshift/machine-config-operator/pull/4624 needs to merge before this PR can since it is dependent on some changes there.

**- How to verify it**

**- Description for the changelog**
NodeController should sync on MachineOSConfig deletion too
