### PR TITLE
OCPBUGS-57423: pkg/operator/status: Drop PoolUpdating as an Upgradeable=False condition

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -316,13 +316,6 @@ func (optr *Operator) syncUpgradeableStatus() error {
 			break
 		}
 	}
-	// this should no longer trigger when adding a node to a pool. It should only trigger if the node actually has to go through an upgrade
-	// updating and degraded can occur together, in that case defer to the degraded Reason that is already set above
-	if updating && !degraded && !interrupted {
-		coStatus.Status = configv1.ConditionFalse
-		coStatus.Reason = "PoolUpdating"
-		coStatus.Message = "One or more machine config pools are updating, please see `oc get mcp` for further details"
-	}
 
 	// don't overwrite status if updating or degraded
 	if !updating && !degraded && !interrupted {


### PR DESCRIPTION
Manually picking #4760 / #5111 back to 4.16, which is using `coStatus` instead of `coStatusCondition`, because it lacks #4321.  Otherwise identical:

```console
$ diff -U1 <(git show --oneline 377a78bb9fd2) <(git show --oneline 6bf0d7135d09)
--- /dev/fd/63  2025-06-12 10:41:31.352490108 -0700
+++ /dev/fd/62  2025-06-12 10:41:31.352490108 -0700
@@ -1,7 +1,7 @@
-377a78bb9 pkg/operator/status: Drop PoolUpdating as an Upgradeable=False condition
+6bf0d7135 pkg/operator/status: Drop PoolUpdating as an Upgradeable=False condition
 diff --git a/pkg/operator/status.go b/pkg/operator/status.go
-index 63699ec5c..eb015e005 100644
+index 69d37ad29..21a5ccc16 100644
 --- a/pkg/operator/status.go
 +++ b/pkg/operator/status.go
-@@ -285,13 +285,6 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error
+@@ -316,13 +316,6 @@ func (optr *Operator) syncUpgradeableStatus() error {
                        break
@@ -12,5 +12,5 @@
 -      if updating && !degraded && !interrupted {
--              coStatusCondition.Status = configv1.ConditionFalse
--              coStatusCondition.Reason = "PoolUpdating"
--              coStatusCondition.Message = "One or more machine config pools are updating, please see `oc get mcp` for further details"
+-              coStatus.Status = configv1.ConditionFalse
+-              coStatus.Reason = "PoolUpdating"
+-              coStatus.Message = "One or more machine config pools are updating, please see `oc get mcp` for further details"
 -      }
 ```