### PR TITLE
OPNET-629: Mark haproxy unhealthy if no healthy backends

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -26,6 +26,12 @@ contents:
       mode http
       monitor-uri /haproxy_ready
       option dontlognull
+    listen monitor_check_http_url
+      bind :::9454 v4v6
+      mode http
+      monitor-uri /haproxy_monitor
+      monitor fail if { nbsrv(masters) lt 1 }
+      option dontlognull
     {{`{{- end }}`}}
     listen stats
       bind localhost:{{`{{ .LBConfig.StatPort }}`}}


### PR DESCRIPTION
Previously we avoided doing this because of potential issues in unhealthy clusters where backends were flapping and we didn't want to trigger failovers. However, given the nature of the firewall rule monitor check that approach was not effective anyway and allowing HAProxy to report its own status to the monitor is much more robust than relying on API calls being routed correctly when API rollouts are happening.

This is being implemented as a separate monitor endpoint because we don't want the Kubelet liveness probes to fail just because there are no backends (which is an expected state in early cluster deployment). That would trigger unnecessary crash loops.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
