### PR TITLE
[release-4.17] OCPBUGS-52257: configure-ovs workaround for ovs-if-br-ex bug

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -76,6 +76,10 @@ contents:
       update_nm_conn_files_base "${NM_CONN_SET_PATH}" "${1}" "${2}"
     }
 
+    update_nm_conn_etc_files() {
+      update_nm_conn_files_base "${NM_CONN_ETC_PATH}" "${1}" "${2}"
+    }
+
     # Move and reload keyfiles at their final destination
     set_nm_conn_files() {
       if [ "$NM_CONN_RUN_PATH" != "$NM_CONN_SET_PATH" ]; then
@@ -219,13 +223,13 @@ contents:
       # find default port to add to bridge
       if ! nmcli connection show "$default_port_name" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" ${iface}
-        add_nm_conn "$default_port_name" type ovs-port conn.interface ${iface} master "$bridge_name" \
+        add_nm_conn "$default_port_name" type ovs-port conn.interface ${iface} slave-type ovs-bridge master "$bridge_name" \
         connection.autoconnect-slaves 1
       fi
 
       if ! nmcli connection show "$ovs_port" &> /dev/null; then
         ovs-vsctl --timeout=30 --if-exists del-port "$bridge_name" "$bridge_name"
-        add_nm_conn "$ovs_port" type ovs-port conn.interface "$bridge_name" master "$bridge_name"
+        add_nm_conn "$ovs_port" type ovs-port conn.interface "$bridge_name" slave-type ovs-bridge master "$bridge_name"
       fi
 
       extra_phys_args=()
@@ -410,6 +414,9 @@ contents:
       update_nm_conn_run_files ${bridge_name} ${port_name}
       rm_nm_conn_files
       update_nm_conn_set_files ${bridge_name} ${port_name}
+      rm_nm_conn_files
+      # Shouldn't be necessary, workaround for https://issues.redhat.com/browse/OCPBUGS-41489
+      update_nm_conn_etc_files ${bridge_name} ${port_name}
       rm_nm_conn_files
 
       # NetworkManager will not remove ${bridge_name} if it has the patch port created by ovn-kubernetes


### PR DESCRIPTION
This required  a manual backport because we didn't backport the previous failed fix to this same code past 4.18. No real conflicts though.

Due to some unexpected behavior when applying NMState configuration, the ovs-if-br-ex connection profile is being persisted to /etc/NetworkManager/system-connections when it shouldn't be. By default, configure-ovs only cleans the /run directory, but if we also clean /etc even when it's not supposed to be used then it will unblock a number of users who are currently hitting this bug.

This also swaps the order of the master and slave-type parameter in the nmcli call since we discovered the previous ordering is ineffective. With the removal of the spurious nmconnection file it's likely that this doesn't matter, but it won't hurt to have it there.

(cherry picked from commit 0a28a50005394f06fb0a868c595aef30bb573de8)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
