### PR TITLE
OCPBUGS-44758: Set priority class for machine-os-builder

### DIFF
--- a/manifests/machineosbuilder/deployment.yaml
+++ b/manifests/machineosbuilder/deployment.yaml
@@ -23,3 +23,4 @@ spec:
         - start
         - -v4
       serviceAccountName: machine-os-builder
+      priorityClassName: "system-cluster-critical"

--- a/manifests/machineosbuilder/deployment.yaml
+++ b/manifests/machineosbuilder/deployment.yaml
@@ -22,5 +22,22 @@ spec:
         args:
         - start
         - -v4
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: machine-os-builder
       priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Closes: [OCPBUGS-44758](https://issues.redhat.com/browse/OCPBUGS-44758)

**- What I did**
deployment: Ensures machine-os-builder has a higher priority when getting scheduled since its a part of the cluster control plane

**- How to verify it**
machine os builder pods should now be scheduled with higher priority and passes the openshift/origin test for pods.

**- Description for the changelog**
<!--
Ensures machine-os-builder has a higher priority when getting scheduled since its a part of the cluster control plane
-->
