### PR TITLE
OCPBUGS-54384: kubelet-service: narrow down restorecon path

### DIFF
--- a/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,7 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-  ExecStartPre=-/usr/sbin/restorecon -rv /var/lib/kubelet/ /usr/local/bin/kubenswrapper /usr/bin/kubensenter
+  ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
 {{- else}}


### PR DESCRIPTION
**- What I did**
Previously the `restorecon` command was applies on /var/lib/kubelet/ This caused the command to hang forever on a stale NFS volumes.

To minimize the affect of the command this command suggest few things:
1. Narrowing down the path so the command will take affect only for the concrete use case we aware of, where pod-resources changes its label due to: https://github.com/containers/container-selinux/pull/329

2. Add the `-i` flag which ignores the path if it doesn't exist. This is done to make sure we're not failing the service in case of missing path.

Fixes: #[OCPBUGS-50535](https://issues.redhat.com/browse/OCPBUGS-50535)

**- How to verify it**
1. Check the new kubelet.service updated correctly.
2.  Verify the service is not hanging on stale NFS mounts anymore.

**- Description for the changelog**
Narrow down restorecon command's path running as part of kubelet systemd service

