### PR TITLE
OCPBUGS-52302: Fix timing of `Spec.ConfigVersion.Desired` update in MCN

### DIFF
--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -315,7 +315,7 @@ func (ctrl *Controller) syncNode(key string) error {
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(ctrl.mcpLister, node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(ctrl.mcpLister, node)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,8 @@ func (ctrl *Controller) syncNode(key string) error {
 				node,
 				ctrl.client,
 				ctrl.fgHandler,
-				pool,
+				mcpName,
+				desiredConfigVersion,
 			)
 			if nErr != nil {
 				klog.Errorf("Error making MCN for Uncordon failure: %v", err)
@@ -349,7 +350,8 @@ func (ctrl *Controller) syncNode(key string) error {
 			node,
 			ctrl.client,
 			ctrl.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for UnCordon success: %v", err)
@@ -405,7 +407,7 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(ctrl.mcpLister, node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(ctrl.mcpLister, node)
 	if err != nil {
 		return err
 	}
@@ -421,7 +423,8 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 				node,
 				ctrl.client,
 				ctrl.fgHandler,
-				pool,
+				mcpName,
+				desiredConfigVersion,
 			)
 			if Nerr != nil {
 				klog.Errorf("Error making MCN for Cordon Failure: %v", Nerr)
@@ -436,7 +439,8 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 			node,
 			ctrl.client,
 			ctrl.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Cordon Success: %v", err)
@@ -453,7 +457,8 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 		node,
 		ctrl.client,
 		ctrl.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Drain beginning: %v", err)
@@ -483,7 +488,8 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 			node,
 			ctrl.client,
 			ctrl.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if nErr != nil {
 			klog.Errorf("Error making MCN for Drain failure: %v", nErr)
@@ -500,7 +506,8 @@ func (ctrl *Controller) drainNode(node *corev1.Node, drainer *drain.Helper) erro
 		node,
 		ctrl.client,
 		ctrl.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Drain success: %v", err)

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	helpers "github.com/openshift/machine-config-operator/pkg/helpers"
+	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
 
 	configv1 "github.com/openshift/api/config/v1"
 	features "github.com/openshift/api/features"
@@ -1221,14 +1222,21 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1.MachineOSConfig, mosb *
 		}
 
 		lns := ctrlcommon.NewLayeredNodeState(oldNode)
+		var desiredConfig string
 		if !layered {
 			lns.SetDesiredStateFromPool(pool)
+			desiredConfig = pool.Spec.Configuration.Name
 		} else {
 			lns.SetDesiredStateFromMachineOSConfig(mosc, mosb)
+			desiredConfig = mosb.Spec.MachineConfig.Name
+		}
+		// Update the desired config version in the node's MCN
+		err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(ctrl.fgHandler, pool.Name, desiredConfig, oldNode, ctrl.client)
+		if err != nil {
+			klog.Errorf("error updating MCN spec for node %s: %v", oldNode.Name, err)
 		}
 
 		// Set the desired state to match the pool.
-
 		newData, err := json.Marshal(lns.Node())
 		if err != nil {
 			return err

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -95,7 +95,7 @@ func newFixtureWithFeatureGates(t *testing.T, enabled, disabled []configv1.Featu
 }
 
 func newFixture(t *testing.T) *fixture {
-	return newFixtureWithFeatureGates(t, []configv1.FeatureGateName{features.FeatureGatePinnedImages, features.FeatureGateOnClusterBuild}, []configv1.FeatureGateName{})
+	return newFixtureWithFeatureGates(t, []configv1.FeatureGateName{features.FeatureGateMachineConfigNodes, features.FeatureGatePinnedImages, features.FeatureGateOnClusterBuild}, []configv1.FeatureGateName{})
 }
 
 func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller {
@@ -144,16 +144,8 @@ func (f *fixture) newController() *Controller {
 	return f.newControllerWithStopChan(stopCh)
 }
 
-func (f *fixture) newControllerWithContext(ctx context.Context) *Controller {
-	return f.newControllerWithStopChan(ctx.Done())
-}
-
 func (f *fixture) run(pool string) {
 	f.runController(pool, false)
-}
-
-func (f *fixture) runExpectError(pool string) {
-	f.runController(pool, true)
 }
 
 func (f *fixture) runController(pool string, expectError bool) {
@@ -264,7 +256,9 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "machineosbuilds") ||
 				action.Matches("watch", "machineosbuilds") ||
 				action.Matches("list", "machineosconfigs") ||
-				action.Matches("watch", "machineosconfigs")) {
+				action.Matches("watch", "machineosconfigs") ||
+				action.Matches("get", "machineconfignodes") ||
+				action.Matches("create", "machineconfignodes")) {
 			continue
 		}
 		ret = append(ret, action)
@@ -1150,7 +1144,7 @@ func TestShouldMakeProgress(t *testing.T) {
 			expectTaintsAddPatch:  false,
 		},
 		{
-			description:           "node not at desired config, patch on annotation and taints", // failing
+			description:           "node not at desired config, patch on annotation and taints",
 			node:                  newNodeWithLabel("nodeNeedingUpdates", machineConfigV0, machineConfigV0, map[string]string{"node-role/worker": "", "node-role/infra": ""}),
 			expectAnnotationPatch: true,
 			expectTaintsAddPatch:  true,
@@ -1439,9 +1433,11 @@ func TestCertStatus(t *testing.T) {
 	mcp := helpers.NewMachineConfigPool("test-cluster-infra", nil, helpers.InfraSelector, "v1")
 	mcpWorker := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v1")
 	mcp.Spec.MaxUnavailable = intStrPtr(intstr.FromInt(1))
+	nodeName0 := "node-0"
+	nodeName1 := "node-1"
 	nodes := []*corev1.Node{
-		newNodeWithLabel("node-0", "v1", "v1", map[string]string{"node-role/worker": "", "node-role/infra": ""}),
-		newNodeWithLabel("node-1", "v1", "v1", map[string]string{"node-role/worker": "", "node-role/infra": ""}),
+		newNodeWithLabel(nodeName0, "v1", "v1", map[string]string{"node-role/worker": "", "node-role/infra": ""}),
+		newNodeWithLabel(nodeName1, "v1", "v1", map[string]string{"node-role/worker": "", "node-role/infra": ""}),
 	}
 
 	f.ccLister = append(f.ccLister, cc)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -712,7 +712,7 @@ func (dn *Daemon) syncNode(key string) error {
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, node)
 	if err != nil {
 		return err
 	}
@@ -727,7 +727,8 @@ func (dn *Daemon) syncNode(key string) error {
 			node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Rebooted: %v", err)
@@ -803,7 +804,8 @@ func (dn *Daemon) syncNode(key string) error {
 			node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Resumed true: %v", err)
@@ -842,7 +844,8 @@ func (dn *Daemon) syncNode(key string) error {
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Updated false: %v", err)
@@ -867,7 +870,8 @@ func (dn *Daemon) syncNode(key string) error {
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Updated: %v", err)
@@ -2318,7 +2322,7 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, bool, erro
 		// let's mark it done!
 
 		// Get MCP associated with node
-		pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+		mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, dn.node)
 		if err != nil {
 			return missingODC, inDesiredConfig, err
 		}
@@ -2331,7 +2335,8 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, bool, erro
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Resumed true: %v", err)

--- a/pkg/daemon/drain.go
+++ b/pkg/daemon/drain.go
@@ -43,7 +43,7 @@ func (dn *Daemon) performDrain() error {
 		logSystem("Drain not required, skipping")
 
 		// Get MCP associated with node
-		pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+		mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, dn.node)
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,8 @@ func (dn *Daemon) performDrain() error {
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Drain not required: %v", err)

--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -546,7 +546,7 @@ func (p *PinnedImageSetManager) updateStatusProgressing(pools []*mcfgv1.MachineC
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(p.mcpLister, node)
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,8 @@ func (p *PinnedImageSetManager) updateStatusProgressing(pools []*mcfgv1.MachineC
 		p.mcfgClient,
 		applyCfg,
 		p.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 }
 
@@ -581,7 +582,7 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(p.mcpLister, node)
 	if err != nil {
 		return err
 	}
@@ -599,7 +600,8 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 		p.mcfgClient,
 		applyCfg,
 		p.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Failed to update machine config node: %v", err)
@@ -619,7 +621,8 @@ func (p *PinnedImageSetManager) updateStatusProgressingComplete(pools []*mcfgv1.
 		p.mcfgClient,
 		nil,
 		p.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 }
 
@@ -636,7 +639,7 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(p.mcpLister, node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(p.mcpLister, node)
 	if err != nil {
 		return err
 	}
@@ -654,7 +657,8 @@ func (p *PinnedImageSetManager) updateStatusError(pools []*mcfgv1.MachineConfigP
 		p.mcfgClient,
 		applyCfg,
 		p.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 }
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -123,7 +123,7 @@ func (dn *Daemon) executeReloadServiceNodeDisruptionAction(serviceName string, r
 	}
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, dn.node)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,8 @@ func (dn *Daemon) executeReloadServiceNodeDisruptionAction(serviceName string, r
 		dn.node,
 		dn.mcfgClient,
 		dn.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Reloading success: %v", err)
@@ -164,7 +165,7 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 		logSystem("Performing post config change action: %v for config %s", action.Type, configName)
 
 		// Get MCP associated with node
-		pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+		mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, dn.node)
 		if err != nil {
 			return err
 		}
@@ -179,7 +180,8 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 				dn.node,
 				dn.mcfgClient,
 				dn.fgHandler,
-				pool,
+				mcpName,
+				desiredConfigVersion,
 			)
 			if err != nil {
 				klog.Errorf("Error making MCN for rebooting: %v", err)
@@ -199,7 +201,8 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 				dn.node,
 				dn.mcfgClient,
 				dn.fgHandler,
-				pool,
+				mcpName,
+				desiredConfigVersion,
 			)
 			if err != nil {
 				klog.Errorf("Error making MCN for no post config change action: %v", err)
@@ -268,7 +271,7 @@ func (dn *Daemon) performPostConfigChangeNodeDisruptionAction(postConfigChangeAc
 // If at any point an error occurs, we reboot the node so that node has correct configuration.
 func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string, configName string) error {
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, dn.node)
 	if err != nil {
 		return err
 	}
@@ -282,7 +285,8 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for rebooting: %v", err)
@@ -303,7 +307,8 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for no post config change action: %v", err)
@@ -329,7 +334,8 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Reloading success: %v", err)
@@ -954,14 +960,14 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}()
 
 	// Get MCP associated with node
-	pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(dn.mcpLister, dn.node)
 	if err != nil {
 		return err
 	}
 
 	// Update the MCN's NodeNodeDegraded condition with the update result
 	defer func() {
-		dn.reportMachineNodeDegradeStatus(retErr, pool)
+		dn.reportMachineNodeDegradeStatus(retErr, mcpName, desiredConfigVersion)
 	}()
 
 	oldConfigName := oldConfig.GetName()
@@ -990,7 +996,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if Nerr != nil {
 			klog.Errorf("Error making MCN for Preparing update failed: %v", err)
@@ -1026,7 +1033,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if Nerr != nil {
 			klog.Errorf("Error making MCN for Preparing update failed: %v", err)
@@ -1058,16 +1066,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.node,
 		dn.mcfgClient,
 		dn.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Update Compatible: %v", err)
 	}
 
-	err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(dn.fgHandler, pool, dn.node, dn.mcfgClient)
-	if err != nil {
-		klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
-	}
 	if drain {
 		if err := dn.performDrain(); err != nil {
 			return err
@@ -1082,7 +1087,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			dn.node,
 			dn.mcfgClient,
 			dn.fgHandler,
-			pool,
+			mcpName,
+			desiredConfigVersion,
 		)
 		if err != nil {
 			klog.Errorf("Error making MCN for Drain not required: %v", err)
@@ -1110,7 +1116,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.node,
 		dn.mcfgClient,
 		dn.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Updating Files and OS: %v", err)
@@ -1232,7 +1239,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 		dn.node,
 		dn.mcfgClient,
 		dn.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	)
 	if err != nil {
 		klog.Errorf("Error making MCN for Updated Files and OS: %v", err)
@@ -2912,7 +2920,7 @@ func canonicalizeMachineConfigImage(img string, mc *mcfgv1.MachineConfig) *mcfgv
 // If the error is not nil the condition status is set to [metav1.ConditionTrue] and the condition
 // message is formatted accordingly to include the error message. The condition is otherwise set to
 // [metav1.ConditionFalse].
-func (dn *Daemon) reportMachineNodeDegradeStatus(err error, pool string) {
+func (dn *Daemon) reportMachineNodeDegradeStatus(err error, mcpName, desiredConfigVersion string) {
 	if dn.node == nil {
 		return
 	}
@@ -2936,7 +2944,8 @@ func (dn *Daemon) reportMachineNodeDegradeStatus(err error, pool string) {
 		dn.node,
 		dn.mcfgClient,
 		dn.fgHandler,
-		pool,
+		mcpName,
+		desiredConfigVersion,
 	); applyErr != nil {
 		klog.Errorf("Error updating MCN degraded status condition %v", applyErr)
 	}

--- a/pkg/daemon/upgrade_monitor_test.go
+++ b/pkg/daemon/upgrade_monitor_test.go
@@ -2,8 +2,9 @@ package daemon
 
 import (
 	"context"
-	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"testing"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 
 	apicfgv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
@@ -154,12 +155,12 @@ func (tc upgradeMonitorTestCase) run(t *testing.T) {
 
 	for _, n := range f.nodeLister {
 		// Get MCP associated with node
-		pool, err := helpers.GetPrimaryPoolNameForMCN(d.mcpLister, n)
+		mcpName, desiredConfigVersion, err := helpers.GetPrimaryPoolDetailsForMCN(d.mcpLister, n)
 		if err != nil {
 			f.t.Fatalf("Error getting primary pool for node: %v", n.Name)
 		}
 
-		err = upgrademonitor.GenerateAndApplyMachineConfigNodes(tc.parentCondition, tc.childCondition, tc.parentStatus, tc.childStatus, n, d.mcfgClient, d.fgHandler, pool)
+		err = upgrademonitor.GenerateAndApplyMachineConfigNodes(tc.parentCondition, tc.childCondition, tc.parentStatus, tc.childStatus, n, d.mcfgClient, d.fgHandler, mcpName, desiredConfigVersion)
 		if err != nil {
 			f.t.Fatalf("Could not generate and apply MCN %v", err)
 		}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -51,30 +51,32 @@ func GetNodesForPool(mcpLister v1.MachineConfigPoolLister, nodeLister corev1list
 	return nodes, nil
 }
 
-// GetPrimaryPoolNameForMCN gets the MCP pool name value that is used in a node's MachineConfigNode object.
-// When the node does not yet exist (is nil) or the node does not yet have annotations, the pool name will
-// temporarily be set to `not-yet-set` (the default not yet set placeholder value for upgrade monitor
-// functions). Once the node exists (is not nil) and the annotations are properly set, the node will update
-// again and the pool name will be updated.
-func GetPrimaryPoolNameForMCN(mcpLister v1.MachineConfigPoolLister, node *corev1.Node) (string, error) {
+// GetPrimaryPoolDetailsForMCN gets the MCP details needed to populate a node's MachineConfigNode object,
+// which are the MCP name and desired config version.
+//   - When the node does not yet exist (is nil) or the node does not yet have annotations, the MCP name
+//     and desried config version will temporarily be set to `not-yet-set` (the default not yet set
+//     placeholder value for upgrade monitor functions).
+//   - Once the node exists (is not nil) and the node annotations are properly set, the node will update
+//     again and the MCP name and desired config version will be updated accordingly.
+func GetPrimaryPoolDetailsForMCN(mcpLister v1.MachineConfigPoolLister, node *corev1.Node) (mcpName, desiredConfig string, err error) {
 	// Handle case of nil node
 	if node == nil {
-		klog.Error("node object is nil, setting associated MCP to unknown")
-		return upgrademonitor.NotYetSet, nil
+		klog.Error("node object is nil, setting associated MCP values to 'not-yet-set'")
+		return upgrademonitor.NotYetSet, upgrademonitor.NotYetSet, nil
 	}
 
 	// Use `GetPrimaryPoolForNode` to get primary MCP associated with node
 	primaryPool, err := GetPrimaryPoolForNode(mcpLister, node)
 	if err != nil {
-		klog.Errorf("error getting primary pool for node: %v", node.Name)
-		return "", err
+		klog.Errorf("error getting primary MCP for node: %v", node.Name)
+		return "", "", err
 	} else if primaryPool == nil {
 		// On first provisioning, the node may not have annoatations and, thus, will not be associated with a pool.
 		// In this case, the pool value will be set to a temporary dummy value.
-		klog.Infof("No primary pool is associated with node: %v", node.Name)
-		return upgrademonitor.NotYetSet, nil
+		klog.Infof("No primary MCP is associated with node: %v", node.Name)
+		return upgrademonitor.NotYetSet, upgrademonitor.NotYetSet, nil
 	}
-	return primaryPool.Name, nil
+	return primaryPool.Name, primaryPool.Spec.Configuration.Name, nil
 }
 
 func GetPrimaryPoolForNode(mcpLister v1.MachineConfigPoolLister, node *corev1.Node) (*mcfgv1.MachineConfigPool, error) {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -769,7 +769,7 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig, _ *configv1.Cluste
 		}
 
 		// Get MCP associated with node
-		pool, err := helpers.GetPrimaryPoolNameForMCN(optr.mcpLister, node)
+		mcpName, mcpDesiredConfig, err := helpers.GetPrimaryPoolDetailsForMCN(optr.mcpLister, node)
 		if err != nil {
 			return err
 		}
@@ -780,7 +780,7 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig, _ *configv1.Cluste
 					Name: node.Name,
 				},
 				Pool: mcfgv1.MCOObjectReference{
-					Name: pool,
+					Name: mcpName,
 				},
 				ConfigVersion: mcfgv1.MachineConfigNodeSpecMachineConfigVersion{
 					Desired: upgrademonitor.NotYetSet,
@@ -814,7 +814,7 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig, _ *configv1.Cluste
 		}
 		// if this is the first time we are applying the MCN and the node is ready, set the config version probably
 		if mcn.Spec.ConfigVersion.Desired == upgrademonitor.NotYetSet {
-			err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(optr.fgHandler, pool, node, optr.client)
+			err = upgrademonitor.GenerateAndApplyMachineConfigNodeSpec(optr.fgHandler, mcpName, mcpDesiredConfig, node, optr.client)
 			if err != nil {
 				klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
 			}

--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -42,9 +42,10 @@ func GenerateAndApplyMachineConfigNodes(
 	node *corev1.Node,
 	mcfgClient mcfgclientset.Interface,
 	fgHandler ctrlcommon.FeatureGatesHandler,
-	pool string,
+	mcpName string,
+	desiredConfigVersion string,
 ) error {
-	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, nil, fgHandler, pool)
+	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, nil, fgHandler, mcpName, desiredConfigVersion)
 }
 
 func UpdateMachineConfigNodeStatus(
@@ -56,9 +57,10 @@ func UpdateMachineConfigNodeStatus(
 	mcfgClient mcfgclientset.Interface,
 	imageSetApplyConfig []*machineconfigurationv1.MachineConfigNodeStatusPinnedImageSetApplyConfiguration,
 	fgHandler ctrlcommon.FeatureGatesHandler,
-	pool string,
+	mcpName string,
+	desiredConfigVersion string,
 ) error {
-	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, imageSetApplyConfig, fgHandler, pool)
+	return generateAndApplyMachineConfigNodes(parentCondition, childCondition, parentStatus, childStatus, node, mcfgClient, imageSetApplyConfig, fgHandler, mcpName, desiredConfigVersion)
 }
 
 // Helper function to convert metav1.Condition to ConditionApplyConfiguration
@@ -91,7 +93,8 @@ func generateAndApplyMachineConfigNodes(
 	mcfgClient mcfgclientset.Interface,
 	imageSetApplyConfig []*machineconfigurationv1.MachineConfigNodeStatusPinnedImageSetApplyConfiguration,
 	fgHandler ctrlcommon.FeatureGatesHandler,
-	pool string,
+	mcpName string,
+	desiredConfigVersion string,
 ) error {
 	if fgHandler == nil || node == nil || parentCondition == nil || mcfgClient == nil {
 		return nil
@@ -302,7 +305,7 @@ func generateAndApplyMachineConfigNodes(
 			newMCNode.Spec.ConfigVersion.Desired = NotYetSet
 		}
 		newMCNode.Name = node.Name
-		newMCNode.Spec.Pool = mcfgv1.MCOObjectReference{Name: pool}
+		newMCNode.Spec.Pool = mcfgv1.MCOObjectReference{Name: mcpName}
 		newMCNode.Spec.Node = mcfgv1.MCOObjectReference{Name: node.Name}
 
 		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Create(context.TODO(), newMCNode, metav1.CreateOptions{})
@@ -313,7 +316,7 @@ func generateAndApplyMachineConfigNodes(
 	}
 	// if this is the first time we are applying the MCN and the node is ready, set the config version probably
 	if node.Status.Phase != corev1.NodePending && node.Status.Phase != corev1.NodePhase("Provisioning") && newMCNode.Spec.ConfigVersion.Desired == "NotYetSet" {
-		err := GenerateAndApplyMachineConfigNodeSpec(fgHandler, pool, node, mcfgClient)
+		err := GenerateAndApplyMachineConfigNodeSpec(fgHandler, mcpName, desiredConfigVersion, node, mcfgClient)
 		if err != nil {
 			klog.Errorf("Error making MCN spec for Update Compatible: %v", err)
 		}
@@ -335,21 +338,22 @@ func isSingletonCondition(singletonConditionTypes []mcfgv1.StateProgress, condit
 	return false
 }
 
-// GenerateAndApplyMachineConfigNodeSpec generates and applies a new MCN spec based off the node state
-func GenerateAndApplyMachineConfigNodeSpec(fgHandler ctrlcommon.FeatureGatesHandler, pool string, node *corev1.Node, mcfgClient mcfgclientset.Interface) error {
+// GenerateAndApplyMachineConfigNodeSpec generates and applies a new MCN spec based off node and MCP properties
+func GenerateAndApplyMachineConfigNodeSpec(fgHandler ctrlcommon.FeatureGatesHandler, mcpName, desiredConfigVersion string, node *corev1.Node, mcfgClient mcfgclientset.Interface) error {
 	if fgHandler == nil || node == nil {
 		return nil
 	}
-
 	if !fgHandler.Enabled(features.FeatureGateMachineConfigNodes) {
-		klog.Infof("MCN Featuregate is not enabled. Please enable the TechPreviewNoUpgrade featureset to use MachineConfigNodes")
+		klog.V(4).Infof("MachineConfigNode feature gate is not enabled. Please enable the featureset to use the MCN resource.")
 		return nil
 	}
-	// get the existing MCN, or if it DNE create one below
-	mcNode, needNewMCNode := createOrGetMachineConfigNode(mcfgClient, node)
-	newMCNode := mcNode.DeepCopy()
-	// set the spec config version
-	newMCNode.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+
+	// Get the existing MCN for the node or, if one does not exist, create one later in the flow
+	mcn, needNewMCN := createOrGetMachineConfigNode(mcfgClient, node)
+	newMCN := mcn.DeepCopy()
+
+	// Set the MCN metadata
+	newMCN.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		{
 			APIVersion: "v1",
 			Name:       node.ObjectMeta.Name,
@@ -358,38 +362,37 @@ func GenerateAndApplyMachineConfigNodeSpec(fgHandler ctrlcommon.FeatureGatesHand
 		},
 	}
 
-	newMCNode.Spec.ConfigVersion = mcfgv1.MachineConfigNodeSpecMachineConfigVersion{
-		Desired: node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey],
+	// Set MCN.Spec values
+	newMCN.Spec.ConfigVersion = mcfgv1.MachineConfigNodeSpecMachineConfigVersion{
+		Desired: desiredConfigVersion,
 	}
-	// Set desired config to NotYetSet if the annotation is empty to satisfy API validation
-	if newMCNode.Spec.ConfigVersion.Desired == "" {
-		newMCNode.Spec.ConfigVersion.Desired = NotYetSet
+	newMCN.Spec.Pool = mcfgv1.MCOObjectReference{
+		Name: mcpName,
 	}
-
-	newMCNode.Spec.Pool = mcfgv1.MCOObjectReference{
-		Name: pool,
-	}
-	newMCNode.Spec.Node = mcfgv1.MCOObjectReference{
+	newMCN.Spec.Node = mcfgv1.MCOObjectReference{
 		Name: node.Name,
 	}
-	if !needNewMCNode {
-		nodeRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCNode.Spec.Node.Name)
-		poolRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCNode.Spec.Pool.Name)
-		specconfigVersionApplyConfig := machineconfigurationv1.MachineConfigNodeSpecMachineConfigVersion().WithDesired(newMCNode.Spec.ConfigVersion.Desired)
-		specApplyConfig := machineconfigurationv1.MachineConfigNodeSpec().WithNode(nodeRefApplyConfig).WithPool(poolRefApplyConfig).WithConfigVersion(specconfigVersionApplyConfig)
-		mcnodeApplyConfig := machineconfigurationv1.MachineConfigNode(newMCNode.Name).WithSpec(specApplyConfig)
-		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Apply(context.TODO(), mcnodeApplyConfig, metav1.ApplyOptions{FieldManager: "machine-config-operator", Force: true})
+
+	// Update the existing MCN if one exists
+	if !needNewMCN {
+		nodeRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCN.Spec.Node.Name)
+		poolRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCN.Spec.Pool.Name)
+		specConfigVersionApplyConfig := machineconfigurationv1.MachineConfigNodeSpecMachineConfigVersion().WithDesired(newMCN.Spec.ConfigVersion.Desired)
+		specApplyConfig := machineconfigurationv1.MachineConfigNodeSpec().WithNode(nodeRefApplyConfig).WithPool(poolRefApplyConfig).WithConfigVersion(specConfigVersionApplyConfig)
+		mcnApplyConfig := machineconfigurationv1.MachineConfigNode(newMCN.Name).WithSpec(specApplyConfig)
+		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Apply(context.TODO(), mcnApplyConfig, metav1.ApplyOptions{FieldManager: "machine-config-operator", Force: true})
 		if err != nil {
 			klog.Errorf("Error applying MCN Spec: %v", err)
 			return err
 		}
-	} else {
-		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Create(context.TODO(), newMCNode, metav1.CreateOptions{})
+	} else { // Create a new MCN if one does not yet exist
+		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Create(context.TODO(), newMCN, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("Error creating MCN: %v", err)
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Closes: OCPBUGS-52302

**- What I did**
This moves the MCN spec update function, `GenerateAndApplyMachineConfigNodeSpec` into the node controller's update function so that the desired config version in the MCN is updated when the node annotation is updated.

**- How to verify it**
1. Launch a 4.20 cluster with this PR build included.
```
launch 4.20,openshift/machine-config-operator#5121 aws
```
2. Apply a MachineConfig to trigger a node update.
3. Track how the desired configs are updated in the MCN's spec and status. The desired config value in the spec should update before the `UpdatePrepared` condition is `True` and before the desired config version is updated in the status.
_Example grep to see the necessary fields:_
```
oc describe machineconfignode/<node-name> | grep -E "Config Version|UpdatePrepared" -A 2
```

**- Description for the changelog**
OCPBUGS-52302: Fix timing of Spec.ConfigVersion.Desired update in MCN