### PR TITLE
OCPBUGS-59543: Watch openshift-config CMs

### DIFF
--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -95,6 +95,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.ConfigInformerFactory.Config().V1().Images(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().ServiceAccounts(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().Secrets(),
+			ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
 			ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.ConfigInformerFactory.Config().V1().ClusterOperators(),

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -93,7 +93,7 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder) *Controll
 	sharedNamespacedInformers := mcfginformers.NewFilteredSharedInformerFactory(client, resyncPeriod()(), MCONamespace, nil)
 	kubeSharedInformer := informers.NewSharedInformerFactory(kubeClient, resyncPeriod()())
 	kubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), MCONamespace, nil)
-	openShiftConfigKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), "openshift-config", nil)
+	openShiftConfigKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), OpenshiftConfigNamespace, nil)
 	openShiftConfigManagedKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), OpenshiftConfigManagedNamespace, nil)
 	openShiftKubeAPIServerKubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient,
 		resyncPeriod()(),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -97,6 +97,7 @@ type Operator struct {
 	dnsLister             configlistersv1.DNSLister
 	mcoSALister           corelisterv1.ServiceAccountLister
 	mcoSecretLister       corelisterv1.SecretLister
+	ocCmLister            corelisterv1.ConfigMapLister
 	ocSecretLister        corelisterv1.SecretLister
 	ocManagedSecretLister corelisterv1.SecretLister
 	clusterOperatorLister configlistersv1.ClusterOperatorLister
@@ -128,6 +129,7 @@ type Operator struct {
 	imgListerSynced                  cache.InformerSynced
 	mcoSAListerSynced                cache.InformerSynced
 	mcoSecretListerSynced            cache.InformerSynced
+	ocCmListerSynced                 cache.InformerSynced
 	ocSecretListerSynced             cache.InformerSynced
 	ocManagedSecretListerSynced      cache.InformerSynced
 	clusterOperatorListerSynced      cache.InformerSynced
@@ -178,6 +180,7 @@ func New(
 	imgInformer configinformersv1.ImageInformer,
 	mcoSAInformer coreinformersv1.ServiceAccountInformer,
 	mcoSecretInformer coreinformersv1.SecretInformer,
+	ocCmInformer coreinformersv1.ConfigMapInformer,
 	ocSecretInformer coreinformersv1.SecretInformer,
 	ocManagedSecretInformer coreinformersv1.SecretInformer,
 	clusterOperatorInformer configinformersv1.ClusterOperatorInformer,
@@ -249,6 +252,7 @@ func New(
 		mcoSAInformer.Informer(),
 		mcoSecretInformer.Informer(),
 		ocSecretInformer.Informer(),
+		ocCmInformer.Informer(),
 		ocManagedSecretInformer.Informer(),
 		mcopInformer.Informer(),
 		mckInformer.Informer(),
@@ -304,6 +308,8 @@ func New(
 	optr.mcoSAListerSynced = mcoSAInformer.Informer().HasSynced
 	optr.mcoSecretLister = mcoSecretInformer.Lister()
 	optr.mcoSecretListerSynced = mcoSecretInformer.Informer().HasSynced
+	optr.ocCmLister = ocCmInformer.Lister()
+	optr.ocCmListerSynced = ocCmInformer.Informer().HasSynced
 	optr.ocSecretLister = ocSecretInformer.Lister()
 	optr.ocSecretListerSynced = ocSecretInformer.Informer().HasSynced
 	optr.ocManagedSecretLister = ocManagedSecretInformer.Lister()
@@ -362,6 +368,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 		optr.imgListerSynced,
 		optr.mcoSAListerSynced,
 		optr.mcoSecretListerSynced,
+		optr.ocCmListerSynced,
 		optr.ocSecretListerSynced,
 		optr.ocManagedSecretListerSynced,
 		optr.clusterOperatorListerSynced,


### PR DESCRIPTION
Closes: [OCPBUGS-59543](https://issues.redhat.com/browse/OCPBUGS-59543)

**- What I did**

This commit adds a watcher for ConfigMaps in the openshift-config namespace as we consume CMs from that namespace to, for example, load CA certificates. If the user perform a change in one of those certificates we do not see the change and only a restart of the controller pod can reload the ConfigMap content.

**- How to verify it**

<tbd>

**- Description for the changelog**
Adds a ConfigMap watcher for the openshift-config namespace.
