### PR TITLE
OCPBUGS-46052: machine-os-builder deployment missing openshift.io/required-scc annotation

### DIFF
--- a/manifests/machineosbuilder/deployment.yaml
+++ b/manifests/machineosbuilder/deployment.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: machine-os-builder
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: anyuid
     spec:
       containers:
       - name: machine-os-builder


### PR DESCRIPTION
**- What I did**
Added required-scc annotation to machineosbuilder manifest
**- How to verify it**
passes from CI for:
- e2e-aws-ovn-ocb-techpreview
- e2e-aws-ovn-upgrade-ocb-techpreview

