### PR TITLE
OCPBUGS-56115: Understand and eliminate noisy logs for MCN

### DIFF
--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -404,12 +404,12 @@ func GenerateAndApplyMachineConfigNodeSpec(fgAccessor featuregates.FeatureGateAc
 func createOrGetMachineConfigNode(mcfgClient mcfgclientset.Interface, node *corev1.Node) (*mcfgv1.MachineConfigNode, bool) {
 	mcNode, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 	if err != nil {
-		//no existing MCN found since no resource found, no error yet just create a new one
+		// no existing MCN found since no resource found, no error yet just create a new one
 		if apierrors.IsNotFound((err)) {
 			klog.V(4).Infof("MachineConfigNode for node %q not found, will create a new one", node.Name)
 			return mcNode, true
 		}
-		//true error getting existing MCN
+		// true error getting existing MCN
 		klog.Errorf("error getting existing MCN: %v", err)
 		return mcNode, true
 	}


### PR DESCRIPTION

**- What I did**
Rearranged the way the errors are checked for the account for the MCN not existing when the node is first created. 

**- How to verify it**
1. Launch a 4.20 single-node openshift cluster on Clusterbot (note it doesn't need to use aws) launch 4.20 aws,single-node
2. Enable tech preview (clusterbot options are bit limited which is why, unless something has changed recently, you cannot launch a tech preview single node cluster from the start) 
3. Look at the machine-config-daemon logs oc logs -n openshift-machine-config-operator -c machine-config-daemon machine-config-daemon-<uuid> -f
 - note that you can get the mcd pod uuid from oc get pods -n openshift-machine-config-operator

**- Description for the changelog**
Fixes logs that start with "error getting existing MCN" from the upgrade monitor.  This should fix bug #56115
