### PR TITLE
OCPBUGS-51130: In OCL. Cannot install extensions

### DIFF
--- a/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
+++ b/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
@@ -22,7 +22,7 @@ RUN container="oci" exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/
 {{if and .ExtensionsImage .ExtensionsPackages}}
 # Mount the extensions image to use the content from it
 # and add the extensions repo to /etc/yum.repos.d/coreos-extensions.repo
-RUN --mount=type=bind,from={{.ExtensionsImage}},source=/,target=/tmp/mco-extensions/os-extensions-content,bind-propagation=rshared,rw,z \
+RUN --mount=type=bind,from={{.ExtensionsImage}},source=/,target=/tmp/mco-extensions/os-extensions-content,bind-propagation=rshared,z \
     echo -e "[coreos-extensions]\n\
 enabled=1\n\
 metadata_expire=1m\n\


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Installs fuse-overlayfs and configures it in storage.conf for rootless containers.

**- How to verify it**
1. opt into OCL
2. create and apply a MC that has ext enabled

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
