### PR TITLE
OCPBUGS-52656: Update the MCN PIS status of only the primary pool

### DIFF
--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -220,17 +220,23 @@ func (p *PinnedImageSetManager) sync(key string) error {
 		return nil
 	}
 
+	primaryPool, err := helpers.GetPrimaryPoolForNode(p.mcpLister, node)
+	if err != nil {
+		klog.Errorf("error getting primary pool for node: %v", node.Name)
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), p.prefetchTimeout)
 	// cancel any currently running tasks in the worker pool
 	p.resetWorkload(cancel)
-	if err := p.updateStatusProgressing(pools); err != nil {
+	if err := p.updateStatusProgressing([]*mcfgv1.MachineConfigPool{primaryPool}); err != nil {
 		klog.Errorf("failed to update status: %v", err)
 	}
 
 	if err := p.syncMachineConfigPools(ctx, pools); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			ctxErr := fmt.Errorf("%w: %v", errRequeueAfterTimeout, p.prefetchTimeout)
-			if err := p.updateStatusError(pools, ctxErr); err != nil {
+			if err := p.updateStatusError([]*mcfgv1.MachineConfigPool{primaryPool}, ctxErr); err != nil {
 				klog.Errorf("failed to update status: %v", err)
 			}
 			klog.Info(ctxErr)
@@ -238,13 +244,13 @@ func (p *PinnedImageSetManager) sync(key string) error {
 		}
 
 		klog.Error(err)
-		if err := p.updateStatusError(pools, err); err != nil {
+		if err := p.updateStatusError([]*mcfgv1.MachineConfigPool{primaryPool}, err); err != nil {
 			klog.Errorf("failed to update status: %v", err)
 		}
 		return err
 	}
 
-	return p.updateStatusProgressingComplete(pools, "All pinned image sets complete")
+	return p.updateStatusProgressingComplete([]*mcfgv1.MachineConfigPool{primaryPool}, "All pinned image sets complete")
 }
 
 func (p *PinnedImageSetManager) syncMachineConfigPools(ctx context.Context, pools []*mcfgv1.MachineConfigPool) error {


### PR DESCRIPTION
**- What I did**
Do not add the same PIS to the MCNStatusPIS for separate different MCPs

**- How to verify it**
1) Create a custom MCP
2) Add a worker node to the custom MCP
3) Create a PIS targeting the Worker MCP
4) Look at the MCD logs and ensure no error like "Failed to update MCN status" pops up


**- Description for the changelog**
<!--
Update the status of only the primary pool
-->
