### PR TITLE
OCPBUGS-31778: Update format verbs for alert logs

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2104,7 +2104,7 @@ func (dn *Daemon) workaroundOcpBugs33694() error {
 	}
 	for _, path := range stalePaths {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("error deleting %s: %w", path, err)
+			return fmt.Errorf("error deleting %q: %w", path, err)
 		} else if err == nil {
 			klog.Infof("Removed stale symlink %q", path)
 		}
@@ -2174,7 +2174,7 @@ func (dn *Daemon) presetUnit(unit ign3types.Unit) error {
 	if err != nil {
 		return fmt.Errorf("error running preset on unit: %s", stdouterr)
 	}
-	klog.Infof("Preset systemd unit %s", unit.Name)
+	klog.Infof("Preset systemd unit %q", unit.Name)
 	return nil
 }
 
@@ -2627,7 +2627,7 @@ func (dn *Daemon) queueRevertKernelSwap() error {
 // updateLayeredOS updates the system OS to the one specified in newConfig
 func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
-	klog.Infof("Updating OS to layered image %s", newURL)
+	klog.Infof("Updating OS to layered image %q", newURL)
 	return dn.updateLayeredOSToPullspec(newURL)
 }
 

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -223,7 +223,7 @@ func (nw *clusterNodeWriter) SetUnreconcilable(err error) error {
 // SetDegraded logs the error and sets the state to Degraded.
 // Returns an error if it couldn't set the annotation.
 func (nw *clusterNodeWriter) SetDegraded(err error) error {
-	klog.Errorf("Marking Degraded due to: %v", err)
+	klog.Errorf("Marking Degraded due to: %q", err)
 	// truncatedErr caps error message at a reasonable length to limit the risk of hitting the total
 	// annotation size limit (256 kb) at any point
 	truncatedErr := fmt.Sprintf("%.2000s", err.Error())


### PR DESCRIPTION
Closes: #[OCPBUGS-31778](https://issues.redhat.com/browse/OCPBUGS-31778)

**- What I did**
- Updated select log messages to use %q format verbs

**- How to verify it**
N/A

**- Description for the changelog**
OCPBUGS-31778: Update format verbs for daemon alert logs