### PR TITLE
MCO-1165: rebuild annotation

### DIFF
--- a/pkg/controller/build/constants/constants.go
+++ b/pkg/controller/build/constants/constants.go
@@ -28,6 +28,12 @@ const (
 	CurrentMachineOSBuildAnnotationKey string = "machineconfiguration.openshift.io/current-machine-os-build"
 )
 
+// When this annotation is added to a MachineOSConfig, the current
+// MachineOSBuild will be deleted, which will cause a rebuild to occur.
+const (
+	RebuildMachineOSConfigAnnotationKey string = "machineconfiguration.openshift.io/rebuild"
+)
+
 // Entitled build secret names
 const (
 	// Name of the etc-pki-entitlement secret from the openshift-config-managed namespace.

--- a/pkg/controller/build/helpers.go
+++ b/pkg/controller/build/helpers.go
@@ -235,7 +235,7 @@ func isMachineOSBuildCurrentForMachineOSConfigWithPullspec(mosc *mcfgv1alpha1.Ma
 
 // Determines if a given MachineOSConfig has the current build annotation.
 func hasCurrentBuildAnnotation(mosc *mcfgv1alpha1.MachineOSConfig) bool {
-	return metav1.HasAnnotation(mosc.ObjectMeta, constants.CurrentMachineOSBuildAnnotationKey)
+	return metav1.HasAnnotation(mosc.ObjectMeta, constants.CurrentMachineOSBuildAnnotationKey) && mosc.Annotations[constants.CurrentMachineOSBuildAnnotationKey] != ""
 }
 
 // Determines if a given MachineOSConfig has the current build annotation and
@@ -246,6 +246,11 @@ func isCurrentBuildAnnotationEqual(mosc *mcfgv1alpha1.MachineOSConfig, mosb *mcf
 	}
 
 	return mosc.Annotations[constants.CurrentMachineOSBuildAnnotationKey] == mosb.Name
+}
+
+// Determines if a given MachineOSConfig has the rebuild annotation.
+func hasRebuildAnnotation(mosc *mcfgv1alpha1.MachineOSConfig) bool {
+	return metav1.HasAnnotation(mosc.ObjectMeta, constants.RebuildMachineOSConfigAnnotationKey)
 }
 
 // Looks at the error chain for the given error and determines if the error


### PR DESCRIPTION
**- What I did**

I added the ability for a cluster admin to request that the currently active
MachineOSBuild be rebuilt. This is done by adding the annotation
`machineconfiguration.openshift.io/rebuild` to the MachineOSConfig.

**- How to verify it**

1. Bring up an OpenShift cluster.
2. Opt into on-cluster layering by creating a MachineOSConfig.
3. Wait for the build to complete.
4. Add the annotation `machineconfiguration.openshift.io/rebuild` onto the MachineOSConfig.
5. The controller should delete the current MachineOSBuild and a new one should be started in its place.

**- Description for the changelog**
Adds rebuild functionality for OCL
