### PR TITLE
OCPNODE-3020: Remove `cgroupv1` references

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -33,9 +33,6 @@ const (
 	managedFeaturesKeyPrefix      = "98"
 	managedKubeletConfigKeyPrefix = "99"
 	protectKernelDefaultsStr      = "\"protectKernelDefaults\":false"
-	cgroupsV1DeprecationMsg       = "cgroups v1 support will soon be deprecated in Openshift, consider switching to cgroups v2"
-	cgroupModeCondType            = "CGroupMode"
-	cgroupCondReason              = "CGroupModeV1"
 )
 
 func createNewKubeletDynamicSystemReservedIgnition(autoSystemReserved *bool, userDefinedSystemReserved map[string]string) *ign3types.File {
@@ -159,9 +156,6 @@ func updateMachineConfigwithCgroup(node *osev1.Node, mc *mcfgv1.MachineConfig) e
 		kernelArgsToAdd, kernelArgsToRemove, adjustedKernelArgs []string
 	)
 	switch node.Spec.CgroupMode {
-	case osev1.CgroupModeV1:
-		kernelArgsToAdd = append(kernelArgsToAdd, kernelArgsv1...)
-		kernelArgsToRemove = append(kernelArgsToRemove, kernelArgsv2...)
 	case osev1.CgroupModeV2, osev1.CgroupModeEmpty:
 		kernelArgsToAdd = append(kernelArgsToAdd, kernelArgsv2...)
 		kernelArgsToRemove = append(kernelArgsToRemove, kernelArgsv1...)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -225,7 +225,7 @@ metadata:
   name: cluster
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction
-  cgroupMode: "v1"`),
+  cgroupMode: "v2"`),
 				[]byte(`apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:


### PR DESCRIPTION
Remove the references of `cgroupv1`
- Do not support setting of `cgroupMode` field to `v1` of the `nodes.config.openshift.io` object
- Remove the `cgroupv1` deprecation message

References:
API PR - https://github.com/openshift/api/pull/2181
Enhancement Proposal - https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/mco-cgroupsv2-support.md 