### PR TITLE
OCPBUGS-56555: openvswitch3.5-ipsec package not included with ipsec os extension

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -144,4 +144,9 @@ const (
 	// ImageRegistryDrainOverrideConfigmap is the name of the Configmap a user can apply to force all
 	// image registry changes to not drain
 	ImageRegistryDrainOverrideConfigmap = "image-registry-override-drain"
+
+	// rpm-ostree command arguments
+	RPMOSTreeUpdateArg    = "update"
+	RPMOSTreeInstallArg   = "--install"
+	RPMOSTreeUninstallArg = "--uninstall"
 )


### PR DESCRIPTION
Closes [OCPBUGS-56555](https://issues.redhat.com/browse/OCPBUGS-56555).

**- What I did**
This updates extension handling to use actual installed packages from rpm-ostree status instead of comparing extension lists between configs. It also removes FCOS conditionals as they are no longer required. I've also added a few units.

**- How to verify it**
- Existing e2es/units should pass. 
- Adding new packages to an existing extension should be correctly handled during upgrades. (https://github.com/openshift/machine-config-operator/pull/4878)
