### PR TITLE
(Not ready for review) OCPBUGS-33366: Remove hostNetwork & hostPID from machine-config-daemon manifest

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -95,8 +95,6 @@ spec:
           name: proxy-tls
         - mountPath: /etc/kube-rbac-proxy
           name: mcd-auth-proxy-config
-      hostNetwork: true
-      hostPID: true
       serviceAccountName: machine-config-daemon
       terminationGracePeriodSeconds: 600
       nodeSelector:


### PR DESCRIPTION
Closes: #OCPBUGS-33366

**- What I did**
- Removed the `hostNetwork` & `hostPID` fields from the MCD manifest

**- How to verify it**
- [ ] Check that tests pass
- [ ] The PR originally introducing these fields (#[60](https://github.com/openshift/machine-config-operator/pull/60)) seemed to center around extensions functionality and the `OSImageURL` MC field, so that functionality should be confirmed as well.

**- Description for the changelog**
OCPBUGS-33366: Remove hostNetwork & hostPID from machine-config-daemon manifest