### PR TITLE
OCPBUGS-45860: daemon: add nil check for annotation fetching

### DIFF
--- a/pkg/daemon/node.go
+++ b/pkg/daemon/node.go
@@ -64,6 +64,9 @@ func getNodeAnnotation(node *corev1.Node, k string) (string, error) {
 
 // getNodeAnnotationExt is like getNodeAnnotation, but allows one to customize ENOENT handling
 func getNodeAnnotationExt(node *corev1.Node, k string, allowNoent bool) (string, error) {
+	if node == nil || node.Annotations == nil {
+		return "", fmt.Errorf("node object is nil")
+	}
 	v, ok := node.Annotations[k]
 	if !ok {
 		if !allowNoent {


### PR DESCRIPTION
Theoretically this shouldn't be empty by the time it gets to here, but in the error stacktrace: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-e2e-vsphere-ovn-upi-serial/1861922894817267712/artifacts/e2e-vsphere-ovn-upi-serial/gather-extra/artifacts/pods/openshift-machine-config-operator_machine-config-daemon-4mzxf_machine-config-daemon_previous.log we see this function panicking.

This seems to have actually been the second place where we hit this function in that logic loop? i.e. loadNodeAnnotations -> getNodeAnnotation -> getNodeAnnotationExt should have panicked if either node or node.Annotations is empty, but for some reason it didn't.  Weird. Also the fact that we have not seen this before makes it extra odd.

In either case, for safety reasons, we shouldn't be attempting to dereference a potentially nil pointer anyways, so let's just make this quick fix.