### PR TITLE
MGMT-19337: enable injection of custom kubelet labels via env var in base template

### DIFF
--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -28,7 +28,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
-        --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master,node.openshift.io/os_id=${ID},${CUSTOM_KUBELET_LABELS} \
 {{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -28,7 +28,7 @@ contents: |
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
         --runtime-cgroups=/system.slice/crio.service \
-        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID} \
+        --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=${ID},${CUSTOM_KUBELET_LABELS} \
 {{- if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") }}
         --node-ip=${KUBELET_NODE_IPS} \
 {{- else}}


### PR DESCRIPTION
Related to https://github.com/openshift/machine-config-operator/pull/4746

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
added CUSTOM_KUBELET_LABELS env var to --node-labels parameter for kubelet in master node's template
The use case is a CAPI bootstrap provider install openshift need to advertise a given provider ID via label, so that the infrastructure provider can set the actual provider ID once verified.
**- How to verify it**
add CUSTOM_KUBELET_LABELS=mydummylabel=myvalue to any of the environmental files used by kubelet (possibly /etc/kubernetes/kubelet-envs)
**- Description for the changelog**
Inject master node labels via CUSTOM_KUBELET_LABELS env var in base template
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
