### PR TITLE
OCPBUGS-55830: Only update boot disks during GCP boot image updates

### DIFF
--- a/pkg/controller/machine-set-boot-image/platform_helpers.go
+++ b/pkg/controller/machine-set-boot-image/platform_helpers.go
@@ -86,7 +86,7 @@ func reconcileGCP(machineSet *machinev1beta1.MachineSet, configMap *corev1.Confi
 	patchRequired = false
 	newProviderSpec := providerSpec.DeepCopy()
 	for idx, disk := range newProviderSpec.Disks {
-		if newBootImage != disk.Image {
+		if newBootImage != disk.Image && disk.Boot {
 			klog.Infof("New target boot image: %s", newBootImage)
 			klog.Infof("Current image: %s", disk.Image)
 			patchRequired = true

--- a/test/e2e/msbic_test.go
+++ b/test/e2e/msbic_test.go
@@ -370,7 +370,9 @@ func verifyMachineSet(t *testing.T, cs *framework.ClientSet, ms machinev1beta1.M
 
 	newProviderSpec := providerSpec.DeepCopy()
 	for idx := range newProviderSpec.Disks {
-		newProviderSpec.Disks[idx].Image = newProviderSpec.Disks[idx].Image + "-fake-update"
+		if newProviderSpec.Disks[idx].Boot {
+			newProviderSpec.Disks[idx].Image = newProviderSpec.Disks[idx].Image + "-fake-update"
+		}
 	}
 
 	newMachineSet := ms.DeepCopy()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add an additional check for `boot:true`, before updating the providerSpec. 

**- How to verify it**
See bug for reproduction steps.


