### PR TITLE
OCPBUGS-59367: Set our test suite as global

### DIFF
--- a/cmd/machine-config-tests-ext/main.go
+++ b/cmd/machine-config-tests-ext/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	// all test cases
 	defaultTimeout := 120 * time.Minute
-	ext.AddSuite(e.Suite{
+	ext.AddGlobalSuite(e.Suite{
 		Name: "openshift/machine-config-operator/disruptive",
 		Parents: []string{
 			"openshift/disruptive",


### PR DESCRIPTION
With this change, origin won't filter out origin defined tests when running the test suite.
If a suite is not declared as global the qualifier specified in the suite definition is always appended by an and condition that enforces the test to live in the repo where the suite is declared.

Closes: [OCPBUGS-59367](https://issues.redhat.com/browse/OCPBUGS-59367)

**- What I did**
Add the `openshift/machine-config-operator/disruptive` as global and not as a regular test-suite.
 
**- How to verify it**

1. Compile the binaries after checking out this PR
2. Run `./machine-config-tests-ext info`
3. The qualifier of the test-suite should be `name.contains(\"[Suite:openshift/machine-config-operator/disruptive\")` and not `(source == \"openshift:payload:machine-config-operator\") \u0026\u0026 (name.contains(\"[Suite:openshift/machine-config-operator/disruptive\"))`

**- Description for the changelog**

Add the `openshift/machine-config-operator/disruptive` as global and not as a regular test-suite.