### PR TITLE
NO-ISSUE: MCN changes for API validation

### DIFF
--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -20,7 +20,7 @@ import (
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 )
 
-const NotYetSet = "NotYetSet"
+const NotYetSet = "not-yet-set"
 
 type Condition struct {
 	State   mcfgalphav1.StateProgress


### PR DESCRIPTION
**- What I did**
Update the `NotYetSet` constant used throughout the upgrade monitor to match the validation enforced by the [updated MCN API](https://github.com/openshift/api/pull/2201).
 
**- How to verify it**
Launch cluster with this and the API PR.
```
launch 4.19,openshift/api#2201,openshift/machine-config-operator#4949 aws,techpreview
```

**- Description for the changelog**
Upgrade monitor: Update default NotYetSet placeholder constant