### PR TITLE
OCPEDGE-1313: feat: added assets for arbiter node role

### DIFF
--- a/manifests/arbiter.machineconfigpool.yaml
+++ b/manifests/arbiter.machineconfigpool.yaml
@@ -1,0 +1,15 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: arbiter
+  labels:
+    "operator.machineconfiguration.openshift.io/required-for-upgrade": ""
+    "machineconfiguration.openshift.io/mco-built-in": ""
+    "pools.operator.machineconfiguration.openshift.io/arbiter": ""
+spec:
+  machineConfigSelector:
+    matchLabels:
+      "machineconfiguration.openshift.io/role": "arbiter"
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/arbiter: ""

--- a/manifests/machineconfigcontroller/custom-machine-config-pool-selector-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/custom-machine-config-pool-selector-validatingadmissionpolicy.yaml
@@ -22,6 +22,8 @@ spec:
             (object.spec.machineConfigSelector.matchLabels["machineconfiguration.openshift.io/role"] == "master")
             ||
             (object.spec.machineConfigSelector.matchLabels["machineconfiguration.openshift.io/role"] == "worker")
+            ||
+            (object.spec.machineConfigSelector.matchLabels["machineconfiguration.openshift.io/role"] == "arbiter")
           )
         )
         ||

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -52,6 +52,9 @@ const (
 	// APIServerInstanceName is a singleton name for APIServer configuration
 	APIServerBootstrapFileLocation = "/etc/mcs/bootstrap/api-server/api-server.yaml"
 
+	// MachineConfigPoolArbiter is the MachineConfigPool name given to the arbiter
+	MachineConfigPoolArbiter = "arbiter"
+
 	// MachineConfigPoolMaster is the MachineConfigPool name given to the master
 	MachineConfigPoolMaster = "master"
 

--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -133,7 +133,8 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 			}
 		}
 		// The following code updates the MC with the relevant CGroups version
-		if role == ctrlcommon.MachineConfigPoolWorker || role == ctrlcommon.MachineConfigPoolMaster {
+		switch role {
+		case ctrlcommon.MachineConfigPoolWorker, ctrlcommon.MachineConfigPoolMaster, ctrlcommon.MachineConfigPoolArbiter:
 			err = updateMachineConfigwithCgroup(nodeConfig, mc)
 			if err != nil {
 				return err

--- a/pkg/controller/template/test_data/controller_config_baremetal_arbiter.yaml
+++ b/pkg/controller/template/test_data/controller_config_baremetal_arbiter.yaml
@@ -1,0 +1,37 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 3
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    spec:
+      cloudConfig:
+        key: config
+        name: cloud-provider-config
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      controlPlaneTopology: HighlyAvailableArbiter
+      platformStatus:
+        type: "BareMetal"
+        baremetal:
+          apiServerInternalIP: 10.0.0.1
+          ingressIP: 10.0.0.2
+          nodeDNSIP: 10.0.0.3
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2728,6 +2728,8 @@ func (dn *Daemon) getControlPlaneTopology() configv1.TopologyMode {
 		return configv1.SingleReplicaTopologyMode
 	case configv1.HighlyAvailableTopologyMode:
 		return configv1.HighlyAvailableTopologyMode
+	case configv1.HighlyAvailableArbiterMode:
+		return configv1.HighlyAvailableArbiterMode
 	default:
 		// for any unhandled case, default to HighlyAvailableTopologyMode
 		return configv1.HighlyAvailableTopologyMode

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -155,7 +155,7 @@ func RenderBootstrap(
 		templatectrl.KubeRbacProxyKey:       imgs.KubeRbacProxy,
 	}
 
-	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra.Status.APIServerInternalURL, nil, []*mcfgv1alpha1.MachineOSConfig{}, nil)
+	config := getRenderConfig("", string(filesData[kubeAPIServerServingCA]), spec, &imgs.RenderConfigImages, infra, nil, []*mcfgv1alpha1.MachineOSConfig{}, nil)
 
 	manifests := []manifest{
 		{
@@ -180,6 +180,13 @@ func RenderBootstrap(
 			name:     "manifests/machineconfigserver/kube-apiserver-serving-ca-configmap.yaml",
 			filename: "manifests/kube-apiserver-serving-ca-configmap.yaml",
 		},
+	}
+
+	if infra.Status.ControlPlaneTopology == configv1.HighlyAvailableArbiterMode {
+		manifests = append(manifests, manifest{
+			name:     "manifests/arbiter.machineconfigpool.yaml",
+			filename: "bootstrap/manifests/arbiter.machineconfigpool.yaml",
+		})
 	}
 
 	manifests = appendManifestsByPlatform(manifests, *infra)

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -62,7 +62,7 @@ func NewBootstrapServer(dir, kubeconfig string, ircerts []string) (Server, error
 const yamlExt = ".yaml"
 
 func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error) {
-	if cr.machineConfigPool != "master" {
+	if cr.machineConfigPool != "master" && cr.machineConfigPool != "arbiter" {
 		return nil, fmt.Errorf("refusing to serve bootstrap configuration to pool %q", cr.machineConfigPool)
 	}
 	// 1. Read the Machine Config Pool object.

--- a/templates/arbiter/00-arbiter/_base/files/kubelet-cgroups.yaml
+++ b/templates/arbiter/00-arbiter/_base/files/kubelet-cgroups.yaml
@@ -1,0 +1,9 @@
+mode: 0644
+path: "/etc/systemd/system.conf.d/kubelet-cgroups.conf"
+contents:
+ inline: |
+    # Turning on Accounting helps track down performance issues.
+    [Manager]
+    DefaultCPUAccounting=yes
+    DefaultMemoryAccounting=yes
+    DefaultBlockIOAccounting=yes

--- a/templates/arbiter/00-arbiter/_base/files/usr-local-bin-openshift-kubeconfig-gen.yaml
+++ b/templates/arbiter/00-arbiter/_base/files/usr-local-bin-openshift-kubeconfig-gen.yaml
@@ -1,0 +1,26 @@
+mode: 0755
+path: "/usr/local/bin/recover-kubeconfig.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    
+    set -eou pipefail
+    
+    # context
+    intapi=$(oc get infrastructures.config.openshift.io cluster -o "jsonpath={.status.apiServerInternalURI}")
+    context="$(oc config current-context)"
+    # cluster
+    cluster="$(oc config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.cluster}")"
+    server="$(oc config view -o "jsonpath={.clusters[?(@.name==\"$cluster\")].cluster.server}")"
+    # token
+    ca_crt_data="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.ca\.crt}" | base64 --decode)"
+    namespace="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token  -o "jsonpath={.data.namespace}" | base64 --decode)"
+    token="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.token}" | base64 --decode)"
+    
+    export KUBECONFIG="$(mktemp)"
+    kubectl config set-credentials "kubelet" --token="$token" >/dev/null
+    ca_crt="$(mktemp)"; echo "$ca_crt_data" > $ca_crt
+    kubectl config set-cluster $cluster --server="$intapi" --certificate-authority="$ca_crt" --embed-certs >/dev/null
+    kubectl config set-context kubelet --cluster="$cluster" --user="kubelet" >/dev/null
+    kubectl config use-context kubelet >/dev/null
+    cat "$KUBECONFIG"

--- a/templates/arbiter/00-arbiter/_base/units/rpm-ostreed.service.yaml
+++ b/templates/arbiter/00-arbiter/_base/units/rpm-ostreed.service.yaml
@@ -1,0 +1,9 @@
+name: rpm-ostreed.service
+dropins:
+- name: mco-controlplane-nice.conf
+  contents: |
+    # See https://github.com/openshift/machine-config-operator/issues/1897
+    [Service]
+    Nice=10
+    IOSchedulingClass=best-effort
+    IOSchedulingPriority=6

--- a/templates/arbiter/00-arbiter/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/arbiter/00-arbiter/azure/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -1,0 +1,45 @@
+mode: 0644
+path: "/etc/kubernetes/manifests/apiserver-watcher.yaml"
+contents:
+  inline: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: apiserver-watcher
+      namespace: openshift-kube-apiserver
+    spec:
+      containers:
+      - name: apiserver-watcher
+        image: "{{.Images.apiServerWatcherKey}}"
+        command:
+          - flock
+          - --verbose
+          - --exclusive
+          - --timeout=300
+          - /rootfs/run/cloud-routes/apiserver-watcher.lock
+          - apiserver-watcher
+        args:
+        - "run"
+        - "--health-check-url={{.Infra.Status.APIServerInternalURL}}/readyz"
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /rootfs
+          name: rootfs
+          mountPropagation: HostToContainer
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      restartPolicy: Always
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+

--- a/templates/arbiter/00-arbiter/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/arbiter/00-arbiter/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -1,0 +1,225 @@
+mode: 0755
+path: "/opt/libexec/openshift-azure-routes.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    # Prevent hairpin traffic when the apiserver is up
+
+    # As per the Azure documentation (https://docs.microsoft.com/en-us/azure/load-balancer/concepts#limitations),
+    # if a backend is load-balanced to itself, then the traffic will be dropped.
+    #
+    # This is because the L3LB does DNAT, so while the outgoing packet has a destination
+    # IP of the VIP, the incoming load-balanced packet has a destination IP of the
+    # host. That means that it "sees" a syn with the source and destination
+    # IPs of itself, and duly replies wit a syn-ack back to itself. However, the client
+    # socket expects a syn-ack with a source IP of the VIP, so it drops the packet.
+    #
+    # The solution is to redirect traffic destined to the lb vip back to ourselves.
+    #
+    # We check /run/cloud-routes/ for files $VIP.up and $VIP.down. If the .up file
+    # exists, then we redirect traffic destined for that vip to ourselves via nftables.
+    # A systemd unit watches the directory for changes.
+    #
+    # TODO: Address the potential issue where apiserver-watcher could create multiple files
+    # and openshift-azure-routes doesn't detect all of them because file change events are not queued
+    # when the service is already running.
+    # https://github.com/openshift/machine-config-operator/pull/3643#issuecomment-1497234369
+
+    set -euo pipefail
+
+    # the list of load balancer IPs that are assigned to this node
+    declare -A v4vips
+    declare -A v6vips
+
+    TABLE_NAME="azure-vips"
+    VIPS_CHAIN="redirect-vips"
+    RUN_DIR="/run/cloud-routes"
+
+    initialize() {
+        nft -f - <<EOF
+            add table inet ${TABLE_NAME} { comment "azure LB vip overriding"; }
+            add chain inet ${TABLE_NAME} ${VIPS_CHAIN}
+
+            add chain inet ${TABLE_NAME} prerouting { type nat hook prerouting priority dstnat; }
+            flush chain inet ${TABLE_NAME} prerouting
+            add rule inet ${TABLE_NAME} prerouting goto ${VIPS_CHAIN}
+
+            add chain inet ${TABLE_NAME} output { type nat hook output priority dstnat; }
+            flush chain inet ${TABLE_NAME} output
+            add rule inet ${TABLE_NAME} output goto ${VIPS_CHAIN}
+    EOF
+    }
+
+    remove_stale_routes() {
+        ## find extra ovn routes
+        local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
+        if [ -z "${ovnkContainerID}" ]; then
+            return
+        fi
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        local routeVIPsV4=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip4" | awk '$8{print $8}')
+        echo "Found v4route vips: ${routeVIPsV4}"
+        local host=$(hostname)
+        echo ${host}
+        for route_vip in ${routeVIPsV4}; do
+            if [[ ! -v v4vips[${route_vip}] ]] || [[ "${v4vips[${route_vip}]}" = down ]]; then
+                echo removing stale vip "${route_vip}" for local clients
+                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${route_vip}"
+                crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${route_vip}"
+            fi
+        done
+
+        if [ ! -f /proc/net/if_inet6 ]; then
+            return
+        fi
+
+        local routeVIPsV6=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip6" | awk '$8{print $8}')
+        echo "Found v6route vips: ${routeVIPsV6}"
+        for route_vip in ${routeVIPsV6}; do
+            if [[ ! -v v6vips[${route_vip}] ]] || [[ "${v6vips[${route_vip}]}" = down ]]; then
+                echo removing stale vip "${route_vip}" for local clients
+                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${route_vip}"
+                crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip6.dst == ${route_vip}"
+            fi
+        done
+
+    }
+
+    sync_rules() {
+        # Construct the VIP lists. (The nftables syntax allows a trailing comma.)
+        v4vipset=""
+        v6vipset=""
+        for vip in "${!v4vips[@]}"; do
+            if [[ "${v4vips[${vip}]}" != down ]]; then
+                v4vipset="${vip}, ${v4vipset}"
+            fi
+        done
+        for vip in "${!v6vips[@]}"; do
+            if [[ "${v6vips[${vip}]}" != down ]]; then
+                v6vipset="${vip}, ${v6vipset}"
+            fi
+        done
+
+        echo "synchronizing IPv4 VIPs to (${v4vipset}), IPv6 VIPS to (${v6vipset})"
+        {
+            echo "flush chain inet ${TABLE_NAME} ${VIPS_CHAIN}"
+            if [[ -n "${v4vipset}" ]]; then
+                echo "add rule inet ${TABLE_NAME} ${VIPS_CHAIN} ip daddr { ${v4vipset} } redirect"
+            fi
+            if [[ -n "${v6vipset}" ]]; then
+                echo "add rule inet ${TABLE_NAME} ${VIPS_CHAIN} ip6 daddr { ${v6vipset} } redirect"
+            fi
+        } | nft -f -
+    }
+
+    add_routes() {
+        local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
+        if [ -z "${ovnkContainerID}" ]; then
+            echo "OVN-Kubernetes is not running; no routes to add."
+            return
+        fi
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        local ovnK8sMp0v4=$(ip -brief address show ovn-k8s-mp0 | awk '{print $3}' | awk -F/ '{print $1}')
+        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v4}"
+        local host=$(hostname)
+        echo ${host}
+        for vip in "${!v4vips[@]}"; do
+            if [[ "${v4vips[${vip}]}" != down ]]; then
+                echo "ensuring route for ${vip} for internal clients"
+                local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v4}")
+                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
+                if [[ "${routes}" == *"${vip}"* ]]; then
+                    echo "Route exists"
+                else
+                    echo "Route does not exist; creating it..."
+                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${vip} reroute ${ovnK8sMp0v4}"
+                    crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${vip}" reroute "${ovnK8sMp0v4}"
+                fi
+            fi
+        done
+
+        if [ ! -f /proc/net/if_inet6 ]; then
+            return
+        fi
+
+        local ovnK8sMp0v6=$(ip -brief address show ovn-k8s-mp0 | awk '{print $4}' | awk -F/ '{print $1}')
+        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v6}"
+
+        for vip in "${!v6vips[@]}"; do
+            if [[ "${v6vips[${vip}]}" != down ]]; then
+                echo "ensuring route for ${vip} for internal clients"
+                local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v6}")
+                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
+                if [[ "${routes}" == *"${vip}"* ]]; then
+                    echo "Route exists"
+                else
+                    echo "Route does not exist; creating it..."
+                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${vip} reroute ${ovnK8sMp0v6}"
+                    crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip6.dst == ${vip}" reroute "${ovnK8sMp0v6}"
+                fi
+            fi
+        done
+    }
+
+    clear_rules() {
+        echo "clearing rules from ${TABLE_NAME}"
+        nft delete table inet "${TABLE_NAME}" || true
+    }
+
+    clear_routes() {
+        local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
+        if [ -z "${ovnkContainerID}" ]; then
+            echo "OVN-Kubernetes is not running; no routes to remove."
+            return
+        fi
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        echo "clearing all routes from ovn-cluster-router"
+        crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010
+    }
+
+    # out parameters: v4vips v6vips
+    list_lb_ips() {
+        for k in "${!v4vips[@]}"; do
+            unset v4vips["${k}"]
+        done
+        for k in "${!v6vips[@]}"; do
+            unset v6vips["${k}"]
+        done
+
+
+        shopt -s nullglob
+        for file in "${RUN_DIR}"/*.up ; do
+            vip=$(basename "${file}" .up)
+            if [[ -e "${RUN_DIR}/${vip}.down" ]]; then
+                echo "${vip} has upfile and downfile, marking as down"
+            else
+                if [[ ${vip} =~ : ]]; then
+                    echo "processing v6 vip ${vip}"
+                    v6vips[${vip}]="${vip}"
+                else
+                    echo "processing v4 vip ${vip}"
+                    v4vips[${vip}]="${vip}"
+                fi
+            fi
+        done
+    }
+
+
+    case "$1" in
+        start)
+            initialize
+            list_lb_ips
+            sync_rules
+            remove_stale_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
+            add_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
+            echo "done applying vip rules"
+            ;;
+        cleanup)
+            clear_rules
+            clear_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
+            ;;
+        *)
+            echo $"Usage: $0 {start|cleanup}"
+            exit 1
+    esac

--- a/templates/arbiter/00-arbiter/azure/units/openshift-azure-routes.path.yaml
+++ b/templates/arbiter/00-arbiter/azure/units/openshift-azure-routes.path.yaml
@@ -1,0 +1,13 @@
+name: openshift-azure-routes.path
+enabled: true
+contents: |
+  [Unit]
+  Description=Watch for downfile changes
+  Before=kubelet-dependencies.target
+
+  [Path]
+  PathChanged=/run/cloud-routes/
+  MakeDirectory=true
+
+  [Install]
+  RequiredBy=kubelet-dependencies.target

--- a/templates/arbiter/00-arbiter/azure/units/openshift-azure-routes.service.yaml
+++ b/templates/arbiter/00-arbiter/azure/units/openshift-azure-routes.service.yaml
@@ -1,0 +1,13 @@
+name: openshift-azure-routes.service
+enabled: false
+contents: |
+  [Unit]
+  Description=Work around Azure load balancer hairpin
+  # We don't need to do this on the firstboot
+  After=firstboot-osupdate.target
+  
+  [Service]
+  Type=simple
+  ExecStart=/bin/bash /opt/libexec/openshift-azure-routes.sh start
+  User=root
+  SyslogIdentifier=openshift-azure-routes

--- a/templates/arbiter/00-arbiter/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
+++ b/templates/arbiter/00-arbiter/gcp/files/etc-kubernetes-manifests-apiserver-watcher.yaml
@@ -1,0 +1,45 @@
+mode: 0644
+path: "/etc/kubernetes/manifests/apiserver-watcher.yaml"
+contents:
+  inline: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: apiserver-watcher
+      namespace: openshift-kube-apiserver
+    spec:
+      containers:
+      - name: apiserver-watcher
+        image: "{{.Images.apiServerWatcherKey}}"
+        command:
+          - flock
+          - --verbose
+          - --exclusive
+          - --timeout=300
+          - /rootfs/run/cloud-routes/apiserver-watcher.lock
+          - apiserver-watcher
+        args:
+        - "run"
+        - "--health-check-url={{.Infra.Status.APIServerInternalURL}}/readyz"
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /rootfs
+          name: rootfs
+          mountPropagation: HostToContainer
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      restartPolicy: Always
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+

--- a/templates/arbiter/00-arbiter/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
+++ b/templates/arbiter/00-arbiter/gcp/files/opt-libexec-openshift-gcp-routes-sh.yaml
@@ -1,0 +1,229 @@
+mode: 0755
+path: "/opt/libexec/openshift-gcp-routes.sh"
+contents:
+  inline: |
+    #!/bin/bash
+
+    # Update nftables rules based on google cloud load balancer VIPS
+    #
+    # This is needed because the GCP L3 load balancer doesn't actually do DNAT;
+    # the destination IP address is still the VIP. Normally, there is an agent that
+    # adds the vip to the local routing table, tricking the kernel in to thinking
+    # it's a local IP and allowing processes doing an accept(0.0.0.0) to receive
+    # the packets. Clever.
+    #
+    # We don't do that. Instead, we DNAT with conntrack. This is so we don't break
+    # existing connections when the vip is removed. This is useful for draining
+    # connections - take ourselves out of the vip, but service existing conns.
+    #
+    # Additionally, clients can write a file to /run/cloud-routes/$IP.down to force
+    # a VIP as down. This is useful for graceful shutdown / upgrade.
+
+    set -e
+
+    # the list of load balancer IPs that are assigned to this node
+    declare -A vips
+
+    curler() {
+      # if the curl succeeds, write the body to stdout for the caller
+      # to consume.
+      #
+      # if the curl fails, write the body to stderr so its in the
+      # logs, but do not write anything to stdout.  The loop that the
+      # curler call was feeding will bail with no results, and we'll
+      # come back in on the next loop and try again.
+      RESPONSE="$(curl --silent --show-error -L -H "Metadata-Flavor: Google" -w '\n%{response_code}' "http://metadata.google.internal/computeMetadata/v1/instance/${1}")" &&
+        RESPONSE_CODE="$(echo "${RESPONSE}" | tail -n 1)" &&
+        BODY="$(echo "${RESPONSE}" | head -n -1)" &&
+        if test 0 -eq "${RESPONSE_CODE}" -o 400 -le "${RESPONSE_CODE}"; then
+          printf "%s" "${BODY}" >&2
+        else
+          printf "%s" "${BODY}"
+        fi
+    }
+
+    TABLE_NAME="gcp-vips"
+    EXTERNAL_VIPS_CHAIN="external-vips"
+    LOCAL_VIPS_CHAIN="local-vips"
+    RUN_DIR="/run/cloud-routes"
+
+    # Set up base table and rules
+    initialize() {
+        nft -f - <<EOF
+            add table ip ${TABLE_NAME} { comment "apiserver loadbalancer routing helper"; }
+            add chain ip ${TABLE_NAME} ${EXTERNAL_VIPS_CHAIN} { type nat hook prerouting priority dstnat; comment "gcp LB vip DNAT for external clients"; }
+            add chain ip ${TABLE_NAME} ${LOCAL_VIPS_CHAIN} { type nat hook output priority dstnat; comment "gcp LB vip DNAT for local clients"; }
+
+            # If a connection for a VIP comes in while we have no rewrite rule for that VIP,
+            # we would think the VIP is an external host and so forward the connection back
+            # off the node. In the specific case of connections from the GCP LB health
+            # checkers to the VIP, this would result in a bad conntrack entry being created
+            # and then never deleted even after the VIP rule was installed, because the health
+            # checker only uses a small range of source ports, so newer health checks would
+            # keep refreshing the bad conntrack entry created by the first failed health
+            # check. As a result, we would end up persistently failing some percentage of
+            # health checks. See https://bugzilla.redhat.com/show_bug.cgi?id=1925698,
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1930457.
+            #
+            # The fix here is a rule that drops health check probes if we notice that we're
+            # about to forward them off-node, which then prevents the bad conntrack entries
+            # from being created. The HealthCheck origin ip-ranges are documented:
+            # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+            add chain ip ${TABLE_NAME} forward { type filter hook forward priority filter; comment "gcp HealthCheck traffic"; }
+            add rule ip ${TABLE_NAME} forward ip saddr 35.191.0.0/16 drop
+            add rule ip ${TABLE_NAME} forward ip saddr 130.211.0.0/22 drop
+    EOF
+
+        mkdir -p "${RUN_DIR}"
+    }
+
+    remove_stale_routes() {
+        ## find extra ovn routes
+        local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
+        if [ -z "${ovnkContainerID}" ]; then
+            return
+        fi
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        local routeVIPsV4=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip4" | awk '$8{print $8}')
+        echo "Found v4route vips: ${routeVIPsV4}"
+        local host=$(hostname)
+        echo ${host}
+        for route_vip in ${routeVIPsV4}; do
+            if [[ ! -v vips[${route_vip}] ]] || [[ "${vips[${route_vip}]}" = down ]]; then
+                echo removing stale vip "${route_vip}" for local clients
+                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${route_vip}"
+                crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${route_vip}" || true
+            fi
+        done
+    }
+
+    sync_rules() {
+        # Construct the VIP lists. (The nftables syntax allows a trailing comma.)
+        external_vips=""
+        local_vips=""
+        for vip in "${!vips[@]}"; do
+            external_vips="${vip}, ${external_vips}"
+            if [[ "${vips[${vip}]}" != down ]]; then
+                local_vips="${vip}, ${local_vips}"
+            fi
+        done
+
+        echo "synchronizing external VIPs to (${external_vips}), local VIPs to (${local_vips})"
+        {
+            echo "flush chain ip ${TABLE_NAME} ${EXTERNAL_VIPS_CHAIN}"
+            if [[ -n "${external_vips}" ]]; then
+                echo "add rule ip ${TABLE_NAME} ${EXTERNAL_VIPS_CHAIN} ip daddr { ${external_vips} } redirect"
+            fi
+            echo "flush chain ip ${TABLE_NAME} ${LOCAL_VIPS_CHAIN}"
+            if [[ -n "${local_vips}" ]]; then
+                echo "add rule ip ${TABLE_NAME} ${LOCAL_VIPS_CHAIN} ip daddr { ${local_vips} } redirect"
+            fi
+        } | nft -f -
+    }
+
+    add_routes() {
+        local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
+        if [ -z "${ovnkContainerID}" ]; then
+            echo "OVN-Kubernetes is not running; no routes to add."
+            return
+        fi
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        local ovnK8sMp0v4=$(ip -brief address show ovn-k8s-mp0 | awk '{print $3}' | awk -F/ '{print $1}')
+        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v4}"
+        local host=$(hostname)
+        echo ${host}
+        for vip in "${!vips[@]}"; do
+            if [[ "${vips[${vip}]}" != down ]]; then
+                echo "ensuring route for ${vip} for internal clients"
+                local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v4}")
+                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
+                if [[ "${routes}" == *"${vip}"* ]]; then
+                    echo "Route exists"
+                else
+                    echo "Route does not exist; creating it..."
+                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${vip} reroute ${ovnK8sMp0v4}"
+                    crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${vip}" reroute "${ovnK8sMp0v4}" || true
+                fi
+            fi
+        done
+    }
+
+    clear_rules() {
+        nft delete table ip "${TABLE_NAME}" || true
+    }
+
+    clear_routes() {
+        local ovnkContainerID=$(crictl ps --name ovnkube-controller | awk '{ print $1 }' | tail -n+2)
+        if [ -z "${ovnkContainerID}" ]; then
+            echo "OVN-Kubernetes is not running; no routes to remove."
+            return
+        fi
+        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
+        echo "clearing all routes from ovn-cluster-router"
+        crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 || true
+    }
+
+    # out parameter: vips
+    list_lb_ips() {
+        for k in "${!vips[@]}"; do
+            unset vips["${k}"]
+        done
+
+        local net_path="network-interfaces/"
+        for vif in $(curler ${net_path}); do
+            local hw_addr; hw_addr=$(curler "${net_path}${vif}mac")
+            local fwip_path; fwip_path="${net_path}${vif}forwarded-ips/"
+            for level in $(curler "${fwip_path}"); do
+                for fwip in $(curler "${fwip_path}${level}"); do
+                    if [[ -e "${RUN_DIR}/${fwip}.down" ]]; then
+                        echo "${fwip} is manually marked as down, skipping for internal clients..."
+                        vips[${fwip}]="down"
+                    else
+                        echo "Processing route for NIC ${vif}${hw_addr} for ${fwip}"
+                        vips[${fwip}]="${fwip}"
+                    fi
+                done
+            done
+        done
+    }
+
+    sleep_or_watch() {
+        if hash inotifywait &> /dev/null; then
+            inotifywait -t 30 -r "${RUN_DIR}" &> /dev/null || true
+        else
+            # no inotify, need to manually poll
+            for i in {0..5}; do
+                for vip in "${!vips[@]}"; do
+                    if [[ "${vips[${vip}]}" != down ]] && [[ -e "${RUN_DIR}/${vip}.down" ]]; then
+                        echo "new downfile detected"
+                        break 2
+                    elif [[ "${vips[${vip}]}" = down ]] && ! [[ -e "${RUN_DIR}/${vip}.down" ]]; then
+                        echo "downfile disappeared"
+                        break 2
+                    fi
+                done
+                sleep 1 # keep this small enough to not make gcp-routes slower than LBs on recovery
+            done
+        fi
+    }
+
+    case "$1" in
+      start)
+        initialize
+        while :; do
+          list_lb_ips
+          sync_rules
+          remove_stale_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
+          add_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
+          echo "done applying vip rules"
+          sleep_or_watch
+        done
+        ;;
+      cleanup)
+        clear_rules
+        clear_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
+        ;;
+      *)
+        echo $"Usage: $0 {start|cleanup}"
+        exit 1
+    esac

--- a/templates/arbiter/00-arbiter/gcp/units/gcp-routes.service.yaml
+++ b/templates/arbiter/00-arbiter/gcp/units/gcp-routes.service.yaml
@@ -1,0 +1,6 @@
+name: gcp-routes.service
+dropins:
+- name: mco-disabled.conf
+  contents: |
+    [Unit]
+    ConditionPathExists=/enoent

--- a/templates/arbiter/00-arbiter/gcp/units/openshift-gcp-routes.service.yaml
+++ b/templates/arbiter/00-arbiter/gcp/units/openshift-gcp-routes.service.yaml
@@ -1,0 +1,21 @@
+name: openshift-gcp-routes.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Update GCP routes for forwarded IPs.
+  ConditionKernelCommandLine=|ignition.platform.id=gce
+  ConditionKernelCommandLine=|ignition.platform.id=gcp
+  Before=network-online.target
+
+  [Service]
+  Type=simple
+  ExecStart=/bin/bash /opt/libexec/openshift-gcp-routes.sh start
+  ExecStopPost=/bin/bash /opt/libexec/openshift-gcp-routes.sh cleanup
+  User=root
+  RestartSec=30
+  Restart=always
+
+  [Install]
+  WantedBy=multi-user.target
+  # Ensure that network-online.target will not complete until the node has working external LBs.
+  RequiredBy=network-online.target

--- a/templates/arbiter/00-arbiter/on-prem/OWNERS
+++ b/templates/arbiter/00-arbiter/on-prem/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - baremetal-reviewers
+  - openstack-reviewers
+  - ovirt-reviewers
+  - vsphere-reviewers

--- a/templates/arbiter/00-arbiter/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/haproxy-haproxy.yaml
@@ -1,0 +1,43 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/haproxy/haproxy.cfg.tmpl"
+contents:
+  inline: |
+    global
+      stats socket /var/lib/haproxy/run/haproxy.sock  mode 600 level admin expose-fd listeners
+    defaults
+      maxconn 20000
+      mode    tcp
+      log     /var/run/haproxy/haproxy-log.sock local0 notice alert
+      log-format "%ci:%cp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
+      option  dontlognull
+      retries 3
+      timeout http-request 30s
+      timeout queue        1m
+      timeout connect      10s
+      timeout client       86400s
+      timeout server       86400s
+      timeout tunnel       86400s
+    {{`{{- if gt (len .LBConfig.Backends) 0 }}`}}
+    frontend  main
+      bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6
+      default_backend masters
+    listen health_check_http_url
+      bind :::9444 v4v6
+      mode http
+      monitor-uri /haproxy_ready
+      option dontlognull
+    {{`{{- end }}`}}
+    listen stats
+      bind localhost:{{`{{ .LBConfig.StatPort }}`}}
+      mode http
+      stats enable
+      stats hide-version
+      stats uri /haproxy_stats
+      stats refresh 30s
+      stats auth Username:Password
+    backend masters
+       option  httpchk GET /readyz HTTP/1.0
+       balance roundrobin
+    {{`{{- range .LBConfig.Backends }}
+       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 1s fall 2 rise 3
+    {{- end }}`}}

--- a/templates/arbiter/00-arbiter/on-prem/files/haproxy.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/haproxy.yaml
@@ -1,0 +1,166 @@
+mode: 0644
+path: {{ if isOpenShiftManagedDefaultLB . -}} "/etc/kubernetes/manifests/haproxy.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/haproxy.yaml" {{ end }}
+contents:
+  inline: |
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: haproxy
+      namespace: openshift-{{ onPremPlatformShortName . }}-infra
+      creationTimestamp:
+      deletionGracePeriodSeconds: 65
+      labels:
+        app: {{ onPremPlatformShortName . }}-infra-api-lb
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+    spec:
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: "/etc/kubernetes/static-pod-resources/haproxy"
+      - name: kubeconfigvarlib
+        hostPath:
+          path: "/var/lib/kubelet"
+      - name: run-dir
+        empty-dir: {}
+      - name: conf-dir
+        hostPath:
+          path: "/etc/haproxy"
+      - name: chroot-host
+        hostPath:
+          path: "/"
+      initContainers:
+      - name: verify-api-int-resolvable
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          /usr/bin/curl -o /dev/null -kLfs https://api-int.{{ .DNS.Spec.BaseDomain }}:6443/healthz
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: chroot-host
+          mountPath: "/host"
+          mountPropagation: HostToContainer
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
+        imagePullPolicy: IfNotPresent
+      containers:
+      - name: haproxy
+        image: {{.Images.haproxyImage}}
+        env:
+          - name: OLD_HAPROXY_PS_FORCE_DEL_TIMEOUT
+            value: "120"
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          #/bin/bash
+          verify_old_haproxy_ps_being_deleted()
+          {
+            local prev_pids
+
+            prev_pids="$1"
+            sleep $OLD_HAPROXY_PS_FORCE_DEL_TIMEOUT
+            cur_pids=$(pidof haproxy)
+
+            for val in $prev_pids; do
+                if [[ $cur_pids =~ (^|[[:space:]])"$val"($|[[:space:]]) ]] ; then
+                   kill $val
+                fi
+            done
+          }
+
+          reload_haproxy()
+          {
+            old_pids=$(pidof haproxy)
+            if [ -n "$old_pids" ]; then
+                /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids &
+                #There seems to be some cases where HAProxy doesn't drain properly.
+                #To handle that case, SIGTERM signal being sent to old HAProxy processes which haven't terminated.
+                verify_old_haproxy_ps_being_deleted "$old_pids"  &
+            else
+                /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
+            fi
+          }
+
+          msg_handler()
+          {
+            while read -r line; do
+              echo "The client send: $line"  >&2
+              # currently only 'reload' msg is supported
+              if [ "$line" = reload ]; then
+                  reload_haproxy
+              fi
+            done
+          }
+          set -ex
+          declare -r haproxy_sock="/var/run/haproxy/haproxy-master.sock"
+          declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
+          export -f msg_handler
+          export -f reload_haproxy
+          export -f verify_old_haproxy_ps_being_deleted
+          rm -f "$haproxy_sock" "$haproxy_log_sock"
+          socat UNIX-RECV:${haproxy_log_sock} STDOUT &
+          if [ -s "/etc/haproxy/haproxy.cfg" ]; then
+              /usr/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg  -p /var/lib/haproxy/run/haproxy.pid &
+          fi
+          socat UNIX-LISTEN:${haproxy_sock},fork system:'bash -c msg_handler'
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/haproxy"
+          mountPropagation: HostToContainer
+        - name: run-dir
+          mountPath: "/var/run/haproxy"
+        livenessProbe:
+          initialDelaySeconds: 50
+          httpGet:
+            path: /haproxy_ready
+            port: 9444
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      - name: haproxy-monitor
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "SYS_CHROOT"]
+        image: {{ .Images.baremetalRuntimeCfgImage }}
+        command:
+        - monitor
+        - "/var/lib/kubelet/kubeconfig"
+        - "/config/haproxy.cfg.tmpl"
+        - "/etc/haproxy/haproxy.cfg"
+        - "--api-vips"
+        - "{{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: conf-dir
+          mountPath: "/etc/haproxy"
+          mountPropagation: HostToContainer
+        - name: run-dir
+          mountPath: "/var/run/haproxy"
+        - name: resource-dir
+          mountPath: "/config"
+          mountPropagation: HostToContainer
+        - name: chroot-host
+          mountPath: "/host"
+          mountPropagation: HostToContainer
+        - name: kubeconfigvarlib
+          mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer
+        terminationMessagePolicy: FallbackToLogsOnError
+        imagePullPolicy: IfNotPresent
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+    status: {}

--- a/templates/arbiter/00-arbiter/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/keepalived-keepalived.yaml
@@ -1,0 +1,156 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl"
+contents:
+  inline: |
+    global_defs {
+        enable_script_security
+        script_user root
+        max_auto_priority -1
+        vrrp_garp_master_refresh 60
+    }
+
+    # These are separate checks to provide the following behavior:
+    # If the loadbalancer is healthy then all is well regardless
+    # of what the local API status is. Both checks will return success and
+    # we'll have the maximum priority. This means as long as there is a node
+    # with a functional loadbalancer it will get the VIP.
+    # If all of the loadbalancers go down but the local API is still running,
+    # the _both check will still succeed and allow any node with a functional
+    # API to take the VIP. This isn't preferred because it means all API
+    # traffic will go through one node, but at least it keeps the API available.
+    vrrp_script chk_ocp_lb {
+        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script.sh"
+        interval 2
+        weight 20
+        rise 3
+        fall 3
+    }
+
+    vrrp_script chk_ocp_both {
+        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_ocp_script_both.sh"
+        interval 2
+        # Use a smaller weight for this check so it won't trigger the move from
+        # bootstrap to master by itself.
+        weight 5
+        rise 3
+        fall 3
+    }
+
+    vrrp_script chk_mcs {
+        script "/usr/bin/timeout 1.9 /etc/keepalived/chk_mcs_script.sh"
+        interval 2
+        weight 3
+        rise 3
+        fall 3
+    }
+
+    # TODO: Improve this check. The port is assumed to be alive.
+    # Need to assess what is the ramification if the port is not there.
+    vrrp_script chk_ingress_ready {
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz/ready"
+        interval 1
+        weight 10
+        rise 3
+        fall 2
+    }
+
+    vrrp_script chk_ingress {
+        script "/usr/bin/timeout 0.9 /usr/bin/curl -o /dev/null -Lfs http://localhost:1936/healthz"
+        interval 1
+        rise 3
+        fall 2
+    }
+
+    vrrp_script chk_default_ingress {
+        script "/usr/bin/timeout 4.9 /etc/keepalived/chk_default_ingress.sh"
+        interval 5
+        weight 50
+        rise 3
+        fall 2
+    }
+
+    {{`{{ range $i, $config := .Configs }}`}}
+    {{`{{$nonVirtualIP := .NonVirtualIP}}`}}
+
+    {{`{{$participateInAPIVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .LBConfig.Backends}}
+    {{- if eq $nonVirtualIP .Address}}
+    {{$participateInAPIVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInAPIVRPP}}`}}
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_API_{{`{{$i}}`}} {
+        state BACKUP
+        interface {{`{{ .VRRPInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.APIVirtualRouterID }}`}}
+        priority 40
+        advert_int 1
+        {{`{{if .EnableUnicast}}`}}
+        unicast_src_ip {{`{{.NonVirtualIP}}`}}
+        unicast_peer {
+            {{`{{- range .LBConfig.Backends -}}
+            {{- if ne $nonVirtualIP .Address}}
+            {{.Address}}
+            {{- end}}
+            {{- end}}`}}
+        }
+        {{`{{end}}`}}
+        authentication {
+            auth_type PASS
+            auth_pass {{`{{ .Cluster.Name }}`}}_api_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.APIVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}} label vip
+        }
+        track_script {
+            chk_ocp_lb
+            chk_ocp_both
+            chk_mcs
+        }
+    }
+    {{`{{end}}`}}
+
+    {{`{{$participateInIngressVRPP := not .EnableUnicast}}`}}
+    {{`{{- if .EnableUnicast}}
+    {{- range .IngressConfig.Peers}}
+    {{- if eq $nonVirtualIP .}}
+    {{$participateInIngressVRPP = true}}
+    {{- end}}
+    {{- end}}
+    {{- end}}`}}
+
+    {{`{{if $participateInIngressVRPP}}`}}
+    vrrp_instance {{`{{ .Cluster.Name }}`}}_INGRESS_{{`{{$i}}`}} {
+        state BACKUP
+        interface {{`{{ .VRRPInterface }}`}}
+        virtual_router_id {{`{{ .Cluster.IngressVirtualRouterID }}`}}
+        priority 20
+        advert_int 1
+        {{`{{if .EnableUnicast}}`}}
+        unicast_src_ip {{`{{.NonVirtualIP}}`}}
+        unicast_peer {
+            {{`{{- range .IngressConfig.Peers}}
+            {{- if ne $nonVirtualIP .}}
+            {{.}}
+            {{- end}}
+            {{- end}}`}}
+        }
+        {{`{{end}}`}}
+        authentication {
+            auth_type PASS
+            auth_pass {{`{{ .Cluster.Name }}`}}_ingress_vip
+        }
+        virtual_ipaddress {
+            {{`{{ .Cluster.IngressVIP }}`}}/{{`{{ .Cluster.VIPNetmask }}`}} label vip
+        }
+        track_script {
+            chk_ingress
+            chk_ingress_ready
+            chk_default_ingress
+        }
+    }
+    {{`{{ end }}`}}
+    {{`{{ end }}`}}

--- a/templates/arbiter/00-arbiter/on-prem/files/keepalived-mcs-script.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/keepalived-mcs-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_mcs_script.sh.tmpl"
+contents:
+  inline: |
+    #!/bin/bash
+    chroot /host /bin/crictl ps --state running | grep -qE '\smachine-config-server\s'

--- a/templates/arbiter/00-arbiter/on-prem/files/keepalived-script-both.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/keepalived-script-both.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script_both.sh.tmpl"
+contents:
+  inline: |
+    #!/bin/bash
+    /usr/bin/curl -o /dev/null -kLfs http://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ] || /usr/bin/curl -kLfs https://localhost:{{`{{ .LBConfig.ApiPort }}`}}/readyz

--- a/templates/arbiter/00-arbiter/on-prem/files/keepalived-script.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/keepalived-script.yaml
@@ -1,0 +1,6 @@
+mode: 0755
+path: "/etc/kubernetes/static-pod-resources/keepalived/scripts/chk_ocp_script.sh.tmpl"
+contents:
+  inline: |
+    #!/bin/bash
+    /usr/bin/curl -o /dev/null -kLfs http://localhost:9444/haproxy_ready && [ -e /var/run/keepalived/iptables-rule-exists ]

--- a/templates/arbiter/00-arbiter/openstack/OWNERS
+++ b/templates/arbiter/00-arbiter/openstack/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers

--- a/templates/arbiter/00-arbiter/sno/OWNERS
+++ b/templates/arbiter/00-arbiter/sno/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - assisted-reviewers

--- a/templates/arbiter/00-arbiter/sno/files/sno-forcedns-fix.yaml
+++ b/templates/arbiter/00-arbiter/sno/files/sno-forcedns-fix.yaml
@@ -1,0 +1,12 @@
+mode: 0755
+path: "/etc/NetworkManager/dispatcher.d/forcedns-rhel9-fix"
+contents:
+  inline: |
+    #!/bin/bash
+    # this script was added as upgrade fix for assisted sno installation were forcedns dispatcher script misses shebang
+    filename="/etc/NetworkManager/dispatcher.d/forcedns"
+    if [ ! -f "$filename" ]; then
+      exit 0
+    fi
+    # in case there is no shebang run forcedns dispatcher script with /bin/bash
+    head -n1 "$filename" | grep -qx '#!/bin/bash' || /bin/bash "$filename" $1 $2

--- a/templates/arbiter/01-arbiter-container-runtime/OWNERS
+++ b/templates/arbiter/01-arbiter-container-runtime/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+approvers:
+  - giuseppe
+  - haircommander
+  - kolyshkin
+  - mrunalp
+  - nalind
+  - saschagrunert
+  - umohnani8
+reviewers:
+  - QiWang19
+  - hasan4791
+  - kwilczynski
+  - mtrmac
+  - sohankunkerkar
+  - wgahnagl

--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/container-registries.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/container-registries.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/containers/registries.conf"
+contents:
+  inline: |
+    unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']

--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -1,0 +1,105 @@
+mode: 0644
+path: "/etc/crio/crio.conf.d/00-default"
+contents:
+  inline: |
+    [crio]
+    internal_wipe = true
+    internal_repair = true
+
+    [crio.api]
+    stream_address = "127.0.0.1"
+    stream_port = "0"
+
+    [crio.runtime]
+    selinux = true
+    conmon = ""
+    conmon_cgroup = "pod"
+    default_env = [
+        "NSS_SDB_USE_CACHE=no",
+    ]
+    default_runtime = "runc"
+    log_level = "info"
+    cgroup_manager = "systemd"
+    default_sysctls = [
+        "net.ipv4.ping_group_range=0 2147483647",
+    ]
+    hooks_dir = [
+        "/etc/containers/oci/hooks.d",
+        "/run/containers/oci/hooks.d",
+        "/usr/share/containers/oci/hooks.d",
+    ]
+    manage_ns_lifecycle = true
+    absent_mount_sources_to_reject = [
+        "/etc/hostname",
+    ]
+    drop_infra_ctr = true
+
+    [crio.runtime.runtimes.runc]
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
+        "io.kubernetes.cri-o.LinkLogs",
+    ]
+
+    [crio.runtime.runtimes.crun]
+    runtime_root = "/run/crun"
+    allowed_annotations = [
+        "io.containers.trace-syscall",
+        "io.kubernetes.cri-o.Devices",
+        "io.kubernetes.cri-o.LinkLogs",
+    ]
+    # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
+    container_min_memory = "512KiB"
+
+    [crio.runtime.workloads.openshift-builder]
+    activation_annotation = "io.openshift.builder"
+    allowed_annotations = [
+      "io.kubernetes.cri-o.userns-mode",
+      "io.kubernetes.cri-o.Devices"
+    ]
+    [crio.runtime.workloads.openshift-builder.resources]
+
+    [crio.image]
+    global_auth_file = "/var/lib/kubelet/config.json"
+    pause_image = "{{.Images.infraImageKey}}"
+    pause_image_auth_file = "/var/lib/kubelet/config.json"
+    pause_command = "/usr/bin/pod"
+
+    [crio.network]
+    network_dir = "/etc/kubernetes/cni/net.d/"
+    plugin_dirs = [
+        "/var/lib/cni/bin",
+        "/usr/libexec/cni",
+    ]
+
+    [crio.metrics]
+    enable_metrics = true
+    metrics_host = "127.0.0.1"
+    metrics_port = 9537
+    metrics_collectors = [
+      "operations", # DEPRECATED: in favour of "operations_total"
+      "operations_latency_microseconds_total", # DEPRECATED: in favour of "operations_latency_seconds_total"
+      "operations_latency_microseconds", # DEPRECATED: in favour of "operations_latency_seconds"
+      "operations_errors", # DEPRECATED: in favour of "operations_errors_total"
+      "image_pulls_layer_size",
+      "containers_oom_total", # DEPRECATED: in favour of "containers_oom_count_total"
+      "containers_oom",
+      # Drop metrics with excessive label cardinality.
+      # "image_pulls_by_digest", # DEPRECATED: in favour of "image_pulls_bytes_total"
+      # "image_pulls_by_name", # DEPRECATED: in favour of "image_pulls_bytes_total"
+      # "image_pulls_by_name_skipped", # DEPRECATED: in favour of "image_pulls_skipped_bytes_total"
+      # "image_pulls_failures", # DEPRECATED: in favour of "image_pulls_failure_total"
+      # "image_pulls_successes", # DEPRECATED: in favour of "image_pulls_success_total"
+      # "image_layer_reuse", # DEPRECATED: in favour of "image_layer_reuse_total"
+      "operations_total",
+      "operations_latency_seconds_total",
+      "operations_latency_seconds",
+      "operations_errors_total",
+      "image_pulls_bytes_total",
+      "image_pulls_skipped_bytes_total",
+      "image_pulls_success_total",
+      "image_pulls_failure_total",
+      "image_layer_reuse_total",
+      "containers_oom_count_total",
+      "processes_defunct"
+    ]

--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/policy.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/policy.yaml
@@ -1,0 +1,18 @@
+mode: 0644
+path: "/etc/containers/policy.json"
+contents:
+  inline: |
+    {
+        "default": [
+            {
+                "type": "insecureAcceptAnything"
+            }
+        ],
+        "transports":
+            {
+                "docker-daemon":
+                    {
+                        "": [{"type":"insecureAcceptAnything"}]
+                    }
+            }
+    }

--- a/templates/arbiter/01-arbiter-container-runtime/openstack/OWNERS
+++ b/templates/arbiter/01-arbiter-container-runtime/openstack/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers

--- a/templates/arbiter/01-arbiter-kubelet/OWNERS
+++ b/templates/arbiter/01-arbiter-kubelet/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - rphillips
+  - sjenning
+  - mrunalp
+

--- a/templates/arbiter/01-arbiter-kubelet/_base/files/cloudconfig.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/cloudconfig.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/kubernetes/cloud.conf"
+contents:
+  inline: |-
+{{indent 4 .CloudProviderConfig}}

--- a/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy-config.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy-config.yaml
@@ -1,0 +1,11 @@
+mode: 0644
+path: "/etc/kubernetes/crio-metrics-proxy.cfg"
+contents:
+  inline: |-
+    authorization:
+      static:
+        - resourceRequest: false
+          path: /metrics
+          verb: get
+          user:
+            name: system:serviceaccount:openshift-monitoring:prometheus-k8s

--- a/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy.yaml
@@ -1,0 +1,79 @@
+mode: 0644
+path: "/etc/kubernetes/manifests/criometricsproxy.yaml"
+contents:
+  inline: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: kube-rbac-proxy-crio
+      namespace: openshift-machine-config-operator
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    spec:
+      volumes:
+      - name: etc-kube
+        hostPath:
+          path: "/etc/kubernetes"
+      - name: var-lib-kubelet
+        hostPath:
+          path: "/var/lib/kubelet"
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      initContainers:
+      - name: setup
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: {{.Images.kubeRbacProxyImage}}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: var-lib-kubelet
+          mountPath: "/var"
+          mountPropagation: HostToContainer
+        command: ['/bin/bash', '-ec']
+        args:
+        - |
+          echo -n "Waiting for kubelet key and certificate to be available"
+          while [ -n "$(test -e /var/lib/kubelet/pki/kubelet-server-current.pem)" ] ; do
+            echo -n "."
+            sleep 1
+            (( tries += 1 ))
+            if [[ "${tries}" -gt 10 ]]; then
+              echo "Timed out waiting for kubelet key and cert."
+              exit 1
+            fi
+          done
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 5m
+      containers:
+      - name: kube-rbac-proxy-crio
+        image: {{.Images.kubeRbacProxyImage}}
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 9637
+        args:
+        - --secure-listen-address=:9637
+        - --config-file=/etc/kubernetes/crio-metrics-proxy.cfg
+        - --client-ca-file=/etc/kubernetes/kubelet-ca.crt
+        - --logtostderr=true
+        - --kubeconfig=/var/lib/kubelet/kubeconfig
+        - --tls-cipher-suites={{join .TLSCipherSuites ","}} 
+        - --tls-min-version={{.TLSMinVersion}}
+        - --upstream=http://127.0.0.1:9537
+        - --tls-cert-file=/var/lib/kubelet/pki/kubelet-server-current.pem
+        - --tls-private-key-file=/var/lib/kubelet/pki/kubelet-server-current.pem
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: etc-kube
+          mountPath: "/etc/kubernetes"
+          mountPropagation: HostToContainer
+        - name: var-lib-kubelet
+          mountPath: "/var/lib/kubelet"
+          mountPropagation: HostToContainer

--- a/templates/arbiter/01-arbiter-kubelet/_base/files/kubelet.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/kubelet.yaml
@@ -1,0 +1,35 @@
+mode: 0644
+path: "/etc/kubernetes/kubelet.conf"
+contents:
+  inline: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/kubelet-ca.crt
+      anonymous:
+        enabled: false
+    cgroupDriver: systemd
+    cgroupRoot: /
+    clusterDNS:
+      - {{.ClusterDNSIP}}
+    clusterDomain: cluster.local
+    containerLogMaxSize: 50Mi
+    enableSystemLogQuery: true
+    maxPods: 250
+    kubeAPIQPS: 50
+    kubeAPIBurst: 100
+    podPidsLimit: 4096
+    protectKernelDefaults: true
+    rotateCertificates: true
+    serializeImagePulls: false
+    staticPodPath: /etc/kubernetes/manifests
+    systemCgroups: /system.slice
+    nodeStatusUpdateFrequency: 10s
+    nodeStatusReportFrequency: 5m
+    serverTLSBootstrap: true
+    tlsMinVersion: {{.TLSMinVersion}}
+    tlsCipherSuites:
+      {{- range .TLSCipherSuites }}
+        - {{ . }}
+      {{- end }}

--- a/templates/arbiter/01-arbiter-kubelet/_base/files/kubenswrapper.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/kubenswrapper.yaml
@@ -1,0 +1,12 @@
+# Note: This compatibility wrapper is needed to bridge the gap from OCP 4.11->4.12 when the new 'kubensenter' script is being introduced.
+# It can be removed (and the kubelet.service should call kubensenter directly) when 4.11 is no longer a release we must upgrade from.
+mode: 0755
+path: "/usr/local/bin/kubenswrapper"
+contents:
+  inline: |
+    #!/bin/sh
+    if [ -x /usr/bin/kubensenter ]; then
+      exec /usr/bin/kubensenter "$@"
+    else
+      exec "$@"
+    fi

--- a/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet-cleanup.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet-cleanup.service.yaml
@@ -1,0 +1,14 @@
+name: kubelet-cleanup.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet After Reboot Cleanup
+  Before=kubelet.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+  ExecStart=/bin/rm -f /var/lib/kubelet/memory_manager_state
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
@@ -1,0 +1,52 @@
+name: kubelet.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
+  After=ostree-finalize-staged.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- else}}
+  Environment="KUBELET_NODE_IP=0.0.0.0"
+{{- end}}
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+  EnvironmentFile=/etc/node-sizing.env
+
+  ExecStart=/usr/local/bin/kubenswrapper \
+      /usr/bin/kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
+        --node-labels=node-role.kubernetes.io/arbiter,node.openshift.io/os_id=${ID} \
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
+        --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
+        --minimum-container-ttl-duration=6m0s \
+        --cloud-provider={{cloudProvider .}} \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        {{credentialProviderConfigFlag . }} \
+        --hostname-override=${KUBELET_NODE_NAME} \
+        --provider-id=${KUBELET_PROVIDERID} \
+        --register-with-taints=node-role.kubernetes.io/arbiter=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
+        --v=${KUBELET_LOG_LEVEL}
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/arbiter/01-arbiter-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/on-prem/units/kubelet.service.yaml
@@ -1,0 +1,51 @@
+name: kubelet.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Kubernetes Kubelet
+  Requires=crio.service kubelet-dependencies.target
+  After=kubelet-dependencies.target
+  After=ostree-finalize-staged.service
+
+  [Service]
+  Type=notify
+  ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+{{- if eq .IPFamilies "IPv6"}}
+  Environment="KUBELET_NODE_IP=::"
+{{- else}}
+  Environment="KUBELET_NODE_IP=0.0.0.0"
+{{- end}}
+  EnvironmentFile=/etc/os-release
+  EnvironmentFile=-/etc/kubernetes/kubelet-workaround
+  EnvironmentFile=-/etc/kubernetes/kubelet-env
+  EnvironmentFile=/etc/node-sizing.env
+
+  ExecStart=/usr/local/bin/kubenswrapper \
+      /usr/bin/kubelet \
+        --config=/etc/kubernetes/kubelet.conf \
+        --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --container-runtime-endpoint=/var/run/crio/crio.sock \
+        --runtime-cgroups=/system.slice/crio.service \
+        --node-labels=node-role.kubernetes.io/arbiter,node.openshift.io/os_id=${ID} \
+{{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
+        --node-ip=${KUBELET_NODE_IPS} \
+{{- else}}
+        --node-ip=${KUBELET_NODE_IP} \
+{{- end}}
+        --address=${KUBELET_NODE_IP} \
+        --minimum-container-ttl-duration=6m0s \
+        --cloud-provider={{cloudProvider .}} \
+        --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+        --hostname-override=${KUBELET_NODE_NAME} \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule,node-role.kubernetes.io/arbiter=:NoSchedule \
+        --pod-infra-container-image={{.Images.infraImageKey}} \
+        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
+        --v=${KUBELET_LOG_LEVEL}
+
+  Restart=always
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target

--- a/templates/arbiter/01-arbiter-kubelet/openstack/OWNERS
+++ b/templates/arbiter/01-arbiter-kubelet/openstack/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added initial support for the arbiter node role. The arbiter role currently mimics the master node in configuration, so we are copying the same assets for master and using it for arbiter. 

This feature is currently for TechPreview but before we hit GA we will re-work this approach to remove duplication.

See: https://github.com/openshift/enhancements/pull/1674

**- How to verify it**

This feature will only work on baremetal HighlyAvailableArbiter control plane topology clusters. When running on those deployments, an MCP for arbiter and MCs for arbiter deployments should be present. Otherwise no trace of Arbiter should be present in the generated configs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
