### PR TITLE
OCPBUGS-45306: Remove trailing periods from AWS provided hostnames

### DIFF
--- a/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
+++ b/templates/common/aws/files/usr-local-bin-aws-kubelet-nodename.yaml
@@ -41,8 +41,19 @@ contents:
       fi 
     done
 
+    # AWS may return multiple, space separate hostnames, ensure we only use the first of these.
+    # REF: OCPBUGS-10498.
+    HOSTNAME=${HOSTNAME%% *}
+
+    # AWS validates DHCP option custom domain names if you create them via the console so that they do not contain
+    # trailing periods. However, if you use the CLI, you can avoid this validation and create a DHCP option set with
+    # a trailing period.
+    # Trailing periods are not compatible with Kube DNS1123 subdomain validation that is used for node names.
+    # Remove trailing periods from the hostname. REF: OCPBUGS-45306.
+    HOSTNAME=${HOSTNAME%%.}
+
     # For compatibility with the AWS in-tree provider
     # Set node name to be instance FQDN instead of the default hostname
     cat > "${NODEENV}" <<EOF
-    KUBELET_NODE_NAME=${HOSTNAME%% *}
+    KUBELET_NODE_NAME=${HOSTNAME}
     EOF


### PR DESCRIPTION
**- What I did**

This ensures that any DHCP option set, configured with a trailing period (which must be done using the AWS CLI, and not the console), does not prevent nodes from joining the cluster.

With the previous logic, the nodename passed would contain a trailing period, which is not compatible with Kube's validation of object names.

This new logic ensures that we trim any trailing periods prior to passing the hostname over to kubelet

**- How to verify it**

Create an AWS cluster with a custom DHCP option set. Ensure the custom domain name in the option set includes a trailing period (`foo.bar.baz.`), and then spin up new nodes. They should join the cluster with a node name, missing the trailing period.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
