### PR TITLE
OCPBUGS-44240: Disable ESP offload for OVS attached interfaces

### DIFF
--- a/templates/common/_base/files/bond-esp-offload.yaml
+++ b/templates/common/_base/files/bond-esp-offload.yaml
@@ -1,0 +1,32 @@
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/99-esp-offload"
+contents:
+    inline: |
+      #!/bin/bash
+
+      # ESP offload, either in actual hardware or as part as GRO (generic
+      # recieve offload) does not work for interfaces attached to an OVS bridge
+      # so turn it off for the time being.
+      # https://issues.redhat.com/browse/RHEL-58811
+      
+      # Depends on ipsec service drop-in to start it after configure-ovs to make
+      # sure offloads are disabled before ipsec starts.
+
+      if [[ "$2" != "up" ]]; then
+        exit
+      fi
+
+      device=$DEVICE_IFACE
+      kind_slave=$(ip -j -d link show "$device" | jq -r '.[0] | .linkinfo.info_slave_kind // empty')
+
+      if [ "$kind_slave" = "openvswitch" ]; then
+        for feature in tx-esp-segmentation esp-hw-offload esp-tx-csum-hw-offload; do
+          if ethtool -k "$device" | grep -qE "^${feature}: off"; then
+            # already disabled, nothing to do
+            continue
+          fi
+          
+          logger -t 99-esp-offload -s "Setting $feature off for $device: unsupported when attached to Open vSwitch bridge"
+          ethtool -K "$device" "$feature" off
+        done
+      fi

--- a/templates/common/_base/units/ipsec.service.yaml
+++ b/templates/common/_base/units/ipsec.service.yaml
@@ -1,0 +1,6 @@
+name: ipsec.service
+dropins:
+  - name: 01-after-configure-ovs.conf
+    contents: |
+      [Unit]
+      After=ovs-configuration.service


### PR DESCRIPTION
Reworked dispatcher script to disable ESP offload if interface is in OVS bridge.

Delay ipsec service after configure-ovs so that we have a chance to disable ESP offloads before it starts. Otherwise libreswan can be tricked into thinking ESP offload is supported and might try to enable it anyway.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit fbf7f02fc8f93481dcc7bb44657046ea98814a07)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
