### PR TITLE
OCPBUGS-49731: Correct MachineConfig documentation on sysstat extension support

### DIFF
--- a/docs/MachineConfig.md
+++ b/docs/MachineConfig.md
@@ -209,7 +209,7 @@ RHCOS is a minimal OCP focused OS which provides capabilities common across all 
 | 4.8           |  `usbguard`, `sandboxed-containers`    |
 | 4.11          |  `usbguard`, `sandboxed-containers`, `kerberos`   |
 | 4.14          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm`   |
-| 4.17          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm` , `sysstat`   |
+| 4.18          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm` , `sysstat`   |
 
 Extensions can be installed by creating a MachineConfig object. Extensions can be enabled as both day1 and day2. Check [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Enabling-RHCOS-Extensions) to enable extensions during cluster install.
 


### PR DESCRIPTION
**- What I did**
Updated the MachineConfig documentation to reflect when `sysstat` extension support was added.

**- How to verify it**
"Add sysstat as RHCOS extension" [epic](https://issues.redhat.com/browse/COS-2945) references 4.18 as the release version.

**- Description for the changelog**
OCPBUGS-49731: Correct MachineConfig documentation on sysstat extension support