### PR TITLE
OCPNODE-3466: Remove containernetworking-plugins directory from crio.conf

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -70,7 +70,6 @@ contents:
     network_dir = "/etc/kubernetes/cni/net.d/"
     plugin_dirs = [
         "/var/lib/cni/bin",
-        "/usr/libexec/cni",
     ]
 
     [crio.metrics]

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -72,7 +72,6 @@ contents:
     network_dir = "/etc/kubernetes/cni/net.d/"
     plugin_dirs = [
         "/var/lib/cni/bin",
-        "/usr/libexec/cni",
     ]
 
     [crio.metrics]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -72,7 +72,6 @@ contents:
     network_dir = "/etc/kubernetes/cni/net.d/"
     plugin_dirs = [
         "/var/lib/cni/bin",
-        "/usr/libexec/cni",
     ]
 
     [crio.metrics]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Since RHEL has dropped the containernetworking-plugins package because podman stopped using it, cri-o is also going to install it as a dependency.
cri-o already stopped using containernetworking-plugins, so remove dependencies from crio.conf as well.

**- How to verify it**

Whether E2E test passes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove /usr/libexec/cni from plugin_dirs