### PR TITLE
OCPBUGS-43552: maxUnavailable value is not honored when disabling OCL

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -1232,10 +1232,13 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1.MachineOSConfig, mosb *
 func getAllCandidateMachines(layered bool, config *mcfgv1.MachineOSConfig, build *mcfgv1.MachineOSBuild, pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) ([]*corev1.Node, uint) {
 	unavail := getUnavailableMachines(nodesInPool, pool, layered, build)
 	if len(unavail) >= maxUnavailable {
-		klog.V(4).Infof("Pool %s: No nodes available for updates", pool.Name)
+		klog.V(4).Infof("getAllCandidateMachines: No capacity left for pool %s (unavail=%d >= maxUnavailable=%d)",
+			pool.Name, len(unavail), maxUnavailable)
 		return nil, 0
 	}
 	capacity := maxUnavailable - len(unavail)
+	klog.V(4).Infof("getAllCandidateMachines: Computed capacity=%d for pool %s", capacity, pool.Name)
+
 	failingThisConfig := 0
 	// We only look at nodes which aren't already targeting our desired config
 	var nodes []*corev1.Node

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -373,13 +373,13 @@ func isNodeDone(node *corev1.Node, layered bool) bool {
 		return false
 	}
 
-	if layered {
-		// The MachineConfig annotations are loaded on boot-up by the daemon which
-		// isn't currently done for the image annotations, so the comparisons here
-		// are a bit more nuanced.
-		cimage, cok := node.Annotations[daemonconsts.CurrentImageAnnotationKey]
-		dimage, dok := node.Annotations[daemonconsts.DesiredImageAnnotationKey]
+	// The MachineConfig annotations are loaded on boot-up by the daemon which
+	// isn't currently done for the image annotations, so the comparisons here
+	// are a bit more nuanced.
+	cimage, cok := node.Annotations[daemonconsts.CurrentImageAnnotationKey]
+	dimage, dok := node.Annotations[daemonconsts.DesiredImageAnnotationKey]
 
+	if layered {
 		// If desired image is not set, but the pool is layered, this node can
 		// be considered ready for an update. This is the very first time node
 		// is being opted into layering.
@@ -396,6 +396,15 @@ func isNodeDone(node *corev1.Node, layered bool) bool {
 		// Current image annotation exists; compare with desired values to determine if the node is done
 		return cconfig == dconfig && cimage == dimage && isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDone)
 
+	}
+
+	// If not in layered mode, we also need to consider the case when the node is rolling back
+	// from layered to non-layered. In those cases, cconfig==dconfig, but the node
+	// will still need to do an update back to dconfig's OSImageURL. We can detect a
+	// rolling back node by checking if the cimage stills exists but the dimage does not exist.
+	if cok && !dok {
+		// The node is not "done" in this case, as the current image annotation still exists.
+		return false
 	}
 
 	return cconfig == dconfig && isNodeMCDState(node, daemonconsts.MachineConfigDaemonStateDone)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added an additional check in `isNodeDone` to verify that a node rolling back is not mistakenly considered as done updating.

**- How to verify it**
As the bug states, this is hard to reproduce, but the typical reproduction path is:

1. Configure maxUnavailable=2 in the worker pool
2. Create a MOSC resource for the worker pool and wait for the images to be applied
3. Remove the MOSC
4. Check if maxUnavailable value is honored

It takes several tries(5+) for this to cause the bug, as it relies on the daemon being slow _enough_ to react to the controller's node annotation updates, it's really a luck of the draw.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
