### PR TITLE
MCO-1741: Fix missing OTE logs

### DIFF
--- a/test/extended/util/logext/log.go
+++ b/test/extended/util/logext/log.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -19,56 +20,67 @@ const (
 	EnableDebugLog = "GINKGO_TEST_ENABLE_DEBUG_LOG"
 )
 
-// logWrapper wrapper interface for zerolog
-type logWrapper struct {
-	log zerolog.Logger
+// ginkgoWriterWrapper wrapper interface for zerolog
+type ginkgoWriterWrapper struct {
 }
 
-var logger = newLogger()
+// Write is a wrapper to redirect all logs to the current Ginkgo writer.
+// The Ginkgo writer may change at any given time (e.g. the OTE framework changes it between tests) so it's required
+// to always point to the global GinkgoWriter variable to write to the current writer and not an old one.
+func (w *ginkgoWriterWrapper) Write(p []byte) (n int, err error) {
+	return ginkgo.GinkgoWriter.Write(p)
+}
 
-// NewLogger initialize log wrapper with zerolog logger
+var logger zerolog.Logger
+var loggerOnce sync.Once
+
+// getLogger initializes the logger variable as a singleton based on a zerolog logger
 // default log level is INFO, user can enable debug logging by env variable GINKGO_TEST_ENABLE_DEBUG_LOG
-func newLogger() *logWrapper {
-
-	// customize time field format to sync with e2e framework
-	zerolog.TimeFieldFormat = time.StampMilli
-	// initialize customized output to integrate with GinkgoWriter
-	output := zerolog.ConsoleWriter{Out: ginkgo.GinkgoWriter, TimeFormat: time.StampMilli}
-	// customize level format e.g. INFO, DEBUG, ERROR
-	output.FormatLevel = func(i interface{}) string {
-		return strings.ToUpper(fmt.Sprintf("%s:", i))
-	}
-	// disable colorful output for timestamp field
-	output.FormatTimestamp = func(i interface{}) string {
-		return fmt.Sprintf("%s:", i)
-	}
-	logger := &logWrapper{log: zerolog.New(output).With().Timestamp().Logger()}
-	// set default log level to INFO
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	// if system env var is defined, enable debug logging
-	if _, enabled := os.LookupEnv(EnableDebugLog); enabled {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
-
-	return logger
+func getLogger() *zerolog.Logger {
+	loggerOnce.Do(func() {
+		// customize time field format to sync with e2e framework
+		zerolog.TimeFieldFormat = time.StampMilli
+		// initialize customized output to integrate with GinkgoWriter
+		output := zerolog.ConsoleWriter{
+			Out:        &ginkgoWriterWrapper{},
+			TimeFormat: time.StampMilli,
+			NoColor:    true,
+		}
+		// customize level format e.g. INFO, DEBUG, ERROR
+		output.FormatLevel = func(i interface{}) string {
+			return strings.ToUpper(fmt.Sprintf("%s:", i))
+		}
+		// disable colorful output for timestamp field
+		output.FormatTimestamp = func(i interface{}) string {
+			return fmt.Sprintf("%s:", i)
+		}
+		logger = zerolog.New(output).With().Timestamp().Logger()
+		// set default log level to INFO
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		// if system env var is defined, enable debug logging
+		if _, enabled := os.LookupEnv(EnableDebugLog); enabled {
+			zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		}
+	})
+	return &logger
 }
 
 // Infof log info level message
 func Infof(format string, v ...interface{}) {
-	logger.log.Info().Msgf(format, v...)
+	getLogger().Info().Msgf(format, v...)
 }
 
 // Debugf log debug level message
 func Debugf(format string, v ...interface{}) {
-	logger.log.Debug().Msgf(format, v...)
+	getLogger().Debug().Msgf(format, v...)
 }
 
 // Errorf log error level message
 func Errorf(format string, v ...interface{}) {
-	logger.log.Error().Msgf(format, v...)
+	getLogger().Error().Msgf(format, v...)
 }
 
 // Warnf log warning level message
 func Warnf(format string, v ...interface{}) {
-	logger.log.Warn().Msgf(format, v...)
+	getLogger().Warn().Msgf(format, v...)
 }


### PR DESCRIPTION
**- What I did**

The OTE framework resets the Ginkgo writer on each test run but our Zerolog logger was taking the default initialized Ginkgo writer for the entire run.
This chnage does two things:
- Make the logger a singleton that uses late initialization
- Wrape the Ginkgo writer with a simple writer that always calls the Ginkgo global writer instead of storing a reference to it.

This change disables coloring/formatting of the zerolog output too.

**- How to verify it**

1. Spin up a cluster
2. Run the new added command machine-config-tests-ext run-suite openshift/machine-config-operator/disruptive
3. Ensure that in the resulting json output **each test result** has at least on `OK!` in the output section.
4. Ensure that the logs we output with zerolog (like "OK!") are not formatted.

**- Description for the changelog**

Fix OTE logging by making logger singleton with late initialization and wrapping Ginkgo writer
