### PR TITLE
OCPBUGS-55597: OWNERS: update owners file with current MCO team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,17 +6,17 @@ approvers:
   - yuqi-zhang
   - cheesesashimi
   - umohnani8
-  - LorbusChris
   - RishabhSaini
   - isabella-janssen
+  - pablintino
 reviewers:
   - djoshy
   - dkhater-redhat
   - yuqi-zhang
   - cheesesashimi
   - umohnani8
-  - LorbusChris
   - RishabhSaini
   - isabella-janssen
+  - pablintino
 
 component: "Machine Config Operator"


### PR DESCRIPTION
Closes: OCPBUGS-55597

**- What I did**
This adds @pablintino to the OWNERS file and updates it generally to be up to date with current MCO team.

**- How to verify it**
N/A

**- Description for the changelog**
OWNERS: update owners file with current MCO team members