### PR TITLE
OCPNODE-2276: Set `Upgradeable=False` when cluster is on cgroup `v1`

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -279,6 +279,15 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error 
 		Reason: asExpectedReason,
 	}
 
+	configNode, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
+	if err != nil {
+		return err
+	}
+	if configNode.Spec.CgroupMode == configv1.CgroupModeV1 {
+		coStatusCondition.Status = configv1.ConditionFalse
+		coStatusCondition.Reason = "ClusterOnCgroupV1"
+		coStatusCondition.Message = "Cluster is using deprecated cgroup v1, which is removed in 4.19.  Please update the `CgroupMode` in the `nodes.config.openshift.io` object to 'v2'. This can be changed back to 'v1' while on 4.18, but must be 'v2' before you update to 4.19.  Once updated to 4.19, cgroup v1 is no longer an option"
+	}
 	var updating, degraded, interrupted bool
 	for _, pool := range pools {
 		// collect updating status but continue to check each pool to see if any pool is degraded

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -690,6 +690,14 @@ func TestOperatorSyncStatus(t *testing.T) {
 		configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
 
+		configNode := &configv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+			Spec:       configv1.NodeSpec{},
+		}
+		configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+		configNodeIndexer.Add(configNode)
+
 		for j, sync := range testCase.syncs {
 			optr.inClusterBringup = sync.inClusterBringUp
 			if sync.nextVersion != "" {
@@ -755,6 +763,14 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 			},
 		},
 	}
+
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
@@ -821,6 +837,13 @@ func TestKubeletSkewUnSupported(t *testing.T) {
 	})
 
 	co := &configv1.ClusterOperator{}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
@@ -920,6 +943,13 @@ func TestCustomPoolKubeletSkewUnSupported(t *testing.T) {
 	})
 
 	co := &configv1.ClusterOperator{}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})
@@ -1017,6 +1047,13 @@ func TestKubeletSkewSupported(t *testing.T) {
 	})
 
 	co := &configv1.ClusterOperator{}
+	configNode := &configv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterNodeInstanceName},
+		Spec:       configv1.NodeSpec{},
+	}
+	configNodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
+	configNodeIndexer.Add(configNode)
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse})
 	cov1helpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse})


### PR DESCRIPTION
CgroupMode `v1` is not supported in OCP-4.19
This change helps in preventing clusters to upgrade to 4.19 before updating the cluster to cgroupMode `v2`

This is a cherry-pick of https://github.com/openshift/machine-config-operator/pull/4822 