### PR TITLE
Update the MCS iptables debug command in docs

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -364,7 +364,7 @@ To use host binaries, run `chroot /host`
 Pod IP: 10.0.147.70
 If you don't see a command prompt, try pressing enter.
 sh-4.2# chroot /host
-sh-4.4# /sbin/iptables -D OPENSHIFT-BLOCK-OUTPUT 1
+sh-4.4# /sbin/iptables -nL FORWARD --line-numbers | grep -E '2262[34]' | awk '{print $1}' | xargs -n 1 echo | tac | xargs -n 1 /sbin/iptables -D FORWARD
 sh-4.4# curl -k https://<api-server-url>:22623/config/worker
 ...
 sh-4.4# curl -H "Accept: application/vnd.coreos.ignition+json; version=3.2.0" -k https://<api-server-url>/config/worker


### PR DESCRIPTION
**- What I did**
Updated the HACKING docs to remove the usage of the OPENSHIFT-BLOCK-OUTPUT iptables chain, that no longer exists.

**- How to verify it**
In a running cluster, run the `oc debug` command in a node and follow the modified HACKING.md instructions.

**- Description for the changelog**
The OPENSHIFT-BLOCK-OUTPUT chain does not exist anymore. Now, to unblock the connectivity to the MCS the two rules that target its ports (22623 and 22624) in the forward chain should be removed.
