### PR TITLE
WIP: Start setting control-plane taint

### DIFF
--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -42,7 +42,10 @@ const (
 	// KernelType64kPages denominates the 64k pages kernel
 	KernelType64kPages = "64k-pages"
 
-	// MasterLabel defines the label associated with master node. The master taint uses the same label as taint's key
+	// ControlPlaneLabel defines the label associated with control plane nodes. The control plane taint uses the same label as taint's key
+	ControlPlaneLabel = "node-role.kubernetes.io/control-plane"
+
+	// MasterLabel defines the label associated with master nodes. The master taint uses the same label as taint's key
 	MasterLabel = "node-role.kubernetes.io/master"
 
 	// MCNameSuffixAnnotationKey is used to keep track of the machine config name associated with a CR


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

The `node-role.kubernetes.io/master` annotation is deprecated in favour of `node-role.kubernetes.io/control-plane` [[1][1]] and currently produces a warning when modifying resources via `oc`/`kubectl`. kubeadm switched to the new label many releases ago [[2][2]].

Continue the process of migrating OpenShift by labeling nodes with the new label. Future changes can remove the old label and rename various methods and tests once this has bedded in.

This is a WIP/RFC PR because we need to update all operators to tolerate this label first. I suspect an enhancement is needed to ensure this happens.

[1]: https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint
[2]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint

**- How to verify it**

TODO.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
