### PR TITLE
OCPBUGS-7747: Do not set cpu system reserve below the default value

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -89,6 +89,10 @@ contents:
                 recommended_systemreserved_cpu=$base_allocation_fraction
             fi
         fi
+
+        # Enforce minimum threshold of 0.5 CPU
+        recommended_systemreserved_cpu=$(awk -v val="$recommended_systemreserved_cpu" 'BEGIN {if (val < 0.5) print 0.5; else print val}')
+
         echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}">> ${NODE_SIZES_ENV}
     }
     function dynamic_ephemeral_sizing {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
If the number of CPUs are below 32, the recommended system reserved by the auto node sizing could be lower than the default 500m value. This PR descards the value calculated by the auto node sizing script if it is lower than 0.5. 

**- How to verify it**
Enable the auto node sizing with the worker nodes having less than 32 CPUs, and the value set for system reserved cpu should be at least 0.5 

**- Description for the changelog**
<!--
System reserved CPU value defaults to 500m if the number of CPUs are less than 32 on the node. 
-->
