### PR TITLE
OCPBUGS-49959: Panic in the MCC when using OCL v1 GA

### DIFF
--- a/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
+++ b/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
@@ -117,6 +117,16 @@ func New(
 		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-machinesetbootimagecontroller"})),
 	}
 
+	ctrl.mcoCmLister = mcoCmInfomer.Lister()
+	ctrl.mapiMachineSetLister = mapiMachineSetInformer.Lister()
+	ctrl.infraLister = infraInformer.Lister()
+	ctrl.mcopLister = mcopInformer.Lister()
+
+	ctrl.mcoCmListerSynced = mcoCmInfomer.Informer().HasSynced
+	ctrl.mapiMachineSetListerSynced = mapiMachineSetInformer.Informer().HasSynced
+	ctrl.infraListerSynced = infraInformer.Informer().HasSynced
+	ctrl.mcopListerSynced = mcopInformer.Informer().HasSynced
+
 	mapiMachineSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ctrl.addMAPIMachineSet,
 		UpdateFunc: ctrl.updateMAPIMachineSet,
@@ -134,16 +144,6 @@ func New(
 		UpdateFunc: ctrl.updateMachineConfiguration,
 		DeleteFunc: ctrl.deleteMachineConfiguration,
 	})
-
-	ctrl.mcoCmLister = mcoCmInfomer.Lister()
-	ctrl.mapiMachineSetLister = mapiMachineSetInformer.Lister()
-	ctrl.infraLister = infraInformer.Lister()
-	ctrl.mcopLister = mcopInformer.Lister()
-
-	ctrl.mcoCmListerSynced = mcoCmInfomer.Informer().HasSynced
-	ctrl.mapiMachineSetListerSynced = mapiMachineSetInformer.Informer().HasSynced
-	ctrl.infraListerSynced = infraInformer.Informer().HasSynced
-	ctrl.mcopListerSynced = mcopInformer.Informer().HasSynced
 
 	ctrl.featureGateAccess = featureGateAccess
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
This change sets up the event handlers after the listers are created, so we shouldn't be running into panics described in the bug. 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
