### PR TITLE
OCPBUGS-43552: maxUnavailable value is not honored when disabling OCL

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -27,6 +27,11 @@ const (
 	DrainerStateDrain = "drain"
 	// DrainerStateUncordon is used for drainer annotation as a value to indicate needing an uncordon
 	DrainerStateUncordon = "uncordon"
+	// UpdateQueuedAnnotation is used to indicate that an update is queued for the machine
+	UpdateQueuedAnnotation = "machineconfiguration.openshift.io/update-queued"
+	// updateQueuedAnnotationValue is used to indicate that an update is queued for the machine
+	UpdateQueuedAnnotationValue = "true"
+
 	// ClusterControlPlaneTopologyAnnotationKey is set by the node controller by reading value from
 	// controllerConfig. MCD uses the annotation value to decide drain action on the node.
 	ClusterControlPlaneTopologyAnnotationKey = "machineconfiguration.openshift.io/controlPlaneTopology"


### PR DESCRIPTION
What I did
Fixed a bug in the node controller where the maxUnavailable setting was not honored when ocl was disabled. The issue was due to the getAllCandidateMachines function not properly checking for nodes that were mid-update. I added a condition to skip nodes that are currently being updated, ensuring that we do not exceed the maxUnavailable limit.

How to verify it

Enable OCL in the worker pool
Remove the MOSC resource to disable OCL
view node status to make sure nodes do not update simultaneously
Description for the changelog

Fixed an issue where maxUnavailable was not honored when ocl is disabled, ensuring node updates respect the maximum unavailable node count.
