### PR TITLE
OCPBUGS-49436: Make resolv-prepender env file optional

### DIFF
--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -59,7 +59,7 @@ contents:
                 {{end -}}
                 {{range onPremPlatformAPIServerInternalIPs . }}"{{.}}" {{end}} \
                 {{range onPremPlatformIngressIPs . }}"{{.}}" {{end}})"
-            DOMAINS="${IP4_DOMAINS} ${IP6_DOMAINS} {{.DNS.Spec.BaseDomain}}"
+            DOMAINS="${IP4_DOMAINS:-} ${IP6_DOMAINS:-} {{.DNS.Spec.BaseDomain}}"
             if [[ -n "$NAMESERVER_IP" ]]; then
                 KNICONFDONEPATH="/run/resolv-prepender-kni-conf-done"
                 if systemctl -q is-enabled systemd-resolved; then

--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -18,4 +18,4 @@ contents: |
     do \
     sleep 10; \
     done"
-  EnvironmentFile=/run/resolv-prepender/env
+  EnvironmentFile=-/run/resolv-prepender/env


### PR DESCRIPTION
With the EnvironmentFile set to mandatory, this service fails if it gets triggered by the path unit before the dispatcher script has populated the env file. We don't want that, so this patch makes the file optional and will allow the service to run if it's not there.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
