### PR TITLE
OCPBUGS-52940: AWS Custom-DNS: Update services that run on control plane nodes

### DIFF
--- a/templates/common/aws/units/aws-update-dns.service.yaml
+++ b/templates/common/aws/units/aws-update-dns.service.yaml
@@ -1,8 +1,8 @@
-name: gcp-update-dns.service
-enabled: {{if and (eq .Infra.Status.PlatformStatus.Type "GCP") (.Infra.Status.PlatformStatus.GCP) (.Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig) (eq .Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType "ClusterHosted") }}true{{else}}false{{end}}
+name: aws-update-dns.service
+enabled: {{if and (eq .Infra.Status.PlatformStatus.Type "AWS") (.Infra.Status.PlatformStatus.AWS) (.Infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig) (eq .Infra.Status.PlatformStatus.AWS.CloudLoadBalancerConfig.DNSType "ClusterHosted") }}true{{else}}false{{end}}
 contents: |
   [Unit]
-  Description=Update Default GCP Resolver
+  Description=Update Default AWS Resolver
   # We don't need to do this on the firstboot
   After=firstboot-osupdate.target
   # Wait for NetworkManager to report it's online

--- a/templates/common/cloud-platform-alt-dns/files/usr-local-bin-update-dns-server.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/usr-local-bin-update-dns-server.yaml
@@ -3,9 +3,9 @@ path: "/usr/local/bin/update-dns-server"
 contents:
   inline: |
     #!/bin/bash
-    # For GCP, updating the NetworkManager configuration file to
+    # Updating the NetworkManager configuration file to
     # include the IP address of the local node as the default DNS
-    # resolver when UserProvisionedDNS is enabled.
+    # resolver when UserProvisionedDNS is enabled on cloud platforms.
     # A CoreDNS static pod running on the node is responsible for
     # resolving the api, api-int and *.apps URLs.
 
@@ -14,7 +14,7 @@ contents:
     cat <<EOF | tee /etc/NetworkManager/conf.d/dns-servers.conf
     # Added by OpenShift
     [global-dns-domain-*]
-    servers=$(ip --json route get 8.8.8.8 | jq -r ".[0].prefsrc"),169.254.169.254
+    servers=$(ip --json route get 8.8.8.8 | jq -r ".[0].prefsrc"),$1
     EOF
 
     # network manager may already be running at this point.


### PR DESCRIPTION
New `update-dns-server` script that adds DNS resolvers to /etc/NetworkManager/conf.d/dns-servers.conf. The script adds the host's own IP address and the cloud metadata server's IP address to the conf file. These would then get added to the local resolv.conf by NetworkManager.
This script is run as part of aws-update-dns.service This service runs when the DNSType on the AWS platform is set to "ClusterHosted".

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
