### PR TITLE
OCPBUGS-58270: Do not set cpu system reserve below the default value

### DIFF
--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -72,6 +72,9 @@ contents:
         if (($total_cpu >= 0)); then # 0.25% of any cores above 4 cores
             recommended_systemreserved_cpu=$(echo $recommended_systemreserved_cpu $(echo $total_cpu 0.0025 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
         fi
+
+         # Enforce minimum threshold of 0.5 CPU
+        recommended_systemreserved_cpu=$(awk -v val="$recommended_systemreserved_cpu" 'BEGIN {if (val < 0.5) print 0.5; else print val}')
         echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}">> ${NODE_SIZES_ENV}
     }
     function dynamic_ephemeral_sizing {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-58270 
This sets the default system-reserved-cpu value of 500 millicore based on our recommendation[1]
This change has been introduced in 4.20 through 4.17 [2]

[1] - https://docs.redhat.com/en/documentation/openshift_container_platform/4.10/html/scalability_and_performance/recommended-host-practices#infrastructure-node-sizing_recommended-host-practices 
[2] - https://github.com/openshift/machine-config-operator/pull/5046 