### PR TITLE
OCPBUGS-38749: add timeout error to applyManifest retry list

### DIFF
--- a/lib/resourceapply/apps.go
+++ b/lib/resourceapply/apps.go
@@ -27,6 +27,10 @@ func IsApplyErrorRetriable(err error) bool {
 	if apierrors.IsConflict(err) {
 		return true
 	}
+	// Retry when the server takes too long to respond to the apply requests.
+	if apierrors.IsTimeout(err) {
+		return true
+	}
 	// Add any other errors to be added to the retry here.
 
 	klog.Infof("Skipping retry in Apply fn for error: %s", err)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Added one more error to the retry list for applyManifest, so we don't immediately degrade. This is follow-up from https://github.com/openshift/machine-config-operator/pull/4698, as merging that uncovered these failures. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
