### PR TITLE
OCPBUGS-38779: Disable tx chksum for driver IDPF on GCP C3/C4

### DIFF
--- a/templates/common/_base/files/gcp-disable-idpf-tx-checksum-off.yaml
+++ b/templates/common/_base/files/gcp-disable-idpf-tx-checksum-off.yaml
@@ -1,0 +1,13 @@
+mode: 0744
+path: "/etc/NetworkManager/dispatcher.d/99-gcp-disable-idpf-tx-checksum-off"
+contents:
+  inline: |
+    #!/bin/bash
+    # Workaround:
+    # https://issues.redhat.com/browse/OCPBUGS-38779
+    
+    driver=$(nmcli -t -m tabular -f general.driver dev show "${DEVICE_IFACE}")
+
+    if [[ "$2" == "up" && "${driver}" == "idpf" ]]; then
+      ethtool -K ${DEVICE_IFACE} tx-checksumming off
+    fi


### PR DESCRIPTION
See bug [1] for more details.

[1] https://issues.redhat.com/browse/OCPBUGS-38779

GCP driver docs: https://cloud.google.com/compute/docs/networking/using-idpf

/hold for:
* QE premerge validation
* GCP team ack
