### PR TITLE
OCPBUGS-48250: MCO CO degrades are stuck on until master pool updates complete

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -196,6 +196,11 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 			}
 			break
 		}
+		// If there was no sync error for this function, attempt to clear degrade
+		updatedCO, err = optr.clearDegradedStatus(updatedCO, sf.name)
+		if err != nil {
+			return fmt.Errorf("error clearing degraded status: %v", err)
+		}
 	}
 
 	optr.syncDegradedStatus(updatedCO, syncErr)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added a clear CO degrade function, which is called after a successful invocation of an operator sync function. 

**- How to verify it**
On a build without this fix:
1. Degrade the operator.  I did this is by scaling down the CVO and editing the `releaseVersion` field in the `machine-config-operator-images` configmap to a bad value. This will cause `syncRenderConfig` to fail and degrade the operator(visible in the CO object and operator logs). 
2. Now, deploy an MC update to the master pool. This will cause the operator to be stuck in `syncRequiredMachineConfigPool` sync function, where it'll wait until the master pool completes the update. 
3. While the master pool is still updating, restore the `releaseVersion` back to the original value. You should see the operator log clear up shortly, but the CO will continue to be degraded. Once the master pool is done updating, the CO degrade will clear up.

On a build with this fix:
Repeat steps 1 to 4 above. This time, you should notice that the CO degrade will clear up shortly after restoring `releaseVersion`, without having to wait for the master pool to complete the update.

Note: The update needs to be applied to a master pool because the `syncRequiredMachineConfigPools` function will only "trap" the operator for master pool updates. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
