### PR TITLE
NO-ISSUE: Add AUTHFILE option to make image

### DIFF
--- a/hack/build-image
+++ b/hack/build-image
@@ -41,6 +41,11 @@ else:
 
 print(f"HEAD commit: {gitrev}")
 args = [podman, 'build', '-t', imgname, '--no-cache', '.']
+# Check if AUTHFILE environment variable is set. Setting this allows the user to specify which file to use
+# for the authentication when building the image
+authfile = os.environ.get('AUTHFILE')
+if authfile:
+    args.extend(['--authfile', authfile])
 for k in openshift_keys:
     args.append(f'--label={k}=')
 args.extend([f'--label=vcs-ref={gitrev}', '--label=vcs-type=git', '--label=vcs-url='])


### PR DESCRIPTION
When building the mco image, add an AUTHFILE check to allow users to specify a different file from the default one for the authentication to be used during the build process.

This is something I kept having to change manually because I use a different location for my openshift auth and not the default one that podman looks at. 

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add AUTHFILE option to make image to allow specifying a file path for the auth needed during build

**- How to verify it**
run make image AUTHFILE=path/to/auth file and the podman build command outputed should have `--authfile=path/you/specified`

**- Description for the changelog**
Add AUTHFILE option to make image to allow specifying a file path for the auth needed during build
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
