### PR TITLE
(not ready for review) OCPBUGS-52302: Fix timing of `Spec.ConfigVersion.Desired` update in MCN

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -665,12 +665,16 @@ func (ctrl *Controller) updateNode(old, cur interface{}) {
 			daemonconsts.DesiredImageAnnotationKey,
 		}
 
+		klog.Errorf("in updateNode with curNode: %v", curNode.Name)
+
 		for _, anno := range annos {
+			klog.Errorf("in updateNode anno loop for anno: %v", anno)
 			if !hasNodeAnnotationChanged(oldNode, curNode, anno) {
 				continue
 			}
 
 			newValue, ok := curNode.Annotations[anno]
+			klog.Errorf("in updateNode anno loop for anno: %v ned to update to new value: %v", anno, newValue)
 
 			var changedMsg string
 			var controlPlaneChangedMsg string

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1088,23 +1088,6 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 //
 //nolint:gocyclo
 func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertificateWrite bool) (retErr error) {
-	// Add the desired config version to the MCN
-	// 	get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
-	if err != nil {
-		return err
-	}
-	//  update the MCN spec
-	specErr := upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
-	if specErr != nil {
-		return fmt.Errorf("error updating MCN spec for node %s: %w", dn.node.Name, specErr)
-	}
-
-	// TODO: remove post testing
-	mcn, needNewMCN := upgrademonitor.CreateOrGetMachineConfigNode(dn.mcfgClient, dn.node)
-	klog.Errorf("mcn: %v", mcn)
-	klog.Errorf("needNewMCN: %v", needNewMCN)
-
 	oldConfig = canonicalizeEmptyMC(oldConfig)
 
 	if dn.nodeWriter != nil {
@@ -1126,16 +1109,27 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.CancelSIGTERM()
 	}()
 
-	// // Get MCP associated with node
-	// pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
-	// if err != nil {
-	// 	return err
-	// }
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
 
 	// Update the MCN's NodeNodeDegraded condition with the update result
 	defer func() {
 		dn.reportMachineNodeDegradeStatus(retErr, pool)
 	}()
+
+	// Add the desired config version to the MCN
+	specErr := upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
+	if specErr != nil {
+		return fmt.Errorf("error updating MCN spec for node %s: %w", dn.node.Name, specErr)
+	}
+
+	// TODO: remove post testing
+	mcn, needNewMCN := upgrademonitor.CreateOrGetMachineConfigNode(dn.mcfgClient, dn.node)
+	klog.Errorf("mcn: %v", mcn)
+	klog.Errorf("needNewMCN: %v", needNewMCN)
 
 	oldConfigName := oldConfig.GetName()
 	newConfigName := newConfig.GetName()

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1088,6 +1088,18 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 //
 //nolint:gocyclo
 func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertificateWrite bool) (retErr error) {
+	// Add the desired config version to the MCN
+	// 	get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
+	//  update the MCN spec
+	specErr := upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
+	if specErr != nil {
+		return fmt.Errorf("error updating MCN spec for node %s: %w", dn.node.Name, specErr)
+	}
+
 	oldConfig = canonicalizeEmptyMC(oldConfig)
 
 	if dn.nodeWriter != nil {
@@ -1109,11 +1121,11 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.CancelSIGTERM()
 	}()
 
-	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
-	if err != nil {
-		return err
-	}
+	// // Get MCP associated with node
+	// pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	// if err != nil {
+	// 	return err
+	// }
 
 	// Update the MCN's NodeNodeDegraded condition with the update result
 	defer func() {
@@ -1234,10 +1246,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		klog.Errorf("Error making MCN for Update Compatible: %v", err)
 	}
 
-	err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
-	if err != nil {
-		klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
-	}
+	// err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
+	// if err != nil {
+	// 	klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
+	// }
 	if drain {
 		if err := dn.performDrain(); err != nil {
 			return err

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1088,17 +1088,17 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 //
 //nolint:gocyclo
 func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertificateWrite bool) (retErr error) {
-	// Add the desired config version to the MCN
-	// 	get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
-	if err != nil {
-		return err
-	}
-	//  update the MCN spec
-	specErr := upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
-	if specErr != nil {
-		return fmt.Errorf("error updating MCN spec for node %s: %w", dn.node.Name, specErr)
-	}
+	// // Add the desired config version to the MCN
+	// // 	get MCP associated with node
+	// pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	// if err != nil {
+	// 	return err
+	// }
+	// //  update the MCN spec
+	// specErr := upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
+	// if specErr != nil {
+	// 	return fmt.Errorf("error updating MCN spec for node %s: %w", dn.node.Name, specErr)
+	// }
 
 	oldConfig = canonicalizeEmptyMC(oldConfig)
 
@@ -1121,11 +1121,11 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.CancelSIGTERM()
 	}()
 
-	// // Get MCP associated with node
-	// pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
-	// if err != nil {
-	// 	return err
-	// }
+	// Get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
 
 	// Update the MCN's NodeNodeDegraded condition with the update result
 	defer func() {
@@ -1246,10 +1246,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		klog.Errorf("Error making MCN for Update Compatible: %v", err)
 	}
 
-	// err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
-	// if err != nil {
-	// 	klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
-	// }
+	err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
+	if err != nil {
+		klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
+	}
 	if drain {
 		if err := dn.performDrain(); err != nil {
 			return err

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -412,6 +412,10 @@ func createOrGetMachineConfigNode(mcfgClient mcfgclientset.Interface, node *core
 	return mcNode, false
 }
 
+func CreateOrGetMachineConfigNode(mcfgClient mcfgclientset.Interface, node *corev1.Node) (*mcfgv1.MachineConfigNode, bool) {
+	return createOrGetMachineConfigNode(mcfgClient, node)
+}
+
 type ApplyCallback struct {
 	StatusConfigFn      func(applyConfig *machineconfigurationv1.MachineConfigNodeStatusApplyConfiguration)
 	MachineConfigNodeFn func(*mcfgv1.MachineConfigNode)

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -351,7 +351,7 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 	}
 	// get the existing MCN, or if it DNE create one below
 	mcNode, needNewMCNode := createOrGetMachineConfigNode(mcfgClient, node)
-	klog.Errorf("mcNode: %v", mcNode)
+	// klog.Errorf("mcNode: %v", mcNode)
 	klog.Errorf("needNewMCNode: %v", needNewMCNode)
 	newMCNode := mcNode.DeepCopy()
 	// set the spec config version
@@ -381,6 +381,7 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 		Name: node.Name,
 	}
 	if !needNewMCNode {
+		klog.Errorf("in !needNewMCNode conditional")
 		nodeRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCNode.Spec.Node.Name)
 		poolRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCNode.Spec.Pool.Name)
 		specconfigVersionApplyConfig := machineconfigurationv1.MachineConfigNodeSpecMachineConfigVersion().WithDesired(newMCNode.Spec.ConfigVersion.Desired)
@@ -392,12 +393,19 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 			return err
 		}
 	} else {
+		klog.Errorf("in else conditional, creating mcn")
 		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Create(context.TODO(), newMCNode, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("Error creating MCN: %v", err)
 			return err
 		}
 	}
+
+	// TODO: remove post debugging
+	// get the existing MCN, or if it DNE create one below
+	updatedMCN, _ := createOrGetMachineConfigNode(mcfgClient, node)
+	klog.Errorf("updatedMCN.Name: %v", updatedMCN.Name)
+	klog.Errorf("updatedMCN.Spec.ConfigVersion.Desired: %v", updatedMCN.Spec.ConfigVersion.Desired)
 	return nil
 }
 

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -336,6 +336,7 @@ func isSingletonCondition(singletonConditionTypes []mcfgv1.StateProgress, condit
 
 // GenerateAndApplyMachineConfigNodeSpec generates and applies a new MCN spec based off the node state
 func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAccess, pool string, node *corev1.Node, mcfgClient mcfgclientset.Interface) error {
+	klog.Errorf("in GenerateAndApplyMachineConfigNodeSpec with node: %v", node.Name)
 	if fgAccessor == nil || node == nil {
 		return nil
 	}
@@ -350,6 +351,8 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 	}
 	// get the existing MCN, or if it DNE create one below
 	mcNode, needNewMCNode := createOrGetMachineConfigNode(mcfgClient, node)
+	klog.Errorf("mcNode: %v", mcNode)
+	klog.Errorf("needNewMCNode: %v", needNewMCNode)
 	newMCNode := mcNode.DeepCopy()
 	// set the spec config version
 	newMCNode.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
@@ -361,6 +364,7 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 		},
 	}
 
+	klog.Errorf("node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]: %v", node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
 	newMCNode.Spec.ConfigVersion = mcfgv1.MachineConfigNodeSpecMachineConfigVersion{
 		Desired: node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey],
 	}

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -364,6 +364,7 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 		},
 	}
 
+	klog.Errorf("newMCNode.Spec.ConfigVersion.Desired: %v", newMCNode.Spec.ConfigVersion.Desired)
 	klog.Errorf("node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]: %v", node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey])
 	newMCNode.Spec.ConfigVersion = mcfgv1.MachineConfigNodeSpecMachineConfigVersion{
 		Desired: node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey],

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -336,10 +336,10 @@ func isSingletonCondition(singletonConditionTypes []mcfgv1.StateProgress, condit
 
 // GenerateAndApplyMachineConfigNodeSpec generates and applies a new MCN spec based off the node state
 func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAccess, pool string, node *corev1.Node, mcfgClient mcfgclientset.Interface) error {
-	klog.Errorf("in GenerateAndApplyMachineConfigNodeSpec with node: %v", node.Name)
 	if fgAccessor == nil || node == nil {
 		return nil
 	}
+	klog.Errorf("in GenerateAndApplyMachineConfigNodeSpec with node: %v", node.Name)
 	fg, err := fgAccessor.CurrentFeatureGates()
 	if err != nil {
 		klog.Errorf("Could not get fg: %v", err)


### PR DESCRIPTION
Closes: OCPBUGS-52302

**- What I did**
This moves the MCN spec update earlier in the update flow (before the compatibility check is started) to align with the intended functionality as highlighted in the [enhancement](https://github.com/openshift/enhancements/blob/303d29a216a4fcbf5d0860028e0cf724d0147122/enhancements/machine-config/machine-config-node.md?plain=1#L132) & [API discussions on the intent of the field](https://github.com/openshift/api/pull/2201#discussion_r1958746545).

**- How to verify it**
1. Create cluster with tech preview enabled.
2. Apply a MC.
3. Watch the MCN during the update. The `Spec.ConfigVersion.Desired` value should update before `Status.ConfigVersion.Desired`.
**To see the full MCN object**
```
$ oc describe machineconfignode/<node-name>
```

**The `DESIREDCONFIG` column in the following command is populated using `Spec.ConfigVersion.Desired` and should flip before the `UPDATEPREPARED` column flips to `True`.
```
$ oc get machineconfignodes -o wide
```

**- Description for the changelog**
OCPBUGS-52302: Fix timing of Spec.ConfigVersion.Desired update in MCN