### PR TITLE
OCPBUGS-55638: OCPBUGS-55637: Add admin_acks handling in the MCO

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -97,6 +97,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Core().V1().Secrets(),
+			ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
 			ctrlctx.ConfigInformerFactory.Config().V1().ClusterOperators(),
 			ctrlctx.ClientBuilder.OperatorClientOrDie(componentName),
 			ctrlctx.OperatorInformerFactory.Operator().V1().MachineConfigurations(),

--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -486,3 +486,13 @@ func CheckNodeDisruptionActionsForTargetActions(actions []opv1.NodeDisruptionPol
 
 	return currentActions.HasAny(targetActions...)
 }
+
+// Returns a MachineConfiguration object with the cluster opted out of boot image updates.
+func GetManagedBootImagesWithUpdateDisabled() opv1.ManagedBootImages {
+	return opv1.ManagedBootImages{MachineManagers: []opv1.MachineManager{}}
+}
+
+// Returns a MachineConfiguration object with an empty configuration; to be used in testing a situation where admin has no opinion.
+func GetManagedBootImagesWithNoConfiguration() opv1.ManagedBootImages {
+	return opv1.ManagedBootImages{}
+}

--- a/pkg/operator/admin_ack.go
+++ b/pkg/operator/admin_ack.go
@@ -17,10 +17,10 @@ import (
 
 const (
 	BootImageAWSGCPKey = "ack-4.18-boot-image-opt-out-in-4.19"
-	BootImageAWSGCPMsg = "GCP or AWS platform with no boot image configuration detected. OCP will automatically opt-in all GCP and AWS clusters that currently do not a boot image configuration in 4.19. Please add a configuration to disable boot image updates if this is not desired. See [insert-doc-link] "
+	BootImageAWSGCPMsg = "This cluster is GCP or AWS but lacks a boot image configuration. OCP will automatically opt this cluster into boot image management in 4.19. Please add a configuration to disable boot image updates if this is not desired. See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/machine_configuration/mco-update-boot-images#mco-update-boot-images-disable_machine-configs-configure for more details."
 
 	AArch64BootImageKey = "ack-4.18-aarch64-bootloader-4.19"
-	AArch64BootImageMsg = "aarch64 nodes detected. Please ensure boot image are updated by following the KCS:(insertlink) prior to upgrading to 4.19."
+	AArch64BootImageMsg = "This cluster has at least one aarch64 node. Please ensure boot images are not too old by following KCS https://access.redhat.com/solutions/7119697 prior to upgrading to 4.19."
 
 	AdminAckGatesConfigMapName = "admin-gates"
 )

--- a/pkg/operator/admin_ack.go
+++ b/pkg/operator/admin_ack.go
@@ -1,0 +1,126 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	configv1 "github.com/openshift/api/config/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+)
+
+const (
+	BootImageAWSGCPKey = "ack-4.18-boot-image-opt-out-in-4.19"
+	BootImageAWSGCPMsg = "GCP or AWS platform with no boot image configuration detected. OCP will automatically opt-in all GCP and AWS clusters that currently do not a boot image configuration in 4.19. Please add a configuration to disable boot image updates if this is not desired. See [insert-doc-link] "
+
+	AArch64BootImageKey = "ack-4.18-aarch64-bootloader-4.19"
+	AArch64BootImageMsg = "aarch64 nodes detected. Please ensure boot image are updated by following the KCS:(insertlink) prior to upgrading to 4.19."
+
+	AdminAckGatesConfigMapName = "admin-gates"
+)
+
+// Syncs the admin-ack configmap in the openshift-config-managed namespace, and adds MCO specific keys if needed.
+func (optr *Operator) syncAdminAckConfigMap() error {
+	cm, err := optr.ocManagedConfigMapLister.ConfigMaps(ctrlcommon.OpenshiftConfigManagedNamespace).Get(AdminAckGatesConfigMapName)
+	if err != nil {
+		return fmt.Errorf("error fetching configmap %s during sync: %w", AdminAckGatesConfigMapName, err)
+	}
+
+	newCM := cm.DeepCopy()
+
+	// Evaluate AWS/GCP boot image guards
+	_, bootImageAWSGCPKeyExists := newCM.Data[BootImageAWSGCPKey]
+	bootImageAWSGCPAdminGuardNeeded, err := optr.checkAWSGCPBootImageGuard()
+	if err != nil {
+		return fmt.Errorf("error determining aws/gcp boot image guard during configmap %s sync: %w", AdminAckGatesConfigMapName, err)
+	}
+	updateGuardKeyIfNeeded(bootImageAWSGCPAdminGuardNeeded, bootImageAWSGCPKeyExists, BootImageAWSGCPKey, BootImageAWSGCPMsg, newCM)
+
+	// Evaluate aarch64 guards
+	_, aarch64BootImageKeyExists := newCM.Data[AArch64BootImageKey]
+	aarch64BootImageAdminGuardNeeded, err := optr.checkAArch64BootImageGuard()
+	if err != nil {
+		return fmt.Errorf("error determining aarch64 boot image guard during configmap %s sync: %w", AdminAckGatesConfigMapName, err)
+	}
+	updateGuardKeyIfNeeded(aarch64BootImageAdminGuardNeeded, aarch64BootImageKeyExists, AArch64BootImageKey, AArch64BootImageMsg, newCM)
+
+	// Only send an API request if an update is needed
+	if !reflect.DeepEqual(cm.Data, newCM.Data) {
+		_, err = optr.kubeClient.CoreV1().ConfigMaps(ctrlcommon.OpenshiftConfigManagedNamespace).Update(context.TODO(), newCM, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("error updating configmap %s during sync: %w", AdminAckGatesConfigMapName, err)
+		}
+		klog.Infof("%s configmap update successful", newCM.Name)
+	}
+
+	return nil
+}
+
+// checkAWSGCPBootImageGuard checks if AWS & GCP Boot Image admin guard is needed
+func (optr *Operator) checkAWSGCPBootImageGuard() (bool, error) {
+
+	// First, check if the cluster is on AWS or GCP platform.
+	infra, err := optr.infraLister.Get("cluster")
+	if err != nil {
+		klog.Errorf("Could not get infra: %v", err)
+		return false, err
+	}
+	platforms := sets.New(configv1.GCPPlatformType, configv1.AWSPlatformType)
+	if !platforms.Has(infra.Status.PlatformStatus.Type) {
+		return false, nil
+	}
+
+	// Next, check if there is any boot image configuration.
+	mcop, err := optr.mcopLister.Get(ctrlcommon.MCOOperatorKnobsObjectName)
+	if err != nil {
+		klog.Errorf("Could not get MachineConfiguration object: %v", err)
+		return false, err
+	}
+
+	// If no machine managers exist, no configuration has been defined
+	return mcop.Spec.ManagedBootImages.MachineManagers == nil, nil
+}
+
+// checkAArch64BootImageGuard checks if aarch64 Boot Image admin guard is needed
+func (optr *Operator) checkAArch64BootImageGuard() (bool, error) {
+
+	// Grab all current nodes
+	nodes, err := optr.nodeLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Could not get nodes: %v", err)
+		return false, err
+	}
+
+	// Check if any node is of the arm64 type (translates to aarch64 in RPM world)
+	for _, node := range nodes {
+		if node.Status.NodeInfo.Architecture == "arm64" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// updateGuardKeyIfNeeded adds a key with a message depending on:
+// If guard is needed and key doesn't exist => create it
+// If guard is needed and key exists => nothing to do
+// If guard is not needed and key exists => delete it
+// If guard is not needed and key doesn't exist => nothing to do
+func updateGuardKeyIfNeeded(guardNeeded, keyExists bool, key, msg string, cm *corev1.ConfigMap) {
+	if guardNeeded && !keyExists {
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[key] = msg
+		klog.Infof("Adding key %s to configmap %s", key, cm.Name)
+	} else if !guardNeeded && keyExists {
+		delete(cm.Data, key)
+		klog.Infof("Deleting key %s from configmap %s", key, cm.Name)
+	}
+}

--- a/pkg/operator/admin_ack_test.go
+++ b/pkg/operator/admin_ack_test.go
@@ -1,0 +1,154 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	mcoplistersv1 "github.com/openshift/client-go/operator/listers/operator/v1"
+	"github.com/openshift/machine-config-operator/pkg/apihelpers"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestAdminAck(t *testing.T) {
+	cases := []struct {
+		name                string
+		infra               *configv1.Infrastructure
+		mcop                *opv1.MachineConfiguration
+		adminCM             *corev1.ConfigMap
+		node                *corev1.Node
+		expectBootImageGate bool
+		expectAArch64Gate   bool
+	}{
+		{
+			name:    "non AWS/GCP platform, with no boot image configuration",
+			infra:   buildInfra(withPlatformType(configv1.AzurePlatformType)),
+			mcop:    buildMachineConfigurationWithNoBootImageConfiguration(),
+			adminCM: buildAdminAckConfigMapWithData(nil),
+		},
+		{
+			name:                "AWS platform, with no boot image configuration",
+			infra:               buildInfra(withPlatformType(configv1.AWSPlatformType)),
+			mcop:                buildMachineConfigurationWithNoBootImageConfiguration(),
+			adminCM:             buildAdminAckConfigMapWithData(nil),
+			expectBootImageGate: true,
+		},
+		{
+			name:                "GCP platform, with no boot image configuration",
+			infra:               buildInfra(withPlatformType(configv1.GCPPlatformType)),
+			mcop:                buildMachineConfigurationWithNoBootImageConfiguration(),
+			adminCM:             buildAdminAckConfigMapWithData(nil),
+			expectBootImageGate: true,
+		},
+		{
+			name:    "non AWS/GCP platform, with a boot image configuration",
+			infra:   buildInfra(withPlatformType(configv1.AzurePlatformType)),
+			mcop:    buildMachineConfigurationWithBootImageUpdateDisabled(),
+			adminCM: buildAdminAckConfigMapWithData(nil),
+		},
+		{
+			name:    "AWS platform, with a boot image configuration",
+			infra:   buildInfra(withPlatformType(configv1.AWSPlatformType)),
+			mcop:    buildMachineConfigurationWithBootImageUpdateDisabled(),
+			adminCM: buildAdminAckConfigMapWithData(map[string]string{BootImageAWSGCPKey: BootImageAWSGCPMsg}),
+		},
+		{
+			name:    "GCP platform, with a boot image configuration",
+			infra:   buildInfra(withPlatformType(configv1.GCPPlatformType)),
+			mcop:    buildMachineConfigurationWithBootImageUpdateDisabled(),
+			adminCM: buildAdminAckConfigMapWithData(map[string]string{BootImageAWSGCPKey: BootImageAWSGCPMsg}),
+		},
+		{
+			name:              "aarch64 Nodes present",
+			infra:             buildInfra(withPlatformType(configv1.GCPPlatformType)),
+			mcop:              buildMachineConfigurationWithBootImageUpdateDisabled(),
+			adminCM:           buildAdminAckConfigMapWithData(nil),
+			node:              buildNodeWithArch("arm64"),
+			expectAArch64Gate: true,
+		},
+		{
+			name:    "aarch64 Nodes not present",
+			infra:   buildInfra(withPlatformType(configv1.GCPPlatformType)),
+			mcop:    buildMachineConfigurationWithBootImageUpdateDisabled(),
+			adminCM: buildAdminAckConfigMapWithData(nil),
+			node:    buildNodeWithArch("amd64"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create clients and listers
+			kubeClient := fake.NewSimpleClientset()
+			infraIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			infraIndexer.Add(tc.infra)
+			mcopIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			mcopIndexer.Add(tc.mcop)
+
+			configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			configMapIndexer.Add(tc.adminCM)
+			_, err := kubeClient.CoreV1().ConfigMaps(ctrlcommon.OpenshiftConfigManagedNamespace).Create(context.TODO(), tc.adminCM, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			if tc.node != nil {
+				nodeIndexer.Add(tc.node)
+				_, err = kubeClient.CoreV1().Nodes().Create(context.TODO(), tc.node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			optr := &Operator{
+				kubeClient:               kubeClient,
+				infraLister:              configlistersv1.NewInfrastructureLister(infraIndexer),
+				mcopLister:               mcoplistersv1.NewMachineConfigurationLister(mcopIndexer),
+				ocManagedConfigMapLister: corelisterv1.NewConfigMapLister(configMapIndexer),
+				nodeLister:               corelisterv1.NewNodeLister(nodeIndexer),
+			}
+			err = optr.syncAdminAckConfigMap()
+			assert.NoError(t, err)
+
+			adminCM, err := kubeClient.CoreV1().ConfigMaps(ctrlcommon.OpenshiftConfigManagedNamespace).Get(context.TODO(), AdminAckGatesConfigMapName, metav1.GetOptions{})
+			assert.NoError(t, err)
+
+			_, gateFound := adminCM.Data[BootImageAWSGCPKey]
+			assert.Equal(t, tc.expectBootImageGate, gateFound)
+
+			_, gateFound = adminCM.Data[AArch64BootImageKey]
+			assert.Equal(t, tc.expectAArch64Gate, gateFound)
+		})
+	}
+}
+
+func buildMachineConfigurationWithBootImageUpdateDisabled() *opv1.MachineConfiguration {
+	return &opv1.MachineConfiguration{Spec: opv1.MachineConfigurationSpec{ManagedBootImages: apihelpers.GetManagedBootImagesWithUpdateDisabled()}, ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+}
+
+func buildMachineConfigurationWithNoBootImageConfiguration() *opv1.MachineConfiguration {
+	return &opv1.MachineConfiguration{Spec: opv1.MachineConfigurationSpec{ManagedBootImages: apihelpers.GetManagedBootImagesWithNoConfiguration()}, ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+}
+
+func buildAdminAckConfigMapWithData(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: AdminAckGatesConfigMapName, Namespace: ctrlcommon.OpenshiftConfigManagedNamespace},
+		Data:       data,
+	}
+}
+
+func buildNodeWithArch(arch string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status: corev1.NodeStatus{
+			NodeInfo: corev1.NodeSystemInfo{
+				Architecture: arch,
+			},
+		},
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -81,33 +81,34 @@ type Operator struct {
 
 	syncHandler func(ic string) error
 
-	imgLister             configlistersv1.ImageLister
-	crdLister             apiextlistersv1.CustomResourceDefinitionLister
-	mcpLister             mcfglistersv1.MachineConfigPoolLister
-	msLister              mcfglistersalphav1.MachineConfigNodeLister
-	ccLister              mcfglistersv1.ControllerConfigLister
-	mcLister              mcfglistersv1.MachineConfigLister
-	deployLister          appslisterv1.DeploymentLister
-	daemonsetLister       appslisterv1.DaemonSetLister
-	infraLister           configlistersv1.InfrastructureLister
-	networkLister         configlistersv1.NetworkLister
-	mcoCmLister           corelisterv1.ConfigMapLister
-	clusterCmLister       corelisterv1.ConfigMapLister
-	proxyLister           configlistersv1.ProxyLister
-	oseKubeAPILister      corelisterv1.ConfigMapLister
-	nodeLister            corelisterv1.NodeLister
-	dnsLister             configlistersv1.DNSLister
-	mcoSALister           corelisterv1.ServiceAccountLister
-	mcoSecretLister       corelisterv1.SecretLister
-	ocSecretLister        corelisterv1.SecretLister
-	ocManagedSecretLister corelisterv1.SecretLister
-	clusterOperatorLister configlistersv1.ClusterOperatorLister
-	mcopLister            mcoplistersv1.MachineConfigurationLister
-	mckLister             mcfglistersv1.KubeletConfigLister
-	crcLister             mcfglistersv1.ContainerRuntimeConfigLister
-	nodeClusterLister     configlistersv1.NodeLister
-	moscLister            mcfglistersalphav1.MachineOSConfigLister
-	apiserverLister       configlistersv1.APIServerLister
+	imgLister                configlistersv1.ImageLister
+	crdLister                apiextlistersv1.CustomResourceDefinitionLister
+	mcpLister                mcfglistersv1.MachineConfigPoolLister
+	msLister                 mcfglistersalphav1.MachineConfigNodeLister
+	ccLister                 mcfglistersv1.ControllerConfigLister
+	mcLister                 mcfglistersv1.MachineConfigLister
+	deployLister             appslisterv1.DeploymentLister
+	daemonsetLister          appslisterv1.DaemonSetLister
+	infraLister              configlistersv1.InfrastructureLister
+	networkLister            configlistersv1.NetworkLister
+	mcoCmLister              corelisterv1.ConfigMapLister
+	clusterCmLister          corelisterv1.ConfigMapLister
+	proxyLister              configlistersv1.ProxyLister
+	oseKubeAPILister         corelisterv1.ConfigMapLister
+	nodeLister               corelisterv1.NodeLister
+	dnsLister                configlistersv1.DNSLister
+	mcoSALister              corelisterv1.ServiceAccountLister
+	mcoSecretLister          corelisterv1.SecretLister
+	ocSecretLister           corelisterv1.SecretLister
+	ocManagedSecretLister    corelisterv1.SecretLister
+	ocManagedConfigMapLister corelisterv1.ConfigMapLister
+	clusterOperatorLister    configlistersv1.ClusterOperatorLister
+	mcopLister               mcoplistersv1.MachineConfigurationLister
+	mckLister                mcfglistersv1.KubeletConfigLister
+	crcLister                mcfglistersv1.ContainerRuntimeConfigLister
+	nodeClusterLister        configlistersv1.NodeLister
+	moscLister               mcfglistersalphav1.MachineOSConfigLister
+	apiserverLister          configlistersv1.APIServerLister
 
 	crdListerSynced                  cache.InformerSynced
 	deployListerSynced               cache.InformerSynced
@@ -132,6 +133,7 @@ type Operator struct {
 	mcoSecretListerSynced            cache.InformerSynced
 	ocSecretListerSynced             cache.InformerSynced
 	ocManagedSecretListerSynced      cache.InformerSynced
+	ocManagedConfigMapListerSynced   cache.InformerSynced
 	clusterOperatorListerSynced      cache.InformerSynced
 	mcopListerSynced                 cache.InformerSynced
 	mckListerSynced                  cache.InformerSynced
@@ -182,6 +184,7 @@ func New(
 	mcoSecretInformer coreinformersv1.SecretInformer,
 	ocSecretInformer coreinformersv1.SecretInformer,
 	ocManagedSecretInformer coreinformersv1.SecretInformer,
+	ocManagedConfigMapInformer coreinformersv1.ConfigMapInformer,
 	clusterOperatorInformer configinformersv1.ClusterOperatorInformer,
 	mcopClient mcopclientset.Interface,
 	mcopInformer mcopinformersv1.MachineConfigurationInformer,
@@ -252,6 +255,7 @@ func New(
 		mcoSecretInformer.Informer(),
 		ocSecretInformer.Informer(),
 		ocManagedSecretInformer.Informer(),
+		ocManagedConfigMapInformer.Informer(),
 		mcopInformer.Informer(),
 		mckInformer.Informer(),
 		crcInformer.Informer(),
@@ -310,6 +314,8 @@ func New(
 	optr.ocSecretListerSynced = ocSecretInformer.Informer().HasSynced
 	optr.ocManagedSecretLister = ocManagedSecretInformer.Lister()
 	optr.ocManagedSecretListerSynced = ocManagedSecretInformer.Informer().HasSynced
+	optr.ocManagedConfigMapLister = ocManagedConfigMapInformer.Lister()
+	optr.ocManagedConfigMapListerSynced = ocManagedConfigMapInformer.Informer().HasSynced
 	optr.clusterOperatorLister = clusterOperatorInformer.Lister()
 	optr.clusterOperatorListerSynced = clusterOperatorInformer.Informer().HasSynced
 	optr.mcopLister = mcopInformer.Lister()
@@ -366,6 +372,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 		optr.mcoSecretListerSynced,
 		optr.ocSecretListerSynced,
 		optr.ocManagedSecretListerSynced,
+		optr.ocManagedConfigMapListerSynced,
 		optr.clusterOperatorListerSynced,
 		optr.mcopListerSynced,
 		optr.mckListerSynced,

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -697,6 +697,21 @@ func TestOperatorSyncStatus(t *testing.T) {
 		optr.nodeClusterLister = configlistersv1.NewNodeLister(configNodeIndexer)
 		configNodeIndexer.Add(configNode)
 
+		managedConfigMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		optr.ocManagedConfigMapLister = corelisterv1.NewConfigMapLister(managedConfigMapIndexer)
+		managedConfigMapIndexer.Add(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "admin-gates", Namespace: "openshift-config-managed"},
+		})
+
+		infraIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		optr.infraLister = configlistersv1.NewInfrastructureLister(infraIndexer)
+		infraIndexer.Add(&configv1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Status: configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{},
+			},
+		})
+
 		for j, sync := range testCase.syncs {
 			optr.inClusterBringup = sync.inClusterBringUp
 			if sync.nextVersion != "" {
@@ -783,6 +798,21 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 
 	configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	optr.mcoCmLister = corelisterv1.NewConfigMapLister(configMapIndexer)
+
+	managedConfigMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.ocManagedConfigMapLister = corelisterv1.NewConfigMapLister(managedConfigMapIndexer)
+	managedConfigMapIndexer.Add(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-gates", Namespace: "openshift-config-managed"},
+	})
+
+	infraIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	optr.infraLister = configlistersv1.NewInfrastructureLister(infraIndexer)
+	infraIndexer.Add(&configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{},
+		},
+	})
 
 	fn1 := func(config *renderConfig, co *configv1.ClusterOperator) error {
 		return errors.New("mocked fn1")

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -235,6 +235,10 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 		return fmt.Errorf("error syncing metrics: %w", err)
 	}
 
+	if err := optr.syncAdminAckConfigMap(); err != nil {
+		return fmt.Errorf("error syncing admin ack configmap: %w", err)
+	}
+
 	if optr.inClusterBringup && syncErr.err == nil {
 		klog.Infof("Initialization complete")
 		optr.inClusterBringup = false


### PR DESCRIPTION
**- What I did**
I added a new sync loop in the operator for the `admin-gates` configmap in the `openshift-config-managed` namespace. This sync loop will now begin to add the following keys:
- `ack-4.18-boot-image-opt-out-in-4.19` when a AWS/GCP cluster does not have a boot image configuration.
- `ack-4.18-aarch64-bootloader-4.19` when an aarch64/arm64 node is detected in the cluster.

These gates are only relevant for upgrades to 4.19, so they will only need to exist in the MCO's `release-4.18` branch. I've also added a few units for this functionality. 

**- How to verify it**
Before testing either case, ensure that any non MCO keys in `admin-gates` have been acknowledged. For example, if there is a key called `ack-4.18-kube-1.32-api-removals-in-4.19` in `admin-gates`, add this key to the `admin-acks` configmap in the `openshift-config` namespace with its value set to true like so:
```
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    include.release.openshift.io/hypershift: "true"
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    kubernetes.io/description: Record administrator acknowledgments of update gates
      defined in the admin-gates ConfigMap in the openshift-config-managed namespace.
    release.openshift.io/create-only: "true"
  creationTimestamp: "2025-05-13T07:51:46Z"
  name: admin-acks
  namespace: openshift-config
  resourceVersion: "2284"
  uid: fdd6b65e-5c83-4d41-a08d-cba2bbdf1e91
data:
  ack-4.18-kube-1.32-api-removals-in-4.19: "true"
```
- AWS/GCP boot image opt-out:
   - Launch this PR against a 4.18 cluster on the AWS or GCP platform without a boot image configuration defined. The CVO should trip `Upgradeable=False` (check via `oc get clusterversion -o yaml`). Now, add a boot image configuration - the CVO should no longer be setting `Upgradeable` to false.
   - This gate should not show up on any other platforms.
- aarch64 bootloader:
   - Launch this PR against a 4.18 aarch64 cluster. The CVO should trip `Upgradeable=False` (check via `oc get clusterversion -o yaml`). 
   - This gate should not show up on clusters of any other architectures.