### PR TITLE
OCPBUGS-49394: fix: write hostname to /etc/hostname and apply it with hostnamectl

### DIFF
--- a/templates/common/openstack/files/usr-local-bin-openstack-afterburn-hostname.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-afterburn-hostname.yaml
@@ -7,4 +7,5 @@ contents:
 
     # Fetch hostname from OpenStack. Set both transient and static hostnames to
     # ensure node-valid-hostname sees the new hostname immediately.
-    /usr/bin/afterburn --provider openstack --hostname=/dev/stdout | xargs hostnamectl set-hostname
+    /usr/bin/afterburn --provider openstack --hostname=/etc/hostname
+    hostnamectl set-hostname "$(cat /etc/hostname)"


### PR DESCRIPTION
**- What I did**

Updated the afterburn command to write the hostname directly to 
/etc/hostname instead of using /dev/stdout or a temporary file. 
This ensures the hostname persists across reboots while also 
applying it immediately with hostnamectl.

Verification: The hostname should be correctly set and persist 
after a reboot. No "Permission denied" errors should occur.

**- How to verify it**

Ensure that running the updated script does not result in a Permission denied error when writing to `/dev/stdout`.
The hostname should be correctly set using `hostnamectl` without any permission issues.

**- Description for the changelog**

Fix issue on OpenStack with afterburn hostname retrieval by avoiding `/dev/stdout`.
