### PR TITLE
[release-4.16] OCPBUGS-44337: Removal of additionalTrustBundle CA does not remove certificate from node backport

### DIFF
--- a/lib/resourceapply/machineconfig.go
+++ b/lib/resourceapply/machineconfig.go
@@ -13,6 +13,7 @@ import (
 	mcoResourceMerge "github.com/openshift/machine-config-operator/lib/resourcemerge"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 // ApplyMachineConfig applies the required machineconfig to the cluster.
@@ -80,21 +81,32 @@ func ApplyMachineConfigNode(client mcfgclientalphav1.MachineConfigNodesGetter, r
 
 // ApplyControllerConfig applies the required machineconfig to the cluster.
 func ApplyControllerConfig(client mcfgclientv1.ControllerConfigsGetter, required *mcfgv1.ControllerConfig) (*mcfgv1.ControllerConfig, bool, error) {
+	klog.V(4).Infof("Getting existing ControllerConfig with name: %s", required.GetName())
 	existing, err := client.ControllerConfigs().Get(context.TODO(), required.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
+		klog.Info("ControllerConfig not found, creating new one")
 		actual, err := client.ControllerConfigs().Create(context.TODO(), required, metav1.CreateOptions{})
+		if err != nil {
+			klog.Errorf("Failed to create ControllerConfig: %v", err)
+		}
 		return actual, true, err
 	}
 	if err != nil {
+		klog.Errorf("Error fetching ControllerConfig: %v", err)
 		return nil, false, err
 	}
 
 	modified := resourcemerge.BoolPtr(false)
 	mcoResourceMerge.EnsureControllerConfig(modified, existing, *required)
 	if !*modified {
+		klog.V(4).Info("No updates required for the ControllerConfig")
 		return existing, false, nil
 	}
 
+	klog.V(4).Info("Updating existing ControllerConfig")
 	actual, err := client.ControllerConfigs().Update(context.TODO(), existing, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("Failed to update ControllerConfig: %v", err)
+	}
 	return actual, true, err
 }

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -1,15 +1,25 @@
 package resourcemerge
 
 import (
+	"bytes"
+
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 )
 
 func setBytesIfSet(modified *bool, existing *[]byte, required []byte) {
+	// Check if the current required bytes are empty
 	if len(required) == 0 {
+		// If existing is not already empty, update it and set modified to true
+		if len(*existing) != 0 {
+			*existing = nil
+			*modified = true
+		}
 		return
 	}
-	if string(required) != string(*existing) {
-		*existing = required
+	// Update only if there is a change in the content
+	if !bytes.Equal(*existing, required) {
+		*existing = make([]byte, len(required))
+		copy(*existing, required)
 		*modified = true
 	}
 }


### PR DESCRIPTION
backport of https://github.com/openshift/machine-config-operator/pull/4378
