### PR TITLE
MCO-1449: Add MCDPivotError runbook to prometheus rules

### DIFF
--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -101,6 +101,7 @@ spec:
           annotations:
             summary: "Alerts the user when an error is detected upon pivot. This triggers if the pivot errors are above zero for 2 minutes."
             description: "Error detected in pivot logs on {{ $labels.node }} , upgrade may be blocked. For more details:  oc logs -f -n {{ $labels.namespace }} {{ $labels.pod }} -c machine-config-daemon "
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/MachineConfigDaemonPivotError.md
     - name: mcd-kubelet-health-state-error
       rules:
         - alert: KubeletHealthState


### PR DESCRIPTION

Please provide the following information:

**- What I did**

Added a runbook I wrote to the MCDPivotError  Alert

**- How to verify it**

Trigger MCDPivotError  on cluster. Alert should now display associated runbook.

**- Description for the changelog**

Added https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/MachineConfigDaemonPivotError.md to alert as a runbook_url.
