### PR TITLE
NO-ISSUE: change branch to main for openshift/api ref in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test-e2e-ocl: install-go-junit-report
 
 bootstrap-e2e: install-go-junit-report install-setup-envtest
 	@echo "Setting up KUBEBUILDER_ASSETS"
-	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --index https://raw.githubusercontent.com/openshift/api/master/envtest-releases.yaml --bin-dir $(PROJECT_DIR)/bin -p path)" && \
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --index https://raw.githubusercontent.com/openshift/api/main/envtest-releases.yaml --bin-dir $(PROJECT_DIR)/bin -p path)" && \
 	echo "KUBEBUILDER_ASSETS=$$KUBEBUILDER_ASSETS" && \
 	set -o pipefail && \
 	KUBEBUILDER_ASSETS=$$KUBEBUILDER_ASSETS go test -tags=$(GOTAGS) -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-bootstrap/ | ./hack/test-with-junit.sh $(@)


### PR DESCRIPTION
**- What I did**

When https://github.com/openshift/release/pull/62711 lands, we need to update our Makefile to reference `main` instead of `master`. With the path format referenced in our Makefile, GitHub will auto-redirect to `main`. However, we should still plan for it to be updated anyway.

**NOTE:** https://github.com/openshift/release/pull/62711 must land first otherwise this change will not work.

**- How to verify it**

Run `make bootstrap-e2e`, which should pass. Alternatively, run the `bootstrap-e2e` CI job, which should also pass.

**- Description for the changelog**
Update API URL in Makefile for branch name change
