### PR TITLE
OCPBUGS-48675, OCPBUGS-48808, OCPBUGS-46421: Ensure build job is deleted when rebuild is triggered

### DIFF
--- a/pkg/controller/build/buildrequest/builder.go
+++ b/pkg/controller/build/buildrequest/builder.go
@@ -83,3 +83,12 @@ func (b *builder) MachineConfigPool() (string, error) {
 func (b *builder) RenderedMachineConfig() (string, error) {
 	return utils.GetRequiredLabelValueFromObject(b, constants.RenderedMachineConfigLabelKey)
 }
+
+// Gets the UID of the Builder object.
+func (b *builder) BuilderUID() (string, error) {
+	uid := string(b.GetUID())
+	if uid == "" {
+		return uid, fmt.Errorf("object %s has no UID", b.GetName())
+	}
+	return uid, nil
+}

--- a/pkg/controller/build/buildrequest/interfaces.go
+++ b/pkg/controller/build/buildrequest/interfaces.go
@@ -19,6 +19,7 @@ type Builder interface {
 	MachineOSBuild() (string, error)
 	MachineConfigPool() (string, error)
 	RenderedMachineConfig() (string, error)
+	BuilderUID() (string, error)
 	GetObject() metav1.Object
 	metav1.Object
 }

--- a/pkg/controller/build/buildrequest/machineosbuild.go
+++ b/pkg/controller/build/buildrequest/machineosbuild.go
@@ -198,6 +198,10 @@ func NewMachineOSBuild(opts MachineOSBuildOpts) (*mcfgv1.MachineOSBuild, error) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   mosbName,
 			Labels: utils.GetMachineOSBuildLabels(opts.MachineOSConfig, opts.MachineConfigPool),
+			// Set finalzer on MOSB to ensure all it dependents are deleted before the MOSB
+			Finalizers: []string{
+				metav1.FinalizerDeleteDependents,
+			},
 		},
 		Spec: mcfgv1.MachineOSBuildSpec{
 			RenderedImagePushSpec: mcfgv1.ImageTagFormat(taggedRef.String()),

--- a/pkg/controller/build/constants/constants.go
+++ b/pkg/controller/build/constants/constants.go
@@ -19,6 +19,7 @@ const (
 	MachineOSConfigNameAnnotationKey = "machineconfiguration.openshift.io/machine-os-config"
 	MachineOSConfigNameLabelKey      = MachineOSConfigNameAnnotationKey
 	MachineOSBuildNameLabelKey       = MachineOSBuildNameAnnotationKey
+	JobUIDAnnotationKey              = "machineconfiguration.openshift.io/job-uid"
 )
 
 // The MachineOSConfig will get updated with this annotation once a

--- a/pkg/controller/build/fixtures/objects.go
+++ b/pkg/controller/build/fixtures/objects.go
@@ -16,6 +16,7 @@ import (
 const (
 	BaseImagePullSecretName  string = "base-image-pull-secret"
 	finalImagePushSecretName string = "final-image-push-secret"
+	JobUID                   string = "bfc35cd0f874c9bfdc586e6ba39f1896"
 )
 
 // Provides consistently instantiated objects for use in a given test.
@@ -100,6 +101,9 @@ func NewObjectBuildersForTest(poolName string) ObjectBuildersForTest {
 			constants.TargetMachineConfigPoolLabelKey: poolName,
 			constants.RenderedMachineConfigLabelKey:   renderedConfigName,
 			constants.MachineOSConfigNameLabelKey:     moscName,
+		}).
+		WithAnnotations(map[string]string{
+			constants.JobUIDAnnotationKey: JobUID,
 		})
 
 	return ObjectBuildersForTest{

--- a/pkg/controller/build/imagebuilder/base.go
+++ b/pkg/controller/build/imagebuilder/base.go
@@ -8,6 +8,7 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/buildrequest"
+	"github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/utils"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	batchv1 "k8s.io/api/batch/v1"
@@ -171,7 +172,17 @@ func (b *baseImageBuilder) getMachineOSConfigName() (string, error) {
 		return b.mosc.Name, nil
 	}
 
-	return b.builder.MachineOSBuild()
+	return b.builder.MachineOSConfig()
+}
+
+// Gets the UID of the builder by either checking the MOSB annotation or
+// getting it directly from the Builder object.
+func (b *baseImageBuilder) getBuilderUID() (string, error) {
+	if b.mosb != nil {
+		return b.mosb.GetAnnotations()[constants.JobUIDAnnotationKey], nil
+	}
+
+	return b.builder.BuilderUID()
 }
 
 // Gets the name of the builder execution unit by

--- a/pkg/controller/build/imagebuilder/cleaner.go
+++ b/pkg/controller/build/imagebuilder/cleaner.go
@@ -47,6 +47,10 @@ func (c *cleanerImpl) Clean(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	mosbJobUIDAnnotation, err := c.getBuilderUID()
+	if err != nil {
+		return err
+	}
 
 	selector, err := c.getSelectorForDeletion()
 	if err != nil {
@@ -58,13 +62,12 @@ func (c *cleanerImpl) Clean(ctx context.Context) error {
 	configmaps, err := c.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector.String(),
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not list configmaps: %w", err)
 	}
 
 	for _, configmap := range configmaps.Items {
-		if err := c.deleteConfigMap(ctx, configmap.Name, mosbName); err != nil {
+		if err := c.deleteConfigMap(ctx, configmap.Name, mosbName, mosbJobUIDAnnotation); err != nil {
 			return fmt.Errorf("could not delete ephemeral configmap %s: %w", configmap.Name, err)
 		}
 	}
@@ -72,13 +75,12 @@ func (c *cleanerImpl) Clean(ctx context.Context) error {
 	secrets, err := c.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector.String(),
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not list secrets: %w", err)
 	}
 
 	for _, secret := range secrets.Items {
-		if err := c.deleteSecret(ctx, secret.Name, mosbName); err != nil {
+		if err := c.deleteSecret(ctx, secret.Name, mosbName, mosbJobUIDAnnotation); err != nil {
 			return fmt.Errorf("could not delete ephemeral configmap %s: %w", secret.Name, err)
 		}
 	}
@@ -88,29 +90,54 @@ func (c *cleanerImpl) Clean(ctx context.Context) error {
 
 // Deletes a given ConfigMap and tolerates that it was not found so that if
 // this is called more than once, it will not error.
-func (c *cleanerImpl) deleteConfigMap(ctx context.Context, cmName, mosbName string) error {
-	err := c.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Delete(ctx, cmName, metav1.DeleteOptions{})
-	if err == nil {
-		klog.Infof("Deleted ephemeral ConfigMap %q for build %q", cmName, mosbName)
+func (c *cleanerImpl) deleteConfigMap(ctx context.Context, cmName, mosbName, mosbJobUIDAnnotation string) error {
+	cm, err := c.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 
+	// Ensure that we delete the correct configmap for the Job we are cleaning up
+	if !hasOwnerRefWithUID(cm.ObjectMeta, mosbJobUIDAnnotation) {
+		return nil
+	}
+
+	err = c.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+	if err == nil {
+		klog.Infof("Deleted ephemeral ConfigMap %q for build %q", cm.Name, mosbName)
+		return nil
+	}
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 
 	return err
+
 }
 
 // Deletes a given Secret and tolerates that it was not found so that if
 // this is called more than once, it will not error.
-func (c *cleanerImpl) deleteSecret(ctx context.Context, secretName, mosbName string) error {
-	err := c.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-	if err == nil {
-		klog.Infof("Deleted ephemeral secret %q for build %q", secretName, mosbName)
+func (c *cleanerImpl) deleteSecret(ctx context.Context, secretName, mosbName, mosbJobUIDAnnotation string) error {
+	secret, err := c.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 
+	// Ensure that we are deleting the correct secret for the Job we are cleaning up
+	if !hasOwnerRefWithUID(secret.ObjectMeta, mosbJobUIDAnnotation) {
+		return nil
+	}
+
+	err = c.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
+	if err == nil {
+		klog.Infof("Deleted ephemeral Secret %q for build %q", secret.Name, mosbName)
+		return nil
+	}
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -152,4 +179,20 @@ func ephemeralBuildObjectSelectorForBuilder(builder buildrequest.Builder) (label
 		constants.RenderedMachineConfigLabelKey:   renderedMC,
 		constants.MachineOSConfigNameLabelKey:     moscName,
 	}), nil
+}
+
+// hasOwnerRefWithUID returns true if the provided object has an
+// owner reference with the provided UID
+func hasOwnerRefWithUID(obj metav1.ObjectMeta, uid string) bool {
+	if obj.OwnerReferences == nil {
+		return false
+	}
+
+	for _, owner := range obj.OwnerReferences {
+		if string(owner.UID) == uid {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/controller/build/imagebuilder/preparer_test.go
+++ b/pkg/controller/build/imagebuilder/preparer_test.go
@@ -7,10 +7,14 @@ import (
 
 	"github.com/openshift/machine-config-operator/pkg/controller/build/buildrequest"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/fixtures"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	testhelpers "github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakecorev1client "k8s.io/client-go/kubernetes/fake"
 )
 
 // This test ensures that cleanups for one build do not interfere with the
@@ -40,16 +44,22 @@ func TestPreparer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, br1)
 	assertObjectsAreCreatedByPreparer(ctx, t, kubeassert, br1)
+	err = setOwnerForObjects(ctx, kubeclient, br1)
+	assert.NoError(t, err)
 
 	br2, err := p2.Prepare(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, br2)
 	assertObjectsAreCreatedByPreparer(ctx, t, kubeassert, br2)
+	err = setOwnerForObjects(ctx, kubeclient, br2)
+	assert.NoError(t, err)
 
 	br3, err := p3.Prepare(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, br3)
 	assertObjectsAreCreatedByPreparer(ctx, t, kubeassert, br3)
+	err = setOwnerForObjects(ctx, kubeclient, br3)
+	assert.NoError(t, err)
 
 	// Create three cleaners assigned to their own MachineOSBuilds though
 	// sharing the same kubeclient and mcfgclient objects.
@@ -60,7 +70,11 @@ func TestPreparer(t *testing.T) {
 	// c3 uses the Builder object from the BuildRequest instead so that we can
 	// ensure that ephemeral build objects will be removed even if only the Builder object
 	// is available.
-	c3 := newCleanerFromBuilder(kubeclient, mcfgclient, br3.Builder())
+	builder3 := br3.Builder()
+	// Set the UID for the builder so that we can ensure that ephemeral build objects
+	// will be removed even if only the Builder object is available.
+	builder3.SetUID(types.UID(fixtures.JobUID))
+	c3 := newCleanerFromBuilder(kubeclient, mcfgclient, builder3)
 
 	// Cleanup the ephemeral objects from the first MachineOSBuild.
 	assert.NoError(t, c1.Clean(ctx))
@@ -121,4 +135,49 @@ func assertObjectsAreRemovedByCleaner(ctx context.Context, t *testing.T, kubeass
 	for _, expectedSecret := range secrets {
 		kubeassert.WithContext(ctx).Now().SecretDoesNotExist(expectedSecret.Name)
 	}
+}
+
+func setOwnerForObjects(ctx context.Context, kubeclient *fakecorev1client.Clientset, br buildrequest.BuildRequest) error {
+	// Add a dummy job as the owner for testing purposes
+	jobOwnerRef := metav1.OwnerReference{
+		APIVersion: "batch/v1",
+		Kind:       "Job",
+		Name:       "test-job",
+		UID:        types.UID(fixtures.JobUID),
+	}
+
+	configmaps, err := br.ConfigMaps()
+	if err != nil {
+		return err
+	}
+	for _, configmap := range configmaps {
+		cm, err := kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configmap.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		cm.SetOwnerReferences([]metav1.OwnerReference{jobOwnerRef})
+		_, err = kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	secrets, err := br.Secrets()
+	if err != nil {
+		return err
+	}
+	for _, secret := range secrets {
+		secret, err := kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(ctx, secret.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		secret.SetOwnerReferences([]metav1.OwnerReference{jobOwnerRef})
+		_, err = kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(ctx, secret, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/controller/build/osbuildcontroller_test.go
+++ b/pkg/controller/build/osbuildcontroller_test.go
@@ -422,33 +422,6 @@ func TestOSBuildController(t *testing.T) {
 	})
 }
 
-// Validates that when a MachineOSConfig gets the rebuild annotation that the
-// MachineOSBuild associated with it is deleted and then rebuilt.
-func TestOSBuildControllerRebuildAnnotation(t *testing.T) {
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	t.Cleanup(cancel)
-
-	_, mcfgclient, mosc, mosb, _, kubeassert := setupOSBuildControllerForTestWithSuccessfulBuild(ctx, t, "worker")
-	assertBuildObjectsAreDeleted(ctx, t, kubeassert, mosb)
-
-	apiMosc, err := mcfgclient.MachineconfigurationV1().MachineOSConfigs().Get(ctx, mosc.Name, metav1.GetOptions{})
-	require.NoError(t, err)
-
-	apiMosc.Annotations[constants.RebuildMachineOSConfigAnnotationKey] = ""
-
-	_, err = mcfgclient.MachineconfigurationV1().MachineOSConfigs().Update(ctx, apiMosc, metav1.UpdateOptions{})
-	require.NoError(t, err)
-
-	assertBuildObjectsAreCreated(ctx, t, kubeassert, mosb)
-
-	apiMosc, err = mcfgclient.MachineconfigurationV1().MachineOSConfigs().Get(ctx, mosc.Name, metav1.GetOptions{})
-	require.NoError(t, err)
-
-	assert.NotContains(t, apiMosc.GetAnnotations(), constants.RebuildMachineOSConfigAnnotationKey)
-
-}
-
 func TestOSBuildControllerBuildFailedDoesNotCascade(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/test/helpers/assertions.go
+++ b/test/helpers/assertions.go
@@ -330,6 +330,66 @@ func (a *Assertions) MachineOSBuildDoesNotExist(mosb *mcfgv1.MachineOSBuild, msg
 	a.machineOSBuildReachesState(mosb, stateFunc, msgAndArgs...)
 }
 
+// Asserts that a pod has an owner set
+func (a *Assertions) PodHasOwnerSet(podName string, msgAndArgs ...interface{}) {
+	a.t.Helper()
+
+	ctx, cancel := a.getContextAndCancel()
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(ctx, a.getPollInterval(), true, func(ctx context.Context) (bool, error) {
+		pod, err := a.kubeclient.CoreV1().Pods(mcoNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		return len(pod.OwnerReferences) > 0, nil
+	})
+
+	msgAndArgs = prefixMsgAndArgs(fmt.Sprintf("Pod %s did not have owner set", podName), msgAndArgs)
+	require.NoError(a.t, err, msgAndArgs...)
+}
+
+// Asserts that a secret has an owner set
+func (a *Assertions) SecretHasOwnerSet(secretName string, msgAndArgs ...interface{}) {
+	a.t.Helper()
+
+	ctx, cancel := a.getContextAndCancel()
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(ctx, a.getPollInterval(), true, func(ctx context.Context) (bool, error) {
+		secret, err := a.kubeclient.CoreV1().Secrets(mcoNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		return len(secret.OwnerReferences) > 0, nil
+	})
+
+	msgAndArgs = prefixMsgAndArgs(fmt.Sprintf("Secret %s did not have owner set", secretName), msgAndArgs)
+	require.NoError(a.t, err, msgAndArgs...)
+}
+
+// Asserts that a configmap has an owner set
+func (a *Assertions) ConfigMapHasOwnerSet(cmName string, msgAndArgs ...interface{}) {
+	a.t.Helper()
+
+	ctx, cancel := a.getContextAndCancel()
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(ctx, a.getPollInterval(), true, func(ctx context.Context) (bool, error) {
+		cm, err := a.kubeclient.CoreV1().ConfigMaps(mcoNamespace).Get(ctx, cmName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		return len(cm.OwnerReferences) > 0, nil
+	})
+
+	msgAndArgs = prefixMsgAndArgs(fmt.Sprintf("ConfigMap %s did not have owner set", cmName), msgAndArgs)
+	require.NoError(a.t, err, msgAndArgs...)
+}
+
 // Asserts that a Secret reaches the desired state.
 func (a *Assertions) secretReachesState(name string, stateFunc func(*corev1.Secret, error) (bool, error), msgAndArgs ...interface{}) {
 	a.t.Helper()

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	machineClientv1beta1 "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
+	buildConstants "github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
 	"github.com/openshift/machine-config-operator/test/framework"
@@ -1753,4 +1754,16 @@ func SetContainerfileContentsOnMachineOSConfig(ctx context.Context, t *testing.T
 	require.NoError(t, err)
 
 	return apiMosc
+}
+
+func SetRebuildAnnotationOnMachineOSConfig(ctx context.Context, t *testing.T, mcfgclient mcfgclientset.Interface, mosc *mcfgv1.MachineOSConfig) {
+	t.Helper()
+
+	apiMosc, err := mcfgclient.MachineconfigurationV1().MachineOSConfigs().Get(ctx, mosc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	apiMosc.Annotations[buildConstants.RebuildMachineOSConfigAnnotationKey] = ""
+
+	_, err = mcfgclient.MachineconfigurationV1().MachineOSConfigs().Update(ctx, apiMosc, metav1.UpdateOptions{})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Ensure that the build job under the MOSB is deleted before deleting the MOSB when the rebuild annotation is added to the MOSC. This ensures proper cleanup so that the build can start again.

Closes https://issues.redhat.com/browse/OCPBUGS-48675
Closes https://issues.redhat.com/browse/OCPBUGS-48808
Closes https://issues.redhat.com/browse/OCPBUGS-46421

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Ensure job is cleaned up when rebuild is triggered.

**- How to verify it**
Follow the steps in the bug lhttps://issues.redhat.com/browse/OCPBUGS-48675. With this fix, the rebuild should be triggered.

**- Description for the changelog**
Ensure rebuild is actually triggered when the rebuild annotation is added to the MOSC.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
