### PR TITLE
OCPBUGS-38749: add retry on error for apply functions

### DIFF
--- a/lib/resourceapply/apps.go
+++ b/lib/resourceapply/apps.go
@@ -2,14 +2,36 @@ package resourceapply
 
 import (
 	"context"
+	"strings"
 
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"k8s.io/utils/ptr"
+
 	mcoResourceMerge "github.com/openshift/machine-config-operator/lib/resourcemerge"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/klog/v2"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
+
+func IsApplyErrorRetriable(err error) bool {
+	// Retry on brief rpc errors
+	// See https://issues.redhat.com/browse/OCPBUGS-24228 for more information.
+	// String compare isn't great, but could not find a good error type for this in the standard libraries
+	if strings.Contains(err.Error(), "rpc error") {
+		return true
+	}
+	// Retry on resource conflict errors, i.e "the object has been modified; please apply your changes to the latest version and try again"
+	// See last few comments on https://issues.redhat.com/browse/OCPBUGS-9108 for more information
+	if apierrors.IsConflict(err) {
+		return true
+	}
+	// Add any other errors to be added to the retry here.
+
+	klog.Infof("Skipping retry in Apply fn for error: %s", err)
+	return false
+}
 
 // ApplyDaemonSet applies the required daemonset to the cluster.
 func ApplyDaemonSet(client appsclientv1.DaemonSetsGetter, required *appsv1.DaemonSet) (*appsv1.DaemonSet, bool, error) {
@@ -22,7 +44,7 @@ func ApplyDaemonSet(client appsclientv1.DaemonSetsGetter, required *appsv1.Daemo
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := ptr.To(false)
 	mcoResourceMerge.EnsureDaemonSet(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil
@@ -43,7 +65,7 @@ func ApplyDeployment(client appsclientv1.DeploymentsGetter, required *appsv1.Dep
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := ptr.To(false)
 	mcoResourceMerge.EnsureDeployment(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil

--- a/lib/resourceapply/machineconfig.go
+++ b/lib/resourceapply/machineconfig.go
@@ -9,11 +9,11 @@ import (
 	mcfgclientv1 "github.com/openshift/client-go/machineconfiguration/clientset/versioned/typed/machineconfiguration/v1"
 	mcfgclientalphav1 "github.com/openshift/client-go/machineconfiguration/clientset/versioned/typed/machineconfiguration/v1alpha1"
 
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	mcoResourceMerge "github.com/openshift/machine-config-operator/lib/resourcemerge"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 // ApplyMachineConfig applies the required machineconfig to the cluster.
@@ -27,7 +27,7 @@ func ApplyMachineConfig(client mcfgclientv1.MachineConfigsGetter, required *mcfg
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := ptr.To(false)
 	mcoResourceMerge.EnsureMachineConfig(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil
@@ -48,7 +48,7 @@ func ApplyMachineConfigPool(client mcfgclientv1.MachineConfigPoolsGetter, requir
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := ptr.To(false)
 	mcoResourceMerge.EnsureMachineConfigPool(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil
@@ -69,7 +69,7 @@ func ApplyMachineConfigNode(client mcfgclientalphav1.MachineConfigNodesGetter, r
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := ptr.To(false)
 	mcoResourceMerge.EnsureMachineConfigNode(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil
@@ -96,7 +96,7 @@ func ApplyControllerConfig(client mcfgclientv1.ControllerConfigsGetter, required
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	modified := ptr.To(false)
 	mcoResourceMerge.EnsureControllerConfig(modified, existing, *required)
 	if !*modified {
 		klog.V(4).Info("No updates required for the ControllerConfig")

--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 func TestMergeDaemonSetUpdateStrategy(t *testing.T) {
@@ -133,7 +133,7 @@ func TestMergeDaemonSetUpdateStrategy(t *testing.T) {
 
 	for idx, test := range daemonset_update_strategy_tests {
 		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
-			modified := resourcemerge.BoolPtr(false)
+			modified := ptr.To(false)
 			EnsureDaemonSet(modified, &test.existing, test.input)
 
 			if *modified != test.expectedModified {

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/ptr"
 )
 
 // Test added for now to test ensureContainer (mostly so we don't break Env Vars - proxy)
@@ -119,7 +119,7 @@ func TestEnsureContainer(t *testing.T) {
 
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
-			modified := resourcemerge.BoolPtr(false)
+			modified := ptr.To(false)
 			ensureContainer(modified, &test.existing, test.input)
 
 			if *modified != test.expectedModified {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -827,29 +827,11 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig, _ *configv1.Cluste
 	return nil
 }
 
-func isApplyManifestErrorRetriable(err error) bool {
-	// Retry on brief rpc errors
-	// See https://issues.redhat.com/browse/OCPBUGS-24228 for more information.
-	// String compare isn't great, but could not find a good error type for this in the standard libraries
-	if strings.Contains(err.Error(), "rpc error") {
-		return true
-	}
-	// Retry on resource conflict errors, i.e "the object has been modified; please apply your changes to the latest version and try again"
-	// See last few comments on https://issues.redhat.com/browse/OCPBUGS-9108 for more information
-	if apierrors.IsConflict(err) {
-		return true
-	}
-	// Add any other errors to be added to the retry here.
-
-	klog.Infof("Skipping retry in ApplyManifests for error: %s", err)
-	return false
-}
-
 //nolint:gocyclo
 func (optr *Operator) applyManifests(config *renderConfig, paths manifestPaths) error {
 	// Retry in case this is a short lived, transient issue.
 	// This does an exponential retry, up to 5 times before it eventually times out and causing a degrade.
-	return retry.OnError(retry.DefaultRetry, isApplyManifestErrorRetriable, func() error {
+	return retry.OnError(retry.DefaultRetry, mcoResourceApply.IsApplyErrorRetriable, func() error {
 		for _, path := range paths.clusterRoles {
 			crBytes, err := renderAsset(config, path)
 			if err != nil {
@@ -1167,9 +1149,12 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig, _ *confi
 	}
 	mcc := resourceread.ReadDeploymentV1OrDie(mccBytes)
 
-	_, updated, err := mcoResourceApply.ApplyDeployment(optr.kubeClient.AppsV1(), mcc)
-	if err != nil {
+	var updated bool
+	if retryErr := retry.OnError(retry.DefaultRetry, mcoResourceApply.IsApplyErrorRetriable, func() error {
+		_, updated, err = mcoResourceApply.ApplyDeployment(optr.kubeClient.AppsV1(), mcc)
 		return err
+	}); retryErr != nil {
+		return retryErr
 	}
 	if updated {
 		if err := optr.waitForDeploymentRollout(mcc); err != nil {
@@ -1466,9 +1451,13 @@ func (optr *Operator) syncMachineConfigDaemon(config *renderConfig, _ *configv1.
 		return err
 	}
 	d := resourceread.ReadDaemonSetV1OrDie(dBytes)
-	_, updated, err := mcoResourceApply.ApplyDaemonSet(optr.kubeClient.AppsV1(), d)
-	if err != nil {
+
+	var updated bool
+	if retryErr := retry.OnError(retry.DefaultRetry, mcoResourceApply.IsApplyErrorRetriable, func() error {
+		_, updated, err = mcoResourceApply.ApplyDaemonSet(optr.kubeClient.AppsV1(), d)
 		return err
+	}); retryErr != nil {
+		return retryErr
 	}
 	if updated {
 		return optr.waitForDaemonsetRollout(d)
@@ -1505,9 +1494,13 @@ func (optr *Operator) syncMachineConfigServer(config *renderConfig, _ *configv1.
 		return err
 	}
 	d := resourceread.ReadDaemonSetV1OrDie(dBytes)
-	_, updated, err := mcoResourceApply.ApplyDaemonSet(optr.kubeClient.AppsV1(), d)
-	if err != nil {
+
+	var updated bool
+	if retryErr := retry.OnError(retry.DefaultRetry, mcoResourceApply.IsApplyErrorRetriable, func() error {
+		_, updated, err = mcoResourceApply.ApplyDaemonSet(optr.kubeClient.AppsV1(), d)
 		return err
+	}); retryErr != nil {
+		return retryErr
 	}
 	if updated {
 		return optr.waitForDaemonsetRollout(d)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Adds a retry on error for applying the MCC deployment, the MCD daemonset and the MCS daemonset. I also took this opportunity to clean up some pointer library references.

**- How to verify it**
These error logs mentioned in the bug [is quite rare](https://search.dptools.openshift.org/?search=MachineConfigDaemonFailed&maxAge=336h&context=1&type=junit&name=periodic-ci-openshift-release-master-ci-4.18-e2e-aws-ovn-techpreview-serial&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job), so it may be hard to verify this. Regardless, it should help clean up such failures. 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
