### PR TITLE
MCO-1810: Support kernelType in OCL

### DIFF
--- a/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
+++ b/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
@@ -19,21 +19,65 @@ COPY --from=extract /etc/machine-config-daemon/currentconfig /etc/machine-config
 RUN container="oci" exec -a ignition-apply /usr/lib/dracut/modules.d/30ignition/ignition --ignore-unsupported <(cat /etc/machine-config-daemon/currentconfig | jq '.spec.config') && \
 	ostree container commit
 # Install any extensions specified
-{{if and .ExtensionsImage .ExtensionsPackages}}
+{{if .ExtensionsImage}}
 # Mount the extensions image to use the content from it
 # and add the extensions repo to /etc/yum.repos.d/coreos-extensions.repo
 RUN --mount=type=bind,from={{.ExtensionsImage}},source=/,target=/tmp/mco-extensions/os-extensions-content,bind-propagation=rshared,z \
-    echo -e "[coreos-extensions]\n\
-enabled=1\n\
-metadata_expire=1m\n\
-baseurl=/tmp/mco-extensions/os-extensions-content/usr/share/rpm-ostree/extensions/\n\
-gpgcheck=0\n\
-skip_if_unavailable=False" > /etc/yum.repos.d/coreos-extensions.repo && \
-    chmod 644 /etc/yum.repos.d/coreos-extensions.repo && \
-    extensions="{{- range $index, $item := .ExtensionsPackages }}{{- if $index }} {{ end }}{{$item}}{{- end }}" && \
-    echo "Installing extension packages: $extensions" && \
-    rpm-ostree install $extensions && \
-    rm /etc/yum.repos.d/coreos-extensions.repo
+    bash <<'EOF'
+set -xeuo pipefail
+
+# Add extensions repo
+cat > /etc/yum.repos.d/coreos-extensions.repo <<REPO
+[coreos-extensions]
+enabled=1
+metadata_expire=1m
+baseurl=/tmp/mco-extensions/os-extensions-content/usr/share/rpm-ostree/extensions/
+gpgcheck=0
+skip_if_unavailable=False
+REPO
+
+chmod 644 /etc/yum.repos.d/coreos-extensions.repo
+
+{{if .ExtensionsPackages}}
+# Install extension packages
+extensions="{{- range $index, $item := .ExtensionsPackages }}{{- if $index }} {{ end }}{{$item}}{{- end }}"
+echo "Installing extension packages: \$extensions"
+rpm-ostree install \$extensions
+{{end}}
+
+{{if and .KernelType .KernelPackages}}
+kernelOldPkgs=""
+# Detect current kernel and compare with desired .KernelType
+if rpm -q kernel-rt-core > /dev/null 2>&1; then
+	if [[ "{{ .KernelType }}" != "realtime" ]]; then
+		echo "Base Image has RT kernel, new KernelType is '{{ .KernelType }}'"
+		kernelOldPkgs="{{- range $index, $item := index .KernelPackages "realtime" -}}{{- if $index }} {{ end }}{{$item}}{{- end }}"
+	fi
+elif rpm -q kernel-64k-core > /dev/null 2>&1; then
+	if [[ "{{ .KernelType }}" != "64k-pages" ]]; then
+		echo "Base Image has 64k-pages kernel, new KernelType is '{{ .KernelType }}'"
+		kernelOldPkgs="{{- range $index, $item := index .KernelPackages "64k-pages" -}}{{- if $index }} {{ end }}{{$item}}{{- end }}"
+	fi
+elif rpm -q kernel > /dev/null 2>&1; then
+	if [[ "{{ .KernelType }}" != "default" ]]; then
+		echo "Base Image has Default kernel, new KernelType is '{{ .KernelType }}'"
+		kernelOldPkgs="{{- range $index, $item := index .KernelPackages "default" -}}{{- if $index }} {{ end }}{{$item}}{{- end }}"
+	fi
+else
+	echo "Error: Unknown base kernel type. Unable to perform the kernel swap to '{{ .KernelType }}'"
+	exit 1;
+fi
+
+# Override existing kernel packages if it differs from the requested kernel type
+if [ -n "$kernelOldPkgs" ]; then
+	installKernelPkgs="{{- range $index, $item := index .KernelPackages .KernelType -}}{{- if $index }} {{ end }}{{$item}}{{- end }}"
+	(echo "remove $kernelOldPkgs"; echo "install $installKernelPkgs"; echo run) | dnf -y shell
+fi
+{{end}}
+
+rm /etc/yum.repos.d/coreos-extensions.repo
+EOF
+
 RUN ostree container commit
 {{end}}
 

--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -311,6 +311,11 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 		return "", err
 	}
 
+	kernelType, kernelPackages, err := br.opts.getKernelPackages()
+	if err != nil {
+		return "", err
+	}
+
 	out := &strings.Builder{}
 
 	// This anonymous struct is necessary because templates cannot access
@@ -324,6 +329,8 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 		BaseOSImage        string
 		ExtensionsImage    string
 		ExtensionsPackages []string
+		KernelType         string
+		KernelPackages     map[string][]string
 	}{
 		MachineOSBuild:     br.opts.MachineOSBuild,
 		MachineOSConfig:    br.opts.MachineOSConfig,
@@ -331,6 +338,8 @@ func (br buildRequestImpl) renderContainerfile() (string, error) {
 		BaseOSImage:        br.opts.OSImageURLConfig.BaseOSContainerImage,
 		ExtensionsImage:    br.opts.OSImageURLConfig.BaseOSExtensionsContainerImage,
 		ExtensionsPackages: extPkgs,
+		KernelType:         kernelType,
+		KernelPackages:     kernelPackages,
 	}
 
 	if err := tmpl.Execute(out, items); err != nil {

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -477,6 +477,18 @@ func validateExtensions(exts []string) error {
 	return nil
 }
 
+func GetPackagesForSupportedKernelType(kernelType string) (string, map[string][]string, error) {
+	kernelPackages := map[string][]string{
+		KernelTypeDefault:  {"kernel", "kernel-core", "kernel-modules", "kernel-modules-core", "kernel-modules-extra"},
+		KernelTypeRealtime: {"kernel-rt-core", "kernel-rt-modules", "kernel-rt-modules-extra", "kernel-rt-kvm"},
+		KernelType64kPages: {"kernel-64k-core", "kernel-64k-modules", "kernel-64k-modules-core", "kernel-64k-modules-extra"},
+	}
+	if _, ok := kernelPackages[kernelType]; ok {
+		return kernelType, kernelPackages, nil
+	}
+	return "", nil, fmt.Errorf("Unhandled kernel type %s", kernelType)
+}
+
 // Resolves a list of supported extensions to the individual packages required
 // for each of those extensions. Returns an error is any of the supplied
 // extensions is invalid.

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -219,3 +219,13 @@ func IsCoreOSNode(node *corev1.Node) bool {
 	}
 	return false
 }
+
+// CanonicalizeKernelType returns a valid kernelType. We consider empty("") and default kernelType as same
+func CanonicalizeKernelType(kernelType string) string {
+	if kernelType == ctrlcommon.KernelTypeRealtime {
+		return ctrlcommon.KernelTypeRealtime
+	} else if kernelType == ctrlcommon.KernelType64kPages {
+		return ctrlcommon.KernelType64kPages
+	}
+	return ctrlcommon.KernelTypeDefault
+}

--- a/test/e2e-ocl/helpers_test.go
+++ b/test/e2e-ocl/helpers_test.go
@@ -882,6 +882,27 @@ func newMachineConfigTriggersImageRebuild(name, pool string, exts []string) *mcf
 	return mc
 }
 
+// newMachineConfigWithKernelType returns the same base MC, but adds the given kernel
+func newMachineConfigWithKernelType(name, pool, kernelType string) *mcfgv1.MachineConfig {
+	mc := newMachineConfig(name, pool)
+	mc.Spec.KernelType = kernelType
+	return mc
+}
+
+func compareKernelType(t *testing.T, foundKernel, requiredKernelType string) bool {
+	switch requiredKernelType {
+	case ctrlcommon.KernelTypeDefault:
+		return !strings.Contains(foundKernel, "rt") && !strings.Contains(foundKernel, "64k")
+	case ctrlcommon.KernelTypeRealtime:
+		return strings.Contains(foundKernel, "rt")
+	case ctrlcommon.KernelType64kPages:
+		return strings.Contains(foundKernel, "64k")
+	default:
+		t.Logf("Unsupported kernel type requested in MC %s", requiredKernelType)
+		return false
+	}
+}
+
 // Gets an override image pullspec for TestGracefulBuildFailureRecovery. We
 // override this option to produce a faster test failure since the image we
 // select will both be smaller than the OS image as well as not contain the


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Containerfile: Remove default kernel packages and add new
buildrequest: Set the template variables for kernel packages
buildrequestopts: validate a kernel switch and get packages
helpers: retrieve packages for each supported kernel type

**- How to verify it**
1) Have a MC that switches kernel type to hugepages / realtimeKernel
```
spec:
  kernelType: realtime
```
2) Create an MOSC from this MC
3) Verify that the built image has the appropriate packages / kernel installed
```
[root@ip-10-0-124-186 ~]# uname -r
5.14.0-570.28.1.el9_6.x86_64+rt
```

**- Description for the changelog**
<!--Support kernelType in OCL-->
