### PR TITLE
OCPBUGS-49737: GCP: Update worker pointer Ignition when DNSType is ClusterHosted

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -662,9 +662,13 @@ func getIgnitionHost(infraStatus *configv1.InfrastructureStatus) (string, error)
 					ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIPs[0], securePortStr)
 				}
 			}
+		case configv1.GCPPlatformType:
+			if infraStatus.PlatformStatus.GCP != nil && infraStatus.PlatformStatus.GCP.CloudLoadBalancerConfig != nil && infraStatus.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType == configv1.ClusterHostedDNSType {
+				apiIntLBIP := infraStatus.PlatformStatus.GCP.CloudLoadBalancerConfig.ClusterHosted.APIIntLoadBalancerIPs[0]
+				ignitionHost = net.JoinHostPort(string(apiIntLBIP), securePortStr)
+			}
 		}
 	}
-
 	return ignitionHost, nil
 }
 


### PR DESCRIPTION
When `UserProvisionedDNS` is enabled, update worker pointer ignition to point to the API-Int LB IP.
Also, add unit test code to test this functionality.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
