### PR TITLE
WIP: GCP: Update /etc/hosts file when ClusterHostedDNS is enabled

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -782,16 +781,13 @@ func cloudPlatformIngressLoadBalancerIPs(cfg RenderConfig) (interface{}, error) 
 // cloudPlatformLBIPAvailable returns true when DNSType is set to `ClusterHosted`
 // and LB IPs are provided as part of `PlatformStatus`.
 func cloudPlatformLBIPAvailable(cfg RenderConfig) bool {
-	logrus.Infof("Inside cloudPlatformLBIPAvailable")
 	if cfg.Infra.Status.PlatformStatus != nil {
 		switch cfg.Infra.Status.PlatformStatus.Type {
 		case configv1.GCPPlatformType:
 			switch cloudPlatformLoadBalancerIPState(cfg) {
 			case availableLBIPState:
-				logrus.Infof("LB IPs available")
 				return true
 			default:
-				logrus.Infof("LB IPs not available")
 				return false
 			}
 		case configv1.AWSPlatformType:

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -80,6 +80,7 @@ func (a *assetRenderer) addTemplateFuncs() {
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
 	funcs["cloudPlatformIngressLoadBalancerIPs"] = cloudPlatformIngressLoadBalancerIPs
+	funcs["cloudPlatformLBIPAvailable"] = cloudPlatformLBIPAvailable
 	funcs["join"] = strings.Join
 
 	a.tmpl = a.tmpl.Funcs(funcs)
@@ -458,6 +459,33 @@ func cloudPlatformIngressLoadBalancerIPs(cfg mcfgv1.ControllerConfigSpec) (inter
 		}
 	} else {
 		return nil, fmt.Errorf("")
+	}
+}
+
+// cloudPlatformLBIPAvailable returns true when DNSType is set to `ClusterHosted`
+// and LB IPs are provided as part of `PlatformStatus`.
+func cloudPlatformLBIPAvailable(cfg mcfgv1.ControllerConfigSpec) bool {
+	if cfg.Infra.Status.PlatformStatus != nil {
+		switch cfg.Infra.Status.PlatformStatus.Type {
+		case configv1.GCPPlatformType:
+			switch cloudPlatformLoadBalancerIPState(cfg) {
+			case availableLBIPState:
+				return true
+			default:
+				return false
+			}
+		case configv1.AWSPlatformType:
+			switch cloudPlatformLoadBalancerIPState(cfg) {
+			case availableLBIPState:
+				return true
+			default:
+				return false
+			}
+		default:
+			return false
+		}
+	} else {
+		return false
 	}
 }
 

--- a/templates/common/gcp/files/usr-local-bin-update-etc-hosts.yaml
+++ b/templates/common/gcp/files/usr-local-bin-update-etc-hosts.yaml
@@ -1,0 +1,27 @@
+mode: 0755
+path: "/usr/local/bin/update-etc-hosts"
+contents:
+  inline: |
+    #!/bin/bash
+
+    {{ if and (cloudPlatformLBIPAvailable .) (gt (len (cloudPlatformAPIIntLoadBalancerIPs .)) 0) }}
+    apiIntLBIP={{ index (cloudPlatformAPIIntLoadBalancerIPs .) 0 }} {{ end }}
+    {{ if and (cloudPlatformLBIPAvailable .) (gt (len (cloudPlatformAPILoadBalancerIPs .)) 0) }}
+    apiLBIP={{ index (cloudPlatformAPILoadBalancerIPs .) 0 }}{{ end }}
+    {{ if and (cloudPlatformLBIPAvailable .) (eq (len (cloudPlatformAPILoadBalancerIPs .)) 0) }}
+    apiLBIP={{ index (cloudPlatformAPIIntLoadBalancerIPs .) 0 }}{{ end }}
+    apiServerURL={{ .Infra.Status.APIServerURL }}
+    apiServerIntURL={{ .Infra.Status.APIServerInternalURL }}
+    apiServerHostPort=${apiServerURL#*//}
+    apiServerIntHostPort=${apiServerIntURL#*//}
+    apiServerHostname=${apiServerHostPort%:*}
+    apiIntServerHostname=${apiServerIntHostPort%:*}
+    mkdir -p /etc/conf.d
+    etc_hosts_config_filename="/etc/conf.d/etc-hosts.conf"
+    echo "${apiLBIP}    ${apiServerHostname}" >> ${etc_hosts_config_filename}
+    echo "${apiIntLBIP}    ${apiIntServerHostname}" >> ${etc_hosts_config_filename}
+    if [ -f ${etc_hosts_config_filename} ]
+    then
+      cat /etc/conf.d/etc-hosts.conf >> /etc/hosts
+      echo "Done updating /etc/hosts"
+    fi

--- a/templates/common/gcp/units/gcp-update-etc-hosts.service.yaml
+++ b/templates/common/gcp/units/gcp-update-etc-hosts.service.yaml
@@ -1,0 +1,19 @@
+name: gcp-update-etc-hosts.service
+enabled: {{if and (eq .Infra.Status.PlatformStatus.Type "GCP") (.Infra.Status.PlatformStatus.GCP) (.Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig) (eq .Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType "ClusterHosted") }}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Update Default GCP /etc/hosts
+  # We don't need to do this on the firstboot
+  After=firstboot-osupdate.target
+  # Wait for NetworkManager to report it's online
+  After=NetworkManager-wait-online.service
+  # Run before kubelet
+  Before=kubelet-dependencies.target
+
+  [Service]
+  # Need oneshot to delay kubelet
+  Type=oneshot
+  ExecStart=/usr/local/bin/update-etc-hosts
+
+  [Install]
+  RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
Append /etc/hosts files with entries to resolve cluster api and api-int URLS. /etc/hosts will provide resolution for these URLs until kubelet joins the cluster and runs its CoreDNS pod which will then take over resolution of those 2 URLs

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
