### PR TITLE
OCPNODE-2842: Set Upgradeable=False when cluster is on cgroup v1

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -280,6 +280,15 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error 
 		Reason: asExpectedReason,
 	}
 
+	configNode, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
+	if err != nil {
+		return err
+	}
+	if configNode.Spec.CgroupMode == configv1.CgroupModeV1 {
+		coStatusCondition.Status = configv1.ConditionFalse
+		coStatusCondition.Reason = "ClusterOnCgroupV1"
+		coStatusCondition.Message = "Cluster is using deprecated cgroup v1 and is not upgradable. Please update the `CgroupMode` in the `nodes.config.openshift.io` object to 'v2'. Once upgraded, the cluster cannot be changed back to cgroup v1"
+	}
 	var updating, degraded, interrupted bool
 	for _, pool := range pools {
 		// collect updating status but continue to check each pool to see if any pool is degraded

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -691,6 +691,14 @@ func TestOperatorSyncStatus(t *testing.T) {
 		configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
 
+		configNode := &configv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+			Spec:       configv1.NodeSpec{},
+		}
+		configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+		configNodeIndexer.Add(configNode)
+
 		for j, sync := range testCase.syncs {
 			optr.inClusterBringup = sync.inClusterBringUp
 			if sync.nextVersion != "" {
@@ -756,6 +764,14 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 			},
 		},
 	}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
+
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse}, clock.RealClock{})
@@ -822,6 +838,13 @@ func TestKubeletSkewUnSupported(t *testing.T) {
 	})
 
 	co := &configv1.ClusterOperator{}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse}, clock.RealClock{})
@@ -921,6 +944,13 @@ func TestCustomPoolKubeletSkewUnSupported(t *testing.T) {
 	})
 
 	co := &configv1.ClusterOperator{}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse}, clock.RealClock{})
@@ -1018,6 +1048,13 @@ func TestKubeletSkewSupported(t *testing.T) {
 	})
 
 	co := &configv1.ClusterOperator{}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse}, clock.RealClock{})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse}, clock.RealClock{})


### PR DESCRIPTION
**- What I did**
Added code to set the cluster operator's status to `Upgradeable=False` when a cluster is found to be on cgroup v1

**- How to verify it**
Update the `CgroupMode` field of ndes.config object to `v1` and verify that the MCO cluster operator's status has the `Upgradeable=False` condition

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Cgroupsv1 support deprecation condition/message has been added in the last release and this PR helps in updating all the clusters to cgroup v2 before upgrading to ocp 4.19

References:
- Enhancement Proposal: https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/mco-cgroupsv2-support.md 
- API PR: https://github.com/openshift/api/pull/2181