### PR TITLE
[release-4.20] OCPBUGS-56744: Fix typo in MCN's `MachineConfigNodePinnedImageSetsDegraded` message

### DIFF
--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -646,7 +646,7 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 		&upgrademonitor.Condition{
 			State:   mcfgv1.MachineConfigNodePinnedImageSetsDegraded,
 			Reason:  "PrefetchFailed",
-			Message: "One or more PinnedImageSet is experiencing an error. See PinnedImageSet list for more details",
+			Message: "One or more PinnedImageSet is experiencing an error. See PinnedImageSet list for more details.",
 		},
 		nil,
 		metav1.ConditionTrue,


### PR DESCRIPTION

**- What I did**
Edited the error message for an invalid PIS to not have a typo. Fixes #[OCPBUGS-56744]

**- How to verify it**
When an invalid PIS is applied, the 'MachineConfigNodePinnedImageSetsDegraded' message has a '.' at the end of the message. The message for `MachineConfigNodePinnedImageSetsDegraded` should not have a typo, so it should be:

"One or more PinnedImageSet is experiencing an error. See PinnedImageSet list for more details."

**- Description for the changelog**
A period added to the end of the error message
