### PR TITLE
NO-ISSUE: Add Jetbrains IDEs files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 _output
 .vscode/
+.idea/
 junit*.xml
 checkstyle*.xml
 mco-unit-test-coverage.out


### PR DESCRIPTION
This simple PR adds Jetbrains IDEs workspace directory to our .gitignore to avoid considering those files from Git's perspective.