### PR TITLE
OCPBUGS-27477: Pausing Master MCP results in Alerts

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1731,6 +1731,9 @@ func (optr *Operator) syncRequiredMachineConfigPools(config *renderConfig, co *c
 				}
 				// If we don't account for pause here, we will spin in this loop until we hit the 10 minute timeout because paused pools can't sync.
 				if pool.Spec.Paused {
+					if isPoolStatusConditionTrue(pool, mcfgv1.MachineConfigPoolUpdated) {
+						return false, fmt.Errorf("the required MachineConfigPool %s was paused with no pending updates; no further syncing will occur until it is unpaused", pool.Name)
+					}
 					return false, fmt.Errorf("error required MachineConfigPool %s is paused and cannot sync until it is unpaused", pool.Name)
 				}
 				return false, nil


### PR DESCRIPTION
**- What I did**
Update the event message on pause of required pool where no updates are outstanding.

**- How to verify it**
Pause a required machine config pool:
```bash
$ oc patch mcp/master --patch '{"spec": {"paused":true}}' --type=merge
```

Watch the `machine-config-operator` pod logs:
```bash
$ oc logs -n openshift-machine-config-operator -c machine-config-operator <pod-name> -f
     Starting MachineConfigOperator
     Event(v1.ObjectReference{Kind:"ClusterOperator", Namespace:"openshift-machine-config-operator", Name:"machine-config", UID:"a22bdfc5-84c1-4063-b66d-87f4e86815e2", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'OperatorDegraded: RequiredPoolsFailed' Failed to resync 4.18.0-0.nightly-arm64-2024-11-06-051902 because: **the required MachineConfigPool master was paused with no pending updates but no futher syncing will occur until it is unpaused**
```

**- Description for the changelog**
OCPBUGS-27477: Update warning message on pause of required MCP.