### PR TITLE
OCPBUGS-55971: Enable debug logging for nodeip-configuration

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -19,6 +19,7 @@ contents: |
     until \
     /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
+    --env 'ENABLE_NODEIP_DEBUG=true' \
     --net=host \
     --security-opt label=disable \
     --volume /etc/systemd/system:/etc/systemd/system \

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -20,6 +20,7 @@ contents: |
     until \
     /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
+    --env 'ENABLE_NODEIP_DEBUG=true' \
     --net=host \
     --security-opt label=disable \
     --volume /etc/systemd/system:/etc/systemd/system \

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -30,6 +30,7 @@ contents: |
     until \
     /usr/bin/podman run --rm \
     --authfile /var/lib/kubelet/config.json \
+    --env 'ENABLE_NODEIP_DEBUG=true' \
     --net=host \
     --security-opt label=disable \
     --volume /etc/systemd/system:/etc/systemd/system \


### PR DESCRIPTION
We turned off most of the log messages from the node-ip command in runtimecfg because it was spamming the keepalived logs. However, for nodeip-configuration we still want those logs in order to debug problems with ip selection. This only runs once per boot so the additional messages won't repeat like they do in the keepalived pod.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
