### PR TITLE
MCO-1501: Add support for custom MCPs in MCN

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -79,6 +79,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		draincontroller := drain.New(
 			drain.DefaultConfig(),
 			ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
+			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctrlctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),
 			ctrlctx.FeatureGateAccess,

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -186,6 +186,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 		ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
 		ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+		ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 		ctrlctx.ClientBuilder.OperatorClientOrDie(componentName),
 		startOpts.kubeletHealthzEnabled,
 		startOpts.kubeletHealthzEndpoint,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -51,9 +51,9 @@ import (
 	mcoResourceRead "github.com/openshift/machine-config-operator/lib/resourceread"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
-	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
-
 	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
+	"github.com/openshift/machine-config-operator/pkg/helpers"
+	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
 )
 
 // Daemon is the dispatch point for the functions of the agent on the
@@ -99,6 +99,9 @@ type Daemon struct {
 
 	mcLister       mcfglistersv1.MachineConfigLister
 	mcListerSynced cache.InformerSynced
+
+	mcpLister       mcfglistersv1.MachineConfigPoolLister
+	mcpListerSynced cache.InformerSynced
 
 	ccLister       mcfglistersv1.ControllerConfigLister
 	ccListerSynced cache.InformerSynced
@@ -362,6 +365,7 @@ func (dn *Daemon) ClusterConnect(
 	mcInformer mcfginformersv1.MachineConfigInformer,
 	nodeInformer coreinformersv1.NodeInformer,
 	ccInformer mcfginformersv1.ControllerConfigInformer,
+	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	mcopClient mcopclientset.Interface,
 	kubeletHealthzEnabled bool,
 	kubeletHealthzEndpoint string,
@@ -396,6 +400,8 @@ func (dn *Daemon) ClusterConnect(
 	})
 	dn.ccLister = ccInformer.Lister()
 	dn.ccListerSynced = ccInformer.Informer().HasSynced
+	dn.mcpLister = mcpInformer.Lister()
+	dn.mcpListerSynced = mcpInformer.Informer().HasSynced
 
 	nw, err := newNodeWriter(dn.name, dn.stopCh)
 	if err != nil {
@@ -705,6 +711,12 @@ func (dn *Daemon) syncNode(key string) error {
 		return nil
 	}
 
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, node)
+	if err != nil {
+		return err
+	}
+
 	if node.Annotations[constants.MachineConfigDaemonPostConfigAction] == constants.MachineConfigDaemonStateRebooting {
 		klog.Info("Detected Rebooting Annotation, applying MCN.")
 		err := upgrademonitor.GenerateAndApplyMachineConfigNodes(
@@ -715,6 +727,7 @@ func (dn *Daemon) syncNode(key string) error {
 			node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Rebooted: %v", err)
@@ -790,6 +803,7 @@ func (dn *Daemon) syncNode(key string) error {
 			node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Resumed true: %v", err)
@@ -828,6 +842,7 @@ func (dn *Daemon) syncNode(key string) error {
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Updated false: %v", err)
@@ -852,6 +867,7 @@ func (dn *Daemon) syncNode(key string) error {
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Updated: %v", err)
@@ -1379,7 +1395,7 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error, errCh chan er
 	defer dn.ccQueue.ShutDown()
 	defer dn.preserveDaemonLogs()
 
-	if !cache.WaitForCacheSync(stopCh, dn.nodeListerSynced, dn.mcListerSynced, dn.ccListerSynced) {
+	if !cache.WaitForCacheSync(stopCh, dn.nodeListerSynced, dn.mcListerSynced, dn.ccListerSynced, dn.mcpListerSynced) {
 		return fmt.Errorf("failed to sync initial listers cache")
 	}
 
@@ -2300,6 +2316,13 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, bool, erro
 	if inDesiredConfig {
 		// Great, we've successfully rebooted for the desired config,
 		// let's mark it done!
+
+		// Get MCP associated with node
+		pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+		if err != nil {
+			return missingODC, inDesiredConfig, err
+		}
+
 		err = upgrademonitor.GenerateAndApplyMachineConfigNodes(
 			&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeResumed, Reason: string(mcfgalphav1.MachineConfigNodeResumed), Message: fmt.Sprintf("In desired config %s. Resumed normal operations. Applying proper annotations.", state.currentConfig.Name)},
 			nil,
@@ -2308,6 +2331,7 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, bool, erro
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Resumed true: %v", err)

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -161,6 +161,7 @@ func (f *fixture) newController() *Daemon {
 		i.Machineconfiguration().V1().MachineConfigs(),
 		k8sI.Core().V1().Nodes(),
 		i.Machineconfiguration().V1().ControllerConfigs(),
+		i.Machineconfiguration().V1().MachineConfigPools(),
 		f.oclient,
 		false,
 		"",
@@ -169,6 +170,7 @@ func (f *fixture) newController() *Daemon {
 
 	d.mcListerSynced = alwaysReady
 	d.nodeListerSynced = alwaysReady
+	d.mcpListerSynced = alwaysReady
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -544,6 +544,12 @@ func (p *PinnedImageSetManager) updateStatusProgressing(pools []*mcfgv1.MachineC
 	}
 	imageSetSpec := getPinnedImageSetSpecForPools(pools)
 
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
+	if err != nil {
+		return err
+	}
+
 	return upgrademonitor.UpdateMachineConfigNodeStatus(
 		&upgrademonitor.Condition{
 			State:   mcfgv1alpha1.MachineConfigNodePinnedImageSetsProgressing,
@@ -558,6 +564,7 @@ func (p *PinnedImageSetManager) updateStatusProgressing(pools []*mcfgv1.MachineC
 		applyCfg,
 		imageSetSpec,
 		p.featureGatesAccessor,
+		pool,
 	)
 }
 
@@ -574,6 +581,12 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 	}
 	imageSetSpec := getPinnedImageSetSpecForPools(pools)
 
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
+	if err != nil {
+		return err
+	}
+
 	err = upgrademonitor.UpdateMachineConfigNodeStatus(
 		&upgrademonitor.Condition{
 			State:   mcfgv1alpha1.MachineConfigNodePinnedImageSetsProgressing,
@@ -588,6 +601,7 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 		applyCfg,
 		imageSetSpec,
 		p.featureGatesAccessor,
+		pool,
 	)
 	if err != nil {
 		klog.Errorf("Failed to updated machine config node: %v", err)
@@ -608,6 +622,7 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 		nil,
 		nil,
 		p.featureGatesAccessor,
+		pool,
 	)
 }
 
@@ -632,6 +647,12 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 		errMsg = statusErr.Error()
 	}
 
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
+	if err != nil {
+		return err
+	}
+
 	return upgrademonitor.UpdateMachineConfigNodeStatus(
 		&upgrademonitor.Condition{
 			State:   mcfgv1alpha1.MachineConfigNodePinnedImageSetsDegraded,
@@ -646,6 +667,7 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 		applyCfg,
 		imageSetSpec,
 		p.featureGatesAccessor,
+		pool,
 	)
 }
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -43,6 +43,7 @@ import (
 	pivottypes "github.com/openshift/machine-config-operator/pkg/daemon/pivot/types"
 	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
 	"github.com/openshift/machine-config-operator/pkg/daemon/runtimeassets"
+	"github.com/openshift/machine-config-operator/pkg/helpers"
 	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
 )
 
@@ -123,7 +124,13 @@ func (dn *Daemon) executeReloadServiceNodeDisruptionAction(serviceName string, r
 		return fmt.Errorf("could not apply update: reloading %s configuration failed. Error: %w", serviceName, reloadErr)
 	}
 
-	err := upgrademonitor.GenerateAndApplyMachineConfigNodes(
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
+
+	err = upgrademonitor.GenerateAndApplyMachineConfigNodes(
 		&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeUpdatePostActionComplete, Reason: string(mcfgalphav1.MachineConfigNodeUpdateReloaded), Message: fmt.Sprintf("Node has reloaded service %s", serviceName)},
 		&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeUpdateReloaded, Reason: fmt.Sprintf("%s%s", string(mcfgalphav1.MachineConfigNodeUpdatePostActionComplete), string(mcfgalphav1.MachineConfigNodeUpdateReloaded)), Message: fmt.Sprintf("Upgrade required a service %s reload. Completed this this as a post update action.", serviceName)},
 		metav1.ConditionTrue,
@@ -131,6 +138,7 @@ func (dn *Daemon) executeReloadServiceNodeDisruptionAction(serviceName string, r
 		dn.node,
 		dn.mcfgClient,
 		dn.featureGatesAccessor,
+		pool,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Reloading success: %v", err)
@@ -157,6 +165,12 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 
 		logSystem("Performing post config change action: %v for config %s", action.Type, configName)
 
+		// Get MCP associated with node
+		pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+		if err != nil {
+			return err
+		}
+
 		switch action.Type {
 		case opv1.RebootStatusAction:
 			err := upgrademonitor.GenerateAndApplyMachineConfigNodes(
@@ -167,6 +181,7 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 				dn.node,
 				dn.mcfgClient,
 				dn.featureGatesAccessor,
+				pool,
 			)
 			if err != nil {
 				klog.Errorf("Error making MCN for rebooting: %v", err)
@@ -186,6 +201,7 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 				dn.node,
 				dn.mcfgClient,
 				dn.featureGatesAccessor,
+				pool,
 			)
 			if err != nil {
 				klog.Errorf("Error making MCN for no post config change action: %v", err)
@@ -253,6 +269,12 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 // In the end uncordon node to schedule workload.
 // If at any point an error occurs, we reboot the node so that node has correct configuration.
 func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string, configName string) error {
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
+
 	if ctrlcommon.InSlice(postConfigChangeActionReboot, postConfigChangeActions) {
 		err := upgrademonitor.GenerateAndApplyMachineConfigNodes(
 			&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeUpdatePostActionComplete, Reason: string(mcfgalphav1.MachineConfigNodeUpdateRebooted), Message: fmt.Sprintf("Node will reboot into config %s", configName)},
@@ -262,6 +284,7 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for rebooting: %v", err)
@@ -282,6 +305,7 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for no post config change action: %v", err)
@@ -307,6 +331,7 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Reloading success: %v", err)
@@ -1087,8 +1112,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		return fmt.Errorf("parsing new Ignition config failed: %w", err)
 	}
 
-	klog.Infof("Checking Reconcilable for config %v to %v", oldConfigName, newConfigName)
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
 
+	klog.Infof("Checking Reconcilable for config %v to %v", oldConfigName, newConfigName)
 	// checking for reconcilability
 	// make sure we can actually reconcile this state
 	diff, reconcilableError := reconcilable(oldConfig, newConfig)
@@ -1102,6 +1132,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if Nerr != nil {
 			klog.Errorf("Error making MCN for Preparing update failed: %v", err)
@@ -1148,6 +1179,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if Nerr != nil {
 			klog.Errorf("Error making MCN for Preparing update failed: %v", err)
@@ -1182,18 +1214,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.node,
 		dn.mcfgClient,
 		dn.featureGatesAccessor,
+		pool,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Update Compatible: %v", err)
-	}
-	pool := ""
-	var ok bool
-	if dn.node != nil {
-		if _, ok = dn.node.Labels["node-role.kubernetes.io/worker"]; ok {
-			pool = "worker"
-		} else if _, ok = dn.node.Labels["node-role.kubernetes.io/master"]; ok {
-			pool = "master"
-		}
 	}
 
 	err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
@@ -1214,6 +1238,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			dn.node,
 			dn.mcfgClient,
 			dn.featureGatesAccessor,
+			pool,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Drain not required: %v", err)
@@ -1241,6 +1266,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.node,
 		dn.mcfgClient,
 		dn.featureGatesAccessor,
+		pool,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Updating Files and OS: %v", err)
@@ -1353,6 +1379,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.node,
 		dn.mcfgClient,
 		dn.featureGatesAccessor,
+		pool,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Updated Files and OS: %v", err)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -50,6 +50,31 @@ func GetNodesForPool(mcpLister v1.MachineConfigPoolLister, nodeLister corev1list
 	return nodes, nil
 }
 
+// GetPrimaryPoolNameForMCN gets the MCP pool name value that is used in a node's MachineConfigNode object.
+// When the node does not yet exist (is nil) or the node does not yet have annotations, the pool name will
+// temporarily be set to `unknown`. Once the node exists (is not nil) and the annotations are properly set,
+// the node will update again and the pool name will be updated.
+func GetPrimaryPoolNameForMCN(mcpLister v1.MachineConfigPoolLister, node *corev1.Node) (string, error) {
+	// Handle case of nil node
+	if node == nil {
+		klog.Error("node object is nil, setting associated MCP to unknown")
+		return "unknown", nil
+	}
+
+	// Use `GetPrimaryPoolForNode` to get primary MCP associated with node
+	primaryPool, err := GetPrimaryPoolForNode(mcpLister, node)
+	if err != nil {
+		klog.Errorf("error getting primary pool for node: %v", node.Name)
+		return "", err
+	} else if primaryPool == nil {
+		// On first provisioning, the node may not have annoatations and, thus, will not be associated with a pool.
+		// In this case, the pool value will be set to a temporary dummy value.
+		klog.Infof("No primary pool is associated with node: %v", node.Name)
+		return "unknown", nil
+	}
+	return primaryPool.Name, nil
+}
+
 func GetPrimaryPoolForNode(mcpLister v1.MachineConfigPoolLister, node *corev1.Node) (*mcfgv1.MachineConfigPool, error) {
 	pools, _, err := GetPoolsForNode(mcpLister, node)
 	if err != nil {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -292,7 +292,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 	if optr.inClusterBringup {
 		klog.V(4).Info("Starting inClusterBringup informers cache sync")
 		// sync now our own informers after having installed the CRDs
-		if !cache.WaitForCacheSync(optr.stopCh, optr.ccListerSynced) {
+		if !cache.WaitForCacheSync(optr.stopCh, optr.ccListerSynced, optr.mcpListerSynced) {
 			return fmt.Errorf("failed to sync caches for informers")
 		}
 		klog.V(4).Info("Finished inClusterBringup informers cache sync")
@@ -768,15 +768,13 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig, _ *configv1.Cluste
 		if node.Status.Phase == corev1.NodePending || node.Status.Phase == corev1.NodePhase("Provisioning") {
 			continue
 		}
-		var pool string
-		var ok bool
-		if _, ok = node.Labels["node-role.kubernetes.io/worker"]; ok {
-			pool = "worker"
-		} else if _, ok = node.Labels["node-role.kubernetes.io/master"]; ok {
-			pool = "master"
-		} else if _, ok = node.Labels["node-role.kubernetes.io/arbiter"]; ok {
-			pool = "arbiter"
+
+		// Get MCP associated with node
+		pool, err := helpers.GetPrimaryPoolNameForMCN(optr.mcpLister, node)
+		if err != nil {
+			return err
 		}
+
 		newMCS := &v1alpha1.MachineConfigNode{
 			Spec: v1alpha1.MachineConfigNodeSpec{
 				Node: v1alpha1.MCOObjectReference{


### PR DESCRIPTION
**- What I did**
This work adds support for custom MCPs in MCN. The update makes use of the previously existing `GetPrimaryPoolForNode` function to get the pool a node is associated with.

**- How to verify it**
**_Test for standard case_**
1. Create a custom MCP named `infra` and add a worker node to the new MCP.
2. View the `machineconfignode` object for the `infra` node and check that the pool name matches.
```
$ oc describe machineconfignode <node-name>
...
Spec:
...
  Pool:
    Name:  infra
```
3. Check that the pool names are properly populated for all `machineconfignode`.
```
$ oc get machineconfignode
NAME                                         POOLNAME   DESIREDCONFIG           CURRENTCONFIG          UPDATED
ip-10-0-101-100.us-west-2.compute.internal   infra      rendered-infra-xxxxx    rendered-infra-xxxxx   True
...
```

**_Test node with multiple labels_**
1. Create 2 MCPs named `infra` and `custom` and add one worker node to each new MCP.
2. Add the `custom` label to the the node part of the `infra` MCP.
```
oc label node <node-name> node-role.kubernetes.io/custom=
```
3. View the `machineconfignode` object for the node part of the `infra` pool and check that the pool name is properly populating as `infra`. _Note that the node will not be a part of `custom`, as that label was added after the node joined the `infra` pool and the node can only be a part of one MCP._
```
$ oc describe machineconfignode <node-name>
...
Spec:
...
  Pool:
    Name:  infra
```
4. Check that the pool names are properly populated for all `machineconfignode`.
```
$ oc get machineconfignode
NAME                                         POOLNAME   DESIREDCONFIG           CURRENTCONFIG          UPDATED
ip-10-0-101-100.us-west-2.compute.internal   infra      rendered-infra-xxxxx    rendered-infra-xxxxx   True
ip-10-0-113-251.us-west-2.compute.internal   custom     rendered-custom-xxxxx   rendered-custom-xxxxx  True
...
...
```
5. Remove the `infra` label from the infra node. This will force the node to become part of the `custom` MCP due to that label on the node.
```
oc label node <node-name-2> node-role.kubernetes.io/infra-
```
6. View the `machineconfignode` object for the node previously part of the `infra` pool and check that the pool name is now properly populating as `custom`.
```
$ oc describe machineconfignode <node-name>
...
Spec:
...
  Pool:
    Name:  custom
```
7. Check that the pool names are properly populated for all `machineconfignode`.
```
$ oc get machineconfignode
NAME                                         POOLNAME   DESIREDCONFIG           CURRENTCONFIG          UPDATED
ip-10-0-101-100.us-west-2.compute.internal   custom     rendered-custom-xxxxx   rendered-custom-xxxxx   True
ip-10-0-113-251.us-west-2.compute.internal   custom     rendered-custom-xxxxx   rendered-custom-xxxxx  True
...
```

**_Test by deleting MCP_**
1. Create a custom MCP named `custom` and add a worker node to the new MCP. Validate the `machineconfignode` for the node in the new MCP.
2. Remove the custom pool labels from the nodes and delete the `custom` MCP. This will force the node previously part of the pool to become part of the default `worker` pool.
```
$ oc label node <node-name> node-role.kubernetes.io/custom-
$ oc delete mcp/custom
```
3. View the `machineconfignode` object for the node part previously part of the `custom` pool and check that the pool name is now properly populating as `worker`.
```
$ oc describe machineconfignode <node-name>
...
Spec:
...
  Pool:
    Name:  worker
```
4. Check that the pool names are properly populated for all `machineconfignode`.
```
$ oc get machineconfignode
NAME                                         POOLNAME   DESIREDCONFIG           CURRENTCONFIG          UPDATED
ip-10-0-101-100.us-west-2.compute.internal   worker     rendered-worker-xxxxx   rendered-worker-xxxxx   True
...
```

**- Description for the changelog**
[MCO-1501](https://issues.redhat.com//browse/MCO-1501): Added support for custom MCPs in MCN