### PR TITLE
OCPBUGS-52280, SDN-5330: Add ipsec connect wait service

### DIFF
--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -1,0 +1,44 @@
+mode: 0755
+path: "/usr/local/bin/ipsec-connect-wait.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    set -x
+
+    if [ ! -e "/etc/ipsec.d/openshift.conf" ]; then
+      exit 0
+    fi
+
+    # Modify existing IPsec connection entries with "auto=start"
+    # option and restart ipsec systemd service. This helps to
+    # establish IKE SAs for the existing IPsec connections with
+    # peer nodes. This option will be deleted from connections
+    # once ovs-monitor-ipsec process spinned up on the node by
+    # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
+    # again with peer nodes, so it shouldn't be a problem.
+    if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
+      sed -i '/^.*conn ovn.*$/a\    auto=start' /etc/ipsec.d/openshift.conf
+    fi
+    chroot /proc/1/root ipsec restart
+
+    # Wait for upto 60s to get IPsec SAs to establish with peer nodes.
+    timeout=60
+    elapsed=0
+    desiredconn=""
+    establishedsa=""
+    while [[ $elapsed -lt $timeout ]]; do
+      desiredconn=$(grep -E '^\s*conn\s+' /etc/ipsec.d/openshift.conf | grep -v '%default' | awk '{print $2}' | tr ' ' '\n' | sort | tr '\n' ' ')
+      establishedsa=$(ipsec showstates | grep STATE_V2_ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
+      if [ "$desiredconn" == "$establishedsa" ]; then
+        echo "IPsec SAs are established for desired connections after ${elapsed}s"
+        break
+      else
+        echo "IPsec SAs are not established yet, total waited time ${elapsed}s"
+        sleep 2s
+      fi
+      elapsed=$((elapsed + 2))
+    done
+
+    if [[ $elapsed -ge $timeout ]]; then
+        echo "Timed out waiting, some connections are not established, desired conns $desiredconn, established conns $establishedsa"
+    fi

--- a/templates/common/_base/units/ipsec.service.yaml
+++ b/templates/common/_base/units/ipsec.service.yaml
@@ -4,3 +4,4 @@ dropins:
     contents: |
       [Unit]
       After=ovs-configuration.service
+      Before=crio.service

--- a/templates/common/_base/units/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/units/wait-for-ipsec-connect.yaml
@@ -1,0 +1,16 @@
+name: wait-for-ipsec-connect.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Ensure IKE SA established for existing IPsec connections.
+  After=ipsec.service
+  Before=kubelet-dependencies.target node-valid-hostname.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/ipsec-connect-wait.sh
+  StandardOutput=journal+console
+  StandardError=journal+console
+
+  [Install]
+  WantedBy=ipsec.service


### PR DESCRIPTION
The IPsec upgrade CI job (`e2e-aws-ovn-ipsec-upgrade`) is never passing and failing with api connection disruptive events and some cluster operator are unavailable for more than allowed period. so we are addressing those issues
with this PR by fixing two things.

**Add ipsec connect wait service**

When node goes for a reboot on an IPsec enabled cluster, once it comes up, after ovn-ipsec-host pod is deployed, the ovs-monitor-ipsec process deployed by the pod parses /etc/ipsec.d/openshift.conf file, makes pluto daemon to
establish IKE SAs with peer nodes, but these are established after kubelet is started, workload pods scheduled on this node would fail communicating with other node pods until IPsec SAs are established.

So the commit e96fe31 adds wait-for-ipsec-connect.service systemd service which depends on ipsecenabler.service created by IPsec machine config. This new
service loads existing IPsec connections created by OVN/OVS into pluto daemon with "auto=start" option and waits upto 3 minutes until IPsec tunnels are established. This gives a better chance IPsec SAs are established even
before kubelet is started and when ovn-ipsec-host pod comes up later, it doesn't have to do anything for existing IPsec connections.

The wait-for-ipsec-connect.service service is added into the base template to avoid two reboots during upgrade if it goes into IPsec machine configs rendered by the network operator.

**Add crio dependency for ipsec.service**

We noticed pluto is tearing down established IPsec connections in parallel with crio stopping all pod containers which includes stopping api server pod container. It happens when node reboot initiated for rendering new
machine configs at the time of OCP upgrade. 

This creates api connection disruptions in the cluster, these disruptions are generating events, caught by origin monitor tests and failing IPsec upgrade CI lane and it may also cause noticeable temporary pod traffic failure during
upgrade for IPsec enabled cluster.

Hence the commit fcf67a9  adds Before=crio.service dependency on the ipsec.service so that pluto daemon is stopped after the shutdown of crio service, all pod containers are stopped on the node. This gives enough room for clients to
gracefully move to another control plane node for API connections.

Big thanks to @igsilya for helping to troubleshoot and fixing this problem.