### PR TITLE
OCPEDGE-1493: Add 2no-ha extension support required by Two Node OpenShift

### DIFF
--- a/docs/MachineConfig.md
+++ b/docs/MachineConfig.md
@@ -210,6 +210,7 @@ RHCOS is a minimal OCP focused OS which provides capabilities common across all 
 | 4.11          |  `usbguard`, `sandboxed-containers`, `kerberos`   |
 | 4.14          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm`   |
 | 4.18          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm` , `sysstat`   |
+| 4.19          |  `usbguard`, `sandboxed-containers`, `kerberos`, `ipsec`, `wasm` , `sysstat` , `two-node-ha`   |
 
 Extensions can be installed by creating a MachineConfig object. Extensions can be enabled as both day1 and day2. Check [installer guide](https://github.com/openshift/installer/blob/master/docs/user/customization.md#Enabling-RHCOS-Extensions) to enable extensions during cluster install.
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -666,6 +666,7 @@ func SupportedExtensions() map[string][]string {
 	// These are RHCOS supported extensions.
 	// Each extension keeps a list of packages required to get enabled on host.
 	return map[string][]string{
+		"two-node-ha":          {"pacemaker", "pcs", "fence-agents-all"},
 		"wasm":                 {"crun-wasm"},
 		"ipsec":                {"NetworkManager-libreswan", "libreswan"},
 		"usbguard":             {"usbguard"},

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -850,6 +850,11 @@ func TestGetPackagesForSupportedExtensions(t *testing.T) {
 			errExpected: true,
 		},
 		{
+			name:             "Supported single multi-package extension",
+			extensions:       []string{"two-node-ha"},
+			expectedPackages: []string{"pacemaker", "pcs", "fence-agents-all"},
+		},
+		{
 			name:             "Supported single package extension",
 			extensions:       []string{"wasm"},
 			expectedPackages: []string{"crun-wasm"},

--- a/test/e2e-single-node/sno_mcd_test.go
+++ b/test/e2e-single-node/sno_mcd_test.go
@@ -196,7 +196,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"wasm", "ipsec", "usbguard", "kernel-devel", "kerberos", "sysstat"},
+			Extensions: []string{"two-node-ha", "wasm", "ipsec", "usbguard", "kernel-devel", "kerberos", "sysstat"},
 		},
 	}
 
@@ -212,8 +212,8 @@ func TestExtensions(t *testing.T) {
 	assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	installedPackages := helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
-	expectedPackages := []string{"crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat"}
+	installedPackages := helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
+	expectedPackages := []string{"pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat"}
 	for _, v := range expectedPackages {
 		if !strings.Contains(installedPackages, v) {
 			t.Fatalf("Node %s doesn't have expected extensions", node.Name)
@@ -237,7 +237,7 @@ func TestExtensions(t *testing.T) {
 	assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], oldMasterRenderedConfig)
 	assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	installedPackages = helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-qa", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
+	installedPackages = helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "rpm", "-qa", "pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
 	for _, v := range expectedPackages {
 		if strings.Contains(installedPackages, v) {
 			t.Fatalf("Node %s did not rollback successfully", node.Name)

--- a/test/e2e/mcd_test.go
+++ b/test/e2e/mcd_test.go
@@ -332,7 +332,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"wasm", "ipsec", "usbguard", "kerberos", "kernel-devel", "sandboxed-containers", "sysstat"},
+			Extensions: []string{"two-node-ha", "wasm", "ipsec", "usbguard", "kerberos", "kernel-devel", "sandboxed-containers", "sysstat"},
 		},
 	}
 
@@ -357,12 +357,12 @@ func TestExtensions(t *testing.T) {
 	if isOKD {
 		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
 		// "sandboxed-containers" extension is not available on OKD
-		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "sysstat")
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "sysstat")
 		// "kerberos" extension is not available on OKD
 		expectedPackages = []string{"libreswan", "usbguard", "kernel-devel"}
 	} else {
-		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat")
-		expectedPackages = []string{"crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat"}
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat")
+		expectedPackages = []string{"pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat"}
 
 	}
 	for _, v := range expectedPackages {


### PR DESCRIPTION
See: https://issues.redhat.com/browse/OCPEDGE-1493

**- Description for the changelog**

Add 2no-ha extension support required by Two Node OpenShift