### PR TITLE
OCPBUGS-43552: maxUnavailable value is not honored when disabling OCL

### DIFF
--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -595,10 +595,9 @@ func TestGetUnavailableMachines(t *testing.T) {
 				pb.WithLayeringEnabled()
 				pb.WithImage(imageV1)
 			}
+			// pool := pb.MachineConfigPool()
 
-			pool := pb.MachineConfigPool()
-
-			unavailableNodes := getUnavailableMachines(test.nodes, pool, test.layeredPool, nil)
+			unavailableNodes := getUnavailableMachines(test.nodes, test.layeredPool)
 			assertExpectedNodes(t, test.unavail, unavailableNodes)
 		})
 	}

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -407,7 +407,7 @@ func TestGetReadyMachines(t *testing.T) {
 	}
 }
 
-func TestGetUnavailableMachines(t *testing.T) {
+func (ctrl *Controller) TestGetUnavailableMachines(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name                 string
@@ -597,7 +597,7 @@ func TestGetUnavailableMachines(t *testing.T) {
 			}
 			// pool := pb.MachineConfigPool()
 
-			unavailableNodes := getUnavailableMachines(test.nodes, test.layeredPool)
+			unavailableNodes := ctrl.getUnavailableMachines(test.nodes, test.layeredPool)
 			assertExpectedNodes(t, test.unavail, unavailableNodes)
 		})
 	}

--- a/pkg/controller/node/txt.txt
+++ b/pkg/controller/node/txt.txt
@@ -1,0 +1,3317 @@
+I0116 21:17:15.781887       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:15.781986       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:15.782048       1 status.go:524] Node ip-10-0-79-21.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782062       1 status.go:524] Node ip-10-0-10-88.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782067       1 status.go:524] Node ip-10-0-52-14.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782071       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:15.782077       1 node_controller.go:1231] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0116 21:17:15.782081       1 node_controller.go:1234] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 21:17:15.782089       1 node_controller.go:1277] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 21:17:15.781990       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782214       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782240       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782269       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:15.782299       1 node_controller.go:1231] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 21:17:15.782311       1 node_controller.go:1234] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 21:17:15.782320       1 node_controller.go:1244] Already picked 2 nodes, capacity is 2, stopping
+I0116 21:17:15.782327       1 node_controller.go:1277] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 21:17:15.782339       1 node_controller.go:1077] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+I0116 21:17:15.782343       1 status.go:518] getUnavailableMachines: checking 2 nodes (layered=false)
+I0116 21:17:15.782348       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782352       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.782355       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:15.782360       1 node_controller.go:1365] Selected node ip-10-0-38-37.ec2.internal for update (current selection count: 1)
+I0116 21:17:15.782363       1 node_controller.go:1365] Selected node ip-10-0-71-35.ec2.internal for update (current selection count: 2)
+
+I0116 21:17:15.782366       1 node_controller.go:1368] Final list of nodes to update in pool worker: 2 nodes (capacity: 2)
+I0116 21:17:15.795144       1 node_controller.go:1180] updateCandidateNode: node=ip-10-0-38-37.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0116 21:17:15.806986       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:15.807129       1 status.go:524] Node ip-10-0-52-14.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.807159       1 status.go:524] Node ip-10-0-79-21.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.807188       1 status.go:524] Node ip-10-0-10-88.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.807215       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:15.814607       1 node_controller.go:560] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0116 21:17:15.820551       1 node_controller.go:1180] updateCandidateNode: node=ip-10-0-71-35.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0116 21:17:15.841784       1 node_controller.go:560] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0116 21:17:15.843023       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"228100", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 2 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 21:17:15.982194       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:15.982220       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.982226       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.982230       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:15.982234       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:20.844400       1 node_controller.go:560] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 21:17:20.890861       1 node_controller.go:560] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+
+I0116 21:17:20.891697       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:20.891718       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:20.891725       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:20.891729       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:20.891733       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:20.891738       1 node_controller.go:1231] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 21:17:20.891741       1 node_controller.go:1234] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 21:17:20.891751       1 node_controller.go:1277] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 21:17:20.891764       1 node_controller.go:1077] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0116 21:17:20.891768       1 status.go:518] getUnavailableMachines: checking 1 nodes (layered=false)
+I0116 21:17:20.891773       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:20.891777       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:20.891781       1 node_controller.go:1365] Selected node ip-10-0-20-116.ec2.internal for update (current selection count: 1)
+
+I0116 21:17:20.891785       1 node_controller.go:1368] Final list of nodes to update in pool worker: 1 nodes (capacity: 2)
+I0116 21:17:20.933143       1 node_controller.go:1180] updateCandidateNode: node=ip-10-0-20-116.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0116 21:17:20.949764       1 node_controller.go:560] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0116 21:17:20.950929       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"229238", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Targeted node ip-10-0-20-116.ec2.internal to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 21:17:21.021498       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:21.021522       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:21.021528       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:21.021532       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:21.021537       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:25.870057       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:25.870789       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:25.870799       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:25.870805       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:25.870809       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:25.870814       1 node_controller.go:1231] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 21:17:25.870818       1 node_controller.go:1234] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 21:17:25.870826       1 node_controller.go:1277] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 21:17:25.870682       1 node_controller.go:560] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 21:17:25.950633       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:25.950657       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:25.950663       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:25.950667       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:25.950671       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 21:17:27.405713       1 node_controller.go:560] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0116 21:17:29.804430       1 node_controller.go:560] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0116 21:17:30.877527       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:30.877552       1 status.go:495] Node ip-10-0-38-37.ec2.internal is unavailable: node is in MCD state=Working
+I0116 21:17:30.877557       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:30.877563       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:30.877568       1 status.go:495] Node ip-10-0-20-116.ec2.internal is unavailable: node is in MCD state=Working
+I0116 21:17:30.877571       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:30.877575       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 21:17:30.896996       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:30.897019       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:30.897025       1 status.go:495] Node ip-10-0-20-116.ec2.internal is unavailable: node is in MCD state=Working
+I0116 21:17:30.897029       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:30.897033       1 status.go:495] Node ip-10-0-38-37.ec2.internal is unavailable: node is in MCD state=Working
+I0116 21:17:30.897037       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:30.897041       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 21:17:32.508730       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: cordoning
+I0116 21:17:32.508753       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: initiating cordon (currently schedulable: true)
+I0116 21:17:32.529955       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: cordon succeeded (currently schedulable: false)
+I0116 21:17:32.547541       1 node_controller.go:560] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 21:17:32.554190       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: initiating drain
+E0116 21:17:33.620997       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-k6rfd, openshift-cluster-node-tuning-operator/tuned-lnw4r, openshift-dns/dns-default-hsbwr, openshift-dns/node-resolver-fmxds, openshift-image-registry/node-ca-bfm99, openshift-ingress-canary/ingress-canary-xzwfm, openshift-insights/insights-runtime-extractor-z4cfx, openshift-machine-config-operator/machine-config-daemon-4fhnv, openshift-monitoring/node-exporter-gfj2k, openshift-multus/multus-additional-cni-plugins-tv4gj, openshift-multus/multus-kwp4z, openshift-multus/network-metrics-daemon-dfm64, openshift-network-diagnostics/network-check-target-9cptd, openshift-network-operator/iptables-alerter-zrb5q, openshift-ovn-kubernetes/ovnkube-node-4wrzb
+I0116 21:17:33.623276       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28951035-jf449
+I0116 21:17:33.623287       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-79b754d856-w88p7
+I0116 21:17:33.623298       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-q9c5n
+I0116 21:17:33.623324       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-rd52m
+I0116 21:17:33.623332       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0116 21:17:33.623276       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-qbp4g
+I0116 21:17:33.623323       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-5fwqx
+I0116 21:17:33.623287       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7948b5c55b-d4pwr
+I0116 21:17:33.623810       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0116 21:17:33.684964       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28951035-jf449
+I0116 21:17:34.707120       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-79b754d856-w88p7
+I0116 21:17:34.873669       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-5fwqx
+I0116 21:17:34.907790       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: cordoning
+I0116 21:17:34.907823       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: initiating cordon (currently schedulable: true)
+I0116 21:17:35.318935       1 node_controller.go:560] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 21:17:35.475528       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: cordon succeeded (currently schedulable: false)
+I0116 21:17:35.494612       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: initiating drain
+I0116 21:17:35.913662       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:35.913690       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:35.913697       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 21:17:35.913701       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:35.913705       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 21:17:35.913708       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:35.913713       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 21:17:36.013855       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:36.013881       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 21:17:36.013886       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:36.013893       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 21:17:36.013898       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 21:17:36.013902       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:36.013906       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 21:17:36.079266       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-598785cd5d-rd52m
+I0116 21:17:36.275602       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0116 21:17:36.676595       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+E0116 21:17:36.702462       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-z4jzd, openshift-cluster-node-tuning-operator/tuned-xnxg6, openshift-dns/dns-default-v68j6, openshift-dns/node-resolver-vfl7g, openshift-image-registry/node-ca-nlskm, openshift-ingress-canary/ingress-canary-qfphk, openshift-insights/insights-runtime-extractor-7qcjl, openshift-machine-config-operator/machine-config-daemon-mfmhq, openshift-monitoring/node-exporter-6rt4m, openshift-multus/multus-additional-cni-plugins-4pb9t, openshift-multus/multus-nmrtv, openshift-multus/network-metrics-daemon-sh2xm, openshift-network-diagnostics/network-check-target-l8gpd, openshift-network-operator/iptables-alerter-l9vg5, openshift-ovn-kubernetes/ovnkube-node-h6qnt
+I0116 21:17:36.704627       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-gfjhg
+I0116 21:17:36.704626       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-dss4c
+I0116 21:17:36.704637       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-79b754d856-zr2kz
+I0116 21:17:36.704640       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7948b5c55b-96r9m
+I0116 21:17:36.704646       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-pk972
+I0116 21:17:36.704657       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-9b2mx
+I0116 21:17:36.869950       1 request.go:700] Waited for 1.110057971s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-7d74fd7b76-qbp4g
+I0116 21:17:38.069953       1 request.go:700] Waited for 1.315613225s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-7948b5c55b-96r9m
+I0116 21:17:40.090363       1 node_controller.go:560] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0116 21:17:40.274233       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-pk972
+I0116 21:17:40.475264       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-79b754d856-zr2kz
+I0116 21:17:40.869757       1 request.go:700] Waited for 1.143172763s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-7948b5c55b-d4pwr
+I0116 21:17:41.870508       1 request.go:700] Waited for 1.593157995s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/thanos-querier-598785cd5d-dss4c
+I0116 21:17:41.875096       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-598785cd5d-dss4c
+I0116 21:17:43.875052       1 request.go:700] Waited for 1.115449797s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-7d74fd7b76-qbp4g
+I0116 21:17:45.096005       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:45.096028       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 21:17:45.096033       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:45.096037       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 21:17:45.096040       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:45.096045       1 status.go:495] Node ip-10-0-71-35.ec2.internal is unavailable: node is in MCD state=Working
+I0116 21:17:45.096049       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:45.096054       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+
+I0116 21:17:45.116494       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 21:17:45.116528       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 21:17:45.116533       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:45.116542       1 status.go:495] Node ip-10-0-71-35.ec2.internal is unavailable: node is in MCD state=Working
+I0116 21:17:45.116547       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:45.116552       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 21:17:45.116555       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 21:17:45.116559       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0116 21:17:45.192874       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: cordoning
+I0116 21:17:45.192896       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: initiating cordon (currently schedulable: true)
+I0116 21:17:46.106089       1 node_controller.go:560] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 21:17:46.870546       1 request.go:700] Waited for 1.110732905s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-7d74fd7b76-qbp4g
+I0116 21:17:47.475153       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: cordon succeeded (currently schedulable: false)
+I0116 21:17:47.494432       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: initiating drain
+I0116 21:17:48.070176       1 request.go:700] Waited for 1.330948948s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-5f97875cc6-q9c5n
+E0116 21:17:49.309986       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-clgqb, openshift-cluster-node-tuning-operator/tuned-9vjmq, openshift-dns/dns-default-b7dmz, openshift-dns/node-resolver-w4fs8, openshift-image-registry/node-ca-27xb5, openshift-ingress-canary/ingress-canary-sv75g, openshift-insights/insights-runtime-extractor-vs5jr, openshift-machine-config-operator/machine-config-daemon-ngkjj, openshift-monitoring/node-exporter-p8sks, openshift-multus/multus-additional-cni-plugins-prd6l, openshift-multus/multus-h8m2r, openshift-multus/network-metrics-daemon-8lbsj, openshift-network-diagnostics/network-check-target-vjknt, openshift-network-operator/iptables-alerter-k2vpm, openshift-ovn-kubernetes/ovnkube-node-w9f4l
+I0116 21:17:49.312203       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-tnnf9
+I0116 21:17:49.312208       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-xzhkc
+I0116 21:17:49.312214       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-s8xvr
+I0116 21:17:49.312217       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-ntkh7
+I0116 21:17:49.31222
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+I0116 23:02:16.349759       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:16.349784       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.349790       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.349794       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.349798       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 23:02:16.349803       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 23:02:16.349807       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 23:02:16.349815       1 node_controller.go:1235] Already picked 2 nodes, capacity is 2, stopping
+I0116 23:02:16.349821       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 23:02:16.349831       1 node_controller.go:1076] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+I0116 23:02:16.349865       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:16.349874       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.349878       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.349900       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.349904       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+
+
+
+//we select two worker nodes to update
+I0116 23:02:16.349909       1 node_controller.go:1360] Selected node ip-10-0-20-116.ec2.internal for update (current selection count: 1)
+I0116 23:02:16.349913       1 node_controller.go:1360] Selected node ip-10-0-38-37.ec2.internal for update (current selection count: 2)
+
+
+// we have a capacity of 2 to update. maxUnavailable is set to 2
+I0116 23:02:16.349918       1 node_controller.go:1364] Final list of nodes to update in pool worker: 2 nodes (capacity: 2)
+I0116 23:02:16.350121       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+
+//still seeing as available but two have already been selected
+I0116 23:02:16.350176       1 status.go:524] Node ip-10-0-79-21.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.350188       1 status.go:524] Node ip-10-0-10-88.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.350193       1 status.go:524] Node ip-10-0-52-14.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.350196       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+//maxUnavailable is 1? why? 
+I0116 23:02:16.350200       1 node_controller.go:1222] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0116 23:02:16.350203       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines) //this means we have 1 left to take in 
+I0116 23:02:16.350210       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+
+//starting to work on the selected nodes
+I0116 23:02:16.359576       1 node_controller.go:1171] updateCandidateNode: node=ip-10-0-20-116.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0116 23:02:16.375611       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0116 23:02:16.385478       1 node_controller.go:1171] updateCandidateNode: node=ip-10-0-38-37.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0116 23:02:16.406127       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"282101", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 2 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:02:16.408641       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+
+//nodes still reporting as available, although node=ip-10-0-20-116.ec2.internal and node=ip-10-0-38-37.ec2.internal are getting worked on
+I0116 23:02:16.551858       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:16.551882       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.551887       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.551890       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:16.551894       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+// we change the annotation for ip-10-0-20-116.ec2.internal, this should be considered unavailable now
+I0116 23:02:17.784464       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0116 23:02:21.402366       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+
+// we have one node unavailable, and node=ip-10-0-38-37.ec2.internal is technically unavailable bc its already been selected
+I0116 23:02:21.436567       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:21.436678       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:21.436714       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:21.436724       1 status.go:495] Node ip-10-0-20-116.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:02:21.436729       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:21.436734       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+
+//maxUnavailable is still 2 and 1 in unavail
+I0116 23:02:21.436739       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines) -true
+
+//that means we have capacity for 1 more, althgouh we already have the nodes selected
+I0116 23:02:21.436743       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines) 
+
+//we hit this log below because length of nodes == capacity, so we dont select another candidate node. is this correct?
+I0116 23:02:21.436753       1 node_controller.go:1235] Already picked 1 nodes, capacity is 1, stopping (getAllCandidateMachines)
+I0116 23:02:21.436759       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:02:21.436769       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+
+I0116 23:02:21.436577       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+
+// ip-10-0-38-37.ec2.internal is technically unavailable but it isnt working yet, so we see it as available
+I0116 23:02:21.436817       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:21.436924       1 status.go:495] Node ip-10-0-20-116.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:02:21.436936       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:21.436954       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:21.436960       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:21.436964       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+
+//we hit this log because uint(len(nodesToUpdate)+unavailableCount) >= capacity. this is correct i believe.
+I0116 23:02:21.436970       1 node_controller.go:1356] Reached capacity limit (1 nodes), stopping selection
+I0116 23:02:21.436975       1 node_controller.go:1364] Final list of nodes to update in pool worker: 0 nodes (capacity: 1)
+I0116 23:02:21.482029       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"285417", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:02:21.493288       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0116 23:02:21.582457       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:21.582482       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:21.582487       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:21.582492       1 status.go:495] Node ip-10-0-20-116.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:02:21.582496       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:21.582501       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+
+E0116 23:02:21.713687       1 render_controller.go:445] Error syncing Generated MCFG: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+E0116 23:02:21.720585       1 render_controller.go:467] Error updating MachineConfigPool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0116 23:02:21.720608       1 render_controller.go:382] Error syncing machineconfigpool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0116 23:02:22.885141       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: cordoning
+I0116 23:02:22.885163       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: initiating cordon (currently schedulable: true)
+I0116 23:02:22.909785       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: cordon succeeded (currently schedulable: false)
+I0116 23:02:22.924874       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:02:22.939850       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: initiating drain
+E0116 23:02:24.000642       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-z4jzd, openshift-cluster-node-tuning-operator/tuned-xnxg6, openshift-dns/dns-default-v68j6, openshift-dns/node-resolver-vfl7g, openshift-image-registry/node-ca-nlskm, openshift-ingress-canary/ingress-canary-qfphk, openshift-insights/insights-runtime-extractor-7qcjl, openshift-machine-config-operator/machine-config-daemon-7dfbq, openshift-monitoring/node-exporter-6rt4m, openshift-multus/multus-additional-cni-plugins-4pb9t, openshift-multus/multus-nmrtv, openshift-multus/network-metrics-daemon-sh2xm, openshift-network-diagnostics/network-check-target-l8gpd, openshift-network-operator/iptables-alerter-l9vg5, openshift-ovn-kubernetes/ovnkube-node-h6qnt
+I0116 23:02:24.003210       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-cxdvf
+I0116 23:02:24.003629       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7948b5c55b-zzlkw
+I0116 23:02:24.003804       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0116 23:02:24.003957       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-xjzwk
+I0116 23:02:24.004204       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-79b754d856-wjrq6
+I0116 23:02:24.004389       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0116 23:02:24.004637       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-5mscf
+I0116 23:02:24.004823       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-qb5k2
+I0116 23:02:24.007824       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-jrpsm
+I0116 23:02:26.073966       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-cxdvf
+I0116 23:02:26.409800       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:26.409825       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:02:26.409830       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:26.409835       1 status.go:495] Node ip-10-0-38-37.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:02:26.409839       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:26.409844       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:26.409848       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 23:02:26.448167       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-5mscf
+I0116 23:02:26.510229       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:26.510253       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:02:26.510258       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:26.510265       1 status.go:495] Node ip-10-0-38-37.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:02:26.510269       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:26.510274       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:26.510278       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 23:02:26.619464       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: cordoning
+I0116 23:02:26.619483       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: initiating cordon (currently schedulable: true)
+I0116 23:02:26.653167       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-79b754d856-wjrq6
+I0116 23:02:26.850322       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0116 23:02:27.244665       1 request.go:700] Waited for 1.098376159s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-7d74fd7b76-jrpsm
+I0116 23:02:27.448816       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-598785cd5d-qb5k2
+I0116 23:02:27.697208       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:02:27.851536       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0116 23:02:28.449326       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: cordon succeeded (currently schedulable: false)
+I0116 23:02:28.469518       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: initiating drain
+E0116 23:02:30.091281       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-k6rfd, openshift-cluster-node-tuning-operator/tuned-lnw4r, openshift-dns/dns-default-hsbwr, openshift-dns/node-resolver-fmxds, openshift-image-registry/node-ca-bfm99, openshift-ingress-canary/ingress-canary-xzwfm, openshift-insights/insights-runtime-extractor-z4cfx, openshift-machine-config-operator/machine-config-daemon-x8lc6, openshift-monitoring/node-exporter-gfj2k, openshift-multus/multus-additional-cni-plugins-tv4gj, openshift-multus/multus-kwp4z, openshift-multus/network-metrics-daemon-dfm64, openshift-network-diagnostics/network-check-target-9cptd, openshift-network-operator/iptables-alerter-zrb5q, openshift-ovn-kubernetes/ovnkube-node-4wrzb
+I0116 23:02:30.093504       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-mj577
+I0116 23:02:30.093551       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-6k2s7
+I0116 23:02:30.093568       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-kczkj
+I0116 23:02:30.093507       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-p49hj
+I0116 23:02:30.093725       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:02:30.093551       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-fz7sg
+I0116 23:02:30.093515       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-79b754d856-qwnc4
+I0116 23:02:30.093524       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-7wdwd
+I0116 23:02:30.093520       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0116 23:02:30.093530       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0116 23:02:30.093533       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7948b5c55b-hdtb6
+I0116 23:02:30.093537       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-9ch4c
+I0116 23:02:30.093544       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-7fcd768d6d-c8f2n
+I0116 23:02:30.093560       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-4plcb
+E0116 23:02:30.104024       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:30.104079       1 drain_controller.go:153] error when evicting pods/"image-registry-7d74fd7b76-mj577" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:30.106645       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:30.106647       1 drain_controller.go:153] error when evicting pods/"thanos-querier-598785cd5d-6k2s7" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:30.107261       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:31.244686       1 request.go:700] Waited for 1.091476019s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/openshift-state-metrics-798f7c49-7wdwd
+I0116 23:02:31.529345       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:31.529368       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:02:31.529375       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:31.529381       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:31.529385       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:02:31.529389       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:31.529393       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 23:02:31.630063       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:02:31.630094       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:02:31.630100       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:31.630106       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:02:31.630110       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:02:31.630114       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:02:31.630118       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+
+I0116 23:02:32.443934       1 request.go:700] Waited for 1.29763005s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-5f97875cc6-xjzwk
+I0116 23:02:32.850717       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-p49hj
+I0116 23:02:33.253870       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-kczkj
+I0116 23:02:33.444625       1 request.go:700] Waited for 1.364597134s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/monitoring-plugin-79b754d856-qwnc4
+I0116 23:02:33.450963       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-79b754d856-qwnc4
+I0116 23:02:33.648063       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-7wdwd
+I0116 23:02:34.048759       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-9ch4c
+I0116 23:02:34.251460       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-7fcd768d6d-c8f2n
+I0116 23:02:34.444782       1 request.go:700] Waited for 1.394700911s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-4plcb
+I0116 23:02:34.449328       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-4plcb
+I0116 23:02:35.104714       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-mj577
+I0116 23:02:35.104727       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:02:35.106846       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-6k2s7
+I0116 23:02:35.106856       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0116 23:02:35.107941       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:02:35.113818       1 drain_controller.go:153] error when evicting pods/"image-registry-7d74fd7b76-mj577" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:35.115633       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:35.116669       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:35.117878       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:35.248796       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-fz7sg
+I0116 23:02:36.244838       1 request.go:700] Waited for 1.098269036s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-5f97875cc6-xjzwk
+I0116 23:02:37.248438       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-598785cd5d-6k2s7
+I0116 23:02:40.114041       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-mj577
+I0116 23:02:40.116173       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:02:40.117234       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0116 23:02:40.118312       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:02:40.129691       1 drain_controller.go:153] error when evicting pods/"image-registry-7d74fd7b76-mj577" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:40.227090       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:40.227187       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:40.227311       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:45.135010       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-mj577
+I0116 23:02:45.231289       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:02:45.234239       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0116 23:02:45.234741       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0116 23:02:45.258846       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:45.292626       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:45.292833       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:50.275483       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+E0116 23:02:50.284884       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:50.292910       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0116 23:02:50.292918       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0116 23:02:50.301116       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:50.301116       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:51.150359       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-image-registry/image-registry-7d74fd7b76-jrpsm
+I0116 23:02:55.285230       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+E0116 23:02:55.294402       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:02:55.301566       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0116 23:02:55.301577       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0116 23:02:55.405204       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0116 23:02:55.405358       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:00.294500       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+E0116 23:03:00.303347       1 drain_controller.go:153] error when evicting pods/"metrics-server-5f97875cc6-t2hgz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:00.405394       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0116 23:03:00.405400       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0116 23:03:00.414734       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:03.518170       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-0
+I0116 23:03:05.303571       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:03:05.415539       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:03:05.427788       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:10.428214       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:03:10.438127       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:12.302359       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-image-registry/image-registry-7d74fd7b76-mj577
+I0116 23:03:15.438545       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:03:15.448763       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:20.449641       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:03:20.458853       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:25.459411       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0116 23:03:25.468177       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0116 23:03:30.468375       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0116 23:03:33.520687       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0116 23:03:41.122197       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-ingress/router-default-7948b5c55b-zzlkw
+I0116 23:03:47.455921       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-ingress/router-default-7948b5c55b-hdtb6
+I0116 23:03:54.151462       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-5f97875cc6-xjzwk" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0116 23:04:00.348509       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-5f97875cc6-t2hgz" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0116 23:04:54.153955       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042012257183055554 hours
+I0116 23:04:54.153981       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: initiating drain
+E0116 23:04:55.200294       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-z4jzd, openshift-cluster-node-tuning-operator/tuned-xnxg6, openshift-dns/dns-default-v68j6, openshift-dns/node-resolver-vfl7g, openshift-image-registry/node-ca-nlskm, openshift-ingress-canary/ingress-canary-qfphk, openshift-insights/insights-runtime-extractor-7qcjl, openshift-machine-config-operator/machine-config-daemon-7dfbq, openshift-monitoring/node-exporter-6rt4m, openshift-multus/multus-additional-cni-plugins-4pb9t, openshift-multus/multus-nmrtv, openshift-multus/network-metrics-daemon-sh2xm, openshift-network-diagnostics/network-check-target-l8gpd, openshift-network-operator/iptables-alerter-l9vg5, openshift-ovn-kubernetes/ovnkube-node-h6qnt
+I0116 23:04:55.202511       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-xjzwk
+I0116 23:04:56.222064       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: Evicted pod openshift-monitoring/metrics-server-5f97875cc6-xjzwk
+I0116 23:04:56.240903       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: operation successful; applying completion annotation
+I0116 23:05:00.348737       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042194272384444446 hours
+I0116 23:05:00.348761       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: initiating drain
+E0116 23:05:01.480186       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-k6rfd, openshift-cluster-node-tuning-operator/tuned-lnw4r, openshift-dns/dns-default-hsbwr, openshift-dns/node-resolver-fmxds, openshift-image-registry/node-ca-bfm99, openshift-ingress-canary/ingress-canary-xzwfm, openshift-insights/insights-runtime-extractor-z4cfx, openshift-machine-config-operator/machine-config-daemon-x8lc6, openshift-monitoring/node-exporter-gfj2k, openshift-multus/multus-additional-cni-plugins-tv4gj, openshift-multus/multus-kwp4z, openshift-multus/network-metrics-daemon-dfm64, openshift-network-diagnostics/network-check-target-9cptd, openshift-network-operator/iptables-alerter-zrb5q, openshift-ovn-kubernetes/ovnkube-node-4wrzb
+I0116 23:05:01.482441       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:05:37.503878       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: Evicted pod openshift-monitoring/metrics-server-5f97875cc6-t2hgz
+I0116 23:05:37.523202       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: operation successful; applying completion annotation
+I0116 23:06:35.154613       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: Reporting unready: node ip-10-0-20-116.ec2.internal is reporting OutOfDisk=Unknown
+I0116 23:06:35.182437       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:06:40.162165       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:06:40.162191       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:06:40.162196       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:40.162201       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:06:40.162205       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:40.162211       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:06:40.162215       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:06:40.182556       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:06:40.182579       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:06:40.182589       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:06:40.182593       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:40.182598       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:06:40.182601       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:40.182605       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:06:40.593198       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:06:45.600526       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:06:45.600549       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:06:45.600554       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:45.600558       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:06:45.600562       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:45.600567       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:06:45.600572       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:06:45.620231       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:06:45.620256       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:06:45.620262       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:45.620266       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:06:45.620270       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:06:45.620275       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:06:45.620280       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:09.376974       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: Reporting unready: node ip-10-0-20-116.ec2.internal is reporting NotReady=False
+I0116 23:07:09.401982       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:09.421200       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:10.580250       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:10.616919       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:14.384803       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:14.384825       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:14.384834       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:07:14.384838       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:14.384843       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:14.384846       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:14.384853       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:14.404838       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:14.404858       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:14.404866       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:07:14.404870       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:14.404875       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:14.404878       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:14.404882       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:20.640112       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: Reporting unready: node ip-10-0-38-37.ec2.internal is reporting OutOfDisk=Unknown
+I0116 23:07:20.673176       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:07:23.344398       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: Reporting unready: node ip-10-0-20-116.ec2.internal is reporting Unschedulable
+I0116 23:07:23.373860       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:25.645736       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:25.645759       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:07:25.645763       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:25.645771       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:25.645774       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:25.645780       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:25.645784       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:25.748361       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:25.748385       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:07:25.748390       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:25.748397       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:25.748400       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:25.748406       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:25.748411       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:26.062090       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:26.098626       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:07:31.067445       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:31.067467       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:07:31.067472       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:31.067479       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:31.067483       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:31.067488       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:31.067493       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:31.086755       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:31.086775       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:31.086784       1 status.go:490] [isNodeUnavailable] Node ip-10-0-20-116.ec2.internal is NOT ready => unavailable
+I0116 23:07:31.086787       1 status.go:521] Node ip-10-0-20-116.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:31.086794       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:31.086797       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:31.086801       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0116 23:07:32.889809       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: uncordoning
+I0116 23:07:32.889843       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: initiating uncordon (currently schedulable: false)
+I0116 23:07:32.913175       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0116 23:07:32.927287       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed taints
+I0116 23:07:32.935481       1 drain_controller.go:183] node ip-10-0-20-116.ec2.internal: operation successful; applying completion annotation
+I0116 23:07:37.913242       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0116 23:07:37.913263       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-20-116.ec2.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0116 23:07:37.938269       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:37.938291       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:37.938298       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:37.938305       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:37.938309       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:37.938314       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:37.938319       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:07:37.938322       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:07:37.938330       1 node_controller.go:1235] Already picked 1 nodes, capacity is 1, stopping
+I0116 23:07:37.938336       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:07:37.938346       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0116 23:07:37.938375       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:37.938386       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:37.938391       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:37.938394       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:37.938398       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:37.938402       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:37.938407       1 node_controller.go:1356] Reached capacity limit (1 nodes), stopping selection
+I0116 23:07:37.938412       1 node_controller.go:1364] Final list of nodes to update in pool worker: 0 nodes (capacity: 1)
+I0116 23:07:37.943467       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"285863", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:07:38.038738       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:38.038759       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:38.038768       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:38.038771       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:38.038776       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:38.038780       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:43.056287       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:43.056311       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:43.056321       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:43.056325       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:43.056330       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:43.056334       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:43.056339       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:07:43.056342       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:07:43.056351       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:07:43.056361       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0116 23:07:43.056394       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:43.056400       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:43.056404       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:43.056407       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:43.056411       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:43.056414       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:43.056421       1 node_controller.go:1356] Reached capacity limit (1 nodes), stopping selection
+I0116 23:07:43.056426       1 node_controller.go:1364] Final list of nodes to update in pool worker: 0 nodes (capacity: 1)
+I0116 23:07:43.061101       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"290182", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:07:43.156607       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:43.156645       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:43.156654       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:43.156658       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:43.156665       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:43.156668       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:53.604576       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: Reporting unready: node ip-10-0-38-37.ec2.internal is reporting NotReady=False
+I0116 23:07:53.625593       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:07:53.648741       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:07:56.090448       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:07:56.114301       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:07:58.611320       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:58.611342       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:58.611352       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:58.611356       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:58.611361       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:58.611365       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:58.611371       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:07:58.611374       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:07:58.611383       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:07:58.611395       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0116 23:07:58.611429       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:58.611438       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:58.611442       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:58.611446       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:58.611449       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:58.611453       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:07:58.611458       1 node_controller.go:1356] Reached capacity limit (1 nodes), stopping selection
+I0116 23:07:58.611462       1 node_controller.go:1364] Final list of nodes to update in pool worker: 0 nodes (capacity: 1)
+I0116 23:07:58.615381       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"290182", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:07:58.712190       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:07:58.712213       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:58.712223       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:07:58.712227       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:07:58.712231       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:07:58.712235       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:08:07.572676       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: Reporting unready: node ip-10-0-38-37.ec2.internal is reporting Unschedulable
+I0116 23:08:07.598106       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:08:11.133841       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:08:12.578414       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:12.578440       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:12.578447       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:08:12.578451       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:12.578456       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:12.578460       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:08:12.578464       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:08:12.578468       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:08:12.578476       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:08:12.578486       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0116 23:08:12.578516       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:12.578521       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:12.578525       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:08:12.578528       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:12.578532       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:12.578537       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:08:12.578541       1 node_controller.go:1356] Reached capacity limit (1 nodes), stopping selection
+I0116 23:08:12.578546       1 node_controller.go:1364] Final list of nodes to update in pool worker: 0 nodes (capacity: 1)
+I0116 23:08:12.585258       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"290182", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:08:12.685008       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:12.685032       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:12.685038       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:12.685043       1 status.go:490] [isNodeUnavailable] Node ip-10-0-38-37.ec2.internal is NOT ready => unavailable
+I0116 23:08:12.685047       1 status.go:521] Node ip-10-0-38-37.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:12.685052       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+
+I0116 23:08:16.718835       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: uncordoning
+I0116 23:08:16.718969       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: initiating uncordon (currently schedulable: false)
+I0116 23:08:16.745157       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0116 23:08:16.755900       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed taints
+I0116 23:08:16.767619       1 drain_controller.go:183] node ip-10-0-38-37.ec2.internal: operation successful; applying completion annotation
+I0116 23:08:21.745373       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0116 23:08:21.745395       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-38-37.ec2.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0116 23:08:21.761128       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:21.761148       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.761163       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.761168       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.761172       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 23:08:21.761177       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 23:08:21.761181       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 23:08:21.761190       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 23:08:21.761200       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0116 23:08:21.761246       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:21.761253       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.761256       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.761259       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.761265       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+I0116 23:08:21.761270       1 node_controller.go:1360] Selected node ip-10-0-71-35.ec2.internal for update (current selection count: 1)
+I0116 23:08:21.761275       1 node_controller.go:1364] Final list of nodes to update in pool worker: 1 nodes (capacity: 2)
+I0116 23:08:21.867433       1 node_controller.go:1171] updateCandidateNode: node=ip-10-0-71-35.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0116 23:08:21.882645       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"42f5e1cf-2bf4-4cf4-919c-6216c6f18147", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"290182", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Targeted node ip-10-0-71-35.ec2.internal to MachineConfig: rendered-worker-434aacb1aa045f6b020f0110fc5f057a
+I0116 23:08:21.883055       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0116 23:08:21.962142       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:21.962165       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.962170       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.962173       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:21.962177       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0116 23:08:23.437179       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0116 23:08:26.909241       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:26.909271       1 status.go:495] Node ip-10-0-71-35.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:08:26.909277       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:26.909283       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:26.909287       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:26.909291       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:08:26.909295       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:08:26.909299       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:08:26.909307       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:08:26.911191       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:08:26.989234       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:26.989254       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:26.989261       1 status.go:495] Node ip-10-0-71-35.ec2.internal is unavailable: node is in MCD state=Working
+I0116 23:08:26.989265       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:26.989269       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:26.989273       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+E0116 23:08:27.111657       1 render_controller.go:445] Error syncing Generated MCFG: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+E0116 23:08:27.118063       1 render_controller.go:467] Error updating MachineConfigPool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0116 23:08:27.118087       1 render_controller.go:382] Error syncing machineconfigpool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0116 23:08:28.547067       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: cordoning
+I0116 23:08:28.547089       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: initiating cordon (currently schedulable: true)
+I0116 23:08:28.566832       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: cordon succeeded (currently schedulable: false)
+I0116 23:08:28.587588       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:08:28.590904       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: initiating drain
+E0116 23:08:29.657972       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-clgqb, openshift-cluster-node-tuning-operator/tuned-9vjmq, openshift-dns/dns-default-b7dmz, openshift-dns/node-resolver-w4fs8, openshift-image-registry/node-ca-27xb5, openshift-ingress-canary/ingress-canary-sv75g, openshift-insights/insights-runtime-extractor-vs5jr, openshift-machine-config-operator/machine-config-daemon-4v9st, openshift-monitoring/node-exporter-p8sks, openshift-multus/multus-additional-cni-plugins-prd6l, openshift-multus/multus-h8m2r, openshift-multus/network-metrics-daemon-8lbsj, openshift-network-diagnostics/network-check-target-vjknt, openshift-network-operator/iptables-alerter-k2vpm, openshift-ovn-kubernetes/ovnkube-node-w9f4l
+I0116 23:08:29.660514       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28951140-nkll8
+I0116 23:08:29.660755       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-7d74fd7b76-5vkc9
+I0116 23:08:29.660942       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7948b5c55b-6rkdp
+I0116 23:08:29.661070       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0116 23:08:29.661170       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-stqpb
+I0116 23:08:29.661304       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-v4kw9
+I0116 23:08:29.661390       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-79b754d856-k4sgd
+I0116 23:08:29.661552       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-4bwxk
+I0116 23:08:29.661679       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0116 23:08:29.661783       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-s6jtv
+I0116 23:08:29.661888       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-7fcd768d6d-swsfp
+I0116 23:08:29.661921       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-598785cd5d-2zslm
+I0116 23:08:29.661949       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-bqhkr
+I0116 23:08:29.661977       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-dmrsn
+I0116 23:08:29.662000       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-v7sz6
+I0116 23:08:29.761089       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28951140-nkll8
+I0116 23:08:31.918498       1 request.go:700] Waited for 1.056533413s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-1
+I0116 23:08:31.919671       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:31.919692       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:31.919698       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:31.919703       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:08:31.919706       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:31.919713       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:08:31.919719       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:08:31.919723       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:08:31.919731       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:08:31.939098       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:08:31.939115       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:31.939122       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:08:31.939125       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:08:31.939130       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:08:31.939134       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:08:33.118733       1 request.go:700] Waited for 1.628942554s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-bqhkr
+I0116 23:08:33.123134       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-bqhkr
+I0116 23:08:33.335654       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-dmrsn
+I0116 23:08:33.522209       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-4bwxk
+I0116 23:08:33.722740       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-stqpb
+I0116 23:08:34.118918       1 request.go:700] Waited for 2.292590735s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-7d74fd7b76-5vkc9
+I0116 23:08:34.522517       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-v7sz6
+I0116 23:08:34.724993       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0116 23:08:34.924467       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0116 23:08:35.324615       1 request.go:700] Waited for 2.396161471s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/monitoring-plugin-79b754d856-k4sgd
+I0116 23:08:35.522899       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-7fcd768d6d-swsfp
+I0116 23:08:35.722342       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-598785cd5d-2zslm
+I0116 23:08:56.922868       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-image-registry/image-registry-7d74fd7b76-5vkc9
+I0116 23:09:02.923647       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-s6jtv
+I0116 23:09:02.931609       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-79b754d856-k4sgd
+I0116 23:09:47.831143       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-ingress/router-default-7948b5c55b-6rkdp
+I0116 23:09:59.849419       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-5f97875cc6-v4kw9" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0116 23:10:59.851496       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04202350728083333 hours
+I0116 23:10:59.851519       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: initiating drain
+E0116 23:11:00.897802       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-clgqb, openshift-cluster-node-tuning-operator/tuned-9vjmq, openshift-dns/dns-default-b7dmz, openshift-dns/node-resolver-w4fs8, openshift-image-registry/node-ca-27xb5, openshift-ingress-canary/ingress-canary-sv75g, openshift-insights/insights-runtime-extractor-vs5jr, openshift-machine-config-operator/machine-config-daemon-4v9st, openshift-monitoring/node-exporter-p8sks, openshift-multus/multus-additional-cni-plugins-prd6l, openshift-multus/multus-h8m2r, openshift-multus/network-metrics-daemon-8lbsj, openshift-network-diagnostics/network-check-target-vjknt, openshift-network-operator/iptables-alerter-k2vpm, openshift-ovn-kubernetes/ovnkube-node-w9f4l
+I0116 23:11:00.899904       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5f97875cc6-v4kw9
+I0116 23:11:01.920004       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: Evicted pod openshift-monitoring/metrics-server-5f97875cc6-v4kw9
+I0116 23:11:01.939421       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: operation successful; applying completion annotation
+I0116 23:12:21.194242       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: Reporting unready: node ip-10-0-71-35.ec2.internal is reporting OutOfDisk=Unknown
+I0116 23:12:21.222922       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:12:26.199321       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:12:26.199344       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:26.199350       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:26.199358       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:12:26.199362       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:12:26.199366       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:12:26.199372       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:12:26.199375       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:12:26.199383       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:12:26.218511       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:12:26.218531       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:26.218536       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:26.218543       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:12:26.218547       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:12:26.218552       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:12:26.860407       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:12:31.865653       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:12:31.865677       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:31.865684       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:31.865691       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:12:31.865695       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:12:31.865699       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:12:31.865704       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:12:31.865708       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:12:31.865719       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:12:31.885579       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:12:31.885600       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:31.885605       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:12:31.885613       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:12:31.885617       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:12:31.885622       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:12:57.609492       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: Reporting unready: node ip-10-0-71-35.ec2.internal is reporting NotReady=False
+I0116 23:12:57.631128       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:12:57.655334       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:13:01.800460       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:13:01.821461       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:13:02.614939       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:02.614961       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:02.614967       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:02.614975       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:13:02.614978       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:13:02.614983       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:13:02.614988       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:13:02.614992       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:13:02.615000       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:13:02.633842       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:02.633860       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:02.633868       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:13:02.633872       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:13:02.633877       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:02.633881       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:13:15.447156       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: Reporting unready: node ip-10-0-71-35.ec2.internal is reporting Unschedulable
+I0116 23:13:15.472270       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:13:16.841320       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:13:20.454294       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:20.454317       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:20.454323       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:20.454329       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:13:20.454333       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:13:20.454337       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:13:20.454344       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0116 23:13:20.454347       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0116 23:13:20.454356       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0116 23:13:20.474512       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:20.474626       1 status.go:490] [isNodeUnavailable] Node ip-10-0-71-35.ec2.internal is NOT ready => unavailable
+I0116 23:13:20.474655       1 status.go:521] Node ip-10-0-71-35.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0116 23:13:20.474702       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:20.474713       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:20.474719       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0116 23:13:21.254035       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: uncordoning
+I0116 23:13:21.254100       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: initiating uncordon (currently schedulable: false)
+I0116 23:13:21.283663       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0116 23:13:21.301847       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed taints
+I0116 23:13:21.317087       1 drain_controller.go:183] node ip-10-0-71-35.ec2.internal: operation successful; applying completion annotation
+I0116 23:13:26.277662       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0116 23:13:26.277779       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-71-35.ec2.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0116 23:13:26.309074       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:26.309096       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:26.309103       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:26.309107       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:26.309111       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0116 23:13:26.309118       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 23:13:26.309123       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 23:13:26.309130       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 23:13:26.410051       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:26.410075       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:26.410080       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:26.410085       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:26.410089       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0116 23:13:31.433403       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:31.433429       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:31.433435       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:31.433439       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:31.433443       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0116 23:13:31.433448       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0116 23:13:31.433452       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0116 23:13:31.433460       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0116 23:13:31.452827       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0116 23:13:31.452845       1 status.go:524] Node ip-10-0-20-116.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:31.452851       1 status.go:524] Node ip-10-0-38-37.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:31.452854       1 status.go:524] Node ip-10-0-71-35.ec2.internal is available (getUnavailableMachines)
+I0116 23:13:31.452858       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+^C
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// bug produced here
+I0117 15:00:02.733774       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:05:59.791402       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:05:59.791420       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.791425       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.791427       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.791430       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:05:59.791434       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:05:59.791437       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:05:59.791442       1 node_controller.go:1283] Pool worker: selected candidate node ip-10-0-16-187.us-east-2.compute.internal
+I0117 15:05:59.791445       1 node_controller.go:1283] Pool worker: selected candidate node ip-10-0-45-63.us-east-2.compute.internal
+I0117 15:05:59.791450       1 node_controller.go:1260] Already picked 2 nodes, capacity is 2, stopping
+I0117 15:05:59.791454       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:05:59.791464       1 node_controller.go:1101] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+I0117 15:05:59.791485       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:05:59.791488       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.791490       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.791493       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.791496       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:05:59.791499       1 node_controller.go:1376] Selected node ip-10-0-16-187.us-east-2.compute.internal for update (current selection count: 1) [updateCandidateMachines]
+I0117 15:05:59.791501       1 node_controller.go:1376] Selected node ip-10-0-45-63.us-east-2.compute.internal for update (current selection count: 2) [updateCandidateMachines]
+I0117 15:05:59.791504       1 node_controller.go:1380] Final list of nodes to update in pool worker: 2 nodes (capacity: 2) [updateCandidateMachines]
+I0117 15:05:59.796575       1 node_controller.go:1196] updateCandidateNode: node=ip-10-0-16-187.us-east-2.compute.internal, pool=worker, layered=false, mosbIsNil=true
+I0117 15:05:59.811113       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0117 15:05:59.816127       1 node_controller.go:1196] updateCandidateNode: node=ip-10-0-45-63.us-east-2.compute.internal, pool=worker, layered=false, mosbIsNil=true
+I0117 15:05:59.834608       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0117 15:05:59.834642       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"12ff33dc-d252-4a32-913d-cef3f1eb5939", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"87635", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 2 nodes to MachineConfig: rendered-worker-3ebfedddbb0d76662ed6f5488fade623
+I0117 15:05:59.891882       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:05:59.891898       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.891905       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.891908       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:05:59.891913       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:06:04.833333       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:06:04.848522       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:04.848594       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:04.848616       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:04.848632       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:04.848646       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:06:04.848661       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:06:04.848676       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:06:04.848693       1 node_controller.go:1283] Pool worker: selected candidate node ip-10-0-77-37.us-east-2.compute.internal
+I0117 15:06:04.848749       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:06:04.848774       1 node_controller.go:1101] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0117 15:06:04.848852       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:04.848882       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:04.848909       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:04.848924       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:04.848929       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:06:04.848935       1 node_controller.go:1376] Selected node ip-10-0-77-37.us-east-2.compute.internal for update (current selection count: 1) [updateCandidateMachines]
+I0117 15:06:04.848940       1 node_controller.go:1380] Final list of nodes to update in pool worker: 1 nodes (capacity: 2) [updateCandidateMachines]
+I0117 15:06:04.853072       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:06:04.920582       1 node_controller.go:1196] updateCandidateNode: node=ip-10-0-77-37.us-east-2.compute.internal, pool=worker, layered=false, mosbIsNil=true
+I0117 15:06:04.941801       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"12ff33dc-d252-4a32-913d-cef3f1eb5939", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"180363", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Targeted node ip-10-0-77-37.us-east-2.compute.internal to MachineConfig: rendered-worker-3ebfedddbb0d76662ed6f5488fade623
+I0117 15:06:04.958097       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0117 15:06:05.016137       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:05.016159       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:05.016164       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:05.016168       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:05.016173       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:06:09.851852       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:06:09.851856       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:09.851900       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:09.851905       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:09.851908       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:09.851913       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:06:09.851918       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:06:09.851922       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:06:09.851932       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:06:09.927925       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0117 15:06:09.937442       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:09.937472       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:09.937479       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:09.937482       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:06:09.937486       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:06:10.863037       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0117 15:06:13.058820       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0117 15:06:14.854483       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:14.854502       1 status.go:495] Node ip-10-0-45-63.us-east-2.compute.internal is unavailable: node is in MCD state=Working
+I0117 15:06:14.854507       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:14.854520       1 status.go:495] Node ip-10-0-77-37.us-east-2.compute.internal is unavailable: node is in MCD state=Working
+I0117 15:06:14.854525       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:14.854529       1 status.go:495] Node ip-10-0-16-187.us-east-2.compute.internal is unavailable: node is in MCD state=Working
+I0117 15:06:14.854532       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:14.854535       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:06:14.866744       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:14.866805       1 status.go:495] Node ip-10-0-16-187.us-east-2.compute.internal is unavailable: node is in MCD state=Working
+I0117 15:06:14.866815       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:14.866820       1 status.go:495] Node ip-10-0-45-63.us-east-2.compute.internal is unavailable: node is in MCD state=Working
+I0117 15:06:14.866824       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:14.866828       1 status.go:495] Node ip-10-0-77-37.us-east-2.compute.internal is unavailable: node is in MCD state=Working
+I0117 15:06:14.866832       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:14.866837       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:06:14.998595       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: cordoning
+I0117 15:06:14.998614       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: initiating cordon (currently schedulable: true)
+I0117 15:06:15.014888       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: cordon succeeded (currently schedulable: false)
+I0117 15:06:15.034570       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: initiating drain
+I0117 15:06:15.050064       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:06:15.928680       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: cordoning
+I0117 15:06:15.928722       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: initiating cordon (currently schedulable: true)
+I0117 15:06:15.946903       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: cordon succeeded (currently schedulable: false)
+I0117 15:06:15.961977       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:06:15.966952       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: initiating drain
+E0117 15:06:16.082265       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-dfs2b, openshift-cluster-node-tuning-operator/tuned-txfwd, openshift-dns/dns-default-zxk44, openshift-dns/node-resolver-lg2lz, openshift-image-registry/node-ca-zscp8, openshift-ingress-canary/ingress-canary-dtl8k, openshift-insights/insights-runtime-extractor-mk2nd, openshift-machine-config-operator/machine-config-daemon-56sp5, openshift-monitoring/node-exporter-pzktg, openshift-multus/multus-additional-cni-plugins-twtrj, openshift-multus/multus-gclpw, openshift-multus/network-metrics-daemon-tqpnc, openshift-network-diagnostics/network-check-target-glpk7, openshift-network-operator/iptables-alerter-g92nw, openshift-ovn-kubernetes/ovnkube-node-khntv
+I0117 15:06:16.083532       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-66988754c4-whs6c
+I0117 15:06:16.083628       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-b7gfh
+I0117 15:06:16.083647       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-58fb6b8db4-vbwqk
+I0117 15:06:16.083668       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-5b9566f87f-rrkhx
+I0117 15:06:16.083650       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-cq76l
+I0117 15:06:16.083679       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-sqjcg
+I0117 15:06:16.083682       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-677949bf88-rv4hz
+I0117 15:06:16.083617       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-vwph9
+I0117 15:06:16.083657       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0117 15:06:16.083690       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-5fbffbc45b-kpkkr
+I0117 15:06:16.083661       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0117 15:06:16.083671       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-qmfd6
+I0117 15:06:16.083599       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-94mzk
+I0117 15:06:17.531920       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-network-console/networking-console-plugin-677949bf88-rv4hz
+I0117 15:06:17.737915       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-network-diagnostics/network-check-source-66988754c4-whs6c
+I0117 15:06:17.931745       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/monitoring-plugin-778bd7ffd6-94mzk
+I0117 15:06:18.127315       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: cordoning
+I0117 15:06:18.127391       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: initiating cordon (currently schedulable: true)
+I0117 15:06:18.156795       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/openshift-state-metrics-58fb6b8db4-vbwqk
+I0117 15:06:18.338305       1 request.go:700] Waited for 1.141947075s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/alertmanager-main-1
+I0117 15:06:18.342105       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0117 15:06:18.732668       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/thanos-querier-7f5797d54f-sqjcg
+E0117 15:06:19.084084       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-qsnrx, openshift-cluster-node-tuning-operator/tuned-dkwjx, openshift-dns/dns-default-8bclb, openshift-dns/node-resolver-sp54h, openshift-image-registry/node-ca-td7p9, openshift-ingress-canary/ingress-canary-pcmkv, openshift-insights/insights-runtime-extractor-tbrl4, openshift-machine-config-operator/machine-config-daemon-g8mrk, openshift-monitoring/node-exporter-bkn7c, openshift-multus/multus-additional-cni-plugins-vx67z, openshift-multus/multus-gnt5q, openshift-multus/network-metrics-daemon-9dzq4, openshift-network-diagnostics/network-check-target-btgj5, openshift-network-operator/iptables-alerter-7sxjr, openshift-ovn-kubernetes/ovnkube-node-rp2vp
+I0117 15:06:19.085800       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28952100-dzhgk
+I0117 15:06:19.085867       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28952070-kx2lw
+I0117 15:06:19.085875       1 drain_controller.go:153] evicting pod openshift-marketplace/qe-app-registry-6rzpk
+I0117 15:06:19.085884       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28952085-2hjj7
+I0117 15:06:19.138405       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-cq76l
+I0117 15:06:19.334692       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0117 15:06:19.530345       1 request.go:700] Waited for 1.559514995s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/telemeter-client-5fbffbc45b-kpkkr
+I0117 15:06:19.532354       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/telemeter-client-5fbffbc45b-kpkkr
+I0117 15:06:19.766076       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:06:19.879737       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:19.879757       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:06:19.879761       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:19.879765       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:06:19.879768       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:19.879771       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:06:19.879774       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:19.879778       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:06:19.892006       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:06:19.892019       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:06:19.892023       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:19.892026       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:06:19.892028       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:19.892030       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:06:19.892033       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:06:19.892038       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:06:20.133144       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/kube-state-metrics-5b9566f87f-rrkhx
+I0117 15:06:20.333807       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28952070-kx2lw
+I0117 15:06:20.531821       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28952100-dzhgk
+I0117 15:06:20.731173       1 request.go:700] Waited for 1.605183086s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-operator-lifecycle-manager/pods/collect-profiles-28952085-2hjj7
+I0117 15:06:20.739427       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28952085-2hjj7
+I0117 15:06:20.942527       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: Evicted pod openshift-marketplace/qe-app-registry-6rzpk
+I0117 15:06:21.096892       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: operation successful; applying completion annotation
+I0117 15:06:21.534078       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: cordon succeeded (currently schedulable: false)
+I0117 15:06:21.547559       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: initiating drain
+E0117 15:06:23.555642       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-qgbc7, openshift-cluster-node-tuning-operator/tuned-578ls, openshift-dns/dns-default-v45xq, openshift-dns/node-resolver-fjgvr, openshift-image-registry/node-ca-mm2tw, openshift-ingress-canary/ingress-canary-m4nlm, openshift-insights/insights-runtime-extractor-mbhvl, openshift-machine-config-operator/machine-config-daemon-kks8x, openshift-monitoring/node-exporter-h6ddc, openshift-multus/multus-7vjc5, openshift-multus/multus-additional-cni-plugins-x8x26, openshift-multus/network-metrics-daemon-d97lv, openshift-network-diagnostics/network-check-target-4cnl2, openshift-network-operator/iptables-alerter-54lwt, openshift-ovn-kubernetes/ovnkube-node-f27lk
+I0117 15:06:23.556812       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:23.556822       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:23.556832       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:06:23.556883       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:23.556932       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:23.556977       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:23.557000       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-677949bf88-82mpx
+I0117 15:06:23.557056       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:06:23.557069       1 drain_controller.go:153] evicting pod openshift-insights/periodic-gathering-wpn6z-2pprb
+I0117 15:06:23.556813       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-66988754c4-ttf85
+I0117 15:06:23.557125       1 drain_controller.go:153] evicting pod openshift-insights/periodic-gathering-w96h7-5c7lr
+I0117 15:06:23.557059       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-677949bf88-wszwz
+I0117 15:06:23.556978       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-58fb6b8db4-r9rfs
+I0117 15:06:23.556970       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-5fbffbc45b-6t7wb
+I0117 15:06:23.556970       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+I0117 15:06:23.556990       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-5b9566f87f-6g8fr
+E0117 15:06:23.571872       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:23.572165       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:23.572237       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:23.573535       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:23.574314       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:23.574499       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:23.574533       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:24.132489       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-insights/periodic-gathering-w96h7-5c7lr
+I0117 15:06:24.332015       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-insights/periodic-gathering-wpn6z-2pprb
+E0117 15:06:24.562346       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:24.757691       1 request.go:700] Waited for 1.200320226s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/kube-state-metrics-5b9566f87f-6g8fr/eviction
+I0117 15:06:24.932630       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-network-console/networking-console-plugin-677949bf88-wszwz
+I0117 15:06:25.332098       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/openshift-state-metrics-58fb6b8db4-r9rfs
+I0117 15:06:25.930253       1 request.go:700] Waited for 1.554918311s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/telemeter-client-5fbffbc45b-6t7wb
+I0117 15:06:25.932945       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/telemeter-client-5fbffbc45b-6t7wb
+I0117 15:06:26.132058       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/kube-state-metrics-5b9566f87f-6g8fr
+I0117 15:06:26.531944       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-network-console/networking-console-plugin-677949bf88-82mpx
+I0117 15:06:26.733324       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-network-diagnostics/network-check-source-66988754c4-ttf85
+I0117 15:06:28.578285       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:28.578329       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:28.578352       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:28.578357       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:28.578361       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:06:28.578384       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:06:28.578402       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0117 15:06:28.590452       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:28.590519       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:28.590571       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:28.590760       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:28.591025       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:28.591121       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:28.592374       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:29.563316       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:29.569415       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:33.591260       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:33.591281       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:33.591284       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:33.591343       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:06:33.591265       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:33.591424       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:33.592561       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:06:33.598928       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:33.598985       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:33.599007       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:33.599068       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:33.599117       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:33.599200       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:33.599872       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:34.570321       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:34.577808       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:38.599758       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:38.599782       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:06:38.599805       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:38.599853       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:38.599902       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:38.599924       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:06:38.599951       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+E0117 15:06:38.606608       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:38.606696       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:38.606776       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:38.606945       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:38.607122       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:38.607155       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:38.608138       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:39.578910       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:39.584180       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:43.197861       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-image-registry/image-registry-655fdbb4f5-vwph9
+I0117 15:06:43.607559       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:06:43.607559       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:43.607567       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:43.607570       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:43.607578       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:43.607577       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:43.608336       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:06:43.615413       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:43.615426       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:43.615479       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:43.615482       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:43.615500       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:43.615528       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:43.615578       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:44.584266       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:44.592046       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:48.615789       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:48.615788       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:48.615802       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:48.615811       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:06:48.615814       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:48.615815       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:48.615818       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+E0117 15:06:48.623415       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:48.623530       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:48.623691       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:48.623743       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:48.623752       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:48.623827       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:48.623841       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:49.592830       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:49.599245       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:53.626290       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:53.626332       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:06:53.626340       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:53.626349       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:53.626357       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:53.626362       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:06:53.626371       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+E0117 15:06:53.639298       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:53.639456       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:53.639732       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:53.640726       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:53.640784       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:53.640830       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:53.641313       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:54.600297       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:54.607188       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:58.640735       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:06:58.640747       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:06:58.640781       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:06:58.640830       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:06:58.640880       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:06:58.640891       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:06:58.642450       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+E0117 15:06:58.646975       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:58.647034       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:58.647720       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:58.647996       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:58.648726       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:58.649147       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:06:58.649247       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:06:59.607847       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:06:59.614524       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:03.647262       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:03.647273       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:03.648308       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:03.648660       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:03.648848       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:03.649578       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:03.650290       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:07:03.654578       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:03.654630       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:03.655674       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:03.655674       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:03.655718       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:03.655726       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:03.657062       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:04.615051       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:04.629030       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:06.358423       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-ingress/router-default-8d84dc64-b7gfh
+I0117 15:07:08.654686       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:08.654699       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:08.655774       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:08.655797       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:08.655804       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:08.655811       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:08.658062       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+E0117 15:07:08.662550       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:08.662611       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:08.662659       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:08.662710       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:08.663474       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:08.664386       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:08.664470       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:09.629758       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:09.637781       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:13.663335       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:13.663350       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:13.663405       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:13.663487       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:13.663511       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:13.664904       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:13.664904       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+E0117 15:07:13.670688       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:13.670749       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:13.670751       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:13.670830       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:13.670853       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:13.670866       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:13.671264       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:14.638725       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:14.646767       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:18.671778       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:18.671779       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:18.671785       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:18.671789       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:18.671796       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:18.671797       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:18.671798       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+E0117 15:07:18.682071       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:18.682162       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:18.682182       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:18.682241       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:18.682169       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:18.682310       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:18.682344       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:19.002787       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: Reporting unready: node ip-10-0-16-187.us-east-2.compute.internal is reporting OutOfDisk=Unknown
+I0117 15:07:19.063232       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:07:19.646946       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:19.651856       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:23.682260       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:23.682260       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:23.682275       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:23.682283       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:23.682284       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:23.682396       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:23.682399       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+E0117 15:07:23.689752       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:23.689752       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:23.689809       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:23.689801       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:23.689853       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:23.689899       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:23.690008       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:24.006325       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:07:24.006342       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:24.006345       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:24.006348       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:24.006350       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:24.006353       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:24.006355       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:24.006358       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:07:24.018086       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:07:24.018104       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:24.018110       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:24.018115       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:24.018118       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:24.018122       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:24.018125       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:24.018129       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:07:24.561181       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:07:24.652495       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:24.659405       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:28.690106       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:28.690138       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:28.690106       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:28.690127       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:28.690127       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:28.690132       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:28.690135       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:07:28.699854       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:28.700270       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:28.700370       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:28.700540       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:28.700611       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:28.700679       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:28.700904       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:29.565193       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:07:29.565232       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:29.565236       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:29.565242       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:29.565244       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:29.565248       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:29.565251       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:29.565255       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:07:29.577449       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:07:29.577463       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:29.577467       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:29.577472       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:29.577474       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:29.577477       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:07:29.577479       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:07:29.577482       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:07:29.659506       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:29.665050       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:33.700094       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:33.700412       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:33.700524       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:33.700607       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:33.700672       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:33.700726       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:33.701340       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:07:33.712718       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:33.712729       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:33.712886       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:33.712944       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:33.712947       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:33.712990       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:33.714038       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:34.665817       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:34.672028       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:38.712760       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:38.712771       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:38.712932       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:38.713055       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:38.712967       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:38.712970       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:38.714652       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+E0117 15:07:38.725467       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:38.725549       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:38.725663       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:38.726488       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:38.727098       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:38.727184       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:38.727254       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:39.672322       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:39.679647       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:43.725853       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:43.725857       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:43.725857       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:43.726957       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:43.727278       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:43.727449       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:43.727503       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+E0117 15:07:43.733766       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:43.733766       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:43.733767       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:43.733816       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:43.734758       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:43.734852       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:43.734873       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:44.680323       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:44.687457       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:46.159372       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-77cb6c884d-qmfd6" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0117 15:07:48.735258       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:48.735259       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:48.735268       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:48.735276       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:48.735280       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:48.735285       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:48.735304       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+E0117 15:07:48.742901       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:48.743230       1 drain_controller.go:153] error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:48.743526       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:48.743619       1 drain_controller.go:153] error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:48.743649       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:48.743749       1 drain_controller.go:153] error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:07:48.744070       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:49.688729       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+E0117 15:07:49.707336       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:07:53.743117       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:07:53.744188       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:07:53.744226       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:07:53.744200       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:07:53.744235       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:07:53.744244       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:07:53.744247       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:07:54.707983       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+I0117 15:07:54.708061       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: [error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring": global timeout reached: 1m30s, error when evicting pods/"prometheus-operator-admission-webhook-cd8d687f7-gdsj6" -n "openshift-monitoring": global timeout reached: 1m30s, error when evicting pods/"router-default-8d84dc64-qxj42" -n "openshift-ingress": global timeout reached: 1m30s, error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring": global timeout reached: 1m30s, error when evicting pods/"thanos-querier-7f5797d54f-nh5ll" -n "openshift-monitoring": global timeout reached: 1m30s, error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring": global timeout reached: 1m30s, error when evicting pods/"image-registry-655fdbb4f5-qt2qz" -n "openshift-image-registry": global timeout reached: 1m30s, error when evicting pods/"monitoring-plugin-778bd7ffd6-bhqhw" -n "openshift-monitoring": global timeout reached: 1m30s]
+I0117 15:08:06.171137       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: Reporting unready: node ip-10-0-16-187.us-east-2.compute.internal is reporting NotReady=False
+I0117 15:08:06.191968       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:06.202867       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:09.482714       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:09.502127       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:11.176520       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:11.176541       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:11.176545       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:11.176552       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:11.176556       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:11.176559       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:11.176562       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:11.176566       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:08:11.189157       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:11.189174       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:11.189179       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:11.189183       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:11.189188       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:11.189192       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:11.189195       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:11.189199       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:08:21.857186       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: Reporting unready: node ip-10-0-16-187.us-east-2.compute.internal is reporting Unschedulable
+I0117 15:08:21.872733       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:24.515863       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:26.860932       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:26.860950       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:26.860955       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:26.860959       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:26.860964       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:26.860968       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:26.860972       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:26.860976       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:08:26.873411       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:26.873427       1 status.go:490] [isNodeUnavailable] Node ip-10-0-16-187.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:26.873431       1 status.go:521] Node ip-10-0-16-187.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:26.873436       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:26.873438       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:26.873440       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:26.873442       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:26.873445       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 3
+I0117 15:08:29.694497       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: uncordoning
+I0117 15:08:29.694550       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: initiating uncordon (currently schedulable: false)
+I0117 15:08:29.713577       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: uncordon succeeded (currently schedulable: true)
+I0117 15:08:29.729141       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed taints
+I0117 15:08:29.737811       1 drain_controller.go:183] node ip-10-0-16-187.us-east-2.compute.internal: operation successful; applying completion annotation
+I0117 15:08:34.771345       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0117 15:08:34.771378       1 node_controller.go:584] Pool worker[zone=us-east-2a]: node ip-10-0-16-187.us-east-2.compute.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0117 15:08:34.778458       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:34.778475       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:08:34.778482       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:34.778487       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:34.778491       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:34.778495       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:34.778507       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:08:34.831715       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:34.831733       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:34.831738       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:34.831745       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:34.831763       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:34.831769       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:08:34.831774       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:08:39.775198       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:39.775233       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:39.775238       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:39.775245       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:08:39.775249       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:39.775255       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:39.775261       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:08:39.789910       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:08:39.789925       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:39.789930       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:39.789934       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:08:39.789937       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:08:39.789942       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:08:39.789947       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:08:46.160364       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04198483034916667 hours
+I0117 15:08:46.160391       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: initiating drain
+E0117 15:08:47.190392       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-dfs2b, openshift-cluster-node-tuning-operator/tuned-txfwd, openshift-dns/dns-default-zxk44, openshift-dns/node-resolver-lg2lz, openshift-image-registry/node-ca-zscp8, openshift-ingress-canary/ingress-canary-dtl8k, openshift-insights/insights-runtime-extractor-mk2nd, openshift-machine-config-operator/machine-config-daemon-56sp5, openshift-monitoring/node-exporter-pzktg, openshift-multus/multus-additional-cni-plugins-twtrj, openshift-multus/multus-gclpw, openshift-multus/network-metrics-daemon-tqpnc, openshift-network-diagnostics/network-check-target-glpk7, openshift-network-operator/iptables-alerter-g92nw, openshift-ovn-kubernetes/ovnkube-node-khntv
+I0117 15:08:47.192071       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-qmfd6
+I0117 15:08:49.219989       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: Evicted pod openshift-monitoring/metrics-server-77cb6c884d-qmfd6
+I0117 15:08:49.233967       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: operation successful; applying completion annotation
+I0117 15:08:54.708458       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04254842560416667 hours
+I0117 15:08:54.708494       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: initiating drain
+E0117 15:08:55.742357       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-qgbc7, openshift-cluster-node-tuning-operator/tuned-578ls, openshift-dns/dns-default-v45xq, openshift-dns/node-resolver-fjgvr, openshift-image-registry/node-ca-mm2tw, openshift-ingress-canary/ingress-canary-m4nlm, openshift-insights/insights-runtime-extractor-mbhvl, openshift-machine-config-operator/machine-config-daemon-kks8x, openshift-monitoring/node-exporter-h6ddc, openshift-multus/multus-7vjc5, openshift-multus/multus-additional-cni-plugins-x8x26, openshift-multus/network-metrics-daemon-d97lv, openshift-network-diagnostics/network-check-target-4cnl2, openshift-network-operator/iptables-alerter-54lwt, openshift-ovn-kubernetes/ovnkube-node-f27lk
+I0117 15:08:55.743753       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:08:55.743794       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+I0117 15:08:55.743794       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:08:55.743758       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:08:55.743771       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:08:55.743779       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:08:55.743812       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:08:55.743785       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0117 15:08:55.751821       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:08:55.755165       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:08:55.755257       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:08:56.855251       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/monitoring-plugin-778bd7ffd6-bhqhw
+I0117 15:08:56.879135       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-cd8d687f7-gdsj6
+I0117 15:08:57.860692       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/thanos-querier-7f5797d54f-nh5ll
+I0117 15:09:00.751985       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:09:00.756136       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0117 15:09:00.756151       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:09:00.758783       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:09:00.762731       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:09:02.788439       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/alertmanager-main-0
+I0117 15:09:05.759331       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:09:05.763469       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+E0117 15:09:05.764606       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0117 15:09:05.769352       1 drain_controller.go:153] error when evicting pods/"metrics-server-77cb6c884d-fc79b" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0117 15:09:10.765594       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0117 15:09:10.769675       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:09:12.823712       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0117 15:09:22.860393       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-image-registry/image-registry-655fdbb4f5-qt2qz
+I0117 15:09:39.554170       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: Reporting unready: node ip-10-0-45-63.us-east-2.compute.internal is reporting OutOfDisk=Unknown
+I0117 15:09:39.575829       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:09:42.879504       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-ingress/router-default-8d84dc64-qxj42
+I0117 15:09:44.558185       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:09:44.558223       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:44.558228       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:44.558233       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:09:44.558241       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:44.558244       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:44.558248       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:09:44.569824       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:09:44.569837       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:09:44.569843       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:44.569846       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:44.569852       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:44.569856       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:44.569861       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:09:45.070235       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:09:50.076341       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:09:50.076359       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:50.076363       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:50.076368       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:09:50.076372       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:50.076375       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:50.076378       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:09:50.088287       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:09:50.088335       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:50.088341       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:50.088346       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:09:50.088349       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:09:50.088355       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:09:50.088360       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:25.052813       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: Reporting unready: node ip-10-0-45-63.us-east-2.compute.internal is reporting NotReady=False
+I0117 15:10:25.072184       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:25.091895       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:25.808708       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-77cb6c884d-fc79b" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0117 15:10:30.039134       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:30.072516       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:30.072597       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:30.072618       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:30.072637       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:30.072651       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:30.072667       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:30.072681       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:30.072909       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:30.160000       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:30.160019       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:30.160022       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:30.160027       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:30.160032       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:30.160037       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:30.160040       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:35.076294       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:35.076311       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:35.076316       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:35.076319       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:35.076321       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:35.076325       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:35.076328       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:35.088631       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:35.088647       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:35.088651       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:35.088655       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:35.088661       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:35.088664       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:35.088669       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:39.834621       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: Reporting unready: node ip-10-0-45-63.us-east-2.compute.internal is reporting Unschedulable
+I0117 15:10:39.855740       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:40.087990       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:44.840592       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:44.840608       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:44.840613       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:44.840616       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:44.840619       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:44.840621       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:44.840625       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:44.853267       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:44.853359       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:44.853369       1 status.go:490] [isNodeUnavailable] Node ip-10-0-45-63.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:44.853373       1 status.go:521] Node ip-10-0-45-63.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:44.853377       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:44.853382       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:44.853388       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 2
+I0117 15:10:49.223193       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: uncordoning
+I0117 15:10:49.223261       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: initiating uncordon (currently schedulable: false)
+I0117 15:10:49.242961       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: uncordon succeeded (currently schedulable: true)
+I0117 15:10:49.258807       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed taints
+I0117 15:10:49.266493       1 drain_controller.go:183] node ip-10-0-45-63.us-east-2.compute.internal: operation successful; applying completion annotation
+I0117 15:10:54.245500       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0117 15:10:54.245576       1 node_controller.go:584] Pool worker[zone=us-east-2b]: node ip-10-0-45-63.us-east-2.compute.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0117 15:10:54.270034       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:54.270113       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:54.270137       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:54.270153       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:54.270183       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:54.270201       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:10:54.270254       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 15:10:54.270271       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:10:54.270295       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:10:54.371235       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:54.371254       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:54.371259       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:54.371265       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:54.371269       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:54.371274       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:10:59.392314       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:59.392353       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:59.392361       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:59.392364       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:59.392369       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:59.392372       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:10:59.392377       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 15:10:59.392381       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:10:59.392390       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:10:59.405108       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:10:59.405123       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:59.405126       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:10:59.405131       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:10:59.405134       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:10:59.405139       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:11:25.809790       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.08452101433555556 hours
+I0117 15:11:25.809818       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: initiating drain
+E0117 15:11:26.842927       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-qgbc7, openshift-cluster-node-tuning-operator/tuned-578ls, openshift-dns/dns-default-v45xq, openshift-dns/node-resolver-fjgvr, openshift-image-registry/node-ca-mm2tw, openshift-ingress-canary/ingress-canary-m4nlm, openshift-insights/insights-runtime-extractor-mbhvl, openshift-machine-config-operator/machine-config-daemon-kks8x, openshift-monitoring/node-exporter-h6ddc, openshift-multus/multus-7vjc5, openshift-multus/multus-additional-cni-plugins-x8x26, openshift-multus/network-metrics-daemon-d97lv, openshift-network-diagnostics/network-check-target-4cnl2, openshift-network-operator/iptables-alerter-54lwt, openshift-ovn-kubernetes/ovnkube-node-f27lk
+I0117 15:11:26.844080       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:11:41.856956       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: Evicted pod openshift-monitoring/metrics-server-77cb6c884d-fc79b
+I0117 15:11:41.870255       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: operation successful; applying completion annotation
+I0117 15:12:35.124546       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: Reporting unready: node ip-10-0-77-37.us-east-2.compute.internal is reporting OutOfDisk=Unknown
+I0117 15:12:35.159622       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:12:40.136519       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:12:40.136612       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:40.136631       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:40.136651       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:12:40.136666       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:12:40.136682       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:12:40.136698       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 15:12:40.136713       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:12:40.136733       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:12:40.189486       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:12:40.189568       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:12:40.189598       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:12:40.189616       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:40.189630       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:40.189644       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:12:40.630790       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:12:45.633994       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:12:45.634011       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:12:45.634015       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:12:45.634019       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:45.634021       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:45.634024       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:12:45.634028       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 15:12:45.634031       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:12:45.634038       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:12:45.644260       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:12:45.644273       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:45.644279       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:12:45.644282       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:12:45.644285       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:12:45.644288       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:13:16.964912       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: Reporting unready: node ip-10-0-77-37.us-east-2.compute.internal is reporting NotReady=False
+I0117 15:13:16.985714       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:17.001366       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:20.566231       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:20.583567       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:21.968063       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:21.968086       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:21.968095       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:13:21.968098       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:13:21.968103       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:21.968107       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:13:21.968111       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 15:13:21.968115       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:13:21.968125       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:13:21.979879       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:21.979896       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:21.979900       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:21.979906       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:13:21.979909       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:13:21.979913       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:13:31.757028       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: Reporting unready: node ip-10-0-77-37.us-east-2.compute.internal is reporting Unschedulable
+I0117 15:13:31.772678       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:35.605201       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:36.762183       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:36.762202       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:36.762222       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:36.762227       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:13:36.762230       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:13:36.762235       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:13:36.762239       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 15:13:36.762242       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:13:36.762250       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:13:36.862271       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:36.862293       1 status.go:490] [isNodeUnavailable] Node ip-10-0-77-37.us-east-2.compute.internal is NOT ready => unavailable
+I0117 15:13:36.862296       1 status.go:521] Node ip-10-0-77-37.us-east-2.compute.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 15:13:36.862301       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:36.862303       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:36.862306       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 1
+I0117 15:13:41.252058       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: uncordoning
+I0117 15:13:41.252104       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: initiating uncordon (currently schedulable: false)
+I0117 15:13:41.270956       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: uncordon succeeded (currently schedulable: true)
+I0117 15:13:41.282687       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed taints
+I0117 15:13:41.297339       1 drain_controller.go:183] node ip-10-0-77-37.us-east-2.compute.internal: operation successful; applying completion annotation
+I0117 15:13:46.273591       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0117 15:13:46.273670       1 node_controller.go:584] Pool worker[zone=us-east-2c]: node ip-10-0-77-37.us-east-2.compute.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0117 15:13:46.288056       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:46.288120       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:46.288139       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:46.288155       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:46.288170       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:13:46.288187       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:13:46.288202       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:13:46.288265       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:13:46.302655       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:46.302669       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:46.302672       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:46.302674       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:46.302677       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:13:51.315013       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:51.315073       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:51.315094       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:51.315110       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:51.315126       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:13:51.315143       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:13:51.315159       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:13:51.315180       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:13:51.327805       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:13:51.327822       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:51.327827       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:51.327830       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:13:51.327834       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:17:16.809537       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0117 15:17:16.909823       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0117 15:17:17.328514       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0117 15:17:17.420765       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0117 15:19:09.479189       1 template_controller.go:146] Re-syncing ControllerConfig due to secret pull-secret change
+I0117 15:23:05.325829       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:23:05.325920       1 status.go:524] Node ip-10-0-10-64.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.325947       1 status.go:524] Node ip-10-0-37-151.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.325964       1 status.go:524] Node ip-10-0-73-212.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.325990       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:23:05.326009       1 node_controller.go:1247] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0117 15:23:05.326025       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:23:05.326046       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:23:05.325851       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:23:05.326267       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.326286       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.326302       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.326318       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:23:05.326334       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:23:05.326351       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:23:05.326371       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:23:05.348558       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:23:05.348621       1 status.go:524] Node ip-10-0-10-64.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.348632       1 status.go:524] Node ip-10-0-37-151.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.348636       1 status.go:524] Node ip-10-0-73-212.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.348641       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:23:05.351504       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:23:05.351549       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.351568       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.351583       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:23:05.351599       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:41:53.662036       1 template_controller.go:146] Re-syncing ControllerConfig due to secret pull-secret change
+I0117 15:44:22.541131       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0117 15:44:22.636189       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0117 15:44:23.076478       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0117 15:44:23.167069       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0117 15:46:08.715058       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:46:08.715152       1 status.go:524] Node ip-10-0-37-151.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.715172       1 status.go:524] Node ip-10-0-73-212.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.715187       1 status.go:524] Node ip-10-0-10-64.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.715219       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:46:08.715240       1 node_controller.go:1247] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0117 15:46:08.715256       1 node_controller.go:1250] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 15:46:08.715278       1 node_controller.go:1293] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 15:46:08.716868       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:46:08.718738       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.718757       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.718761       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.718765       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:46:08.718770       1 node_controller.go:1247] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 15:46:08.718773       1 node_controller.go:1250] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 15:46:08.718782       1 node_controller.go:1293] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 15:46:08.815166       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:46:08.815267       1 status.go:524] Node ip-10-0-73-212.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.815276       1 status.go:524] Node ip-10-0-10-64.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.815280       1 status.go:524] Node ip-10-0-37-151.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.815284       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+I0117 15:46:08.815167       1 status.go:518] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 15:46:08.815389       1 status.go:524] Node ip-10-0-16-187.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.815397       1 status.go:524] Node ip-10-0-45-63.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.815401       1 status.go:524] Node ip-10-0-77-37.us-east-2.compute.internal is available (getUnavailableMachines)
+I0117 15:46:08.815404       1 status.go:527] Total unavailable nodes (getUnavailableMachines): 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// bug produced here
+I0117 19:15:36.205257       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:36.205277       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205282       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205286       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205290       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:36.205295       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 19:15:36.205298       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 19:15:36.205304       1 node_controller.go:1258] Pool worker: selected candidate node ip-10-0-89-228.ec2.internal
+I0117 19:15:36.205309       1 node_controller.go:1258] Pool worker: selected candidate node ip-10-0-9-81.ec2.internal
+I0117 19:15:36.205315       1 node_controller.go:1235] Already picked 2 nodes, capacity is 2, stopping
+I0117 19:15:36.205321       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 19:15:36.205332       1 node_controller.go:1076] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+I0117 19:15:36.205362       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:36.205367       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205370       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205373       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205377       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:36.205382       1 node_controller.go:1351] Selected node ip-10-0-89-228.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0117 19:15:36.205385       1 node_controller.go:1351] Selected node ip-10-0-9-81.ec2.internal for update (current selection count: 2) [updateCandidateMachines]
+I0117 19:15:36.205390       1 node_controller.go:1355] Final list of nodes to update in pool worker: 2 nodes (capacity: 2) [updateCandidateMachines]
+I0117 19:15:36.205607       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:36.205620       1 status.go:558] Node ip-10-0-59-146.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205624       1 status.go:558] Node ip-10-0-91-109.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205628       1 status.go:558] Node ip-10-0-26-222.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.205632       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:36.205635       1 node_controller.go:1222] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0117 19:15:36.205639       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 19:15:36.205646       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 19:15:36.215605       1 node_controller.go:1171] updateCandidateNode: node=ip-10-0-89-228.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0117 19:15:36.234009       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-89-228.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0117 19:15:36.247460       1 node_controller.go:1171] updateCandidateNode: node=ip-10-0-9-81.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0117 19:15:36.265547       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-9-81.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0117 19:15:36.265611       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"1aa52889-c963-45d5-90fd-6dae84131562", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"90607", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 2 nodes to MachineConfig: rendered-worker-9c89081124944527cb19e80fa16d369b
+I0117 19:15:36.306179       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:36.306202       1 status.go:558] Node ip-10-0-91-109.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.306207       1 status.go:558] Node ip-10-0-26-222.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.306210       1 status.go:558] Node ip-10-0-59-146.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.306214       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:36.404480       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:36.404502       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.404508       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.404512       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:36.404516       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:41.277120       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-89-228.ec2.internal: changed taints
+I0117 19:15:41.312018       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:41.312752       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.312766       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.312771       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.312775       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:41.312782       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 19:15:41.312786       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 19:15:41.312793       1 node_controller.go:1258] Pool worker: selected candidate node ip-10-0-37-137.ec2.internal
+I0117 19:15:41.312812       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 19:15:41.312826       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0117 19:15:41.312875       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:41.312885       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.312889       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.312893       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.312897       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:41.312902       1 node_controller.go:1351] Selected node ip-10-0-37-137.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0117 19:15:41.312907       1 node_controller.go:1355] Final list of nodes to update in pool worker: 1 nodes (capacity: 2) [updateCandidateMachines]
+I0117 19:15:41.312094       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-9-81.ec2.internal: changed taints
+I0117 19:15:41.350149       1 node_controller.go:1171] updateCandidateNode: node=ip-10-0-37-137.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0117 19:15:41.367981       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"1aa52889-c963-45d5-90fd-6dae84131562", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"128372", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Targeted node ip-10-0-37-137.ec2.internal to MachineConfig: rendered-worker-9c89081124944527cb19e80fa16d369b
+I0117 19:15:41.369358       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-37-137.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0117 19:15:41.441963       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:41.441987       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.441993       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.441999       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:41.442003       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:46.304727       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:46.304751       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:46.304757       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:46.304761       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:46.304765       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:46.304785       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 19:15:46.304791       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 19:15:46.304812       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 19:15:46.305510       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-37-137.ec2.internal: changed taints
+I0117 19:15:46.383802       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:46.383919       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:46.383956       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:46.383983       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:46.384020       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:51.312601       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:51.312707       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:51.312737       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:51.312748       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:51.312753       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:15:51.312759       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0117 19:15:51.312763       1 node_controller.go:1225] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0117 19:15:51.312774       1 node_controller.go:1268] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0117 19:15:51.333461       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:15:51.333480       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:51.333486       1 status.go:558] Node ip-10-0-9-81.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:51.333489       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:15:51.333493       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 0
+I0117 19:16:11.413952       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-9-81.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0117 19:16:16.421595       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:16.421624       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:16.421630       1 status.go:494] Node ip-10-0-9-81.ec2.internal is unavailable: node is in MCD state=Working
+I0117 19:16:16.421634       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:16.421640       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:16.421644       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 1
+I0117 19:16:16.421649       1 node_controller.go:1222] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0117 19:16:16.421653       1 node_controller.go:1225] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0117 19:16:16.421661       1 node_controller.go:1268] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0117 19:16:16.444483       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:16.444511       1 status.go:494] Node ip-10-0-9-81.ec2.internal is unavailable: node is in MCD state=Working
+I0117 19:16:16.444517       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:16.444523       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:16.444527       1 status.go:558] Node ip-10-0-89-228.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:16.444531       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 1
+I0117 19:16:16.514386       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: cordoning
+I0117 19:16:16.514406       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: initiating cordon (currently schedulable: true)
+I0117 19:16:16.545896       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: cordon succeeded (currently schedulable: false)
+I0117 19:16:16.570219       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: initiating drain
+I0117 19:16:16.611971       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-9-81.ec2.internal: changed taints
+I0117 19:16:17.060645       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-89-228.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+E0117 19:16:17.633655       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-ft47x, openshift-cluster-node-tuning-operator/tuned-jqx8t, openshift-dns/dns-default-5f5pn, openshift-dns/node-resolver-gz9b6, openshift-image-registry/node-ca-z4mfv, openshift-ingress-canary/ingress-canary-llnkk, openshift-insights/insights-runtime-extractor-6tcqh, openshift-machine-config-operator/machine-config-daemon-nqbnf, openshift-monitoring/node-exporter-nmx2c, openshift-multus/multus-additional-cni-plugins-rlgvp, openshift-multus/multus-q24c8, openshift-multus/network-metrics-daemon-fj8tm, openshift-network-diagnostics/network-check-target-rxh4w, openshift-network-operator/iptables-alerter-869gc, openshift-ovn-kubernetes/ovnkube-node-z4h7z
+I0117 19:16:17.636317       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-qmp7q
+I0117 19:16:17.636334       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7988869fd8-fggbt
+I0117 19:16:17.636362       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0117 19:16:17.636379       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5595785c56-5b7jl
+I0117 19:16:17.636393       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-5b9d96887c-sj8vb
+I0117 19:16:17.636407       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-p4zqt
+I0117 19:16:17.636434       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-75fcc4d9f4-fqjtm
+I0117 19:16:17.636451       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-fcc54b96c-9kgbd
+I0117 19:16:17.636323       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0117 19:16:19.717581       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-qmp7q
+I0117 19:16:19.723622       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-5b9d96887c-sj8vb
+I0117 19:16:19.892576       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-75fcc4d9f4-fqjtm
+I0117 19:16:20.292513       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-p4zqt
+I0117 19:16:20.886461       1 request.go:700] Waited for 1.107110775s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/alertmanager-main-1
+I0117 19:16:20.892611       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0117 19:16:21.093060       1 drain_controller.go:183] node ip-10-0-9-81.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0117 19:16:21.464936       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:21.464956       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:21.464963       1 status.go:494] Node ip-10-0-89-228.ec2.internal is unavailable: node is in MCD state=Working
+I0117 19:16:21.464966       1 status.go:555] Node ip-10-0-89-228.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:21.464972       1 status.go:488] [isNodeUnavailable] Node ip-10-0-9-81.ec2.internal is NOT ready => unavailable
+I0117 19:16:21.464975       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:21.464979       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 2
+I0117 19:16:21.564472       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:21.564496       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:21.564503       1 status.go:494] Node ip-10-0-89-228.ec2.internal is unavailable: node is in MCD state=Working
+I0117 19:16:21.564507       1 status.go:555] Node ip-10-0-89-228.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:21.564513       1 status.go:488] [isNodeUnavailable] Node ip-10-0-9-81.ec2.internal is NOT ready => unavailable
+I0117 19:16:21.564517       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:21.564521       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 2
+E0117 19:16:21.602543       1 render_controller.go:445] Error syncing Generated MCFG: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+E0117 19:16:21.612751       1 render_controller.go:467] Error updating MachineConfigPool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0117 19:16:21.612774       1 render_controller.go:382] Error syncing machineconfigpool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0117 19:16:22.161640       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: cordoning
+I0117 19:16:22.161694       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: initiating cordon (currently schedulable: true)
+I0117 19:16:22.534126       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-89-228.ec2.internal: changed taints
+I0117 19:16:22.692294       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: cordon succeeded (currently schedulable: false)
+I0117 19:16:22.712102       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: initiating drain
+E0117 19:16:24.120876       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-mvbgj, openshift-cluster-node-tuning-operator/tuned-rqbwj, openshift-dns/dns-default-hmm4q, openshift-dns/node-resolver-dhhzh, openshift-image-registry/node-ca-2ffl5, openshift-ingress-canary/ingress-canary-z98mv, openshift-insights/insights-runtime-extractor-gv59z, openshift-machine-config-operator/machine-config-daemon-xv7g2, openshift-monitoring/node-exporter-hfqsf, openshift-multus/multus-additional-cni-plugins-x5tmp, openshift-multus/multus-n62zf, openshift-multus/network-metrics-daemon-fnndb, openshift-network-diagnostics/network-check-target-6wvfh, openshift-network-operator/iptables-alerter-xhlhl, openshift-ovn-kubernetes/ovnkube-node-2tvkj
+I0117 19:16:24.123273       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28952355-vm6ss
+I0117 19:16:24.123292       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-8l4dn
+I0117 19:16:24.123307       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28952325-jj54l
+I0117 19:16:24.123375       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-dnpwt
+I0117 19:16:24.123470       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28952340-vwtzr
+I0117 19:16:24.123278       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-7988869fd8-9tgpd
+I0117 19:16:24.123604       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-5595785c56-g49x7
+I0117 19:16:24.123633       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-75fcc4d9f4-dcxb6
+I0117 19:16:24.123714       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-5b9d96887c-hw5pg
+I0117 19:16:24.123294       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-fcc54b96c-4vvgd
+I0117 19:16:24.123725       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0117 19:16:24.123731       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0117 19:16:24.328778       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28952325-jj54l
+I0117 19:16:24.492538       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28952355-vm6ss
+I0117 19:16:24.692003       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28952340-vwtzr
+I0117 19:16:25.285818       1 request.go:700] Waited for 1.094351676s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-fcc54b96c-4vvgd
+I0117 19:16:26.092806       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-dnpwt
+I0117 19:16:26.286303       1 request.go:700] Waited for 1.889509188s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/alertmanager-main-1
+I0117 19:16:26.292872       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0117 19:16:26.493249       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0117 19:16:26.586010       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:26.586033       1 status.go:488] [isNodeUnavailable] Node ip-10-0-9-81.ec2.internal is NOT ready => unavailable
+I0117 19:16:26.586038       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:26.586044       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:26.586048       1 status.go:488] [isNodeUnavailable] Node ip-10-0-89-228.ec2.internal is NOT ready => unavailable
+I0117 19:16:26.586052       1 status.go:555] Node ip-10-0-89-228.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:26.586056       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 2
+I0117 19:16:26.686611       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:26.686632       1 status.go:558] Node ip-10-0-37-137.ec2.internal is available (getUnavailableMachines)
+I0117 19:16:26.686638       1 status.go:488] [isNodeUnavailable] Node ip-10-0-89-228.ec2.internal is NOT ready => unavailable
+I0117 19:16:26.686642       1 status.go:555] Node ip-10-0-89-228.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:26.686647       1 status.go:488] [isNodeUnavailable] Node ip-10-0-9-81.ec2.internal is NOT ready => unavailable
+I0117 19:16:26.686650       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:26.686654       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 2
+I0117 19:16:27.291058       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-75fcc4d9f4-dcxb6
+I0117 19:16:27.486411       1 request.go:700] Waited for 1.395198449s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/monitoring-plugin-5b9d96887c-hw5pg
+I0117 19:16:27.490345       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-5b9d96887c-hw5pg
+I0117 19:16:28.091707       1 drain_controller.go:183] node ip-10-0-89-228.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-8l4dn
+I0117 19:16:28.486551       1 request.go:700] Waited for 1.59321404s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-5595785c56-g49x7
+I0117 19:16:30.885862       1 request.go:700] Waited for 1.144799s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-fcc54b96c-9kgbd
+I0117 19:16:31.884665       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-37-137.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0117 19:16:33.885892       1 request.go:700] Waited for 1.144546082s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-fcc54b96c-9kgbd
+I0117 19:16:35.885650       1 request.go:700] Waited for 1.144804694s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-fcc54b96c-9kgbd
+I0117 19:16:36.885738       1 request.go:700] Waited for 1.145334594s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-7988869fd8-fggbt
+I0117 19:16:36.891120       1 status.go:552] getUnavailableMachines: checking 3 nodes (layered=false)
+I0117 19:16:36.891144       1 status.go:494] Node ip-10-0-37-137.ec2.internal is unavailable: node is in MCD state=Working
+I0117 19:16:36.891150       1 status.go:555] Node ip-10-0-37-137.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:36.891156       1 status.go:488] [isNodeUnavailable] Node ip-10-0-89-228.ec2.internal is NOT ready => unavailable
+I0117 19:16:36.891159       1 status.go:555] Node ip-10-0-89-228.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:36.891163       1 status.go:488] [isNodeUnavailable] Node ip-10-0-9-81.ec2.internal is NOT ready => unavailable
+I0117 19:16:36.891167       1 status.go:555] Node ip-10-0-9-81.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0117 19:16:36.891171       1 status.go:561] Total unavailable nodes (getUnavailableMachines): 3
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+I0120 21:38:17.784410       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784421       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784427       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784432       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784436       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784440       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784444       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784448       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784452       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784457       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.784463       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:38:17.784467       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+
+I0120 21:38:17.784473       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-46-217.ec2.internal
+I0120 21:38:17.784478       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-5-10.ec2.internal
+I0120 21:38:17.784484       1 node_controller.go:1261] Already picked 2 nodes, capacity is 2, stopping
+I0120 21:38:17.784490       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:38:17.784500       1 node_controller.go:1076] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+
+I0120 21:38:17.784537       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.784545       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784549       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784553       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784557       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784561       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784564       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784568       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784572       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784575       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784579       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+
+I0120 21:38:17.784584       1 node_controller.go:1378] Selected node ip-10-0-46-217.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0120 21:38:17.784590       1 node_controller.go:1378] Selected node ip-10-0-5-10.ec2.internal for update (current selection count: 2) [updateCandidateMachines]
+
+I0120 21:38:17.784594       1 node_controller.go:1382] Final list of nodes to update in pool worker: 2 nodes (capacity: 2) [updateCandidateMachines]
+I0120 21:38:17.784877       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.784891       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784896       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784900       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784904       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784908       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784911       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784915       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784919       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784922       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.784926       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.784929       1 node_controller.go:1248] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0120 21:38:17.784933       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:38:17.784940       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:38:17.801852       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-46-217.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0120 21:38:17.823860       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0120 21:38:17.833296       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-5-10.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0120 21:38:17.850879       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"216260", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 2 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.852509       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+
+
+I0120 21:38:17.883386       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.983012       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.983039       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983047       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983052       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.983056       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983060       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983064       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.983068       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983073       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983076       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+
+I0120 21:38:17.983080       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:19.066718       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:38:19.132791       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:38:22.851385       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+
+I0120 21:38:22.888966       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:22.888995       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.889001       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.889007       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.889012       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+
+I0120 21:38:22.889016       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:22.889021       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.889024       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.889028       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+
+I0120 21:38:22.890705       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+
+I0120 21:38:22.931179       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:22.931201       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.931208       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.931213       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:22.931217       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.931221       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.931226       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.931229       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+
+I0120 21:38:22.931233       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+
+
+I0120 21:38:27.856295       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:27.856319       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.856325       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.856329       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:27.856334       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.856338       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.856342       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.856345       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.856349       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:38:27.957154       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:27.957181       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.957187       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.957194       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.957197       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.957202       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.957208       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.957212       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:27.957215       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:26:59.084666       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:26:59.212149       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:26:59.212173       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212181       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212185       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.212190       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212194       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212197       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.212201       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212205       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212208       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.212212       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:27:00.992450       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:27:01.096067       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:27:04.086378       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:27:04.110510       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:04.110619       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.110647       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.110676       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:04.110696       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.110702       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.110707       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.110712       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.110716       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:27:04.112305       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:27:04.161850       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:04.161873       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.161878       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.161883       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:04.161887       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.161891       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.161896       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.161900       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.161903       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:27:06.102044       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: cordoning
+I0120 21:27:06.102109       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:27:06.125641       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:27:06.141078       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:27:06.152715       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating drain
+I0120 21:27:06.204990       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: cordoning
+I0120 21:27:06.205011       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:27:06.224858       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:27:06.242882       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:27:06.248112       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating drain
+E0120 21:27:08.010177       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-vl8gn, openshift-cluster-node-tuning-operator/tuned-qslsp, openshift-dns/dns-default-vvzxt, openshift-dns/node-resolver-5srtq, openshift-image-registry/node-ca-9psxx, openshift-ingress-canary/ingress-canary-l6pth, openshift-insights/insights-runtime-extractor-hl5q4, openshift-machine-config-operator/machine-config-daemon-rmtb2, openshift-monitoring/node-exporter-vb9lg, openshift-multus/multus-additional-cni-plugins-xc5b9, openshift-multus/multus-mp8bq, openshift-multus/network-metrics-daemon-c8vng, openshift-network-diagnostics/network-check-target-vmvjd, openshift-network-operator/iptables-alerter-zhxcz, openshift-ovn-kubernetes/ovnkube-node-qc66q
+I0120 21:27:08.011956       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-xhx4j
+I0120 21:27:08.011960       1 drain_controller.go:153] evicting pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-l6qqp
+I0120 21:27:08.011971       1 drain_controller.go:153] evicting pod openshift-cluster-api/capi-controller-manager-8598896b96-7k4rp
+I0120 21:27:08.011972       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:27:08.011978       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-kk5sk
+I0120 21:27:08.011981       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0120 21:27:08.011981       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-49p2s
+I0120 21:27:08.011987       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-lnqjp
+I0120 21:27:08.011988       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-g247h
+I0120 21:27:08.011993       1 drain_controller.go:153] evicting pod openshift-insights/periodic-gathering-ksjbs-rpzds
+I0120 21:27:08.011992       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-cn2wt
+I0120 21:27:08.011996       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-sdwmj
+I0120 21:27:08.011999       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-9mwr9
+I0120 21:27:08.095718       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-insights/periodic-gathering-ksjbs-rpzds
+I0120 21:27:09.113869       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:09.113892       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.113897       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.113905       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.113909       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.113914       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.113919       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.113923       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:09.113927       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:27:09.140105       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:09.140128       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.140136       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.140140       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:09.140145       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.140149       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.140154       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.140157       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.140161       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+E0120 21:27:10.218306       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-w2bqn, openshift-cluster-node-tuning-operator/tuned-r9wt5, openshift-dns/dns-default-kh6dw, openshift-dns/node-resolver-sxwkk, openshift-image-registry/node-ca-cq7nn, openshift-ingress-canary/ingress-canary-mhb88, openshift-insights/insights-runtime-extractor-sd5zx, openshift-machine-config-operator/machine-config-daemon-mxfsq, openshift-monitoring/node-exporter-tn6kd, openshift-multus/multus-additional-cni-plugins-hrr9q, openshift-multus/multus-pc2gv, openshift-multus/network-metrics-daemon-v7nr4, openshift-network-diagnostics/network-check-target-drltj, openshift-network-operator/iptables-alerter-f2gl5, openshift-ovn-kubernetes/ovnkube-node-f9gcr
+I0120 21:27:10.220078       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-dzm4g
+I0120 21:27:10.220121       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-lr9q6
+I0120 21:27:10.220134       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:10.220244       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+I0120 21:27:10.220289       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:10.220360       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:10.220255       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-kbmqb
+I0120 21:27:10.220263       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:27:10.220271       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-55469dfcdf-9gts8
+I0120 21:27:10.220277       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-dp6lr
+I0120 21:27:10.220283       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-6ccdb
+I0120 21:27:10.220647       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-fwdvs
+E0120 21:27:10.237492       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.243572       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-57b46cfd5c-lr9q6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:10.256045       1 request.go:700] Waited for 1.126318218s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-787b98474-lnqjp
+E0120 21:27:10.335584       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.335584       1 drain_controller.go:153] error when evicting pods/"thanos-querier-68d8f8f746-7ql87" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.335593       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.335673       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.838610       1 drain_controller.go:153] error when evicting pods/"router-default-787b98474-6ccdb" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:10.860488       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-sdwmj
+I0120 21:27:11.059903       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-9mwr9
+E0120 21:27:11.090547       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-5d9668865-fwdvs" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:11.257344       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-xhx4j
+I0120 21:27:11.456909       1 request.go:700] Waited for 1.371044171s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-cluster-api/pods/capi-controller-manager-8598896b96-7k4rp
+I0120 21:27:11.466459       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-cluster-api/capi-controller-manager-8598896b96-7k4rp
+I0120 21:27:11.658553       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0120 21:27:11.859788       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-49p2s
+I0120 21:27:12.059391       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0120 21:27:12.653305       1 request.go:700] Waited for 2.396843186s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-dzm4g
+I0120 21:27:12.660289       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-dzm4g
+I0120 21:27:12.880923       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-kbmqb
+I0120 21:27:13.057831       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-55469dfcdf-9gts8
+I0120 21:27:13.255860       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-dp6lr
+I0120 21:27:13.852931       1 request.go:700] Waited for 2.511510129s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/prometheus-operator-admission-webhook-5d9668865-cn2wt
+I0120 21:27:13.856073       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-cn2wt
+I0120 21:27:15.238458       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:27:15.244599       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-lr9q6
+E0120 21:27:15.247613       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:15.336686       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+I0120 21:27:15.336958       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:15.337067       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:15.337158       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:15.348229       1 drain_controller.go:153] error when evicting pods/"thanos-querier-68d8f8f746-7ql87" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:15.349672       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:15.358135       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:15.358146       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:15.839458       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-6ccdb
+I0120 21:27:16.091290       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-fwdvs
+I0120 21:27:17.257965       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-lr9q6
+I0120 21:27:18.254302       1 request.go:700] Waited for 1.123919358s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:18.458088       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-fwdvs
+I0120 21:27:20.248182       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+E0120 21:27:20.255947       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:20.349721       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:20.352828       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:20.359022       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:20.359177       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+E0120 21:27:20.369273       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:20.370678       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:20.380282       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:22.253729       1 request.go:700] Waited for 1.123709064s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:23.256726       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:24.253355       1 request.go:700] Waited for 1.122780946s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:25.256425       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+E0120 21:27:25.264893       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:25.369333       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:25.371474       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+E0120 21:27:25.377802       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:25.378187       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:25.381294       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:25.478269       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:30.265769       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:27:30.378201       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:30.378516       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+E0120 21:27:30.387448       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:30.478852       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:30.491940       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:31.454329       1 request.go:700] Waited for 1.037730388s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-c66456f44-gpml7
+I0120 21:27:34.253691       1 request.go:700] Waited for 1.123605419s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-787b98474-lnqjp
+I0120 21:27:35.387920       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:35.396782       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:35.453851       1 request.go:700] Waited for 1.351482975s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-c66456f44-kk5sk
+I0120 21:27:35.456575       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-kk5sk
+I0120 21:27:35.492735       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:35.502629       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:37.253355       1 request.go:700] Waited for 1.122400487s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:39.856373       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-l6qqp
+I0120 21:27:40.253470       1 request.go:700] Waited for 1.120697615s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:40.397584       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:40.405648       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:40.503128       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:40.514510       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:45.406660       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:45.414836       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:45.515120       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:48.257702       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:50.414947       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:50.424920       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:55.425265       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:55.434699       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:58.057290       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-gpml7
+I0120 21:28:00.134525       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-lnqjp
+I0120 21:28:00.435391       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:28:00.443676       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:28:05.444637       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:28:05.453339       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:28:10.454050       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:28:10.462025       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:28:15.462889       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:28:22.510399       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0120 21:28:33.064858       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-6ccdb
+I0120 21:28:38.135339       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-g247h" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:28:40.264347       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-7h9lh" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:29:38.135867       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042225049974166665 hours
+I0120 21:29:38.135894       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating drain
+E0120 21:29:39.178046       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-vl8gn, openshift-cluster-node-tuning-operator/tuned-qslsp, openshift-dns/dns-default-vvzxt, openshift-dns/node-resolver-5srtq, openshift-image-registry/node-ca-9psxx, openshift-ingress-canary/ingress-canary-l6pth, openshift-insights/insights-runtime-extractor-hl5q4, openshift-machine-config-operator/machine-config-daemon-rmtb2, openshift-monitoring/node-exporter-vb9lg, openshift-multus/multus-additional-cni-plugins-xc5b9, openshift-multus/multus-mp8bq, openshift-multus/network-metrics-daemon-c8vng, openshift-network-diagnostics/network-check-target-vmvjd, openshift-network-operator/iptables-alerter-zhxcz, openshift-ovn-kubernetes/ovnkube-node-qc66q
+I0120 21:29:39.179712       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-g247h
+I0120 21:29:40.197619       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-g247h
+I0120 21:29:40.217558       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: operation successful; applying completion annotation
+I0120 21:29:40.264655       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04278880547333333 hours
+I0120 21:29:40.264741       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating drain
+E0120 21:29:42.178869       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-w2bqn, openshift-cluster-node-tuning-operator/tuned-r9wt5, openshift-dns/dns-default-kh6dw, openshift-dns/node-resolver-sxwkk, openshift-image-registry/node-ca-cq7nn, openshift-ingress-canary/ingress-canary-mhb88, openshift-insights/insights-runtime-extractor-sd5zx, openshift-machine-config-operator/machine-config-daemon-mxfsq, openshift-monitoring/node-exporter-tn6kd, openshift-multus/multus-additional-cni-plugins-hrr9q, openshift-multus/multus-pc2gv, openshift-multus/network-metrics-daemon-v7nr4, openshift-network-diagnostics/network-check-target-drltj, openshift-network-operator/iptables-alerter-f2gl5, openshift-ovn-kubernetes/ovnkube-node-f9gcr
+I0120 21:29:42.180569       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:30:02.200057       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:30:02.220475       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: operation successful; applying completion annotation
+I0120 21:30:59.942092       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:30:59.986567       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:04.957883       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:04.957908       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.957914       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.957920       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.957925       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.957929       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:04.957933       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.957936       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.957941       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:04.990928       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:04.990950       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.990955       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.990962       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.990965       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.990970       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.990974       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.990979       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:04.990983       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:05.633878       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:10.650225       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:10.650246       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.650251       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.650258       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.650270       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.650277       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.650282       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.650286       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:10.650291       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:10.670464       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:10.670486       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.670491       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.670499       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.670503       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.670508       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.670512       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.670516       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:10.670520       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:13.651444       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting NotReady=False
+I0120 21:31:13.685774       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:13.717280       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:15.555300       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:15.590248       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:18.667758       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:18.667781       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.667786       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.667794       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.667799       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.667803       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:18.667807       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.667810       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.667814       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:18.691457       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:18.691478       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.691483       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.691491       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.691496       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.691500       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:18.691504       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.691507       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.691511       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:25.610394       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:31:25.653391       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:27.137131       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting Unschedulable
+I0120 21:31:27.160666       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:30.630885       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:30.630908       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.630914       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.630919       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.630924       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.630928       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:30.630934       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.630938       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.630942       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:30.732184       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:30.732208       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.732215       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.732220       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:30.732226       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.732230       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.732235       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.732239       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.732280       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:31.251836       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:31.307367       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:36.269554       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:36.269578       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.269584       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.269589       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.269592       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.269597       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.269602       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.269606       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:36.269611       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:36.293576       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:36.293599       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.293604       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.293609       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.293614       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.293619       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.293623       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.293627       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:36.293631       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:36.865897       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting NotReady=False
+I0120 21:31:36.897921       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:36.923127       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:37.051546       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: uncordoning
+I0120 21:31:37.051591       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:31:37.072659       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:31:37.092921       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: operation successful; applying completion annotation
+I0120 21:31:37.108129       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:41.273797       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:41.308847       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:41.888180       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:41.888202       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:31:41.888207       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.888213       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.888218       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.888222       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:41.888228       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:41.888231       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.888237       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:41.909976       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:41.910001       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:41.910005       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.910011       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:31:41.910015       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.910020       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.910024       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.910029       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:41.910032       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:42.076006       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:31:42.076564       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/currentImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:31:47.091181       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:47.091204       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091211       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091215       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091220       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091224       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091228       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091234       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:47.091238       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:47.091243       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:47.091248       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:31:47.091253       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:31:47.091260       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:31:47.091266       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:31:47.091272       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:31:47.091282       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:31:47.091314       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:31:47.091322       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091327       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091331       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091335       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:47.091338       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:31:47.091342       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091346       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091350       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091354       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:47.091359       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:31:47.091363       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:31:47.101006       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:31:47.101134       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"207984", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:31:47.107366       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:31:47.284060       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:47.284086       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:47.284091       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:47.284099       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284103       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284107       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.284111       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284115       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284119       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.284123       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:51.356410       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting Unschedulable
+I0120 21:31:51.393296       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:52.313020       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:52.313068       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313074       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313079       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313084       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313094       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313097       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313102       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:52.313106       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:52.313111       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:52.313116       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:31:52.313120       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:31:52.313127       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:31:52.313135       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:31:52.313141       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:31:52.313152       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:31:52.313202       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:31:52.313212       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313217       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313221       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313225       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:52.313306       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:31:52.313349       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313368       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313375       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313379       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:52.313385       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:31:52.313390       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:31:52.323569       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:31:52.323684       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"212304", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:31:52.331571       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:31:52.502921       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:52.502946       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:52.502951       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:52.502957       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502961       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502965       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.502971       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502975       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502977       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.502981       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:56.327592       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:32:00.411278       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: uncordoning
+I0120 21:32:00.411323       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:32:00.434169       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:32:00.468406       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:32:00.468516       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: operation successful; applying completion annotation
+I0120 21:32:01.352408       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:01.352431       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:01.352437       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:01.352443       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352448       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352453       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352457       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352461       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352464       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352469       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:01.352474       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:32:01.352478       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:32:01.352485       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:32:01.352492       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:32:01.352502       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:32:01.352535       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:32:01.352542       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:01.352547       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:32:01.352551       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352555       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352559       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352565       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352569       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352572       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352576       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:01.352581       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:32:01.352586       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:32:01.359168       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:32:01.359300       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"212304", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:01.365177       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:32:01.533807       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:01.533829       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533835       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533840       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.533845       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533849       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533852       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.533856       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:01.533860       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:01.533864       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:05.433432       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:32:05.433540       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/currentImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:10.448354       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:10.448376       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448382       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448387       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448392       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448396       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448399       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448404       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448407       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448411       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448414       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:32:10.448419       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:32:10.448423       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:32:10.448430       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:32:10.448437       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:32:10.448446       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0120 21:32:10.448480       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:32:10.448488       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448493       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448498       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448501       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448505       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448509       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448512       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448516       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448519       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448523       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:32:10.448528       1 node_controller.go:1378] Selected node ip-10-0-86-209.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0120 21:32:10.448533       1 node_controller.go:1382] Final list of nodes to update in pool worker: 1 nodes (capacity: 2) [updateCandidateMachines]
+I0120 21:32:10.455576       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:32:10.460667       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-86-209.ec2.internal, pool=worker, layered=true, mosbIsNil=false
+I0120 21:32:10.474995       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"212304", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Targeted node ip-10-0-86-209.ec2.internal to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:10.476783       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/desiredImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:10.494284       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:32:10.641063       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:10.641086       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641093       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641098       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.641102       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641107       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641110       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.641114       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641118       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641121       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.641125       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:32:12.088994       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:32:15.509278       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:15.509302       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509307       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509312       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.509317       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509321       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509325       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.509330       1 status.go:495] Node ip-10-0-86-209.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:15.509334       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:15.509341       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:15.509347       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:32:15.509350       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:32:15.509361       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:32:15.509581       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:32:15.586937       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:15.586961       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586967       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586972       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.586976       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586980       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586984       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.586989       1 status.go:495] Node ip-10-0-86-209.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:15.586992       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:15.586996       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:17.195908       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: cordoning
+I0120 21:32:17.195932       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:32:17.223387       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:32:17.249101       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:32:17.254141       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating drain
+E0120 21:32:18.327587       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-8khhk, openshift-cluster-node-tuning-operator/tuned-g7zp9, openshift-dns/dns-default-mk56w, openshift-dns/node-resolver-hwqv4, openshift-image-registry/node-ca-8msd2, openshift-ingress-canary/ingress-canary-5nfvj, openshift-insights/insights-runtime-extractor-tc9l7, openshift-machine-config-operator/machine-config-daemon-m6t4q, openshift-monitoring/node-exporter-f4mcq, openshift-multus/multus-6kxrr, openshift-multus/multus-additional-cni-plugins-97f84, openshift-multus/network-metrics-daemon-cjxq7, openshift-network-diagnostics/network-check-target-h5k4g, openshift-network-operator/iptables-alerter-x2bn5, openshift-ovn-kubernetes/ovnkube-node-9n6w2
+I0120 21:32:18.329375       1 drain_controller.go:153] evicting pod openshift-cluster-api/capi-controller-manager-8598896b96-sg2cj
+I0120 21:32:18.329397       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-ld64r
+I0120 21:32:18.329413       1 drain_controller.go:153] evicting pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-nq78n
+I0120 21:32:18.329440       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28956810-pmpb5
+I0120 21:32:18.329520       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-7l4qm
+I0120 21:32:18.329533       1 drain_controller.go:153] evicting pod openshift-console/downloads-6ffc5555fc-nlq7r
+I0120 21:32:18.329587       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-qr6zv
+I0120 21:32:18.329617       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-kbfqs
+I0120 21:32:18.329627       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-55469dfcdf-rv594
+I0120 21:32:18.329699       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-458wh
+I0120 21:32:18.329708       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28956780-4j452
+I0120 21:32:18.329732       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-wfl4n
+I0120 21:32:18.329619       1 drain_controller.go:153] evicting pod openshift-machine-config-operator/machine-os-builder-b76f56d79-skclc
+I0120 21:32:18.329774       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-pf8sf
+I0120 21:32:18.329602       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-rcp6v
+I0120 21:32:18.329820       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-5d8qj
+I0120 21:32:18.329525       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-zdpvv
+I0120 21:32:18.329758       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-kmg2b
+I0120 21:32:18.329609       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0120 21:32:18.329611       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:32:18.329766       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28956795-5j6l4
+I0120 21:32:18.402153       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28956810-pmpb5
+I0120 21:32:18.447625       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-console/downloads-6ffc5555fc-nlq7r
+I0120 21:32:18.631951       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28956780-4j452
+I0120 21:32:19.332570       1 request.go:700] Waited for 1.002686252s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-5d8qj/eviction
+I0120 21:32:20.530241       1 request.go:700] Waited for 2.200128169s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-operator-lifecycle-manager/pods/collect-profiles-28956795-5j6l4/eviction
+I0120 21:32:20.930887       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:20.930911       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930917       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930921       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:20.930925       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930930       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930933       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:20.930938       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:32:20.930941       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:20.930945       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:20.930951       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:32:20.930955       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:32:20.930964       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:32:21.036972       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:21.036994       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037000       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037005       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:21.037010       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037016       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037019       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:21.037023       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:32:21.037027       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:21.037031       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:21.579494       1 request.go:700] Waited for 1.690831725s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-machine-config-operator/pods/machine-os-builder-b76f56d79-skclc
+I0120 21:32:22.775564       1 request.go:700] Waited for 2.356913687s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-kube-storage-version-migrator/pods/migrator-6dcd57bc4f-nq78n
+I0120 21:32:23.603084       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0120 21:32:23.791681       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28956795-5j6l4
+I0120 21:32:23.977349       1 request.go:700] Waited for 2.972019725s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-5d8qj
+I0120 21:32:24.179025       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-kbfqs
+I0120 21:32:24.378903       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-qr6zv
+I0120 21:32:24.578752       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-ld64r
+I0120 21:32:24.778241       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-machine-config-operator/machine-os-builder-b76f56d79-skclc
+I0120 21:32:24.977870       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-pf8sf
+I0120 21:32:25.174964       1 request.go:700] Waited for 2.88445679s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-rcp6v
+I0120 21:32:25.178392       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-rcp6v
+I0120 21:32:25.579094       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-kmg2b
+I0120 21:32:25.978178       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-cluster-api/capi-controller-manager-8598896b96-sg2cj
+I0120 21:32:26.175483       1 request.go:700] Waited for 2.763361506s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/telemeter-client-55469dfcdf-rv594
+I0120 21:32:26.178912       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-55469dfcdf-rv594
+I0120 21:32:27.575140       1 request.go:700] Waited for 1.156942259s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-kube-storage-version-migrator/pods/migrator-6dcd57bc4f-nq78n
+I0120 21:32:31.353928       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-wfl4n
+I0120 21:32:31.362345       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-458wh
+I0120 21:32:31.376155       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0120 21:32:46.459114       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-7l4qm
+I0120 21:32:50.421499       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-nq78n
+I0120 21:33:37.385327       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-zdpvv
+I0120 21:33:49.007305       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-5d8qj" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:34:49.007474       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042162233666944444 hours
+I0120 21:34:49.007500       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating drain
+E0120 21:34:50.052524       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-8khhk, openshift-cluster-node-tuning-operator/tuned-g7zp9, openshift-dns/dns-default-mk56w, openshift-dns/node-resolver-hwqv4, openshift-image-registry/node-ca-8msd2, openshift-ingress-canary/ingress-canary-5nfvj, openshift-insights/insights-runtime-extractor-tc9l7, openshift-machine-config-operator/machine-config-daemon-m6t4q, openshift-monitoring/node-exporter-f4mcq, openshift-multus/multus-6kxrr, openshift-multus/multus-additional-cni-plugins-97f84, openshift-multus/network-metrics-daemon-cjxq7, openshift-network-diagnostics/network-check-target-h5k4g, openshift-network-operator/iptables-alerter-x2bn5, openshift-ovn-kubernetes/ovnkube-node-9n6w2
+I0120 21:34:50.054263       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-5d8qj
+I0120 21:34:51.071004       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-5d8qj
+I0120 21:34:51.088971       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: operation successful; applying completion annotation
+I0120 21:36:06.392018       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: Reporting unready: node ip-10-0-86-209.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:36:06.434214       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:11.410080       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:11.410102       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410109       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410113       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.410120       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:11.410124       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:11.410129       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410133       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410137       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.410140       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:11.410146       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:11.410149       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:11.410159       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:11.432004       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:11.432026       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432033       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432038       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.432042       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432046       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432049       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.432055       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:11.432059       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:11.432063       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:12.252719       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:17.266775       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:17.266798       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266805       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266809       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.266815       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266819       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266822       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.266828       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:17.266832       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:17.266836       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:17.266841       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:17.266845       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:17.266854       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:17.287801       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:17.287824       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287830       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287835       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.287841       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:17.287845       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:17.287850       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287854       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287858       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.287862       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:23.978961       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: Reporting unready: node ip-10-0-86-209.ec2.internal is reporting NotReady=False
+I0120 21:36:24.010686       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:24.032889       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:27.158536       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:27.182037       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:29.009454       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:29.009497       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009504       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009509       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.009513       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009517       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009521       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.009527       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:29.009531       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:29.009535       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:29.009540       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:29.009544       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:29.009553       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:29.031347       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:29.031371       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031377       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031381       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.031385       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031390       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031394       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.031400       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:29.031404       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:29.031408       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:38.372286       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: Reporting unready: node ip-10-0-86-209.ec2.internal is reporting Unschedulable
+I0120 21:36:38.420884       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:42.205158       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:43.389316       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:43.389341       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389348       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389352       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.389357       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389361       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389365       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.389370       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:43.389373       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:43.389378       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:43.389382       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:43.389386       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:43.389395       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:43.482578       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:43.482600       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:43.482605       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:43.482610       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482614       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482618       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.482622       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482626       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482630       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.482634       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:47.399112       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: uncordoning
+I0120 21:36:47.399155       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:36:47.424863       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:36:47.443926       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: operation successful; applying completion annotation
+I0120 21:36:47.455581       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:52.423574       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:36:52.423606       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/currentImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:36:52.478483       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:52.478587       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478599       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478605       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.478610       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478614       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478617       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.478622       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478626       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478630       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.478633       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:36:52.478638       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:36:52.478642       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:36:52.478651       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:36:52.567100       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:52.567123       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567129       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567134       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.567138       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567142       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567146       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.567149       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567154       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567157       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.567161       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:36:57.593906       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:57.593929       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593937       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593942       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.593946       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593951       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593956       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.593960       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593964       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593967       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.593972       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:36:57.593977       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:36:57.593981       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:36:57.593990       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:36:57.612434       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:57.612455       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612460       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612465       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.612469       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612473       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612476       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.612480       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612484       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612488       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.612492       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:37:31.402313       1 template_controller.go:146] Re-syncing ControllerConfig due to secret pull-secret change
+^C
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+I0120 20:59:13.066963       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: cordoning
+I0120 20:59:13.066986       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: initiating cordon (currently schedulable: false)
+I0120 20:59:13.072038       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 20:59:13.119521       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: initiating drain
+I0120 20:59:13.366881       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 20:59:13.366907       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.366914       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.366920       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.366924       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.366928       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.366932       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.366936       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.366940       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.366944       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.366947       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 20:59:13.366952       1 node_controller.go:1248] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0120 20:59:13.366956       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 20:59:13.366964       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 20:59:13.367165       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 20:59:13.367181       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 20:59:13.367186       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 20:59:13.367191       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.367195       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.367198       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.367203       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.367206       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.367210       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.367214       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 20:59:13.389504       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 20:59:13.389553       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.389558       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.389566       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.389570       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.389574       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 20:59:13.389577       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.389582       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 20:59:13.389585       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 20:59:13.389596       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 20:59:13.465509       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 20:59:13.465601       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.465631       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.465661       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.465689       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.465721       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.465748       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.465777       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.465806       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 20:59:13.465842       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 20:59:13.465869       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+E0120 20:59:14.184408       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-m4g7h, openshift-cluster-node-tuning-operator/tuned-25k5k, openshift-dns/dns-default-9678x, openshift-dns/node-resolver-6tbw7, openshift-image-registry/node-ca-sjcw9, openshift-machine-config-operator/machine-config-daemon-ntz6l, openshift-machine-config-operator/machine-config-server-9wjcs, openshift-monitoring/node-exporter-4cdk4, openshift-multus/multus-additional-cni-plugins-ccl6f, openshift-multus/multus-hqz5x, openshift-multus/network-metrics-daemon-5ztjf, openshift-network-diagnostics/network-check-target-t2mhj, openshift-network-node-identity/network-node-identity-cvqgf, openshift-network-operator/iptables-alerter-dxhjj, openshift-ovn-kubernetes/ovnkube-node-f54zp; deleting Pods that declare no controller: openshift-kube-controller-manager/kube-controller-manager-guard-ip-10-0-49-30.ec2.internal
+I0120 20:59:14.186497       1 drain_controller.go:153] evicting pod openshift-authentication/oauth-openshift-54d7bb95c9-429m9
+I0120 20:59:14.186577       1 drain_controller.go:153] evicting pod openshift-machine-config-operator/machine-config-operator-7d7f549797-c9b4n
+I0120 20:59:14.186501       1 drain_controller.go:153] evicting pod openshift-service-ca/service-ca-6f9ddc486-sl6n7
+I0120 20:59:14.186504       1 drain_controller.go:153] evicting pod openshift-apiserver/apiserver-65477b6457-srk7k
+I0120 20:59:14.186512       1 drain_controller.go:153] evicting pod openshift-cloud-controller-manager-operator/cluster-cloud-controller-manager-operator-9df66689-rz7vx
+I0120 20:59:14.186522       1 drain_controller.go:153] evicting pod openshift-marketplace/redhat-marketplace-t77nl
+I0120 20:59:14.186522       1 drain_controller.go:153] evicting pod openshift-marketplace/certified-operators-jw5vl
+I0120 20:59:14.186529       1 drain_controller.go:153] evicting pod openshift-marketplace/redhat-operators-2q7sn
+I0120 20:59:14.186530       1 drain_controller.go:153] evicting pod openshift-cloud-controller-manager/aws-cloud-controller-manager-dc7d565f9-qscmw
+I0120 20:59:14.186536       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-599d8f4f59-bqpmk
+I0120 20:59:14.186538       1 drain_controller.go:153] evicting pod openshift-console/console-546fbc4456-mlpxf
+I0120 20:59:14.186542       1 drain_controller.go:153] evicting pod openshift-oauth-apiserver/apiserver-6c7f8bb7fc-t2p6h
+I0120 20:59:14.186545       1 drain_controller.go:153] evicting pod openshift-kube-apiserver/revision-pruner-8-ip-10-0-49-30.ec2.internal
+I0120 20:59:14.186552       1 drain_controller.go:153] evicting pod openshift-operator-controller/operator-controller-controller-manager-58f7b8c4f8-2hk25
+I0120 20:59:14.186553       1 drain_controller.go:153] evicting pod openshift-kube-controller-manager/installer-5-ip-10-0-49-30.ec2.internal
+I0120 20:59:14.186557       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/packageserver-859b56b859-x7pdr
+I0120 20:59:14.186559       1 drain_controller.go:153] evicting pod openshift-kube-controller-manager/installer-6-ip-10-0-49-30.ec2.internal
+I0120 20:59:14.186564       1 drain_controller.go:153] evicting pod openshift-ovn-kubernetes/ovnkube-control-plane-75bf5c5bd5-jf2q5
+I0120 20:59:14.186564       1 drain_controller.go:153] evicting pod openshift-kube-controller-manager/installer-7-ip-10-0-49-30.ec2.internal
+I0120 20:59:14.186570       1 drain_controller.go:153] evicting pod openshift-route-controller-manager/route-controller-manager-577978497f-b7bnf
+I0120 20:59:14.186571       1 drain_controller.go:153] evicting pod openshift-kube-controller-manager/kube-controller-manager-guard-ip-10-0-49-30.ec2.internal
+I0120 20:59:14.893236       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-kube-apiserver/revision-pruner-8-ip-10-0-49-30.ec2.internal
+I0120 20:59:15.189940       1 request.go:700] Waited for 1.002506761s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-kube-controller-manager/pods/installer-5-ip-10-0-49-30.ec2.internal/eviction
+I0120 20:59:15.409399       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-kube-controller-manager/installer-5-ip-10-0-49-30.ec2.internal
+I0120 20:59:16.387839       1 request.go:700] Waited for 2.200158157s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-kube-controller-manager/pods/kube-controller-manager-guard-ip-10-0-49-30.ec2.internal/eviction
+I0120 20:59:17.404525       1 request.go:700] Waited for 1.960358411s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-console/pods/console-546fbc4456-mlpxf
+I0120 20:59:17.817214       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-kube-controller-manager/installer-6-ip-10-0-49-30.ec2.internal
+I0120 20:59:18.211858       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-ovn-kubernetes/ovnkube-control-plane-75bf5c5bd5-jf2q5
+I0120 20:59:18.414465       1 request.go:700] Waited for 2.379909698s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-operator-controller/pods/operator-controller-controller-manager-58f7b8c4f8-2hk25
+I0120 20:59:18.421987       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-operator-controller/operator-controller-controller-manager-58f7b8c4f8-2hk25
+I0120 20:59:18.614781       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-kube-controller-manager/installer-7-ip-10-0-49-30.ec2.internal
+I0120 20:59:19.216135       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-route-controller-manager/route-controller-manager-577978497f-b7bnf
+I0120 20:59:19.407763       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-599d8f4f59-bqpmk
+I0120 20:59:19.603298       1 request.go:700] Waited for 3.33862378s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-cloud-controller-manager-operator/pods/cluster-cloud-controller-manager-operator-9df66689-rz7vx
+I0120 20:59:19.635086       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-cloud-controller-manager-operator/cluster-cloud-controller-manager-operator-9df66689-rz7vx
+I0120 20:59:19.842888       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-marketplace/redhat-operators-2q7sn
+I0120 20:59:20.032528       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-kube-controller-manager/kube-controller-manager-guard-ip-10-0-49-30.ec2.internal
+I0120 20:59:20.223376       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-marketplace/certified-operators-jw5vl
+I0120 20:59:20.418794       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-marketplace/redhat-marketplace-t77nl
+I0120 20:59:20.603825       1 request.go:700] Waited for 3.309110723s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-service-ca/pods/service-ca-6f9ddc486-sl6n7
+I0120 20:59:20.611963       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-service-ca/service-ca-6f9ddc486-sl6n7
+I0120 20:59:20.826121       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-cloud-controller-manager/aws-cloud-controller-manager-dc7d565f9-qscmw
+I0120 20:59:21.020084       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-machine-config-operator/machine-config-operator-7d7f549797-c9b4n
+I0120 20:59:21.414971       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/packageserver-859b56b859-x7pdr
+I0120 20:59:21.604627       1 request.go:700] Waited for 2.890992283s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-oauth-apiserver/pods/apiserver-6c7f8bb7fc-t2p6h
+I0120 20:59:26.475401       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-console/console-546fbc4456-mlpxf
+I0120 20:59:28.229870       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-authentication/oauth-openshift-54d7bb95c9-429m9
+I0120 21:00:08.716870       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-oauth-apiserver/apiserver-6c7f8bb7fc-t2p6h
+I0120 21:00:44.245186       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "apiserver-65477b6457-srk7k" in namespace "openshift-apiserver" to terminate: global timeout reached: 1m30s
+I0120 21:01:44.246085       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04199278127055556 hours
+I0120 21:01:44.246111       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: initiating drain
+E0120 21:01:45.297821       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-m4g7h, openshift-cluster-node-tuning-operator/tuned-25k5k, openshift-dns/dns-default-9678x, openshift-dns/node-resolver-6tbw7, openshift-image-registry/node-ca-sjcw9, openshift-machine-config-operator/machine-config-daemon-ntz6l, openshift-machine-config-operator/machine-config-server-9wjcs, openshift-monitoring/node-exporter-4cdk4, openshift-multus/multus-additional-cni-plugins-ccl6f, openshift-multus/multus-hqz5x, openshift-multus/network-metrics-daemon-5ztjf, openshift-network-diagnostics/network-check-target-t2mhj, openshift-network-node-identity/network-node-identity-cvqgf, openshift-network-operator/iptables-alerter-dxhjj, openshift-ovn-kubernetes/ovnkube-node-f54zp
+I0120 21:01:45.299648       1 drain_controller.go:153] evicting pod openshift-etcd/revision-pruner-8-ip-10-0-49-30.ec2.internal
+I0120 21:01:45.334339       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: Evicted pod openshift-etcd/revision-pruner-8-ip-10-0-49-30.ec2.internal
+I0120 21:01:45.370657       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: operation successful; applying completion annotation
+I0120 21:03:03.619953       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: Reporting unready: node ip-10-0-49-30.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:03:03.703194       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:03:08.625639       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:03:08.625664       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.625671       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.625675       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:08.625680       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.625684       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.625687       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:08.625694       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 21:03:08.625698       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:03:08.625703       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:03:08.648130       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:03:08.648153       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.648160       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.648165       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:08.648172       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 21:03:08.648176       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:03:08.648180       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.648184       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:08.648188       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:08.648191       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:03:09.555347       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:03:14.562611       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:03:14.562659       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 21:03:14.562664       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:03:14.562670       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.562675       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.562679       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:14.562683       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.562687       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.562690       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:14.562694       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:03:14.579761       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:03:14.579786       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.579794       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.579798       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:14.579806       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 21:03:14.579810       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:03:14.579814       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.579818       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:03:14.579821       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:03:14.579826       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:04:44.428571       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: Reporting unready: node ip-10-0-49-30.ec2.internal is reporting NotReady=False
+I0120 21:04:44.472499       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:04:44.511192       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:04:44.558589       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:04:44.613004       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:04:49.434575       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:04:49.434604       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 21:04:49.434610       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:04:49.434616       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.434621       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.434625       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:04:49.434630       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.434636       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.434640       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:04:49.434644       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:04:49.538996       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:04:49.539016       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.539023       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.539027       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:04:49.539034       1 status.go:490] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal is NOT ready => unavailable
+I0120 21:04:49.539038       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:04:49.539042       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.539055       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:04:49.539061       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:04:49.539065       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:05:07.590641       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: Reporting unready: node ip-10-0-49-30.ec2.internal is reporting Unschedulable
+I0120 21:05:07.675305       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:05:09.648103       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:05:11.284300       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: uncordoning
+I0120 21:05:11.284348       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:05:11.308753       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:05:11.328939       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: changed taints
+I0120 21:05:11.348626       1 drain_controller.go:183] node ip-10-0-49-30.ec2.internal: operation successful; applying completion annotation
+I0120 21:05:12.601049       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:05:12.601072       1 status.go:495] Node ip-10-0-49-30.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:05:12.601078       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:05:12.601084       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.601088       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.601093       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:12.601098       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.601102       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.601105       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:12.601110       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:05:12.701902       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:05:12.701929       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.701935       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.701939       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:12.701944       1 status.go:495] Node ip-10-0-49-30.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:05:12.701948       1 status.go:539] Node ip-10-0-49-30.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:05:12.701952       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.701956       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:12.701959       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:12.701965       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:05:16.320834       1 node_controller.go:559] Pool master[zone=us-east-1b]: node ip-10-0-49-30.ec2.internal: Completed update to rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327421       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:05:21.327446       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327452       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327459       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:21.327464       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327468       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327472       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:21.327476       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327480       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.327483       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:21.327487       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:05:21.327492       1 node_controller.go:1248] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0120 21:05:21.327496       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:05:21.327505       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:05:21.344589       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:05:21.344617       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.344623       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.344631       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:21.344635       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.344639       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.344643       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:21.344647       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.344651       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:21.344654       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:21.344657       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:05:21.344679       1 status.go:266] Pool master: All nodes are updated with MachineConfig rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362214       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:05:26.362244       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362251       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362256       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:26.362260       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362265       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362268       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:26.362273       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362277       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.362281       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:26.362285       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:05:26.362290       1 node_controller.go:1248] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0120 21:05:26.362293       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:05:26.362302       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:05:26.387039       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:05:26.387064       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.387070       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.387077       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:26.387081       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.387085       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.387089       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:05:26.387093       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.387097       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:05:26.387100       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/pkg/controller/node/txt2.txt
+++ b/pkg/controller/node/txt2.txt
@@ -1,0 +1,1718 @@
+I0120 21:05:26.387104       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:21:37.294938       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:21:37.294966       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.294974       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.294979       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:37.294984       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.294988       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.294991       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:37.294996       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.295000       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.295004       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:37.295007       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:21:37.295012       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:21:37.295016       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:21:37.295038       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:21:37.312264       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:21:37.312283       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.312288       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.312293       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:37.312297       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.312301       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.312306       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:37.312309       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.312315       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:37.312318       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:37.312322       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+E0120 21:21:37.428784       1 render_controller.go:445] Error syncing Generated MCFG: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+E0120 21:21:37.434586       1 render_controller.go:467] Error updating MachineConfigPool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0120 21:21:37.434607       1 render_controller.go:382] Error syncing machineconfigpool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0120 21:21:42.329711       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:21:42.329735       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.329743       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.329748       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:42.329753       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.329757       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.329761       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:42.329765       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.329769       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.329772       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:42.329776       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:21:42.329781       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:21:42.329785       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:21:42.329793       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:21:42.346473       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:21:42.346494       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.346501       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.346506       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:42.346510       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.346514       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.346517       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:42.346523       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.346527       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:21:42.346530       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:21:42.346534       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:22:17.599674       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:22:17.599770       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.599905       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.599938       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.599967       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.599996       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.600023       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.600052       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.600081       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.600108       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.600137       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:22:17.600166       1 node_controller.go:1248] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0120 21:22:17.600193       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:22:17.600226       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:22:17.601976       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:22:17.602033       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.602060       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.602074       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.602081       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.602085       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.602089       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.602093       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.602097       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.602100       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.602104       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:22:17.602110       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:22:17.602114       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:22:17.602122       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:22:17.623383       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:22:17.623405       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.623412       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.623417       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.623421       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.623425       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.623429       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.623433       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.623436       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:22:17.623440       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.623443       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:22:17.624937       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:22:17.624999       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.625029       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.625059       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.625088       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.625117       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.625151       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.625178       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.625206       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:17.625234       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:17.625262       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:22:35.392923       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0120 21:22:35.547123       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0120 21:22:35.784320       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0120 21:22:35.937990       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0120 21:22:44.684957       1 node_controller.go:1012] Requeueing layered pool worker: Desired Image not set in MachineOSBuild
+I0120 21:22:44.703450       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:22:44.703472       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:44.703479       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:44.703484       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:44.703488       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:44.703493       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:44.703496       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:44.703501       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:44.703505       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:44.703509       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:44.703513       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:22:49.732214       1 node_controller.go:1012] Requeueing layered pool worker: Desired Image not set in MachineOSBuild
+I0120 21:22:49.752028       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:22:49.752051       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:49.752056       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:49.752061       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:49.752066       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:49.752070       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:49.752074       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:49.752079       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:49.752083       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:22:49.752086       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:22:49.752090       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:26:59.023131       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:26:59.023155       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023163       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023167       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.023172       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023176       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023180       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.023185       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023188       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023192       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.023195       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+
+I0120 21:26:59.023200       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:26:59.023204       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:26:59.023210       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-46-217.ec2.internal
+I0120 21:26:59.023215       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-5-10.ec2.internal
+I0120 21:26:59.023222       1 node_controller.go:1261] Already picked 2 nodes, capacity is 2, stopping
+
+I0120 21:26:59.023228       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:26:59.023239       1 node_controller.go:1076] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+I0120 21:26:59.023271       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:26:59.023280       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023285       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023288       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.023292       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023296       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023300       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.023304       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023310       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.023314       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.023318       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:26:59.023323       1 node_controller.go:1378] Selected node ip-10-0-46-217.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0120 21:26:59.023327       1 node_controller.go:1378] Selected node ip-10-0-5-10.ec2.internal for update (current selection count: 2) [updateCandidateMachines]
+I0120 21:26:59.023332       1 node_controller.go:1382] Final list of nodes to update in pool worker: 2 nodes (capacity: 2) [updateCandidateMachines]
+I0120 21:26:59.030142       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:26:59.034188       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-46-217.ec2.internal, pool=worker, layered=true, mosbIsNil=false
+I0120 21:26:59.050769       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/desiredImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:26:59.057684       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-5-10.ec2.internal, pool=worker, layered=true, mosbIsNil=false
+I0120 21:26:59.076535       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"205758", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 2 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:26:59.076708       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/desiredImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:26:59.084666       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:26:59.212149       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:26:59.212173       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212181       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212185       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.212190       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212194       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212197       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.212201       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212205       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:26:59.212208       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:26:59.212212       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:27:00.992450       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:27:01.096067       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:27:04.086378       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:27:04.110510       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:04.110619       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.110647       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.110676       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:04.110696       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.110702       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.110707       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.110712       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.110716       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:27:04.112305       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:27:04.161850       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:04.161873       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.161878       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:04.161883       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:04.161887       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.161891       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.161896       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:27:04.161900       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:04.161903       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:27:06.102044       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: cordoning
+I0120 21:27:06.102109       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:27:06.125641       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:27:06.141078       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:27:06.152715       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating drain
+I0120 21:27:06.204990       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: cordoning
+I0120 21:27:06.205011       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:27:06.224858       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:27:06.242882       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:27:06.248112       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating drain
+E0120 21:27:08.010177       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-vl8gn, openshift-cluster-node-tuning-operator/tuned-qslsp, openshift-dns/dns-default-vvzxt, openshift-dns/node-resolver-5srtq, openshift-image-registry/node-ca-9psxx, openshift-ingress-canary/ingress-canary-l6pth, openshift-insights/insights-runtime-extractor-hl5q4, openshift-machine-config-operator/machine-config-daemon-rmtb2, openshift-monitoring/node-exporter-vb9lg, openshift-multus/multus-additional-cni-plugins-xc5b9, openshift-multus/multus-mp8bq, openshift-multus/network-metrics-daemon-c8vng, openshift-network-diagnostics/network-check-target-vmvjd, openshift-network-operator/iptables-alerter-zhxcz, openshift-ovn-kubernetes/ovnkube-node-qc66q
+I0120 21:27:08.011956       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-xhx4j
+I0120 21:27:08.011960       1 drain_controller.go:153] evicting pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-l6qqp
+I0120 21:27:08.011971       1 drain_controller.go:153] evicting pod openshift-cluster-api/capi-controller-manager-8598896b96-7k4rp
+I0120 21:27:08.011972       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:27:08.011978       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-kk5sk
+I0120 21:27:08.011981       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0120 21:27:08.011981       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-49p2s
+I0120 21:27:08.011987       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-lnqjp
+I0120 21:27:08.011988       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-g247h
+I0120 21:27:08.011993       1 drain_controller.go:153] evicting pod openshift-insights/periodic-gathering-ksjbs-rpzds
+I0120 21:27:08.011992       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-cn2wt
+I0120 21:27:08.011996       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-sdwmj
+I0120 21:27:08.011999       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-9mwr9
+I0120 21:27:08.095718       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-insights/periodic-gathering-ksjbs-rpzds
+I0120 21:27:09.113869       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:09.113892       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.113897       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.113905       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.113909       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.113914       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.113919       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.113923       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:09.113927       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:27:09.140105       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:27:09.140128       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.140136       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:27:09.140140       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:27:09.140145       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.140149       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.140154       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:27:09.140157       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:27:09.140161       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+E0120 21:27:10.218306       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-w2bqn, openshift-cluster-node-tuning-operator/tuned-r9wt5, openshift-dns/dns-default-kh6dw, openshift-dns/node-resolver-sxwkk, openshift-image-registry/node-ca-cq7nn, openshift-ingress-canary/ingress-canary-mhb88, openshift-insights/insights-runtime-extractor-sd5zx, openshift-machine-config-operator/machine-config-daemon-mxfsq, openshift-monitoring/node-exporter-tn6kd, openshift-multus/multus-additional-cni-plugins-hrr9q, openshift-multus/multus-pc2gv, openshift-multus/network-metrics-daemon-v7nr4, openshift-network-diagnostics/network-check-target-drltj, openshift-network-operator/iptables-alerter-f2gl5, openshift-ovn-kubernetes/ovnkube-node-f9gcr
+I0120 21:27:10.220078       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-dzm4g
+I0120 21:27:10.220121       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-lr9q6
+I0120 21:27:10.220134       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:10.220244       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+I0120 21:27:10.220289       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:10.220360       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:10.220255       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-kbmqb
+I0120 21:27:10.220263       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:27:10.220271       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-55469dfcdf-9gts8
+I0120 21:27:10.220277       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-dp6lr
+I0120 21:27:10.220283       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-6ccdb
+I0120 21:27:10.220647       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-fwdvs
+E0120 21:27:10.237492       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.243572       1 drain_controller.go:153] error when evicting pods/"monitoring-plugin-57b46cfd5c-lr9q6" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:10.256045       1 request.go:700] Waited for 1.126318218s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-787b98474-lnqjp
+E0120 21:27:10.335584       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.335584       1 drain_controller.go:153] error when evicting pods/"thanos-querier-68d8f8f746-7ql87" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.335593       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.335673       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:10.838610       1 drain_controller.go:153] error when evicting pods/"router-default-787b98474-6ccdb" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:10.860488       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-sdwmj
+I0120 21:27:11.059903       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-9mwr9
+E0120 21:27:11.090547       1 drain_controller.go:153] error when evicting pods/"prometheus-operator-admission-webhook-5d9668865-fwdvs" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:11.257344       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-xhx4j
+I0120 21:27:11.456909       1 request.go:700] Waited for 1.371044171s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-cluster-api/pods/capi-controller-manager-8598896b96-7k4rp
+I0120 21:27:11.466459       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-cluster-api/capi-controller-manager-8598896b96-7k4rp
+I0120 21:27:11.658553       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0120 21:27:11.859788       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-49p2s
+I0120 21:27:12.059391       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0120 21:27:12.653305       1 request.go:700] Waited for 2.396843186s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-dzm4g
+I0120 21:27:12.660289       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-dzm4g
+I0120 21:27:12.880923       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-kbmqb
+I0120 21:27:13.057831       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-55469dfcdf-9gts8
+I0120 21:27:13.255860       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-dp6lr
+I0120 21:27:13.852931       1 request.go:700] Waited for 2.511510129s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/prometheus-operator-admission-webhook-5d9668865-cn2wt
+I0120 21:27:13.856073       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-cn2wt
+I0120 21:27:15.238458       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:27:15.244599       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-lr9q6
+E0120 21:27:15.247613       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:15.336686       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+I0120 21:27:15.336958       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:15.337067       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:15.337158       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:15.348229       1 drain_controller.go:153] error when evicting pods/"thanos-querier-68d8f8f746-7ql87" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:15.349672       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:15.358135       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:15.358146       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:15.839458       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-6ccdb
+I0120 21:27:16.091290       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-fwdvs
+I0120 21:27:17.257965       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-lr9q6
+I0120 21:27:18.254302       1 request.go:700] Waited for 1.123919358s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:18.458088       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-fwdvs
+I0120 21:27:20.248182       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+E0120 21:27:20.255947       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:20.349721       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:20.352828       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:20.359022       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:20.359177       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+E0120 21:27:20.369273       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:20.370678       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:20.380282       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:22.253729       1 request.go:700] Waited for 1.123709064s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:23.256726       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-7ql87
+I0120 21:27:24.253355       1 request.go:700] Waited for 1.122780946s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:25.256425       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+E0120 21:27:25.264893       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-7h9lh" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:25.369333       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:25.371474       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+E0120 21:27:25.377802       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:27:25.378187       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-gpml7" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:25.381294       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:25.478269       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:30.265769       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:27:30.378201       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:27:30.378516       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-gpml7
+E0120 21:27:30.387448       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:30.478852       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:30.491940       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:31.454329       1 request.go:700] Waited for 1.037730388s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-c66456f44-gpml7
+I0120 21:27:34.253691       1 request.go:700] Waited for 1.123605419s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-787b98474-lnqjp
+I0120 21:27:35.387920       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:35.396782       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:35.453851       1 request.go:700] Waited for 1.351482975s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-c66456f44-kk5sk
+I0120 21:27:35.456575       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-kk5sk
+I0120 21:27:35.492735       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:35.502629       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:37.253355       1 request.go:700] Waited for 1.122400487s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:39.856373       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-l6qqp
+I0120 21:27:40.253470       1 request.go:700] Waited for 1.120697615s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-g247h
+I0120 21:27:40.397584       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:40.405648       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:40.503128       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:27:40.514510       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:45.406660       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:45.414836       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:45.515120       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:48.257702       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-0
+I0120 21:27:50.414947       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:50.424920       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:55.425265       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:27:55.434699       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:27:58.057290       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-gpml7
+I0120 21:28:00.134525       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-lnqjp
+I0120 21:28:00.435391       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:28:00.443676       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:28:05.444637       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:28:05.453339       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:28:10.454050       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:28:10.462025       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:28:15.462889       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:28:22.510399       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0120 21:28:33.064858       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-6ccdb
+I0120 21:28:38.135339       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-g247h" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:28:40.264347       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-7h9lh" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:29:38.135867       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042225049974166665 hours
+I0120 21:29:38.135894       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating drain
+E0120 21:29:39.178046       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-vl8gn, openshift-cluster-node-tuning-operator/tuned-qslsp, openshift-dns/dns-default-vvzxt, openshift-dns/node-resolver-5srtq, openshift-image-registry/node-ca-9psxx, openshift-ingress-canary/ingress-canary-l6pth, openshift-insights/insights-runtime-extractor-hl5q4, openshift-machine-config-operator/machine-config-daemon-rmtb2, openshift-monitoring/node-exporter-vb9lg, openshift-multus/multus-additional-cni-plugins-xc5b9, openshift-multus/multus-mp8bq, openshift-multus/network-metrics-daemon-c8vng, openshift-network-diagnostics/network-check-target-vmvjd, openshift-network-operator/iptables-alerter-zhxcz, openshift-ovn-kubernetes/ovnkube-node-qc66q
+I0120 21:29:39.179712       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-g247h
+I0120 21:29:40.197619       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-g247h
+I0120 21:29:40.217558       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: operation successful; applying completion annotation
+I0120 21:29:40.264655       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04278880547333333 hours
+I0120 21:29:40.264741       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating drain
+E0120 21:29:42.178869       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-w2bqn, openshift-cluster-node-tuning-operator/tuned-r9wt5, openshift-dns/dns-default-kh6dw, openshift-dns/node-resolver-sxwkk, openshift-image-registry/node-ca-cq7nn, openshift-ingress-canary/ingress-canary-mhb88, openshift-insights/insights-runtime-extractor-sd5zx, openshift-machine-config-operator/machine-config-daemon-mxfsq, openshift-monitoring/node-exporter-tn6kd, openshift-multus/multus-additional-cni-plugins-hrr9q, openshift-multus/multus-pc2gv, openshift-multus/network-metrics-daemon-v7nr4, openshift-network-diagnostics/network-check-target-drltj, openshift-network-operator/iptables-alerter-f2gl5, openshift-ovn-kubernetes/ovnkube-node-f9gcr
+I0120 21:29:42.180569       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:30:02.200057       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-7h9lh
+I0120 21:30:02.220475       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: operation successful; applying completion annotation
+I0120 21:30:59.942092       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:30:59.986567       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:04.957883       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:04.957908       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.957914       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.957920       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.957925       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.957929       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:04.957933       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.957936       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.957941       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:04.990928       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:04.990950       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.990955       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.990962       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:04.990965       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:04.990970       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.990974       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:04.990979       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:04.990983       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:05.633878       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:10.650225       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:10.650246       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.650251       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.650258       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.650270       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.650277       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.650282       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.650286       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:10.650291       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:10.670464       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:10.670486       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.670491       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.670499       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:10.670503       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:10.670508       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.670512       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:10.670516       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:10.670520       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:13.651444       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting NotReady=False
+I0120 21:31:13.685774       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:13.717280       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:15.555300       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:15.590248       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:18.667758       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:18.667781       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.667786       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.667794       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.667799       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.667803       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:18.667807       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.667810       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.667814       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:18.691457       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:18.691478       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.691483       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.691491       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.691496       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:18.691500       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:18.691504       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:18.691507       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:18.691511       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:25.610394       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:31:25.653391       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:27.137131       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting Unschedulable
+I0120 21:31:27.160666       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:30.630885       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:30.630908       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.630914       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.630919       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.630924       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.630928       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:30.630934       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.630938       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.630942       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:30.732184       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:30.732208       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.732215       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:30.732220       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:30.732226       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.732230       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.732235       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:30.732239       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:30.732280       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:31.251836       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:31.307367       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:36.269554       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:36.269578       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.269584       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.269589       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.269592       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.269597       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.269602       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.269606       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:36.269611       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:36.293576       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:36.293599       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.293604       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.293609       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:31:36.293614       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:36.293619       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.293623       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:36.293627       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:36.293631       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:36.865897       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting NotReady=False
+I0120 21:31:36.897921       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:36.923127       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:37.051546       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: uncordoning
+I0120 21:31:37.051591       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:31:37.072659       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:31:37.092921       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: operation successful; applying completion annotation
+I0120 21:31:37.108129       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:31:41.273797       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:41.308847       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:41.888180       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:41.888202       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:31:41.888207       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.888213       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.888218       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.888222       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:41.888228       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:41.888231       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.888237       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:41.909976       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:41.910001       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:41.910005       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.910011       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:31:41.910015       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:41.910020       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.910024       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:41.910029       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:41.910032       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:31:42.076006       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:31:42.076564       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/currentImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:31:47.091181       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:47.091204       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091211       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091215       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091220       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091224       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091228       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091234       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:47.091238       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:47.091243       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:47.091248       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:31:47.091253       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:31:47.091260       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:31:47.091266       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:31:47.091272       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:31:47.091282       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:31:47.091314       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:31:47.091322       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091327       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091331       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091335       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:47.091338       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:31:47.091342       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091346       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.091350       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.091354       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:47.091359       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:31:47.091363       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:31:47.101006       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:31:47.101134       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"207984", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:31:47.107366       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:31:47.284060       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:47.284086       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:47.284091       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:47.284099       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284103       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284107       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.284111       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284115       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:47.284119       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:47.284123       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:51.356410       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting Unschedulable
+I0120 21:31:51.393296       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:31:52.313020       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:52.313068       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313074       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313079       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313084       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313094       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313097       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313102       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:52.313106       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:52.313111       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:52.313116       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:31:52.313120       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:31:52.313127       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:31:52.313135       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:31:52.313141       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:31:52.313152       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:31:52.313202       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:31:52.313212       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313217       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313221       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313225       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:52.313306       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:31:52.313349       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313368       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.313375       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.313379       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:52.313385       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:31:52.313390       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:31:52.323569       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:31:52.323684       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"212304", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:31:52.331571       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:31:52.502921       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:31:52.502946       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:31:52.502951       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:31:52.502957       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502961       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502965       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.502971       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502975       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:31:52.502977       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:31:52.502981       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:31:56.327592       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:32:00.411278       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: uncordoning
+I0120 21:32:00.411323       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:32:00.434169       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:32:00.468406       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:32:00.468516       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: operation successful; applying completion annotation
+I0120 21:32:01.352408       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:01.352431       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:01.352437       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:01.352443       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352448       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352453       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352457       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352461       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352464       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352469       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:01.352474       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:32:01.352478       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:32:01.352485       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:32:01.352492       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:32:01.352502       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:32:01.352535       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:32:01.352542       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:01.352547       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:32:01.352551       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352555       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352559       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352565       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352569       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.352572       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.352576       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:01.352581       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:32:01.352586       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:32:01.359168       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:32:01.359300       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"212304", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:01.365177       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:32:01.533807       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:01.533829       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533835       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533840       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.533845       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533849       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:01.533852       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:01.533856       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:01.533860       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:01.533864       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:05.433432       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:32:05.433540       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/currentImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:10.448354       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:10.448376       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448382       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448387       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448392       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448396       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448399       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448404       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448407       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448411       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448414       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:32:10.448419       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:32:10.448423       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:32:10.448430       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:32:10.448437       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:32:10.448446       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0120 21:32:10.448480       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:32:10.448488       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448493       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448498       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448501       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448505       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448509       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448512       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448516       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.448519       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.448523       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:32:10.448528       1 node_controller.go:1378] Selected node ip-10-0-86-209.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0120 21:32:10.448533       1 node_controller.go:1382] Final list of nodes to update in pool worker: 1 nodes (capacity: 2) [updateCandidateMachines]
+I0120 21:32:10.455576       1 node_controller.go:1399] Continuing to sync layered MachineConfigPool worker
+I0120 21:32:10.460667       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-86-209.ec2.internal, pool=worker, layered=true, mosbIsNil=false
+I0120 21:32:10.474995       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"212304", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfigAndOSImage' Targeted node ip-10-0-86-209.ec2.internal to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6 / Image: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:10.476783       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/desiredImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:32:10.494284       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:32:10.641063       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:10.641086       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641093       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641098       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.641102       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641107       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641110       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.641114       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641118       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:10.641121       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:10.641125       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:32:12.088994       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:32:15.509278       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:15.509302       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509307       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509312       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.509317       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509321       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.509325       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.509330       1 status.go:495] Node ip-10-0-86-209.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:15.509334       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:15.509341       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:15.509347       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:32:15.509350       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:32:15.509361       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:32:15.509581       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:32:15.586937       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:15.586961       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586967       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586972       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.586976       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586980       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:15.586984       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:15.586989       1 status.go:495] Node ip-10-0-86-209.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:32:15.586992       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:15.586996       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:17.195908       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: cordoning
+I0120 21:32:17.195932       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:32:17.223387       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:32:17.249101       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:32:17.254141       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating drain
+E0120 21:32:18.327587       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-8khhk, openshift-cluster-node-tuning-operator/tuned-g7zp9, openshift-dns/dns-default-mk56w, openshift-dns/node-resolver-hwqv4, openshift-image-registry/node-ca-8msd2, openshift-ingress-canary/ingress-canary-5nfvj, openshift-insights/insights-runtime-extractor-tc9l7, openshift-machine-config-operator/machine-config-daemon-m6t4q, openshift-monitoring/node-exporter-f4mcq, openshift-multus/multus-6kxrr, openshift-multus/multus-additional-cni-plugins-97f84, openshift-multus/network-metrics-daemon-cjxq7, openshift-network-diagnostics/network-check-target-h5k4g, openshift-network-operator/iptables-alerter-x2bn5, openshift-ovn-kubernetes/ovnkube-node-9n6w2
+I0120 21:32:18.329375       1 drain_controller.go:153] evicting pod openshift-cluster-api/capi-controller-manager-8598896b96-sg2cj
+I0120 21:32:18.329397       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-ld64r
+I0120 21:32:18.329413       1 drain_controller.go:153] evicting pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-nq78n
+I0120 21:32:18.329440       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28956810-pmpb5
+I0120 21:32:18.329520       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-7l4qm
+I0120 21:32:18.329533       1 drain_controller.go:153] evicting pod openshift-console/downloads-6ffc5555fc-nlq7r
+I0120 21:32:18.329587       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-qr6zv
+I0120 21:32:18.329617       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-kbfqs
+I0120 21:32:18.329627       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-55469dfcdf-rv594
+I0120 21:32:18.329699       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-458wh
+I0120 21:32:18.329708       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28956780-4j452
+I0120 21:32:18.329732       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-wfl4n
+I0120 21:32:18.329619       1 drain_controller.go:153] evicting pod openshift-machine-config-operator/machine-os-builder-b76f56d79-skclc
+I0120 21:32:18.329774       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-pf8sf
+I0120 21:32:18.329602       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-rcp6v
+I0120 21:32:18.329820       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-5d8qj
+I0120 21:32:18.329525       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-zdpvv
+I0120 21:32:18.329758       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-kmg2b
+I0120 21:32:18.329609       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0120 21:32:18.329611       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:32:18.329766       1 drain_controller.go:153] evicting pod openshift-operator-lifecycle-manager/collect-profiles-28956795-5j6l4
+I0120 21:32:18.402153       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28956810-pmpb5
+I0120 21:32:18.447625       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-console/downloads-6ffc5555fc-nlq7r
+I0120 21:32:18.631951       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28956780-4j452
+I0120 21:32:19.332570       1 request.go:700] Waited for 1.002686252s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-5d8qj/eviction
+I0120 21:32:20.530241       1 request.go:700] Waited for 2.200128169s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/api/v1/namespaces/openshift-operator-lifecycle-manager/pods/collect-profiles-28956795-5j6l4/eviction
+I0120 21:32:20.930887       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:20.930911       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930917       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930921       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:20.930925       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930930       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:20.930933       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:20.930938       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:32:20.930941       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:20.930945       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:20.930951       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:32:20.930955       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:32:20.930964       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:32:21.036972       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:32:21.036994       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037000       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037005       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:21.037010       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037016       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:32:21.037019       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:32:21.037023       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:32:21.037027       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:32:21.037031       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:32:21.579494       1 request.go:700] Waited for 1.690831725s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-machine-config-operator/pods/machine-os-builder-b76f56d79-skclc
+I0120 21:32:22.775564       1 request.go:700] Waited for 2.356913687s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-kube-storage-version-migrator/pods/migrator-6dcd57bc4f-nq78n
+I0120 21:32:23.603084       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0120 21:32:23.791681       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-operator-lifecycle-manager/collect-profiles-28956795-5j6l4
+I0120 21:32:23.977349       1 request.go:700] Waited for 2.972019725s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-5d8qj
+I0120 21:32:24.179025       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-kbfqs
+I0120 21:32:24.378903       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-qr6zv
+I0120 21:32:24.578752       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-ld64r
+I0120 21:32:24.778241       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-machine-config-operator/machine-os-builder-b76f56d79-skclc
+I0120 21:32:24.977870       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-pf8sf
+I0120 21:32:25.174964       1 request.go:700] Waited for 2.88445679s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-rcp6v
+I0120 21:32:25.178392       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-rcp6v
+I0120 21:32:25.579094       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-kmg2b
+I0120 21:32:25.978178       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-cluster-api/capi-controller-manager-8598896b96-sg2cj
+I0120 21:32:26.175483       1 request.go:700] Waited for 2.763361506s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/telemeter-client-55469dfcdf-rv594
+I0120 21:32:26.178912       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-55469dfcdf-rv594
+I0120 21:32:27.575140       1 request.go:700] Waited for 1.156942259s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-kube-storage-version-migrator/pods/migrator-6dcd57bc4f-nq78n
+I0120 21:32:31.353928       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-wfl4n
+I0120 21:32:31.362345       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-458wh
+I0120 21:32:31.376155       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0120 21:32:46.459114       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-7l4qm
+I0120 21:32:50.421499       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-kube-storage-version-migrator/migrator-6dcd57bc4f-nq78n
+I0120 21:33:37.385327       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-zdpvv
+I0120 21:33:49.007305       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-5d8qj" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:34:49.007474       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042162233666944444 hours
+I0120 21:34:49.007500       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating drain
+E0120 21:34:50.052524       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-8khhk, openshift-cluster-node-tuning-operator/tuned-g7zp9, openshift-dns/dns-default-mk56w, openshift-dns/node-resolver-hwqv4, openshift-image-registry/node-ca-8msd2, openshift-ingress-canary/ingress-canary-5nfvj, openshift-insights/insights-runtime-extractor-tc9l7, openshift-machine-config-operator/machine-config-daemon-m6t4q, openshift-monitoring/node-exporter-f4mcq, openshift-multus/multus-6kxrr, openshift-multus/multus-additional-cni-plugins-97f84, openshift-multus/network-metrics-daemon-cjxq7, openshift-network-diagnostics/network-check-target-h5k4g, openshift-network-operator/iptables-alerter-x2bn5, openshift-ovn-kubernetes/ovnkube-node-9n6w2
+I0120 21:34:50.054263       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-5d8qj
+I0120 21:34:51.071004       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-5d8qj
+I0120 21:34:51.088971       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: operation successful; applying completion annotation
+I0120 21:36:06.392018       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: Reporting unready: node ip-10-0-86-209.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:36:06.434214       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:11.410080       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:11.410102       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410109       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410113       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.410120       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:11.410124       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:11.410129       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410133       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.410137       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.410140       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:11.410146       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:11.410149       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:11.410159       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:11.432004       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:11.432026       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432033       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432038       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.432042       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432046       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:11.432049       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:11.432055       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:11.432059       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:11.432063       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:12.252719       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:17.266775       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:17.266798       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266805       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266809       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.266815       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266819       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.266822       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.266828       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:17.266832       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:17.266836       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:17.266841       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:17.266845       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:17.266854       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:17.287801       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:17.287824       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287830       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287835       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.287841       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:17.287845       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:17.287850       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287854       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:17.287858       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:17.287862       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:23.978961       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: Reporting unready: node ip-10-0-86-209.ec2.internal is reporting NotReady=False
+I0120 21:36:24.010686       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:24.032889       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:27.158536       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:27.182037       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:29.009454       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:29.009497       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009504       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009509       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.009513       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009517       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.009521       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.009527       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:29.009531       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:29.009535       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:29.009540       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:29.009544       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:29.009553       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:29.031347       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:29.031371       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031377       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031381       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.031385       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031390       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:29.031394       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:29.031400       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:29.031404       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:29.031408       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:38.372286       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: Reporting unready: node ip-10-0-86-209.ec2.internal is reporting Unschedulable
+I0120 21:36:38.420884       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:42.205158       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:43.389316       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:43.389341       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389348       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389352       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.389357       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389361       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.389365       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.389370       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:43.389373       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:43.389378       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:43.389382       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:36:43.389386       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:36:43.389395       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:36:43.482578       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:43.482600       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:36:43.482605       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=true
+I0120 21:36:43.482610       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482614       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482618       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.482622       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482626       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:43.482630       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:43.482634       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:36:47.399112       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: uncordoning
+I0120 21:36:47.399155       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:36:47.424863       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:36:47.443926       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: operation successful; applying completion annotation
+I0120 21:36:47.455581       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:36:52.423574       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:36:52.423606       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/currentImage = image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:eb1974454fda480b3bbcfdf1747bdb23bea394055e2fdbc3929b2a794fbbb150
+I0120 21:36:52.478483       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:52.478587       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478599       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478605       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.478610       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478614       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478617       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.478622       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478626       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.478630       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.478633       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:36:52.478638       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:36:52.478642       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:36:52.478651       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:36:52.567100       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:52.567123       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567129       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567134       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.567138       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567142       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567146       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.567149       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567154       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:52.567157       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:52.567161       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:36:57.593906       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:57.593929       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593937       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593942       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.593946       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593951       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593956       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.593960       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593964       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.593967       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.593972       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:36:57.593977       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:36:57.593981       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:36:57.593990       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:36:57.612434       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=true)
+I0120 21:36:57.612455       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612460       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612465       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.612469       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612473       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612476       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.612480       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612484       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:36:57.612488       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:36:57.612492       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:37:31.402313       1 template_controller.go:146] Re-syncing ControllerConfig due to secret pull-secret change
+I0120 21:38:12.681554       1 start.go:61] Version: 649ff75f-dirty (ad0657ecb77b5d5aca6b18b95146ced293f83b75)
+I0120 21:38:12.681781       1 leaderelection.go:121] The leader election gives 4 retries and allows for 30s of clock skew. The kube-apiserver downtime tolerance is 78s. Worst non-graceful lease acquisition is 2m43s. Worst graceful lease acquisition is {26s}.
+I0120 21:38:12.705712       1 leaderelection.go:254] attempting to acquire leader lease openshift-machine-config-operator/machine-config-controller...
+I0120 21:38:12.719776       1 leaderelection.go:268] successfully acquired lease openshift-machine-config-operator/machine-config-controller
+I0120 21:38:12.720544       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
+I0120 21:38:12.720744       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
+I0120 21:38:12.737946       1 metrics.go:92] Registering Prometheus metrics
+I0120 21:38:12.737997       1 metrics.go:99] Starting metrics listener on 127.0.0.1:8797
+I0120 21:38:12.738029       1 simple_featuregate_reader.go:171] Starting feature-gate-detector
+I0120 21:38:12.750464       1 reflector.go:368] Caches populated for *v1.Secret from k8s.io/client-go/informers/factory.go:160
+I0120 21:38:12.750861       1 reflector.go:368] Caches populated for *v1.ClusterVersion from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.753239       1 reflector.go:368] Caches populated for *v1.ControllerConfig from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:12.757320       1 reflector.go:368] Caches populated for *v1.FeatureGate from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.757449       1 event.go:377] Event(v1.ObjectReference{Kind:"Node", Namespace:"openshift-machine-config-operator", Name:"ip-10-0-12-37.ec2.internal", UID:"3966fb07-ed60-4892-92f4-2597e9c54157", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'FeatureGatesInitialized' FeatureGates updated to featuregates.Features{Enabled:[]v1.FeatureGateName{"AWSClusterHostedDNS", "AWSEFSDriverVolumeMetrics", "AdditionalRoutingCapabilities", "AdminNetworkPolicy", "AlibabaPlatform", "AutomatedEtcdBackup", "AzureWorkloadIdentity", "BareMetalLoadBalancer", "BootcNodeManagement", "BuildCSIVolumes", "CSIDriverSharedResource", "ChunkSizeMiB", "CloudDualStackNodeIPs", "ClusterMonitoringConfig", "ConsolePluginContentSecurityPolicy", "DNSNameResolver", "DisableKubeletCloudCredentialProviders", "DynamicResourceAllocation", "EtcdBackendQuota", "Example", "ExternalOIDC", "GCPClusterHostedDNS", "GCPLabelsTags", "HardwareSpeed", "ImageStreamImportMode", "IngressControllerDynamicConfigurationManager", "IngressControllerLBSubnetsAWS", "InsightsConfig", "InsightsConfigAPI", "InsightsOnDemandDataGather", "InsightsRuntimeExtractor", "KMSv1", "MachineAPIProviderOpenStack", "MachineConfigNodes", "ManagedBootImages", "ManagedBootImagesAWS", "MaxUnavailableStatefulSet", "MetricsCollectionProfiles", "MinimumKubeletVersion", "MixedCPUsAllocation", "MultiArchInstallAWS", "MultiArchInstallGCP", "NetworkDiagnosticsConfig", "NetworkLiveMigration", "NetworkSegmentation", "NewOLM", "NodeDisruptionPolicy", "NodeSwap", "NutanixMultiSubnets", "OVNObservability", "OnClusterBuild", "OpenShiftPodSecurityAdmission", "PersistentIPsForVirtualization", "PinnedImages", "PlatformOperators", "PrivateHostedZoneAWS", "ProcMountType", "RouteAdvertisements", "RouteExternalCertificate", "ServiceAccountTokenNodeBinding", "SetEIPForNLBIngressController", "SignatureStores", "SigstoreImageVerification", "TranslateStreamCloseWebsocketRequests", "UpgradeStatus", "UserNamespacesPodSecurityStandards", "UserNamespacesSupport", "VSphereControlPlaneMachineSet", "VSphereDriverConfiguration", "VSphereMultiNetworks", "VSphereMultiVCenters", "VSphereStaticIPs", "ValidatingAdmissionPolicy", "VolumeAttributesClass", "VolumeGroupSnapshot"}, Disabled:[]v1.FeatureGateName{"ClusterAPIInstall", "ClusterAPIInstallIBMCloud", "EventedPLEG", "GatewayAPI", "MachineAPIMigration", "MachineAPIOperatorDisableMachineHealthCheckController", "MultiArchInstallAzure"}}
+I0120 21:38:12.757485       1 start.go:105] FeatureGates initialized: enabled=[AWSClusterHostedDNS AWSEFSDriverVolumeMetrics AdditionalRoutingCapabilities AdminNetworkPolicy AlibabaPlatform AutomatedEtcdBackup AzureWorkloadIdentity BareMetalLoadBalancer BootcNodeManagement BuildCSIVolumes CSIDriverSharedResource ChunkSizeMiB CloudDualStackNodeIPs ClusterMonitoringConfig ConsolePluginContentSecurityPolicy DNSNameResolver DisableKubeletCloudCredentialProviders DynamicResourceAllocation EtcdBackendQuota Example ExternalOIDC GCPClusterHostedDNS GCPLabelsTags HardwareSpeed ImageStreamImportMode IngressControllerDynamicConfigurationManager IngressControllerLBSubnetsAWS InsightsConfig InsightsConfigAPI InsightsOnDemandDataGather InsightsRuntimeExtractor KMSv1 MachineAPIProviderOpenStack MachineConfigNodes ManagedBootImages ManagedBootImagesAWS MaxUnavailableStatefulSet MetricsCollectionProfiles MinimumKubeletVersion MixedCPUsAllocation MultiArchInstallAWS MultiArchInstallGCP NetworkDiagnosticsConfig NetworkLiveMigration NetworkSegmentation NewOLM NodeDisruptionPolicy NodeSwap NutanixMultiSubnets OVNObservability OnClusterBuild OpenShiftPodSecurityAdmission PersistentIPsForVirtualization PinnedImages PlatformOperators PrivateHostedZoneAWS ProcMountType RouteAdvertisements RouteExternalCertificate ServiceAccountTokenNodeBinding SetEIPForNLBIngressController SignatureStores SigstoreImageVerification TranslateStreamCloseWebsocketRequests UpgradeStatus UserNamespacesPodSecurityStandards UserNamespacesSupport VSphereControlPlaneMachineSet VSphereDriverConfiguration VSphereMultiNetworks VSphereMultiVCenters VSphereStaticIPs ValidatingAdmissionPolicy VolumeAttributesClass VolumeGroupSnapshot]  disabled=[ClusterAPIInstall ClusterAPIInstallIBMCloud EventedPLEG GatewayAPI MachineAPIMigration MachineAPIOperatorDisableMachineHealthCheckController MultiArchInstallAzure]
+I0120 21:38:12.757925       1 template_controller.go:146] Re-syncing ControllerConfig due to secret pull-secret change
+I0120 21:38:12.759118       1 reflector.go:368] Caches populated for *v1.Node from k8s.io/client-go/informers/factory.go:160
+E0120 21:38:12.759174       1 node_controller.go:488] getting scheduler config failed: cluster scheduler couldn't be found
+E0120 21:38:12.773539       1 node_controller.go:488] getting scheduler config failed: cluster scheduler couldn't be found
+E0120 21:38:12.773574       1 node_controller.go:488] getting scheduler config failed: cluster scheduler couldn't be found
+I0120 21:38:12.774066       1 reflector.go:368] Caches populated for *v1.MachineConfigPool from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:12.800616       1 reflector.go:368] Caches populated for *v1.Node from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.801052       1 reflector.go:368] Caches populated for *v1alpha1.PinnedImageSet from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:12.802677       1 drain_controller.go:169] Starting MachineConfigController-DrainController
+I0120 21:38:12.813391       1 container_runtime_config_controller.go:237] addded image policy observers with sigstore featuregate enabled
+I0120 21:38:12.824358       1 reflector.go:368] Caches populated for *v1alpha1.ImageContentSourcePolicy from github.com/openshift/client-go/operator/informers/externalversions/factory.go:125
+I0120 21:38:12.832781       1 reflector.go:368] Caches populated for *v1.Infrastructure from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.834943       1 reflector.go:368] Caches populated for *v1.ConfigMap from k8s.io/client-go/informers/factory.go:160
+I0120 21:38:12.835151       1 machine_set_boot_image_controller.go:221] configMap coreos-bootimages added, reconciling enrolled machine resources
+I0120 21:38:12.835213       1 machine_set_boot_image_controller.go:334] MachineConfiguration knobs was not found, so no MAPI machinesets will be enqueued.
+I0120 21:38:12.835402       1 reflector.go:368] Caches populated for *v1.ImageDigestMirrorSet from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.842362       1 reflector.go:368] Caches populated for *v1.Scheduler from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.854706       1 reflector.go:368] Caches populated for *v1.MachineConfig from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:12.863722       1 reflector.go:368] Caches populated for *v1.Image from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.873240       1 pinned_image_set.go:118] Starting MachineConfigController-PinnedImageSetController
+I0120 21:38:12.902756       1 reflector.go:368] Caches populated for *v1.ContainerRuntimeConfig from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:12.906648       1 reflector.go:368] Caches populated for *v1.APIServer from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.906941       1 kubelet_config_controller.go:222] Re-syncing all kubelet config controller generated MachineConfigs due to apiServer cluster change
+I0120 21:38:12.907202       1 template_controller.go:198] Re-syncing ControllerConfig due to apiServer cluster change
+I0120 21:38:12.915397       1 node_controller.go:248] Starting MachineConfigController-NodeController
+I0120 21:38:12.915506       1 render_controller.go:129] Starting MachineConfigController-RenderController
+I0120 21:38:12.922506       1 reflector.go:368] Caches populated for *v1.ImageTagMirrorSet from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:12.925744       1 template_controller.go:294] Starting MachineConfigController-TemplateController
+I0120 21:38:12.941036       1 reflector.go:368] Caches populated for *v1.KubeletConfig from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:12.970646       1 reflector.go:368] Caches populated for *v1.Pod from k8s.io/client-go/informers/factory.go:160
+I0120 21:38:13.000036       1 reflector.go:368] Caches populated for *v1.MachineConfiguration from github.com/openshift/client-go/operator/informers/externalversions/factory.go:125
+I0120 21:38:13.000199       1 machine_set_boot_image_controller.go:275] Bootimages management configuration has been added, reconciling enrolled machine resources
+I0120 21:38:13.000265       1 helpers.go:76] No machine manager were found, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.000297       1 machine_set_boot_image_controller.go:361] No MAPI machinesets were enrolled, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.017044       1 kubelet_config_controller.go:201] Starting MachineConfigController-KubeletConfigController
+I0120 21:38:13.028686       1 reflector.go:368] Caches populated for *v1beta1.MachineSet from github.com/openshift/client-go/machine/informers/externalversions/factory.go:125
+I0120 21:38:13.029872       1 machine_set_boot_image_controller.go:171] MAPI MachineSet dkhater-01-20-1-ocp-a-srprh-worker-us-east-1a added, reconciling enrolled machine resources
+I0120 21:38:13.036143       1 machine_set_boot_image_controller.go:171] MAPI MachineSet dkhater-01-20-1-ocp-a-srprh-worker-us-east-1b added, reconciling enrolled machine resources
+I0120 21:38:13.036181       1 machine_set_boot_image_controller.go:171] MAPI MachineSet dkhater-01-20-1-ocp-a-srprh-worker-us-east-1c added, reconciling enrolled machine resources
+I0120 21:38:13.036212       1 machine_set_boot_image_controller.go:171] MAPI MachineSet dkhater-01-20-1-ocp-a-srprh-worker-us-east-1d added, reconciling enrolled machine resources
+I0120 21:38:13.036244       1 machine_set_boot_image_controller.go:171] MAPI MachineSet dkhater-01-20-1-ocp-a-srprh-worker-us-east-1f added, reconciling enrolled machine resources
+I0120 21:38:13.083423       1 helpers.go:76] No machine manager were found, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.083987       1 machine_set_boot_image_controller.go:361] No MAPI machinesets were enrolled, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.127793       1 machine_set_boot_image_controller.go:161] Starting MachineConfigController-MachineSetBootImageController
+I0120 21:38:13.128303       1 reflector.go:368] Caches populated for *v1alpha1.ClusterImagePolicy from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:13.128923       1 reflector.go:368] Caches populated for *v1alpha1.ImagePolicy from github.com/openshift/client-go/config/informers/externalversions/factory.go:125
+I0120 21:38:13.138854       1 reflector.go:368] Caches populated for *v1alpha1.MachineOSConfig from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:13.210353       1 helpers.go:76] No machine manager were found, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.210384       1 machine_set_boot_image_controller.go:361] No MAPI machinesets were enrolled, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.229388       1 container_runtime_config_controller.go:247] Starting MachineConfigController-ContainerRuntimeConfigController
+I0120 21:38:13.249649       1 helpers.go:76] No machine manager were found, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.249684       1 machine_set_boot_image_controller.go:361] No MAPI machinesets were enrolled, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.325192       1 kubelet_config_features.go:126] Applied FeatureSet cluster on MachineConfigPool master
+I0120 21:38:13.367340       1 kubelet_config_nodes.go:169] Applied Node configuration 97-worker-generated-kubelet on MachineConfigPool worker
+I0120 21:38:13.426849       1 helpers.go:76] No machine manager were found, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.426944       1 machine_set_boot_image_controller.go:361] No MAPI machinesets were enrolled, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.468518       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool master
+I0120 21:38:13.485708       1 kubelet_config_features.go:126] Applied FeatureSet cluster on MachineConfigPool worker
+I0120 21:38:13.617050       1 container_runtime_config_controller.go:957] Applied ImageConfig cluster on MachineConfigPool worker
+I0120 21:38:13.806012       1 helpers.go:76] No machine manager were found, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.806038       1 machine_set_boot_image_controller.go:361] No MAPI machinesets were enrolled, so no MAPI machinesets will be enqueued.
+I0120 21:38:13.824138       1 kubelet_config_nodes.go:169] Applied Node configuration 97-master-generated-kubelet on MachineConfigPool master
+I0120 21:38:14.183073       1 reflector.go:368] Caches populated for *v1.ContainerRuntimeConfig from github.com/openshift/client-go/machineconfiguration/informers/externalversions/factory.go:125
+I0120 21:38:14.424770       1 kubelet_config_features.go:126] Applied FeatureSet cluster on MachineConfigPool master
+I0120 21:38:15.024864       1 kubelet_config_features.go:126] Applied FeatureSet cluster on MachineConfigPool worker
+I0120 21:38:17.784373       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.784410       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784421       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784427       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784432       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784436       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784440       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784444       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784448       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784452       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784457       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.784463       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:38:17.784467       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:38:17.784473       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-46-217.ec2.internal
+I0120 21:38:17.784478       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-5-10.ec2.internal
+I0120 21:38:17.784484       1 node_controller.go:1261] Already picked 2 nodes, capacity is 2, stopping
+I0120 21:38:17.784490       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:38:17.784500       1 node_controller.go:1076] worker: 2 candidate nodes in 2 zones for update, capacity: 2
+I0120 21:38:17.784537       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.784545       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784549       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784553       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784557       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784561       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784564       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784568       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784572       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.784575       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784579       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.784584       1 node_controller.go:1378] Selected node ip-10-0-46-217.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0120 21:38:17.784590       1 node_controller.go:1378] Selected node ip-10-0-5-10.ec2.internal for update (current selection count: 2) [updateCandidateMachines]
+I0120 21:38:17.784594       1 node_controller.go:1382] Final list of nodes to update in pool worker: 2 nodes (capacity: 2) [updateCandidateMachines]
+I0120 21:38:17.784877       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.784891       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784896       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784900       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784904       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784908       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784911       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784915       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784919       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.784922       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.784926       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.784929       1 node_controller.go:1248] maxUnavailable is 1 and unavail is 0 (getAllCandidateMachines)
+I0120 21:38:17.784933       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:38:17.784940       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:38:17.801852       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-46-217.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0120 21:38:17.823860       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0120 21:38:17.833296       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-5-10.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0120 21:38:17.850879       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"216260", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 2 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.852509       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0120 21:38:17.858509       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:38:17.883311       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.883342       1 status.go:500] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.883349       1 status.go:502] [isNodeUnavailable] Node ip-10-0-12-37.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.883354       1 status.go:542] Node ip-10-0-12-37.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.883358       1 status.go:500] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.883363       1 status.go:502] [isNodeUnavailable] Node ip-10-0-49-30.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.883367       1 status.go:542] Node ip-10-0-49-30.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.883374       1 status.go:500] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal currentConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.883379       1 status.go:502] [isNodeUnavailable] Node ip-10-0-74-240.ec2.internal desiredConfig: rendered-master-6a154b7cddf64d36429e9c0f4c5482a3
+I0120 21:38:17.883382       1 status.go:542] Node ip-10-0-74-240.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.883386       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:17.983012       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:17.983039       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983047       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983052       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.983056       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983060       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983064       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.983068       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983073       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:17.983076       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:17.983080       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:38:19.066718       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:38:19.132791       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:38:22.851385       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:38:22.888966       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:22.888995       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.889001       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.889007       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.889012       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.889016       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:22.889021       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.889024       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.889028       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:38:22.890705       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:38:22.931179       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:22.931201       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.931208       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:22.931213       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:22.931217       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.931221       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.931226       1 status.go:495] Node ip-10-0-5-10.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:38:22.931229       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:22.931233       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:38:24.170838       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: cordoning
+I0120 21:38:24.170876       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:38:24.192790       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:38:24.213168       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:38:24.221993       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating drain
+I0120 21:38:24.238119       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: cordoning
+I0120 21:38:24.238149       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:38:24.266297       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:38:24.292895       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:38:24.301319       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating drain
+E0120 21:38:26.085540       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-w2bqn, openshift-cluster-node-tuning-operator/tuned-r9wt5, openshift-dns/dns-default-kh6dw, openshift-dns/node-resolver-sxwkk, openshift-image-registry/node-ca-cq7nn, openshift-ingress-canary/ingress-canary-mhb88, openshift-insights/insights-runtime-extractor-sd5zx, openshift-machine-config-operator/machine-config-daemon-m7dpr, openshift-monitoring/node-exporter-tn6kd, openshift-multus/multus-additional-cni-plugins-hrr9q, openshift-multus/multus-pc2gv, openshift-multus/network-metrics-daemon-v7nr4, openshift-network-diagnostics/network-check-target-drltj, openshift-network-operator/iptables-alerter-f2gl5, openshift-ovn-kubernetes/ovnkube-node-f9gcr
+I0120 21:38:26.087479       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-lwn9w
+I0120 21:38:26.087505       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-7kwxm
+I0120 21:38:26.087519       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:38:26.087508       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-55469dfcdf-qql6l
+I0120 21:38:26.087548       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-ncbp6
+I0120 21:38:26.087488       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-fcq79
+I0120 21:38:26.087610       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-qjlxt
+I0120 21:38:26.087635       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-b6bzw
+I0120 21:38:26.087580       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-g7p72
+I0120 21:38:26.087587       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0120 21:38:26.087593       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-ffr42
+I0120 21:38:26.087601       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-j6pjl
+I0120 21:38:26.087479       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-dv4cd
+I0120 21:38:27.556205       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-b6bzw
+I0120 21:38:27.856295       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:27.856319       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.856325       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.856329       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:27.856334       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.856338       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.856342       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.856345       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.856349       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:38:27.957154       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:38:27.957181       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.957187       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.957194       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:38:27.957197       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:38:27.957202       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.957208       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:38:27.957212       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:38:27.957215       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+E0120 21:38:28.286510       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-vl8gn, openshift-cluster-node-tuning-operator/tuned-qslsp, openshift-dns/dns-default-vvzxt, openshift-dns/node-resolver-5srtq, openshift-image-registry/node-ca-9psxx, openshift-ingress-canary/ingress-canary-l6pth, openshift-insights/insights-runtime-extractor-hl5q4, openshift-machine-config-operator/machine-config-daemon-dtlln, openshift-monitoring/node-exporter-vb9lg, openshift-multus/multus-additional-cni-plugins-xc5b9, openshift-multus/multus-mp8bq, openshift-multus/network-metrics-daemon-c8vng, openshift-network-diagnostics/network-check-target-vmvjd, openshift-network-operator/iptables-alerter-zhxcz, openshift-ovn-kubernetes/ovnkube-node-qc66q
+I0120 21:38:28.288417       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-8dvq7
+I0120 21:38:28.288437       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-q2pc4
+I0120 21:38:28.288495       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:38:28.288573       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:38:28.288423       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-s8hr2
+I0120 21:38:28.288692       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-9lzxz
+I0120 21:38:28.288792       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:28.288971       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-ctn4g
+I0120 21:38:28.288427       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-qd4zv
+E0120 21:38:28.300708       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-ctn4g" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:28.300775       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:28.300884       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:28.302331       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:28.302709       1 drain_controller.go:153] error when evicting pods/"router-default-787b98474-s8hr2" -n "openshift-ingress" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:28.310638       1 drain_controller.go:153] error when evicting pods/"thanos-querier-68d8f8f746-9lzxz" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:28.341260       1 request.go:700] Waited for 1.130479168s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0
+I0120 21:38:28.549234       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-ncbp6
+I0120 21:38:29.351529       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-7kwxm
+I0120 21:38:29.541343       1 request.go:700] Waited for 1.386597282s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-diagnostics/pods/network-check-source-77c8b75fd4-lwn9w
+I0120 21:38:29.546682       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-lwn9w
+I0120 21:38:29.748000       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-g7p72
+I0120 21:38:30.148052       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-55469dfcdf-qql6l
+I0120 21:38:30.350011       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0120 21:38:30.741400       1 request.go:700] Waited for 2.424691808s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-8dvq7
+I0120 21:38:30.745766       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-8dvq7
+I0120 21:38:30.945779       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-q2pc4
+I0120 21:38:31.146078       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-qd4zv
+I0120 21:38:31.346977       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0120 21:38:31.546073       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-ffr42
+I0120 21:38:31.741510       1 request.go:700] Waited for 2.250261804s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-ingress/pods/router-default-787b98474-dv4cd
+I0120 21:38:33.301347       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:33.301352       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:38:33.301927       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-ctn4g
+I0120 21:38:33.302482       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:38:33.302784       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-s8hr2
+I0120 21:38:33.311531       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-9lzxz
+E0120 21:38:33.311636       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-ctn4g" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:33.311848       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:33.312513       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:33.312651       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:35.344701       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-9lzxz
+I0120 21:38:38.313000       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:38:38.313030       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:38.313005       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-ctn4g
+I0120 21:38:38.313014       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:38:38.322795       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-ctn4g" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:38.322869       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:38.323189       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:38.323247       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:43.323789       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:38:43.323806       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:43.323815       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-ctn4g
+I0120 21:38:43.323798       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:38:43.332410       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:43.332550       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:43.333171       1 drain_controller.go:153] error when evicting pods/"image-registry-c66456f44-ctn4g" -n "openshift-image-registry" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:43.333177       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:48.333176       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+I0120 21:38:48.333195       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:48.333233       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:38:48.333240       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-ctn4g
+E0120 21:38:48.342239       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:48.343327       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:48.344758       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:51.741073       1 request.go:700] Waited for 1.079398986s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/metrics-server-69d8d5dd44-qjlxt
+I0120 21:38:53.343372       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:38:53.343812       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:53.345646       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:38:53.357545       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:53.357929       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:53.358909       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:53.944916       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-fcq79
+I0120 21:38:58.358166       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:38:58.358166       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:38:58.359471       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:38:58.373277       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:58.373276       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:38:58.373330       1 drain_controller.go:153] error when evicting pods/"alertmanager-main-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:38:59.945958       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-j6pjl
+I0120 21:39:03.373619       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:39:03.373628       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:39:03.373929       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-0
+E0120 21:39:03.383188       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:39:03.383962       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:39:06.425771       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-0
+I0120 21:39:08.384065       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:39:08.384391       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+E0120 21:39:08.400112       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+E0120 21:39:08.400129       1 drain_controller.go:153] error when evicting pods/"metrics-server-69d8d5dd44-dt2xd" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:39:13.400702       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:39:13.400715       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:39:13.410500       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:39:15.952018       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-ctn4g
+I0120 21:39:18.410628       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:39:18.419849       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:39:23.420511       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:39:23.432022       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:39:28.432558       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+E0120 21:39:28.444585       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-1" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:39:33.446026       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-1
+I0120 21:39:35.500936       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-1
+I0120 21:39:43.495410       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-dv4cd
+I0120 21:39:50.554791       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-s8hr2
+I0120 21:39:56.666974       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-qjlxt" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:39:58.443456       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-dt2xd" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+I0120 21:40:56.667152       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.04235397935527778 hours
+I0120 21:40:56.667180       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating drain
+E0120 21:40:57.711420       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-w2bqn, openshift-cluster-node-tuning-operator/tuned-r9wt5, openshift-dns/dns-default-kh6dw, openshift-dns/node-resolver-sxwkk, openshift-image-registry/node-ca-cq7nn, openshift-ingress-canary/ingress-canary-mhb88, openshift-insights/insights-runtime-extractor-sd5zx, openshift-machine-config-operator/machine-config-daemon-m7dpr, openshift-monitoring/node-exporter-tn6kd, openshift-multus/multus-additional-cni-plugins-hrr9q, openshift-multus/multus-pc2gv, openshift-multus/network-metrics-daemon-v7nr4, openshift-network-diagnostics/network-check-target-drltj, openshift-network-operator/iptables-alerter-f2gl5, openshift-ovn-kubernetes/ovnkube-node-f9gcr
+I0120 21:40:57.713351       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-qjlxt
+I0120 21:40:57.736260       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: operation successful; applying completion annotation
+I0120 21:40:58.444494       1 drain_controller.go:380] Previous node drain found. Drain has been going on for 0.042827268506944446 hours
+I0120 21:40:58.444519       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating drain
+E0120 21:41:00.712831       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-vl8gn, openshift-cluster-node-tuning-operator/tuned-qslsp, openshift-dns/dns-default-vvzxt, openshift-dns/node-resolver-5srtq, openshift-image-registry/node-ca-9psxx, openshift-ingress-canary/ingress-canary-l6pth, openshift-insights/insights-runtime-extractor-hl5q4, openshift-machine-config-operator/machine-config-daemon-dtlln, openshift-monitoring/node-exporter-vb9lg, openshift-multus/multus-additional-cni-plugins-xc5b9, openshift-multus/multus-mp8bq, openshift-multus/network-metrics-daemon-c8vng, openshift-network-diagnostics/network-check-target-vmvjd, openshift-network-operator/iptables-alerter-zhxcz, openshift-ovn-kubernetes/ovnkube-node-qc66q
+I0120 21:41:00.714584       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:41:44.735103       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: Evicted pod openshift-monitoring/metrics-server-69d8d5dd44-dt2xd
+I0120 21:41:44.754512       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: operation successful; applying completion annotation
+I0120 21:42:17.279223       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:42:17.317181       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:42:22.285070       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:42:22.285097       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:42:22.285103       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:22.285109       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:42:22.285112       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:22.285118       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:22.285122       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:22.285126       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:42:22.285130       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:42:22.306048       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:42:22.306071       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:42:22.306076       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:22.306081       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:42:22.306084       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:22.306089       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:22.306094       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:22.306098       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:42:22.306102       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:42:22.955720       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:42:27.961111       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:42:27.961136       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:27.961145       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:27.961150       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:42:27.961157       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:42:27.961161       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:27.961167       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:42:27.961170       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:27.961174       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:42:27.979996       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:42:27.980023       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:42:27.980031       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:27.980036       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:42:27.980039       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:27.980044       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:27.980049       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:27.980053       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:42:27.980057       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:42:52.460449       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting NotReady=False
+I0120 21:42:52.483973       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:42:52.513381       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:42:52.869025       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:42:52.891549       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:42:57.468265       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:42:57.468289       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:57.468296       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:57.468300       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:42:57.468308       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:42:57.468313       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:57.468318       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:42:57.468322       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:57.468326       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:42:57.488411       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:42:57.488438       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:42:57.488443       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:57.488449       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:57.488453       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:42:57.488457       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:42:57.488463       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:42:57.488467       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:42:57.488471       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:43:04.929093       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: Reporting unready: node ip-10-0-46-217.ec2.internal is reporting Unschedulable
+I0120 21:43:04.968152       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:43:07.915986       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting OutOfDisk=Unknown
+I0120 21:43:07.916071       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:43:07.952841       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:09.938147       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:09.938173       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:43:09.938178       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:09.938187       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:09.938190       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:09.938196       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:09.938201       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:09.938206       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:09.938210       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:43:09.955795       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:09.955817       1 status.go:490] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal is NOT ready => unavailable
+I0120 21:43:09.955822       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:09.955830       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:09.955833       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:09.955839       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:09.955843       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:09.955847       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:09.955853       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:43:13.583646       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:15.660512       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: uncordoning
+I0120 21:43:15.660562       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:43:15.691370       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:43:15.706995       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed taints
+I0120 21:43:15.719795       1 drain_controller.go:183] node ip-10-0-46-217.ec2.internal: operation successful; applying completion annotation
+I0120 21:43:18.587660       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:18.587685       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:18.587690       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:18.587696       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:18.587701       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:18.587705       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:18.587710       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:43:18.587713       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:18.587717       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:43:18.607752       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:18.607774       1 status.go:495] Node ip-10-0-46-217.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:43:18.607779       1 status.go:539] Node ip-10-0-46-217.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:18.607787       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:18.607790       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:18.607795       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:18.607800       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:18.607804       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:18.607807       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 2
+I0120 21:43:20.688731       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:43:20.688752       1 node_controller.go:559] Pool worker[zone=us-east-1b]: node ip-10-0-46-217.ec2.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0120 21:43:25.693580       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:25.693604       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693610       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693615       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:25.693619       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693623       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693628       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:25.693634       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:25.693638       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:25.693642       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:25.693648       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:43:25.693653       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:43:25.693659       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:43:25.693665       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:43:25.693671       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:43:25.693681       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:43:25.693715       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:25.693725       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693730       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693734       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:25.693739       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:25.693743       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:25.693747       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693751       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.693754       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:25.693758       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:25.693763       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:43:25.693767       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:43:25.697449       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"217172", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.705042       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:43:25.794137       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:25.794161       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.794167       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.794174       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:25.794178       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.794182       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:25.794186       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:25.794193       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:25.794197       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:25.794201       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:30.810055       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:30.810081       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810087       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810092       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:30.810099       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:30.810103       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:30.810108       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810112       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810116       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:30.810120       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:30.810125       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:43:30.810129       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:43:30.810136       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:43:30.810142       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:43:30.810369       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:43:30.810479       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:30.810516       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810545       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810577       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:30.810604       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810634       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.810673       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:30.810706       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:30.810722       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:30.810728       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:30.810734       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:43:30.810739       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:43:30.822035       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"221346", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.829131       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:43:30.910893       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:30.910917       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.910923       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.910928       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:30.910932       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.910936       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:30.910939       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:30.910946       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:30.910950       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:30.910955       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:39.400769       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting NotReady=False
+I0120 21:43:39.442563       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:39.497190       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:43.518133       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:43.548189       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:44.405630       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:44.405655       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405662       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405667       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:44.405672       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405678       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405682       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:44.405688       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:44.405692       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:44.405697       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:44.405701       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:43:44.405705       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:43:44.405711       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:43:44.405717       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:43:44.405723       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:43:44.405733       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:43:44.405766       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:44.405776       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:44.405780       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:44.405785       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405789       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405794       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:44.405798       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405802       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.405806       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:44.405810       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:44.405824       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:43:44.405829       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:43:44.409228       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"221346", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.415393       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:43:44.506320       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:44.506342       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.506350       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.506354       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:44.506358       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.506363       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:44.506366       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:44.506373       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:44.506376       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:44.506380       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:53.799272       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: Reporting unready: node ip-10-0-5-10.ec2.internal is reporting Unschedulable
+I0120 21:43:53.842396       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:58.568945       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:43:58.804170       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:58.804193       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804199       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804204       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:58.804209       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804213       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804217       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:58.804221       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:58.804224       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:58.804229       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:58.804234       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:43:58.804238       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:43:58.804243       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:43:58.804250       1 node_controller.go:1261] Already picked 1 nodes, capacity is 1, stopping
+I0120 21:43:58.804255       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:43:58.804266       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 1
+I0120 21:43:58.804302       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:58.804310       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804315       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804320       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:58.804323       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:58.804327       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:58.804333       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804337       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.804341       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:58.804344       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:43:58.804349       1 node_controller.go:1374] Reached capacity limit (1 nodes), stopping selection [updateCandidateMachines]
+I0120 21:43:58.804354       1 node_controller.go:1382] Final list of nodes to update in pool worker: 0 nodes (capacity: 1) [updateCandidateMachines]
+I0120 21:43:58.807791       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"221346", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Set target for 0 nodes to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.813335       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:43:58.905551       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:43:58.905573       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.905579       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.905584       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:58.905588       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.905592       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:43:58.905596       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:43:58.905601       1 status.go:490] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal is NOT ready => unavailable
+I0120 21:43:58.905605       1 status.go:539] Node ip-10-0-5-10.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:43:58.905609       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:44:03.215781       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: uncordoning
+I0120 21:44:03.215817       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: initiating uncordon (currently schedulable: false)
+I0120 21:44:03.245379       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: uncordon succeeded (currently schedulable: true)
+I0120 21:44:03.260298       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed taints
+I0120 21:44:03.272636       1 drain_controller.go:183] node ip-10-0-5-10.ec2.internal: operation successful; applying completion annotation
+I0120 21:44:08.240112       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Done
+I0120 21:44:08.240680       1 node_controller.go:559] Pool worker[zone=us-east-1a]: node ip-10-0-5-10.ec2.internal: lost annotation machineconfiguration.openshift.io/currentImage
+I0120 21:44:08.267565       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:08.267590       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267597       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267601       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.267606       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267611       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267614       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.267619       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267622       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267626       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.267629       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:44:08.267634       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 0 (getAllCandidateMachines)
+I0120 21:44:08.267638       1 node_controller.go:1251] calculated initialcapacity is 2 (getAllCandidateMachines)
+I0120 21:44:08.267644       1 node_controller.go:1284] Pool worker: selected candidate node ip-10-0-86-209.ec2.internal
+I0120 21:44:08.267652       1 node_controller.go:1294] calculated capacity after failingThisConfig is 2 (getAllCandidateMachines)
+I0120 21:44:08.267662       1 node_controller.go:1076] worker: 1 candidate nodes in 1 zones for update, capacity: 2
+I0120 21:44:08.267697       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:08.267754       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267765       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267771       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.267775       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267779       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267784       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.267788       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267792       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.267795       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.267799       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:44:08.267836       1 node_controller.go:1378] Selected node ip-10-0-86-209.ec2.internal for update (current selection count: 1) [updateCandidateMachines]
+I0120 21:44:08.267843       1 node_controller.go:1382] Final list of nodes to update in pool worker: 1 nodes (capacity: 2) [updateCandidateMachines]
+I0120 21:44:08.280462       1 node_controller.go:1197] updateCandidateNode: node=ip-10-0-86-209.ec2.internal, pool=worker, layered=false, mosbIsNil=true
+I0120 21:44:08.296349       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: lost annotation machineconfiguration.openshift.io/desiredImage
+I0120 21:44:08.296538       1 event.go:377] Event(v1.ObjectReference{Kind:"MachineConfigPool", Namespace:"openshift-machine-config-operator", Name:"worker", UID:"99931134-ecd3-4f30-97ca-27ce887f9e8f", APIVersion:"machineconfiguration.openshift.io/v1", ResourceVersion:"221346", FieldPath:""}): type: 'Normal' reason: 'SetDesiredConfig' Targeted node ip-10-0-86-209.ec2.internal to MachineConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.306999       1 node_controller.go:1110] forceReListNodesFromAPIServer: found 3 nodes for pool worker
+I0120 21:44:08.371424       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:08.371446       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.371453       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.371457       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.371462       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.371466       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.371469       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.371475       1 status.go:500] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.371478       1 status.go:502] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:08.371482       1 status.go:542] Node ip-10-0-86-209.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:08.371485       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 0
+I0120 21:44:09.788400       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed annotation machineconfiguration.openshift.io/state = Working
+I0120 21:44:13.326219       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:13.326331       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.326364       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.326397       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:13.326427       1 status.go:495] Node ip-10-0-86-209.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:44:13.326457       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:44:13.326498       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.326526       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.326555       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:13.326585       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:44:13.326616       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:44:13.326646       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:44:13.326682       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:44:13.327007       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:44:13.404747       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:13.404772       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.404779       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.404784       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:13.404788       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.404791       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:13.404796       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:13.404800       1 status.go:495] Node ip-10-0-86-209.ec2.internal is unavailable: node is in MCD state=Working
+I0120 21:44:13.404803       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:44:13.404808       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+E0120 21:44:13.527496       1 render_controller.go:445] Error syncing Generated MCFG: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+E0120 21:44:13.534056       1 render_controller.go:467] Error updating MachineConfigPool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0120 21:44:13.534079       1 render_controller.go:382] Error syncing machineconfigpool worker: Operation cannot be fulfilled on machineconfigpools.machineconfiguration.openshift.io "worker": the object has been modified; please apply your changes to the latest version and try again
+I0120 21:44:14.895217       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: cordoning
+I0120 21:44:14.895244       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating cordon (currently schedulable: true)
+I0120 21:44:14.932645       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: cordon succeeded (currently schedulable: false)
+I0120 21:44:14.932970       1 node_controller.go:559] Pool worker[zone=us-east-1c]: node ip-10-0-86-209.ec2.internal: changed taints
+I0120 21:44:14.960201       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: initiating drain
+E0120 21:44:16.021745       1 drain_controller.go:153] WARNING: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-8khhk, openshift-cluster-node-tuning-operator/tuned-g7zp9, openshift-dns/dns-default-mk56w, openshift-dns/node-resolver-hwqv4, openshift-image-registry/node-ca-8msd2, openshift-ingress-canary/ingress-canary-5nfvj, openshift-insights/insights-runtime-extractor-tc9l7, openshift-machine-config-operator/machine-config-daemon-4sr5n, openshift-monitoring/node-exporter-f4mcq, openshift-multus/multus-6kxrr, openshift-multus/multus-additional-cni-plugins-97f84, openshift-multus/network-metrics-daemon-cjxq7, openshift-network-diagnostics/network-check-target-h5k4g, openshift-network-operator/iptables-alerter-x2bn5, openshift-ovn-kubernetes/ovnkube-node-9n6w2
+I0120 21:44:16.023760       1 drain_controller.go:153] evicting pod openshift-image-registry/image-registry-c66456f44-94wgx
+I0120 21:44:16.023776       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-dh229
+I0120 21:44:16.023788       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:44:16.023771       1 drain_controller.go:153] evicting pod openshift-monitoring/telemeter-client-55469dfcdf-7w5fr
+I0120 21:44:16.023870       1 drain_controller.go:153] evicting pod openshift-ingress/router-default-787b98474-sc2rg
+I0120 21:44:16.023759       1 drain_controller.go:153] evicting pod openshift-network-diagnostics/network-check-source-77c8b75fd4-h25tr
+I0120 21:44:16.024090       1 drain_controller.go:153] evicting pod openshift-monitoring/alertmanager-main-1
+I0120 21:44:16.023764       1 drain_controller.go:153] evicting pod openshift-monitoring/openshift-state-metrics-798f7c49-7x2hq
+I0120 21:44:16.024274       1 drain_controller.go:153] evicting pod openshift-monitoring/kube-state-metrics-7789cb954-cr6nx
+I0120 21:44:16.023769       1 drain_controller.go:153] evicting pod openshift-monitoring/thanos-querier-68d8f8f746-crmqw
+I0120 21:44:16.024314       1 drain_controller.go:153] evicting pod openshift-monitoring/monitoring-plugin-57b46cfd5c-trf7d
+I0120 21:44:16.024321       1 drain_controller.go:153] evicting pod openshift-monitoring/metrics-server-69d8d5dd44-xn2km
+I0120 21:44:16.024327       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-7lvsm
+I0120 21:44:16.024387       1 drain_controller.go:153] evicting pod openshift-network-console/networking-console-plugin-5f88d5854c-h7dhf
+E0120 21:44:16.036918       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:44:18.270382       1 request.go:700] Waited for 1.148558396s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-image-registry/pods/image-registry-c66456f44-94wgx
+I0120 21:44:18.331574       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:18.331599       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.331607       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.331612       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:18.331617       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.331621       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.331625       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:18.331630       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:44:18.331634       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:44:18.331640       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:44:18.331645       1 node_controller.go:1248] maxUnavailable is 2 and unavail is 1 (getAllCandidateMachines)
+I0120 21:44:18.331648       1 node_controller.go:1251] calculated initialcapacity is 1 (getAllCandidateMachines)
+I0120 21:44:18.331656       1 node_controller.go:1294] calculated capacity after failingThisConfig is 1 (getAllCandidateMachines)
+I0120 21:44:18.431715       1 status.go:536] getUnavailableMachines: checking 3 nodes (layered=false)
+I0120 21:44:18.431737       1 status.go:500] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.431745       1 status.go:502] [isNodeUnavailable] Node ip-10-0-46-217.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.431749       1 status.go:542] Node ip-10-0-46-217.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:18.431753       1 status.go:500] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal currentConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.431757       1 status.go:502] [isNodeUnavailable] Node ip-10-0-5-10.ec2.internal desiredConfig: rendered-worker-dddd0a5264747386d04285f0fda42fa6
+I0120 21:44:18.431760       1 status.go:542] Node ip-10-0-5-10.ec2.internal is available (getUnavailableMachines)
+I0120 21:44:18.431766       1 status.go:490] [isNodeUnavailable] Node ip-10-0-86-209.ec2.internal is NOT ready => unavailable
+I0120 21:44:18.431769       1 status.go:539] Node ip-10-0-86-209.ec2.internal marked as unavailable (getUnavailableMachines): layered=false
+I0120 21:44:18.431773       1 status.go:545] Total unavailable nodes (getUnavailableMachines): 1
+I0120 21:44:19.078086       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/prometheus-operator-admission-webhook-5d9668865-7lvsm
+I0120 21:44:19.270384       1 request.go:700] Waited for 1.362964969s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-h7dhf
+I0120 21:44:19.274174       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-h7dhf
+I0120 21:44:19.474313       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/kube-state-metrics-7789cb954-cr6nx
+I0120 21:44:19.680170       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/openshift-state-metrics-798f7c49-7x2hq
+I0120 21:44:19.886813       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/telemeter-client-55469dfcdf-7w5fr
+I0120 21:44:20.074551       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-diagnostics/network-check-source-77c8b75fd4-h25tr
+I0120 21:44:20.270403       1 request.go:700] Waited for 2.15091988s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-network-console/pods/networking-console-plugin-5f88d5854c-dh229
+I0120 21:44:20.274723       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-network-console/networking-console-plugin-5f88d5854c-dh229
+I0120 21:44:20.693815       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/alertmanager-main-1
+I0120 21:44:21.037435       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+E0120 21:44:21.049779       1 drain_controller.go:153] error when evicting pods/"prometheus-k8s-0" -n "openshift-monitoring" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
+I0120 21:44:21.074088       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/thanos-querier-68d8f8f746-crmqw
+I0120 21:44:21.270515       1 request.go:700] Waited for 1.95529385s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/pods/monitoring-plugin-57b46cfd5c-trf7d
+I0120 21:44:21.273927       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/monitoring-plugin-57b46cfd5c-trf7d
+I0120 21:44:26.050450       1 drain_controller.go:153] evicting pod openshift-monitoring/prometheus-k8s-0
+I0120 21:44:29.095491       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-monitoring/prometheus-k8s-0
+I0120 21:44:43.126413       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-image-registry/image-registry-c66456f44-94wgx
+I0120 21:45:33.124938       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Evicted pod openshift-ingress/router-default-787b98474-sc2rg
+I0120 21:45:46.568943       1 drain_controller.go:183] node ip-10-0-86-209.ec2.internal: Drain failed. Waiting 1 minute then retrying. Error message from drain: error when waiting for pod "metrics-server-69d8d5dd44-xn2km" in namespace "openshift-monitoring" to terminate: global timeout reached: 1m30s
+
+

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -38,7 +38,8 @@ const (
 	ControllerConfigSyncServerCA = "machineconfiguration.openshift.io/lastObservedServerCAAnnotation"
 	// GeneratedByVersionAnnotationKey is used to tag the controllerconfig to synchronize the MCO and MCC
 	GeneratedByVersionAnnotationKey = "machineconfiguration.openshift.io/generated-by-version"
-
+	// UpdateQueuedAnnotationKey is set on a node to indicate that it is queued for an update.
+	UpdateQueuedAnnotationKey = "machineconfiguration.openshift.io/update-queued"
 	// MachineConfigDaemonStateWorking is set by daemon when it is beginning to apply an update.
 	MachineConfigDaemonStateWorking = "Working"
 	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.

--- a/push-to-cluster.sh
+++ b/push-to-cluster.sh
@@ -1,0 +1,5 @@
+podman build -t quay.io/dkhater/testing:latest .
+
+podman push --authfile  /Users/daliakhater/Downloads/dkhater-dkhater-workstation-auth.json quay.io/dkhater/testing:latest
+
+mco-push replace quay.io/dkhater/testing:latest


### PR DESCRIPTION
- What I did

Fixed a bug in the node controller where the maxUnavailable setting was not honored when ocl was disabled. The issue was due to the getAllCandidateMachines function not properly checking for nodes that were mid-update. I added a condition to skip nodes that are currently being updated, ensuring that we do not exceed the maxUnavailable limit.

- How to verify it


   1. Enable OCL in the worker pool
   2. Remove the MOSC resource to disable OCL
   3. view node status to make sure nodes do not update simultaneously

- Description for the changelog

Fixed an issue where maxUnavailable was not honored when ocl is disabled, ensuring node updates respect the maximum unavailable node count.
