### PR TITLE
OCPBUGS-54287: Add ValidatingAdmissionPolicy for MOSC

### DIFF
--- a/manifests/machineosbuilder/machineosconfig-validatingadmissionpolicy.yaml
+++ b/manifests/machineosbuilder/machineosconfig-validatingadmissionpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "machineosconfig-name-check"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
+    resourceRules:
+    - apiGroups:   ["machineconfiguration.openshift.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE"]
+      resources:   ["machineosconfigs"]
+      scope: "Cluster"
+  validations:
+  - expression: "object.metadata.name == object.spec.machineConfigPool.name"
+    message: "MachineOSConfig metadata.name must equal spec.machineConfigPool.name; can only have one MachineOSConfig per MachineConfigPool"
+    reason: Invalid
+  - expression: "has(object.metadata.name) && object.metadata.name != ''"
+    message: "object.metadata.name is required and cannot be empty"
+    reason: Invalid

--- a/manifests/machineosbuilder/machineosconfig-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineosbuilder/machineosconfig-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "machineosconfig-name-check-binding"
+spec:
+  policyName: "machineosconfig-name-check"
+  validationActions: [Deny]

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -99,13 +99,15 @@ const (
 	mccUpdateBootImagesValidatingAdmissionPolicyBindingPath           = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml"
 
 	// Machine OS Builder manifest paths
-	mobClusterRoleManifestPath                      = "manifests/machineosbuilder/clusterrole.yaml"
-	mobEventsClusterRoleManifestPath                = "manifests/machineosbuilder/events-clusterrole.yaml"
-	mobEventsRoleBindingDefaultManifestPath         = "manifests/machineosbuilder/events-rolebinding-default.yaml"
-	mobEventsRoleBindingTargetManifestPath          = "manifests/machineosbuilder/events-rolebinding-target.yaml"
-	mobClusterRoleBindingServiceAccountManifestPath = "manifests/machineosbuilder/clusterrolebinding-service-account.yaml"
-	mobClusterRolebindingAnyUIDManifestPath         = "manifests/machineosbuilder/clusterrolebinding-anyuid.yaml"
-	mobServiceAccountManifestPath                   = "manifests/machineosbuilder/sa.yaml"
+	mobClusterRoleManifestPath                             = "manifests/machineosbuilder/clusterrole.yaml"
+	mobEventsClusterRoleManifestPath                       = "manifests/machineosbuilder/events-clusterrole.yaml"
+	mobEventsRoleBindingDefaultManifestPath                = "manifests/machineosbuilder/events-rolebinding-default.yaml"
+	mobEventsRoleBindingTargetManifestPath                 = "manifests/machineosbuilder/events-rolebinding-target.yaml"
+	mobClusterRoleBindingServiceAccountManifestPath        = "manifests/machineosbuilder/clusterrolebinding-service-account.yaml"
+	mobClusterRolebindingAnyUIDManifestPath                = "manifests/machineosbuilder/clusterrolebinding-anyuid.yaml"
+	mobServiceAccountManifestPath                          = "manifests/machineosbuilder/sa.yaml"
+	mobMachineOSConfigValidatingAdmissionPolicyPath        = "manifests/machineosbuilder/machineosconfig-validatingadmissionpolicy.yaml"
+	mobMachineOSConfigValidatingAdmissionPolicyBindingPath = "manifests/machineosbuilder/machineosconfig-validatingadmissionpolicybinding.yaml"
 
 	// Machine Config Daemon manifest paths
 	mcdClusterRoleManifestPath                      = "manifests/machineconfigdaemon/clusterrole.yaml"
@@ -1129,11 +1131,13 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig, _ *confi
 			mccMachineConfigurationGuardsValidatingAdmissionPolicyPath,
 			mccUpdateBootImagesValidatingAdmissionPolicyPath,
 			mccMachineConfigPoolSelectorValidatingAdmissionPolicyPath,
+			mobMachineOSConfigValidatingAdmissionPolicyPath,
 		},
 		validatingAdmissionPolicyBindings: []string{
 			mccMachineConfigurationGuardsValidatingAdmissionPolicyBindingPath,
 			mccUpdateBootImagesValidatingAdmissionPolicyBindingPath,
 			mccMachineConfigPoolSelectorValidatingAdmissionPolicyBindingPath,
+			mobMachineOSConfigValidatingAdmissionPolicyBindingPath,
 		},
 	}
 	if err := optr.applyManifests(config, paths); err != nil {


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/OCPBUGS-54287
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add a ValidatingAdmissionPolicy to ensure that
only one MachineOSConfig is made per pool.
This is done by ensuring that the MOSC name
matched the MCP given in the spec.

**- How to verify it**
Create a MachineOSConfig with a name that doesn't match the pool it is being created for, an error should occur and the MOSC will not be created.

**- Description for the changelog**
Name of MachineOSConfig object must match the pool that it being created for.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
