### PR TITLE
[release-4.17] OCPBUGS-49363: Auto-recover from MC with invalid extension

### DIFF
--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -793,3 +793,40 @@ func TestParseAndConvertGzippedConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMachineConfigExtensions(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		extensions  []string
+		errExpected bool
+	}{
+		{
+			name:       "Supported",
+			extensions: []string{"kerberos", "sandboxed-containers"},
+		},
+		{
+			name:        "Unsupported",
+			extensions:  []string{"unsupported1", "unsupported2"},
+			errExpected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			mcfgSpec := mcfgv1.MachineConfigSpec{
+				Extensions: testCase.extensions,
+			}
+			err := ValidateMachineConfigExtensions(mcfgSpec)
+			if testCase.errExpected {
+				assert.Error(t, err)
+				for _, ext := range testCase.extensions {
+					assert.Contains(t, err.Error(), ext)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2862,7 +2862,7 @@ func (dn *Daemon) getUnsupportedPackages() {
 	}
 
 	supportedPackages := make(map[string]bool)
-	for _, packages := range getSupportedExtensions() {
+	for _, packages := range ctrlcommon.SupportedExtensions() {
 		for _, pkg := range packages {
 			supportedPackages[pkg] = true
 		}


### PR DESCRIPTION
This is a manual cherrypick of #4805. The automatic cherrypick in #4809 failed due to the necessary extension validation function not existing in the correct directory.

**- What I did**
- Added the bug fix first introduced in #4763 for OCPBUGS-49363
- Pulled in the changes from [this commit](https://github.com/openshift/machine-config-operator/commit/69e89548cd5fb4ed45e3c823ea8a1021b6743ea2) that enable the extension validation

**- How to verify it**
See steps in #4763.

**- Description for the changelog**
OCPBUGS-34586: Auto-recover from MC with invalid extension & move extensions validation helpers into ctrlcommon