### PR TITLE
[release 4.18] OCPBUGS-50954: In OCL, MCPs are reporting Updating=false while the image is being built

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -278,6 +278,21 @@ func (ctrl *Controller) calculateStatus(fg featuregates.FeatureGate, mcs []*mcfg
 		}
 	}
 
+	if mosc != nil && !pool.Spec.Paused {
+		// MOSC exists but MOSB doesn't exist yet -> change MCP to update
+		if mosb == nil {
+			updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for a new OS image build to start (mosc: %s)", mosc.Name))
+			apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+		} else {
+			// Some cases we have an old MOSB object that still exists, we still update MCP
+			mosbState := ctrlcommon.NewMachineOSBuildState(mosb)
+			if mosbState.IsBuilding() || mosbState.IsBuildPrepared() {
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for OS image build to complete (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			}
+		}
+	}
+
 	var nodeDegraded bool
 	for _, m := range degradedMachines {
 		klog.Infof("Degraded Machine: %v and Degraded Reason: %v", m.Name, m.Annotations[constants.MachineConfigDaemonReasonAnnotationKey])


### PR DESCRIPTION
OCPBUGS-44618: In OCL, MCPs are reporting Updating=false while the image is being built

- What I did
added mcp reporting status to follow mosb's
- How to verify it
1. Enable techpreview
2. Create a MOSC
3. watch mcp status change

NOTE mcp will not degrade if a build fails.
- Description for the changelog
