### PR TITLE
OCPEDGE-1419: Add ksan-storage extension

### DIFF
--- a/docs/MachineConfig.md
+++ b/docs/MachineConfig.md
@@ -210,6 +210,7 @@ RHCOS is a minimal OCP focused OS which provides capabilities common across all 
 | 4.11          |  `usbguard`, `sandboxed-containers`, `kerberos`   |
 | 4.14          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm`   |
 | 4.17          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm` , `sysstat`   |
+| 4.19          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm` , `sysstat` , `ksan-storage`   |
 
 Extensions can be installed by creating a MachineConfig object. Extensions can be enabled as both day1 and day2. Check [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Enabling-RHCOS-Extensions) to enable extensions during cluster install.
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -666,6 +666,7 @@ func SupportedExtensions() map[string][]string {
 		"kernel-devel":         {"kernel-devel", "kernel-headers"},
 		"sandboxed-containers": {"kata-containers"},
 		"sysstat":              {"sysstat"},
+		"ksan-storage":         {"lvm2-lockd", "sanlock"},
 	}
 }
 

--- a/test/e2e-single-node/sno_mcd_test.go
+++ b/test/e2e-single-node/sno_mcd_test.go
@@ -196,7 +196,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"wasm", "ipsec", "usbguard", "kernel-devel", "kerberos", "sysstat"},
+			Extensions: []string{"wasm", "ipsec", "usbguard", "kernel-devel", "kerberos", "sysstat", "ksan-storage"},
 		},
 	}
 
@@ -212,8 +212,8 @@ func TestExtensions(t *testing.T) {
 	assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	installedPackages := helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
-	expectedPackages := []string{"crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat"}
+	installedPackages := helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat", "lvm2-lockd", "sanlock")
+	expectedPackages := []string{"crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat", "lvm2-lockd", "sanlock"}
 	for _, v := range expectedPackages {
 		if !strings.Contains(installedPackages, v) {
 			t.Fatalf("Node %s doesn't have expected extensions", node.Name)
@@ -237,7 +237,7 @@ func TestExtensions(t *testing.T) {
 	assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], oldMasterRenderedConfig)
 	assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	installedPackages = helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-qa", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
+	installedPackages = helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-qa", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat", "lvm2-lockd", "sanlock")
 	for _, v := range expectedPackages {
 		if strings.Contains(installedPackages, v) {
 			t.Fatalf("Node %s did not rollback successfully", node.Name)

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -332,7 +332,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"wasm", "ipsec", "usbguard", "kerberos", "kernel-devel", "sandboxed-containers", "sysstat"},
+			Extensions: []string{"wasm", "ipsec", "usbguard", "kerberos", "kernel-devel", "sandboxed-containers", "sysstat", "ksan-storage"},
 		},
 	}
 
@@ -357,12 +357,12 @@ func TestExtensions(t *testing.T) {
 	if isOKD {
 		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
 		// "sandboxed-containers" extension is not available on OKD
-		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "sysstat")
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "sysstat", "lvm2-lockd", "sanlock")
 		// "kerberos" extension is not available on OKD
 		expectedPackages = []string{"libreswan", "usbguard", "kernel-devel"}
 	} else {
-		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat")
-		expectedPackages = []string{"crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat"}
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat", "lvm2-lockd", "sanlock")
+		expectedPackages = []string{"crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat", "lvm2-lockd", "sanlock"}
 
 	}
 	for _, v := range expectedPackages {


### PR DESCRIPTION
**- What I did**
The KubeSAN operator requires the addition of 2 host level dependencies: `lvm2-lockd` and `sanlock` in order to manage shared LVM volumeGroup access.

- Added `ksan-storage` extension

**- How to verify it**

Post boot, the extensions can be queried on each node via `rpm -qa | grep -E 'lvm2-lockd|sanlock'`

**- Description for the changelog**

Added host-level support for kubesan operator