### PR TITLE
OCPBUGS-49592: Remove service dependencies on crio-wipe.service as it doesn't exist anymore

### DIFF
--- a/templates/common/_base/units/kubelet-dependencies.target.yaml
+++ b/templates/common/_base/units/kubelet-dependencies.target.yaml
@@ -4,5 +4,5 @@ contents: |
   Description=Dependencies necessary to run kubelet
   Documentation=https://github.com/openshift/machine-config-operator/
   Requires=basic.target network-online.target
-  Wants=NetworkManager-wait-online.service crio-wipe.service
+  Wants=NetworkManager-wait-online.service
   Wants=rpc-statd.service chrony-wait.service

--- a/templates/common/_base/units/machine-config-daemon-pull.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-pull.service.yaml
@@ -8,9 +8,8 @@ contents: |
   # This "stamp file" is unlinked when we complete
   # machine-config-daemon-firstboot.service
   ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
-  # Run after crio-wipe so the pulled MCD image is protected against a corrupted storage from a forced shutdown
-  Wants=crio-wipe.service NetworkManager-wait-online.service
-  After=crio-wipe.service NetworkManager-wait-online.service network.service
+  Wants=NetworkManager-wait-online.service
+  After=NetworkManager-wait-online.service network.service
 
   [Service]
   Type=oneshot

--- a/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
+++ b/templates/common/on-prem/units/on-prem-resolv-prepender.service.yaml
@@ -4,8 +4,6 @@ enabled: false
 contents: |
   [Unit]
   Description=Populates resolv.conf according to on-prem IPI needs
-  # Per https://issues.redhat.com/browse/OCPBUGS-27162 there is a problem if this is started before crio-wipe
-  After=crio-wipe.service
   StartLimitIntervalSec=0
   [Service]
   Type=oneshot


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
I removed references to crio-wipe.service from the service templates, as crio-wipe doesn't exist anymore as evident in OCPBUGS-49592.

**- How to verify it**
`systemctl cat crio-wipe.service` should yield the following output if crio-wipe.service really does not exist anymore:
```
No files found for crio-wipe.service.
```

`systemctl cat on-prem-resolv-prepender` should yield the following output:

```
# /etc/systemd/system/on-prem-resolv-prepender.service
[Unit]
Description=Populates resolv.conf according to on-prem IPI needs
StartLimitIntervalSec=0
[Service]
Type=oneshot
# Would prefer to do Restart=on-failure instead of this bash retry loop, but
# the version of systemd we have right now doesn't support it. It should be
# available in systemd v244 and higher.
ExecStart=/bin/bash -c " \
  until \
  /usr/local/bin/resolv-prepender.sh; \
  do \
  sleep 10; \
  done"
EnvironmentFile=-/run/resolv-prepender/env
```

`systemctl cat kubelet-dependencies.target` should show:

```
# /etc/systemd/system/kubelet-dependencies.target
[Unit]
Description=Dependencies necessary to run kubelet
Documentation=https://github.com/openshift/machine-config-operator/
Requires=basic.target network-online.target
Wants=NetworkManager-wait-online.service
Wants=rpc-statd.service chrony-wait.service
```

`systemctl cat machine-config-daemon-pull.service` should show:

```
# /etc/systemd/system/machine-config-daemon-pull.service
[Unit]
Description=Machine Config Daemon Pull
# Make sure it runs only on OSTree booted system
ConditionPathExists=/run/ostree-booted
# This "stamp file" is unlinked when we complete
# machine-config-daemon-firstboot.service
ConditionPathExists=/etc/ignition-machine-config-encapsulated.json
Wants=NetworkManager-wait-online.service
After=NetworkManager-wait-online.service network.service

[Service]
Type=oneshot
RemainAfterExit=yes
ExecStartPre=/etc/machine-config-daemon/generate_podman_policy_args.sh
ExecStart=/bin/sh -c "while ! /usr/bin/podman pull $(cat /tmp/podman_policy_args) --authfile=/var/lib/kubelet/config.json 'virthost.ostest.test.metalkube.org:5000/localimages/machine-config-operator:latest'; do sleep 1; done"

[Install]
RequiredBy=machine-config-daemon-firstboot.service
```

**- Description for the changelog**
Remove references to crio-wipe.service in other service definitions because it doesn't exist anymore.
