### PR TITLE
OCPBUGS-33894: Avoid dumping Go struct in potentially user-facing reason annotation

### DIFF
--- a/internal/kubeutils.go
+++ b/internal/kubeutils.go
@@ -22,7 +22,7 @@ import (
 // a retry is necessary.
 func UpdateNodeRetry(client corev1client.NodeInterface, lister corev1lister.NodeLister, nodeName string, f func(*corev1.Node)) (*corev1.Node, error) {
 	var node *corev1.Node
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		n, err := lister.Get(nodeName)
 		if err != nil {
 			return err
@@ -54,7 +54,7 @@ func UpdateNodeRetry(client corev1client.NodeInterface, lister corev1lister.Node
 		return err
 	}); err != nil {
 		// may be conflict if max retries were hit
-		return nil, fmt.Errorf("unable to update node %q: %w", node, err)
+		return nil, fmt.Errorf("unable to update node %q: %w", nodeName, err)
 	}
 	return node, nil
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Use nodeName instead of node in error message for setting node annotations. On a degraded node, such an error would result in the entire node object to be dumped in the node's annotation which was not user friendly.
- I also changed retry mechanism to use a backoff of `retry.DefaultRetry`, instead of `retry.DefaultBackoff` which is recommended for conflicts. 

**- How to verify it**
- Reading through the bug, this seems to surface during upgrades/installs when the APIServer goes unavailable/nodes have high activity. It may be useful to simulate such conditions and see if the errors resurface.
- I suppose one could also explore ways to make the API update calls from the MCO to fail to simulate a retry error scenario.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
