### PR TITLE
"NO-ISSUE: ensure that client configs are not mutable"

### DIFF
--- a/test/framework/clientset.go
+++ b/test/framework/clientset.go
@@ -39,9 +39,10 @@ type ClientSet struct {
 	mcfgclient mcfgclientset.Interface
 }
 
-// Allows the instantiation of additional clients with the same config.
+// Returns a copy of the config so that additional clients may be instantiated
+// from it. By making a copy, callers are free to modify the config as needed.
 func (cs *ClientSet) GetRestConfig() *rest.Config {
-	return cs.config
+	return rest.CopyConfig(cs.config)
 }
 
 func (cs *ClientSet) GetKubeconfig() (string, error) {


### PR DESCRIPTION
**- What I did**

This fixes a bug in CreateLongLivedPullSecret() where the base rest.Config was being mutated. Now, any calls to clientset.GetRestConfig() will get a copy of the config that can be mutated without affecting the original config.

**- How to verify it**

Run the test-ocl job. Also, run the onclustertesting devex helper, which is where this was occurring.

**- Description for the changelog**
Ensure that client configs are not mutable
