### PR TITLE
Revert "[release-4.19] OCPBUGS-56263: scope MCD node listers to current node"

### DIFF
--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -22,8 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
-	corev1informers "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -163,34 +161,4 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder) *Controll
 		ImageInformerFactory:                                imageSharedInformer,
 		RouteInformerFactory:                                routeSharedInformer,
 	}
-}
-
-// Creates a NodeInformer that is bound to a single node. This is for use by
-// the MCD to ensure that the MCD only receives watch events for the node that
-// it is running on as opposed to all cluster nodes. Doing this helps reduce
-// the load on the apiserver. Because the filters are applied to *all*
-// informers constructed by the informer factory, we want to ensure that this
-// factory is only used to construct a NodeInformer.
-//
-// Therefore, to ensure that this informer factory is only used for
-// constructing a NodeInformer with this specific filter, we only return the
-// instantiated NodeInformer instance and a start function.
-func NewScopedNodeInformer(kubeclient kubernetes.Interface, nodeName string) (corev1informers.NodeInformer, func(<-chan struct{})) {
-	sif := informers.NewSharedInformerFactoryWithOptions(
-		kubeclient,
-		resyncPeriod()(),
-		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
-			opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", nodeName).String()
-		}),
-	)
-
-	return sif.Core().V1().Nodes(), sif.Start
-}
-
-// Creates a scoped node informer that is bound to a single node from a
-// clients.Builder instance. It sets the user-agent for the client to
-// node-scoped-informer before instantiating the node informer. Returns the
-// instantiated NodeInformer and a start function.
-func NewScopedNodeInformerFromClientBuilder(cb *clients.Builder, nodeName string) (corev1informers.NodeInformer, func(<-chan struct{})) {
-	return NewScopedNodeInformer(cb.KubeClientOrDie("node-scoped-informer"), nodeName)
 }

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -85,16 +86,10 @@ func newNodeWriter(nodeName string, stopCh <-chan struct{}) (NodeWriter, error) 
 	}
 
 	klog.Infof("NodeWriter initialized with credentials from %s", nodeWriterKubeconfigPath)
-	// This informer needs to use the a different service account than the rest
-	// of the MCD, which is bound to the machine-config-daemon service account.
-	// Consequently, it must use a different informer factory than the parent
-	// informer factory. However, we can instantiate both that informer factory
-	// and the node informer in the same way that we instantiate the MCD
-	// informer.
-	informer, startFunc := ctrlcommon.NewScopedNodeInformer(kubeClient, nodeName)
-	nodeInformer := informer.Informer()
-	nodeLister := informer.Lister()
-	nodeListerSynced := nodeInformer.HasSynced
+	informer := informers.NewSharedInformerFactory(kubeClient, ctrlcommon.DefaultResyncPeriod()())
+	nodeInformer := informer.Core().V1().Nodes()
+	nodeLister := nodeInformer.Lister()
+	nodeListerSynced := nodeInformer.Informer().HasSynced
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.V(2).Infof)
@@ -110,12 +105,12 @@ func newNodeWriter(nodeName string, stopCh <-chan struct{}) (NodeWriter, error) 
 		kubeClient:       kubeClient,
 	}
 
-	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    nw.handleNodeWriterEvent,
 		UpdateFunc: func(_, newObj interface{}) { nw.handleNodeWriterEvent(newObj) },
 	})
 
-	startFunc(stopCh)
+	informer.Start(stopCh)
 
 	return nw, nil
 }


### PR DESCRIPTION
Reverts openshift/machine-config-operator#5058

Supposedly it breaks cert rotation on suspend