### PR TITLE
MCO-1587: Add runbook for ExtremelyHighIndividualControlPlaneMemory

### DIFF
--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -189,6 +189,7 @@ spec:
               Moreover, OOM kill is expected which negatively influences the pod scheduling.
               If this happens on container level, the descheduler will not be able to detect it, as it works on the pod level.
               To fix this, increase memory of the affected node of control plane nodes.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneMemory.md
     - name: mcd-missing-mc
       rules:
         - alert: MissingMachineConfig


### PR DESCRIPTION
- What I did

Added a runbook I wrote to the ExtremelyHighIndividualControlPlaneMemory Alert

- How to verify it

Trigger ExtremelyHighIndividualControlPlaneMemory on cluster. Alert should now display associated runbook.

- Description for the changelog

Added https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneMemory.md to alert as a runbook_url.