### PR TITLE
OCPBUGS-34586: Auto-recover from MC with invalid extension

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -608,6 +608,12 @@ func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
 		if err := ValidateIgnition(ignCfg); err != nil {
 			return err
 		}
+		// Validate MC extensions are in allowlist
+		if len(cfg.Extensions) > 0 {
+			if err := ValidateMachineConfigExtensions(cfg); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes: OCPBUGS-34586

**- What I did**
Add extension validation to controller's machine config validation function to catch the extension error before the daemon attempts to start updating nodes.

**- How to verify it**
Example MC with an invalid extension `1-worker-extension.yaml`:
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 80-worker-extensions
spec:
  config:
    ignition:
      version: 3.2.0
  extensions:
    - badName
```

#### Auto-recovery by deleting MC
1. Apply MC
```
$ oc apply -f 1-worker-extension.yaml
```
2. Wait for MCP to be in degraded state
```
$ oc get mcp
     NAME     CONFIG                 UPDATED   UPDATING   DEGRADED 
     worker   rendered-worker-XXXX   True      False      True
```
3. Delete MC
```
$ oc delete mc/80-worker-extensions
```
4. MCP should no longer be in a degraded state & nodes should update to new rendered config.
```
$ oc get mcp
     NAME     CONFIG                 UPDATED   UPDATING   DEGRADED 
     worker   rendered-worker-XXXX   True      False      False
```

#### Auto-recovery by reapplying MC with valid extension
1. Apply MC with invalid extension
2. Wait for MCP to be in degraded state
3. Update the MC to have a valid extension (example: change `badName` to `usbguard`) & apply it
4. MCP should no longer be in a degraded state & nodes should update to new rendered config with valid extension
5. Check that new extension was installed on the node
```
$ oc debug node/ip-10-0-91-65.us-west-2.compute.internal
     sh-5.1# chroot /host
     sh-5.1# rpm -q usbguard
     usbguard-1.0.0-15.el9.aarch64
```

**- Description for the changelog**
OCPBUGS-34586: Auto-recover from MC with invalid extension