### PR TITLE
OCPBUGS-47743: Update cluster-reader ClusterRole permissions

### DIFF
--- a/install/0000_80_machine-config_00_clusterreader_clusterrole.yaml
+++ b/install/0000_80_machine-config_00_clusterreader_clusterrole.yaml
@@ -15,13 +15,17 @@ rules:
       - tokenreviews
       - subjectaccessreviews
     verbs:
-      - create
+      - get
+      - list
+      - watch
   - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
     verbs:
-      - create
+      - get
+      - list
+      - watch
   - apiGroups:
       - machineconfiguration.openshift.io
     resources:
@@ -29,21 +33,16 @@ rules:
       - controllerconfigs
       - kubeletconfigs
       - machineconfigpools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - machineconfiguration.openshift.io
-    resources:
       - machineconfignodes
       - machineconfignodes/status
+      - machineosconfigs 
+      - machineosconfigs/status
+      - machineosbuilds
+      - machineosbuilds/status
     verbs:
       - get
       - list
       - watch
-      - delete
-      - create
   - apiGroups:
       - config.openshift.io
     resources: 
@@ -57,23 +56,3 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
-      - machineconfiguration.openshift.io
-    resources: 
-      - machineosconfigs 
-      - machineosconfigs/status
-    verbs: 
-      - create
-      - update 
-      - patch 
-      - get
-  - apiGroups: 
-      - machineconfiguration.openshift.io
-    resources: 
-      - machineosbuilds
-      - machineosbuilds/status
-    verbs: 
-      - create
-      - update 
-      - patch
-      - get


### PR DESCRIPTION
**- What I did**
- Update the cluster-reader ClusterRole to have read-only permissions (get, list, and watch).

**- How to verify it**
_Testing permission updates:_
1. Use this PR to launch a cluster.
2. View the cluster-reader permissions in the Openshift UI by going to `User Management` &#8594; `Roles` &#8594; `cluster-reader`

_Testing that functionality remained unchanged:_
- [x] Tests pass
- [x] The cluster-reader permissions for the `machineconfignodes` resource were originally updated in #4062, so I tested that this permission change did not re-introduce the bug fixed in that PR.
- [x] This updates the permissions for the `machineosconfigs`and `machineosbuilds` resouces, so general OCL functionality was tested.
- [x] Test that updates to Prometheus metrics originally introduced in #3537 still work as intended with updated auth permissions.

**- Description for the changelog**
OCPBUGS-47743: Update cluster-reader ClusterRole permissions