### PR TITLE
OCPBUGS-43896: add revert logic to OCL path in MCD

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2553,7 +2553,7 @@ func (dn *Daemon) triggerUpdate(currentConfig, desiredConfig *mcfgv1.MachineConf
 	dn.stopConfigDriftMonitor()
 
 	klog.Infof("Performing layered OS update")
-	return dn.updateOnClusterBuild(currentConfig, desiredConfig, currentImage, desiredImage, true)
+	return dn.updateOnClusterLayering(currentConfig, desiredConfig, currentImage, desiredImage, true)
 }
 
 // triggerUpdateWithMachineConfig starts the update. It queries the cluster for


### PR DESCRIPTION
**- What I did**

If a problem occurs while attempting to reboot a given node while OCL is enabled, the degradation message did not indicate what the problem was. Instead, it would indicate a problem with rpm-ostree because it would attempt to reapply the same image, which it can't do. Additionally, the MCDRebootError metric was not being surfaced in certain cases (although I did not actually observe this to be the case).

To remedy this, I did the following:
- Refactored the onClusterBuildUpdate() function in the MCD to include more state restorations in the event of an error. Additioanlly, this function now uses the applyOSChanges() method which includes benefits such as additional eventing and metrics.
- Refactored the finalizeOCLRevert() function to do more state restorations.
- Modified the machineConfigDiff object to include a boolean oclEnabled field which will allow us to use that information. This includes the creation of a new constructor just for OCL cases.

**- How to verify it**

1. Bring up a cluster.
2. Enable OCL.
3. Break reboots on one of the worker nodes by doing something like: `$ oc debug node-name -- chroot /host sh -c "mount -o remount,rw /usr; mv /usr/bin/systemd-run /usr/bin/systemd-run2"`
4. Move that worker node into the layered pool.
5. Wait for the MCDRebootError to appear in the Alerts / Metrics part of the web UI console. There should also be a message on the node object which indicates the cause of the failure.
6. Fix the reboot process by doing something like: `$ oc debug node-name -- chroot /host sh -c "mount -o remount,rw /usr; mv /usr/bin/systemd-run2 /usr/bin/systemd-run"`.
7. The node should eventually reboot into the correct configuration / image. When that happens, the degradation message should be cleared from the node object. Additionally, the MCDRebootError alert / metric should clear.

**- Description for the changelog**
Make MCDRebootErrors clearer for OCL
