### PR TITLE
DNM: test against RHEL 9.6

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -118,7 +118,7 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
-	baseOSContainerImageTag := "rhel-coreos"
+	baseOSContainerImageTag := "rhel-coreos-next"
 	if version.IsFCOS() {
 		baseOSContainerImageTag = "fedora-coreos"
 	} else if version.IsSCOS() {

--- a/install/0000_80_machine-config_05_osimageurl.yaml
+++ b/install/0000_80_machine-config_05_osimageurl.yaml
@@ -11,8 +11,8 @@ data:
   releaseVersion: 0.0.1-snapshot
   # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
   # progresses towards the default.
-  baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos"
-  baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions"
+  baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-next"
+  baseOSExtensionsContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions-next"
   # The OS payload used for 4.10 and below; more information in
   # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
   # (The original issue was  https://github.com/openshift/machine-config-operator/issues/183 )

--- a/install/image-references
+++ b/install/image-references
@@ -20,14 +20,14 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-rbac-proxy
-  - name: rhel-coreos
+  - name: rhel-coreos-next
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos
-  - name: rhel-coreos-extensions
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-next
+  - name: rhel-coreos-extensions-next
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions-next
   - name: keepalived-ipfailover
     from:
       kind: DockerImage


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/COS-3086.

Hopefully this is the last time we have to do this! (This should become obsoleted by https://github.com/openshift/enhancements/pull/1637).