### PR TITLE
OCPBUGS-51150: daemon: ensure ostree-finalize-staged is started before rebooting

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -270,6 +270,8 @@ func (e *ErrMissingMachineConfig) MissingMachineConfig() string {
 // https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 func rebootCommand(rationale string) *exec.Cmd {
 	return exec.Command("systemd-run", "--unit", "machine-config-daemon-reboot",
+		// we need this until we have https://github.com/ostreedev/ostree/pull/3389
+		"-p", "Requires=ostree-finalize-staged.service", "-p", "After=ostree-finalize-staged.service",
 		"--description", fmt.Sprintf("machine-config-daemon: %s", rationale), "/bin/sh", "-c", "systemctl reboot")
 }
 


### PR DESCRIPTION
This works around the race condition in libostree identified in https://issues.redhat.com/browse/OCPBUGS-51150

Since we're conveniently already running `reboot` via `systemd-run`, we can just inline more requirements to ensure that the transient unit doesn't start until `ostree-finalize-staged.service` has been started.

Fixes: https://issues.redhat.com/browse/OCPBUGS-51150