### PR TITLE
OCPBUGS-49394: Fix SELinux failures running afterburn-hostname

### DIFF
--- a/templates/common/openstack/files/usr-local-bin-openstack-afterburn-hostname.yaml
+++ b/templates/common/openstack/files/usr-local-bin-openstack-afterburn-hostname.yaml
@@ -5,6 +5,8 @@ contents:
     #!/bin/bash
     set -euo pipefail
 
-    # Fetch hostname from OpenStack. Set both transient and static hostnames to
-    # ensure node-valid-hostname sees the new hostname immediately.
-    /usr/bin/afterburn --provider openstack --hostname=/dev/stdout | xargs hostnamectl set-hostname
+    # Read metadata written by afterburn service
+    . /run/metadata/afterburn
+
+    # node-valid-hostname sets persistent hostname from /proc/sys/kernel/hostname
+    echo "$AFTERBURN_OPENSTACK_HOSTNAME" > /proc/sys/kernel/hostname

--- a/templates/common/openstack/units/afterburn-hostname.service.yaml
+++ b/templates/common/openstack/units/afterburn-hostname.service.yaml
@@ -9,6 +9,9 @@ contents: |
   After=NetworkManager-wait-online.service
   # Run before hostname checks
   Before=node-valid-hostname.service
+  # We require afterburn to have run first
+  Wants=afterburn.service
+  After=afterburn.service
 
   [Service]
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
@@ -26,4 +29,4 @@ contents: |
   RemainAfterExit=true
 
   [Install]
-  WantedBy=network-online.target
+  WantedBy=node-valid-hostname.service


### PR DESCRIPTION
SELinux is preventing the afterburn binary in OpenStack's afterburn-hostname from writing anywhere useful. Instead we invoke the afterburn service and read its output.

Closes: #OCPBUGS-49394