### PR TITLE
MCO-1331: Install extensions via Containerfile for OCL

### DIFF
--- a/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
+++ b/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
@@ -10,16 +10,6 @@ COPY ./machineconfig/machineconfig.json.gz /tmp/machineconfig.json.gz
 RUN mkdir -p /etc/machine-config-daemon && \
 	cat /tmp/machineconfig.json.gz | base64 -d | gunzip - > /etc/machine-config-daemon/currentconfig
 
-{{if .ExtensionsImage}}
-# Pull our extensions image. Not sure yet what / how this should be wired up
-# though. Ideally, I'd like to use some Buildah tricks to have the extensions
-# directory mounted into the container at build-time so that I don't have to
-# copy the RPMs into the container, configure the repo, and do the
-# installation. Alternatively, I'd have to start a pod with an HTTP server.
-FROM {{.ExtensionsImage}} AS extensions
-{{end}}
-
-
 FROM {{.BaseOSImage}} AS configs
 # Copy the extracted MachineConfig into the expected place in the image.
 COPY --from=extract /etc/machine-config-daemon/currentconfig /etc/machine-config-daemon/currentconfig
@@ -28,6 +18,24 @@ COPY --from=extract /etc/machine-config-daemon/currentconfig /etc/machine-config
 # since it should be set by the container runtime / builder.
 RUN container="oci" exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported <(cat /etc/machine-config-daemon/currentconfig | jq '.spec.config') && \
 	ostree container commit
+# Install any extensions specified
+{{if and .ExtensionsImage .Extensions}}
+# Mount the extensions image to use the content from it
+# and add the extensions repo to /etc/yum.repos.d/coreos-extensions.repo
+RUN --mount=type=bind,from={{.ExtensionsImage}},source=/,target=/tmp/mco-extensions/os-extensions-content,bind-propagation=rshared,rw,z \
+    echo -e "[coreos-extensions]\n\
+enabled=1\n\
+metadata_expire=1m\n\
+baseurl=/tmp/mco-extensions/os-extensions-content/usr/share/rpm-ostree/extensions/\n\
+gpgcheck=0\n\
+skip_if_unavailable=False" > /etc/yum.repos.d/coreos-extensions.repo && \
+    chmod 644 /etc/yum.repos.d/coreos-extensions.repo && \
+    extensions="{{- range $index, $item := .Extensions }}{{- if $index }} {{ end }}{{$item}}{{- end }}" && \
+    echo "Installing packages: $extensions" && \
+    rpm-ostree install $extensions && \
+    rm /etc/yum.repos.d/coreos-extensions.repo
+RUN ostree container commit
+{{end}}
 
 LABEL machineconfig={{.MachineOSBuild.Spec.DesiredConfig.Name}}
 LABEL machineconfigpool={{.MachineOSConfig.Spec.MachineConfigPool.Name}}

--- a/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
+++ b/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
@@ -19,7 +19,7 @@ COPY --from=extract /etc/machine-config-daemon/currentconfig /etc/machine-config
 RUN container="oci" exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported <(cat /etc/machine-config-daemon/currentconfig | jq '.spec.config') && \
 	ostree container commit
 # Install any extensions specified
-{{if and .ExtensionsImage .Extensions}}
+{{if and .ExtensionsImage .ExtensionsPackages}}
 # Mount the extensions image to use the content from it
 # and add the extensions repo to /etc/yum.repos.d/coreos-extensions.repo
 RUN --mount=type=bind,from={{.ExtensionsImage}},source=/,target=/tmp/mco-extensions/os-extensions-content,bind-propagation=rshared,rw,z \
@@ -30,8 +30,8 @@ baseurl=/tmp/mco-extensions/os-extensions-content/usr/share/rpm-ostree/extension
 gpgcheck=0\n\
 skip_if_unavailable=False" > /etc/yum.repos.d/coreos-extensions.repo && \
     chmod 644 /etc/yum.repos.d/coreos-extensions.repo && \
-    extensions="{{- range $index, $item := .Extensions }}{{- if $index }} {{ end }}{{$item}}{{- end }}" && \
-    echo "Installing packages: $extensions" && \
+    extensions="{{- range $index, $item := .ExtensionsPackages }}{{- if $index }} {{ end }}{{$item}}{{- end }}" && \
+    echo "Installing extension packages: $extensions" && \
     rpm-ostree install $extensions && \
     rm /etc/yum.repos.d/coreos-extensions.repo
 RUN ostree container commit

--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -211,6 +211,7 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 		ReleaseVersion    string
 		BaseOSImage       string
 		ExtensionsImage   string
+		Extensions        []string
 	}{
 		MachineOSBuild:    br.opts.MachineOSBuild,
 		MachineOSConfig:   br.opts.MachineOSConfig,
@@ -218,6 +219,7 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 		ReleaseVersion:    br.opts.getReleaseVersion(),
 		BaseOSImage:       br.opts.getBaseOSImagePullspec(),
 		ExtensionsImage:   br.opts.getExtensionsImagePullspec(),
+		Extensions:        br.opts.getExtensions(),
 	}
 
 	if err := tmpl.Execute(out, items); err != nil {

--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -198,6 +198,11 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 		return "", fmt.Errorf("could not parse containerfile template: %w", err)
 	}
 
+	extPkgs, err := br.opts.getExtensionsPackages()
+	if err != nil {
+		return "", err
+	}
+
 	out := &strings.Builder{}
 
 	// This anonymous struct is necessary because templates cannot access
@@ -205,21 +210,21 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 	// default to a value from a different location, it makes more sense for us
 	// to implement that logic in Go as opposed to the Go template language.
 	items := struct {
-		MachineOSBuild    *mcfgv1alpha1.MachineOSBuild
-		MachineOSConfig   *mcfgv1alpha1.MachineOSConfig
-		UserContainerfile string
-		ReleaseVersion    string
-		BaseOSImage       string
-		ExtensionsImage   string
-		Extensions        []string
+		MachineOSBuild     *mcfgv1alpha1.MachineOSBuild
+		MachineOSConfig    *mcfgv1alpha1.MachineOSConfig
+		UserContainerfile  string
+		ReleaseVersion     string
+		BaseOSImage        string
+		ExtensionsImage    string
+		ExtensionsPackages []string
 	}{
-		MachineOSBuild:    br.opts.MachineOSBuild,
-		MachineOSConfig:   br.opts.MachineOSConfig,
-		UserContainerfile: br.userContainerfile,
-		ReleaseVersion:    br.opts.getReleaseVersion(),
-		BaseOSImage:       br.opts.getBaseOSImagePullspec(),
-		ExtensionsImage:   br.opts.getExtensionsImagePullspec(),
-		Extensions:        br.opts.getExtensions(),
+		MachineOSBuild:     br.opts.MachineOSBuild,
+		MachineOSConfig:    br.opts.MachineOSConfig,
+		UserContainerfile:  br.userContainerfile,
+		ReleaseVersion:     br.opts.getReleaseVersion(),
+		BaseOSImage:        br.opts.getBaseOSImagePullspec(),
+		ExtensionsImage:    br.opts.getExtensionsImagePullspec(),
+		ExtensionsPackages: extPkgs,
 	}
 
 	if err := tmpl.Execute(out, items); err != nil {

--- a/pkg/controller/build/buildrequest/buildrequest_test.go
+++ b/pkg/controller/build/buildrequest/buildrequest_test.go
@@ -19,6 +19,24 @@ const (
 	mcoImagePullspec = "registry.hostname.com/org/repo@sha256:87980e0edfc86d01182f70c53527f74b5b01df00fe6d47668763d228d4de43a9"
 )
 
+// Validates that if an invalid extension is provided that the ConfigMap
+// generation fails and the error contains the names of the invalid extensions.
+func TestBuildRequestInvalidExtensions(t *testing.T) {
+	t.Parallel()
+
+	opts := getBuildRequestOpts()
+	opts.MachineConfig.Spec.Extensions = []string{"invalid-ext1", "invalid-ext2"}
+
+	br := newBuildRequest(opts)
+
+	_, err := br.ConfigMaps()
+	assert.Error(t, err)
+
+	for _, ext := range opts.MachineConfig.Spec.Extensions {
+		assert.Contains(t, err.Error(), ext)
+	}
+}
+
 // Tests that the BuildRequest is constructed as expected.
 func TestBuildRequest(t *testing.T) {
 	t.Parallel()
@@ -48,7 +66,19 @@ func TestBuildRequest(t *testing.T) {
 			},
 			expectedContainerfileContents: append(expectedContents(), []string{
 				fmt.Sprintf("RUN --mount=type=bind,from=%s", osImageURLConfig.BaseOSExtensionsContainerImage),
-				"extensions=\"usbguard\"",
+				`extensions="usbguard"`,
+			}...),
+		},
+		{
+			name: "With extensions image and resolved extensions packages",
+			optsFunc: func() BuildRequestOpts {
+				opts := getBuildRequestOpts()
+				opts.MachineConfig.Spec.Extensions = []string{"kerberos", "usbguard"}
+				return opts
+			},
+			expectedContainerfileContents: append(expectedContents(), []string{
+				fmt.Sprintf("RUN --mount=type=bind,from=%s", osImageURLConfig.BaseOSExtensionsContainerImage),
+				`extensions="krb5-workstation libkadm5 usbguard"`,
 			}...),
 		},
 		{

--- a/pkg/controller/build/buildrequest/buildrequestopts.go
+++ b/pkg/controller/build/buildrequest/buildrequestopts.go
@@ -68,12 +68,13 @@ func (b BuildRequestOpts) getReleaseVersion() string {
 	return b.OSImageURLConfig.ReleaseVersion
 }
 
-// Gets the extensions from the MachineConfig if available.
-func (b BuildRequestOpts) getExtensions() []string {
-	if len(b.MachineConfig.Spec.Extensions) > 0 {
-		return b.MachineConfig.Spec.Extensions
+// Gets the packages for the extensions from the MachineConfig, if available.
+func (b BuildRequestOpts) getExtensionsPackages() ([]string, error) {
+	if len(b.MachineConfig.Spec.Extensions) == 0 {
+		return nil, nil
 	}
-	return []string{}
+
+	return ctrlcommon.GetPackagesForSupportedExtensions(b.MachineConfig.Spec.Extensions)
 }
 
 // Gets all of the image build request opts from the Kube API server.

--- a/pkg/controller/build/buildrequest/buildrequestopts.go
+++ b/pkg/controller/build/buildrequest/buildrequestopts.go
@@ -68,6 +68,14 @@ func (b BuildRequestOpts) getReleaseVersion() string {
 	return b.OSImageURLConfig.ReleaseVersion
 }
 
+// Gets the extensions from the MachineConfig if available.
+func (b BuildRequestOpts) getExtensions() []string {
+	if len(b.MachineConfig.Spec.Extensions) > 0 {
+		return b.MachineConfig.Spec.Extensions
+	}
+	return []string{}
+}
+
 // Gets all of the image build request opts from the Kube API server.
 func newBuildRequestOptsFromAPI(ctx context.Context, kubeclient clientset.Interface, mcfgclient mcfgclientset.Interface, mosb *mcfgv1alpha1.MachineOSBuild, mosc *mcfgv1alpha1.MachineOSConfig) (*BuildRequestOpts, error) {
 	og := optsGetter{

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2862,7 +2862,7 @@ func (dn *Daemon) getUnsupportedPackages() {
 	}
 
 	supportedPackages := make(map[string]bool)
-	for _, packages := range getSupportedExtensions() {
+	for _, packages := range ctrlcommon.SupportedExtensions() {
 		for _, pkg := range packages {
 			supportedPackages[pkg] = true
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1731,7 +1731,7 @@ func (dn *Daemon) generateExtensionsArgs(oldConfig, newConfig *mcfgv1.MachineCon
 	extArgs := []string{"update"}
 
 	if dn.os.IsEL() {
-		extensions := getSupportedExtensions()
+		extensions := ctrlcommon.SupportedExtensions()
 		for _, ext := range added {
 			for _, pkg := range extensions[ext] {
 				extArgs = append(extArgs, "--install", pkg)
@@ -1761,39 +1761,6 @@ func (dn *Daemon) generateExtensionsArgs(oldConfig, newConfig *mcfgv1.MachineCon
 	return extArgs
 }
 
-// Returns list of extensions possible to install on a CoreOS based system.
-func getSupportedExtensions() map[string][]string {
-	// In future when list of extensions grow, it will make
-	// more sense to populate it in a dynamic way.
-
-	// These are RHCOS supported extensions.
-	// Each extension keeps a list of packages required to get enabled on host.
-	return map[string][]string{
-		"wasm":                 {"crun-wasm"},
-		"ipsec":                {"NetworkManager-libreswan", "libreswan"},
-		"usbguard":             {"usbguard"},
-		"kerberos":             {"krb5-workstation", "libkadm5"},
-		"kernel-devel":         {"kernel-devel", "kernel-headers"},
-		"sandboxed-containers": {"kata-containers"},
-		"sysstat":              {"sysstat"},
-	}
-}
-
-func validateExtensions(exts []string) error {
-	supportedExtensions := getSupportedExtensions()
-	invalidExts := []string{}
-	for _, ext := range exts {
-		if _, ok := supportedExtensions[ext]; !ok {
-			invalidExts = append(invalidExts, ext)
-		}
-	}
-	if len(invalidExts) != 0 {
-		return fmt.Errorf("invalid extensions found: %v", invalidExts)
-	}
-	return nil
-
-}
-
 func (dn *CoreOSDaemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConfig) error {
 	extensionsEmpty := len(oldConfig.Spec.Extensions) == 0 && len(newConfig.Spec.Extensions) == 0
 	if (extensionsEmpty) ||
@@ -1802,7 +1769,7 @@ func (dn *CoreOSDaemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConf
 	}
 
 	// Validate extensions allowlist on RHCOS nodes
-	if err := validateExtensions(newConfig.Spec.Extensions); err != nil && dn.os.IsEL() {
+	if err := ctrlcommon.ValidateMachineConfigExtensions(newConfig.Spec); err != nil && dn.os.IsEL() {
 		return err
 	}
 

--- a/test/e2e-techpreview/onclusterlayering_test.go
+++ b/test/e2e-techpreview/onclusterlayering_test.go
@@ -88,6 +88,9 @@ type onClusterLayeringTestOpts struct {
 
 	// Inject YUM repo information from a Centos 9 stream container
 	useYumRepos bool
+
+	// Add Extensions for testing
+	useExtensions bool
 }
 
 func TestOnClusterBuildsOnOKD(t *testing.T) {
@@ -113,12 +116,13 @@ func TestOnClusterBuildsCustomPodBuilder(t *testing.T) {
 
 // Tests that an on-cluster build can be performed and that the resulting image
 // is rolled out to an opted-in node.
-func TestOnClusterBuildRollsOutImage(t *testing.T) {
+func TestOnClusterBuildRollsOutImageWithExtensionsInstalled(t *testing.T) {
 	imagePullspec := runOnClusterLayeringTest(t, onClusterLayeringTestOpts{
 		poolName: layeredMCPName,
 		customDockerfiles: map[string]string{
 			layeredMCPName: cowsayDockerfile,
 		},
+		useExtensions: true,
 	})
 
 	cs := framework.NewClientSet("")
@@ -129,12 +133,14 @@ func TestOnClusterBuildRollsOutImage(t *testing.T) {
 
 	helpers.AssertNodeBootedIntoImage(t, cs, node, imagePullspec)
 	t.Logf("Node %s is booted into image %q", node.Name, imagePullspec)
+	assertExtensionInstalledOnNode(t, cs, node, true)
 
 	t.Log(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "cowsay", "Moo!"))
 
 	unlabelFunc()
 
 	assertNodeRevertsToNonLayered(t, cs, node)
+	assertExtensionInstalledOnNode(t, cs, node, false)
 }
 
 func assertNodeRevertsToNonLayered(t *testing.T, cs *framework.ClientSet, node corev1.Node) {
@@ -149,6 +155,22 @@ func assertNodeRevertsToNonLayered(t *testing.T, cs *framework.ClientSet, node c
 
 	helpers.AssertFileNotOnNode(t, cs, node, filepath.Join("/etc/systemd/system", runtimeassets.RevertServiceName))
 	helpers.AssertFileNotOnNode(t, cs, node, runtimeassets.RevertServiceMachineConfigFile)
+}
+
+func assertExtensionInstalledOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, shouldExist bool) {
+	foundPkg, err := helpers.ExecCmdOnNodeWithError(cs, node, "chroot", "/rootfs", "rpm", "-q", "usbguard")
+	if shouldExist {
+		require.NoError(t, err, "usbguard extension not found")
+		if strings.Contains(foundPkg, "package usbguard is not installed") {
+			t.Fatalf("usbguard package not installed on node %s, got %s", node.Name, foundPkg)
+		}
+		t.Logf("usbguard extension installed, got %s", foundPkg)
+	} else {
+		if !strings.Contains(foundPkg, "package usbguard is not installed") {
+			t.Fatalf("usbguard package is installed on node %s, got %s", node.Name, foundPkg)
+		}
+		t.Logf("usbguard extension not installed as expected, got %s", foundPkg)
+	}
 }
 
 // This test extracts the /etc/yum.repos.d and /etc/pki/rpm-gpg content from a
@@ -921,6 +943,34 @@ func prepareForOnClusterLayeringTest(t *testing.T, cs *framework.ClientSet, test
 		t.Cleanup(makeIdempotentAndRegister(t, helpers.CreatePoolWithNode(t, cs, testOpts.poolName, *testOpts.targetNode)))
 	} else {
 		t.Cleanup(makeIdempotentAndRegister(t, helpers.CreateMCP(t, cs, testOpts.poolName)))
+	}
+
+	if testOpts.useExtensions {
+		extensionsMC := &mcfgv1.MachineConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "99-extensions",
+				Labels: helpers.MCLabelForRole(testOpts.poolName),
+			},
+			Spec: mcfgv1.MachineConfigSpec{
+				Config: runtime.RawExtension{
+					Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
+				},
+				Extensions: []string{"usbguard"},
+			},
+		}
+
+		helpers.SetMetadataOnObject(t, extensionsMC)
+		// Apply the extensions MC
+		mcCleanupFunc := helpers.ApplyMC(t, cs, extensionsMC)
+		t.Cleanup(func() {
+			mcCleanupFunc()
+			t.Logf("Deleted MachineConfig %s", extensionsMC.Name)
+		})
+		t.Logf("Created new MachineConfig %q", extensionsMC.Name)
+		// Wait for rendered config to finish creating
+		renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, testOpts.poolName, extensionsMC.Name)
+		require.NoError(t, err)
+		t.Logf("Finished rendering config %s", renderedConfig)
 	}
 
 	_, err := helpers.WaitForRenderedConfig(t, cs, testOpts.poolName, "00-worker")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add logic to the Containerfile used to build the new OS image to be able to install extensions when using OCL. Extensions are installed via rpm-ostree and commited to the container image.

**- How to verify it**
Enable OCL and create a MC with to install extensions, wait for the image to build and roll out and the extensions installed should be installed on the nodes.

**- Description for the changelog**
Install extension via Containerfile when using OCL.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
