### PR TITLE
OPNET-681,OCPBUGS-57484: Support migration to NMState

### DIFF
--- a/templates/common/_base/files/nmstate-configuration.yaml
+++ b/templates/common/_base/files/nmstate-configuration.yaml
@@ -39,5 +39,8 @@ contents:
     # Handle the case where we're migrating from configure-ovs
     ovs-vsctl --timeout=30 --if-exists del-br br-ex
 
+    # Handle the case where we're migrating from OpenShift SDN
+    ovs-vsctl --timeout=30 --if-exists del-br br0
+
     cp "$src_path/$config_file" /etc/nmstate
     touch /etc/nmstate/openshift/applied

--- a/templates/common/_base/files/nmstate-configuration.yaml
+++ b/templates/common/_base/files/nmstate-configuration.yaml
@@ -36,5 +36,8 @@ contents:
       exit 1
     fi
 
+    # Handle the case where we're migrating from configure-ovs
+    ovs-vsctl --timeout=30 --if-exists del-br br-ex
+
     cp "$src_path/$config_file" /etc/nmstate
     touch /etc/nmstate/openshift/applied


### PR DESCRIPTION
This PR adds logic to handle two migration paths to NMState: one from an existing OVNK cluster using configure-ovs, and one from OpenShift SDN directly to NMState without ever using configure-ovs.

In the former case, we need to clean up the left over remnants of configure-ovs's br-ex configuration. In the latter we need to clean up br0, which would otherwise have been done by configure-ovs.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
