### PR TITLE
OCPBUGS-49737: GCP: Include the gcp-routes.service for all GCP installs

### DIFF
--- a/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
+++ b/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
@@ -1,5 +1,5 @@
 name: openshift-gcp-routes.service
-enabled: {{if and (eq .Infra.Status.PlatformStatus.Type "GCP") (.Infra.Status.PlatformStatus.GCP) (.Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig) (eq .Infra.Status.PlatformStatus.GCP.CloudLoadBalancerConfig.DNSType "ClusterHosted") }}false{{else}}true{{end}}
+enabled: true
 contents: |
   [Unit]
   Description=Update GCP routes for forwarded IPs.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The openshift-gcp-routes service is required eve during GCP installs with in-cluster DNS. During some early work on the in-cluster DNS feature, I had concluded that this service may not be necessary. After testing the in-cluster DNS further it is clear that this service is required even in this case.

**- How to verify it**
Enable `userProvisionedDNS` via install-config for GCP platform

**- Description for the changelog**
<!--
Allows openshift-gcp-routes service to run on all GCP installs whether we use the cloud default DNS or in-cluster DNS.
-->
