### PR TITLE
OCPBUGS-55663: Remove NodeDisruptionPolicy featuregate

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1300,7 +1300,7 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig(machineConfigFile string) er
 	// This "false" is a compatibility for IBM's use case, where they are using the MCD to write the full configuration instead of just
 	// the encapsulated config. This shouldn't affect normal OCP operations, but will allow anyone using this code to write configs to
 	// still get the kubelet cert
-	err = dn.update(oldConfig, &mc, false)
+	err = dn.update(oldConfig, &mc, false, true)
 	if err != nil {
 		return err
 	}
@@ -2399,7 +2399,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 	}
 	if contentFrom == onceFromLocalConfig {
 		// Execute update without hitting the cluster
-		return dn.update(nil, &machineConfig, false)
+		return dn.update(nil, &machineConfig, false, true)
 	}
 	// Otherwise return an error as the input format is unsupported
 	return fmt.Errorf("%v is not a path nor url; can not run once", contentFrom)
@@ -2611,7 +2611,7 @@ func (dn *Daemon) triggerUpdateWithMachineConfig(currentConfig, desiredConfig *m
 	dn.stopConfigDriftMonitor()
 
 	// run the update process. this function doesn't currently return.
-	return dn.update(currentConfig, desiredConfig, skipCertificateWrite)
+	return dn.update(currentConfig, desiredConfig, skipCertificateWrite, false)
 }
 
 // validateKernelArguments checks that the current boot has all arguments specified

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -375,7 +375,7 @@ func TestSyncMachineConfiguration(t *testing.T) {
 			optr := &Operator{
 				eventRecorder: &record.FakeRecorder{},
 				fgAccessor: featuregates.NewHardcodedFeatureGateAccess(
-					[]configv1.FeatureGateName{features.FeatureGateManagedBootImages, features.FeatureGateManagedBootImagesAWS, features.FeatureGateNodeDisruptionPolicy}, []configv1.FeatureGateName{},
+					[]configv1.FeatureGateName{features.FeatureGateManagedBootImages, features.FeatureGateManagedBootImagesAWS}, []configv1.FeatureGateName{},
 				),
 				infraLister: configlistersv1.NewInfrastructureLister(infraIndexer),
 				mcopLister:  mcoplistersv1.NewMachineConfigurationLister(mcopIndexer),


### PR DESCRIPTION
**- What I did**
Removed all references to `FeatureGateNodeDisruptionPolicy`

**- How to verify it**
Existing e2es should pass. 