### PR TITLE
NO-ISSUE: Remove etc-pki-entitlement cruft

### DIFF
--- a/devex/cmd/onclustertesting/README.md
+++ b/devex/cmd/onclustertesting/README.md
@@ -87,10 +87,8 @@ feature is implemented in OCL, this should no longer be a problem.
 ### RHEL entitlements
 
 If your cluster has the `etc-pki-entitlement` secret in the
-`openshift-config-managed` namespace, you can use the
-`--copy-etc-pki-entitlement-secret` flag with the `setup` command. This will
-clone the secret into the MCO namespace. This copy will be removed during the
-teardown process.
+`openshift-config-managed` namespace, the operator will automatically
+copy it into the MCO namespace, when a build is required.
 
 ### /etc/yum.repos.d and /etc/pki/rpm-gpg
 

--- a/devex/cmd/onclustertesting/ci.go
+++ b/devex/cmd/onclustertesting/ci.go
@@ -21,10 +21,6 @@ const (
 func runCiSetupCmd(setupOpts opts) error {
 	utils.ParseFlags()
 
-	if setupOpts.injectYumRepos && setupOpts.copyEtcPkiEntitlementSecret {
-		return fmt.Errorf("flags --inject-yum-repos and --copy-etc-pki-entitlement cannot be combined")
-	}
-
 	if err := utils.CheckForBinaries([]string{"oc"}); err != nil {
 		return err
 	}

--- a/devex/cmd/onclustertesting/machineosconfigs.go
+++ b/devex/cmd/onclustertesting/machineosconfigs.go
@@ -44,7 +44,7 @@ func newMachineOSConfig(opts moscOpts) *mcfgv1.MachineOSConfig {
 			},
 			RenderedImagePushSpec: mcfgv1.ImageTagFormat(opts.finalImagePullspec),
 			ImageBuilder: mcfgv1.MachineOSImageBuilder{
-				ImageBuilderType: mcfgv1.MachineOSImageBuilderType("PodImageBuilder"),
+				ImageBuilderType: mcfgv1.JobBuilder,
 			},
 			Containerfile: []mcfgv1.MachineOSContainerfile{
 				{

--- a/devex/cmd/onclustertesting/opts.go
+++ b/devex/cmd/onclustertesting/opts.go
@@ -9,36 +9,34 @@ import (
 )
 
 type opts struct {
-	pushSecretName              string
-	pullSecretName              string
-	finalImagePullSecretName    string
-	pushSecretPath              string
-	pullSecretPath              string
-	finalImagePullspec          string
-	containerfilePath           string
-	containerfileContents       string
-	poolName                    string
-	injectYumRepos              bool
-	waitForBuildInfo            bool
-	copyEtcPkiEntitlementSecret bool
-	enableFeatureGate           bool
+	pushSecretName           string
+	pullSecretName           string
+	finalImagePullSecretName string
+	pushSecretPath           string
+	pullSecretPath           string
+	finalImagePullspec       string
+	containerfilePath        string
+	containerfileContents    string
+	poolName                 string
+	injectYumRepos           bool
+	waitForBuildInfo         bool
+	enableFeatureGate        bool
 }
 
 func (o *opts) deepCopy() opts {
 	return opts{
-		pushSecretName:              o.pushSecretName,
-		pullSecretName:              o.pullSecretName,
-		pushSecretPath:              o.pushSecretPath,
-		pullSecretPath:              o.pullSecretPath,
-		finalImagePullspec:          o.finalImagePullspec,
-		finalImagePullSecretName:    o.finalImagePullSecretName,
-		containerfilePath:           o.containerfilePath,
-		containerfileContents:       o.containerfileContents,
-		poolName:                    o.poolName,
-		injectYumRepos:              o.injectYumRepos,
-		waitForBuildInfo:            o.waitForBuildInfo,
-		copyEtcPkiEntitlementSecret: o.copyEtcPkiEntitlementSecret,
-		enableFeatureGate:           o.enableFeatureGate,
+		pushSecretName:           o.pushSecretName,
+		pullSecretName:           o.pullSecretName,
+		pushSecretPath:           o.pushSecretPath,
+		pullSecretPath:           o.pullSecretPath,
+		finalImagePullspec:       o.finalImagePullspec,
+		finalImagePullSecretName: o.finalImagePullSecretName,
+		containerfilePath:        o.containerfilePath,
+		containerfileContents:    o.containerfileContents,
+		poolName:                 o.poolName,
+		injectYumRepos:           o.injectYumRepos,
+		waitForBuildInfo:         o.waitForBuildInfo,
+		enableFeatureGate:        o.enableFeatureGate,
 	}
 }
 

--- a/devex/cmd/onclustertesting/secrets.go
+++ b/devex/cmd/onclustertesting/secrets.go
@@ -39,32 +39,6 @@ func copyGlobalPullSecret(cs *framework.ClientSet) error {
 	return utils.CloneSecretWithLabels(cs, src, dst, labels)
 }
 
-func copyEtcPkiEntitlementSecret(cs *framework.ClientSet) error {
-	name := "etc-pki-entitlement"
-
-	src := utils.SecretRef{
-		Name:      name,
-		Namespace: "openshift-config-managed",
-	}
-
-	dst := utils.SecretRef{
-		Name:      name,
-		Namespace: ctrlcommon.MCONamespace,
-	}
-
-	labels := map[string]string{
-		createdByOnClusterBuildsHelper: "",
-	}
-
-	err := utils.CloneSecretWithLabels(cs, src, dst, labels)
-	if apierrs.IsNotFound(err) {
-		klog.Warningf("Secret %s not found, cannot copy", src.String())
-		return nil
-	}
-
-	return fmt.Errorf("could not copy secret %s to %s: %w", src.String(), dst.String(), err)
-}
-
 func getSecretNameFromFile(path string) (string, error) {
 	secret, err := loadSecretFromFile(path)
 

--- a/pkg/controller/build/buildrequest/machineosbuild_test.go
+++ b/pkg/controller/build/buildrequest/machineosbuild_test.go
@@ -28,7 +28,7 @@ func TestMachineOSBuild(t *testing.T) {
 	}
 
 	// Some of the test cases expect the hash name to be the same. This is that hash value.
-	expectedCommonHashName := "worker-e945ec808b468c07f6a2cf1936c23a13"
+	expectedCommonHashName := "worker-55592464e51104dcc274a300565fec9e"
 
 	testCases := []struct {
 		name         string

--- a/test/helpers/machineosconfigbuilder.go
+++ b/test/helpers/machineosconfigbuilder.go
@@ -26,7 +26,7 @@ func NewMachineOSConfigBuilder(name string) *MachineOSConfigBuilder {
 
 				Containerfile: []mcfgv1.MachineOSContainerfile{},
 				ImageBuilder: mcfgv1.MachineOSImageBuilder{
-					ImageBuilderType: mcfgv1.MachineOSImageBuilderType("PodImageBuilder"),
+					ImageBuilderType: mcfgv1.JobBuilder,
 				},
 				BaseImagePullSecret:     nil,
 				RenderedImagePushSecret: mcfgv1.ImageSecretObjectReference{},


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

- Removed some old code that dealt with copy etc-pki-entitlement secrets. This is now handled by the operator in https://github.com/openshift/machine-config-operator/pull/4756 which merged recently. 
- Fixed a couple of places where old "PodImageBuilder" was being assigned to `ImageBuilderType`. This isn't used anywhere in the controller, so it didn't break anything, but we should clean this up.

**- How to verify it**
Existing e2es should pass. QE testing shouldn't be needed since this is just removing test/devex code.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
