### PR TITLE
OCPBUGS-45621: Fix `dynamic-system-reserved-calc.sh` when only `true` parameter is used

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -121,8 +121,8 @@ contents:
     function dynamic_node_sizing {
         rm -f ${NODE_SIZES_ENV}
         dynamic_memory_sizing
-        dynamic_cpu_sizing $2
-        set_es $1
+        dynamic_cpu_sizing $1
+        set_es $2
         #dynamic_ephemeral_sizing
         #dynamic_pid_sizing
     }
@@ -140,7 +140,7 @@ contents:
     fi
     new_version=$(jq .version $NODE_AUTO_SIZING_VERSION_FILE)
     if [ $1 == "true" ]; then
-        dynamic_node_sizing $4 $new_version
+        dynamic_node_sizing $new_version $4
     elif [ $1 == "false" ]; then
         static_node_sizing $2 $3 $4
     else


### PR DESCRIPTION
When using the `dynamic-system-reserved-calc.sh` command with only `true` parameter, the call to function `dynamic_node_sizing` only has 1 parameter, and then the call to function `dynamic_cpu_sizing $2` has no parameter and fail.

Fixes: OCPBUGS-45621


**- What I did**

Changed the order of the parameters passed to function `dynamic_node_sizing`, as `$4` is optional

**- How to verify it**

Run the command this way (to not override the default env file) and check the output file:
~~~
# NODE_SIZES_ENV=/tmp/node-sizing.txt /usr/local/sbin/dynamic-system-reserved-calc.sh true
# cat /tmp/node-sizing.txt
~~~

**- Description for the changelog**

Fix the `dynamic-system-reserved-calc.sh` script when only `true` parameter is used.
