### PR TITLE
OCPBUGS-50849: add RHEL variant to IsEL() check

### DIFF
--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -91,8 +91,12 @@ func (os OperatingSystem) BaseVersionMajor() string {
 
 // IsEL is true if the OS is an Enterprise Linux variant of CoreOS
 // i.e. RHEL CoreOS (RHCOS) or CentOS Stream CoreOS (SCOS)
+//
+// In 4.19, os-release content has been changed as part of
+// https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/split-rhcos-into-layers.md
+// Additional info here: https://github.com/openshift/enhancements/pull/1755
 func (os OperatingSystem) IsEL() bool {
-	return os.id == rhcos || os.id == scos
+	return os.id == rhcos || os.id == scos || (os.id == rhel && os.variantID == coreos)
 }
 
 // IsEL8 is true if the OS is RHCOS 8 or SCOS 8

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1786,6 +1786,7 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 	// We support Kernel update only on RHCOS and SCOS nodes
 	if !dn.os.IsEL() {
 		klog.Info("updating kernel on non-RHCOS nodes is not supported")
+		klog.Infof("Detected osrelease \n %+q", dn.os)
 		return nil
 	}
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added an additional case for the isEL() check to account for the changes in `/etc/os-release` from [RHCOS layers EP](https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/split-rhcos-into-layers.md). Some more context here: https://github.com/openshift/enhancements/pull/1755

**- How to verify it**
The test listed in the bug, `periodic-ci-openshift-openshift-tests-private-release-4.19-multi-nightly-gcp-ipi-ovn-ipsec-arm-mixarch-f14` should succeed. I don't think there is a way to directly run it from this PR, so @sergiordlr will be doing this test manually via the QE private deck.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
