### PR TITLE
OCPBUGS-54161: use the same success criteria for OCL e2e tests

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -250,12 +250,15 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 // podToJob creates a Job with the spec of the given Pod
 func (br buildRequestImpl) podToJob(pod *corev1.Pod) *batchv1.Job {
 	// Set the backoffLimit to 3 so the job will retry 4 times before reporting a failure
-	var backoffLimit int32 = 3
+	var backoffLimit int32 = constants.JobMaxRetries
+
 	// Set completion to 1 so that as soon as the pod has completed successfully the job is
 	// considered a success
-	var completions int32 = 1
+	var completions int32 = constants.JobCompletions
+
 	// Set the owner ref of the job to the MOSB
 	oref := metav1.NewControllerRef(br.opts.MachineOSBuild, mcfgv1.SchemeGroupVersion.WithKind("MachineOSBuild"))
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pod.ObjectMeta.Name,

--- a/pkg/controller/build/constants/constants.go
+++ b/pkg/controller/build/constants/constants.go
@@ -63,3 +63,9 @@ const (
 	EtcYumReposDAnnotationKey      = entitlementsAnnotationKeyBase + EtcYumReposDConfigMapName
 	EtcPkiRpmGpgAnnotationKey      = entitlementsAnnotationKeyBase + EtcPkiRpmGpgSecretName
 )
+
+// batchv1.Job configuration
+const (
+	JobMaxRetries  int32 = 3
+	JobCompletions int32 = 1
+)

--- a/pkg/controller/build/imagebuilder/jobimagebuilder_test.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder_test.go
@@ -12,6 +12,7 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/buildrequest"
+	"github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/fixtures"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/utils"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -100,7 +101,7 @@ func TestJobImageBuilder(t *testing.T) {
 			js: fixtures.JobStatus{
 				Active:    0,
 				Succeeded: 0,
-				Failed:    4,
+				Failed:    constants.JobMaxRetries + 1,
 			},
 		},
 	}


### PR DESCRIPTION
**- What I did**

There was a potential discrepancy in the success / fail criteria for *batchv1.Jobs in our E2E tests which could potentially explain why the `TestControllerEventuallyReconciles` test frequently fails. The following serves as a potential remedy:

- Set some of the values such as maxBackoff and completions as constants so that we can adjust them more easily in the future since we'll only have to adjust them in one place.
- Exported the `MapJobToBuildStatus()` function from `imagebuilder` and modified the `TestControllerEventuallyReconciles` to use that plus the various MachineOSBuild statuses in order to determine whether a job is successful or not.

**- How to verify it**

Run e2e-gcp-op-ocl

**- Description for the changelog**
Use the same success criteria for OCL e2e tests
