### PR TITLE
e2e test failures should not clean up after themselves in CI

### DIFF
--- a/test/e2e-ocl/helpers_test.go
+++ b/test/e2e-ocl/helpers_test.go
@@ -40,6 +40,16 @@ const (
 	clonedSecretLabelKey string = "machineconfiguration.openshift.io/cloned-secret"
 )
 
+func applyMC(t *testing.T, cs *framework.ClientSet, mc *mcfgv1.MachineConfig) func() {
+	cleanupFunc := helpers.ApplyMC(t, cs, mc)
+	t.Logf("Created new MachineConfig %q", mc.Name)
+
+	return makeIdempotentAndRegister(t, func() {
+		cleanupFunc()
+		t.Logf("Deleted MachineConfig %q", mc.Name)
+	})
+}
+
 func createMachineOSConfig(t *testing.T, cs *framework.ClientSet, mosc *mcfgv1alpha1.MachineOSConfig) func() {
 	helpers.SetMetadataOnObject(t, mosc)
 
@@ -257,14 +267,28 @@ func waitForPoolToReachState(t *testing.T, cs *framework.ClientSet, poolName str
 	require.NoError(t, err, "MachineConfigPool %q did not reach desired state", poolName)
 }
 
-// Registers a cleanup function, making it idempotent, and wiring up the
-// skip-cleanup flag to it which will cause cleanup to be skipped, if set.
+// Registers a cleanup function, making it idempotent, and wiring up the skip
+// cleanup checks which will cause cleanup to be skipped under certain
+// conditions.
 func makeIdempotentAndRegister(t *testing.T, cleanupFunc func()) func() {
-	out := helpers.MakeIdempotent(func() {
-		if !skipCleanup {
-			cleanupFunc()
-		}
-	})
+	skipFunc := func() bool {
+		return shouldRunCleanup(t)
+	}
+
+	out := helpers.MakeIdempotentSkippable(skipFunc, cleanupFunc)
+	t.Cleanup(out)
+	return out
+}
+
+// Registers a cleanup function, making it idempotent and ensures that it will
+// always be run, regardless of skip cleanup opts or whether we're in CI.
+//
+// Note: Use this wrapper only in cases where you want to ensure that a
+// function is only called once despite there being multiple calls to the
+// returned function. If there is only one call to the returned function, use
+// t.Cleanup() instead for clarity.
+func makeIdempotentAndRegisterAlwaysRun(t *testing.T, cleanupFunc func()) func() {
+	out := helpers.MakeIdempotent(cleanupFunc)
 	t.Cleanup(out)
 	return out
 }
@@ -851,4 +875,51 @@ func resolveTaggedPullspecToDigestedPullspec(ctx context.Context, pullspec strin
 	}
 
 	return canonical.String(), nil
+}
+
+// Determines if we're running in a CI system based upon the presence (or lack thereof) of certain environment variables.
+func inCI() bool {
+	items := []string{
+		// Specific to OpenShift CI.
+		"OPENSHIFT_CI",
+		// Common to all CI systems.
+		"CI",
+	}
+
+	for _, item := range items {
+		if _, ok := os.LookupEnv(item); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Determines if a given cleanup function should run based upon whether the
+// skip-cleanup or skip-cleanup-on-failure flags are set or whether we're
+// running in CI.
+func shouldRunCleanup(t *testing.T) bool {
+	// If skipCleanupAlways is set, then we should not run cleanups regardless of
+	// outcome. This will override the inCI() check.
+	if skipCleanupAlways {
+		return false
+	}
+
+	// If the test failed and skipCleanupOnlyAfterFailure is set, we should skip
+	// cleanup. This will override the inCI() check.
+	if t.Failed() && skipCleanupOnlyAfterFailure {
+		return false
+	}
+
+	// If the test failed, the skip cleanup after failures flag is not set, and
+	// we're in CI, skip running cleanups since the CI system will dump the
+	// current cluster state which can be valuable for debugging the test
+	// failure.
+	if t.Failed() && inCI() {
+		return false
+	}
+
+	// At this point, we know the test passed and that there is nothing
+	// precluding us from running the cleanups.
+	return true
 }

--- a/test/e2e-ocl/main_test.go
+++ b/test/e2e-ocl/main_test.go
@@ -1,10 +1,16 @@
 package e2e_ocl_test
 
 import (
+	"flag"
 	"os"
 	"testing"
+
+	"k8s.io/klog/v2"
 )
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+	klog.Infof("-skip-cleanup: %v", skipCleanupAlways)
+	klog.Infof("-skip-cleanup-on-failure: %v", skipCleanupOnlyAfterFailure)
 	os.Exit(m.Run())
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -110,6 +110,17 @@ func MakeIdempotent(f func()) func() {
 	}
 }
 
+// Ensures that a given cleanup function only runs once; even if called once.
+// When the provided skipFunc returns true, executing the cleanup will be
+// skipped. The skipFunc will also only be executed once.
+func MakeIdempotentSkippable(skipFunc func() bool, f func()) func() {
+	return MakeIdempotent(func() {
+		if !skipFunc() {
+			f()
+		}
+	})
+}
+
 // Applies a MachineConfig to a given MachineConfigPool, if a MachineConfig is
 // provided. If a MachineConfig is not provided (i.e., nil), it will skip the
 // apply process and wait for the MachineConfigPool to include the "00-worker"

--- a/test/helpers/utils_test.go
+++ b/test/helpers/utils_test.go
@@ -50,3 +50,62 @@ func TestMakeIdempotent(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeIdempotentSkippable(t *testing.T) {
+	t.Parallel()
+
+	count := 0
+
+	increment := func() { count++ }
+
+	skipFunc := func(result bool) func() bool {
+		return func() bool {
+			return result
+		}
+	}
+
+	testCases := []struct {
+		name          string
+		incrementer   func()
+		expectedCount int
+	}{
+		{
+			name:          "Not idempotent",
+			incrementer:   increment,
+			expectedCount: 10,
+		},
+		{
+			name:          "Is idempotent; not skipped - Single-wrapped",
+			incrementer:   MakeIdempotentSkippable(skipFunc(false), increment),
+			expectedCount: 1,
+		},
+		{
+			name:          "Is idempotent; not skipped - Double-wrapped",
+			incrementer:   MakeIdempotentSkippable(skipFunc(false), MakeIdempotentSkippable(skipFunc(false), increment)),
+			expectedCount: 1,
+		},
+		{
+			name:          "Is idempotent; skipped - Single-wrapped",
+			incrementer:   MakeIdempotentSkippable(skipFunc(true), increment),
+			expectedCount: 0,
+		},
+		{
+			name:          "Is idempotent; skipped - Double-wrapped",
+			incrementer:   MakeIdempotentSkippable(skipFunc(true), MakeIdempotentSkippable(skipFunc(true), increment)),
+			expectedCount: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			count = 0
+
+			for i := 0; i < 10; i++ {
+				testCase.incrementer()
+			}
+
+			assert.Equal(t, testCase.expectedCount, count)
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

I modified the e2e-ocl test suite to leave objects in-situ whenever the test suite is being run in OpenShift CI. This is because the OpenShift CI process includes significant tooling that collects the current cluster state upon failure for easier debugging.

**- How to verify it**

Run the test suite

**- Description for the changelog**
e2e tests should not clean up upon failure in CI
