### PR TITLE
OCPBUGS-53085: Add scc label to arbitor crio-metrics-proxy

### DIFF
--- a/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy.yaml
@@ -9,6 +9,7 @@ contents:
       namespace: openshift-machine-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       volumes:
       - name: etc-kube


### PR DESCRIPTION
I think we missed this originally since those PRs were being worked on around the same time.

Fixes e.g. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-metal-ovn-arbiter/1899662618499485696

Marking no-jira since we don't need to backport anything (and arbiter hasn't yet GA'ed)

cc @eggfoobar 