### PR TITLE
Do not persist statically configured DHCP addresses with OVN-Kubernetes

### DIFF
--- a/templates/common/baremetal/files/NetworkManager-static-dhcp.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcp.yaml
@@ -29,6 +29,8 @@ contents:
 
     TYPE=$(nmcli --get-values connection.type connection show "$CONNECTION_ID")
 
+    nmcli_args=()
+
     # Modifying the default connection id directly doesn't do what we want.
     # If we see that, then we need to create a new connection.
     if [ "$CONNECTION_ID" == "Wired Connection" ]
@@ -40,8 +42,11 @@ contents:
         STATIC_INT_NAME=inf-lease-to-static
     else
         STATIC_INT_NAME="$CONNECTION_ID"
+
+        # OVN-Kubernetes configuration is rolled back and generated on every boot again.
+        nmcli_args+=(--temporary)
     fi
-    nmcli con mod "$STATIC_INT_NAME" \
+    nmcli con mod "${nmcli_args[@]}" "$STATIC_INT_NAME" \
       conn.interface "$1" \
       connection.autoconnect yes \
       ipv4.addresses "$CIDR" \
@@ -50,13 +55,13 @@ contents:
       ipv4.dns "$IP4_NAMESERVERS"
 
     if [ -n "$IP4_DOMAINS" ]; then
-        nmcli con mod "$STATIC_INT_NAME" ipv4.dns-search "$IP4_DOMAINS"
+        nmcli con mod "${nmcli_args[@]}" "$STATIC_INT_NAME" ipv4.dns-search "$IP4_DOMAINS"
     fi
     plus=''
     for i in $(seq 0 $(($IP4_NUM_ROUTES-1)) )
     do
         varname="IP4_ROUTE_$i"
-        nmcli con mod "$STATIC_INT_NAME" ${plus}ipv4.routes "${!varname}"
+        nmcli con mod "${nmcli_args[@]}" "$STATIC_INT_NAME" ${plus}ipv4.routes "${!varname}"
         plus='+'
     done
 

--- a/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
+++ b/templates/common/baremetal/files/NetworkManager-static-dhcpv6.yaml
@@ -28,23 +28,28 @@ contents:
         exit 0
     fi
 
+    nmcli_args=()
+
+    if [ "$CONNECTION_ID" != "inf-lease-to-static" ]
+    then
+        # OVN-Kubernetes configuration is rolled back and generated on every boot again.
+        nmcli_args+=(--temporary)
+    fi
+
     CIDR="$DHCP6_IP6_ADDRESS/$PREFIX_LEN"
-    nmcli con mod "$CONNECTION_ID" ipv6.addresses "$CIDR"
-    nmcli con mod "$CONNECTION_ID" connection.autoconnect "yes"
-    nmcli con mod "$CONNECTION_ID" ipv6.method "manual"
-    nmcli con mod "$CONNECTION_ID" ipv6.gateway "$IP6_GATEWAY"
-    nmcli con mod "$CONNECTION_ID" ipv6.dns "$IP6_NAMESERVERS"
+    nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" ipv6.addresses "$CIDR"
+    nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" connection.autoconnect "yes"
+    nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" ipv6.method "manual"
+    nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" ipv6.gateway "$IP6_GATEWAY"
+    nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" ipv6.dns "$IP6_NAMESERVERS"
     SEARCH_DOMAIN="${DHCP6_FQDN_FQDN#*.}"
     if [ -n "$SEARCH_DOMAIN" ]; then
-        nmcli con mod "$CONNECTION_ID" ipv6.dns-search "$SEARCH_DOMAIN"
+        nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" ipv6.dns-search "$SEARCH_DOMAIN"
     fi
     plus=''
     for i in $(seq 0 $(($IP6_NUM_ROUTES-1)) )
     do
         varname="IP6_ROUTE_$i"
-        nmcli con mod "$CONNECTION_ID" ${plus}ipv6.routes "${!varname}"
+        nmcli con mod "${nmcli_args[@]}" "$CONNECTION_ID" ${plus}ipv6.routes "${!varname}"
         plus='+'
     done
-
-    # Copy it from the OverlayFS mount to the persistent lowerdir
-    cp "$CONNECTION_FILENAME" /etc/NetworkManager/system-connections


### PR DESCRIPTION
OVN-Kubernetes configuration is rolled back and generated on every boot again, to take in any changes that have possibly been applied in the standard configuration sources.

NetworkManager dispatcher scripts 30-static-dhcp and 30-static-dhcpv6 modify the NetworkManager connection of the OVS interface ovs-if-br-ex in case of a infinite DHCP lease: They will change ipv4.method and ipv6.method from auto to manual in order to statically assign DHCP addresses etc. Previously, these changes were saved to disk which broke the rollback behaviour of configure-ovs.sh (ovs-configuration.service).

Now, both dispatcher scripts will apply those changes to the temporary NetworkManager connections that configure-ovs.sh creates. Thus, connections will be rolled back correctly during reboots. While a node is running, DHCP servers can go away and the network configuration is not affected. With this change however, connectivity to a DHCP server is still required when rebooting a node.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
