### PR TITLE
OCPBUGS-51273: Don't crashloop for HAProxy init container

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -37,7 +37,9 @@ contents:
         - "/bin/bash"
         - "-c"
         - |
-          /usr/bin/curl -o /dev/null -kLfs https://api-int.{{ .DNS.Spec.BaseDomain }}:6443/healthz
+          while ! /usr/bin/curl -o /dev/null -kLfs https://api-int.{{ .DNS.Spec.BaseDomain }}:6443/healthz; do
+            sleep 5
+          done
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:


### PR DESCRIPTION
Previously we just crashlooped when the HAProxy init container failed, which is a normal, expected condition when HAProxy starts before CoreDNS. This is causing issues in CI because having a pod crash more than 3 times in a row is considered a failure. While it usually doesn't take that long for it to pass, we are hitting a weird timing issue during upgrades when the node is just about to reboot after MCO updates the pod definitions and it's taking longer than normal because ostree is updating the node at the same time.

Since this is just a case of everything behaving as expected, let's stop failing the pod for an expected situation. This change puts the api-int call in a loop so it will just run until coredns is ready and we'll never trigger any error reporting just because of harmless timing issues.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
