### PR TITLE
OCPBUGS-45928,OCPBUGS-46531: crio: drop crun subcgroup

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -50,6 +50,7 @@ contents:
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
+    default_annotations = {"run.oci.systemd.subgroup" = ""}
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -50,6 +50,7 @@ contents:
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
+    default_annotations = {"run.oci.systemd.subgroup" = ""}
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"


### PR DESCRIPTION
historically crun has run with a subcgroup to allow it to own the cgroup configuration of a container this is more idiomatic with systemd's single owner rule.

The problem is the subcgroup means there is an extra cgroup for cadvisor to read metrics for, so moving to crun by default actually increases cpu usage. Dropping the subcgroup (with a new cri-o knob and this annotation) fixes this regression.
