### PR TITLE
[release-4.16] OCPBUGS-52421: Update format verbs for alert logs

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1099,7 +1099,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 		return nil
 	}
 
-	klog.Infof("Update is reconcilable. Diff: %v", mcDiff)
+	klog.Infof("Update is reconcilable. Diff: %+v", mcDiff)
 
 	// This should be eventually de-duplicated with the update() function.
 	oldIgnConfig, err := ctrlcommon.ParseAndConvertConfig(currentConfig.Spec.Config.Raw)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2044,7 +2044,7 @@ func (dn *Daemon) workaroundOcpBugs33694() error {
 	}
 	for _, path := range stalePaths {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("error deleting %s: %w", path, err)
+			return fmt.Errorf("error deleting %q: %w", path, err)
 		} else if err == nil {
 			klog.Infof("Removed stale symlink %q", path)
 		}
@@ -2114,7 +2114,7 @@ func (dn *Daemon) presetUnit(unit ign3types.Unit) error {
 	if err != nil {
 		return fmt.Errorf("error running preset on unit: %s", stdouterr)
 	}
-	klog.Infof("Preset systemd unit %s", unit.Name)
+	klog.Infof("Preset systemd unit %q", unit.Name)
 	return nil
 }
 
@@ -2178,7 +2178,7 @@ func (dn *Daemon) writeFiles(files []ign3types.File, skipCertificateWrite bool) 
 // Ensures that both the SSH root directory (/home/core/.ssh) as well as any
 // subdirectories are created with the correct (0700) permissions.
 func createSSHKeyDir(authKeyDir string) error {
-	klog.Infof("Creating missing SSH key dir at %s", authKeyDir)
+	klog.Infof("Creating missing SSH key dir at %q", authKeyDir)
 
 	mkdir := func(dir string) error {
 		return exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", dir).Run()
@@ -2563,7 +2563,7 @@ func (dn *Daemon) queueRevertKernelSwap() error {
 // updateLayeredOS updates the system OS to the one specified in newConfig
 func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
-	klog.Infof("Updating OS to layered image %s", newURL)
+	klog.Infof("Updating OS to layered image %q", newURL)
 	return dn.updateLayeredOSToPullspec(newURL)
 }
 
@@ -2606,6 +2606,7 @@ func runCmdSync(cmdName string, args ...string) error {
 // Log a message to the systemd journal as well as our stdout
 func logSystem(format string, a ...interface{}) {
 	message := fmt.Sprintf(format, a...)
+	message = fmt.Sprintf("%q", message)
 	klog.Info(message)
 	// Since we're chrooted into the host rootfs with /run mounted,
 	// we can just talk to the journald socket.  Doing this as a

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -223,7 +223,7 @@ func (nw *clusterNodeWriter) SetUnreconcilable(err error) error {
 // SetDegraded logs the error and sets the state to Degraded.
 // Returns an error if it couldn't set the annotation.
 func (nw *clusterNodeWriter) SetDegraded(err error) error {
-	klog.Errorf("Marking Degraded due to: %v", err)
+	klog.Errorf("Marking Degraded due to: %q", err)
 	// truncatedErr caps error message at a reasonable length to limit the risk of hitting the total
 	// annotation size limit (256 kb) at any point
 	truncatedErr := fmt.Sprintf("%.2000s", err.Error())

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -113,13 +113,13 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	poolName := path.Base(r.URL.Path)
 	useragent := r.Header.Get("User-Agent")
 	acceptHeader := r.Header.Get("Accept")
-	klog.Infof("Pool %s requested by address:%q User-Agent:%q Accept-Header: %q", poolName, r.RemoteAddr, useragent, acceptHeader)
+	klog.Infof("Pool %q requested by address:%q User-Agent:%q Accept-Header: %q", poolName, r.RemoteAddr, useragent, acceptHeader)
 
 	reqConfigVer, err := detectSpecVersionFromAcceptHeader(acceptHeader)
 	if err != nil {
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusBadRequest)
-		klog.Error(err)
+		klog.Error(err.Error())
 		return
 	}
 
@@ -132,7 +132,7 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusInternalServerError)
-		klog.Errorf("couldn't get config for req: %v, error: %v", cr, err)
+		klog.Errorf("couldn't get config for req: %+v, error: %v", cr, err)
 		return
 	}
 	if conf == nil {


### PR DESCRIPTION
Closes: OCPBUGS-52421

**- What I did**
This includes:
- Changes part of the automated cherrypick PR #4899 
- Changes made for OCPBUGS-31777 in PR #4369 

Pulling in changes for OCPBUGS-31777 was necessary as it originally addressed many of the log issues highlighted in OCPBUGS-31778, but was not backported beyond 4.17.

**- How to verify it**
N/A

**- Description for the changelog**
OCPBUGS-31778: Update format verbs for daemon & server alert logs
