### PR TITLE
OCPBUGS-53425: Make mtu-migration run after wait-for-primary-ip

### DIFF
--- a/templates/common/_base/units/mtu-migration.service.yaml
+++ b/templates/common/_base/units/mtu-migration.service.yaml
@@ -6,7 +6,7 @@ contents: |
   Description=Configures interfaces and routes with temporary MTUs during MTU migration
   Requires=openvswitch.service ovs-configuration.service
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service openvswitch.service network.service ovs-configuration.service
+  After=NetworkManager-wait-online.service openvswitch.service network.service ovs-configuration.service wait-for-primary-ip.service
   Before=kubelet-dependencies.target node-valid-hostname.service
 
   [Service]


### PR DESCRIPTION
When NMState is used to manage br-ex, we need mtu-migration to run after the wait-for-primary-ip service so we know the network is ready to go. If not, the script can have trouble getting the current configuration.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
