### PR TITLE
OCPBUGS-54175: Add /etc/docker/certs.d to template

### DIFF
--- a/templates/common/_base/files/etc-docker-certs.d.yaml
+++ b/templates/common/_base/files/etc-docker-certs.d.yaml
@@ -1,0 +1,5 @@
+mode: 0600
+path: "/etc/docker/certs.d/.create"
+contents:
+  inline: |
+    Initial Creation


### PR DESCRIPTION
OLMv1 uses containers/images/v5 which looks in the /etc/docker/certs.d directory for certificates used in image fetching. It is necessary for local registries as well as additional CAs specified in images.config.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added /etc/docker/certs.d to template

**- How to verify it**
Ensure /etc/docker/certs.d exists after cluster startup

**- Description for the changelog**
Add /etc/docker/certs.d to template
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
