### PR TITLE
OCPBUGS-45459: Remove trailing period from Openstack provided hostnames

### DIFF
--- a/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-kubelet-nodename.yaml
@@ -58,7 +58,8 @@ contents:
             umount "${tmp_mount}" && rmdir "${tmp_mount}"
             exit 1
         fi
-
+        # Remove trailing period from the hostname. REF: OCPBUGS-45459.
+        hostname="${hostname%.}"
         echo "KUBELET_NODE_NAME=${hostname}" > ${NODEENV}
         umount "${tmp_mount}" && rmdir "${tmp_mount}"
     else
@@ -87,7 +88,8 @@ contents:
                 sleep 5
                 continue
             fi
-
+            # Remove trailing period from the hostname. REF: OCPBUGS-45459.
+            hostname="${hostname%.}"
             echo "KUBELET_NODE_NAME=${hostname}" > ${NODEENV}
             break
         done


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed an issue where hostnames with a trailing dot were not properly handled
Based on https://github.com/openshift/machine-config-operator/pull/4729
**- How to verify it**
1. Provide a hostname with a trailing dot in the configuration.
2. Ensure the trailing dot is stripped and the correct hostname is set.
**- Description for the changelog**
<!--
Remove trailing periods from Openstack provided hostnames
pull request for inclusion in the changelog:
#4778
-->
