### PR TITLE
OCPBUGS-48195: use new buffer for decoding clusterOverridePolicyJSON

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -1133,12 +1133,11 @@ func updateNamespacedPolicyJSONs(clusterOverridePolicyJSON []byte, internalBlock
 	}
 
 	namespacedPolicyJSONs := make(map[string][]byte)
-	decoder := json.NewDecoder(bytes.NewBuffer(clusterOverridePolicyJSON))
 
 	for namespace, requirements := range namespacedPolicies {
 
 		policyObj := &signature.Policy{}
-		err := decoder.Decode(policyObj)
+		err := json.NewDecoder(bytes.NewBuffer(clusterOverridePolicyJSON)).Decode(policyObj)
 		if err != nil {
 			return nil, fmt.Errorf("error decoding policy json for namespaced policies: %w", err)
 		}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the bug where ImagePolicy fails to roll out for different namespaces due to a decoding error.
**- How to verify it**
Apply ImagePolicy objects for different namespaces, the files under /etc/crio/policies will bu updated for all corresponding namespaces.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
