### PR TITLE
OCPBUGS-38869: Update desired config in MCN on OCL update

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -868,6 +868,18 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 	oldConfigName := oldConfig.GetName()
 	newConfigName := newConfig.GetName()
 
+	// Add the desired config version to the MCN
+	// 	get MCP associated with node
+	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if err != nil {
+		return err
+	}
+	//  update the MCN spec
+	err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.featureGatesAccessor, pool, dn.node, dn.mcfgClient)
+	if err != nil {
+		return fmt.Errorf("error updating MCN spec for node %s: %w", dn.node.Name, err)
+	}
+
 	oldIgnConfig, err := ctrlcommon.ParseAndConvertConfig(oldConfig.Spec.Config.Raw)
 	if err != nil {
 		return fmt.Errorf("parsing old Ignition config failed: %w", err)


### PR DESCRIPTION
Closes: OCPBUGS-38869

**- What I did**
This adds an MCN spec update during the OCL update flow to ensure the desired config version is properly set when OCL is enabled.

**- How to verify it**
1. Create a cluster and enable OCL.
2. Apply an MC targeting the MCP with OCL enabled.
3. Watch the MCN objects during the MC application.
   - The DESIREDCONFIG column in the `oc get machineconfignode` output should update properly.
   - The spec.configVersion.desired value in the `oc describe machineconfignode/<node-name>` output should update properly.

**- Description for the changelog**
 OCPBUGS-38869: Update desired config in MCN on OCL update
