### PR TITLE
MCO-1741: Bump OTE framework to add skip reason

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250702172817-97309544869d
 	github.com/openshift/api v0.0.0-20250620092249-a8cbc218cd2c
 	github.com/openshift/client-go v0.0.0-20250623095455-7b2007868c76
 	github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c h1:R5dI2oOF2RtS1sKtLrhW9KMg0ydzF0XM2Q//ma55nWI=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250702172817-97309544869d h1:nlVcuw7cyXIYMtQn97y/CMq1yoovvLnc2AFqi15DgXA=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250702172817-97309544869d/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20250620092249-a8cbc218cd2c h1:0Np840IRyzpvHLWxcE1AZ8sttVZe+a3Y6QBS3Ge+umA=
 github.com/openshift/api v0.0.0-20250620092249-a8cbc218cd2c/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
 github.com/openshift/client-go v0.0.0-20250623095455-7b2007868c76 h1:tH4ZSE+YLzV6B8gsXCz/VDdWnkBo7TDST+fhGExWFig=

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/util.go
@@ -96,6 +96,23 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunc
 					result.Result = ext.ResultPassed
 				case summary.State == types.SpecStateSkipped:
 					result.Result = ext.ResultSkipped
+					if len(summary.Failure.Message) > 0 {
+						result.Output = fmt.Sprintf(
+							"%s\n skip [%s:%d]: %s\n",
+							result.Output,
+							lastFilenameSegment(summary.Failure.Location.FileName),
+							summary.Failure.Location.LineNumber,
+							summary.Failure.Message,
+						)
+					} else if len(summary.Failure.ForwardedPanic) > 0 {
+						result.Output = fmt.Sprintf(
+							"%s\n skip [%s:%d]: %s\n",
+							result.Output,
+							lastFilenameSegment(summary.Failure.Location.FileName),
+							summary.Failure.Location.LineNumber,
+							summary.Failure.ForwardedPanic,
+						)
+					}
 				case summary.State == types.SpecStateFailed, summary.State == types.SpecStatePanicked, summary.State == types.SpecStateInterrupted:
 					result.Result = ext.ResultFailed
 					var errors []string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1203,7 +1203,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250522124649-4ffcd156ec7c
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250702172817-97309544869d
 ## explicit; go 1.23.0
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages


### PR DESCRIPTION
After introducing a small change in the OTE framework to report back to origin the skip reason we need to include the new version as part of our binary.

**- What I did**

Update `github.com/openshift-eng/openshift-tests-extension ` dependency to the latest one that contains https://github.com/openshift-eng/openshift-tests-extension/pull/33.

**- How to verify it**

No need to verify from our side. This change is just a transparent version bump-

**- Description for the changelog**

Bump the OTE framework dependency to add the reporting of test skip reasons.
