### PR TITLE
CORENET-5524: Modify regex for ipsec showstates command

### DIFF
--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -28,7 +28,7 @@ contents:
     establishedsa=""
     while [[ $elapsed -lt $timeout ]]; do
       desiredconn=$(grep -E '^\s*conn\s+' /etc/ipsec.d/openshift.conf | grep -v '%default' | awk '{print $2}' | tr ' ' '\n' | sort | tr '\n' ' ')
-      establishedsa=$(ipsec showstates | grep STATE_V2_ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
+      establishedsa=$(ipsec showstates | grep ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
       if [ "$desiredconn" == "$establishedsa" ]; then
         echo "IPsec SAs are established for desired connections after ${elapsed}s"
         break


### PR DESCRIPTION
The Libreswan 5.2 uses a slightly updated string for displaying established child SAs for an IPsec connection. So this PR updates ipsec showstates command with right regex value. The modified command is harmless and can also work well with Libreswan 4.x version.
