### PR TITLE
OCPBUGS-59672: TestMCNPoolNameCustom should clean up resources properly

### DIFF
--- a/test/e2e/mcn_test.go
+++ b/test/e2e/mcn_test.go
@@ -83,7 +83,7 @@ func TestMCNPoolNameCustom(t *testing.T) {
 	// Create a custom MCP and assign a worker node to it
 	customMCPName := "infra"
 	customNode := helpers.GetRandomNode(t, cs, "worker")
-	helpers.CreatePoolWithNode(t, cs, customMCPName, customNode)
+	t.Cleanup(helpers.CreatePoolWithNode(t, cs, customMCPName, customNode))
 
 	// Test that MCN pool name value matches MCP association
 	customNodeMCN, customErr := cs.MachineconfigurationV1Interface.MachineConfigNodes().Get(context.TODO(), customNode.Name, metav1.GetOptions{})


### PR DESCRIPTION
**- What I did**
Added a cleanup call after the custom MCP MCN test. This may be causing conflicts with later tests as the node remains associated with the custom pool, and the same custom pool is used by other tests. 

**- How to verify it**
Existing tests/e2es should pass. This should not need QE as it is only a test fix. 
