### PR TITLE
OCPBUGS-36859: Support NODEIP_HINT in IPI deployments too

### DIFF
--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -35,6 +35,7 @@ contents: |
     --prefer-ipv6 \
     {{end -}}
     --retry-on-failure \
+    ${NODEIP_HINT:-} \
     {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}} \
     {{ range onPremPlatformIngressIPs . }}{{.}} {{end}}; \
     do \
@@ -48,6 +49,7 @@ contents: |
   ExecStartPost=+/usr/local/bin/configure-ip-forwarding.sh
   StandardOutput=journal+console
   StandardError=journal+console
+  EnvironmentFile=-/etc/default/nodeip-configuration
 
   [Install]
   RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
Originally this was only enabled for UPI deployments because in IPI we expected the node IP to match the VIP subnet. However, since then two scenarios have come up where that may not be true:
- VSphere clusters are often deployed with VIPs that are not on the Machine Network
- User-namaged loadbalancers may be on any subnet In either of these cases we currently fall back to the remote worker behavior of selecting based on the default route. This is a problem if there are two interfaces, both with default routes. The order of activation can cause nondeterministic behavior.

This deliberately does not support the old KUBELET_NODEIP_HINT name that the UPI service does because it was never a thing in IPI and we don't need the backward compatibility with it.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
