### PR TITLE
OCPBUGS-48469: Fix CoreDNS static pod bring-up on cloud platforms

### DIFF
--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -10,6 +10,7 @@ metadata:
     app: cloud-platform-infra-coredns
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: privileged
 spec:
   volumes:
   - name: resource-dir

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -44,16 +44,17 @@ type RenderConfig struct {
 }
 
 const (
-	filesDir       = "files"
-	unitsDir       = "units"
-	extensionsDir  = "extensions"
-	platformBase   = "_base"
-	platformOnPrem = "on-prem"
-	sno            = "sno"
-	tnf            = "two-node-with-fencing"
-	masterRole     = "master"
-	workerRole     = "worker"
-	arbiterRole    = "arbiter"
+	filesDir            = "files"
+	unitsDir            = "units"
+	extensionsDir       = "extensions"
+	platformBase        = "_base"
+	platformOnPrem      = "on-prem"
+	sno                 = "sno"
+	tnf                 = "two-node-with-fencing"
+	masterRole          = "master"
+	workerRole          = "worker"
+	arbiterRole         = "arbiter"
+	cloudPlatformAltDNS = "cloud-platform-alt-dns"
 )
 
 // generateTemplateMachineConfigs returns MachineConfig objects from the templateDir and a config object
@@ -224,6 +225,12 @@ func getPaths(config *RenderConfig, platformString string) []string {
 	platformBasedPaths := []string{platformBase}
 	if onPremPlatform(config.Infra.Status.PlatformStatus.Type) {
 		platformBasedPaths = append(platformBasedPaths, platformOnPrem)
+	}
+
+	// If this is a cloud platform with DNSType set to `ClusterHosted` with
+	// LB IPs provided, include path for their CoreDNS files
+	if cloudPlatformLoadBalancerIPState(*config) == availableLBIPState {
+		platformBasedPaths = append(platformBasedPaths, cloudPlatformAltDNS)
 	}
 
 	// specific platform should be the last one in order

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -382,6 +382,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
 	funcs["cloudPlatformIngressLoadBalancerIPs"] = cloudPlatformIngressLoadBalancerIPs
+	funcs["platformType"] = platformType
 	funcs["join"] = strings.Join
 	tmpl, err := template.New(path).Funcs(funcs).Parse(string(b))
 	if err != nil {
@@ -845,4 +846,13 @@ func hasControlPlaneTopology(r *RenderConfig, topo configv1.TopologyMode) bool {
 		return false
 	}
 	return r.Infra.Status.ControlPlaneTopology == topo
+}
+
+// platformType provides the platform name that can be used to determine
+// platform specific acions to take.
+func platformType(cfg RenderConfig) (interface{}, error) {
+	if cfg.Infra.Status.PlatformStatus != nil {
+		return cfg.Infra.Status.PlatformStatus.Type, nil
+	}
+	return "", fmt.Errorf("could not determine platform type")
 }

--- a/pkg/controller/template/test_data/controller_config_gcp_custom_dns.yaml
+++ b/pkg/controller/template/test_data/controller_config_gcp_custom_dns.yaml
@@ -1,0 +1,36 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 3
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      platformStatus:
+        type: "GCP"
+        gcp:
+          cloudLoadBalancerConfig:
+            dnsType: "ClusterHosted"
+            clusterHosted:
+              apiLoadBalancerIPs:
+              - 20.20.20.20
+              apiIntLoadBalancerIPs:
+              - 10.10.10.10
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/pkg/controller/template/test_data/controller_config_gcp_default_dns.yaml
+++ b/pkg/controller/template/test_data/controller_config_gcp_default_dns.yaml
@@ -1,0 +1,28 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 3
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      platformStatus:
+        type: "GCP"
+        gcp:
+          cloudLoadBalancerConfig:
+            dnsType: "PlatformDefault"

--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -23,12 +23,12 @@ contents:
         }
         template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match ^api.{{ .DNS.Spec.BaseDomain }}
-            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 0 }}{{ index (cloudPlatformAPILoadBalancerIPs) 0 }}{{ end }}"
+            answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 0 }}{{ index (cloudPlatformAPILoadBalancerIPs .) 0 }}{{ end }}"
             fallthrough
         }
         template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match ^api.{{ .DNS.Spec.BaseDomain }}
-            {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformAPILoadBalancerIPs) 1 }}"{{ end }}
+            {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformAPILoadBalancerIPs .) 1 }}"{{ end }}
             fallthrough
         }
         template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -25,6 +25,9 @@ contents:
       - name: conf-dir
         hostPath:
           path: "/etc/coredns"
+      - name: nm-resolv
+        hostPath:
+          path: "/var/run/NetworkManager"
       initContainers:
       - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -38,6 +41,8 @@ contents:
         - "{{- range $index, $ip := cloudPlatformAPIIntLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
         - "--cloud-ingress-lb-ips"
         - "{{- range $index, $ip := cloudPlatformIngressLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "--platform"
+        - "{{platformType .}}"
         - "/config"
         - "--out-dir"
         - "/etc/coredns"
@@ -95,6 +100,8 @@ contents:
         - "{{- range $index, $ip := cloudPlatformAPIIntLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
         - "--cloud-ingress-lb-ips"
         - "{{- range $index, $ip := cloudPlatformIngressLoadBalancerIPs .}}{{ if gt $index 0 }},{{end}}{{$ip}}{{end}}"
+        - "--platform"
+        - "{{platformType .}}"
         resources:
           requests:
             cpu: 100m
@@ -110,6 +117,9 @@ contents:
         - name: conf-dir
           mountPath: "/etc/coredns"
           mountPropagation: HostToContainer
+        - name: nm-resolv
+          mountPath: "/var/run/NetworkManager"
+          mountPropagation: HostToContainer 
         imagePullPolicy: IfNotPresent        
       hostNetwork: true
       tolerations:

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -40,6 +40,8 @@ contents:
         - "/config"
         - "--out-dir"
         - "/etc/coredns"
+        - "--resolvconf-path"
+        - "/etc/resolv.conf"
         resources: {}
         volumeMounts:
         - name: kubeconfig

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -13,6 +13,7 @@ contents:
         app: cloud-platform-infra-coredns
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: resource-dir


### PR DESCRIPTION
Fixes: OCPBUGS-48469

**- What I did**
1. Updated CoreDNS Corefile errors for cloud platforms needing alternate in-cluster DNS when UserProvisionedDNS is enabled via the install-config
2. Updated the list of directories to include the location of the CoreDNS files for cloud platforms
3. Updated test data and unit tests for UserProvisionedDNS enabled on GCP.

**- How to verify it**
Set `UserProvisionedDNS` to `Enabled` for GCP via install-config and start installation

**- Description for the changelog**
Fixed issues with CoreDNS Corefile and template path for cloud platforms when UserProvisionedDNS is enabled.
Added test_data for GCP with all the UserProvisionedDNS configuration to better test this path.

