### PR TITLE
WIP TEST: Reproduce OCPBUGS-23514 for CVO

### DIFF
--- a/install/0000_80_machine-config_02_images.configmap.yaml
+++ b/install/0000_80_machine-config_02_images.configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   images.json: >
     {
-      "releaseVersion": "0.0.1-snapshot",
+      "releaseVersion": "4.19.0-ec.2",
       "machineConfigOperator": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator",
       "infraImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:pod",
       "keepalivedImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:keepalived-ipfailover",

--- a/install/0000_80_machine-config_04_deployment.yaml
+++ b/install/0000_80_machine-config_04_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         args:
         - "start"
         - "--images-json=/etc/mco/images/images.json"
-        - "--payload-version=0.0.1-snapshot"
+        - "--payload-version=4.19.0-ec.2"
         - "--operator-image=placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator"
         resources:
           requests:
@@ -38,7 +38,7 @@ spec:
             memory: 50Mi
         env:
           - name: RELEASE_VERSION
-            value: "0.0.1-snapshot"
+            value: "4.19.0-ec.2"
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: images

--- a/install/0000_80_machine-config_05_osimageurl.yaml
+++ b/install/0000_80_machine-config_05_osimageurl.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 data:
-  releaseVersion: 0.0.1-snapshot
+  releaseVersion: 4.19.0-ec.2
   # This (will eventually) replace the below when https://github.com/openshift/enhancements/pull/1032
   # progresses towards the default.
   baseOSContainerImage: "placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos"

--- a/install/0000_80_machine-config_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config_06_clusteroperator.yaml
@@ -10,7 +10,7 @@ spec: {}
 status:
   versions:
     - name: operator
-      version: "4.19.0-ec.2"
+      version: "0.0.1-snapshot"
     - name: operator-image
       version: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
   relatedObjects:

--- a/install/0000_80_machine-config_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config_06_clusteroperator.yaml
@@ -10,7 +10,7 @@ spec: {}
 status:
   versions:
     - name: operator
-      version: "0.0.1-snapshot"
+      version: "4.19.0-ec.2"
     - name: operator-image
       version: placeholder.url.oc.will.replace.this.org/placeholdernamespace:machine-config-operator
   relatedObjects:


### PR DESCRIPTION
(sorry for the noise)

Attempt to make OCPBUGS-23514 reproducible by creating an ephemeral payload that will not respect CVO's update assumptions/contract. I try to make the following work:

Install 4.19 EC2
Build a 4.19 ephemeral payload with this patch, containing an machine-config CO with hardcoded 4.19.0-ec.2 "--payload-version,RELEASE_VERSION(=instead of actual payload image version)
Update the cluster to this ephemeral payload
machine-config operator should set the CO version to 4.19.0-ec.2 and therefore CVO will never consider the CO as updated, and the update should get stuck on it (reproducing OCPBUGS-23514)