### PR TITLE
OCPBUGS-52827: Fixing typos for MachineConfigNode

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -125,7 +125,7 @@ func (dn *Daemon) executeReloadServiceNodeDisruptionAction(serviceName string, r
 
 	err := upgrademonitor.GenerateAndApplyMachineConfigNodes(
 		&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeUpdatePostActionComplete, Reason: string(mcfgalphav1.MachineConfigNodeUpdateReloaded), Message: fmt.Sprintf("Node has reloaded service %s", serviceName)},
-		&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeUpdateReloaded, Reason: fmt.Sprintf("%s%s", string(mcfgalphav1.MachineConfigNodeUpdatePostActionComplete), string(mcfgalphav1.MachineConfigNodeUpdateReloaded)), Message: fmt.Sprintf("Upgrade required a service %s reload. Completed this this as a post update action.", serviceName)},
+		&upgrademonitor.Condition{State: mcfgalphav1.MachineConfigNodeUpdateReloaded, Reason: fmt.Sprintf("%s%s", string(mcfgalphav1.MachineConfigNodeUpdatePostActionComplete), string(mcfgalphav1.MachineConfigNodeUpdateReloaded)), Message: fmt.Sprintf("Upgrade required a service %s reload. Completed this as a post update action.", serviceName)},
 		metav1.ConditionTrue,
 		metav1.ConditionTrue,
 		dn.node,

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -182,7 +182,7 @@ func generateAndApplyMachineConfigNodes(
 					metav1.Condition{
 						Type:               string(condType),
 						Message:            fmt.Sprintf("This node has not yet entered the %s phase", string(condType)),
-						Reason:             "NotYetOccured",
+						Reason:             "NotYetOccurred",
 						LastTransitionTime: metav1.Now(),
 						Status:             metav1.ConditionFalse,
 					})


### PR DESCRIPTION
Closes : OCPBUGS-52827

**- What I did**
Fixed typos for MachineConfigNode.

**- How to verify it**
N/A

**- Description for the changelog**
OCPBUGS-52827: Fixes typos for MachienConfigNode
