### PR TITLE
enable legacy extensions for OCL

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2553,7 +2553,7 @@ func (dn *Daemon) triggerUpdate(currentConfig, desiredConfig *mcfgv1.MachineConf
 	dn.stopConfigDriftMonitor()
 
 	klog.Infof("Performing layered OS update")
-	return dn.updateOnClusterBuild(currentConfig, desiredConfig, currentImage, desiredImage, true)
+	return dn.updateOnClusterLayering(currentConfig, desiredConfig, currentImage, desiredImage, true)
 }
 
 // triggerUpdateWithMachineConfig starts the update. It queries the cluster for

--- a/pkg/daemon/runtimeassets/machine-config-daemon-revert.service.yaml
+++ b/pkg/daemon/runtimeassets/machine-config-daemon-revert.service.yaml
@@ -21,8 +21,10 @@ contents: |
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .MCOImage }}' firstboot-complete-machineconfig --persist-nics --machineconfig-file {{ .RevertServiceMachineConfigFile }}
   ExecStart=/usr/bin/podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .MCOImage }}' firstboot-complete-machineconfig --machineconfig-file {{ .RevertServiceMachineConfigFile }}
+  ExecStartPost=rm {{ .RevertServiceMachineConfigFile }}
   {{if .Proxy -}}
-  EnvironmentFile=/etc/mco/proxy.env
+  EnvironmentFile={{ .ProxyFile }}
+  ExecStartPost=rm {{ .ProxyFile }}
   {{end -}}
 
   [Install]

--- a/pkg/daemon/runtimeassets/revertservice.go
+++ b/pkg/daemon/runtimeassets/revertservice.go
@@ -3,6 +3,7 @@ package runtimeassets
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 
@@ -17,6 +18,7 @@ var _ RuntimeAsset = &revertService{}
 const (
 	RevertServiceName              string = "machine-config-daemon-revert.service"
 	RevertServiceMachineConfigFile string = "/etc/mco/machineconfig-revert.json"
+	RevertServiceProxyFile         string = "/etc/mco/proxy.env.backup"
 )
 
 //go:embed machine-config-daemon-revert.service.yaml
@@ -27,11 +29,15 @@ type revertService struct {
 	MCOImage string
 	// Whether the proxy file exists and should be considered.
 	Proxy bool
+	// The current MachineConfig to write to disk.
+	mc      *mcfgv1.MachineConfig
+	ctrlcfg *mcfgv1.ControllerConfig
 }
 
-// Constructs a revertService instance from a ControllerConfig. Returns an
-// error if the provided ControllerConfig cannot be used.
-func NewRevertService(ctrlcfg *mcfgv1.ControllerConfig) (RuntimeAsset, error) {
+// Constructs a revertService instance from a ControllerConfig and
+// MachineConfig. Returns an error if the provided ControllerConfig or
+// MachineConfig cannot be used.
+func NewRevertService(ctrlcfg *mcfgv1.ControllerConfig, mc *mcfgv1.MachineConfig) (RuntimeAsset, error) {
 	mcoImage, ok := ctrlcfg.Spec.Images["machineConfigOperator"]
 	if !ok {
 		return nil, fmt.Errorf("controllerconfig Images does not have machineConfigOperator image")
@@ -41,52 +47,65 @@ func NewRevertService(ctrlcfg *mcfgv1.ControllerConfig) (RuntimeAsset, error) {
 		return nil, fmt.Errorf("controllerconfig Images has machineConfigOperator but it is empty")
 	}
 
-	hasProxy := false
-	if ctrlcfg.Spec.Proxy != nil {
-		hasProxy = true
-	}
-
 	return &revertService{
 		MCOImage: mcoImage,
-		Proxy:    hasProxy,
+		Proxy:    ctrlcfg.Spec.Proxy != nil,
+		ctrlcfg:  ctrlcfg,
+		mc:       mc,
 	}, nil
 }
 
 // Returns an Ignition config containing the
-// machine-config-daemon-revert.service systemd unit.
+// machine-config-daemon-revert.service systemd unit, the proxy config file,
+// and the on-disk MachineConfig needed by the systemd unit.
 func (r *revertService) Ignition() (*ign3types.Config, error) {
-	rendered, err := r.render()
+	unit, err := r.renderServiceTemplate()
 	if err != nil {
 		return nil, err
 	}
 
-	out := &ign3types.Unit{}
-
-	if err := yaml.Unmarshal(rendered, out); err != nil {
-		return nil, err
+	mcOnDisk, err := r.getMachineConfigJSONFile()
+	if err != nil {
+		return nil, fmt.Errorf("could not create Ignition file %q for MachineConfig %q: %w", RevertServiceMachineConfigFile, r.mc.Name, err)
 	}
 
 	ignConfig := ctrlcommon.NewIgnConfig()
+	ignConfig.Storage.Files = []ign3types.File{*mcOnDisk}
 	ignConfig.Systemd = ign3types.Systemd{
-		Units: []ign3types.Unit{
-			*out,
-		},
+		Units: []ign3types.Unit{*unit},
+	}
+
+	if r.Proxy {
+		// TODO: Should we fall back to the ControllerConfig if this file is not
+		// present?
+		proxyfile, err := findFileInMachineConfig(r.mc, "/etc/mco/proxy.env")
+		if err != nil {
+			return nil, err
+		}
+
+		proxyfile.Path = RevertServiceProxyFile
+		ignConfig.Storage.Files = append(ignConfig.Storage.Files, *proxyfile)
 	}
 
 	return &ignConfig, nil
 }
 
-// Renders the embedded template with the provided values.
-func (r *revertService) render() ([]byte, error) {
-	if r.MCOImage == "" {
-		return nil, fmt.Errorf("MCOImage field must be provided")
+// Converts a MachineConfig to a JSON representation and returns an Ignition
+// file containing the appropriate path for the file.
+func (r *revertService) getMachineConfigJSONFile() (*ign3types.File, error) {
+	outBytes, err := json.Marshal(r.mc)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal MachineConfig %q to JSON: %w", r.mc.Name, err)
 	}
 
-	tmpl := template.New(RevertServiceName)
+	ignFile := ctrlcommon.NewIgnFileBytes(RevertServiceMachineConfigFile, outBytes)
+	return &ignFile, nil
+}
 
-	tmpl, err := tmpl.Parse(mcdRevertServiceIgnYAML)
-	if err != nil {
-		return nil, err
+// Renders the embedded service template with the provided values.
+func (r *revertService) renderServiceTemplate() (*ign3types.Unit, error) {
+	if r.MCOImage == "" {
+		return nil, fmt.Errorf("MCOImage field must be provided")
 	}
 
 	// Golang templates must be rendered using exported fields. However, we want
@@ -96,17 +115,71 @@ func (r *revertService) render() ([]byte, error) {
 	data := struct {
 		ServiceName                    string
 		RevertServiceMachineConfigFile string
+		ProxyFile                      string
 		revertService
 	}{
 		ServiceName:                    RevertServiceName,
 		RevertServiceMachineConfigFile: RevertServiceMachineConfigFile,
+		ProxyFile:                      RevertServiceProxyFile,
 		revertService:                  *r,
+	}
+
+	out := &ign3types.Unit{}
+
+	if err := renderTemplate(RevertServiceName, mcdRevertServiceIgnYAML, data, out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// Finds a given file by path in a given MachineConfig. Returns an error if the
+// file cannot be found.
+func findFileInMachineConfig(mc *mcfgv1.MachineConfig, path string) (*ign3types.File, error) {
+	ignConfig, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
+	if err != nil {
+		return nil, err
+	}
+
+	ignFile := findFileInIgnitionConfig(&ignConfig, path)
+	if ignFile == nil {
+		return nil, fmt.Errorf("file %q not found in MachineConfig %q", path, mc.Name)
+	}
+
+	return ignFile, nil
+}
+
+// Finds a given file by path in a given Ignition config. Returns nil if the
+// file is not found.
+func findFileInIgnitionConfig(ignConfig *ign3types.Config, path string) *ign3types.File {
+	for _, file := range ignConfig.Storage.Files {
+		if file.Path == path {
+			out := file
+			return &out
+		}
+	}
+
+	return nil
+}
+
+// Renders the given data into the given YAML template source. Then attempts to
+// decode it into the given struct instance. Returns any errors encountered.
+func renderTemplate(name, src string, data, out interface{}) error {
+	tmpl := template.New(name)
+
+	tmpl, err := tmpl.Parse(src)
+	if err != nil {
+		return err
 	}
 
 	buf := bytes.NewBuffer([]byte{})
 	if err := tmpl.Execute(buf, data); err != nil {
-		return nil, err
+		return err
 	}
 
-	return buf.Bytes(), nil
+	if err := yaml.Unmarshal(buf.Bytes(), out); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/daemon/runtimeassets/revertservice_test.go
+++ b/pkg/daemon/runtimeassets/revertservice_test.go
@@ -4,25 +4,39 @@ import (
 	"fmt"
 	"testing"
 
+	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRevertService(t *testing.T) {
 	mcoImagePullspec := "mco.image.pullspec"
 
-	proxyContents := "EnvironmentFile=/etc/mco/proxy.env"
+	proxyContents := []string{
+		"EnvironmentFile=/etc/mco/proxy.env.backup",
+		"ExecStartPost=rm /etc/mco/proxy.env.backup",
+	}
+
+	proxyStatus := configv1.ProxyStatus{
+		HTTPProxy:  "http://1.2.3.4",
+		HTTPSProxy: "https://5.6.7.8",
+		NoProxy:    "no.proxy.local",
+	}
 
 	alwaysExpectedContents := []string{
 		fmt.Sprintf("ConditionPathExists=%s", RevertServiceMachineConfigFile),
 		fmt.Sprintf("podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '%s' firstboot-complete-machineconfig --persist-nics --machineconfig-file %s", mcoImagePullspec, RevertServiceMachineConfigFile),
 		fmt.Sprintf("podman run --authfile=/var/lib/kubelet/config.json --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '%s' firstboot-complete-machineconfig --machineconfig-file %s", mcoImagePullspec, RevertServiceMachineConfigFile),
+		fmt.Sprintf("ExecStartPost=rm %s", RevertServiceMachineConfigFile),
 	}
 
 	testCases := []struct {
 		name               string
 		ctrlcfg            *mcfgv1.ControllerConfig
+		mc                 *mcfgv1.MachineConfig
 		expectedContents   []string
 		unexpectedContents []string
 		errExpected        bool
@@ -36,26 +50,37 @@ func TestRevertService(t *testing.T) {
 					},
 				},
 			},
-			expectedContents: alwaysExpectedContents,
-			unexpectedContents: []string{
-				proxyContents,
-			},
+			expectedContents:   alwaysExpectedContents,
+			unexpectedContents: proxyContents,
 		},
 		{
 			name: "with proxy",
 			ctrlcfg: &mcfgv1.ControllerConfig{
 				Spec: mcfgv1.ControllerConfigSpec{
-					Proxy: &configv1.ProxyStatus{},
+					Proxy: &proxyStatus,
 					Images: map[string]string{
 						"machineConfigOperator": mcoImagePullspec,
 					},
 				},
 			},
-			expectedContents: append(alwaysExpectedContents, proxyContents),
+			expectedContents: append(alwaysExpectedContents, proxyContents...),
 		},
 		{
 			name:        "no mco image found",
 			ctrlcfg:     &mcfgv1.ControllerConfig{},
+			errExpected: true,
+		},
+		{
+			name: "no proxy file found in MachineConfig despite proxy being enabled",
+			mc:   helpers.NewMachineConfig("", map[string]string{}, "", []ign3types.File{}),
+			ctrlcfg: &mcfgv1.ControllerConfig{
+				Spec: mcfgv1.ControllerConfigSpec{
+					Proxy: &proxyStatus,
+					Images: map[string]string{
+						"machineConfigOperator": mcoImagePullspec,
+					},
+				},
+			},
 			errExpected: true,
 		},
 	}
@@ -65,8 +90,21 @@ func TestRevertService(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			rs, err := NewRevertService(testCase.ctrlcfg)
+			mc := helpers.NewMachineConfig("", map[string]string{}, "", []ign3types.File{ctrlcommon.NewIgnFile("/etc/mco/proxy.env", "proxycontents")})
+			if testCase.mc != nil {
+				mc = testCase.mc
+			}
+
+			rs, err := NewRevertService(testCase.ctrlcfg, mc)
 			if testCase.errExpected {
+				// If the returned error is nil, try calling the Ignition() method to
+				// see if it returns an error.
+				if err == nil {
+					ign, err := rs.Ignition()
+					assert.Error(t, err)
+					assert.Nil(t, ign)
+					return
+				}
 				assert.Error(t, err)
 				assert.Nil(t, rs)
 				return
@@ -91,6 +129,22 @@ func TestRevertService(t *testing.T) {
 
 			assert.Equal(t, unit.Name, RevertServiceName)
 			assert.True(t, *unit.Enabled)
+
+			if testCase.ctrlcfg.Spec.Proxy != nil {
+				assertFileExistsInIgnConfig(t, ign, RevertServiceProxyFile)
+			}
+
+			assertFileExistsInIgnConfig(t, ign, RevertServiceMachineConfigFile)
 		})
 	}
+}
+
+func assertFileExistsInIgnConfig(t *testing.T, igncfg *ign3types.Config, filename string) {
+	t.Helper()
+
+	file := findFileInIgnitionConfig(igncfg, filename)
+	assert.NotNil(t, file, "expected to find file %q in ignition config", filename)
+
+	_, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+	assert.NoError(t, err, "expected %s to be encoded", file.Path)
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -983,16 +983,35 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 	if mcDiff.revertFromOCL {
 		odc.currentImage = ""
 
-		// If we're reverting from OCL, finalize the process by writing the configs
-		// and revert systemd unit to disk.
+		// Finalizes the revert process by enabling a special systemd unit prior to
+		// rebooting the node.
 		//
-		// Unfortunately, the pattern of deferred functions checking for error
-		// conditions only works within a given function. We need a better way to
-		// handle the case where we encounter an error and want to undo everything
-		// that we did up until that point.
-		if err := dn.finalizeRevertToNonLayering(newConfig); err != nil {
-			return fmt.Errorf("could not finalize revert to non-OCL: %w", err)
+		// After we write the original factory image to the node, none of the files
+		// specified in the MachineConfig will be written due to how rpm-ostree handles
+		// file writes. Because those files are owned by the layered container image,
+		// they are not present after reboot; even if we were to write them to the node
+		// before rebooting. Consequently, after reverting back to the original image,
+		// the node will lose contact with the control plane and the easiest way to
+		// reestablish contact is to rebootstrap the node.
+		//
+		// By comparison, if we write a file that is _not_ owned by the layered
+		// container image, this file will persist after reboot. So what we do is write
+		// a special systemd unit that will rebootstrap the node upon reboot.
+		// Unfortunately, this will incur a second reboot during the rollback process,
+		// so there is room for improvement here.
+		if err := dn.enableRevertSystemdUnit(newConfig); err != nil {
+			return fmt.Errorf("could not enable revert systemd service: %w", err)
 		}
+
+		defer func() {
+			if retErr != nil {
+				if err := dn.disableRevertSystemdUnit(); err != nil {
+					errs := kubeErrs.NewAggregate([]error{err, retErr})
+					retErr = fmt.Errorf("error rolling back systemd unit %q on disk: %e", runtimeassets.RevertServiceName, errs)
+					return
+				}
+			}
+		}()
 	}
 
 	if err := dn.storeCurrentConfigOnDisk(odc); err != nil {
@@ -1012,69 +1031,6 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 	}()
 
 	return dn.reboot(fmt.Sprintf("Node will reboot into image %s / MachineConfig %s", canonicalizeMachineConfigImage(newImage, newConfig).Spec.OSImageURL, newConfigName))
-}
-
-// Finalizes the revert process by enabling a special systemd unit prior to
-// rebooting the node.
-//
-// After we write the original factory image to the node, none of the files
-// specified in the MachineConfig will be written due to how rpm-ostree handles
-// file writes. Because those files are owned by the layered container image,
-// they are not present after reboot; even if we were to write them to the node
-// before rebooting. Consequently, after reverting back to the original image,
-// the node will lose contact with the control plane and the easiest way to
-// reestablish contact is to rebootstrap the node.
-//
-// By comparison, if we write a file that is _not_ owned by the layered
-// container image, this file will persist after reboot. So what we do is write
-// a special systemd unit that will rebootstrap the node upon reboot.
-// Unfortunately, this will incur a second reboot during the rollback process,
-// so there is room for improvement here.
-func (dn *Daemon) finalizeRevertToNonLayering(newConfig *mcfgv1.MachineConfig) (retErr error) {
-	// First, we write the new MachineConfig to a file. This is both the signal
-	// that the revert systemd unit should fire as well as the desired source of
-	// truth.
-	outBytes, err := json.Marshal(newConfig)
-	if err != nil {
-		return fmt.Errorf("could not marshal MachineConfig %q to JSON: %w", newConfig.Name, err)
-	}
-
-	if err := writeFileAtomicallyWithDefaults(runtimeassets.RevertServiceMachineConfigFile, outBytes); err != nil {
-		return fmt.Errorf("could not write MachineConfig %q to %q: %w", newConfig.Name, runtimeassets.RevertServiceMachineConfigFile, err)
-	}
-
-	klog.Infof("Wrote MachineConfig %q to %q", newConfig.Name, runtimeassets.RevertServiceMachineConfigFile)
-
-	defer func() {
-		if retErr != nil {
-			if err := os.RemoveAll(runtimeassets.RevertServiceMachineConfigFile); err != nil {
-				errs := kubeErrs.NewAggregate([]error{err, retErr})
-				retErr = fmt.Errorf("error rolling back %q on disk: %q", runtimeassets.RevertServiceMachineConfigFile, errs)
-				return
-			}
-		}
-	}()
-
-	// Next, we enable the revert systemd unit. This renders and writes the
-	// machine-config-daemon-revert.service systemd unit, clones it, and writes
-	// it to disk. The reason for doing it this way is because it will persist
-	// after the reboot since it was not written or mutated by the rpm-ostree
-	// process.
-	if err := dn.enableRevertSystemdUnit(); err != nil {
-		return err
-	}
-
-	defer func() {
-		if retErr != nil {
-			if err := dn.disableRevertSystemdUnit(); err != nil {
-				errs := kubeErrs.NewAggregate([]error{err, retErr})
-				retErr = fmt.Errorf("error rolling back systemd unit %q on disk: %e", runtimeassets.RevertServiceName, errs)
-				return
-			}
-		}
-	}()
-
-	return nil
 }
 
 // Update the node to the provided node configuration.
@@ -2980,22 +2936,26 @@ func (dn *Daemon) hasImageRegistryDrainOverrideConfigMap() (bool, error) {
 //
 // To enable the unit, we perform the following operations:
 // 1. Retrieve the ControllerConfig.
-// 2. Generate the Ignition config from the ControllerConfig.
-// 3. Writes the new systemd unit to disk and enables it.
-func (dn *Daemon) enableRevertSystemdUnit() error {
+// 2. Generate the Ignition config from the ControllerConfig and the supplied MachineConfig.
+// 3. Writes the new systemd unit and its needed files to disk and enable it.
+func (dn *Daemon) enableRevertSystemdUnit(newConfig *mcfgv1.MachineConfig) error {
 	ctrlcfg, err := dn.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
 		return fmt.Errorf("could not get controllerconfig %s: %w", ctrlcommon.ControllerConfigName, err)
 	}
 
-	revertService, err := runtimeassets.NewRevertService(ctrlcfg)
+	rs, err := runtimeassets.NewRevertService(ctrlcfg, newConfig)
 	if err != nil {
 		return err
 	}
 
-	revertIgn, err := revertService.Ignition()
+	revertIgn, err := rs.Ignition()
 	if err != nil {
 		return fmt.Errorf("could not create %s: %w", runtimeassets.RevertServiceName, err)
+	}
+
+	if err := dn.writeFiles(revertIgn.Storage.Files, false); err != nil {
+		return fmt.Errorf("could not write files for %s: %w", runtimeassets.RevertServiceName, err)
 	}
 
 	if err := dn.writeUnits(revertIgn.Systemd.Units); err != nil {
@@ -3022,7 +2982,7 @@ func (dn *Daemon) disableRevertSystemdUnit() error {
 		return fmt.Errorf("could not determine if service %q exists: %w", runtimeassets.RevertServiceName, err)
 	}
 
-	// If the unit path does not exist, there is nothing left to do.
+	// If the unit path does not exist, there is nothing to do.
 	if !unitPathExists {
 		return nil
 	}
@@ -3036,6 +2996,7 @@ func (dn *Daemon) disableRevertSystemdUnit() error {
 	filesToRemove := []string{
 		unitPath,
 		runtimeassets.RevertServiceMachineConfigFile,
+		runtimeassets.RevertServiceProxyFile,
 	}
 
 	// systemd removes the unit file, but there is no harm in calling

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2678,7 +2678,6 @@ func (dn *Daemon) queueRevertKernelSwap() error {
 // updateLayeredOS updates the system OS to the one specified in newConfig
 func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
-
 	klog.Infof("Updating OS to layered image %q", newURL)
 
 	newEnough, err := dn.NodeUpdaterClient.IsNewEnoughForLayering()

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -962,13 +962,6 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 		}
 	}()
 
-	// Update the kernal args if there is a difference
-	if diff.kargs && dn.os.IsCoreOSVariant() {
-		if err := coreOSDaemon.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {
-			return err
-		}
-	}
-
 	// Ideally we would want to update kernelArguments only via MachineConfigs.
 	// We are keeping this to maintain compatibility and OKD requirement.
 	if err := UpdateTuningArgs(KernelTuningFile, CmdLineFile); err != nil {
@@ -2816,16 +2809,12 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	if mcDiff.osUpdate && dn.bootedOSImageURL == newConfig.Spec.OSImageURL {
 		klog.Infof("Already in desired image %s", newConfig.Spec.OSImageURL)
 		mcDiff.osUpdate = false
-		// If OCL is enabled, return early here since there is nothing else to do.
-		if mcDiff.oclEnabled {
-			return nil
-		}
 	}
 
 	var osExtensionsContentDir string
 	var err error
+	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType) {
 
-	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType) && !mcDiff.oclEnabled {
 		// TODO(jkyros): the original intent was that we use the extensions container as a service, but that currently results
 		// in a lot of complexity due to boostrap and firstboot where the service isn't easily available, so for now we are going
 		// to extract them to disk like we did previously.
@@ -2863,19 +2852,17 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		}
 	}()
 
-	if !mcDiff.oclEnabled {
-		// If we have an OS update *or* a kernel type change, then we must undo the kernel swap
-		// enablement.
-		if mcDiff.osUpdate || mcDiff.kernelType {
-			if err := dn.queueRevertKernelSwap(); err != nil {
-				mcdPivotErr.Inc()
-				return err
-			}
+	// If we have an OS update *or* a kernel type change, then we must undo the kernel swap
+	// enablement.
+	if mcDiff.osUpdate || mcDiff.kernelType {
+		if err := dn.queueRevertKernelSwap(); err != nil {
+			mcdPivotErr.Inc()
+			return err
 		}
 	}
 
 	// Update OS
-	if mcDiff.osUpdate || mcDiff.oclEnabled {
+	if mcDiff.osUpdate {
 		if err := dn.updateLayeredOS(newConfig); err != nil {
 			mcdPivotErr.Inc()
 			return err
@@ -2892,11 +2879,6 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	// if we're here, we've successfully pivoted, or pivoting wasn't necessary, so we reset the error gauge
 	mcdPivotErr.Set(0)
-
-	// If on-cluster layering is enabled, we can skip the rest of this process.
-	if mcDiff.oclEnabled {
-		return nil
-	}
 
 	if mcDiff.kargs {
 		if err := dn.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -512,7 +512,7 @@ func removePendingDeployment() error {
 // applyOSChanges extracts the OS image and adds coreos-extensions repo if we have either OS update or package layering to perform
 func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
 	// We previously did not emit this event when kargs changed, so we still don't
-	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType {
+	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType || mcDiff.oclEnabled {
 		// We emitted this event before, so keep it
 		if dn.nodeWriter != nil {
 			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "InClusterUpgrade", fmt.Sprintf("Updating from oscontainer %s", newConfig.Spec.OSImageURL))
@@ -523,11 +523,12 @@ func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newC
 	// - machineconfig changed
 	// - we're staying on a realtime kernel ( need to run rpm-ostree update )
 	// - we have extensions ( need to run rpm-ostree update )
+	// - OCL is enabled ( need to run rpm-ostree update )
 	// We have at least one customer that removes the pull secret from the cluster to "shrinkwrap" it for distribution and we want
 	// to make sure we don't break that use case, but realtime kernel update and extensions update always ran
 	// if they were in use, so we also need to preserve that behavior.
 	// https://issues.redhat.com/browse/OCPBUGS-4049
-	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType || mcDiff.kargs ||
+	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType || mcDiff.kargs || mcDiff.oclEnabled ||
 		canonicalizeKernelType(newConfig.Spec.KernelType) == ctrlcommon.KernelTypeRealtime ||
 		canonicalizeKernelType(newConfig.Spec.KernelType) == ctrlcommon.KernelType64kPages ||
 		len(newConfig.Spec.Extensions) > 0 {
@@ -806,8 +807,13 @@ func (dn *Daemon) calculatePostConfigChangeNodeDisruptionAction(diff *machineCon
 // This function should be consolidated with dn.update() and dn.updateHypershift(). See: https://issues.redhat.com/browse/MCO-810 for further discussion.
 //
 //nolint:gocyclo
-func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfig, oldImage, newImage string, skipCertificateWrite bool) (retErr error) {
+func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineConfig, oldImage, newImage string, skipCertificateWrite bool) (retErr error) {
 	oldConfig = canonicalizeEmptyMC(oldConfig)
+
+	mcDiff, err := newMachineConfigDiffFromLayered(oldConfig, newConfig, oldImage, newImage)
+	if err != nil {
+		return fmt.Errorf("could not get layered diff from MachineConfig(s) %q / %q and images %q / %q: %w", oldConfig.Name, newConfig.Name, oldImage, newImage, err)
+	}
 
 	if dn.nodeWriter != nil {
 		state, err := getNodeAnnotationExt(dn.node, constants.MachineConfigDaemonStateAnnotationKey, true)
@@ -840,7 +846,7 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 		return fmt.Errorf("parsing new Ignition config failed: %w", err)
 	}
 
-	klog.Infof("Checking Reconcilable for config %v to %v", oldConfigName, newConfigName)
+	klog.Infof("Checking Reconcilable for config %s to %s", oldConfigName, newConfigName)
 
 	// Make sure we can actually reconcile this state. In the future, this check should be moved to the BuildController and performed prior to the build occurring. This addresses the following bugs:
 	// - https://issues.redhat.com/browse/OCPBUGS-18670
@@ -856,41 +862,48 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 		return &unreconcilableErr{wrappedErr}
 	}
 
-	if oldImage == newImage && newImage != "" {
-		if oldImage == "" {
-			logSystem("Starting transition to %q", newImage)
-		} else {
-			logSystem("Starting transition from %q to %q", oldImage, newImage)
-		}
-	}
-
 	if err := dn.performDrain(); err != nil {
 		return err
 	}
 
-	// If the new image pullspec is already on disk, do not attempt to re-apply
-	// it. rpm-ostree will throw an error as a result.
-	// See: https://issues.redhat.com/browse/OCPBUGS-18414.
-	if oldImage != newImage {
-		// If the new image field is empty, set it to the OS image URL value
-		// provided by the MachineConfig to do a rollback.
-		if newImage == "" {
-			klog.Infof("%s empty, reverting to osImageURL %s from MachineConfig %s", constants.DesiredImageAnnotationKey, newConfig.Spec.OSImageURL, newConfig.Name)
-			newImage = newConfig.Spec.OSImageURL
-		}
-		if err := dn.updateLayeredOSToPullspec(newImage); err != nil {
-			return err
-		}
-	} else {
-		klog.Infof("Image pullspecs equal, skipping rpm-ostree rebase")
+	if mcDiff.revertFromOCL {
+		klog.Infof("%s empty, reverting to osImageURL %s from MachineConfig %s", constants.DesiredImageAnnotationKey, newConfig.Spec.OSImageURL, newConfig.Name)
 	}
 
-	// If the new OS image equals the OS image URL value, this means we're in a
-	// revert-from-layering situation. This also means we can return early after
-	// taking a different path.
-	if newImage == newConfig.Spec.OSImageURL {
-		return dn.finalizeRevertToNonLayering(newConfig)
+	if !dn.os.IsCoreOSVariant() {
+		return fmt.Errorf("on-cluster layering on non-CoreOS nodes is not supported")
 	}
+
+	// We have a separate path for OS images and MachineConfigs because we needed
+	// a way to handle the case where a node was either opting into or opting out
+	// of OCL. If either the oldImage or newImage is empty, this has a special
+	// meaning for OCL depending on which one is empty:
+	// - If oldImage is empty, this means that we are transitioning into OCL operation.
+	// - If newImage is empty, this means that we are transitioning out of OCL operation.
+	//
+	// The code paths that apply an OS image to the node do not handle the case
+	// where the image is empty. So here, we "canoncalize" the OSImageURL field
+	// on both the oldConfig and newConfig. These copies are only used for the OS
+	// update itself and should not be used for anything else.
+	oldConfigCopy := canonicalizeMachineConfigImage(oldImage, oldConfig)
+	newConfigCopy := canonicalizeMachineConfigImage(newImage, newConfig)
+
+	klog.Infof("Old MachineConfig %s / Image %s -> New MachineConfig %s / Image %s", oldConfigName, oldConfigCopy.Spec.OSImageURL, newConfigName, newConfigCopy.Spec.OSImageURL)
+
+	coreOSDaemon := CoreOSDaemon{dn}
+	if err := coreOSDaemon.applyOSChanges(*mcDiff, oldConfigCopy, newConfigCopy); err != nil {
+		return err
+	}
+
+	defer func() {
+		if retErr != nil {
+			if err := coreOSDaemon.applyOSChanges(*mcDiff, newConfigCopy, oldConfigCopy); err != nil {
+				errs := kubeErrs.NewAggregate([]error{err, retErr})
+				retErr = fmt.Errorf("error rolling back changes to OS: %w", errs)
+				return
+			}
+		}
+	}()
 
 	// update files on disk that need updating
 	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, skipCertificateWrite); err != nil {
@@ -951,7 +964,6 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 
 	// Update the kernal args if there is a difference
 	if diff.kargs && dn.os.IsCoreOSVariant() {
-		coreOSDaemon := CoreOSDaemon{dn}
 		if err := coreOSDaemon.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {
 			return err
 		}
@@ -966,6 +978,21 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 	odc := &onDiskConfig{
 		currentImage:  newImage,
 		currentConfig: newConfig,
+	}
+
+	if mcDiff.revertFromOCL {
+		odc.currentImage = ""
+
+		// If we're reverting from OCL, finalize the process by writing the configs
+		// and revert systemd unit to disk.
+		//
+		// Unfortunately, the pattern of deferred functions checking for error
+		// conditions only works within a given function. We need a better way to
+		// handle the case where we encounter an error and want to undo everything
+		// that we did up until that point.
+		if err := dn.finalizeRevertToNonLayering(newConfig); err != nil {
+			return fmt.Errorf("could not finalize revert to non-OCL: %w", err)
+		}
 	}
 
 	if err := dn.storeCurrentConfigOnDisk(odc); err != nil {
@@ -984,7 +1011,7 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 		}
 	}()
 
-	return dn.reboot(fmt.Sprintf("Node will reboot into image %s / MachineConfig %s", newImage, newConfigName))
+	return dn.reboot(fmt.Sprintf("Node will reboot into image %s / MachineConfig %s", canonicalizeMachineConfigImage(newImage, newConfig).Spec.OSImageURL, newConfigName))
 }
 
 // Finalizes the revert process by enabling a special systemd unit prior to
@@ -1003,7 +1030,7 @@ func (dn *Daemon) updateOnClusterBuild(oldConfig, newConfig *mcfgv1.MachineConfi
 // a special systemd unit that will rebootstrap the node upon reboot.
 // Unfortunately, this will incur a second reboot during the rollback process,
 // so there is room for improvement here.
-func (dn *Daemon) finalizeRevertToNonLayering(newConfig *mcfgv1.MachineConfig) error {
+func (dn *Daemon) finalizeRevertToNonLayering(newConfig *mcfgv1.MachineConfig) (retErr error) {
 	// First, we write the new MachineConfig to a file. This is both the signal
 	// that the revert systemd unit should fire as well as the desired source of
 	// truth.
@@ -1018,6 +1045,16 @@ func (dn *Daemon) finalizeRevertToNonLayering(newConfig *mcfgv1.MachineConfig) e
 
 	klog.Infof("Wrote MachineConfig %q to %q", newConfig.Name, runtimeassets.RevertServiceMachineConfigFile)
 
+	defer func() {
+		if retErr != nil {
+			if err := os.RemoveAll(runtimeassets.RevertServiceMachineConfigFile); err != nil {
+				errs := kubeErrs.NewAggregate([]error{err, retErr})
+				retErr = fmt.Errorf("error rolling back %q on disk: %q", runtimeassets.RevertServiceMachineConfigFile, errs)
+				return
+			}
+		}
+	}()
+
 	// Next, we enable the revert systemd unit. This renders and writes the
 	// machine-config-daemon-revert.service systemd unit, clones it, and writes
 	// it to disk. The reason for doing it this way is because it will persist
@@ -1027,23 +1064,22 @@ func (dn *Daemon) finalizeRevertToNonLayering(newConfig *mcfgv1.MachineConfig) e
 		return err
 	}
 
-	// Clear the current image field so that after reboot, the node will clear
-	// the currentImage annotation.
-	odc := &onDiskConfig{
-		currentImage:  "",
-		currentConfig: newConfig,
-	}
+	defer func() {
+		if retErr != nil {
+			if err := dn.disableRevertSystemdUnit(); err != nil {
+				errs := kubeErrs.NewAggregate([]error{err, retErr})
+				retErr = fmt.Errorf("error rolling back systemd unit %q on disk: %e", runtimeassets.RevertServiceName, errs)
+				return
+			}
+		}
+	}()
 
-	if err := dn.storeCurrentConfigOnDisk(odc); err != nil {
-		return err
-	}
-
-	return dn.reboot(fmt.Sprintf("Node will reboot into image %s / MachineConfig %s", newConfig.Spec.OSImageURL, newConfig.Name))
+	return nil
 }
 
 // Update the node to the provided node configuration.
 // This function should be de-duped with dn.updateHypershift() and
-// dn.updateOnClusterBuild(). See: https://issues.redhat.com/browse/MCO-810 for
+// dn.updateOnClusterLayering(). See: https://issues.redhat.com/browse/MCO-810 for
 // discussion.
 //
 //nolint:gocyclo
@@ -1448,14 +1484,16 @@ func (dn *Daemon) removeRollback() error {
 // and the MCO would just operate on that.  For now we're just doing this to get
 // improved logging.
 type machineConfigDiff struct {
-	osUpdate   bool
-	kargs      bool
-	fips       bool
-	passwd     bool
-	files      bool
-	units      bool
-	kernelType bool
-	extensions bool
+	osUpdate      bool
+	kargs         bool
+	fips          bool
+	passwd        bool
+	files         bool
+	units         bool
+	kernelType    bool
+	extensions    bool
+	oclEnabled    bool
+	revertFromOCL bool
 }
 
 // isEmpty returns true if the machineConfigDiff has no changes, or
@@ -1524,6 +1562,19 @@ func newMachineConfigDiff(oldConfig, newConfig *mcfgv1.MachineConfig) (*machineC
 		kernelType: canonicalizeKernelType(oldConfig.Spec.KernelType) != canonicalizeKernelType(newConfig.Spec.KernelType),
 		extensions: !(extensionsEmpty || reflect.DeepEqual(oldConfig.Spec.Extensions, newConfig.Spec.Extensions)),
 	}, nil
+}
+
+func newMachineConfigDiffFromLayered(oldConfig, newConfig *mcfgv1.MachineConfig, oldImage, newImage string) (*machineConfigDiff, error) {
+	mcDiff, err := newMachineConfigDiff(oldConfig, newConfig)
+	if err != nil {
+		return mcDiff, err
+	}
+
+	mcDiff.oclEnabled = true
+	// If the new OS image is empty, that means we are in a revert-from-OCL situation.
+	mcDiff.revertFromOCL = newImage == ""
+	mcDiff.osUpdate = oldImage != newImage || forceFileExists()
+	return mcDiff, nil
 }
 
 // reconcilable checks the configs to make sure that the only changes requested
@@ -2627,11 +2678,9 @@ func (dn *Daemon) queueRevertKernelSwap() error {
 // updateLayeredOS updates the system OS to the one specified in newConfig
 func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
-	klog.Infof("Updating OS to layered image %q", newURL)
-	return dn.updateLayeredOSToPullspec(newURL)
-}
 
-func (dn *Daemon) updateLayeredOSToPullspec(newURL string) error {
+	klog.Infof("Updating OS to layered image %q", newURL)
+
 	newEnough, err := dn.NodeUpdaterClient.IsNewEnoughForLayering()
 	if err != nil {
 		return err
@@ -2812,12 +2861,16 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 	if mcDiff.osUpdate && dn.bootedOSImageURL == newConfig.Spec.OSImageURL {
 		klog.Infof("Already in desired image %s", newConfig.Spec.OSImageURL)
 		mcDiff.osUpdate = false
+		// If OCL is enabled, return early here since there is nothing else to do.
+		if mcDiff.oclEnabled {
+			return nil
+		}
 	}
 
 	var osExtensionsContentDir string
 	var err error
-	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType) {
 
+	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType) && !mcDiff.oclEnabled {
 		// TODO(jkyros): the original intent was that we use the extensions container as a service, but that currently results
 		// in a lot of complexity due to boostrap and firstboot where the service isn't easily available, so for now we are going
 		// to extract them to disk like we did previously.
@@ -2855,17 +2908,19 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		}
 	}()
 
-	// If we have an OS update *or* a kernel type change, then we must undo the kernel swap
-	// enablement.
-	if mcDiff.osUpdate || mcDiff.kernelType {
-		if err := dn.queueRevertKernelSwap(); err != nil {
-			mcdPivotErr.Inc()
-			return err
+	if !mcDiff.oclEnabled {
+		// If we have an OS update *or* a kernel type change, then we must undo the kernel swap
+		// enablement.
+		if mcDiff.osUpdate || mcDiff.kernelType {
+			if err := dn.queueRevertKernelSwap(); err != nil {
+				mcdPivotErr.Inc()
+				return err
+			}
 		}
 	}
 
 	// Update OS
-	if mcDiff.osUpdate {
+	if mcDiff.osUpdate || mcDiff.oclEnabled {
 		if err := dn.updateLayeredOS(newConfig); err != nil {
 			mcdPivotErr.Inc()
 			return err
@@ -2882,6 +2937,11 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	// if we're here, we've successfully pivoted, or pivoting wasn't necessary, so we reset the error gauge
 	mcdPivotErr.Set(0)
+
+	// If on-cluster layering is enabled, we can skip the rest of this process.
+	if mcDiff.oclEnabled {
+		return nil
+	}
 
 	if mcDiff.kargs {
 		if err := dn.updateKernelArguments(oldConfig.Spec.KernelArguments, newConfig.Spec.KernelArguments); err != nil {
@@ -2988,4 +3048,20 @@ func (dn *Daemon) disableRevertSystemdUnit() error {
 	}
 
 	return nil
+}
+
+// If the provided image is empty, then the OSImageURL value on the
+// MachineConfig should take precedence. Otherwise, if the provided image is
+// set, then it should take precedence over the OSImageURL value. This is only
+// used for OCL OS updates and should not be used for anything else.
+func canonicalizeMachineConfigImage(img string, mc *mcfgv1.MachineConfig) *mcfgv1.MachineConfig {
+	copied := mc.DeepCopy()
+
+	if img == "" {
+		return copied
+	}
+
+	copied.Spec.OSImageURL = img
+
+	return copied
 }


### PR DESCRIPTION
**- What I did**

This removes some of the OCL-specific code paths within the applyLayeredOSUpdate() method so that OS extensions and kernel-type changes may be handled by the MCD instead of via OCL. This workaround is required due to a current bug with installing extensions within an OCL image build.

**- How to verify it**

1. Bring up a cluster.
2. Opt into OCL.
3. Create a MachineConfig to install any supported OCP extensions such as `usbguard`, or change the kernel type to a non-default value, e.g. `realtime`.
4. Wait for the image build and rollout to a node to occur.
5. Verify that the extension was installed.
6. Remove the MachineConfig.
7. Wait for the config to revert.
8. Verify that the extensions are no longer present and that the kernel switched back to the default value.

**- Description for the changelog**
Use legacy extensions installation path for OCL
