### PR TITLE
MCO-1739: Tell origin our suite is disruptive and set timeout

### DIFF
--- a/cmd/machine-config-tests-ext/main.go
+++ b/cmd/machine-config-tests-ext/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd"
 	v "github.com/openshift-eng/openshift-tests-extension/pkg/version"
@@ -27,6 +28,7 @@ func main() {
 	ext := e.NewExtension("openshift", "payload", "machine-config-operator")
 
 	// all test cases
+	defaultTimeout := 120 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "openshift/machine-config-operator/disruptive",
 		Parents: []string{
@@ -35,6 +37,8 @@ func main() {
 		Qualifiers: []string{
 			`name.contains("[Suite:openshift/machine-config-operator/disruptive")`,
 		},
+		ClusterStability: e.ClusterStabilityDisruptive,
+		TestTimeout:      &defaultTimeout,
 	})
 
 	// If using Ginkgo, build test specs automatically


### PR DESCRIPTION
**- What I did**
Set the `ClusterStability` for our `openshift/machine-config-operator/disruptive` suite to `ClusterStabilityDisruptive and set test timeout to 120 minutes

**- How to verify it**

1. Build the OTE binary
2. Call it to check if it properly reports its disruptive nature and a `7200000000000` timeout
```bash
_output/linux/amd64/machine-config-tests-ext info
```
```json
{
    "apiVersion": "v1.1",
    "source": {
        "commit": "8e4b9682a339d243b8d562902fa1d39fd16bd3ed",
        "build_date": "2025-07-08T12:00:11Z",
        "git_tree_state": "clean"
    },
    "component": {
        "product": "openshift",
        "type": "payload",
        "name": "machine-config-operator"
    },
    "suites": [
        {
            "name": "openshift/machine-config-operator/disruptive",
            "description": "",
            "parents": [
                "openshift/disruptive"
            ],
            "qualifiers": [
                "(source == \"openshift:payload:machine-config-operator\") \u0026\u0026 (name.contains(\"[Suite:openshift/machine-config-operator/disruptive\"))"
            ],
            "clusterStability": "Disruptive",
            "testTimeout": 7200000000000
        }
    ],
    "images": null
}
```

**- Description for the changelog**
Set the `ClusterStability` for our `openshift/machine-config-operator/disruptive` suite to `ClusterStabilityDisruptive and set test timeout to 120 minutes