### PR TITLE
OCPBUGS-43406: Add workaround fix for static pod race

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2572,8 +2572,23 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 			return fmt.Errorf("failed to update OS from local storage: %s: %w", newURL, err)
 		}
 	} else {
-		if err := dn.NodeUpdaterClient.RebaseLayered(newURL); err != nil {
-			return fmt.Errorf("failed to update OS to %s: %w", newURL, err)
+		// Workaround for OCPBUGS-43406, retry the remote rebase with backoff,
+		// such that if we happen to update while the CoreDNS pod is being restarted,
+		// the next retry should succeed if no other issues are present.
+		backoff := wait.Backoff{
+			Duration: 5 * time.Second,
+			Factor:   2,
+			Steps:    5,
+		}
+
+		if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+			if err := dn.NodeUpdaterClient.RebaseLayered(newURL); err != nil {
+				klog.Warningf("Failed to update OS to %s (will retry): %v", newURL, err)
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			return fmt.Errorf("Failed to update OS to %s after retries: %w", newURL, err)
 		}
 	}
 


### PR DESCRIPTION
The rpm-ostree rebase call makes a remote fetch for the image, which can race with the static coredns pod and attempt the fetch while the static pod is updating.

Add a small 5x retry so we can workaround this issue. Long term we'd like to do some mix of retrying in rpm-ostree + image mode making updates more transactional.