### PR TITLE
OCPBUGS-46072: create /run/nodeip-configuration before use

### DIFF
--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -63,6 +63,7 @@ contents:
         fi
 
         if [[ "$STATUS" == "up" ]] && [[ $IFACE == "br-ex" ]]; then
+            /bin/mkdir -p /run/nodeip-configuration
             touch /run/nodeip-configuration/br-ex-up
         fi
       ;;


### PR DESCRIPTION
With nmstate `br-ex` creation using static IP, it looks like the systemd boot ordering can change and we can attempt to run `30-resolv-prepender` before `nodeip-configuration.service`.

When `30-resolv-prepender` runs it tries to touch a file in `/run/nodeip-configuration` when it does not exist.

```log
nm-dispatcher[2409]: touch: cannot touch '/run/nodeip-configuration/br-ex-up': No such file or directory
```

The quick fix is to always mkdir before touching, then we don't have to track the global state of `/run/nodeip-configuration`
