### PR TITLE
[release-4.15] OCPBUGS-44565: Post upgrading from 4.14 to 4.15.36, the observedGeneration count increased tremendously

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -434,6 +435,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 	if len(mcs) == 0 {
 		return ctrl.syncFailingStatus(pool, fmt.Errorf("no MachineConfigs found matching selector %v", selector))
 	}
+	sort.SliceStable(mcs, func(i, j int) bool { return mcs[i].Name < mcs[j].Name })
 
 	if err := ctrl.syncGeneratedMachineConfig(pool, mcs); err != nil {
 		klog.Errorf("Error syncing Generated MCFG: %w", err)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This fix ensures that the list of source MCs stored in a MachineConfigPool is always sorted and fixed.

**- How to verify it**
Install a cluster on this PR, the MCPs should not be being constantly updated when there is no MC rollout taking place. You could also look at the test results for e2e-aws-ovn and compare [it to a previous run](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_machine-config-operator/4687/pull-ci-openshift-machine-config-operator-release-4.15-e2e-aws-ovn/1857109181102821376/artifacts/e2e-aws-ovn/gather-extra/artifacts/machineconfigpools.json); there should be a substantial drop in the generation count.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
