### PR TITLE
OCPBUGS-44732: Support for br-ex with DHCP and static DNS

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -390,6 +390,16 @@ contents:
             extra_if_brex_args+="ipv6.addr-gen-mode ${ipv6_addr_gen_mode} "
           fi
 
+          # check for static DNS address
+          ipv4_dns=$(nmcli --get-values ipv4.dns conn show ${old_conn})
+          if [ -n "$ipv4_dns" ]; then
+            extra_if_brex_args+="ipv4.dns ${ipv4_dns} "
+          fi
+          ipv6_dns=$(nmcli --get-values ipv6.dns conn show ${old_conn})
+          if [ -n "$ipv6_dns" ]; then
+            extra_if_brex_args+="ipv6.dns ${ipv6_dns} "
+          fi
+
           add_nm_conn "$ovs_interface" type ovs-interface slave-type ovs-port conn.interface "$bridge_name" master "$ovs_port_conn" \
             802-3-ethernet.mtu ${iface_mtu} 802-3-ethernet.cloned-mac-address ${iface_mac} \
             ipv4.method "${ipv4_method}" ipv4.route-metric "${bridge_metric}" \


### PR DESCRIPTION
Currently the only supported combination is either DHCP or static IP on the default gateway interface. This leads to the scenario when IP address from DHCP and static DNS address is not working (the custom DNS is just ignored).

With this change we allow to have DNS configured manually no matter where the IP address of the interface comes from.

In principle this should be done using k-nmstate operator and its global DNS configuration, but it seems there are scenarios where we want this functionality already at installation time.

Closes: OCPBUGS-44732