### PR TITLE
MCO-1584: Opt-in boot image updates for AWS & GCP by default

### DIFF
--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -486,3 +486,18 @@ func CheckNodeDisruptionActionsForTargetActions(actions []opv1.NodeDisruptionPol
 
 	return currentActions.HasAny(targetActions...)
 }
+
+// Returns a MachineConfiguration object with the cluster opted into boot image updates.
+func GetManagedBootImagesWithUpdateEnabled() opv1.ManagedBootImages {
+	return opv1.ManagedBootImages{MachineManagers: []opv1.MachineManager{{Resource: opv1.MachineSets, APIGroup: opv1.MachineAPI, Selection: opv1.MachineManagerSelector{Mode: opv1.All}}}}
+}
+
+// Returns a MachineConfiguration object with the cluster opted out of boot image updates.
+func GetManagedBootImagesWithUpdateDisabled() opv1.ManagedBootImages {
+	return opv1.ManagedBootImages{MachineManagers: []opv1.MachineManager{{Resource: opv1.MachineSets, APIGroup: opv1.MachineAPI, Selection: opv1.MachineManagerSelector{Mode: opv1.None}}}}
+}
+
+// Returns a MachineConfiguration object with an empty configuration; to be used in testing a situation where admin has no opinion.
+func GetManagedBootImagesWithNoConfiguration() opv1.ManagedBootImages {
+	return opv1.ManagedBootImages{}
+}

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -109,6 +109,9 @@ const (
 	// MCOOperatorKnobsObjectName is the name of the global MachineConfiguration "knobs" object that the MCO watches.
 	MCOOperatorKnobsObjectName = "cluster"
 
+	// BootImageOptedInAnnotation is used for book keeping when the MCO applies a default boot image configuration
+	BootImageOptedInAnnotation = "machineconfiguration.openshift.io/boot-image-updates-opted-in-at"
+
 	ServiceCARotateAnnotation = "machineconfiguration.openshift.io/service-ca-rotate"
 
 	ServiceCARotateTrue  = "true"

--- a/pkg/controller/common/featuregates.go
+++ b/pkg/controller/common/featuregates.go
@@ -52,9 +52,6 @@ func GetEnabledDisabledFeatures(features featuregates.FeatureGate) ([]string, []
 // IsBootImageControllerRequired checks that the currently enabled feature gates and
 // the platform of the cluster requires a boot image controller. If any errors are
 // encountered, it will log them and return false.
-// Current valid feature gate and platform combinations:
-// GCP -> FeatureGateManagedBootImages
-// AWS -> FeatureGateManagedBootImagesAWS
 func IsBootImageControllerRequired(ctx *ControllerContext) bool {
 	configClient := ctx.ClientBuilder.ConfigClientOrDie("ensure-boot-image-infra-client")
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.TODO(), "cluster", metav1.GetOptions{})
@@ -71,6 +68,13 @@ func IsBootImageControllerRequired(ctx *ControllerContext) bool {
 		klog.Errorf("unable to get features for boot image controller startup: %v", err)
 		return false
 	}
+	return CheckBootImagePlatform(infra, fg)
+}
+
+// Current valid feature gate and platform combinations:
+// GCP -> FeatureGateManagedBootImages
+// AWS -> FeatureGateManagedBootImagesAWS
+func CheckBootImagePlatform(infra *configv1.Infrastructure, fg featuregates.FeatureGate) bool {
 	switch infra.Status.PlatformStatus.Type {
 	case configv1.AWSPlatformType:
 		return fg.Enabled(features.FeatureGateManagedBootImagesAWS)

--- a/pkg/controller/machine-set-boot-image/helpers.go
+++ b/pkg/controller/machine-set-boot-image/helpers.go
@@ -84,11 +84,14 @@ func getMachineResourceSelectorFromMachineManagers(machineManagers []opv1.Machin
 	}
 	for _, machineManager := range machineManagers {
 		if machineManager.APIGroup == apiGroup && machineManager.Resource == resource {
-			if machineManager.Selection.Mode == opv1.Partial {
+			switch machineManager.Selection.Mode {
+			case opv1.Partial:
 				selector, err := metav1.LabelSelectorAsSelector(machineManager.Selection.Partial.MachineResourceSelector)
 				return true, selector, err
-			} else if machineManager.Selection.Mode == opv1.All {
+			case opv1.All:
 				return true, labels.Everything(), nil
+			case opv1.None:
+				return true, labels.Nothing(), nil
 			}
 		}
 	}

--- a/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
+++ b/pkg/controller/machine-set-boot-image/machine_set_boot_image_controller.go
@@ -395,7 +395,8 @@ func (ctrl *Controller) syncMAPIMachineSet(machineSet *machinev1beta1.MachineSet
 	// If the machineset has an owner reference, exit and report error. This means
 	// that the machineset may be managed by another workflow and should not be reconciled.
 	if len(machineSet.GetOwnerReferences()) != 0 {
-		return fmt.Errorf("unexpected OwnerReference: %v. Please remove this machineset from boot image management to avoid errors", machineSet.GetOwnerReferences()[0].Kind+"/"+machineSet.GetOwnerReferences()[0].Name)
+		klog.Infof("machineset %s has OwnerReference: %v, skipping boot image update", machineSet.GetOwnerReferences()[0].Kind+"/"+machineSet.GetOwnerReferences()[0].Name, machineSet.Name)
+		return nil
 	}
 
 	// Fetch the architecture type of this machineset

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -2270,7 +2270,9 @@ func (optr *Operator) syncMachineConfiguration(_ *renderConfig, _ *configv1.Clus
 			klog.Info("MachineConfiguration object doesn't exist; a new one will be created")
 			// Using server-side apply here as the NodeDisruption API has a rule technicality which prevents apply using a template manifest like the MCO typically does
 			// [spec.nodeDisruptionPolicy.sshkey.actions: Required value, <nil>: Invalid value: "null"]
-			p := mcoac.MachineConfiguration(ctrlcommon.MCOOperatorKnobsObjectName).WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed"))
+			p := mcoac.MachineConfiguration(ctrlcommon.MCOOperatorKnobsObjectName).
+				WithSpec(mcoac.MachineConfigurationSpec().
+					WithManagementState("Managed"))
 			_, err := optr.mcopClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 			if err != nil {
 				klog.Infof("applying mco object failed: %s", err)

--- a/test/e2e/msbic_test.go
+++ b/test/e2e/msbic_test.go
@@ -69,6 +69,9 @@ func TestBootImageReconciliationonSingleMachineSet(t *testing.T) {
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target one machineset for boot image updates")
 
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
 	// Pick a random machineset to test
 	machineSetUnderTest := getRandomMachineSet(t, machineClient)
 	t.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
@@ -123,6 +126,9 @@ func TestBootImageReconciliationonAllMachineSets(t *testing.T) {
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
 
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
 	machineSets, err := machineClient.MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
 	require.NoError(t, err, "failed to grab machineset list")
 
@@ -158,6 +164,9 @@ func TestBootImageReconciliationonNoMachineSets(t *testing.T) {
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target no machinesets for boot image updates")
+
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
 
 	machineSets, err := machineClient.MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
 	require.NoError(t, err, "failed to grab machineset list")
@@ -196,6 +205,8 @@ func TestBootImageDegradeCondition(t *testing.T) {
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
 
 	// Pick a random machineset to test
 	machineSetUnderTest := getRandomMachineSet(t, machineClient)
@@ -291,6 +302,9 @@ func TestStubIgnitionUpgrade(t *testing.T) {
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 
 	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
+
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
 
 	// Pick a random machineset to test
 	machineSetUnderTest := getRandomMachineSet(t, machineClient)
@@ -482,4 +496,33 @@ func getOldMAOSecret(name string) *corev1.Secret {
 		},
 		Data: map[string][]byte{"disableTemplating": []byte("true"), "userData": []byte(`{"ignition":{"config":{"append":[{"source":"https://test-cluster-api:22623/config/worker"}]},"security":{"tls":{"certificateAuthorities":[{"source":"data:text/plain;charset=utf-8;base64,LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClJPT1QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="}]}},"version":"2.2.0"}}`)},
 	}
+}
+
+// waitForMachineConfigurationStatus waits until the MCO syncs the operator status to the latest spec
+func waitForMachineConfigurationStatusUpdate(t *testing.T, cs *framework.ClientSet) error {
+
+	startTime := time.Now()
+
+	mcopClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	// Wait for mcop.Status to populate, otherwise error out. This shouldn't take very long
+	// as this is done by the operator sync loop.
+	if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, false, func(_ context.Context) (bool, error) {
+		mcop, pollError := mcopClient.OperatorV1().MachineConfigurations().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		if pollError != nil {
+			t.Logf("MachineConfiguration/cluster has not been created yet")
+			return false, nil
+		}
+
+		// Ensure status.ObservedGeneration matches the last generation of MachineConfiguration
+		if mcop.Generation != mcop.Status.ObservedGeneration {
+			t.Logf("MachineConfiguration.Status is not up to date.")
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("MachineConfiguration was not ready: (waited %s): %w", time.Since(startTime), err)
+	}
+
+	t.Logf("MachineConfiguration is ready (waited %v)", time.Since(startTime))
+	return nil
 }

--- a/test/e2e/msbic_test.go
+++ b/test/e2e/msbic_test.go
@@ -170,6 +170,7 @@ func TestBootImageReconciliationonNoMachineSets(t *testing.T) {
 }
 
 func TestBootImageDegradeCondition(t *testing.T) {
+	t.Skip("Temporarily skipping this test until boot image skew enforcement is implemented")
 
 	cs := framework.NewClientSet("")
 

--- a/test/e2e/msbic_test.go
+++ b/test/e2e/msbic_test.go
@@ -53,17 +53,17 @@ func TestBootImageReconciliationonSingleMachineSet(t *testing.T) {
 	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
 	labelSelector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "test", "fake-update-on")
 	applyLabelSelector := applymetav1.LabelSelector().WithMatchLabels(labelSelector.MatchLabels)
-
-	p := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().
-		WithManagementState("Managed").
-		WithManagedBootImages(mcoac.ManagedBootImages().
-			WithMachineManagers(mcoac.MachineManager().
-				WithAPIGroup(opv1.MachineAPI).
-				WithResource(opv1.MachineSets).
-				WithSelection(mcoac.MachineManagerSelector().
-					WithMode(opv1.Partial).
-					WithPartial(mcoac.PartialSelector().
-						WithMachineResourceSelector(applyLabelSelector))))))
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.Partial).
+						WithPartial(mcoac.PartialSelector().
+							WithMachineResourceSelector(applyLabelSelector))))))
 
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
@@ -110,7 +110,15 @@ func TestBootImageReconciliationonAllMachineSets(t *testing.T) {
 
 	// Update the machineconfiguration object to opt-in all machinesets
 	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
-	p := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed").WithManagedBootImages(mcoac.ManagedBootImages().WithMachineManagers(mcoac.MachineManager().WithAPIGroup(opv1.MachineAPI).WithResource(opv1.MachineSets).WithSelection(mcoac.MachineManagerSelector().WithMode(opv1.All)))))
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.All)))))
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
@@ -138,7 +146,15 @@ func TestBootImageReconciliationonNoMachineSets(t *testing.T) {
 
 	// Update the machineconfiguration object to opt-in no machinesets
 	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
-	p := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed").WithManagedBootImages(nil))
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.None)))))
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target no machinesets for boot image updates")
@@ -167,7 +183,15 @@ func TestBootImageDegradeCondition(t *testing.T) {
 
 	// Update the machineconfiguration object to opt-in all machinesets
 	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
-	p := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed").WithManagedBootImages(mcoac.ManagedBootImages().WithMachineManagers(mcoac.MachineManager().WithAPIGroup(opv1.MachineAPI).WithResource(opv1.MachineSets).WithSelection(mcoac.MachineManagerSelector().WithMode(opv1.All)))))
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.All)))))
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
 	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
 	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- The operator will begin to opt-in clusters for boot image updates by default on AWS and GCP, **except** for cases where the cluster already has an existing boot image update configuration.
- The operator will populate a new API field called `ManagedBootImagesStatus` in the `MachineConfiguration` object's status. This will reflect the `spec.managedBootImages` of the object. When the `spec.managedBootImages` is empty, it will reflect the cluster defaults. On platforms that have no boot image updates support, the `managedBootImagesStatus` field will be empty. Currently, only AWS and GCP will be opt-ed in by default. 
 
Following are some examples:

Scenario: No admin configuration and the current release **does not** opt-in by default:
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
spec:
status:
  managedBootImagesStatus:
    machineManagers:
    - resource: machinesets
      apiGroup: machine.openshift.io
      selection:
         mode: None
```
Scenario: No admin configuration and the current release **does** opt-in by default:
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
spec:
status:
  managedBootImagesStatus:
    machineManagers:
    - resource: machinesets
      apiGroup: machine.openshift.io
      selection:
         mode: All
```
Regardless of the default-on behavior of the release, if the admin were to add a configuration, the status must reflect that in the next update.
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
spec:
  managedBootImages:
    machineManagers:
    - resource: machinesets
      apiGroup: machine.openshift.io
      selection:
         mode: Partial
         partial:
           machineResourceSelector:
             matchLabels: {}
status:
  managedBootImagesStatus:
    machineManagers:
    - resource: machinesets
      apiGroup: machine.openshift.io
      selection:
         mode: Partial
         partial:
           machineResourceSelector:
             matchLabels: {}
```
Scenario: When the current release **does** not have boot image updates support:
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
spec:
status:
```

**- How to verify it**
- Bring up a cluster with this PR on the GCP/AWS platform. You should see the cluster come up with boot image updates enabled. Edit the `MachineConfiguration` to opt-out the cluster by using "None" example above. You can also set it to a different configuration such as the partial mode. The operator should not attempt to overwrite this configuration.
- Repeat the above procedure on any other platform, you should not see the operator attempt to opt-in the cluster to boot image updates by default.
- Bring up a cluster on GCP/AWS on a build without this PR. Set the `MachineConfiguration.Spec.ManagedBootImages` object to a value of your choosing. Upgrade the cluster to a build with this PR and check the `MachineConfiguration` object. The operator should not attempt to overwrite the configuration you chose pre-upgrade.
- Bring up a cluster on GCP/AWS on a build without this PR. Leave `MachineConfiguration.Spec.ManagedBootImages` field undefined. Upgrade the cluster to a build with this PR and check the `MachineConfiguration` object. The operator should have opt-ed in your cluster to boot image updates.
