### PR TITLE
OCPBUGS-55262: Use auto=start only for IPsec out connections

### DIFF
--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -9,15 +9,18 @@ contents:
       exit 0
     fi
 
-    # Modify existing IPsec connection entries with "auto=start"
+    # Modify existing IPsec out connection entries with "auto=start"
     # option and restart ipsec systemd service. This helps to
     # establish IKE SAs for the existing IPsec connections with
     # peer nodes. This option will be deleted from connections
     # once ovs-monitor-ipsec process spinned up on the node by
     # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
     # again with peer nodes, so it shouldn't be a problem.
+    # We are updating only out connections with "auto=start" to
+    # avoid cross stream issue with Libreswan 5.2.
+    # The in connections use default auto=route parameter.
     if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
-      sed -i '/^.*conn ovn.*$/a\    auto=start' /etc/ipsec.d/openshift.conf
+      sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
     fi
     chroot /proc/1/root ipsec restart
 


### PR DESCRIPTION
We noticed a cross streaming issue with Libreswan 5.2 creating duplicate child SAs on the node and no matching SA on the other end causing packet drops. To fix it, this commit makes `wait-for-ipsec-connect.service` updates `openshift.conf` with `auto=start` only for out connections.
