### PR TITLE
OCPBUGS-57458: add MachineConfiguration to CO related objects

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -64,6 +64,7 @@ func (optr *Operator) syncRelatedObjects(co *configv1.ClusterOperator) {
 		{Group: "machineconfiguration.openshift.io", Resource: "kubeletconfigs"},
 		{Group: "machineconfiguration.openshift.io", Resource: "containerruntimeconfigs"},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigs"},
+		{Group: "operator.openshift.io", Resource: "machineconfigurations"},
 		// gathered because the machineconfigs created container bootstrap credentials and node configuration that gets reflected via the API and is needed for debugging
 		{Group: "", Resource: "nodes"},
 		// Gathered for the on-prem services running in static pods.
@@ -537,6 +538,7 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "master"},
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "worker"},
 		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "machine-config-controller"},
+		{Group: "operator.openshift.io", Resource: "machineconfigurations"},
 	}
 	// During an installation we report the RELEASE_VERSION as soon as the component is created.
 	// For both normal runs and upgrades, this code isn't hit and we get the right version every

--- a/test/e2e/mco_test.go
+++ b/test/e2e/mco_test.go
@@ -33,14 +33,20 @@ func TestClusterOperatorRelatedObjects(t *testing.T) {
 	if len(co.Status.RelatedObjects) == 0 {
 		t.Error("expected RelatedObjects to be populated but it was not")
 	}
-	var foundNS bool
+	var foundNS, foundOperatorConfig bool
 	for _, ro := range co.Status.RelatedObjects {
 		if ro.Resource == "namespaces" && ro.Name == ctrlcommon.MCONamespace {
 			foundNS = true
 		}
+		if ro.Resource == "machineconfigurations" {
+			foundOperatorConfig = true
+		}
 	}
 	if !foundNS {
 		t.Error("ClusterOperator.RelatedObjects should contain the MCO namespace")
+	}
+	if !foundOperatorConfig {
+		t.Error("ClusterOperator.RelatedObjects should contain the MCO operator knob object")
 	}
 }
 


### PR DESCRIPTION
**- What I did**
Adds `MachineConfiguration`(where the MCO's global knobs live) to the CO's related objects.

**- How to verify it**
- `status.relatedObjects` & must gathers should now include the `MachineConfiguration` object.