### PR TITLE
OCPBUGS-51132: [release-4.18] /etc/crio/crio.conf.d/00-default should contain runtime_root for runc

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -35,6 +35,7 @@ contents:
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]
+    runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -35,6 +35,7 @@ contents:
     drop_infra_ctr = true
 
     [crio.runtime.runtimes.runc]
+    runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
