### PR TITLE
OCPBUGS-44602: Set ownerReference for OCL build objects

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -254,8 +254,16 @@ func (br buildRequestImpl) podToJob(pod *corev1.Pod) *batchv1.Job {
 	// Set completion to 1 so that as soon as the pod has completed successfully the job is
 	// considered a success
 	var completions int32 = 1
+	// Set the owner ref of the job to the MOSB
+	oref := metav1.NewControllerRef(br.opts.MachineOSBuild, mcfgv1.SchemeGroupVersion.WithKind("MachineOSBuild"))
 	return &batchv1.Job{
-		ObjectMeta: pod.ObjectMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pod.ObjectMeta.Name,
+			Namespace:       pod.ObjectMeta.Namespace,
+			Labels:          pod.ObjectMeta.Labels,
+			Annotations:     pod.ObjectMeta.Annotations,
+			OwnerReferences: []metav1.OwnerReference{*oref},
+		},
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "batch/v1",
 			Kind:       "Job",

--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -102,6 +102,35 @@ func (j *jobImageBuilder) start(ctx context.Context) (*batchv1.Job, error) {
 	bj, err := j.kubeclient.BatchV1().Jobs(ctrlcommon.MCONamespace).Create(ctx, buildJob, metav1.CreateOptions{})
 	if err == nil {
 		klog.Infof("Build job %q created for MachineOSBuild %q", bj.Name, mosbName)
+
+		// Set the owner reference of the configmaps and secrets created to be the Job
+		// Set blockOwnerDeletion and Controller to false as Job ownership doesn't work when set to true
+		oref := metav1.NewControllerRef(bj, batchv1.SchemeGroupVersion.WithKind("Job"))
+		falseBool := false
+		oref.BlockOwnerDeletion = &falseBool
+		oref.Controller = &falseBool
+
+		cms, err := j.buildrequest.ConfigMaps()
+		if err != nil {
+			return nil, err
+		}
+		for _, cm := range cms {
+			cm.SetOwnerReferences([]metav1.OwnerReference{*oref})
+			if _, err := j.kubeclient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+				return nil, err
+			}
+		}
+
+		secrets, err := j.buildrequest.Secrets()
+		if err != nil {
+			return nil, err
+		}
+		for _, secret := range secrets {
+			secret.SetOwnerReferences([]metav1.OwnerReference{*oref})
+			if _, err := j.kubeclient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+				return nil, err
+			}
+		}
 		return bj, nil
 	}
 

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -471,6 +471,10 @@ func (b *buildReconciler) createNewMachineOSBuildOrReuseExisting(ctx context.Con
 		return fmt.Errorf("could not instantiate new MachineOSBuild: %w", err)
 	}
 
+	// Set owner reference of the machineOSBuild to the machineOSConfig that created this
+	oref := metav1.NewControllerRef(mosc, mcfgv1.SchemeGroupVersion.WithKind("MachineOSConfig"))
+	mosb.SetOwnerReferences([]metav1.OwnerReference{*oref})
+
 	existingMosb, err := b.machineOSBuildLister.Get(mosb.Name)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("could not get MachineOSBuild: %w", err)


### PR DESCRIPTION
Closes [OCPBUGS-44602](https://issues.redhat.com/browse/OCPBUGS-44602)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Set an owenrship hierarchy for the OCL build objects created to ensure that everything is linked and cleaned up properly.
Here is how the ownerships are created:
- MOSC owns the MOSB
- MOSB owns the Job
- Job owns the configmaps and secrets

**- How to verify it**
Create a MOSC and delete the build objects to verify that their dependencies are cleaned up. Also, run `oc get object -o yaml` to ensure that the ownerReference is set for them.

**- Description for the changelog**
Add ownerReferences for OCL build objects
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
