### PR TITLE
OCPBUGS-42695: Sort the moscs alphanumerically

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2178,7 +2179,13 @@ func (optr *Operator) getMachineOSConfigs() ([]*mcfgv1alpha1.MachineOSConfig, er
 		return nil, nil
 	}
 
-	return optr.moscLister.List(labels.Everything())
+	moscs, err := optr.moscLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(moscs, func(i, j int) bool { return moscs[i].Name < moscs[j].Name })
+	return moscs, nil
 }
 
 // Fetches and validates the MachineOSConfigs. For now, validation consists of


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: OCPBUGS-42695

**- What I did**

The lister returns mosc's which have no guarantee of the order. When template renderer controller consumes this list, its order varies every control loop iteration. Since the MCD's daemonset has every MOSC's image pull secret in it, an order change means a difference in spec causing it to be restarted again. Have the order constant by sorting it by alphanumerical name prevents changes to the manifest MCD daemonset template

**- How to verify it**

Configure several MOSC resources for several MCPs, the MCD pods should only restart per MOSC

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Sort the moscs alphanumerically
