### PR TITLE
OCPBUGS-41489: Specify interface type when adding ovs-port

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -219,13 +219,13 @@ contents:
       # find default port to add to bridge
       if ! nmcli connection show "$default_port_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" ${iface}
-        add_nm_conn "$default_port_name" type ovs-port conn.interface ${iface} master "$bridge_name" \
+        add_nm_conn "$default_port_name" type ovs-port conn.interface ${iface} master "$bridge_name" slave-type ovs-bridge \
         connection.autoconnect-slaves 1
       fi
 
       if ! nmcli connection show "$ovs_port" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" "$bridge_name"
-        add_nm_conn "$ovs_port" type ovs-port conn.interface "$bridge_name" master "$bridge_name"
+        add_nm_conn "$ovs_port" type ovs-port conn.interface "$bridge_name" master "$bridge_name" slave-type ovs-bridge
       fi
 
       extra_phys_args=()


### PR DESCRIPTION
We already do this in a few other places, but not on these two calls. Under some circumstances, this is causing ovs-configuration to fail until manual intervention is done.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
