### PR TITLE
[release-4.18] OCPBUGS-56133: OWNERS: update owners file with current MCO team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,15 +6,17 @@ approvers:
   - yuqi-zhang
   - cheesesashimi
   - umohnani8
-  - LorbusChris
   - RishabhSaini
+  - isabella-janssen
+  - pablintino
 reviewers:
   - djoshy
   - dkhater-redhat
   - yuqi-zhang
   - cheesesashimi
   - umohnani8
-  - LorbusChris
   - RishabhSaini
+  - isabella-janssen
+  - pablintino
 
 component: "Machine Config Operator"


### PR DESCRIPTION
Closes: [OCPBUGS-56133](https://issues.redhat.com/browse/OCPBUGS-56133)

**- What I did**
This is a manual backport of #5040 since the [automated cherry-pick failed](https://github.com/openshift/machine-config-operator/pull/5040#issuecomment-2877515046). This updates the OWNERS file to be up to date with the current members of the MCO team.

**- How to verify it**
N/A

**- Description for the changelog**
OWNERS: update owners file with current MCO team members
