### PR TITLE
MCO-1282: Remove all code related to the Image Registry workaround Config Map

### DIFF
--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -1,31 +1,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: machine-config-operator
-  namespace: openshift-machine-config-operator
-  labels:
-    k8s-app: machine-config-operator
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-spec:
-  groups:
-    - name: drain-override-configmap-present
-      rules:
-        - alert: MCODrainOverrideConfigMapAlert
-          expr: |
-            mco_image_registry_drain_override_exists > 0
-          labels:
-            namespace: openshift-machine-config-operator
-            severity: warning
-          annotations:
-            summary: "Alerts the user to the presence of a drain override configmap that is being deprecated and removed in a future release."
-            description: "Image Registry Drain Override configmap has been detected. Please use the Node Disruption Policy feature to control the cluster's drain behavior as the configmap method is currently deprecated and will be removed in a future release."
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
   name: machine-config-controller
   namespace: openshift-machine-config-operator
   labels:

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -141,10 +141,6 @@ const (
 	// changes to this path. Note that other files added to the parent directory will not be handled specially
 	GPGNoRebootPath = "/etc/machine-config-daemon/no-reboot/containers-gpg.pub"
 
-	// ImageRegistryDrainOverrideConfigmap is the name of the Configmap a user can apply to force all
-	// image registry changes to not drain
-	ImageRegistryDrainOverrideConfigmap = "image-registry-override-drain"
-
 	// rpm-ostree command arguments
 	RPMOSTreeUpdateArg    = "update"
 	RPMOSTreeInstallArg   = "--install"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1139,7 +1139,7 @@ func (dn *Daemon) syncNodeHypershift(key string) error {
 	}
 
 	// Check and perform node drain if required
-	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig, false)
+	drain, err := isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -128,17 +128,13 @@ func (dn *Daemon) performDrain() error {
 }
 
 // isDrainRequiredForNodeDisruptionActions determines whether node drain is required or not to apply config changes for this set of NodeDisruptionActions
-func isDrainRequiredForNodeDisruptionActions(actions []opv1.NodeDisruptionPolicyStatusAction, oldIgnConfig, newIgnConfig ign3types.Config, overrideImageRegistryDrain bool) (bool, error) {
+func isDrainRequiredForNodeDisruptionActions(actions []opv1.NodeDisruptionPolicyStatusAction, oldIgnConfig, newIgnConfig ign3types.Config) (bool, error) {
 	klog.Infof("Checking drain required for node disruption actions")
 	if apihelpers.CheckNodeDisruptionActionsForTargetActions(actions, opv1.RebootStatusAction, opv1.DrainStatusAction) {
 		// We definitely want to perform drain for these cases
 		return true, nil
 	} else if apihelpers.CheckNodeDisruptionActionsForTargetActions(actions, opv1.SpecialStatusAction) {
 		// This is a specially reserved action for "/etc/containers/registries.conf" and for this action, drain may or may not be necessary
-		if overrideImageRegistryDrain {
-			klog.Warningf("Drain was skipped for this image registry update due to the configmap %s being present. This may not be a safe change", constants.ImageRegistryDrainOverrideConfigmap)
-			return false, nil
-		}
 		isSafe, err := isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig)
 		if err != nil {
 			return false, err
@@ -150,7 +146,7 @@ func isDrainRequiredForNodeDisruptionActions(actions []opv1.NodeDisruptionPolicy
 }
 
 // isDrainRequired determines whether node drain is required or not to apply config changes.
-func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig ign3types.Config, overrideImageRegistryDrain bool) (bool, error) {
+func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig ign3types.Config) (bool, error) {
 	switch {
 	case ctrlcommon.InSlice(postConfigChangeActionReboot, actions):
 		// Node is going to reboot, we definitely want to perform drain
@@ -158,10 +154,6 @@ func isDrainRequired(actions, diffFileSet []string, oldIgnConfig, newIgnConfig i
 	case ctrlcommon.InSlice(postConfigChangeActionReloadCrio, actions), ctrlcommon.InSlice(postConfigChangeActionRestartCrio, actions):
 		// Drain may or may not be necessary in case of container registry config changes.
 		if ctrlcommon.InSlice(constants.ContainerRegistryConfPath, diffFileSet) {
-			if overrideImageRegistryDrain {
-				klog.Warningf("Drain was skipped for this image registry update due to the configmap %s being present. This may not be a safe change", constants.ImageRegistryDrainOverrideConfigmap)
-				return false, nil
-			}
 			isSafe, err := isSafeContainerRegistryConfChanges(oldIgnConfig, newIgnConfig)
 			if err != nil {
 				return false, err

--- a/pkg/daemon/drain_test.go
+++ b/pkg/daemon/drain_test.go
@@ -468,7 +468,7 @@ location = "mirror.com/repo/test-img-14"
 				t.Errorf("parsing new Ignition config failed: %v", err)
 			}
 			diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
-			drain, err := isDrainRequired(test.actions, diffFileSet, oldIgnConfig, newIgnConfig, false)
+			drain, err := isDrainRequired(test.actions, diffFileSet, oldIgnConfig, newIgnConfig)
 			if !reflect.DeepEqual(test.expectedAction, drain) {
 				t.Errorf("Failed determining drain behavior: expected: %v but result is: %v. Error: %v", test.expectedAction, drain, err)
 			}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -22,7 +22,6 @@ import (
 	"github.com/coreos/go-semver/semver"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeErrs "k8s.io/apimachinery/pkg/util/errors"
@@ -1191,21 +1190,17 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}
 
 	var drain bool
-	crioOverrideConfigmapExists, err := dn.hasImageRegistryDrainOverrideConfigMap()
-	if err != nil {
-		return err
-	}
 	// Node Disruption Policies cannot be used during firstboot as API is not accessible.
 	if !firstBoot {
 		// Check actions list and perform node drain if required
-		drain, err = isDrainRequiredForNodeDisruptionActions(nodeDisruptionActions, oldIgnConfig, newIgnConfig, crioOverrideConfigmapExists)
+		drain, err = isDrainRequiredForNodeDisruptionActions(nodeDisruptionActions, oldIgnConfig, newIgnConfig)
 		if err != nil {
 			return err
 		}
 		klog.Infof("Drain calculated for node disruption: %v for config %s", drain, newConfigName)
 	} else {
 		// Check and perform node drain if required
-		drain, err = isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig, crioOverrideConfigmapExists)
+		drain, err = isDrainRequired(actions, diffFileSet, oldIgnConfig, newIgnConfig)
 		if err != nil {
 			return err
 		}
@@ -2968,23 +2963,6 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 
 	// Apply extensions
 	return dn.applyExtensions(oldConfig, newConfig)
-}
-
-func (dn *Daemon) hasImageRegistryDrainOverrideConfigMap() (bool, error) {
-	if dn.kubeClient == nil {
-		return false, nil
-	}
-
-	_, err := dn.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), constants.ImageRegistryDrainOverrideConfigmap, metav1.GetOptions{})
-	if err == nil {
-		return true, nil
-	}
-
-	if apierrors.IsNotFound(err) {
-		return false, nil
-	}
-
-	return false, fmt.Errorf("Error fetching image registry drain override configmap: %w", err)
 }
 
 // Enables the revert layering systemd unit.

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -45,13 +45,6 @@ var (
 			Name: "mco_unavailable_machine_count",
 			Help: "total number of unavailable machines in specified pool",
 		}, []string{"pool"})
-	// mcoImageRegistryDrainOverrideConfigmapExists tracks the presence of the image registry drain override configmap
-	mcoImageRegistryDrainOverrideConfigmapExists = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "mco_image_registry_drain_override_exists",
-			Help: "tracks presence of the image registry drain override configmap",
-		},
-	)
 )
 
 func RegisterMCOMetrics() error {
@@ -61,7 +54,6 @@ func RegisterMCOMetrics() error {
 		mcoUpdatedMachineCount,
 		mcoDegradedMachineCount,
 		mcoUnavailableMachineCount,
-		mcoImageRegistryDrainOverrideConfigmapExists,
 	})
 
 	if err != nil {

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	kcc "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
-	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
 )
 
@@ -332,19 +331,6 @@ func (optr *Operator) syncMetrics() error {
 		mcoDegradedMachineCount.WithLabelValues(pool.Name).Set(float64(pool.Status.DegradedMachineCount))
 		mcoUnavailableMachineCount.WithLabelValues(pool.Name).Set(float64(pool.Status.UnavailableMachineCount))
 	}
-
-	// Attempt to fetch image-registry-override-drain configmap
-	_, err = optr.mcoCmLister.ConfigMaps(ctrlcommon.MCONamespace).Get(daemonconsts.ImageRegistryDrainOverrideConfigmap)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("error fetching configmap %s during metrics sync", daemonconsts.ImageRegistryDrainOverrideConfigmap)
-	}
-	// If the configmap is present, fire an alert warning admin of deprecation
-	if apierrors.IsNotFound(err) {
-		mcoImageRegistryDrainOverrideConfigmapExists.Set(0)
-	} else {
-		mcoImageRegistryDrainOverrideConfigmapExists.Set(1)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Removed all code and related alerts for the Image Registry Workaround ([PR#4514](https://github.com/openshift/machine-config-operator/pull/4514) and [PR#4139](https://github.com/openshift/machine-config-operator/pull/4139)) due to NodeDisruptionPolicy going GA.

**- How to verify it**

// Apply imagecontentsourcepolicy

```
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  name: quay-mirror
spec:
  repositoryDigestMirrors:
  - mirrors:
    - my-quay.io.mirror
    source: quay.io
    
cruhm@cruhm-thinkpadp16vgen1:~$ vim imagecontent.yaml
cruhm@cruhm-thinkpadp16vgen1:~$ oc create -f imagecontent.yaml 
imagecontentsourcepolicy.operator.openshift.io/quay-mirror created
```
// Apply override config map

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: image-registry-override-drain
  namespace: openshift-machine-config-operator
  
cruhm@cruhm-thinkpadp16vgen1:~$ vim override.yaml
cruhm@cruhm-thinkpadp16vgen1:~$ oc apply -f override.yaml 
configmap/image-registry-override-drain created
```

// Wait for the initial MCP rollover to finish. Check to make sure that the MCODrainOverrideConfigMapAlert exists and no longer fires

```
cruhm@cruhm-thinkpadp16vgen1:~/frr/jshivers/frr$ oc get configmap prometheus-k8s-rulefiles-0 -o yaml | grep MCODrainOverrideConfigMapAlert

cruhm@cruhm-thinkpadp16vgen1:~/frr/jshivers/frr$
```

// Delete the ImageContentSourcePolicy. You  should see the MCP rollover again even with the override file present. 

~~~
cruhm@cruhm-thinkpadp16vgen1:~$ oc get mcp
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
master   rendered-master-aa75b71b868b370bb85e66fe0d82d293   True      False      False      3              3                   3                     0                      65m
worker   rendered-worker-d9cd5ae52d8e497b19fc8f39532486ff   True      False      False      3              3                   3                     0                      65m

$ oc delete ImageContentSourcePolicy quay-mirror

cruhm@cruhm-thinkpadp16vgen1:~$ oc get mcp 
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
master   rendered-master-aa75b71b868b370bb85e66fe0d82d293   False     True       False      3              0                   0                     0                      66m
worker   rendered-worker-d9cd5ae52d8e497b19fc8f39532486ff   False     True       False      3              0                   0                     0                      66m
~~~


**- Description for the changelog**
<!--

-->

 Remove all code related to the Image Registry workaround Config Map
