### PR TITLE
MCO-1627: Get rid of setting mcn.Spec.PinnedImageSets field

### DIFF
--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -542,7 +542,6 @@ func (p *PinnedImageSetManager) updateStatusProgressing(pools []*mcfgv1.MachineC
 	if err != nil {
 		return fmt.Errorf("failed to get image set apply configs: %w", err)
 	}
-	imageSetSpec := getPinnedImageSetSpecForPools(pools)
 
 	// Get MCP associated with node
 	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
@@ -562,7 +561,6 @@ func (p *PinnedImageSetManager) updateStatusProgressing(pools []*mcfgv1.MachineC
 		node,
 		p.mcfgClient,
 		applyCfg,
-		imageSetSpec,
 		p.featureGatesAccessor,
 		pool,
 	)
@@ -579,7 +577,6 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 	if err != nil {
 		return fmt.Errorf("failed to get image set apply configs: %w", err)
 	}
-	imageSetSpec := getPinnedImageSetSpecForPools(pools)
 
 	// Get MCP associated with node
 	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
@@ -599,7 +596,6 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 		node,
 		p.mcfgClient,
 		applyCfg,
-		imageSetSpec,
 		p.featureGatesAccessor,
 		pool,
 	)
@@ -620,7 +616,6 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 		node,
 		p.mcfgClient,
 		nil,
-		nil,
 		p.featureGatesAccessor,
 		pool,
 	)
@@ -637,7 +632,6 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 	if err != nil {
 		return fmt.Errorf("failed to get image set apply configs: %w", err)
 	}
-	imageSetSpec := getPinnedImageSetSpecForPools(pools)
 
 	var errMsg string
 	if isErrNoSpace(statusErr) {
@@ -665,7 +659,6 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 		node,
 		p.mcfgClient,
 		applyCfg,
-		imageSetSpec,
 		p.featureGatesAccessor,
 		pool,
 	)

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -43,7 +43,7 @@ func GenerateAndApplyMachineConfigNodes(
 	fgAccessor featuregates.FeatureGateAccess,
 	pool string,
 ) error {
-	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, nil, nil, fgAccessor, pool)
+	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, nil, fgAccessor, pool)
 }
 
 func UpdateMachineConfigNodeStatus(
@@ -54,11 +54,10 @@ func UpdateMachineConfigNodeStatus(
 	node *corev1.Node,
 	mcfgClient mcfgclientset.Interface,
 	imageSetApplyConfig []*machineconfigurationalphav1.MachineConfigNodeStatusPinnedImageSetApplyConfiguration,
-	imageSetSpec []mcfgalphav1.MachineConfigNodeSpecPinnedImageSet,
 	fgAccessor featuregates.FeatureGateAccess,
 	pool string,
 ) error {
-	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, imageSetApplyConfig, imageSetSpec, fgAccessor, pool)
+	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, imageSetApplyConfig, fgAccessor, pool)
 }
 
 // Helper function to convert metav1.Condition to ConditionApplyConfiguration
@@ -90,7 +89,6 @@ func generateAndApplyMachineConfigNodes(
 	node *corev1.Node,
 	mcfgClient mcfgclientset.Interface,
 	imageSetApplyConfig []*machineconfigurationalphav1.MachineConfigNodeStatusPinnedImageSetApplyConfiguration,
-	imageSetSpec []mcfgalphav1.MachineConfigNodeSpecPinnedImageSet,
 	fgAccessor featuregates.FeatureGateAccess,
 	pool string,
 ) error {
@@ -300,9 +298,6 @@ func generateAndApplyMachineConfigNodes(
 		newMCNode.Name = node.Name
 		newMCNode.Spec.Pool = mcfgalphav1.MCOObjectReference{Name: pool}
 		newMCNode.Spec.Node = mcfgalphav1.MCOObjectReference{Name: node.Name}
-		if imageSetSpec != nil {
-			newMCNode.Spec.PinnedImageSets = imageSetSpec
-		}
 
 		_, err := mcfgClient.MachineconfigurationV1alpha1().MachineConfigNodes().Create(context.TODO(), newMCNode, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
MCN.Spec.PinnedImageSets should not exist. There is no benefit to it existing as a "psuedo" Status that we don't react to
