### PR TITLE
OCPBUGS-55770: Compare the osImageURLs for OS validation check

### DIFF
--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -644,6 +645,10 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 	// the operator shouldn't stop the rest of the upgrade from progressing/completing.
 	if merged.Spec.OSImageURL != ctrlcommon.GetDefaultBaseImageContainer(&cconfig.Spec) {
 		merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] = "true"
+		// Log a warning if the osImageURL is set using a tag instead of a digest
+		if !strings.Contains(merged.Spec.OSImageURL, "sha256:") {
+			klog.Warningf("OSImageURL %q for MachineConfig %s is set using a tag instead of a digest. It is highly recommended to use a digest", merged.Spec.OSImageURL, merged.Name)
+		}
 	}
 
 	return merged, nil


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/OCPBUGS-55770

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
There is no need to check the ostree.commit label
to validate the os image on disk. Use the osImageURL value instead as the digest is what is used to verify.

**- How to verify it**
Start a cluster and delete a MCD pod, the logs should show that no remote inspect is happening anymore in the `checkOS()` call. 

**- Description for the changelog**
Use osImageURL to validate the on disk OS image.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
