### PR TITLE
OCPBUGS-53390: Fix interrupt state to account for failure correctly

### DIFF
--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -329,7 +329,7 @@ func (j *jobImageBuilder) validateBuilderType(builder buildrequest.Builder) erro
 func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1.Condition) {
 	// If the job is being deleted and it was not in either a successful or failed state
 	// then the MachineOSBuild should be considered "interrupted"
-	if job.DeletionTimestamp != nil && job.Status.Succeeded == 0 && job.Status.Failed == 0 {
+	if job.DeletionTimestamp != nil && job.Status.Succeeded == 0 && job.Status.Failed < constants.JobMaxRetries+1 {
 		return mcfgv1.MachineOSBuildInterrupted, apihelpers.MachineOSBuildInterruptedConditions()
 	}
 


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/OCPBUGS-53390
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
If the job hasn't completely failed but some of the pods have failed and we deleted the job we weren't setting the MOSB to interrupted as expected. This was because we had a wrong check for failure state. This patch fixes that.

**- How to verify it**
Create a failing MOSC and then delete the job after on pod has failed, the MOSB should be in interrupted state.

**- Description for the changelog**
Fix validation for MOSB interrupted state.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
