### PR TITLE
MCO-1505: allows user-configurable resource requests and limits via MachineOSConfig annotations

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequest_test.go
+++ b/pkg/controller/build/buildrequest/buildrequest_test.go
@@ -161,7 +161,10 @@ func TestBuildRequest(t *testing.T) {
 				assert.NotContains(t, containerfile, content)
 			}
 
-			buildJob := br.Builder().GetObject().(*batchv1.Job)
+			builder, err := br.Builder()
+			assert.NoError(t, err)
+
+			buildJob := builder.GetObject().(*batchv1.Job)
 
 			_, err = NewBuilder(buildJob)
 			assert.NoError(t, err)

--- a/pkg/controller/build/buildrequest/interfaces.go
+++ b/pkg/controller/build/buildrequest/interfaces.go
@@ -7,7 +7,7 @@ import (
 
 type BuildRequest interface {
 	Opts() BuildRequestOpts
-	Builder() Builder
+	Builder() (Builder, error)
 	Secrets() ([]*corev1.Secret, error)
 	ConfigMaps() ([]*corev1.ConfigMap, error)
 }

--- a/pkg/controller/build/buildrequest/resources.go
+++ b/pkg/controller/build/buildrequest/resources.go
@@ -1,0 +1,199 @@
+package buildrequest
+
+import (
+	"fmt"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type resourceAnnotationKey string
+
+// Resource request and limit annotation keys
+const (
+	cpuResourceRequestAnnotationKey              resourceAnnotationKey = "machineconfiguration.openshift.io/cpu-request"
+	cpuResourceLimitAnnotationKey                resourceAnnotationKey = "machineconfiguration.openshift.io/cpu-limit"
+	memoryResourceRequestAnnotationKey           resourceAnnotationKey = "machineconfiguration.openshift.io/memory-request"
+	memoryResourceLimitAnnotationKey             resourceAnnotationKey = "machineconfiguration.openshift.io/memory-limit"
+	storageResourceRequestAnnotationKey          resourceAnnotationKey = "machineconfiguration.openshift.io/storage-request"
+	storageResourceLimitAnnotationKey            resourceAnnotationKey = "machineconfiguration.openshift.io/storage-limit"
+	ephemeralStorageResourceRequestAnnotationKey resourceAnnotationKey = "machineconfiguration.openshift.io/ephemeral-storage-request"
+	ephemeralStorageResourceLimitAnnotationKey   resourceAnnotationKey = "machineconfiguration.openshift.io/ephemeral-storage-limit"
+
+	// Default CPU request value. Taken from the machine-os-builder deployment
+	// spec.
+	defaultCPURequest string = "20m"
+	// Default memory request value. Taken from the machine-os-builder deployment
+	// spec.
+	defaultMemoryRequest string = "50Mi"
+)
+
+// Holds all of the functions required for getting the resource requests. This
+// allows to keep these functions cleanly separated while simultaneously
+// allowing a single linear path through them.
+type resources struct {
+	mosc *mcfgv1.MachineOSConfig
+}
+
+// The finalized resource requirements for both the builder container as well
+// as the waiting container.
+type resourceRequirements struct {
+	builder  *corev1.ResourceRequirements
+	defaults *corev1.ResourceRequirements
+}
+
+// The main entrypoint into getting the resource requirements for the
+// BuildRequest.
+func getResourceRequirements(mosc *mcfgv1.MachineOSConfig) (*resourceRequirements, error) {
+	r := &resources{mosc: mosc}
+
+	builder, err := r.getBuilderResourceRequirements()
+	if err != nil {
+		return nil, fmt.Errorf("could not get ResourceRequirements for builder: %w", err)
+	}
+
+	defaults, err := r.getDefaultResourceRequirements()
+	if err != nil {
+		return nil, fmt.Errorf("could not get ResourceRequiremnts for defaults: %w", err)
+	}
+
+	return &resourceRequirements{
+		builder:  builder,
+		defaults: defaults,
+	}, nil
+}
+
+// Gets the resource requirements for the build pod from the MachineOSConfig
+// annotations or falls back to the default hard-coded values we specified.
+func (r *resources) getBuilderResourceRequirements() (*corev1.ResourceRequirements, error) {
+	defaults, err := r.getDefaultResourceRequirements()
+	if err != nil {
+		return nil, err
+	}
+
+	userProvided, err := r.getUserProvidedResourceRequirements()
+	if err != nil {
+		return nil, fmt.Errorf("could not get user-provided ResourceRequirements: %w", err)
+	}
+
+	// If no user-provided values are found, return early.
+	if userProvided == nil {
+		return defaults, nil
+	}
+
+	// User-provided requests override the default requests.
+	for key, val := range userProvided.Requests {
+		defaults.Requests[key] = val
+	}
+
+	// User-provided limits override the default limits.
+	for key, val := range userProvided.Limits {
+		defaults.Limits[key] = val
+	}
+
+	return defaults, nil
+}
+
+// Gets the default resource requirements.
+func (r *resources) getDefaultResourceRequirements() (*corev1.ResourceRequirements, error) {
+	requestList, err := getResourceList(map[corev1.ResourceName]string{
+		corev1.ResourceCPU:    defaultCPURequest,
+		corev1.ResourceMemory: defaultMemoryRequest,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot get RequestList for default resource requirements: %w", err)
+	}
+
+	return &corev1.ResourceRequirements{
+		Requests: requestList,
+		Limits:   corev1.ResourceList{},
+	}, nil
+}
+
+// Gets the user-provided resource requirements, if any.
+func (r *resources) getUserProvidedResourceRequirements() (*corev1.ResourceRequirements, error) {
+	requests, err := r.getResourceListFromAnnotations(map[corev1.ResourceName]resourceAnnotationKey{
+		corev1.ResourceCPU:              cpuResourceRequestAnnotationKey,
+		corev1.ResourceMemory:           memoryResourceRequestAnnotationKey,
+		corev1.ResourceStorage:          storageResourceRequestAnnotationKey,
+		corev1.ResourceEphemeralStorage: ephemeralStorageResourceRequestAnnotationKey,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not get user-provided resource requests: %w", err)
+	}
+
+	limits, err := r.getResourceListFromAnnotations(map[corev1.ResourceName]resourceAnnotationKey{
+		corev1.ResourceCPU:              cpuResourceLimitAnnotationKey,
+		corev1.ResourceMemory:           memoryResourceLimitAnnotationKey,
+		corev1.ResourceStorage:          storageResourceLimitAnnotationKey,
+		corev1.ResourceEphemeralStorage: ephemeralStorageResourceLimitAnnotationKey,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not get user-provided resource limits: %w", err)
+	}
+
+	// If no user-provided resources are found, return nil here since there is
+	// nothing further to do.
+	if len(requests) == 0 && len(limits) == 0 {
+		return nil, nil
+	}
+
+	return &corev1.ResourceRequirements{
+		Requests: requests,
+		Limits:   limits,
+	}, nil
+}
+
+// Gets the ResourceList from the MachineOSConfig annotation.
+func (r *resources) getResourceListFromAnnotations(in map[corev1.ResourceName]resourceAnnotationKey) (corev1.ResourceList, error) {
+	out := corev1.ResourceList{}
+
+	for name, annoKey := range in {
+		val, ok := r.mosc.Annotations[string(annoKey)]
+		if !ok {
+			continue
+		}
+
+		qty, err := parseResourceQuantity(val)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse annotation %q value %q: %w", annoKey, val, err)
+		}
+
+		out[name] = qty
+	}
+
+	return out, nil
+}
+
+// Parses the resource string for each resource name into a resource.Quantity
+// and inserts it into a ResourceList. This is needed because the
+// resource.Quantity values are private.
+func getResourceList(in map[corev1.ResourceName]string) (corev1.ResourceList, error) {
+	out := corev1.ResourceList{}
+
+	for name, qtyStr := range in {
+		qty, err := parseResourceQuantity(qtyStr)
+		if err != nil {
+			return nil, err
+		}
+
+		out[name] = qty
+	}
+
+	return out, nil
+}
+
+// Parses a string into a resource quantity. This was made into its own
+// function for more consistent error wrapping.
+func parseResourceQuantity(qtyStr string) (resource.Quantity, error) {
+	qty, err := resource.ParseQuantity(qtyStr)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("could not parse %q into a resource.Quantity: %w", qtyStr, err)
+	}
+
+	return qty, nil
+}

--- a/pkg/controller/build/buildrequest/resources_test.go
+++ b/pkg/controller/build/buildrequest/resources_test.go
@@ -1,0 +1,234 @@
+package buildrequest
+
+import (
+	"testing"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Validates that resource requirements are set correctly, based upon whether
+// they are user-provided or the system defaults. This is done by ensuring that
+// the resource request annotations from the MachineOSConfig are honored. These
+// are checked both in isolation as well as on a per-container basis.
+//
+// In the future, the MachineOSConfig API should be modified to allow the
+// corev1.ResourceRequirements struct to be embedded within it. That would make
+// this test mostly moot with the exception of allowing default values.
+func TestResources(t *testing.T) {
+	t.Parallel()
+
+	// Gets a ResourceList, but fails the test if err is not nil. Used as a closure to
+	// ensure that it only be used during unit tests.
+	mustGetResourceList := func(in map[corev1.ResourceName]string) corev1.ResourceList {
+		l, err := getResourceList(in)
+		require.NoError(t, err)
+		return l
+	}
+
+	defaultResourceReq := &corev1.ResourceRequirements{
+		Requests: mustGetResourceList(map[corev1.ResourceName]string{
+			corev1.ResourceCPU:    defaultCPURequest,
+			corev1.ResourceMemory: defaultMemoryRequest,
+		}),
+		Limits: corev1.ResourceList{},
+	}
+
+	req, err := getResourceRequirements(&mcfgv1.MachineOSConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, req.defaults, defaultResourceReq)
+
+	testCases := []struct {
+		name              string
+		annotations       map[resourceAnnotationKey]string
+		expectedResources *corev1.ResourceRequirements
+		errExpected       bool
+	}{
+		{
+			name:              "No resource requests",
+			annotations:       map[resourceAnnotationKey]string{},
+			expectedResources: defaultResourceReq,
+		},
+		{
+			name: "CPU request only",
+			annotations: map[resourceAnnotationKey]string{
+				cpuResourceRequestAnnotationKey: "750m",
+			},
+			expectedResources: &corev1.ResourceRequirements{
+				Requests: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:    "750m",
+					corev1.ResourceMemory: defaultMemoryRequest,
+				}),
+				Limits: corev1.ResourceList{},
+			},
+		},
+		{
+			name: "Memory request only",
+			annotations: map[resourceAnnotationKey]string{
+				memoryResourceRequestAnnotationKey: "2Gi",
+			},
+			expectedResources: &corev1.ResourceRequirements{
+				Requests: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:    defaultCPURequest,
+					corev1.ResourceMemory: "2Gi",
+				}),
+				Limits: corev1.ResourceList{},
+			},
+		},
+		{
+			name: "Requests only",
+			annotations: map[resourceAnnotationKey]string{
+				cpuResourceRequestAnnotationKey:              "750m",
+				memoryResourceRequestAnnotationKey:           "2Gi",
+				storageResourceRequestAnnotationKey:          "20Gi",
+				ephemeralStorageResourceRequestAnnotationKey: "20Gi",
+			},
+			expectedResources: &corev1.ResourceRequirements{
+				Requests: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:              "750m",
+					corev1.ResourceMemory:           "2Gi",
+					corev1.ResourceStorage:          "20Gi",
+					corev1.ResourceEphemeralStorage: "20Gi",
+				}),
+				Limits: corev1.ResourceList{},
+			},
+		},
+		{
+			name: "Limits only",
+			annotations: map[resourceAnnotationKey]string{
+				cpuResourceLimitAnnotationKey:              "750m",
+				memoryResourceLimitAnnotationKey:           "2Gi",
+				storageResourceLimitAnnotationKey:          "20Gi",
+				ephemeralStorageResourceLimitAnnotationKey: "20Gi",
+			},
+			expectedResources: &corev1.ResourceRequirements{
+				Requests: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:    defaultCPURequest,
+					corev1.ResourceMemory: defaultMemoryRequest,
+				}),
+				Limits: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:              "750m",
+					corev1.ResourceMemory:           "2Gi",
+					corev1.ResourceStorage:          "20Gi",
+					corev1.ResourceEphemeralStorage: "20Gi",
+				}),
+			},
+		},
+		{
+			name: "Requests and limits",
+			annotations: map[resourceAnnotationKey]string{
+				cpuResourceRequestAnnotationKey:              "750m",
+				memoryResourceRequestAnnotationKey:           "2Gi",
+				storageResourceRequestAnnotationKey:          "20Gi",
+				ephemeralStorageResourceRequestAnnotationKey: "20Gi",
+				cpuResourceLimitAnnotationKey:                "750m",
+				memoryResourceLimitAnnotationKey:             "2Gi",
+				storageResourceLimitAnnotationKey:            "20Gi",
+				ephemeralStorageResourceLimitAnnotationKey:   "20Gi",
+			},
+			expectedResources: &corev1.ResourceRequirements{
+				Requests: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:              "750m",
+					corev1.ResourceMemory:           "2Gi",
+					corev1.ResourceStorage:          "20Gi",
+					corev1.ResourceEphemeralStorage: "20Gi",
+				}),
+				Limits: mustGetResourceList(map[corev1.ResourceName]string{
+					corev1.ResourceCPU:              "750m",
+					corev1.ResourceMemory:           "2Gi",
+					corev1.ResourceStorage:          "20Gi",
+					corev1.ResourceEphemeralStorage: "20Gi",
+				}),
+			},
+		},
+		{
+			name: "Invalid resource quantity",
+			annotations: map[resourceAnnotationKey]string{
+				cpuResourceRequestAnnotationKey: "invalid-value",
+			},
+			errExpected: true,
+		},
+		{
+			name: "Empty annotation value",
+			annotations: map[resourceAnnotationKey]string{
+				cpuResourceRequestAnnotationKey: "",
+			},
+			// TODO: What happens when a resource field is requested but is empty?
+			// This should mimic that behavior.
+			errExpected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("ResourceRequests", func(t *testing.T) {
+				t.Parallel()
+
+				opts := getBuildRequestOpts()
+
+				if testCase.annotations != nil {
+					for key, val := range testCase.annotations {
+						opts.MachineOSConfig.Annotations[string(key)] = val
+					}
+				}
+
+				resourceReq, err := getResourceRequirements(opts.MachineOSConfig)
+				if testCase.errExpected {
+					assert.Error(t, err)
+					t.Log(err)
+					return
+				}
+
+				assert.Equal(t, testCase.expectedResources, resourceReq.builder)
+			})
+
+			t.Run("BuildRequest", func(t *testing.T) {
+				t.Parallel()
+
+				opts := getBuildRequestOpts()
+
+				if testCase.annotations != nil {
+					for key, val := range testCase.annotations {
+						opts.MachineOSConfig.Annotations[string(key)] = val
+					}
+				}
+
+				br := newBuildRequest(opts)
+
+				builder, err := br.Builder()
+				if testCase.errExpected {
+					assert.Error(t, err)
+					t.Log(err)
+					return
+				}
+
+				assert.NoError(t, err)
+
+				buildJob := builder.GetObject().(*batchv1.Job)
+				// TODO(zzlotnik): This field is still alpha and is not respected when the
+				// PodLevelResources feature gate is not enabled. Additionally, this
+				// field only accepts CPU and memory values, so non-CPU / memory values
+				// should be stripped.
+				//
+				// assert.Equal(t, testCase.expectedResources, buildJob.Spec.Template.Spec.Resources)
+
+				for _, container := range buildJob.Spec.Template.Spec.Containers {
+					if container.Name == imageBuildContainerName {
+						assert.Equal(t, *testCase.expectedResources, container.Resources)
+					}
+
+					if container.Name == waitForDoneContainerName {
+						assert.Equal(t, *defaultResourceReq, container.Resources)
+					}
+				}
+			})
+		})
+	}
+}

--- a/pkg/controller/build/imagebuilder/base.go
+++ b/pkg/controller/build/imagebuilder/base.go
@@ -197,5 +197,5 @@ func (b *baseImageBuilder) prepareForBuild(ctx context.Context) (buildrequest.Bu
 
 	b.buildrequest = br
 
-	return br.Builder(), nil
+	return br.Builder()
 }

--- a/pkg/controller/build/imagebuilder/preparer_test.go
+++ b/pkg/controller/build/imagebuilder/preparer_test.go
@@ -60,7 +60,10 @@ func TestPreparer(t *testing.T) {
 	// c3 uses the Builder object from the BuildRequest instead so that we can
 	// ensure that ephemeral build objects will be removed even if only the Builder object
 	// is available.
-	c3 := newCleanerFromBuilder(kubeclient, mcfgclient, br3.Builder())
+
+	build, err := br3.Builder()
+	require.NoError(t, err)
+	c3 := newCleanerFromBuilder(kubeclient, mcfgclient, build)
 
 	// Cleanup the ephemeral objects from the first MachineOSBuild.
 	assert.NoError(t, c1.Clean(ctx))

--- a/pkg/controller/build/osbuildcontroller_test.go
+++ b/pkg/controller/build/osbuildcontroller_test.go
@@ -639,7 +639,10 @@ func TestOSBuildControllerReconcilesJobsAfterRestart(t *testing.T) {
 			br, err := buildrequest.NewBuildRequestFromAPI(ctx, kubeclient, mcfgclient, apiMosb, mosc)
 			require.NoError(t, err)
 
-			buildJob := br.Builder().GetObject().(*batchv1.Job)
+			builder, err := br.Builder()
+			require.NoError(t, err)
+
+			buildJob := builder.GetObject().(*batchv1.Job)
 
 			_, err = kubeclient.BatchV1().Jobs(ctrlcommon.MCONamespace).Create(ctx, buildJob, metav1.CreateOptions{})
 			require.NoError(t, err)


### PR DESCRIPTION
**- What I did**

To allow resource requests and limits to be set for on-cluster layering (OCL), I added the capability of setting these values via an annotation on the MachineOSConfig object. Additionally, in the absence of these annotations being set, we now have a default resource request set that mirrors the resource requests of the rest of the MCO's components.

**- How to verify it**

1. Bring up an OCL-enabled cluster.
2. Set any of the following annotations on a MachineOSConfig:
    - `machineconfiguration.openshift.io/cpu-request`
    - `machineconfiguration.openshift.io/cpu-limit`
    - `machineconfiguration.openshift.io/memory-request`
    - `machineconfiguration.openshift.io/memory-limit`
    - `machineconfiguration.openshift.io/storage-request`
    - `machineconfiguration.openshift.io/storage-limit`
    - `machineconfiguration.openshift.io/ephemeral-storage-request`
    - `machineconfiguration.openshift.io/ephemeral-storage-limit`
3. Trigger a new build.
4. The containers on the pod where the new MachineOSBuild is running should have those resource requests / limits set.

In the absence of those values being set, CPU should be set to `20m` and memory should be set to `50Mi`. The default resource request values are the same as the ones applied to the various MCO components.

**- Description for the changelog**
Allows user-configurable resource requests and limits via MachineOSConfig annotations
