### PR TITLE
[release-1.17]OCPBUGS-52188: ignore mc not found error

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -1149,7 +1149,7 @@ func (ctrl *Controller) determineContainerRuntimeForFinalRuntimeConfig(pool *mcf
 		for _, finalizer := range finalizers {
 			mcName := finalizer
 			mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mcName, metav1.GetOptions{})
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				return "", fmt.Errorf("error getting MachineConfig %s: %w", mcName, err)
 			}
 			machineConfigs = append(machineConfigs, mc)


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The machine config that is called by Get might be cleaned up when the cluster encountered regression https://issues.redhat.com/browse/OCPBUGS-7719. We should ignore is not found error to avoid controller failure.
**- How to verify it**
1. Reproduce the cluster:  create two ctrcfg, and then delete the first ctrcfg, edit the second ctrcfg finalizers field, adding 99-worker-generated-containerruntime to the list
```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
  annotations:
    machineconfiguration.openshift.io/mc-name-suffix: "1"
  creationTimestamp: "2025-03-29T05:22:44Z"
  finalizers:
  - 99-worker-generated-containerruntime
  - 99-worker-generated-containerruntime-1
 
`oc get mc` displays `99-worker-generated-containerruntime-1`,  `99-worker-generated-containerruntime` does not exist

```
2. upgrade to release image built from this PR.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
