### PR TITLE
OCPBUGS-55681: Give keepalived container chroot cap

### DIFF
--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -73,7 +73,7 @@ contents:
       - name: keepalived
         securityContext:
           capabilities:
-            add: ["NET_ADMIN", "NET_RAW"]
+            add: ["NET_ADMIN", "NET_RAW", "SYS_CHROOT"]
         image: {{.Images.keepalivedImage}}
         env:
           - name: NSS_SDB_USE_CACHE


### PR DESCRIPTION
When we switched our containers to use capabilities intead of giving them full admin access to everything, we missed that the keepalived container needs to be able to chroot for one of its health checks. Because this check is always failing now, we may place the VIP incorrectly and break access to ingress services on the cluster. This just adds the necessary capability to the container.

There will be a followup change in the origin repo to add a test that would have caught this, since it's not a problem in a normal CI run.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
