### PR TITLE
[DO NOT MERGE]: validates assumptions about duplicate extensions and kargs

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -585,16 +585,6 @@ func DecodeIgnitionFileContents(source, compression *string) ([]byte, error) {
 	return contentsBytes, nil
 }
 
-// InSlice search for an element in slice and return true if found, otherwise return false
-func InSlice(elem string, slice []string) bool {
-	for _, k := range slice {
-		if k == elem {
-			return true
-		}
-	}
-	return false
-}
-
 // ValidateMachineConfig validates that given MachineConfig Spec is valid.
 func ValidateMachineConfig(cfg mcfgv1.MachineConfigSpec) error {
 	if !(cfg.KernelType == "" || cfg.KernelType == KernelTypeDefault || cfg.KernelType == KernelTypeRealtime || cfg.KernelType == KernelType64kPages) {

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -259,8 +259,6 @@ func TestMergeMachineConfigs(t *testing.T) {
 	cconfig.Spec.OSImageURL = "testURL"
 	cconfig.Spec.BaseOSContainerImage = "newformatURL"
 	fips := true
-	kargs := []string{"testKarg", "kargFromIgnitionDowngrade"}
-	extensions := []string{"testExtensions"}
 
 	// Test that a singular base config that sets FIPS also sets other defaults correctly
 	machineConfigFIPS := &mcfgv1.MachineConfig{
@@ -313,13 +311,31 @@ func TestMergeMachineConfigs(t *testing.T) {
 			OSImageURL: "overriddenURL",
 		},
 	}
-	machineConfigKernelArgs := &mcfgv1.MachineConfig{
+	machineConfigKernelArgs1 := &mcfgv1.MachineConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "kargs",
+			Name:   "kargs1",
 			Labels: map[string]string{MachineConfigRoleLabel: MachineConfigPoolWorker},
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			KernelArguments: kargs,
+			KernelArguments: []string{"karg-c"},
+		},
+	}
+	machineConfigKernelArgs2 := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kargs2",
+			Labels: map[string]string{MachineConfigRoleLabel: MachineConfigPoolWorker},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			KernelArguments: []string{"karg-c", "karg-b"},
+		},
+	}
+	machineConfigKernelArgs3 := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kargs3",
+			Labels: map[string]string{MachineConfigRoleLabel: MachineConfigPoolWorker},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			KernelArguments: []string{"karg-c", "karg-b", "karg-a"},
 		},
 	}
 	machineConfigKernelType := &mcfgv1.MachineConfig{
@@ -331,16 +347,33 @@ func TestMergeMachineConfigs(t *testing.T) {
 			KernelType: KernelTypeRealtime,
 		},
 	}
-	machineConfigExtensions := &mcfgv1.MachineConfig{
+	machineConfigExtensions1 := &mcfgv1.MachineConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "extension",
+			Name:   "extension1",
 			Labels: map[string]string{MachineConfigRoleLabel: MachineConfigPoolWorker},
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			Extensions: extensions,
+			Extensions: []string{"ext-c"},
 		},
 	}
-
+	machineConfigExtensions2 := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "extension2",
+			Labels: map[string]string{MachineConfigRoleLabel: MachineConfigPoolWorker},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Extensions: []string{"ext-c", "ext-b"},
+		},
+	}
+	machineConfigExtensions3 := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "extension3",
+			Labels: map[string]string{MachineConfigRoleLabel: MachineConfigPoolWorker},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Extensions: []string{"ext-c", "ext-b", "ext-a"},
+		},
+	}
 	machineConfigIgnSSHUser := helpers.CreateMachineConfigFromIgnitionWithMetadata(ign3types.Config{
 		Ignition: ign3types.Ignition{
 			Version: ign3types.MaxVersion.String(),
@@ -384,9 +417,13 @@ func TestMergeMachineConfigs(t *testing.T) {
 	// Now merge all of the above
 	inMachineConfigs = []*mcfgv1.MachineConfig{
 		machineConfigOSImageURL,
-		machineConfigKernelArgs,
+		machineConfigKernelArgs1,
+		machineConfigKernelArgs2,
+		machineConfigKernelArgs3,
 		machineConfigKernelType,
-		machineConfigExtensions,
+		machineConfigExtensions3,
+		machineConfigExtensions2,
+		machineConfigExtensions1,
 		machineConfigIgn,
 		machineConfigFIPS,
 		machineConfigIgnPasswdHashUser,
@@ -400,7 +437,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 	expectedMachineConfig = &mcfgv1.MachineConfig{
 		Spec: mcfgv1.MachineConfigSpec{
 			OSImageURL:      "overriddenURL",
-			KernelArguments: kargs,
+			KernelArguments: []string{"karg-c", "karg-c", "karg-b", "karg-c", "karg-b", "karg-a"},
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ign3types.Config{
 					Ignition: ign3types.Ignition{
@@ -415,7 +452,7 @@ func TestMergeMachineConfigs(t *testing.T) {
 			},
 			FIPS:       true,
 			KernelType: KernelTypeRealtime,
-			Extensions: extensions,
+			Extensions: []string{"ext-c", "ext-c", "ext-b", "ext-c", "ext-b", "ext-a"},
 		},
 	}
 	assert.Equal(t, *mergedMachineConfig, *expectedMachineConfig)

--- a/pkg/controller/common/slices.go
+++ b/pkg/controller/common/slices.go
@@ -1,0 +1,61 @@
+package common
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// InSlice search for an element in slice and return true if found, otherwise return false
+func InSlice(elem string, slice []string) bool {
+	for _, k := range slice {
+		if k == elem {
+			return true
+		}
+	}
+	return false
+}
+
+// DedupeSlice will ensure that all elements within a slice are unique while
+// preserving the slice's original order and the first appearance of any unique
+// elements.
+func DedupeSlice(slice []string) []string {
+	tracker := map[string]struct{}{}
+
+	out := []string{}
+
+	for _, item := range slice {
+		if _, ok := tracker[item]; ok {
+			continue
+		}
+
+		tracker[item] = struct{}{}
+		out = append(out, item)
+	}
+
+	return out
+}
+
+// Determines if two slices have the same unique elements without considering
+// order or duplicates.
+func IsSliceElementsEqual(a, b []string) bool {
+	return sets.New(a...).Equal(sets.New(b...))
+}
+
+// Determines if two slices have the same unique elements without considering
+// order. Two slices of different lengths will return false even if they have
+// the same unique elements.
+func IsSliceElementsAndLengthEqual(a, b []string) bool {
+	return len(a) == len(b) && IsSliceElementsEqual(a, b)
+}
+
+// Determines if a given slice has duplicate entries.
+func IsSliceElementsUnique(slice []string) bool {
+	tracker := map[string]struct{}{}
+
+	for _, item := range slice {
+		if _, ok := tracker[item]; ok {
+			return false
+		}
+
+		tracker[item] = struct{}{}
+	}
+
+	return true
+}

--- a/pkg/controller/common/slices_test.go
+++ b/pkg/controller/common/slices_test.go
@@ -1,0 +1,176 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInSlice(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    []string
+		element  string
+		expected bool
+	}{
+		{
+			name:     "Has element",
+			input:    []string{"value1", "value2"},
+			element:  "value2",
+			expected: true,
+		},
+		{
+			name:     "Does not have element",
+			input:    []string{"value1", "value2"},
+			element:  "value3",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, InSlice(testCase.element, testCase.input))
+		})
+	}
+}
+
+func TestDedupeSlice(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Duplicates removed",
+			input:    []string{"value1", "value1", "value1"},
+			expected: []string{"value1"},
+		},
+		{
+			name:     "Order preserved while removing duplicates",
+			input:    []string{"value1", "value2", "value3", "value2", "value1", "value4", "value3", "value1", "value5"},
+			expected: []string{"value1", "value2", "value3", "value4", "value5"},
+		},
+		{
+			name:     "Unsorted output",
+			input:    []string{"efg", "zyx", "abc", "efg", "abc", "zyx"},
+			expected: []string{"efg", "zyx", "abc"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			output := DedupeSlice(testCase.input)
+			assert.Equal(t, testCase.expected, DedupeSlice(testCase.input))
+			// Call again on its output to ensure that nothing changes.
+			assert.Equal(t, testCase.expected, DedupeSlice(output))
+		})
+	}
+}
+
+func TestIsSliceElementsEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected bool
+	}{
+		{
+			name:     "Equal",
+			a:        []string{"value1", "value2"},
+			b:        []string{"value1", "value2"},
+			expected: true,
+		},
+		{
+			name:     "Equal but different order",
+			a:        []string{"value1", "value2"},
+			b:        []string{"value2", "value1"},
+			expected: true,
+		},
+		{
+			name:     "Equal with duplicates",
+			a:        []string{"value1", "value1", "value2"},
+			b:        []string{"value1", "value2"},
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, IsSliceElementsEqual(testCase.a, testCase.b))
+		})
+	}
+}
+
+func TestIsSliceElementsAndLengthEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected bool
+	}{
+		{
+			name:     "Equal",
+			a:        []string{"value1", "value2"},
+			b:        []string{"value1", "value2"},
+			expected: true,
+		},
+		{
+			name:     "Equal but different order",
+			a:        []string{"value1", "value2"},
+			b:        []string{"value2", "value1"},
+			expected: true,
+		},
+		{
+			name:     "Equal with duplicates",
+			a:        []string{"value1", "value1", "value2"},
+			b:        []string{"value1", "value2", "value2"},
+			expected: true,
+		},
+		{
+			name: "Not equal with duplicates due to length",
+			a:    []string{"value1", "value1", "value2"},
+			b:    []string{"value1", "value2"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, IsSliceElementsAndLengthEqual(testCase.a, testCase.b))
+		})
+	}
+}
+
+func TestIsSliceElementsUnique(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    []string
+		expected bool
+	}{
+		{
+			name:     "Unique items",
+			input:    []string{"value1", "value2"},
+			expected: true,
+		},
+		{
+			name:     "Non-unique items",
+			input:    []string{"value1", "value1"},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, IsSliceElementsUnique(testCase.input))
+		})
+	}
+}


### PR DESCRIPTION
This PR does two primary things which are intended to be more illustrative as opposed to something that we should merge directly:

1. It adds additional test cases to ctrlcommon.MergeMachineConfigs() in order to validate the assumption that we do not de-duplicate kernel arguments or extensions and that we preserve the order of the individual kernel arguments and extensions lists.
2. It adds some additional helpers to aid in determining string slice equality, element uniqueness, etc. as well as tests to validate their correctness.
