### PR TITLE
OCPBUGS-42636: Wait to render for other MC generating sub-controllers

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -224,6 +224,8 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
 			ctx.ClientBuilder.KubeClientOrDie("render-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("render-controller"),
 		),

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -70,6 +70,12 @@ type Controller struct {
 	ccLister       mcfglistersv1.ControllerConfigLister
 	ccListerSynced cache.InformerSynced
 
+	crcLister       mcfglistersv1.ContainerRuntimeConfigLister
+	crcListerSynced cache.InformerSynced
+
+	mckLister       mcfglistersv1.KubeletConfigLister
+	mckListerSynced cache.InformerSynced
+
 	queue workqueue.TypedRateLimitingInterface[string]
 }
 
@@ -78,6 +84,8 @@ func New(
 	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	mcInformer mcfginformersv1.MachineConfigInformer,
 	ccInformer mcfginformersv1.ControllerConfigInformer,
+	crcInformer mcfginformersv1.ContainerRuntimeConfigInformer,
+	mckInformer mcfginformersv1.KubeletConfigInformer,
 	kubeClient clientset.Interface,
 	mcfgClient mcfgclientset.Interface,
 ) *Controller {
@@ -113,6 +121,10 @@ func New(
 	ctrl.mcListerSynced = mcInformer.Informer().HasSynced
 	ctrl.ccLister = ccInformer.Lister()
 	ctrl.ccListerSynced = ccInformer.Informer().HasSynced
+	ctrl.crcLister = crcInformer.Lister()
+	ctrl.crcListerSynced = crcInformer.Informer().HasSynced
+	ctrl.mckLister = mckInformer.Lister()
+	ctrl.mckListerSynced = mckInformer.Informer().HasSynced
 
 	return ctrl
 }
@@ -428,6 +440,10 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 
 	// TODO(runcom): add tests in render_controller_test.go for this condition
 	if err := apihelpers.IsControllerConfigCompleted(ctrlcommon.ControllerConfigName, ctrl.ccLister.Get); err != nil {
+		return err
+	}
+
+	if err := apihelpers.AreMCGeneratingSubControllersCompleted(ctrl.crcLister.List, ctrl.mckLister.List, selector); err != nil {
 		return err
 	}
 

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -46,6 +46,8 @@ type fixture struct {
 	mcpLister []*mcfgv1.MachineConfigPool
 	mcLister  []*mcfgv1.MachineConfig
 	ccLister  []*mcfgv1.ControllerConfig
+	crcLister []*mcfgv1.ContainerRuntimeConfig
+	mckLister []*mcfgv1.KubeletConfig
 
 	actions []core.Action
 
@@ -65,11 +67,13 @@ func (f *fixture) newController() *Controller {
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 
 	c := New(i.Machineconfiguration().V1().MachineConfigPools(), i.Machineconfiguration().V1().MachineConfigs(),
-		i.Machineconfiguration().V1().ControllerConfigs(), k8sfake.NewSimpleClientset(), f.client)
+		i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().ContainerRuntimeConfigs(), i.Machineconfiguration().V1().KubeletConfigs(), k8sfake.NewSimpleClientset(), f.client)
 
 	c.mcpListerSynced = alwaysReady
 	c.mcListerSynced = alwaysReady
 	c.ccListerSynced = alwaysReady
+	c.crcListerSynced = alwaysReady
+	c.mckListerSynced = alwaysReady
 	c.eventRecorder = ctrlcommon.NamespacedEventRecorder(&record.FakeRecorder{})
 
 	stopCh := make(chan struct{})
@@ -89,6 +93,14 @@ func (f *fixture) newController() *Controller {
 
 	for _, m := range f.ccLister {
 		i.Machineconfiguration().V1().ControllerConfigs().Informer().GetIndexer().Add(m)
+	}
+
+	for _, m := range f.crcLister {
+		i.Machineconfiguration().V1().ContainerRuntimeConfigs().Informer().GetIndexer().Add(m)
+	}
+
+	for _, m := range f.mckLister {
+		i.Machineconfiguration().V1().KubeletConfigs().Informer().GetIndexer().Add(m)
 	}
 
 	return c
@@ -184,7 +196,11 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "controllerconfigs") ||
 				action.Matches("watch", "controllerconfigs") ||
 				action.Matches("list", "machineconfigs") ||
-				action.Matches("watch", "machineconfigs")) {
+				action.Matches("watch", "machineconfigs") ||
+				action.Matches("list", "kubeletconfigs") ||
+				action.Matches("watch", "kubeletconfigs") ||
+				action.Matches("list", "containerruntimeconfigs") ||
+				action.Matches("watch", "containerruntimeconfigs")) {
 			continue
 		}
 		ret = append(ret, action)
@@ -261,8 +277,12 @@ func TestCreatesGeneratedMachineConfig(t *testing.T) {
 		helpers.NewMachineConfig("05-extra-master", map[string]string{"node-role/master": ""}, "dummy://1", []ign3types.File{files[1]}),
 	}
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
+	crc := &mcfgv1.ContainerRuntimeConfig{}
+	mck := &mcfgv1.KubeletConfig{}
 
 	f.ccLister = append(f.ccLister, cc)
+	f.crcLister = append(f.crcLister, crc)
+	f.mckLister = append(f.mckLister, mck)
 	f.mcpLister = append(f.mcpLister, mcp)
 	f.objects = append(f.objects, mcp)
 	f.mcLister = append(f.mcLister, mcs...)
@@ -356,8 +376,12 @@ func TestUpdatesGeneratedMachineConfig(t *testing.T) {
 	mcp.Spec.Configuration.Name = gmc.Name
 	mcp.Status.Configuration.Name = gmc.Name
 
-	f.ccLister = append(f.ccLister, cc)
+	crc := &mcfgv1.ContainerRuntimeConfig{}
+	mck := &mcfgv1.KubeletConfig{}
 
+	f.ccLister = append(f.ccLister, cc)
+	f.crcLister = append(f.crcLister, crc)
+	f.mckLister = append(f.mckLister, mck)
 	f.mcpLister = append(f.mcpLister, mcp)
 	f.objects = append(f.objects, mcp)
 	f.mcLister = append(f.mcLister, mcs...)
@@ -469,8 +493,12 @@ func TestDoNothing(t *testing.T) {
 	mcp.Spec.Configuration.Name = gmc.Name
 	mcp.Status.Configuration.Name = gmc.Name
 
-	f.ccLister = append(f.ccLister, cc)
+	crc := &mcfgv1.ContainerRuntimeConfig{}
+	mck := &mcfgv1.KubeletConfig{}
 
+	f.ccLister = append(f.ccLister, cc)
+	f.crcLister = append(f.crcLister, crc)
+	f.mckLister = append(f.mckLister, mck)
 	f.mcpLister = append(f.mcpLister, mcp)
 	f.objects = append(f.objects, mcp)
 	f.mcLister = append(f.mcLister, mcs...)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -509,6 +509,8 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
 			ctx.ClientBuilder.KubeClientOrDie("render-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("render-controller"),
 		),


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Instead of the render controller just waiting on the controllerConfig status to reach completed (which requires template controller status to be completed), the render controller also should wait on the status of containerRuntime config and kubeletConfig

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
