### PR TITLE
OCPBUGS-55365: Regardless of Pool configuration wait on other sub-controllers to Render

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -601,14 +601,6 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 	}
 
 	for _, pool := range mcpPools {
-		if pool.Spec.Configuration.Name == "" {
-			updateDelay := 5 * time.Second
-			// Previously we spammed the logs about empty pools.
-			// Let's just pause for a bit here to let the renderer
-			// initialize them.
-			time.Sleep(updateDelay)
-			return fmt.Errorf("Pool %s is unconfigured, pausing %v for renderer to initialize", pool.Name, updateDelay)
-		}
 		role := pool.Name
 		// Get MachineConfig
 		managedKey, err := getManagedKubeletConfigKey(pool, ctrl.client, cfg)

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -443,11 +443,8 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return err
 	}
 
-	// If the Pool is unconfigured, let it generate the renderedMC before waiting. This prevents a deadlock between render controller and kubelet config controller.
-	if pool.Spec.Configuration.Name != "" {
-		if err := apihelpers.AreMCGeneratingSubControllersCompletedForPool(ctrl.crcLister.List, ctrl.mckLister.List, pool.Labels); err != nil {
-			return err
-		}
+	if err := apihelpers.AreMCGeneratingSubControllersCompletedForPool(ctrl.crcLister.List, ctrl.mckLister.List, pool.Labels); err != nil {
+		return err
 	}
 
 	mcs, err := ctrl.mcLister.List(selector)


### PR DESCRIPTION
**- What I did**
render_controller: Wait for other sub-controllers regardless of Pool configuration
kubelet_congfig_controller: Don't wait for Pool to be configured to sync

**- How to verify it**
Install a custom CRC or KC at install time and see if the render_controller waits for the ContainerRuntimeConfig Controller and the KubeletConfigController before it proceeds to generate a rendered MC

**- Description for the changelog**
<!--
Wait for other sub-controllers regardless of Pool configuration
-->
