### PR TITLE
MCO-1416: Increase timeouts in OCL e2e tests

### DIFF
--- a/test/e2e-ocl/onclusterlayering_test.go
+++ b/test/e2e-ocl/onclusterlayering_test.go
@@ -496,7 +496,7 @@ func TestDeletedTransientMachineOSBuildIsRecreated(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait a few seconds for the MachineOSBuild deletion to complete.
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 10)
 	// Ensure that the Job is deleted as this might take some time
 	kubeassert := helpers.AssertClientSet(t, cs).WithContext(ctx).Eventually()
 	kubeassert.Eventually().JobDoesNotExist(firstJob.Name)
@@ -873,7 +873,7 @@ func waitForBuildToStart(t *testing.T, cs *framework.ClientSet, build *mcfgv1alp
 
 	t.Logf("Waiting for MachineOSBuild %s to start", build.Name)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
 
 	start := time.Now()
@@ -907,7 +907,7 @@ func waitForBuildToStart(t *testing.T, cs *framework.ClientSet, build *mcfgv1alp
 func waitForBuildToBeDeleted(t *testing.T, cs *framework.ClientSet, build *mcfgv1alpha1.MachineOSBuild) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
 
 	t.Logf("Waiting for MachineOSBuild %s to be deleted", build.Name)


### PR DESCRIPTION
**- What I did**

Increase the timeouts in different stages of the ocl e2e tests.

**- How to verify it**

N/A

**- Description for the changelog**

[MCO-1416](https://issues.redhat.com//browse/MCO-1416): Increase timeouts in OCL e2e tests