### PR TITLE
OCPBUGS-48759: Add required-scc to criometricsproxy

### DIFF
--- a/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
@@ -9,6 +9,7 @@ contents:
       namespace: openshift-machine-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: etc-kube

--- a/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
@@ -9,6 +9,7 @@ contents:
       namespace: openshift-machine-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: etc-kube


### PR DESCRIPTION
Match 4.18+. I don't think this was checked in 4.17 explicitly but it does sometimes fail when you do a 4.17->4.18 upgrade.