### PR TITLE
OCPNODE-3173: Disable OCI artifact mount by default.

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -66,6 +66,7 @@ contents:
     pause_image = "{{.Images.infraImageKey}}"
     pause_image_auth_file = "/var/lib/kubelet/config.json"
     pause_command = "/usr/bin/pod"
+    oci_artifact_mount_support = false
 
     [crio.network]
     network_dir = "/etc/kubernetes/cni/net.d/"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -66,6 +66,7 @@ contents:
     pause_image = "{{.Images.infraImageKey}}"
     pause_image_auth_file = "/var/lib/kubelet/config.json"
     pause_command = "/usr/bin/pod"
+    oci_artifact_mount_support = false
 
     [crio.network]
     network_dir = "/etc/kubernetes/cni/net.d/"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes https://issues.redhat.com/browse/OCPNODE-3173

Disable OCI artifacts mount by specifying the newly added option `oci_artifact_mount_support`.

https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crioimage-table

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added `oci_artifact_mount_support = false` in the default crio config.