### PR TITLE
OCPBUGS-47629: /etc/crio/crio.conf.d/00-default should contain runtime_root for runc

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -35,6 +35,7 @@ contents:
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]
+    runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -35,6 +35,7 @@ contents:
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]
+    runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -35,6 +35,7 @@ contents:
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]
+    runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Master, Worker and Arbiter /etc/crio/crio.conf.d/00-default contains runtime_root for runc

**- How to verify it**
Instructions in JIRA

**- Description for the changelog**
<!--
crio: Master, Worker and Arbiter /etc/crio/crio.conf.d/00-default contains runtime_root for runc
-->
