### PR TITLE
OCPBUGS-51041: Update nodeip-configuration.service service files to use SyslogIdentifier

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -12,6 +12,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
+  SyslogIdentifier=nodeip-configuration
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be
   # available in systemd v244 and higher.

--- a/templates/common/kubevirt/units/nodeip-configuration.service.yaml
+++ b/templates/common/kubevirt/units/nodeip-configuration.service.yaml
@@ -10,6 +10,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
+  SyslogIdentifier=nodeip-configuration
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be
   # available in systemd v244 and higher.

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -13,6 +13,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
+  SyslogIdentifier=nodeip-configuration
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be
   # available in systemd v244 and higher.

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -23,6 +23,7 @@ contents: |
   [Service]
   # Need oneshot to delay kubelet
   Type=oneshot
+  SyslogIdentifier=nodeip-configuration
   # Would prefer to do Restart=on-failure instead of this bash retry loop, but
   # the version of systemd we have right now doesn't support it. It should be
   # available in systemd v244 and higher.


### PR DESCRIPTION
**- What I did**
Modified the following files:
 - templates/common/_base/units/nodeip-configuration.service.yaml
 - templates/common/kubevirt/units/nodeip-configuration.service.yaml
 - templates/common/on-prem/units/nodeip-configuration.service.yaml
 - templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml

by adding `SyslogIdentifier=nodeip-configuration` into the `[Service]` section.

**- Description for the changelog**
Update nodeip-configuration.service service files to use SyslogIdentifier
