### PR TITLE
MCO-1485: MCO:1486: MCO-1324: Attempt stub Ignition upgrade

### DIFF
--- a/pkg/controller/certrotation/helpers.go
+++ b/pkg/controller/certrotation/helpers.go
@@ -21,7 +21,7 @@ func isUserDataSecret(secret corev1.Secret) bool {
 	// These secrets don't really have a label or not, so the determining factor is if they:
 	// 1. have a userData field
 	// 2. is an ignition config
-	userData, exists := secret.Data[userDataKey]
+	userData, exists := secret.Data[ctrlcommon.UserDataKey]
 	if !exists {
 		return false
 	}
@@ -32,7 +32,7 @@ func isUserDataSecret(secret corev1.Secret) bool {
 		return false
 	}
 
-	_, isIgn, err := unstructured.NestedMap(userDataIgn.(map[string]interface{}), ignFieldIgnition)
+	_, isIgn, err := unstructured.NestedMap(userDataIgn.(map[string]interface{}), ctrlcommon.IgnFieldIgnition)
 	if !isIgn || err != nil {
 		// Didn't find ignition in user-data, warn but continue
 		klog.Infof("Unable to find ignition in user-data, skipping secret %s\n", secret.Name)

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -100,6 +100,9 @@ const (
 	// MCOReleaseImageVersionKey is the key for indexing the MCO release version stored in the bootimages configmap
 	MCOReleaseImageVersionKey = "MCOReleaseImageVersion"
 
+	// MCOReleaseImageVersionKey is the key for indexing the OCP release version stored in the bootimages configmap
+	OCPReleaseVersionKey = "releaseVersion"
+
 	// MCOOperatorKnobsObjectName is the name of the global MachineConfiguration "knobs" object that the MCO watches.
 	MCOOperatorKnobsObjectName = "cluster"
 

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -88,6 +88,9 @@ const (
 	// it's supposed to be the internal default version.
 	InternalMCOIgnitionVersion = "3.4.0"
 
+	// This is the minimum acceptable ignition spec required for boot image updates. This should be updated to be in line with the above.
+	MinimumAcceptableStubIgnitionSpec = "3"
+
 	// MachineConfigRoleLabel is the role on MachineConfigs, used to select for pools
 	MachineConfigRoleLabel = "machineconfiguration.openshift.io/role"
 
@@ -122,6 +125,18 @@ const (
 
 	// This is the label applied to *-user-data-managed secrets
 	MachineConfigServerCAManagedByConfigMapKey = "machineconfiguration.openshift.io/managed-ca-bundle-derived-from-configmap"
+
+	// This is used to key in to the user-data secret
+	UserDataKey = "userData"
+
+	// ign* are for the user-data ignition fields
+	IgnFieldIgnition = "ignition"
+	IgnFieldSource   = "source"
+	IgnFieldVersion  = "version"
+
+	// Stub Ignition upgrade related annotation keys
+	StubIgnitionVersionAnnotation   = "machineconfiguration.openshift.io/stub-ignition-upgraded-to"
+	StubIgnitionTimestampAnnotation = "machineconfiguration.openshift.io/stub-ignition-upgraded-at"
 )
 
 // Commonly-used MCO ConfigMap names

--- a/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
+++ b/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
@@ -451,7 +451,7 @@ func (ctrl *Controller) syncMAPIMachineSet(machineSet *machinev1beta1.MachineSet
 	}
 
 	// Check if the this MachineSet requires an update
-	patchRequired, newMachineSet, err := checkMachineSet(infra, machineSet, configMap, arch)
+	patchRequired, newMachineSet, err := checkMachineSet(infra, machineSet, configMap, arch, ctrl.kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile machineset %s, err: %w", machineSet.Name, err)
 	}

--- a/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
+++ b/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
@@ -90,9 +90,6 @@ const (
 	// Labels and Annotations required for determining architecture of a machineset
 	MachineSetArchAnnotationKey = "capacity.cluster-autoscaler.kubernetes.io/labels"
 	ArchLabelKey                = "kubernetes.io/arch="
-
-	// Name of managed worker secret
-	ManagedWorkerSecretName = "worker-user-data-managed"
 )
 
 // New returns a new machine-set-boot-image controller.

--- a/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
+++ b/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
@@ -434,13 +434,13 @@ func (ctrl *Controller) syncMAPIMachineSet(machineSet *machinev1beta1.MachineSet
 			pollError = fmt.Errorf("mismatch between MCO hash version stored in configmap and current MCO version; sync will exit to wait for the MCO upgrade to complete")
 			return false, nil
 		}
-		releaseVersionFromCM, releaseVersionFound := configMap.Data[ctrlcommon.MCOReleaseImageVersionKey]
+		releaseVersionFromCM, releaseVersionFound := configMap.Data[ctrlcommon.OCPReleaseVersionKey]
 		if !releaseVersionFound {
-			pollError = fmt.Errorf("failed to find mco release version in %s configmap, sync will exit to wait for the MCO upgrade to complete", ctrlcommon.BootImagesConfigMapName)
+			pollError = fmt.Errorf("failed to find OCP release version in %s configmap, sync will exit to wait for the MCO upgrade to complete", ctrlcommon.BootImagesConfigMapName)
 			return false, nil
 		}
 		if releaseVersionFromCM != operatorversion.ReleaseVersion {
-			pollError = fmt.Errorf("mismatch between MCO release version stored in configmap and current MCO release version; sync will exit to wait for the MCO upgrade to complete")
+			pollError = fmt.Errorf("mismatch between OCP release version stored in configmap and current MCO release version; sync will exit to wait for the MCO upgrade to complete")
 			return false, nil
 		}
 		return true, nil
@@ -449,10 +449,6 @@ func (ctrl *Controller) syncMAPIMachineSet(machineSet *machinev1beta1.MachineSet
 		klog.Errorf("Timed out waiting for coreos-bootimages config map: %v", pollError)
 		return fmt.Errorf("timed out waiting for coreos-bootimages config map: %v", pollError)
 	}
-
-	// TODO: Also check against the release version stored in the configmap under releaseVersion. This is currently broken as the version
-	// stored is "0.0.1-snapshot" and does not reflect the correct value. Tracked in this bug https://issues.redhat.com/browse/OCPBUGS-19824
-	// The current hash and version check should be enough to skate by for now, but fixing this would be additional safety - djoshy
 
 	// Check if the this MachineSet requires an update
 	patchRequired, newMachineSet, err := checkMachineSet(infra, machineSet, configMap, arch)

--- a/pkg/controller/machine-set-boot-image/platform_helpers.go
+++ b/pkg/controller/machine-set-boot-image/platform_helpers.go
@@ -5,22 +5,68 @@ import (
 
 	"github.com/coreos/stream-metadata-go/stream"
 	corev1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 )
 
+// This function calls the appropriate reconcile function based on the infra type
+// On success, it will return a bool indicating if a patch is required, and an updated
+// machineset object if any. It will return an error if any of the above steps fail.
+func checkMachineSet(infra *osconfigv1.Infrastructure, machineSet *machinev1beta1.MachineSet, configMap *corev1.ConfigMap, arch string, secretClient clientset.Interface) (bool, *machinev1beta1.MachineSet, error) {
+	switch infra.Status.PlatformStatus.Type {
+	case osconfigv1.AWSPlatformType:
+		return reconcileAWS(machineSet, configMap, arch, secretClient)
+	case osconfigv1.AzurePlatformType:
+		return reconcileAzure(machineSet, configMap, arch)
+	case osconfigv1.BareMetalPlatformType:
+		return reconcileBareMetal(machineSet, configMap, arch)
+	case osconfigv1.OpenStackPlatformType:
+		return reconcileOpenStack(machineSet, configMap, arch)
+	case osconfigv1.EquinixMetalPlatformType:
+		return reconcileEquinixMetal(machineSet, configMap, arch)
+	case osconfigv1.GCPPlatformType:
+		return reconcileGCP(machineSet, configMap, arch, secretClient)
+	case osconfigv1.KubevirtPlatformType:
+		return reconcileKubevirt(machineSet, configMap, arch)
+	case osconfigv1.IBMCloudPlatformType:
+		return reconcileIBMCCloud(machineSet, configMap, arch)
+	case osconfigv1.LibvirtPlatformType:
+		return reconcileLibvirt(machineSet, configMap, arch)
+	case osconfigv1.VSpherePlatformType:
+		return reconcileVSphere(machineSet, configMap, arch)
+	case osconfigv1.NutanixPlatformType:
+		return reconcileNutanix(machineSet, configMap, arch)
+	case osconfigv1.OvirtPlatformType:
+		return reconcileOvirt(machineSet, configMap, arch)
+	case osconfigv1.ExternalPlatformType:
+		return reconcileExternal(machineSet, configMap, arch)
+	case osconfigv1.PowerVSPlatformType:
+		return reconcilePowerVS(machineSet, configMap, arch)
+	case osconfigv1.NonePlatformType:
+		return reconcileNone(machineSet, configMap, arch)
+	default:
+		return unmarshalToFindPlatform(machineSet, configMap, arch)
+	}
+}
+
 // GCP reconciliation function. Key points:
 // -GCP images aren't region specific
 // -GCPMachineProviderSpec.Disk(s) stores actual bootimage URL
 // -identical for x86_64/amd64 and aarch64/arm64
-func reconcileGCP(machineSet *machinev1beta1.MachineSet, configMap *corev1.ConfigMap, arch string) (patchRequired bool, newMachineSet *machinev1beta1.MachineSet, err error) {
+func reconcileGCP(machineSet *machinev1beta1.MachineSet, configMap *corev1.ConfigMap, arch string, secretClient clientset.Interface) (patchRequired bool, newMachineSet *machinev1beta1.MachineSet, err error) {
 	klog.Infof("Reconciling MAPI machineset %s on GCP, with arch %s", machineSet.Name, arch)
 
 	// First, unmarshal the GCP providerSpec
 	providerSpec := new(machinev1beta1.GCPMachineProviderSpec)
 	if err := unmarshalProviderSpec(machineSet, providerSpec); err != nil {
+		return false, nil, err
+	}
+
+	// Ensure the ignition stub is the minimum acceptable spec required for boot image updates
+	if err := upgradeStubIgnitionIfRequired(providerSpec.UserDataSecret.Name, secretClient); err != nil {
 		return false, nil, err
 	}
 
@@ -58,52 +104,18 @@ func reconcileGCP(machineSet *machinev1beta1.MachineSet, configMap *corev1.Confi
 	return patchRequired, newMachineSet, nil
 }
 
-// This function calls the appropriate reconcile function based on the infra type
-// On success, it will return a bool indicating if a patch is required, and an updated
-// machineset object if any. It will return an error if any of the above steps fail.
-func checkMachineSet(infra *osconfigv1.Infrastructure, machineSet *machinev1beta1.MachineSet, configMap *corev1.ConfigMap, arch string) (bool, *machinev1beta1.MachineSet, error) {
-	switch infra.Status.PlatformStatus.Type {
-	case osconfigv1.AWSPlatformType:
-		return reconcileAWS(machineSet, configMap, arch)
-	case osconfigv1.AzurePlatformType:
-		return reconcileAzure(machineSet, configMap, arch)
-	case osconfigv1.BareMetalPlatformType:
-		return reconcileBareMetal(machineSet, configMap, arch)
-	case osconfigv1.OpenStackPlatformType:
-		return reconcileOpenStack(machineSet, configMap, arch)
-	case osconfigv1.EquinixMetalPlatformType:
-		return reconcileEquinixMetal(machineSet, configMap, arch)
-	case osconfigv1.GCPPlatformType:
-		return reconcileGCP(machineSet, configMap, arch)
-	case osconfigv1.KubevirtPlatformType:
-		return reconcileKubevirt(machineSet, configMap, arch)
-	case osconfigv1.IBMCloudPlatformType:
-		return reconcileIBMCCloud(machineSet, configMap, arch)
-	case osconfigv1.LibvirtPlatformType:
-		return reconcileLibvirt(machineSet, configMap, arch)
-	case osconfigv1.VSpherePlatformType:
-		return reconcileVSphere(machineSet, configMap, arch)
-	case osconfigv1.NutanixPlatformType:
-		return reconcileNutanix(machineSet, configMap, arch)
-	case osconfigv1.OvirtPlatformType:
-		return reconcileOvirt(machineSet, configMap, arch)
-	case osconfigv1.ExternalPlatformType:
-		return reconcileExternal(machineSet, configMap, arch)
-	case osconfigv1.PowerVSPlatformType:
-		return reconcilePowerVS(machineSet, configMap, arch)
-	case osconfigv1.NonePlatformType:
-		return reconcileNone(machineSet, configMap, arch)
-	default:
-		return unmarshalToFindPlatform(machineSet, configMap, arch)
-	}
-}
+func reconcileAWS(machineSet *machinev1beta1.MachineSet, configMap *corev1.ConfigMap, arch string, secretClient clientset.Interface) (patchRequired bool, newMachineSet *machinev1beta1.MachineSet, err error) {
 
-func reconcileAWS(machineSet *machinev1beta1.MachineSet, configMap *corev1.ConfigMap, arch string) (patchRequired bool, newMachineSet *machinev1beta1.MachineSet, err error) {
 	klog.Infof("Reconciling MAPI machineset %s on AWS, with arch %s", machineSet.Name, arch)
 
 	// First, unmarshal the AWS providerSpec
 	providerSpec := new(machinev1beta1.AWSMachineProviderConfig)
 	if err := unmarshalProviderSpec(machineSet, providerSpec); err != nil {
+		return false, nil, err
+	}
+
+	// Ensure the ignition stub is the minimum acceptable spec required for boot image updates
+	if err := upgradeStubIgnitionIfRequired(providerSpec.UserDataSecret.Name, secretClient); err != nil {
 		return false, nil, err
 	}
 

--- a/pkg/controller/machine-set-boot-image/platform_helpers.go
+++ b/pkg/controller/machine-set-boot-image/platform_helpers.go
@@ -48,13 +48,6 @@ func reconcileGCP(machineSet *machinev1beta1.MachineSet, configMap *corev1.Confi
 		}
 	}
 
-	// For now, hardcode to the managed worker secret, until Custom Pool Booting is implemented. When that happens, this will have to
-	// respect the pool this machineset is targeted for.
-	if newProviderSpec.UserDataSecret.Name != ManagedWorkerSecretName {
-		newProviderSpec.UserDataSecret.Name = ManagedWorkerSecretName
-		patchRequired = true
-	}
-
 	// If patch is required, marshal the new providerspec into the machineset
 	if patchRequired {
 		newMachineSet = machineSet.DeepCopy()
@@ -140,11 +133,6 @@ func reconcileAWS(machineSet *machinev1beta1.MachineSet, configMap *corev1.Confi
 		klog.Infof("Current image: %s: %s", region, currentAMI)
 		patchRequired = true
 		newProviderSpec.AMI.ID = &newami
-	}
-
-	if newProviderSpec.UserDataSecret.Name != ManagedWorkerSecretName {
-		newProviderSpec.UserDataSecret.Name = ManagedWorkerSecretName
-		patchRequired = true
 	}
 
 	if patchRequired {

--- a/test/e2e/msbic_test.go
+++ b/test/e2e/msbic_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -30,6 +32,7 @@ import (
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 
 	mcoac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -233,6 +236,91 @@ func TestBootImageDegradeCondition(t *testing.T) {
 	t.Logf("Succesfully verified that the operator is no longer degraded")
 }
 
+func TestStubIgnitionUpgrade(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Check if the cluster is running on GCP platform
+	if !verifyGCPPlatform(t, cs) {
+		return
+	}
+	testStubSecretName := "test-user-data"
+	machineClient := machineClientv1beta1.NewForConfigOrDie(cs.GetRestConfig())
+	// Create a 2.2 stub secret in the test cluster
+	_, err := cs.CoreV1Interface.Secrets(ctrlcommon.MachineAPINamespace).Create(context.TODO(), getOldMAOSecret(testStubSecretName), metav1.CreateOptions{})
+	require.Nil(t, err, "create test secret failed")
+	t.Logf("Created test stub secret")
+	// Update the machineconfiguration object to opt-in all machinesets
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.All)))))
+	_, err = machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
+
+	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
+
+	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
+
+	// Pick a random machineset to test
+	machineSetUnderTest := getRandomMachineSet(t, machineClient)
+	t.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
+
+	// Update machineset to point to 2.2 stub
+	providerSpec := new(machinev1beta1.GCPMachineProviderSpec)
+	err = unmarshalProviderSpec(&machineSetUnderTest, providerSpec)
+	require.Nil(t, err, "failed to unmarshal Machine Set: %s", machineSetUnderTest.Name)
+
+	newProviderSpec := providerSpec.DeepCopy()
+	newProviderSpec.UserDataSecret.Name = testStubSecretName
+	newMachineSet := machineSetUnderTest.DeepCopy()
+	err = marshalProviderSpec(newMachineSet, newProviderSpec)
+	require.Nil(t, err, "failed to marshal new Provider Spec object")
+
+	err = patchMachineSet(&machineSetUnderTest, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset for test secret failed")
+
+	// Ensure atleast one master node is ready
+	t.Logf("Waiting until atleast one master node is ready...")
+	helpers.WaitForOneMasterNodeToBeReady(t, cs)
+	t.Logf("Updated MachineSet %s with stub secret", machineSetUnderTest.Name)
+
+	// Check if secret got upgraded to spec 3
+	secret, err := cs.CoreV1Interface.Secrets(ctrlcommon.MachineAPINamespace).Get(context.TODO(), testStubSecretName, metav1.GetOptions{})
+	require.Nil(t, err, "get test secret failed")
+	userData := secret.Data[ctrlcommon.UserDataKey]
+	var userDataIgn interface{}
+	err = json.Unmarshal(userData, &userDataIgn)
+	require.Nil(t, err, "failed to unmarshal decoded user-data to json (secret %s): %wt", secret.Name, err)
+	versionPath := []string{ctrlcommon.IgnFieldIgnition, ctrlcommon.IgnFieldVersion}
+	version, _, err := unstructured.NestedString(userDataIgn.(map[string]any), versionPath...)
+	require.Nil(t, err, "failed to find version field in ignition (user data secret %s): %w", secret.Name, err)
+	require.Equal(t, strings.HasPrefix(version, ctrlcommon.MinimumAcceptableStubIgnitionSpec), true, "Upgraded stub ignition doesn't have the correct version")
+	t.Logf("Test stub secret was upgraded correctly")
+
+	// Restore machineset to original providerSpec
+	machineSetUnderTestUpdated, err := machineClient.MachineSets("openshift-machine-api").Get(context.TODO(), machineSetUnderTest.Name, metav1.GetOptions{})
+	require.Nil(t, err, "failed to re-fetch machineset under test")
+	newMachineSet = machineSetUnderTestUpdated.DeepCopy()
+	err = marshalProviderSpec(newMachineSet, providerSpec)
+	require.Nil(t, err, "failed to marshal new Provider Spec object during restoration")
+	err = patchMachineSet(machineSetUnderTestUpdated, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset during restoration failed")
+
+	t.Logf("Restored MachineSet %s to original values", machineSetUnderTest.Name)
+
+	// Delete test secret
+	err = cs.CoreV1Interface.Secrets(ctrlcommon.MachineAPINamespace).Delete(context.TODO(), testStubSecretName, metav1.DeleteOptions{})
+	require.Nil(t, err, "delete test secret failed")
+	t.Logf("Test stub secret %s deleted", testStubSecretName)
+
+}
+
 // This function verifies if the boot image values of the MachineSet are in an expected state
 func verifyMachineSet(t *testing.T, cs *framework.ClientSet, ms machinev1beta1.MachineSet, machineClient *machineClientv1beta1.MachineV1beta1Client, reconciliationExpected bool) {
 	providerSpec := new(machinev1beta1.GCPMachineProviderSpec)
@@ -358,4 +446,15 @@ func patchMachineSet(oldMachineSet, newMachineSet *machinev1beta1.MachineSet, ma
 		return fmt.Errorf("unable to patch new machineset: %w", err)
 	}
 	return nil
+}
+
+// This is a spec 2 stub generated by the installer, in older versions of OCP(<4.6)
+func getOldMAOSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ctrlcommon.MachineAPINamespace,
+		},
+		Data: map[string][]byte{"disableTemplating": []byte("true"), "userData": []byte(`{"ignition":{"config":{"append":[{"source":"https://test-cluster-api:22623/config/worker"}]},"security":{"tls":{"certificateAuthorities":[{"source":"data:text/plain;charset=utf-8;base64,LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClJPT1QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="}]}},"version":"2.2.0"}}`)},
+	}
 }


### PR DESCRIPTION
**- What I did**
- If a `MachineSet` enrolled for boot image updates has a spec 2 Ignition stub, the boot image controller will attempt to upgrade it to the latest Ignition version used by the MCO(which at the moment, is `3.4.0`). 
- If the upgrade fails, the boot image controller will degrade and abort the boot image update. When an upgrade is successful, the timestamp and new version is annotated on the secret object.
- The boot image controller will no longer hardcode an update enrolled `MachineSet` to `*-managed` stub. The e2e tests have been adjusted accordingly.
- As https://issues.redhat.com/browse/OCPBUGS-19824 is now fixed, we can directly use the `releaseVersion` in the `coreos-bootimages` configmap instead of the one written into the configmap by the MCO. 
- Added an e2e to verify the stub upgrade behavior

**- How to verify it**
- Manually edit the Ignition stub in a `*-user-data` secret to use a spec 2 stub. This [link](https://access.redhat.com/solutions/5514051) should give you an idea of what a spec 2 stub should look like. Reference the secret in a `MachineSet` object and then opt-in said `MachineSet` for boot image updates.
- Check the MCC logs to ensure that the stub upgrade successfully took place. This should also be apparent by examining the contents and the annotation on the `*-user-data` secret.
- Scale up a node that uses this Ignition stub. This should succeed.

Error modes:
I haven't been able to test this, because I'm not sure how to create an un-upgradeable 2.2 stub. Once could reference  this "invalid stub" in a `MachineSet` enrolled for boot image updates, and this should result in a degrade.
