### PR TITLE
OCPBUGS-55450: Only populate `Status.PinnedImageSets.CurrentGeneration` on valid generation value

### DIFF
--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -268,10 +268,14 @@ func generateAndApplyMachineConfigNodes(
 		if fg.Enabled(features.FeatureGatePinnedImages) {
 			if imageSetApplyConfig == nil {
 				for _, imageSet := range newMCNode.Status.PinnedImageSets {
+					// By default, a PinnedImageSet reference must include the name of the PIS and the desired generation
 					pisApplyConfig := &machineconfigurationv1.MachineConfigNodeStatusPinnedImageSetApplyConfiguration{
 						DesiredGeneration: ptr.To(imageSet.DesiredGeneration),
-						CurrentGeneration: ptr.To(imageSet.CurrentGeneration),
 						Name:              ptr.To(imageSet.Name),
+					}
+					// Only set `CurrentGeneration` value when we are currently on a valid generation (imageSet.CurrentGeneration value is non-0)
+					if imageSet.CurrentGeneration != 0 {
+						pisApplyConfig.CurrentGeneration = ptr.To(imageSet.CurrentGeneration)
 					}
 					// Only set `LastFailedGeneration` value when it is a non-default (non-0) value
 					if imageSet.LastFailedGeneration != 0 {


### PR DESCRIPTION
Closes: OCPBUGS-55450

**- What I did**
This adds a check to only set `Status.PinnedImageSets.CurrentGeneration` in a MachineConfigNode object when the generation value is valid, or non-zero.

**- How to verify it**
1. Launch a cluster with this PR.
2. Apply an invalid PIS.
<details><summary>Example Invalid PIS targeting "custom" MCP</summary>
<pre>
apiVersion: machineconfiguration.openshift.io/v1
kind: PinnedImageSet
metadata:
  name: test-pinned
  labels:
    machineconfiguration.openshift.io/role: "custom"
spec:
  pinnedImages:
   - name: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:86d26e7ebcccd6f07a75db5b1e56283b25c2ee1c6a755d6ffc5a4d59beb9cdef
</pre>
</details>
3. Check that the PIS reference in the MCN has values for `Name`, `DesiredGeneration`, `LastFailedGeneration`, and `LastFailedGenerationError`.

```
...
Status:
  Conditions:
    Last Transition Time:  2025-05-07T13:11:46Z
    Message:               node is prefetching images: ip-10-0-46-80.ec2.internal
    Reason:                ImagePrefetch
    Status:                True
    Type:                  PinnedImageSetsProgressing
...
    Last Transition Time:  2025-05-07T13:11:48Z
    Message:               One or more PinnedImageSet is experiencing an error. See PinnedImageSet list for more details
    Reason:                PrefetchFailed
    Status:                True
    Type:                  PinnedImageSetsDegraded
...
Pinned Image Sets:
    Desired Generation:            1
    Last Failed Generation:        1
    Last Failed Generation Error:  failed to execute podman manifest inspect for "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:86d26e7ebcccd6f07a75db5b1e56283b25c2ee1c6a755d6ffc5a4d59beb9cdef": exit status 125
    Name:                          test-pinned
```

4. Apply a valid PIS.
<details><summary>Example valid PIS targeting "custom" MCP</summary>
<pre>
apiVersion: machineconfiguration.openshift.io/v1
kind: PinnedImageSet
metadata:
  name: test-pinned
  labels:
    machineconfiguration.openshift.io/role: "custom"
spec:
  pinnedImages:
   - name: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1
</pre>
</details>

5. Check that the PIS reference in the MCN has values for `Name`, `DesiredGeneration`, and `CurrentGeneration`.

```
...
Status:
  Conditions:
    Last Transition Time:  2025-05-07T13:21:19Z
    Message:               All pinned image sets complete
    Reason:                AsExpected
    Status:                False
    Type:                  PinnedImageSetsProgressing
...
Last Transition Time:  2025-05-07T13:21:19Z
    Message:               All is good
    Reason:                AsExpected
    Status:                False
    Type:                  PinnedImageSetsDegraded
...
  Pinned Image Sets:
    Current Generation:  2
    Desired Generation:  2
    Name:                test-pinned
```

6. Check that there are no error logs (especially those starting with "Error applying MCN status").

_Note:_ To see the original failures, see this example payload job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-machine-config-operator-5034-ci-4.19-e2e-gcp-ovn-techpreview-serial/1919889377152995328.

**- Description for the changelog**
OCPBUGS-55450: Only populate `Status.PinnedImageSets.CurrentGeneration` on valid generation value