### PR TITLE
NO-ISSUE: Split gcp-op into two tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,12 @@ verify-e2e: $(patsubst %,_verify-e2e-%,$(E2E_SUITES))
 test-e2e: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 190m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e/ ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
 
+test-e2e-1of2: install-go-junit-report
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 100m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-1of2/ ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
+
+test-e2e-2of2: install-go-junit-report
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 90m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-2of2/ ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
+
 test-e2e-techpreview: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 170m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-techpreview  ./test/e2e-techpreview-shared/ | ./hack/test-with-junit.sh $(@)
 

--- a/test/e2e-1of2/main_test.go
+++ b/test/e2e-1of2/main_test.go
@@ -1,0 +1,10 @@
+package e2e_1of2_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -1,0 +1,1302 @@
+package e2e_1of2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+
+	e2eShared "github.com/openshift/machine-config-operator/test/e2e-shared-tests"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineclientset "github.com/openshift/client-go/machine/clientset/versioned"
+	"github.com/openshift/machine-config-operator/pkg/apihelpers"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/pkg/secrets"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+)
+
+// Test case for https://github.com/openshift/machine-config-operator/issues/358
+func TestMCDToken(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}).String(),
+	}
+
+	mcdList, err := cs.Pods(ctrlcommon.MCONamespace).List(context.TODO(), listOptions)
+	require.Nil(t, err)
+
+	for _, pod := range mcdList.Items {
+		res, err := cs.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+			Container: "machine-config-daemon",
+		}).DoRaw(context.TODO())
+		require.Nil(t, err)
+		for _, line := range strings.Split(string(res), "\n") {
+			if strings.Contains(line, "Unable to rotate token") {
+				t.Fatalf("found token rotation failure message: %s", line)
+			}
+		}
+	}
+}
+
+func TestMCDeployed(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	ctx := context.Background()
+
+	startTime := time.Now()
+	mcadd := createMCToAddFile("add-a-file", "/etc/mytestconf", "test")
+
+	// create the dummy MC now
+	_, err := cs.MachineConfigs().Create(ctx, mcadd, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("failed to create machine config %v", err)
+	}
+
+	t.Logf("Created %s", mcadd.Name)
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "worker", mcadd.Name)
+	require.Nil(t, err)
+	err = helpers.WaitForPoolComplete(t, cs, "worker", renderedConfig)
+	require.Nil(t, err)
+	nodes, err := helpers.GetNodesByRole(cs, "worker")
+	require.Nil(t, err)
+	for _, node := range nodes {
+		assert.Equal(t, renderedConfig, node.Annotations[constants.CurrentMachineConfigAnnotationKey])
+		assert.Equal(t, constants.MachineConfigDaemonStateDone, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey])
+	}
+	t.Logf("All nodes updated with %s (%s elapsed)", mcadd.Name, time.Since(startTime))
+}
+
+func TestRunShared(t *testing.T) {
+	mcpName := "infra"
+
+	cleanupFuncs := helpers.NewCleanupFuncs()
+	cs := framework.NewClientSet("")
+
+	configOpts := e2eShared.ConfigDriftTestOpts{
+		ClientSet: cs,
+		MCPName:   mcpName,
+		SetupFunc: func(mc *mcfgv1.MachineConfig) {
+			cleanupFuncs.Add(helpers.CreatePoolAndApplyMC(t, cs, mcpName, mc))
+		},
+		TeardownFunc: func() {
+			cleanupFuncs.Run()
+		},
+	}
+
+	sharedOpts := e2eShared.SharedTestOpts{
+		ConfigDriftTestOpts: configOpts,
+	}
+
+	e2eShared.Run(t, sharedOpts)
+}
+
+func TestKernelArguments(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	delete := helpers.CreateMCP(t, cs, "infra")
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
+	oldInfraConfig := helpers.CreateMC("old-infra", "infra")
+
+	t.Cleanup(func() {
+		unlabelFunc()
+		// wait for the mcp to go back to previous config
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+			t.Fatal(err)
+		}
+		delete()
+		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
+	})
+	// create old mc to have something to verify we successfully rolled back
+	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+
+	// create kargs MC
+	kargsMC := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("kargs-%s", uuid.NewUUID()),
+			Labels: helpers.MCLabelForRole("infra"),
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
+			},
+			KernelArguments: []string{"nosmt", "foo=bar", "foo=baz", " baz=test bar=hello world"},
+		},
+	}
+
+	_, err = cs.MachineConfigs().Create(context.TODO(), kargsMC, metav1.CreateOptions{})
+	require.Nil(t, err)
+	t.Logf("Created %s", kargsMC.Name)
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", kargsMC.Name)
+	require.Nil(t, err)
+	err = helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig)
+	require.Nil(t, err)
+
+	// Re-fetch the infra node for updated annotations
+	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+	kargs := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/cmdline")
+	expectedKernelArgs := []string{"nosmt", "foo=bar", "foo=baz", "baz=test", "bar=hello world"}
+	for _, v := range expectedKernelArgs {
+		if !strings.Contains(kargs, v) {
+			t.Fatalf("Missing %q in kargs: %q", v, kargs)
+		}
+	}
+	t.Logf("Node %s has expected kargs", infraNode.Name)
+
+	// cleanup - delete karg mc and rollback
+	if err := cs.MachineConfigs().Delete(context.TODO(), kargsMC.Name, metav1.DeleteOptions{}); err != nil {
+		t.Error(err)
+	}
+	t.Logf("Deleted MachineConfig %s", kargsMC.Name)
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+
+	unlabelFunc()
+
+	workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	require.Nil(t, err)
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), infraNode.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+		if node.Annotations[constants.DesiredMachineConfigAnnotationKey] != workerMCP.Spec.Configuration.Name {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("infra node hasn't moved back to worker config: %v", err)
+	}
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+}
+
+func TestKernelType(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	isOKD, err := helpers.IsOKDCluster(cs)
+	require.Nil(t, err)
+	if isOKD {
+		t.Skip("skipping test on OKD")
+	}
+
+	delete := helpers.CreateMCP(t, cs, "infra")
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
+	oldInfraConfig := helpers.CreateMC("old-infra", "infra")
+
+	t.Cleanup(func() {
+		unlabelFunc()
+		// wait for the mcp to go back to previous config
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+			t.Fatal(err)
+		}
+		delete()
+		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
+
+	})
+
+	_, err = cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+	// create kernel type MC and roll out
+	kernelType := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("kerneltype-%s", uuid.NewUUID()),
+			Labels: helpers.MCLabelForRole("infra"),
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
+			},
+			KernelType: "realtime",
+		},
+	}
+
+	_, err = cs.MachineConfigs().Create(context.TODO(), kernelType, metav1.CreateOptions{})
+	require.Nil(t, err)
+	t.Logf("Created %s", kernelType.Name)
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", kernelType.Name)
+	require.Nil(t, err)
+	if err := helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig); err != nil {
+		t.Fatal(err)
+	}
+	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	kernelInfo := helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "kernel-rt-core")
+	if !strings.Contains(kernelInfo, "kernel-rt-core") {
+		t.Fatalf("Node %s doesn't have expected kernel", infraNode.Name)
+	}
+	t.Logf("Node %s has expected kernel", infraNode.Name)
+
+	// Delete the applied kerneltype MachineConfig to make sure rollback works fine
+	if err := cs.MachineConfigs().Delete(context.TODO(), kernelType.Name, metav1.DeleteOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Deleted MachineConfig %s", kernelType.Name)
+
+	// Wait for the mcp to rollback to previous config
+	if err := helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-fetch the infra node for updated annotations
+	infraNode = helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+	kernelInfo = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "kernel-rt-core")
+	if strings.Contains(kernelInfo, "kernel-rt-core") {
+		t.Fatalf("Node %s did not rollback successfully", infraNode.Name)
+	}
+	t.Logf("Node %s has successfully rolled back", infraNode.Name)
+
+	unlabelFunc()
+
+	workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	require.Nil(t, err)
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), infraNode.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+		if node.Annotations[constants.DesiredMachineConfigAnnotationKey] != workerMCP.Spec.Configuration.Name {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("infra node hasn't moved back to worker config: %v", err)
+	}
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+
+}
+
+func TestExtensions(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	delete := helpers.CreateMCP(t, cs, "infra")
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
+	oldInfraConfig := helpers.CreateMC("old-infra", "infra")
+
+	t.Cleanup(func() {
+		unlabelFunc()
+		// wait for the mcp to go back to previous config
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+			t.Fatal(err)
+		}
+		delete()
+		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
+
+	})
+
+	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+	// Apply extensions
+	extensions := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("extensions-%s", uuid.NewUUID()),
+			Labels: helpers.MCLabelForRole("infra"),
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
+			},
+			Extensions: []string{"two-node-ha", "wasm", "ipsec", "usbguard", "kerberos", "kernel-devel", "sandboxed-containers", "sysstat"},
+		},
+	}
+
+	_, err = cs.MachineConfigs().Create(context.TODO(), extensions, metav1.CreateOptions{})
+	require.Nil(t, err)
+	t.Logf("Created %s", extensions.Name)
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", extensions.Name)
+	require.Nil(t, err)
+	if err := helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig); err != nil {
+		t.Fatal(err)
+	}
+	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	isOKD, err := helpers.IsOKDCluster(cs)
+	require.Nil(t, err)
+
+	var installedPackages string
+	var expectedPackages []string
+	if isOKD {
+		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
+		// "sandboxed-containers" extension is not available on OKD
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "sysstat")
+		// "kerberos" extension is not available on OKD
+		expectedPackages = []string{"libreswan", "usbguard", "kernel-devel"}
+	} else {
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat")
+		expectedPackages = []string{"pacemaker", "pcs", "fence-agents-all", "crun-wasm", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat"}
+
+	}
+	for _, v := range expectedPackages {
+		if !strings.Contains(installedPackages, v) {
+			t.Fatalf("Node %s doesn't have expected extensions", infraNode.Name)
+		}
+	}
+
+	t.Logf("Node %s has expected extensions installed", infraNode.Name)
+
+	// Delete the applied kerneltype MachineConfig to make sure rollback works fine
+	if err := cs.MachineConfigs().Delete(context.TODO(), extensions.Name, metav1.DeleteOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Deleted MachineConfig %s", extensions.Name)
+
+	// Wait for the mcp to rollback to previous config
+	if err := helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-fetch the infra node for updated annotations
+	infraNode = helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	if isOKD {
+		// OKD does not support grouped extensions yet, so installing kernel-devel will not also pull in kernel-headers
+		// "sandboxed-containers" extension is not available on OKD
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel")
+	} else {
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5")
+	}
+	for _, v := range expectedPackages {
+		if strings.Contains(installedPackages, v) {
+			t.Fatalf("Node %s did not rollback successfully", infraNode.Name)
+		}
+	}
+
+	t.Logf("Node %s has successfully rolled back", infraNode.Name)
+
+	unlabelFunc()
+
+	workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	require.Nil(t, err)
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), infraNode.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+		if node.Annotations[constants.DesiredMachineConfigAnnotationKey] != workerMCP.Spec.Configuration.Name {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("infra node hasn't moved back to worker config: %v", err)
+	}
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+}
+
+func TestNoReboot(t *testing.T) {
+	cs := framework.NewClientSet("")
+	delete := helpers.CreateMCP(t, cs, "infra")
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
+	oldInfraConfig := helpers.CreateMC("old-infra", "infra")
+
+	t.Cleanup(func() {
+		unlabelFunc()
+		// wait for the mcp to go back to previous config
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+			t.Fatal(err)
+		}
+		delete()
+		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
+
+	})
+	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	sshKeyContent := "test adding authorized key without node reboot"
+
+	nodeOS := helpers.GetOSReleaseForNode(t, cs, infraNode).OS
+
+	sshPaths := helpers.GetSSHPaths(nodeOS)
+
+	t.Logf("Expecting SSH keys to be in %s", sshPaths.Expected)
+
+	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
+		// Write an SSH key to the old location on the node because the update process should remove this file.
+		t.Logf("Writing SSH key to %s to ensure that it will be removed later", sshPaths.NotExpected)
+		bashCmd := fmt.Sprintf("printf '%s' > %s", sshKeyContent, filepath.Join("/rootfs", sshPaths.NotExpected))
+		helpers.ExecCmdOnNode(t, cs, infraNode, "/bin/bash", "-c", bashCmd)
+	}
+
+	// Delete the expected SSH keys directory to ensure that the directories are
+	// (re)created correctly by the MCD. This targets the upgrade case where that
+	// directory may not previously exist. Note: This will need to be revisited
+	// once Config Drift Monitor is aware of SSH keys.
+	helpers.ExecCmdOnNode(t, cs, infraNode, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+
+	output := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
+	oldTime := strings.Split(output, " ")[0]
+	t.Logf("Node %s initial uptime: %s", infraNode.Name, oldTime)
+	initialEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
+
+	// Adding authorized key for user core
+	testIgnConfig := ctrlcommon.NewIgnConfig()
+	testPasswdHash := "testpass"
+
+	testIgnConfig.Passwd.Users = []ign3types.PasswdUser{
+		{
+			Name:              "core",
+			SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{ign3types.SSHAuthorizedKey(sshKeyContent)},
+			PasswordHash:      &testPasswdHash,
+		},
+	}
+
+	addAuthorizedKey := &mcfgv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("authorized-key-infra-%s", uuid.NewUUID()),
+			Labels: helpers.MCLabelForRole("infra"),
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: helpers.MarshalOrDie(testIgnConfig),
+			},
+		},
+	}
+
+	_, err = cs.MachineConfigs().Create(context.TODO(), addAuthorizedKey, metav1.CreateOptions{})
+	require.Nil(t, err, "failed to create MC")
+	t.Logf("Created %s", addAuthorizedKey.Name)
+
+	// grab the latest worker- MC
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", addAuthorizedKey.Name)
+	require.Nil(t, err)
+	err = helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig)
+	require.Nil(t, err)
+
+	// Re-fetch the infra node for updated annotations
+	infraNode = helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
+	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
+
+	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	if !strings.Contains(foundSSHKey, sshKeyContent) {
+		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSHKey)
+	}
+	t.Logf("Node %s has SSH key", infraNode.Name)
+
+	assertExpectedPerms(t, cs, infraNode, "/home/core/.ssh", []string{constants.CoreUserName, constants.CoreGroupName, "700"})
+
+	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
+		// /home/core/.ssh/authorized_keys.d
+		assertExpectedPerms(t, cs, infraNode, filepath.Dir(constants.RHCOS9SSHKeyPath), []string{constants.CoreUserName, constants.CoreGroupName, "700"})
+	}
+
+	assertExpectedPerms(t, cs, infraNode, sshPaths.Expected, []string{constants.CoreUserName, constants.CoreGroupName, "600"})
+
+	currentEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
+
+	if currentEtcShadowContents == initialEtcShadowContents {
+		t.Fatalf("updated password hash not found in etc/shadow, got %s", currentEtcShadowContents)
+	}
+
+	t.Logf("Node %s has Password Hash", infraNode.Name)
+
+	output = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
+	newTime := strings.Split(output, " ")[0]
+
+	// To ensure we didn't reboot, new uptime should be greater than old uptime
+	uptimeOld, err := strconv.ParseFloat(oldTime, 64)
+	require.Nil(t, err)
+
+	uptimeNew, err := strconv.ParseFloat(newTime, 64)
+	require.Nil(t, err)
+
+	if uptimeOld > uptimeNew {
+		t.Fatalf("Node %s rebooted uptime decreased from %f to %f", infraNode.Name, uptimeOld, uptimeNew)
+	}
+
+	t.Logf("Node %s didn't reboot as expected, uptime increased from %f to %f ", infraNode.Name, uptimeOld, uptimeNew)
+
+	// Delete the applied authorized key MachineConfig to make sure rollback works fine without node reboot
+	if err := cs.MachineConfigs().Delete(context.TODO(), addAuthorizedKey.Name, metav1.DeleteOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	t.Logf("Deleted MachineConfig %s", addAuthorizedKey.Name)
+
+	// Wait for the mcp to rollback to previous config
+	if err := helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-fetch the infra node for updated annotations
+	infraNode = helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	if strings.Contains(foundSSHKey, sshKeyContent) {
+		t.Fatalf("Node %s did not rollback successfully", infraNode.Name)
+	}
+
+	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
+	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
+
+	t.Logf("Node %s has successfully rolled back", infraNode.Name)
+
+	// Ensure that node didn't reboot during rollback
+	output = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
+	newTime = strings.Split(output, " ")[0]
+
+	uptimeNew, err = strconv.ParseFloat(newTime, 64)
+	require.Nil(t, err)
+
+	if uptimeOld > uptimeNew {
+		t.Fatalf("Node %s rebooted during rollback, uptime decreased from %f to %f", infraNode.Name, uptimeOld, uptimeNew)
+	}
+
+	t.Logf("Node %s didn't reboot as expected during rollback, uptime increased from %f to %f ", infraNode.Name, uptimeOld, uptimeNew)
+
+	unlabelFunc()
+
+	workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	require.Nil(t, err)
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), infraNode.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+		if node.Annotations[constants.DesiredMachineConfigAnnotationKey] != workerMCP.Spec.Configuration.Name {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("infra node hasn't moved back to worker config: %v", err)
+	}
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+
+	rollbackEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
+	assert.Equal(t, initialEtcShadowContents, rollbackEtcShadowContents)
+}
+
+func TestPoolDegradedOnFailToRender(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	mcadd := createMCToAddFile("add-a-file", "/etc/mytestconfs", "test")
+	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mcadd.Spec.Config.Raw)
+	require.Nil(t, err, "failed to parse ignition config")
+	ignCfg.Ignition.Version = "" // invalid, won't render
+	rawIgnCfg := helpers.MarshalOrDie(ignCfg)
+	mcadd.Spec.Config.Raw = rawIgnCfg
+
+	// create the dummy MC now
+	_, err = cs.MachineConfigs().Create(context.TODO(), mcadd, metav1.CreateOptions{})
+	require.Nil(t, err, "failed to create machine config")
+
+	// verify the pool goes degraded
+	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if apihelpers.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolDegraded) {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("machine config pool never switched to Degraded on failure to render: %v", err)
+	}
+
+	// now delete the bad MC and watch pool flipping back to not degraded
+	if err := cs.MachineConfigs().Delete(context.TODO(), mcadd.Name, metav1.DeleteOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	// wait for the mcp to go back to previous config
+	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if apihelpers.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, mcfgv1.MachineConfigPoolRenderDegraded) {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("machine config pool never switched back to Degraded=False: %v", err)
+	}
+}
+
+// Test that deleting a MC that changes a file does not completely delete the file
+// entirely but rather restores it to its original state.
+func TestDontDeleteRPMFiles(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	delete := helpers.CreateMCP(t, cs, "infra")
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
+	oldInfraConfig := helpers.CreateMC("old-infra", "infra")
+
+	t.Cleanup(func() {
+		unlabelFunc()
+		// wait for the mcp to go back to previous config
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+			t.Fatal(err)
+		}
+		delete()
+		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
+
+	})
+
+	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+
+	mcHostFile := createMCToAddFileForRole("modify-host-file", "infra", "/etc/motd", "mco-test")
+
+	// create the dummy MC now
+	_, err = cs.MachineConfigs().Create(context.TODO(), mcHostFile, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("failed to create machine config %v", err)
+	}
+
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", mcHostFile.Name)
+	require.Nil(t, err)
+	err = helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig)
+	require.Nil(t, err)
+
+	// now delete the bad MC and watch the nodes reconciling as expected
+	if err := cs.MachineConfigs().Delete(context.TODO(), mcHostFile.Name, metav1.DeleteOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	// wait for the mcp to go back to previous config
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+
+	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	found := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/etc/motd")
+	if strings.Contains(found, "mco-test") {
+		t.Fatalf("updated file doesn't contain expected data, got %s", found)
+	}
+
+	unlabelFunc()
+
+	workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	require.Nil(t, err)
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), infraNode.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+		if node.Annotations[constants.DesiredMachineConfigAnnotationKey] != workerMCP.Spec.Configuration.Name {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("infra node hasn't moved back to worker config: %v", err)
+	}
+	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
+	require.Nil(t, err)
+
+}
+
+func TestIgn3Cfg(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	delete := helpers.CreateMCP(t, cs, "infra")
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
+
+	t.Cleanup(func() {
+		unlabelFunc()
+		// wait for the mcp to go back to previous config
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
+			t.Fatal(err)
+		}
+		delete()
+	})
+	// create a dummy MC with an sshKey for user Core
+	mcName := fmt.Sprintf("99-ign3cfg-infra-%s", uuid.NewUUID())
+	mcadd := &mcfgv1.MachineConfig{}
+	mcadd.ObjectMeta = metav1.ObjectMeta{
+		Name:   mcName,
+		Labels: helpers.MCLabelForRole("infra"),
+	}
+	// create a new MC that adds a valid user & ssh key
+	testIgn3Config := ign3types.Config{}
+	tempUser := ign3types.PasswdUser{Name: "core", SSHAuthorizedKeys: []ign3types.SSHAuthorizedKey{"1234_test_ign3"}}
+	testIgn3Config.Passwd.Users = append(testIgn3Config.Passwd.Users, tempUser)
+	testIgn3Config.Ignition.Version = "3.2.0"
+	mode := 420
+	testfiledata := "data:,test-ign3-stuff"
+	tempFile := ign3types.File{Node: ign3types.Node{Path: "/etc/testfileconfig"},
+		FileEmbedded1: ign3types.FileEmbedded1{Contents: ign3types.Resource{Source: &testfiledata}, Mode: &mode}}
+	testIgn3Config.Storage.Files = append(testIgn3Config.Storage.Files, tempFile)
+	rawIgnConfig := helpers.MarshalOrDie(testIgn3Config)
+	mcadd.Spec.Config.Raw = rawIgnConfig
+
+	_, err := cs.MachineConfigs().Create(context.TODO(), mcadd, metav1.CreateOptions{})
+	require.Nil(t, err, "failed to create MC")
+	t.Logf("Created %s", mcadd.Name)
+
+	// grab the latest worker- MC
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", mcadd.Name)
+	require.Nil(t, err)
+	err = helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig)
+	require.Nil(t, err)
+
+	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
+
+	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
+	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
+
+	sshPaths := helpers.GetSSHPaths(helpers.GetOSReleaseForNode(t, cs, infraNode).OS)
+
+	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", filepath.Join("/rootfs", sshPaths.Expected))
+	if !strings.Contains(foundSSH, "1234_test_ign3") {
+		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSH)
+	}
+	t.Logf("Node %s has SSH key", infraNode.Name)
+
+	foundFile := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/etc/testfileconfig")
+	if !strings.Contains(foundFile, "test-ign3-stuff") {
+		t.Fatalf("updated file doesn't contain expected data, got %s", foundFile)
+	}
+	t.Logf("Node %s has file", infraNode.Name)
+
+	unlabelFunc()
+
+	workerMCP, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	require.Nil(t, err)
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		node, err := cs.CoreV1Interface.Nodes().Get(context.TODO(), infraNode.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+		if node.Annotations[constants.DesiredMachineConfigAnnotationKey] != workerMCP.Spec.Configuration.Name {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("infra node hasn't moved back to worker config: %v", err)
+	}
+	err = helpers.WaitForPoolComplete(t, cs, "infra", renderedConfig)
+	require.Nil(t, err)
+}
+
+// Test case for correct certificate rotation, even if a pool is paused
+func TestMCDRotatesCerts(t *testing.T) {
+	var testPool = "master"
+
+	cs := framework.NewClientSet("")
+
+	// Rotate the certificates
+	controllerConfig, err := cs.ControllerConfigs().Get(context.TODO(), "machine-config-controller", metav1.GetOptions{})
+	require.Nil(t, err)
+
+	oldData := ""
+	for _, cert := range controllerConfig.Status.ControllerCertificates {
+		if cert.BundleFile == "KubeAPIServerServingCAData" {
+			oldData = cert.Subject
+		}
+	}
+	t.Logf("Patching certificate")
+	err = helpers.ForceKubeApiserverCertificateRotation(cs)
+	require.Nil(t, err)
+	t.Logf("Patched")
+
+	// Get the on-disk state for the cert
+	nodes, err := helpers.GetNodesByRole(cs, testPool)
+	require.NotEmpty(t, nodes)
+	selectedNode := nodes[0]
+	controllerConfig, err = cs.ControllerConfigs().Get(context.TODO(), "machine-config-controller", metav1.GetOptions{})
+	require.Nil(t, err)
+	err = helpers.WaitForMCDToSyncCert(t, cs, selectedNode, controllerConfig.ResourceVersion)
+	require.Nil(t, err)
+
+	// Due to the nature of the cert updates(more info in https://github.com/openshift/machine-config-operator/pull/3718#discussion_r1218282540)
+	// attempt to retry on failure after waiting for a few seconds before failing the test
+	// To be extra safe, we re-fetch both certs on every try
+
+	if err := wait.PollImmediate(5*time.Second, 15*time.Second, func() (bool, error) {
+		inClusterCert, err := helpers.GetKubeletCABundleFromConfigmap(cs)
+		require.Nil(t, err)
+		onDiskCert := helpers.ExecCmdOnNode(t, cs, selectedNode, "cat", "/rootfs/etc/kubernetes/kubelet-ca.crt")
+		return (onDiskCert == inClusterCert), nil
+	}); err != nil {
+		t.Errorf("Mismatch between on disk cert and in cluster cert: %v", err)
+	}
+
+	err = helpers.WaitForCertStatusToChange(t, cs, oldData)
+	require.Nil(t, err)
+}
+
+// This test provisions a new node by using the MachineSet API to ensure that
+// the SSH is present on the node after first boot. This will eventually need
+// to migrate to using the Cluster API (CAPI) instead.
+func TestFirstBootHasSSHKeys(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cs := framework.NewClientSet("")
+
+	// This client is not part of framework.ClientSet, but we can instantiate it
+	// and use the config from our ClientSet.
+	machineclient := machineclientset.NewForConfigOrDie(cs.GetRestConfig())
+
+	// Any MachineSets returned by this list will be worker MachineSets. Control
+	// plane nodes are wrapped in a separate ControlPlaneMachineSet type with its
+	// own client methods.
+	machinesets, err := machineclient.MachineV1beta1().MachineSets("openshift-machine-api").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	// Just grab the first MachineSet we get back. It doesn't matter which one we
+	// use for this test.
+	machineset := machinesets.Items[0]
+
+	// Scale up our MachineSet to add a new node to target for our test.
+	newNodes, cleanupFunc := helpers.ScaleMachineSetAndWaitForNodesToBeReady(t, cs, machineset.Name, *machineset.Spec.Replicas+1)
+	newNode := newNodes[0]
+	t.Cleanup(func() {
+		if t.Failed() {
+			helpers.CollectDebugInfoFromNode(t, cs, newNode)
+		}
+
+		cleanupFunc()
+	})
+
+	sshKeyFileExistsOnNode := func(keyPath string) bool {
+		_, err := helpers.ExecCmdOnNodeWithError(cs, *newNode, "stat", filepath.Join("/rootfs", keyPath))
+		return err == nil
+	}
+
+	assertSSHKeyContents := func(keyPath string) {
+		// Now that the new node is ready, ensure that the SSH key file is populated.
+		out := helpers.ExecCmdOnNode(t, cs, *newNode, "cat", filepath.Join("/rootfs", keyPath))
+		t.Logf("Got ssh key file data: %s", out)
+		// TODO: Assert that the file contents equals the SSH key field on the
+		// MachineConfig. In theory, this may seem easy to do, but in practice it's a
+		// bit more involved because the SSH key field on MachineConfigs can accept
+		// multiple SSH keys per item with line breaks or single SSH keys
+		// one-per-line. For now, we just assert that the field is not empty.
+		assert.NotEmpty(t, out, "expected SSH key file %s on %s to contain SSH keys, but it was empty", keyPath, newNode.Name)
+	}
+
+	isFound := false
+	isFoundRhcos8KeyPath := false
+	isFoundRhcos9KeyPath := false
+
+	if sshKeyFileExistsOnNode(constants.RHCOS8SSHKeyPath) {
+		assertSSHKeyContents(constants.RHCOS8SSHKeyPath)
+		isFound = true
+		isFoundRhcos8KeyPath = true
+	}
+
+	if sshKeyFileExistsOnNode(constants.RHCOS9SSHKeyPath) {
+		assertSSHKeyContents(constants.RHCOS9SSHKeyPath)
+		isFound = true
+		isFoundRhcos9KeyPath = true
+	}
+
+	if isFound {
+		t.Logf("SSH keys found on node in RHCOS8 location %v / RHCOS9 location %v", isFoundRhcos8KeyPath, isFoundRhcos9KeyPath)
+	} else {
+		t.Logf("Neither %s or %s exists on the node", constants.RHCOS8SSHKeyPath, constants.RHCOS9SSHKeyPath)
+		t.FailNow()
+	}
+}
+
+func sshKeyFileExistsOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
+	_, err := helpers.ExecCmdOnNodeWithError(cs, node, "stat", filepath.Join("/rootfs", path))
+	return err == nil
+}
+
+func createMCToAddFileForRole(name, role, filename, data string) *mcfgv1.MachineConfig {
+	mcadd := helpers.CreateMC(fmt.Sprintf("%s-%s", name, uuid.NewUUID()), role)
+
+	ignConfig := ctrlcommon.NewIgnConfig()
+	ignFile := helpers.CreateUncompressedIgn3File(filename, "data:,"+data, 420)
+	ignConfig.Storage.Files = append(ignConfig.Storage.Files, ignFile)
+	rawIgnConfig := helpers.MarshalOrDie(ignConfig)
+	mcadd.Spec.Config.Raw = rawIgnConfig
+	return mcadd
+}
+
+func createMCToAddFile(name, filename, data string) *mcfgv1.MachineConfig {
+	return createMCToAddFileForRole(name, "worker", filename, data)
+}
+
+// Checks that a file or directory on a given node matches the expected
+// permissions in the form of [username, groupname, octal file permissions].
+func assertExpectedPerms(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string, expectedPerms []string) {
+	t.Helper()
+
+	actualPerms := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "stat", "--format=%U %G %a", path), "\n"), " ")
+	assert.Equal(t, expectedPerms, actualPerms, "expected %s to have perms %v, got: %v", path, expectedPerms, actualPerms)
+}
+
+// Tests that changes to the internal image registry pull secret has the
+// desired effect on both the ControllerConfig and the individual nodes
+// filesystems.
+func TestInternalImageRegistryPullSecret(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	hostnames := []string{
+		"registry1.hostname.com",
+		"registry2.hostname.com",
+		"registry3.hostname.com",
+	}
+
+	filename := "/etc/mco/internal-registry-pull-secret.json"
+	canonicalizedFilename := filepath.Join("/rootfs", filename)
+
+	// For each hostname, we do the following (in parallel to make the test
+	// faster and ensure that we don't run into any unforeseen edge-cases):
+	//
+	// 1. Create a new secret with the sanitized hostname as the secret name.
+	// 2. Append the secret name to the machine-os-puller service account.
+	// 3. Wait for the ControllerConfig to pick up the new hostname.
+	// 4. Wait for each of the nodes to pick up the new hostname.
+	// 5. Delete the secret.
+	// 6. Remove the secret name from the machine-os-puller service account.
+	// 7. Wait for the ControllerConfig to lose the hostname.
+	// 8. Wait for each of the nodes to lose the new hostname.
+	for _, imageRegistryHostname := range hostnames {
+		imageRegistryHostname := imageRegistryHostname
+		t.Run(imageRegistryHostname, func(t *testing.T) {
+			t.Parallel()
+
+			revertFunc := setupForInternalImageRegistryPullSecretTest(t, cs, imageRegistryHostname)
+			t.Cleanup(revertFunc)
+
+			t.Logf("Waiting for ControllerConfig to get hostname %s", imageRegistryHostname)
+
+			helpers.AssertControllerConfigReachesExpectedState(t, cs, func(cc *mcfgv1.ControllerConfig) bool {
+				return strings.Contains(string(cc.Spec.InternalRegistryPullSecret), imageRegistryHostname)
+			})
+
+			t.Logf("Waiting for all nodes to get hostname %s", imageRegistryHostname)
+
+			helpers.AssertAllNodesReachExpectedState(t, cs, func(node corev1.Node) bool {
+				contents := helpers.ExecCmdOnNode(t, cs, node, "cat", canonicalizedFilename)
+				return strings.Contains(contents, imageRegistryHostname)
+			})
+
+			// Undo the change.
+			revertFunc()
+
+			t.Logf("Waiting for ControllerConfig to lose hostname %s", imageRegistryHostname)
+
+			helpers.AssertControllerConfigReachesExpectedState(t, cs, func(cc *mcfgv1.ControllerConfig) bool {
+				return !strings.Contains(string(cc.Spec.InternalRegistryPullSecret), imageRegistryHostname)
+			})
+
+			t.Logf("Waiting for all nodes to lose hostname %s", imageRegistryHostname)
+
+			helpers.AssertAllNodesReachExpectedState(t, cs, func(node corev1.Node) bool {
+				contents := helpers.ExecCmdOnNode(t, cs, node, "cat", canonicalizedFilename)
+				return !strings.Contains(contents, imageRegistryHostname)
+			})
+		})
+	}
+}
+
+// Creates a secret containing an arbitrary image registry hostname and appends
+// it to the machine-os-puller service account. Returns an idempotent function
+// which undoes these changes.
+func setupForInternalImageRegistryPullSecretTest(t *testing.T, cs *framework.ClientSet, imageRegistryHostname string) func() {
+	t.Helper()
+
+	serviceAccountName := "machine-os-puller"
+	secretName := strings.ReplaceAll(imageRegistryHostname, ".", "-")
+
+	auths := secrets.DockerConfig{
+		imageRegistryHostname: secrets.DockerConfigEntry{
+			Username: "user",
+			Password: "secret",
+			Email:    "user@hostname.com",
+			Auth:     "auth",
+		},
+	}
+
+	is, err := secrets.NewImageRegistrySecret(auths)
+	require.NoError(t, err)
+
+	newSecret, err := is.K8sSecret(corev1.SecretTypeDockercfg)
+	require.NoError(t, err)
+
+	newSecret.Name = secretName
+	newSecret.Namespace = ctrlcommon.MCONamespace
+
+	_, err = cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		sa, err := cs.CoreV1Interface.ServiceAccounts(ctrlcommon.MCONamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{
+			Name: secretName,
+		})
+
+		_, err = cs.CoreV1Interface.ServiceAccounts(ctrlcommon.MCONamespace).Update(context.TODO(), sa, metav1.UpdateOptions{})
+		return err
+	})
+
+	require.NoError(t, err)
+
+	t.Logf("Added secret %s with registry hostname %s to %s serviceaccount", secretName, imageRegistryHostname, serviceAccountName)
+
+	return helpers.MakeIdempotent(func() {
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			sa, err := cs.CoreV1Interface.ServiceAccounts(ctrlcommon.MCONamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			refs := []corev1.LocalObjectReference{}
+
+			for _, ref := range sa.ImagePullSecrets {
+				if ref.Name != secretName {
+					refs = append(refs, ref)
+				}
+			}
+
+			sa.ImagePullSecrets = refs
+
+			_, err = cs.CoreV1Interface.ServiceAccounts(ctrlcommon.MCONamespace).Update(context.TODO(), sa, metav1.UpdateOptions{})
+			return err
+		})
+
+		require.NoError(t, err)
+
+		require.NoError(t, cs.CoreV1Interface.Secrets(ctrlcommon.MCONamespace).Delete(context.TODO(), secretName, metav1.DeleteOptions{}))
+
+		t.Logf("Removed secret %s with hostname %s from %s service account", secretName, imageRegistryHostname, serviceAccountName)
+	})
+}
+
+func TestInstallRPMAndCheckMCDMetrics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	t.Cleanup(cancel)
+
+	// Start a goroutine to check for context timeout
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					t.Fatalf("Test deadline exceeded")
+				}
+				return
+			default:
+				time.Sleep(time.Second)
+			}
+		}
+	}()
+
+	cs := framework.NewClientSet("")
+	t.Log("Starting test: TestInstallRPMAndCheckMCDMetrics")
+
+	// Select a random worker node
+	t.Log("Selecting a random worker node to check the installation")
+	node := helpers.GetRandomNode(t, cs, "worker")
+	t.Logf("Selected node: %s", node.Name)
+
+	// Define cleanup function to uninstall the RPM and reboot the node
+	uninstallRpmFunc := helpers.MakeIdempotent(func() {
+		t.Log("Starting cleanup: Uninstalling the RPM")
+
+		err := helpers.WaitForNodeReady(t, cs, node)
+		if err != nil {
+			t.Logf("Node %s is not ready: %v.", node.Name, err)
+			return
+		}
+
+		uninstallCmd := []string{
+			"chroot", "/rootfs", "rpm-ostree", "uninstall", "epel-release",
+		}
+
+		_, err = helpers.ExecCmdOnNodeWithError(cs, node, uninstallCmd...)
+		if err != nil {
+			t.Logf("Failed to uninstall RPM package on node %s: %v", node.Name, err)
+			return
+		}
+		t.Log("RPM package uninstalled successfully")
+
+		t.Logf("Rebooting node %s to apply the changes", node.Name)
+
+		rebootCmd := []string{
+			"chroot", "/rootfs", "sudo", "systemctl", "reboot",
+		}
+
+		_, err = helpers.ExecCmdOnNodeWithError(cs, node, rebootCmd...)
+		if err != nil {
+			t.Logf("Failed to reboot node %s: %v", node.Name, err)
+			return
+		}
+
+		err = helpers.WaitForNodeReady(t, cs, node)
+		if err != nil {
+			t.Logf("Node %s is not ready after reboot: %v.", node.Name, err)
+			return
+		}
+		t.Logf("Node %s rebooted successfully and RPM package is removed", node.Name)
+	})
+
+	// Register the uninstall function for cleanup
+	t.Cleanup(uninstallRpmFunc)
+
+	// Download the RPM package on the node
+	t.Logf("Downloading the RPM package on node %s", node.Name)
+	downloadCmd := []string{
+		"chroot", "/rootfs", "curl", "-KL", "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm", "-o", "/tmp/epel-release-latest-9.noarch.rpm",
+	}
+
+	_, err := helpers.ExecCmdOnNodeWithError(cs, node, downloadCmd...)
+	require.NoError(t, err, "Failed to download RPM package on node %s: %v", node.Name, err)
+	t.Logf("RPM package downloaded successfully")
+
+	// Reboot the node to apply changes
+	t.Logf("Rebooting node %s to apply the changes", node.Name)
+	rebootCmd := []string{
+		"chroot", "/rootfs", "sudo", "systemctl", "reboot",
+	}
+
+	t.Logf("Executing rpm-ostree install command on node %s", node.Name)
+	// Install the RPM package
+	installCmd := []string{
+		"chroot", "/rootfs", "rpm-ostree", "install", "/tmp/epel-release-latest-9.noarch.rpm",
+	}
+
+	out, err := helpers.ExecCmdOnNodeWithError(cs, node, installCmd...)
+	if err != nil {
+		t.Fatalf("Failed to install RPM package on node %s: %v. Output: %s", node.Name, err, out)
+	}
+	t.Logf("Output from rpm-ostree install: %s", out)
+
+	// Reboot the node to apply the changes
+	t.Logf("Rebooting node %s to apply the layered package", node.Name)
+	_, err = helpers.ExecCmdOnNodeWithError(cs, node, rebootCmd...)
+	require.NoError(t, err, "Failed to reboot node %s: %v", node.Name, err)
+	t.Logf("Reboot command issued successfully")
+	t.Logf("Waiting for node %s to be ready after reboot", node.Name)
+	require.NoError(t, helpers.WaitForNodeReady(t, cs, node))
+
+	// Wait for the MCD to detect the change and update metrics
+	t.Logf("Waiting for MCD metrics to reflect the installed package")
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		cmd := []string{
+			"curl", "-s", "http://127.0.0.1:8797/metrics",
+		}
+
+		out, err := helpers.ExecCmdOnNodeWithError(cs, node, cmd...)
+		if err != nil {
+			t.Logf("Error executing curl on node %s: %v", node.Name, err)
+			return false, nil
+		}
+
+		// Check for the metric
+		metricName := "mcd_local_unsupported_packages"
+		if !strings.Contains(out, metricName) {
+			t.Logf("Metric %s not found in metrics output", metricName)
+			return false, nil
+		}
+
+		// Parse the metric to make sure it reflects the installed package
+		metricLine := findMetricLine(out, metricName)
+		if metricLine == "" {
+			t.Logf("Metric %s line not found in metrics output", metricName)
+			return false, nil
+		}
+
+		// Get the metric value
+		metricValue, err := parseMetricValue(metricLine)
+		if err != nil {
+			t.Logf("Failed to parse metric value: %v", err)
+			return false, nil
+		}
+
+		if metricValue == 1 {
+			t.Logf("Metric %s value is 1, test passed", metricName)
+			return true, nil
+		}
+
+		t.Logf("Metric %s value is %d, expected 1", metricName, metricValue)
+		return false, nil
+	})
+
+	require.NoError(t, err, "Failed to verify MCD metrics for unsupported packages on node %s", node.Name)
+
+	t.Log("Test completed successfully")
+}
+
+// Helper function to find the metric line in the metrics output
+func findMetricLine(metricsOutput, metricName string) string {
+	lines := strings.Split(metricsOutput, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, metricName) {
+			return line
+		}
+	}
+	return ""
+}
+
+// Helper function to parse the metric value from the metric line
+func parseMetricValue(metricLine string) (int, error) {
+	parts := strings.Fields(metricLine)
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("invalid metric line: %s", metricLine)
+	}
+	value, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return 0, err
+	}
+	return value, nil
+}

--- a/test/e2e-2of2/ctrcfg_test.go
+++ b/test/e2e-2of2/ctrcfg_test.go
@@ -1,0 +1,332 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	ctrcfg "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultPath          = "/etc/crio/crio.conf.d/00-default"
+	crioDropinDir        = "/etc/crio/crio.conf.d"
+	registriesConfigPath = "/etc/containers/registries.conf"
+)
+
+func TestContainerRuntimeConfigLogLevel(t *testing.T) {
+	ctrcfg1 := &mcfgv1.ContainerRuntimeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-debug"},
+		Spec: mcfgv1.ContainerRuntimeConfigSpec{
+			ContainerRuntimeConfig: &mcfgv1.ContainerRuntimeConfiguration{
+				LogLevel: "debug",
+			},
+		},
+	}
+	ctrcfg2 := &mcfgv1.ContainerRuntimeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-warn"},
+		Spec: mcfgv1.ContainerRuntimeConfigSpec{
+			ContainerRuntimeConfig: &mcfgv1.ContainerRuntimeConfiguration{
+				LogLevel: "warn",
+			},
+		},
+	}
+	runTestWithCtrcfg(t, "log-level", `log_level = (\S+)`, "\"debug\"", "\"warn\"", ctrcfg1, ctrcfg2)
+}
+
+func TestICSPConfigMirror(t *testing.T) {
+	icspRule := &apioperatorsv1alpha1.ImageContentSourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-digest-only"},
+		Spec: apioperatorsv1alpha1.ImageContentSourcePolicySpec{
+			RepositoryDigestMirrors: []apioperatorsv1alpha1.RepositoryDigestMirrors{
+				{Source: "registry.access.redhat.com/ubi8/icsp-ubi-minimal", Mirrors: []string{"mirror.com/ubi8/ubi-minimal"}},
+			},
+		},
+	}
+	runTestWithICSP(t, "digest-only", icspRule.Spec.RepositoryDigestMirrors[0].Source, icspRule)
+}
+
+// runTestWithCtrcfg creates a ctrcfg and checks whether the expected updates were applied, then deletes the ctrcfg and makes
+// sure the node rolled back as expected
+// testName is a string to identify the objects created (MCP, MC, ctrcfg)
+// regex key is the searching critera in the crio.conf. It is expected that a single field is in a capture group, and this field
+// should equal expectedConfValue upon update
+// cfg is the ctrcfg config to update to and rollback from
+func runTestWithCtrcfg(t *testing.T, testName, regexKey, expectedConfVal1, expectedConfVal2 string, cfg1, cfg2 *mcfgv1.ContainerRuntimeConfig) {
+	cs := framework.NewClientSet("")
+	matchValue := fmt.Sprintf("%s", testName)
+	ctrcfgName1 := fmt.Sprintf("ctrcfg-%s", cfg1.GetName())
+	ctrcfgName2 := fmt.Sprintf("ctrcfg-%s", cfg2.GetName())
+	poolName := fmt.Sprintf("node-%s", matchValue)
+	mcName := fmt.Sprintf("mc-%s", matchValue)
+
+	// instead of a bunch of individual defers, we can run through all of them
+	// in a single one
+	cleanupFuncs := make([]func(), 0)
+	defer func() {
+		for _, f := range cleanupFuncs {
+			f()
+		}
+	}()
+
+	// label one node from the pool to specify which worker to update
+	cleanupFuncs = append(cleanupFuncs, helpers.LabelRandomNodeFromPool(t, cs, "worker", helpers.MCPNameToRole(poolName)))
+	// upon cleaning up, we need to wait for the pool to reconcile after unlabelling
+	cleanupFuncs = append(cleanupFuncs, func() {
+		// the sleep allows the unlabelling to take effect
+		time.Sleep(time.Second * 5)
+		// wait until worker pool updates the node we labelled before we delete the test specific mc and mcp
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", helpers.GetMcName(t, cs, "worker")); err != nil {
+			t.Logf("failed to wait for pool %v", err)
+		}
+	})
+
+	// cache the old configuration value to check against later
+	node := helpers.GetSingleNodeByRole(t, cs, poolName)
+	defaultConfVal := getValueFromCrioConfig(t, cs, node, regexKey, defaultPath)
+	if defaultConfVal == expectedConfVal1 || defaultConfVal == expectedConfVal2 {
+		t.Logf("default configuration value %s same as values being tested against. Consider updating the test", defaultConfVal)
+		return
+	}
+
+	// create an MCP to match the node we tagged
+	cleanupFuncs = append(cleanupFuncs, helpers.CreateMCP(t, cs, poolName))
+
+	// create default mc to have something to verify we successfully rolled back
+	defaultMCConfig := helpers.CreateMC(mcName, poolName)
+	_, err := cs.MachineConfigs().Create(context.TODO(), defaultMCConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	cleanupFuncs = append(cleanupFuncs, func() {
+		err := cs.MachineConfigs().Delete(context.TODO(), defaultMCConfig.Name, metav1.DeleteOptions{})
+		require.Nil(t, err, "machine config deletion failed")
+	})
+	defaultTarget := helpers.WaitForConfigAndPoolComplete(t, cs, poolName, defaultMCConfig.Name)
+
+	// create our first ctrcfg and attach it to our created node pool
+	cleanupCtrcfgFunc1 := createCtrcfgWithConfig(t, cs, ctrcfgName1, poolName, cfg1.Spec.ContainerRuntimeConfig, "")
+	// wait for the first ctrcfg to show up
+	ctrcfgMCName1, err := getMCFromCtrcfg(t, cs, ctrcfgName1)
+	require.Nil(t, err, "failed to render machine config from first container runtime config")
+	// ensure the first ctrcfg update rolls out to the pool
+	ctrcfg1Target := helpers.WaitForConfigAndPoolComplete(t, cs, poolName, ctrcfgMCName1)
+	// verify value was changed to match that of the first ctrcfg
+	firstConfValue := getValueFromCrioConfig(t, cs, node, regexKey, ctrcfg.CRIODropInFilePathLogLevel)
+	require.Equal(t, firstConfValue, expectedConfVal1, "value in crio config not updated as expected")
+
+	// create our second ctrcfg and attach it to our created node pool
+	cleanupCtrcfgFunc2 := createCtrcfgWithConfig(t, cs, ctrcfgName2, poolName, cfg2.Spec.ContainerRuntimeConfig, "1")
+	// wait for the second ctrcfg to show up
+	ctrcfgMCName2, err := getMCFromCtrcfg(t, cs, ctrcfgName2)
+	require.Nil(t, err, "failed to render machine config from second container runtime config")
+	// ensure the second ctrcfg update rolls out to the pool
+	helpers.WaitForConfigAndPoolComplete(t, cs, poolName, ctrcfgMCName2)
+	// verify value was changed to match that of the first ctrcfg
+	secondConfValue := getValueFromCrioConfig(t, cs, node, regexKey, ctrcfg.CRIODropInFilePathLogLevel)
+	require.Equal(t, secondConfValue, expectedConfVal2, "value in crio config not updated as expected")
+
+	// cleanup the second ctrcfg and make sure it doesn't error
+	err = cleanupCtrcfgFunc2()
+	require.Nil(t, err)
+	t.Logf("Deleted ContainerRuntimeConfig %s", ctrcfgName2)
+	// ensure config rolls back to the previous ctrcfg as expected
+	helpers.WaitForPoolComplete(t, cs, poolName, ctrcfg1Target)
+	// verify that the config value rolled back to that from the first ctrcfg
+	rollbackConfValue := getValueFromCrioConfig(t, cs, node, regexKey, ctrcfg.CRIODropInFilePathLogLevel)
+	require.Equal(t, rollbackConfValue, expectedConfVal1, "ctrcfg deletion didn't cause node to roll back to previous ctrcfg config")
+
+	// cleanup the first ctrcfg and make sure it doesn't error
+	err = cleanupCtrcfgFunc1()
+	require.Nil(t, err)
+	t.Logf("Deleted ContainerRuntimeConfig %s", ctrcfgName1)
+	// ensure config rolls back as expected
+	helpers.WaitForPoolComplete(t, cs, poolName, defaultTarget)
+
+	restoredConfValue := getValueFromCrioConfig(t, cs, node, regexKey, defaultPath)
+	require.Equal(t, restoredConfValue, defaultConfVal, "ctrcfg deletion didn't cause node to roll back to default config")
+	// Verify that the override file doesn't exist in crio.conf.d anymore
+	arr := strings.Split(ctrcfg.CRIODropInFilePathLogLevel, "/")
+	overrideFileName := arr[len(arr)-1]
+	if fileExists(t, cs, node, overrideFileName) {
+		err := fmt.Errorf("override file still exists in crio.conf.d")
+		require.Nil(t, err)
+	}
+}
+
+// createCtrcfgWithConfig takes a config spec and creates a ContainerRuntimeConfig object
+// to use this ctrcfg, create a pool label key
+// this function assumes there is a mcp with label 'key='
+func createCtrcfgWithConfig(t *testing.T, cs *framework.ClientSet, name, key string, config *mcfgv1.ContainerRuntimeConfiguration, suffix string) func() error {
+	ctrcfg := &mcfgv1.ContainerRuntimeConfig{}
+	ctrcfg.ObjectMeta = metav1.ObjectMeta{
+		Name: name,
+	}
+	spec := mcfgv1.ContainerRuntimeConfigSpec{
+		MachineConfigPoolSelector: &metav1.LabelSelector{
+			MatchLabels: make(map[string]string),
+		},
+		ContainerRuntimeConfig: config,
+	}
+	spec.MachineConfigPoolSelector.MatchLabels[key] = ""
+	ctrcfg.Spec = spec
+	// Add the suffix value the MC created for this ctrcfg should have. This helps decide
+	// the priority order
+	if suffix != "" {
+		ctrcfg.Annotations = map[string]string{
+			ctrlcommon.MCNameSuffixAnnotationKey: suffix,
+		}
+	}
+
+	_, err := cs.ContainerRuntimeConfigs().Create(context.TODO(), ctrcfg, metav1.CreateOptions{})
+	require.Nil(t, err)
+	return func() error {
+		return cs.ContainerRuntimeConfigs().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+}
+
+// getMCFromCtrcfg returns a rendered machine config that was generated from the ctrcfg ctrcfgName
+func getMCFromCtrcfg(t *testing.T, cs *framework.ClientSet, ctrcfgName string) (string, error) {
+	var mcName string
+	// get the machine config created when we deploy the ctrcfg
+	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcs, err := cs.MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, mc := range mcs.Items {
+			ownerRefs := mc.GetOwnerReferences()
+			for _, ownerRef := range ownerRefs {
+				// TODO can't find anywhere this value is defined publically
+				if ownerRef.Kind == "ContainerRuntimeConfig" && ownerRef.Name == ctrcfgName {
+					mcName = mc.Name
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return "", fmt.Errorf("can't find machine config created by ctrcfg %s: %w", ctrcfgName, err)
+	}
+	return mcName, nil
+}
+
+// getValueFromCrioConfig jumps onto the node and gets the crio config. It then uses the regexKey to
+// find the value that is being searched for
+// regexKey is expected to be in the form `key = (\S+)` to search for the value of key
+func getValueFromCrioConfig(t *testing.T, cs *framework.ClientSet, node corev1.Node, regexKey, confPath string) string {
+	// get the contents of the crio.conf on nodeName
+	out := helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", confPath))
+
+	// search based on the regex key. The output should have two members:
+	// one with the entire line `value = key` and one with just the key, in that order
+	re := regexp.MustCompile(regexKey)
+	matches := re.FindStringSubmatch(string(out))
+	require.Len(t, matches, 2)
+
+	require.NotEmpty(t, matches[1], "regex %s attempted on crio config of node %s came back empty", node.Name, regexKey)
+	return matches[1]
+}
+
+// fileExists checks whether overrideFile exists in /etc/crio/crio.conf.d
+func fileExists(t *testing.T, cs *framework.ClientSet, node corev1.Node, overrideFile string) bool {
+	// get the contents of the crio drop in directory
+	out := helpers.ExecCmdOnNode(t, cs, node, "ls", filepath.Join("/rootfs", crioDropinDir))
+
+	// Check if the overrideFile name exists in the output
+	return strings.Contains(string(out), overrideFile)
+}
+
+func runTestWithICSP(t *testing.T, testName, expectedVal string, icspRule *apioperatorsv1alpha1.ImageContentSourcePolicy) {
+	cs := framework.NewClientSet("")
+	icspObjName := fmt.Sprintf("icsp-%s", icspRule.GetName())
+	labelName := fmt.Sprintf("node-%s", testName)
+	poolName := fmt.Sprintf("node-%s", testName)
+	searchKey := icspRule.Spec.RepositoryDigestMirrors[0].Source
+	// instead of a bunch of individual defers, we can run through all of them
+	// in a single one
+	cleanupFuncs := make([]func(), 0)
+	defer func() {
+		for _, f := range cleanupFuncs {
+			f()
+		}
+	}()
+
+	// label one node from the pool to specify which worker to update
+	cleanupFuncs = append(cleanupFuncs, helpers.LabelRandomNodeFromPool(t, cs, "worker", helpers.MCPNameToRole(labelName)))
+	// upon cleaning up, we need to wait for the pool to reconcile after unlabelling
+	cleanupFuncs = append(cleanupFuncs, func() {
+		// the sleep allows the unlabelling to take effect
+		time.Sleep(time.Second * 5)
+		// wait until worker pool updates the node we labelled before we delete the test specific mc and mcp
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", helpers.GetMcName(t, cs, "worker")); err != nil {
+			t.Logf("failed to wait for pool %v", err)
+		}
+	})
+
+	// cache the old configuration value to check against later
+	node := helpers.GetSingleNodeByRole(t, cs, labelName)
+	// cache the old configuration value to check against later
+	defaultConfVal := getValueFromRegistriesConfig(t, cs, node, searchKey, registriesConfigPath)
+	if defaultConfVal == expectedVal {
+		t.Logf("default configuration value %s same as values being tested against. Consider updating the test", defaultConfVal)
+		return
+	}
+
+	// create an MCP to match the node we tagged
+	cleanupFuncs = append(cleanupFuncs, helpers.CreateMCP(t, cs, poolName))
+
+	// create icsp and attach it to our cluster
+	cleanupICSPFunc := createICSPWithConfig(t, cs, icspObjName, icspRule.Spec.RepositoryDigestMirrors)
+	// wait for the icsp to show up
+	// ensure the first icsp update rolls out to the cluster
+	err := helpers.WaitForPoolCompleteAny(t, cs, poolName)
+	require.Nil(t, err)
+	// verify value was changed to match that of the icsp
+	confVal := getValueFromRegistriesConfig(t, cs, node, searchKey, registriesConfigPath)
+	require.Equal(t, expectedVal, confVal, "value in registries config not updated as expected")
+
+	// cleanup the icsp and make sure it doesn't error
+	err = cleanupICSPFunc()
+	require.Nil(t, err)
+	t.Logf("Deleted icsp %s", icspObjName)
+	// ensure config rolls back as expected
+	err = helpers.WaitForPoolCompleteAny(t, cs, poolName)
+	require.Nil(t, err)
+}
+
+func createICSPWithConfig(t *testing.T, cs *framework.ClientSet, name string, config []apioperatorsv1alpha1.RepositoryDigestMirrors) func() error {
+	icspRule := &apioperatorsv1alpha1.ImageContentSourcePolicy{}
+	icspRule.ObjectMeta = metav1.ObjectMeta{
+		Name: name,
+	}
+	icspRule.Spec.RepositoryDigestMirrors = config
+	_, err := cs.ImageContentSourcePolicies().Create(context.TODO(), icspRule, metav1.CreateOptions{})
+	require.Nil(t, err)
+	return func() error {
+		return cs.ImageContentSourcePolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+}
+
+func getValueFromRegistriesConfig(t *testing.T, cs *framework.ClientSet, node corev1.Node, searchKey, confPath string) string {
+	// get the contents of the registries.conf on nodeName
+	out := helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", confPath))
+
+	// search based on the regex key. The output should have two members:
+	// one with the entire line `value = key` and one with just the key, in that order
+	if strings.Contains(out, searchKey) {
+		return searchKey
+	}
+	return ""
+}

--- a/test/e2e-2of2/kubeletcfg_test.go
+++ b/test/e2e-2of2/kubeletcfg_test.go
@@ -1,0 +1,305 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	kcfg "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+)
+
+const (
+	kubeletPath = "/etc/kubernetes/kubelet.conf"
+)
+
+func TestKubeletConfigDefaultUpdateFreq(t *testing.T) {
+	autoSizing := false
+	resources := make(map[string]string)
+	matchLabels := make(map[string]string)
+	matchLabels["pools.operator.machineconfiguration.openshift.io/infra"] = ""
+	resources["cpu"] = "100m"
+	// this might get caught by the test below that says if default == current but that is ok since we want to make sure nodeStatusUpdateFrequency is 10s
+	kcRaw1, err := kcfg.EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{}, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
+	require.Nil(t, err, "failed to encode kubelet config")
+	kc1 := &mcfgv1.KubeletConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-100"},
+		Spec: mcfgv1.KubeletConfigSpec{
+			AutoSizingReserved: &autoSizing,
+			KubeletConfig: &runtime.RawExtension{
+				Raw: kcRaw1,
+			}, MachineConfigPoolSelector: &metav1.LabelSelector{MatchLabels: matchLabels},
+		},
+	}
+
+	runTestWithKubeletCfg(t, "resources", []string{`"?nodeStatusUpdateFrequency"?: (\S+)`}, []string{"nodeStatusUpdateFrequency"}, [][]string{{"10s"}}, kc1, nil)
+}
+func TestKubeletConfigMaxPods(t *testing.T) {
+	kcRaw1, err := kcfg.EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 100}, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
+	require.Nil(t, err, "failed to encode kubelet config")
+	autoNodeSizing := true
+	kc1 := &mcfgv1.KubeletConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-101"},
+		Spec: mcfgv1.KubeletConfigSpec{
+			AutoSizingReserved: &autoNodeSizing,
+			KubeletConfig: &runtime.RawExtension{
+				Raw: kcRaw1,
+			},
+		},
+	}
+	kcRaw2, err := kcfg.EncodeKubeletConfig(&kubeletconfigv1beta1.KubeletConfiguration{MaxPods: 200}, kubeletconfigv1beta1.SchemeGroupVersion, runtime.ContentTypeJSON)
+	require.Nil(t, err, "failed to encode kubelet config")
+	kc2 := &mcfgv1.KubeletConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-200"},
+		Spec: mcfgv1.KubeletConfigSpec{
+			KubeletConfig: &runtime.RawExtension{
+				Raw: kcRaw2,
+			},
+		},
+	}
+
+	runTestWithKubeletCfg(t, "max-pods", []string{`"?maxPods"?: (\S+)`}, []string{"maxPods"}, [][]string{{"100", "200"}}, kc1, kc2)
+}
+
+// runTestWithKubeletCfg creates a kubelet config and checks whether the expected updates were applied, then deletes the kubelet config and makes
+// sure the node rolled back as expected
+// testName is a string to identify the objects created (MCP, MC, kubeletConfig)
+// regex key is the searching critera in the kubelet.conf. It is expected that a single field is in a capture group, and this field
+// should equal expectedConfValue upon update
+// kc1 and kc2 are the kubelet configs to update to and rollback from
+func runTestWithKubeletCfg(t *testing.T, testName string, regexKey []string, stringKey []string, expectedConfVals [][]string, kc1, kc2 *mcfgv1.KubeletConfig) {
+	cs := framework.NewClientSet("")
+	matchValue := fmt.Sprintf("%s", testName)
+	kcName1 := fmt.Sprintf("kubelet-%s", kc1.GetName())
+	kcName2 := ""
+	if kc2 != nil {
+		kcName2 = fmt.Sprintf("kubelet-%s", kc2.GetName())
+	}
+	poolName := fmt.Sprintf("node-%s", matchValue)
+	mcName := fmt.Sprintf("mc-%s", matchValue)
+
+	// instead of a bunch of individual defers, we can run through all of them
+	// in a single one
+	cleanupFuncs := make([]func(), 0)
+	defer func() {
+		for _, f := range cleanupFuncs {
+			f()
+		}
+	}()
+
+	// label one node from the pool to specify which worker to update
+	cleanupFuncs = append(cleanupFuncs, helpers.LabelRandomNodeFromPool(t, cs, "worker", helpers.MCPNameToRole(poolName)))
+	// upon cleaning up, we need to wait for the pool to reconcile after unlabelling
+	cleanupFuncs = append(cleanupFuncs, func() {
+		// the sleep allows the unlabelling to take effect
+		time.Sleep(time.Second * 5)
+		// wait until worker pool updates the node we labelled before we delete the test specific mc and mcp
+		if err := helpers.WaitForPoolComplete(t, cs, "worker", helpers.GetMcName(t, cs, "worker")); err != nil {
+			t.Logf("failed to wait for pool %v", err)
+		}
+	})
+
+	// cache the old configuration value to check against later
+	node := helpers.GetSingleNodeByRole(t, cs, poolName)
+	// the kubelet.conf format is yaml when in the default state and becomes a json when we apply a kubelet config CR
+	defaultConfVals := []string{}
+	for i, val := range regexKey {
+		if strings.Contains(val, "systemReserved") {
+			defaultConfVals = append(defaultConfVals, "")
+			continue
+		}
+		out, _ := getValueFromKubeletConfig(t, cs, node, val, stringKey[i], kubeletPath)
+		defaultConfVals = append(defaultConfVals, out)
+		for _, expect := range expectedConfVals[i] {
+			if defaultConfVals[i] == expect {
+				t.Logf("default configuration value %s same as values being tested against. Consider updating the test", defaultConfVals[i])
+				return
+			}
+		}
+	}
+
+	// create an MCP to match the node we tagged
+	cleanupFuncs = append(cleanupFuncs, helpers.CreateMCP(t, cs, poolName))
+
+	// create default mc to have something to verify we successfully rolled back
+	defaultMCConfig := helpers.CreateMC(mcName, poolName)
+	_, err := cs.MachineConfigs().Create(context.TODO(), defaultMCConfig, metav1.CreateOptions{})
+	require.Nil(t, err)
+	cleanupFuncs = append(cleanupFuncs, func() {
+		err := cs.MachineConfigs().Delete(context.TODO(), defaultMCConfig.Name, metav1.DeleteOptions{})
+		require.Nil(t, err, "machine config deletion failed")
+	})
+	defaultTarget := helpers.WaitForConfigAndPoolComplete(t, cs, poolName, defaultMCConfig.Name)
+
+	// create our first kubelet config and attach it to our created node pool
+	cleanupKcFunc1 := createKcWithConfig(t, cs, kcName1, poolName, &kc1.Spec, "")
+	// wait for the first kubelet config to show up
+	kcMCName1, err := getMCFromKubeletCfg(t, cs, kcName1)
+	require.Nil(t, err, "failed to render machine config from first container runtime config")
+	// ensure the first kubelet config update rolls out to the pool
+	kc1Target := helpers.WaitForConfigAndPoolComplete(t, cs, poolName, kcMCName1)
+	// verify value was changed to match that of the first kubelet config
+	for i, val := range regexKey {
+		out, found := getValueFromKubeletConfig(t, cs, node, val, stringKey[i], kubeletPath)
+		if found {
+			require.Equal(t, expectedConfVals[i][0], out, "value in kubelet config not updated as expected")
+		} else { // sometimes it seems regexp does not work here
+			require.True(t, strings.Contains(out, expectedConfVals[i][0]))
+		}
+	}
+
+	// Get the new node object which should reflect new values for the allocatables
+	if *kc1.Spec.AutoSizingReserved {
+		refreshedNode := helpers.GetSingleNodeByRole(t, cs, poolName)
+
+		// The value for the allocatable should have changed because of the auto node sizing.
+		// We cannot predict if the values of the allocatables will increase or decrease,
+		// as it depends on the configuration of the system under test.
+		require.NotEqual(t, refreshedNode.Status.Allocatable.Memory().Value(), node.Status.Allocatable.Memory().Value(), "value of the allocatable should have changed")
+	}
+
+	if kc2 != nil {
+		// create our second kubelet config and attach it to our created node pool
+		cleanupKcFunc2 := createKcWithConfig(t, cs, kcName2, poolName, &kc2.Spec, "1")
+		// wait for the second kubelet config to show up
+		kcMCName2, err := getMCFromKubeletCfg(t, cs, kcName2)
+		require.Nil(t, err, "failed to render machine config from second container runtime config")
+		// ensure the second kubelet config update rolls out to the pool
+		helpers.WaitForConfigAndPoolComplete(t, cs, poolName, kcMCName2)
+		// verify value was changed to match that of the first kubelet config
+		for i, val := range regexKey {
+			out, found := getValueFromKubeletConfig(t, cs, node, val, stringKey[i], kubeletPath)
+			if found {
+				require.Equal(t, out, expectedConfVals[i][1], "value in kubelet config not updated as expected")
+			} else { // sometimes it seems regexp does not work here
+				require.True(t, strings.Contains(out, expectedConfVals[i][1]))
+			}
+		}
+
+		// cleanup the second kubelet config and make sure it doesn't error
+		err = cleanupKcFunc2()
+		require.Nil(t, err)
+		t.Logf("Deleted KubeletConfig %s", kcName2)
+
+		// ensure config rolls back to the previous kubelet config as expected
+		helpers.WaitForPoolComplete(t, cs, poolName, kc1Target)
+		// verify that the config value rolled back to that from the first kubelet config
+		for i, val := range regexKey {
+			out, found := getValueFromKubeletConfig(t, cs, node, val, stringKey[i], kubeletPath)
+			if found {
+				require.Equal(t, out, expectedConfVals[i][0], "value in kubelet config not updated as expected")
+			} else { // sometimes it seems regexp does not work here
+				require.True(t, strings.Contains(out, expectedConfVals[i][0]))
+			}
+		}
+
+		// cleanup the first kubelet config and make sure it doesn't error
+		err = cleanupKcFunc1()
+		require.Nil(t, err)
+		t.Logf("Deleted KubeletConfig %s", kcName1)
+		// ensure config rolls back as expected
+		helpers.WaitForPoolComplete(t, cs, poolName, defaultTarget)
+		// verify that the config value rolled back to the default value
+		for i, val := range regexKey {
+			out, found := getValueFromKubeletConfig(t, cs, node, val, stringKey[i], kubeletPath)
+			if found {
+				require.Equal(t, out, defaultConfVals[i], "value in kubelet config not updated as expected")
+			} else { // sometimes it seems regexp does not work here
+				require.True(t, strings.Contains(out, defaultConfVals[i]))
+			}
+		}
+	}
+}
+
+// createKcWithConfig takes a config spec and creates a KubeletConfig object
+// to use this kubelet config, create a pool label key
+// this function assumes there is a mcp with label 'key='
+func createKcWithConfig(t *testing.T, cs *framework.ClientSet, name, key string, config *mcfgv1.KubeletConfigSpec, suffix string) func() error {
+	kc := &mcfgv1.KubeletConfig{}
+	kc.ObjectMeta = metav1.ObjectMeta{
+		Name: name,
+	}
+
+	spec := mcfgv1.KubeletConfigSpec{
+		AutoSizingReserved: config.AutoSizingReserved,
+		MachineConfigPoolSelector: &metav1.LabelSelector{
+			MatchLabels: make(map[string]string),
+		},
+		KubeletConfig: config.KubeletConfig,
+	}
+	spec.MachineConfigPoolSelector.MatchLabels[key] = ""
+	kc.Spec = spec
+	// Add the suffix value the MC created for this kubelet config should have. This helps decide
+	// the priority order
+	if suffix != "" {
+		kc.Annotations = map[string]string{
+			ctrlcommon.MCNameSuffixAnnotationKey: suffix,
+		}
+	}
+
+	_, err := cs.KubeletConfigs().Create(context.TODO(), kc, metav1.CreateOptions{})
+	require.Nil(t, err)
+	return func() error {
+		return cs.KubeletConfigs().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+}
+
+// getMCFromKubeletCfg returns a rendered machine config that was generated from the kubelet config kcName
+func getMCFromKubeletCfg(t *testing.T, cs *framework.ClientSet, kcName string) (string, error) {
+	var mcName string
+	// get the machine config created when we deploy the kubelet config
+	if err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcs, err := cs.MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, mc := range mcs.Items {
+			ownerRefs := mc.GetOwnerReferences()
+			for _, ownerRef := range ownerRefs {
+				// TODO can't find anywhere this value is defined publically
+				if ownerRef.Kind == "KubeletConfig" && ownerRef.Name == kcName {
+					mcName = mc.Name
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return "", fmt.Errorf("can't find machine config created by kubelet config %s: %w", kcName, err)
+	}
+	return mcName, nil
+}
+
+// getValueFromKubeletConfig jumps onto the node and gets the kubelet config. It then uses the regexKey to
+// find the value that is being searched for
+// regexKey is expected to be in the form `"key": (\S+)` to search for the value of key
+func getValueFromKubeletConfig(t *testing.T, cs *framework.ClientSet, node corev1.Node, regexKey, stringKey, confPath string) (string, bool) {
+	// get the contents of the kubelet.conf on nodeName
+	out := helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", confPath))
+	t.Log(out)
+
+	// search based on the regex key. The output should have two members:
+	// one with the entire line `value = key` and one with just the key, in that order
+	re := regexp.MustCompile(regexKey)
+	matches := re.FindStringSubmatch(string(out))
+	if len(matches) != 2 && strings.Contains(string(out), stringKey) {
+		return string(out), false
+	}
+	require.Len(t, matches, 2, fmt.Sprintf("failed to get %s", regexKey))
+
+	require.NotEmpty(t, matches[1], "regex %s attempted on kubelet config of node %s came back empty", node.Name, regexKey)
+	return matches[1], true
+}

--- a/test/e2e-2of2/main_test.go
+++ b/test/e2e-2of2/main_test.go
@@ -1,0 +1,10 @@
+package e2e_2of2_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/test/e2e-2of2/mcc_test.go
+++ b/test/e2e-2of2/mcc_test.go
@@ -1,0 +1,115 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/machine-config-operator/pkg/apihelpers"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// This test was inspired by the old TestReconcileAfterBadMC test. It checks
+// that the Machine Config Controller (MCC) can reconcile after a bad
+// MachineConfig. Previously, this test would infer reconciliation based upon
+// the state of the node. Now that we're checking for reconciliation in both
+// the MCC and the Machine Config Daemon (MCD), it is unlikely that an
+// unreconcilable config could make it to the MCD. So instead, we must infer
+// this failure and recovery from the MachineConfigPool (MCP) object instead.
+func TestMCCReconcileAfterBadMC(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	// create a MC that contains a valid ignition config but is not reconcilable
+	mcadd := createMCToAddFile("add-a-file", "/etc/mytestconfs", "test")
+	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mcadd.Spec.Config.Raw)
+	require.Nil(t, err, "failed to parse ignition config")
+	ignCfg.Storage.Disks = []ign3types.Disk{
+		{
+			Device: "/one",
+		},
+	}
+	rawIgnCfg := helpers.MarshalOrDie(ignCfg)
+	mcadd.Spec.Config.Raw = rawIgnCfg
+
+	workerOldMc := helpers.GetMcName(t, cs, "worker")
+
+	// create the dummy MC now
+	_, err = cs.MachineConfigs().Create(context.TODO(), mcadd, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("failed to create machine config %v", err)
+	}
+
+	// Wait for the MachineConfigPool to degrade
+	err = wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// The MachineConfigPool should not change MachineConfigs since it was
+		// unable to reconcile this bad MachineConfig.
+		if mcp.Spec.Configuration.Name != workerOldMc {
+			return false, fmt.Errorf("expected rendered MachineConfig on pool %s to not change from %q, got %q", mcp.Name, workerOldMc, mcp.Spec.Configuration.Name)
+		}
+
+		// Check that the MachineConfigPool degrades.
+		if apihelpers.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolRenderDegraded) {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	require.NoError(t, err)
+
+	// Next, we delete the bad MachineConfig
+	require.NoError(t, cs.MachineConfigs().Delete(context.TODO(), mcadd.Name, metav1.DeleteOptions{}))
+
+	// Wait for the MachineConfigPool to stop being degraded.
+	err = wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		mcp, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// The MachineConfigPool should not change MachineConfigs since it was
+		// unable to reconcile this bad MachineConfig.
+		if mcp.Spec.Configuration.Name != workerOldMc {
+			return false, fmt.Errorf("expected rendered MachineConfig on pool %s to not change from %q, got %q", mcp.Name, workerOldMc, mcp.Spec.Configuration.Name)
+		}
+
+		// Check that the MachineConfigPool cleras the degraded status and switches back to updated.
+		if apihelpers.IsMachineConfigPoolConditionFalse(mcp.Status.Conditions, mcfgv1.MachineConfigPoolRenderDegraded) &&
+			apihelpers.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	require.NoError(t, err)
+}
+
+func createMCToAddFileForRole(name, role, filename, data string) *mcfgv1.MachineConfig {
+	mcadd := helpers.CreateMC(fmt.Sprintf("%s-%s", name, uuid.NewUUID()), role)
+
+	ignConfig := ctrlcommon.NewIgnConfig()
+	ignFile := helpers.CreateUncompressedIgn3File(filename, "data:,"+data, 420)
+	ignConfig.Storage.Files = append(ignConfig.Storage.Files, ignFile)
+	rawIgnConfig := helpers.MarshalOrDie(ignConfig)
+	mcadd.Spec.Config.Raw = rawIgnConfig
+	return mcadd
+}
+
+func createMCToAddFile(name, filename, data string) *mcfgv1.MachineConfig {
+	return createMCToAddFileForRole(name, "worker", filename, data)
+}

--- a/test/e2e-2of2/mcn_test.go
+++ b/test/e2e-2of2/mcn_test.go
@@ -1,0 +1,92 @@
+package e2e_2of2_test
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMCNScopeSadPath(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab two random nodes from different pools, so we don't end up testing and targetting the same node.
+	nodeUnderTest := helpers.GetRandomNode(t, cs, "worker")
+	targetNode := helpers.GetRandomNode(t, cs, "master")
+
+	// Attempt to patch the MCN owned by targetNode from nodeUnderTest's MCD. This should fail.
+	// This oc command effectively use the service account of the nodeUnderTest's MCD pod, which should only be able to edit nodeUnderTest's MCN.
+	cmdOutput, err := helpers.ExecCmdOnNodeWithError(cs, nodeUnderTest, "chroot", "/rootfs", "oc", "patch", "machineconfignodes", targetNode.Name, "--type=merge", "-p", "{\"spec\":{\"configVersion\":{\"desired\":\"rendered-worker-test\"}}}")
+	require.Error(t, err, "No errors found during failure path :%v", err)
+	require.Contains(t, cmdOutput, "updates to MCN "+targetNode.Name+" can only be done from the MCN's owner node")
+}
+
+func TestMCNScopeImpersonationPath(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab a random node from the worker pool
+	nodeUnderTest := helpers.GetRandomNode(t, cs, "worker")
+
+	var errb bytes.Buffer
+	// Attempt to patch the MCN owned by nodeUnderTest by impersonating the MCD SA. This should fail.
+	cmd := exec.Command("oc", "patch", "machineconfignodes", nodeUnderTest.Name, "--type=merge", "-p", "{\"spec\":{\"configVersion\":{\"desired\":\"rendered-worker-test\"}}}", "--as=system:serviceaccount:openshift-machine-config-operator:machine-config-daemon")
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	require.Error(t, err, "No errors found during impersonation path :%v", err)
+	require.Contains(t, errb.String(), "this user must have a \"authentication.kubernetes.io/node-name\" claim")
+
+}
+
+func TestMCNScopeHappyPath(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab a random node from the worker pool
+	nodeUnderTest := helpers.GetRandomNode(t, cs, "worker")
+
+	// Attempt to patch the MCN owned by nodeUnderTest from nodeUnderTest's MCD. This should succeed.
+	// This oc command effectively use the service account of the nodeUnderTest's MCD pod, which should only be able to edit nodeUnderTest's MCN.
+	helpers.ExecCmdOnNode(t, cs, nodeUnderTest, "chroot", "/rootfs", "oc", "patch", "machineconfignodes", nodeUnderTest.Name, "--type=merge", "-p", "{\"spec\":{\"configVersion\":{\"desired\":\"rendered-worker-test\"}}}")
+}
+
+// `TestMCNPoolNameDefault` checks that the MCP name is correctly populated in a node's MCN object for default MCPs
+func TestMCNPoolNameDefault(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Grab a random node from each default pool
+	workerNode := helpers.GetRandomNode(t, cs, "worker")
+	masterNode := helpers.GetRandomNode(t, cs, "master")
+
+	// Test that MCN pool name value matches MCP association
+	workerNodeMCN, workerErr := cs.MachineconfigurationV1Interface.MachineConfigNodes().Get(context.TODO(), workerNode.Name, metav1.GetOptions{})
+	require.Equal(t, "worker", workerNodeMCN.Spec.Pool.Name)
+	require.NoError(t, workerErr)
+	masterNodeMCN, masterErr := cs.MachineconfigurationV1Interface.MachineConfigNodes().Get(context.TODO(), masterNode.Name, metav1.GetOptions{})
+	require.Equal(t, "master", masterNodeMCN.Spec.Pool.Name)
+	require.NoError(t, masterErr)
+}
+
+// `TestMCNPoolNameCustom` checks that the MCP name is correctly populated in a node's MCN object for custom MCPs
+func TestMCNPoolNameCustom(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Create a custom MCP and assign a worker node to it
+	customMCPName := "infra"
+	customNode := helpers.GetRandomNode(t, cs, "worker")
+	t.Cleanup(helpers.CreatePoolWithNode(t, cs, customMCPName, customNode))
+
+	// Test that MCN pool name value matches MCP association
+	customNodeMCN, customErr := cs.MachineconfigurationV1Interface.MachineConfigNodes().Get(context.TODO(), customNode.Name, metav1.GetOptions{})
+	require.Equal(t, customMCPName, customNodeMCN.Spec.Pool.Name)
+	require.NoError(t, customErr)
+}

--- a/test/e2e-2of2/mco_test.go
+++ b/test/e2e-2of2/mco_test.go
@@ -1,0 +1,303 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/openshift/api/config/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/controller/node"
+	e2e_shared_test "github.com/openshift/machine-config-operator/test/e2e-shared-tests"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+func TestClusterOperatorRelatedObjects(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	co, err := cs.ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("couldn't get clusteroperator %v", err)
+	}
+	if len(co.Status.RelatedObjects) == 0 {
+		t.Error("expected RelatedObjects to be populated but it was not")
+	}
+	var foundNS, foundOperatorConfig bool
+	for _, ro := range co.Status.RelatedObjects {
+		if ro.Resource == "namespaces" && ro.Name == ctrlcommon.MCONamespace {
+			foundNS = true
+		}
+		if ro.Resource == "machineconfigurations" {
+			foundOperatorConfig = true
+		}
+	}
+	if !foundNS {
+		t.Error("ClusterOperator.RelatedObjects should contain the MCO namespace")
+	}
+	if !foundOperatorConfig {
+		t.Error("ClusterOperator.RelatedObjects should contain the MCO operator knob object")
+	}
+}
+
+func TestMastersSchedulable(t *testing.T) {
+	cs := framework.NewClientSet("")
+	schedulerCR, err := cs.ConfigV1Interface.Schedulers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error while listing scheduler CR with error %v", err)
+	}
+	schedulerCR.Spec.MastersSchedulable = true
+	if _, err = cs.ConfigV1Interface.Schedulers().Update(context.TODO(), schedulerCR, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Error while updating scheduler CR with error %v", err)
+	}
+	err = waitForAllMastersUpdate(cs, true)
+	if err != nil {
+		t.Fatalf("Expected all master nodes to be schedulable but it's not the case with %v", err)
+	}
+	// Reset scheduler CR
+	schedulerCR, err = cs.ConfigV1Interface.Schedulers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error while listing scheduler CR with error %v", err)
+	}
+	schedulerCR.Spec.MastersSchedulable = false
+	if _, err = cs.ConfigV1Interface.Schedulers().Update(context.TODO(), schedulerCR, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Error while updating scheduler CR with error %v", err)
+	}
+	err = waitForAllMastersUpdate(cs, false)
+	if err != nil {
+		t.Fatalf("Expected all master nodes to be unschedulable but it's not the case with %v", err)
+	}
+}
+
+func checkMasterNodesSchedulability(cs *framework.ClientSet, masterSchedulable bool) bool {
+	masterNodes, err := cs.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/master="})
+	if err != nil {
+		klog.Errorf("error while listing master nodes with %v", err)
+	}
+	if masterSchedulable {
+		for _, masterNode := range masterNodes.Items {
+			if !CheckMasterIsAlreadySchedulable(&masterNode) {
+				return false
+			}
+		}
+	} else {
+		for _, masterNode := range masterNodes.Items {
+			if CheckMasterIsAlreadySchedulable(&masterNode) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// CheckMasterIsAlreadySchedulable checks if the given node has a worker label and doesn't have NoSchedule master
+// taint
+func CheckMasterIsAlreadySchedulable(master *corev1.Node) bool {
+	_, hasWorkerLabel := master.Labels[node.WorkerLabel]
+	hasMasterTaint := false
+	for _, taint := range master.Spec.Taints {
+		if taint.Key == ctrlcommon.MasterLabel && taint.Effect == corev1.TaintEffectNoSchedule {
+			hasMasterTaint = true
+		}
+	}
+	return hasWorkerLabel && !hasMasterTaint
+}
+
+func waitForAllMastersUpdate(cs *framework.ClientSet, mastersSchedulable bool) error {
+	return wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		if !checkMasterNodesSchedulability(cs, mastersSchedulable) {
+			klog.Infof("All masters are not in desired state")
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func TestClusterOperatorStatusExtension(t *testing.T) {
+	cs := framework.NewClientSet("")
+	co, err := cs.ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+	require.Nil(t, err)
+	ext := map[string]string{
+		"test": "extension",
+	}
+	rawExt, err := json.Marshal(ext)
+	require.Nil(t, err)
+	co.Status.Extension.Raw = rawExt
+	_, err = cs.ClusterOperators().UpdateStatus(context.TODO(), co, metav1.UpdateOptions{})
+	require.Nil(t, err)
+	co, err = cs.ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+	require.Nil(t, err)
+	require.NotNil(t, co.Status.Extension)
+	coExt := map[string]string{}
+	err = json.Unmarshal(co.Status.Extension.Raw, &coExt)
+	require.Nil(t, err)
+	v, ok := coExt["test"]
+	require.True(t, ok)
+	require.Equal(t, "extension", v)
+}
+
+func TestMetrics(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	poolName := "metrics"
+
+	node := helpers.GetRandomNode(t, cs, "worker")
+	t.Cleanup(helpers.CreatePoolAndApplyMCToNode(t, cs, poolName, node, nil))
+
+	mcp, err := cs.MachineConfigPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	t.Cleanup(e2e_shared_test.MutateNodeAndWait(t, cs, &node, mcp))
+
+	if err := wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
+		svc, err := cs.Services("openshift-machine-config-operator").Get(context.TODO(), "machine-config-operator", metav1.GetOptions{})
+		require.Nil(t, err)
+
+		// Extract the IP and port and build the URL
+		requestTarget := svc.Spec.ClusterIP
+		requestPort := svc.Spec.Ports[0].Port
+		url := fmt.Sprintf("https://%s:%d/metrics", requestTarget, requestPort)
+
+		t.Logf("Getting monitoring token")
+		token, err := helpers.GetMonitoringToken(t, cs)
+		require.Nil(t, err)
+
+		out := helpers.ExecCmdOnNode(t, cs, node, []string{"curl", "-s", "-k", "-H", "Authorization: Bearer " + string(token), url}...)
+
+		// The /metrics output will contain the metric if it works
+		promMetric := fmt.Sprintf(`mco_unavailable_machine_count{pool="%s"} 1`, poolName)
+		if !strings.Contains(out, promMetric) {
+			t.Logf("%s: Metric should have been set, but were NOT", out)
+			return false, nil
+		}
+		t.Log("Metric successfully set")
+		return true, nil
+	}); err != nil {
+		t.Errorf("error getting metrics: %q", err)
+	}
+}
+
+func TestImageRegistryMergedCM(t *testing.T) {
+	// patch the cluster object with a fake registry
+	// make sure the merged cm does not get deleted, (look at creation time?)
+	cs := framework.NewClientSet("")
+
+	caData := make(map[string]string)
+	caData["foo"] = "bar"
+	_, err := cs.CoreV1Interface.ConfigMaps("openshift-config").Create(
+		context.TODO(),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mcotestingca",
+			},
+			Data: caData,
+		},
+		metav1.CreateOptions{},
+	)
+	require.Nil(t, err)
+
+	trustedCM, err := cs.CoreV1Interface.ConfigMaps("openshift-config-managed").Get(context.TODO(), "merged-trusted-image-registry-ca", metav1.GetOptions{})
+	require.Nil(t, err)
+
+	cfg, err := cs.ConfigV1Interface.Images().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	require.Nil(t, err)
+
+	cfgJson, err := json.Marshal(cfg)
+	require.Nil(t, err)
+
+	newCfg := cfg.DeepCopy()
+
+	newCfg.Spec.AdditionalTrustedCA = v1.ConfigMapNameReference{Name: "mcotestingca"}
+
+	newCfgJson, err := json.Marshal(newCfg)
+
+	require.Nil(t, err)
+
+	patchBytes, err := jsonmergepatch.CreateThreeWayJSONMergePatch(cfgJson, newCfgJson, cfgJson)
+
+	//	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(cfgJson, newCfgJson, v1.Image{})
+	require.Nil(t, err)
+	_, err = cs.ConfigV1Interface.Images().Patch(context.TODO(), "cluster", types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	require.Nil(t, err)
+
+	cfg, err = cs.ConfigV1Interface.Images().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	cfgJson, err = json.Marshal(cfg)
+	t.Logf("CFG: %s", string(cfgJson))
+
+	newTrustedCM := &corev1.ConfigMap{}
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		newTrustedCM, err = cs.CoreV1Interface.ConfigMaps("openshift-config-managed").Get(context.TODO(), "merged-trusted-image-registry-ca", metav1.GetOptions{})
+		require.Nil(t, err)
+
+		if _, ok := newTrustedCM.Data["foo"]; ok {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, newTrustedCM.CreationTimestamp, trustedCM.CreationTimestamp)
+
+	nodes, err := helpers.GetNodesByRole(cs, "worker")
+	require.Nil(t, err)
+
+	//mcd, err := helpers.MCDForNode(cs, &nodes[0])
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		out, err := helpers.ExecCmdOnNodeWithError(cs, nodes[0], "ls", "/rootfs/etc/docker/certs.d")
+		if err != nil {
+			t.Logf("Error while exec'ing on node. Probably transient due to commands being executed: %s", err.Error())
+			nodes, err = helpers.GetNodesByRole(cs, "worker")
+			require.Nil(t, err)
+			return false, nil
+		}
+		t.Logf("OUTPUT: %s", out)
+		return strings.Contains(out, "foo"), nil
+	})
+
+	cfg, err = cs.ConfigV1Interface.Images().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	require.Nil(t, err)
+
+	cfgJson, err = json.Marshal(cfg)
+	require.Nil(t, err)
+
+	newCfg = cfg.DeepCopy()
+
+	newCfg.Spec.AdditionalTrustedCA = v1.ConfigMapNameReference{}
+
+	newCfgJson, err = json.Marshal(newCfg)
+
+	require.Nil(t, err)
+
+	patchBytes, err = jsonmergepatch.CreateThreeWayJSONMergePatch(cfgJson, newCfgJson, cfgJson)
+	require.Nil(t, err)
+
+	_, err = cs.ConfigV1Interface.Images().Patch(context.TODO(), "cluster", types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	require.Nil(t, err)
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		newTrustedCM, err = cs.CoreV1Interface.ConfigMaps("openshift-config-managed").Get(context.TODO(), "merged-trusted-image-registry-ca", metav1.GetOptions{})
+		require.Nil(t, err)
+		if _, ok := newTrustedCM.Data["foo"]; ok {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		out := helpers.ExecCmdOnNode(t, cs, nodes[0], "ls", "/rootfs/etc/docker/certs.d")
+		return !strings.Contains(out, "foo"), nil
+	})
+	err = cs.CoreV1Interface.ConfigMaps("openshift-config").Delete(context.TODO(), "mcotestingca", metav1.DeleteOptions{})
+	require.Nil(t, err)
+}

--- a/test/e2e-2of2/msbic_test.go
+++ b/test/e2e-2of2/msbic_test.go
@@ -1,0 +1,537 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/yaml"
+
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	opv1 "github.com/openshift/api/operator/v1"
+	machineClientv1beta1 "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
+	mcopclientset "github.com/openshift/client-go/operator/clientset/versioned"
+
+	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+
+	mcoac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+func TestBootImageReconciliationonSingleMachineSet(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Check if the cluster is running on GCP platform
+	if !verifyGCPPlatform(t, cs) {
+		return
+	}
+
+	machineClient := machineClientv1beta1.NewForConfigOrDie(cs.GetRestConfig())
+	testOnLabel := map[string]string{"test": "fake-update-on"}
+	testOffLabel := map[string]string{"test": "fake-update-off"}
+
+	// Update the machineconfiguration object to opt-in the label
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	labelSelector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "test", "fake-update-on")
+	applyLabelSelector := applymetav1.LabelSelector().WithMatchLabels(labelSelector.MatchLabels)
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.Partial).
+						WithPartial(mcoac.PartialSelector().
+							WithMachineResourceSelector(applyLabelSelector))))))
+
+	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
+	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
+	t.Logf("Updated machine configuration knob to target one machineset for boot image updates")
+
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
+	// Pick a random machineset to test
+	machineSetUnderTest := getRandomMachineSet(t, machineClient)
+	t.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
+
+	// Label this machineset with the test label and update it
+	newMachineSet := machineSetUnderTest.DeepCopy()
+	newMachineSet.SetLabels(testOnLabel)
+	err = patchMachineSet(&machineSetUnderTest, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset for adding test on label failed")
+	t.Logf("Added testing ON label to MachineSet %s", machineSetUnderTest.Name)
+
+	machineSets, err := machineClient.MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to grab machineset list")
+	for _, ms := range machineSets.Items {
+		verifyMachineSet(t, cs, ms, machineClient, newMachineSet.Name == ms.Name)
+	}
+
+	// Unlabel the machineset as it may be used in other tests
+	machineSetUnderTestUpdated, err := machineClient.MachineSets("openshift-machine-api").Get(context.TODO(), machineSetUnderTest.Name, metav1.GetOptions{})
+	require.Nil(t, err, "failed to re-fetch machineset under test")
+
+	newMachineSet = machineSetUnderTestUpdated.DeepCopy()
+	newMachineSet.SetLabels(testOffLabel)
+	err = patchMachineSet(machineSetUnderTestUpdated, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset for test label failed")
+	t.Logf("Added testing OFF label to MachineSet %s", machineSetUnderTestUpdated.Name)
+}
+
+func TestBootImageReconciliationonAllMachineSets(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Check if the cluster is running on GCP platform
+	if !verifyGCPPlatform(t, cs) {
+		return
+	}
+
+	machineClient := machineClientv1beta1.NewForConfigOrDie(cs.GetRestConfig())
+
+	// Update the machineconfiguration object to opt-in all machinesets
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.All)))))
+	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
+	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
+	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
+
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
+	machineSets, err := machineClient.MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to grab machineset list")
+
+	// Test all machinesets
+	for _, ms := range machineSets.Items {
+		verifyMachineSet(t, cs, ms, machineClient, true)
+	}
+
+}
+
+func TestBootImageReconciliationonNoMachineSets(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Check if the cluster is running on GCP platform
+	if !verifyGCPPlatform(t, cs) {
+		return
+	}
+
+	machineClient := machineClientv1beta1.NewForConfigOrDie(cs.GetRestConfig())
+
+	// Update the machineconfiguration object to opt-in no machinesets
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.None)))))
+	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
+	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
+	t.Logf("Updated machine configuration knob to target no machinesets for boot image updates")
+
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
+	machineSets, err := machineClient.MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to grab machineset list")
+
+	// Test that no machinesets got updated
+	for _, ms := range machineSets.Items {
+		verifyMachineSet(t, cs, ms, machineClient, false)
+	}
+
+}
+
+func TestBootImageDegradeCondition(t *testing.T) {
+	t.Skip("Temporarily skipping this test until boot image skew enforcement is implemented")
+
+	cs := framework.NewClientSet("")
+
+	// Check if the cluster is running on GCP platform
+	if !verifyGCPPlatform(t, cs) {
+		return
+	}
+
+	machineClient := machineClientv1beta1.NewForConfigOrDie(cs.GetRestConfig())
+	oref := []metav1.OwnerReference{{APIVersion: "test", Kind: "test", Name: "test", UID: "test"}}
+
+	// Update the machineconfiguration object to opt-in all machinesets
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.All)))))
+	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
+	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
+	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
+	// Pick a random machineset to test
+	machineSetUnderTest := getRandomMachineSet(t, machineClient)
+	t.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
+
+	// Set an ownership label on this machineset
+	newMachineSet := machineSetUnderTest.DeepCopy()
+	newMachineSet.SetOwnerReferences(oref)
+	err = patchMachineSet(&machineSetUnderTest, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset for adding owner reference failed")
+	t.Logf("Added ownerreference to MachineSet %s", machineSetUnderTest.Name)
+
+	var pollError error
+	// Use a polling function as the CO may take a few seconds to update
+	if err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
+		// Check that the cluster operator is degraded
+		co, getErr := cs.ConfigV1Interface.ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+		require.NoError(t, getErr, "failed to grab cluster operator")
+
+		if cov1helpers.IsStatusConditionFalse(co.Status.Conditions, osconfigv1.OperatorDegraded) {
+			pollError = fmt.Errorf("Cluster Operator has not degraded")
+			return false, nil
+		}
+
+		degradedCondition := cov1helpers.FindStatusCondition(co.Status.Conditions, osconfigv1.OperatorDegraded)
+		if !strings.Contains(degradedCondition.Message, "error syncing MAPI MachineSet "+newMachineSet.Name+": unexpected OwnerReference: test/test") {
+			pollError = fmt.Errorf("Cluster Operator condition does not have the correct message")
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for cluster operator to degrade: %v", pollError)
+	}
+
+	t.Logf("Succesfully verified that the operator degraded")
+
+	// Remove the ownerreference on the machineneset
+	machineSetUnderTestUpdated, err := machineClient.MachineSets("openshift-machine-api").Get(context.TODO(), machineSetUnderTest.Name, metav1.GetOptions{})
+	require.Nil(t, err, "failed to re-fetch machineset under test")
+	newMachineSet = machineSetUnderTestUpdated.DeepCopy()
+	newMachineSet.SetOwnerReferences(nil)
+	err = patchMachineSet(machineSetUnderTestUpdated, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset while removing ownerreference failed")
+
+	t.Logf("Removed ownerreference on MachineSet %s", machineSetUnderTest.Name)
+
+	// Verify that the cluster operator is no longer degraded
+	// Use a polling function as the CO may take a few seconds to update
+	if err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
+		// Check that the cluster operator is degraded
+		co, getErr := cs.ConfigV1Interface.ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+		require.NoError(t, getErr, "failed to grab cluster operator")
+
+		if cov1helpers.IsStatusConditionTrue(co.Status.Conditions, osconfigv1.OperatorDegraded) {
+			pollError = fmt.Errorf("Cluster Operator is still degraded")
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for cluster operator to not be degraded: %v", pollError)
+	}
+	t.Logf("Succesfully verified that the operator is no longer degraded")
+}
+
+func TestStubIgnitionUpgrade(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+
+	// Check if the cluster is running on GCP platform
+	if !verifyGCPPlatform(t, cs) {
+		return
+	}
+	testStubSecretName := "test-user-data"
+	machineClient := machineClientv1beta1.NewForConfigOrDie(cs.GetRestConfig())
+	// Create a 2.2 stub secret in the test cluster
+	_, err := cs.CoreV1Interface.Secrets(ctrlcommon.MachineAPINamespace).Create(context.TODO(), getOldMAOSecret(testStubSecretName), metav1.CreateOptions{})
+	require.Nil(t, err, "create test secret failed")
+	t.Logf("Created test stub secret")
+	// Update the machineconfiguration object to opt-in all machinesets
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	p := mcoac.MachineConfiguration("cluster").
+		WithSpec(mcoac.MachineConfigurationSpec().
+			WithManagementState("Managed").
+			WithManagedBootImages(mcoac.ManagedBootImages().
+				WithMachineManagers(mcoac.MachineManager().
+					WithAPIGroup(opv1.MachineAPI).
+					WithResource(opv1.MachineSets).
+					WithSelection(mcoac.MachineManagerSelector().
+						WithMode(opv1.All)))))
+	_, err = machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), p, metav1.ApplyOptions{FieldManager: "machine-config-operator"})
+
+	require.Nil(t, err, "updating machineconfiguration boot image knob failed")
+
+	t.Logf("Updated machine configuration knob to target all machinesets for boot image updates")
+
+	err = waitForMachineConfigurationStatusUpdate(t, cs)
+	require.NoError(t, err, "timeout waiting for MachineConfigurationStatus")
+
+	// Pick a random machineset to test
+	machineSetUnderTest := getRandomMachineSet(t, machineClient)
+	t.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
+
+	// Update machineset to point to 2.2 stub
+	providerSpec := new(machinev1beta1.GCPMachineProviderSpec)
+	err = unmarshalProviderSpec(&machineSetUnderTest, providerSpec)
+	require.Nil(t, err, "failed to unmarshal Machine Set: %s", machineSetUnderTest.Name)
+
+	newProviderSpec := providerSpec.DeepCopy()
+	newProviderSpec.UserDataSecret.Name = testStubSecretName
+	// Set a fake boot image value so a machineset update is required
+	for idx := range newProviderSpec.Disks {
+		if newProviderSpec.Disks[idx].Boot {
+			newProviderSpec.Disks[idx].Image = newProviderSpec.Disks[idx].Image + "-fake-update"
+		}
+	}
+
+	newMachineSet := machineSetUnderTest.DeepCopy()
+	err = marshalProviderSpec(newMachineSet, newProviderSpec)
+	require.Nil(t, err, "failed to marshal new Provider Spec object")
+
+	err = patchMachineSet(&machineSetUnderTest, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset for test secret failed")
+
+	// Ensure atleast one master node is ready
+	t.Logf("Waiting until atleast one master node is ready...")
+	helpers.WaitForOneMasterNodeToBeReady(t, cs)
+	t.Logf("Updated MachineSet %s with stub secret", machineSetUnderTest.Name)
+
+	// Check if secret got upgraded to spec 3
+	secret, err := cs.CoreV1Interface.Secrets(ctrlcommon.MachineAPINamespace).Get(context.TODO(), testStubSecretName, metav1.GetOptions{})
+	require.Nil(t, err, "get test secret failed")
+	userData := secret.Data[ctrlcommon.UserDataKey]
+	var userDataIgn interface{}
+	err = json.Unmarshal(userData, &userDataIgn)
+	require.Nil(t, err, "failed to unmarshal decoded user-data to json (secret %s): %wt", secret.Name, err)
+	versionPath := []string{ctrlcommon.IgnFieldIgnition, ctrlcommon.IgnFieldVersion}
+	version, _, err := unstructured.NestedString(userDataIgn.(map[string]any), versionPath...)
+	require.Nil(t, err, "failed to find version field in ignition (user data secret %s): %w", secret.Name, err)
+	require.Equal(t, strings.HasPrefix(version, ctrlcommon.MinimumAcceptableStubIgnitionSpec), true, "Upgraded stub ignition doesn't have the correct version")
+	t.Logf("Test stub secret was upgraded correctly")
+
+	// Restore machineset to original providerSpec
+	machineSetUnderTestUpdated, err := machineClient.MachineSets("openshift-machine-api").Get(context.TODO(), machineSetUnderTest.Name, metav1.GetOptions{})
+	require.Nil(t, err, "failed to re-fetch machineset under test")
+	newMachineSet = machineSetUnderTestUpdated.DeepCopy()
+	err = marshalProviderSpec(newMachineSet, providerSpec)
+	require.Nil(t, err, "failed to marshal new Provider Spec object during restoration")
+	err = patchMachineSet(machineSetUnderTestUpdated, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset during restoration failed")
+
+	t.Logf("Restored MachineSet %s to original values", machineSetUnderTest.Name)
+
+	// Delete test secret
+	err = cs.CoreV1Interface.Secrets(ctrlcommon.MachineAPINamespace).Delete(context.TODO(), testStubSecretName, metav1.DeleteOptions{})
+	require.Nil(t, err, "delete test secret failed")
+	t.Logf("Test stub secret %s deleted", testStubSecretName)
+
+}
+
+// This function verifies if the boot image values of the MachineSet are in an expected state
+func verifyMachineSet(t *testing.T, cs *framework.ClientSet, ms machinev1beta1.MachineSet, machineClient *machineClientv1beta1.MachineV1beta1Client, reconciliationExpected bool) {
+	providerSpec := new(machinev1beta1.GCPMachineProviderSpec)
+	err := unmarshalProviderSpec(&ms, providerSpec)
+	require.Nil(t, err, "failed to unmarshal Machine Set: %s", ms.Name)
+
+	originalBootImageValue := providerSpec.Disks[0].Image
+
+	newProviderSpec := providerSpec.DeepCopy()
+	for idx := range newProviderSpec.Disks {
+		if newProviderSpec.Disks[idx].Boot {
+			newProviderSpec.Disks[idx].Image = newProviderSpec.Disks[idx].Image + "-fake-update"
+		}
+	}
+
+	newMachineSet := ms.DeepCopy()
+	err = marshalProviderSpec(newMachineSet, newProviderSpec)
+	require.Nil(t, err, "failed to marshal new Provider Spec object")
+
+	err = patchMachineSet(&ms, newMachineSet, machineClient)
+	require.Nil(t, err, "patching machineset failed")
+	t.Logf("Updated build name in machineset %s to \"%s\"", ms.Name, originalBootImageValue+"-fake-update")
+
+	// Ensure atleast one master node is ready
+	t.Logf("Waiting until atleast one master node is ready...")
+	helpers.WaitForOneMasterNodeToBeReady(t, cs)
+
+	// Fetch the machineset under test again
+	t.Logf("Fetching machineset/%s again...", ms.Name)
+	machineSetUnderTestUpdated, err := machineClient.MachineSets("openshift-machine-api").Get(context.TODO(), ms.Name, metav1.GetOptions{})
+	require.Nil(t, err, "failed to re-fetch machineset under test")
+
+	// Verify that the boot images have been correctly reconciled to the expected value
+	providerSpec = new(machinev1beta1.GCPMachineProviderSpec)
+	err = unmarshalProviderSpec(machineSetUnderTestUpdated, providerSpec)
+	require.Nil(t, err, "failed to unmarshal updated Machine Set: %s", machineSetUnderTestUpdated.Name)
+	for _, disk := range providerSpec.Disks {
+		if reconciliationExpected {
+			require.Equal(t, originalBootImageValue, disk.Image, "boot images have not been updated correctly")
+		} else {
+			require.NotEqual(t, originalBootImageValue, disk.Image, "boot images have been unexpectedly updated")
+		}
+	}
+
+	if reconciliationExpected {
+		t.Logf("The boot image have been reconciled, as expected")
+	} else {
+		t.Logf("The boot images have not been reconciled, as expected")
+		// Restore machineSet to original values in this case, as the machineset may be used by other test variants
+		patchMachineSet(newMachineSet, &ms, machineClient)
+		t.Logf("Restored build name in the machineset %s to \"%s\"", ms.Name, originalBootImageValue)
+	}
+
+}
+
+// This function verifies that this test is running on a GCP cluster
+func verifyGCPPlatform(t *testing.T, cs *framework.ClientSet) bool {
+	infra, err := cs.ConfigV1Interface.Infrastructures().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	require.NoError(t, err, "failed to grab cluster infrastructure")
+	if infra.Status.PlatformStatus.Type != osconfigv1.GCPPlatformType {
+		t.Logf("This test is only applicable on the GCP platform, exiting test.")
+		return false
+	}
+	t.Logf("GCP platform detected, continuing test...")
+	return true
+}
+
+// Picks a random machineset present on the cluster
+func getRandomMachineSet(t *testing.T, machineClient *machineClientv1beta1.MachineV1beta1Client) machinev1beta1.MachineSet {
+	machineSets, err := machineClient.MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to grab machineset list")
+
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	machineSetUnderTest := machineSets.Items[rnd.Intn(len(machineSets.Items))]
+	return machineSetUnderTest
+}
+
+// This function unmarshals the machineset's provider spec into
+// a ProviderSpec object. Returns an error if providerSpec field is nil,
+// or the unmarshal fails
+func unmarshalProviderSpec(ms *machinev1beta1.MachineSet, providerSpec interface{}) error {
+	if ms.Spec.Template.Spec.ProviderSpec.Value == nil {
+		return fmt.Errorf("providerSpec field was empty")
+	}
+	if err := yaml.Unmarshal(ms.Spec.Template.Spec.ProviderSpec.Value.Raw, &providerSpec); err != nil {
+		return fmt.Errorf("unmarshal into providerSpec failedL %w", err)
+	}
+	return nil
+}
+
+// This function marshals the ProviderSpec object into a MachineSet object.
+// Returns an error if ProviderSpec or MachineSet is nil, or if the marshal fails
+func marshalProviderSpec(ms *machinev1beta1.MachineSet, providerSpec interface{}) error {
+	if ms == nil {
+		return fmt.Errorf("MachineSet object was nil")
+	}
+	if providerSpec == nil {
+		return fmt.Errorf("ProviderSpec object was nil")
+	}
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		return fmt.Errorf("marshal into machineset failed: %w", err)
+	}
+	ms.Spec.Template.Spec.ProviderSpec.Value = &kruntime.RawExtension{Raw: rawBytes}
+	return nil
+}
+
+// This function patches the machineset object using the machineClient
+// Returns an error if marshsalling or patching fails.
+func patchMachineSet(oldMachineSet, newMachineSet *machinev1beta1.MachineSet, machineClient *machineClientv1beta1.MachineV1beta1Client) error {
+	machineSetMarshal, err := json.Marshal(oldMachineSet)
+	if err != nil {
+		return fmt.Errorf("unable to marshal old machineset: %w", err)
+	}
+	newMachineSetMarshal, err := json.Marshal(newMachineSet)
+	if err != nil {
+		return fmt.Errorf("unable to marshal new machineset: %w", err)
+	}
+	patchBytes, err := jsonmergepatch.CreateThreeWayJSONMergePatch(machineSetMarshal, newMachineSetMarshal, machineSetMarshal)
+	if err != nil {
+		return fmt.Errorf("unable to create patch for new machineset: %w", err)
+	}
+	_, err = machineClient.MachineSets("openshift-machine-api").Patch(context.TODO(), oldMachineSet.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to patch new machineset: %w", err)
+	}
+	return nil
+}
+
+// This is a spec 2 stub generated by the installer, in older versions of OCP(<4.6)
+func getOldMAOSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ctrlcommon.MachineAPINamespace,
+		},
+		Data: map[string][]byte{"disableTemplating": []byte("true"), "userData": []byte(`{"ignition":{"config":{"append":[{"source":"https://test-cluster-api:22623/config/worker"}]},"security":{"tls":{"certificateAuthorities":[{"source":"data:text/plain;charset=utf-8;base64,LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClJPT1QgQ0EgREFUQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="}]}},"version":"2.2.0"}}`)},
+	}
+}
+
+// waitForMachineConfigurationStatus waits until the MCO syncs the operator status to the latest spec
+func waitForMachineConfigurationStatusUpdate(t *testing.T, cs *framework.ClientSet) error {
+
+	startTime := time.Now()
+
+	mcopClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+	// Wait for mcop.Status to populate, otherwise error out. This shouldn't take very long
+	// as this is done by the operator sync loop.
+	if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, false, func(_ context.Context) (bool, error) {
+		mcop, pollError := mcopClient.OperatorV1().MachineConfigurations().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		if pollError != nil {
+			t.Logf("MachineConfiguration/cluster has not been created yet")
+			return false, nil
+		}
+
+		// Ensure status.ObservedGeneration matches the last generation of MachineConfiguration
+		if mcop.Generation != mcop.Status.ObservedGeneration {
+			t.Logf("MachineConfiguration.Status is not up to date.")
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("MachineConfiguration was not ready: (waited %s): %w", time.Since(startTime), err)
+	}
+
+	t.Logf("MachineConfiguration is ready (waited %v)", time.Since(startTime))
+	return nil
+}

--- a/test/e2e-2of2/node_os_test.go
+++ b/test/e2e-2of2/node_os_test.go
@@ -1,0 +1,81 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Verifies that the OS on each node is identifiable using the mechanism the
+// MCD does. This is done to ensure that we get an early warning if the
+// contents of /etc/os-release or /usr/lib/os-release unexpectedly change.
+func TestOSDetection(t *testing.T) {
+	cs := framework.NewClientSet("")
+	nodes, err := cs.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	for _, node := range nodes.Items {
+		node := node
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			nodeOSRelease := helpers.GetOSReleaseForNode(t, cs, node)
+
+			assert.Equal(t, nodeOSRelease.EtcContent, nodeOSRelease.LibContent)
+			assert.True(t, nodeOSRelease.OS.IsCoreOSVariant(), "expected IsCoreOSVariant() to be true: %s", nodeOSRelease.EtcContent)
+			assert.False(t, nodeOSRelease.OS.IsLikeTraditionalRHEL7(), "expected IsLikeTraditionalRHEL7() to be false: %s", nodeOSRelease.EtcContent)
+
+			switch {
+			case strings.Contains(nodeOSRelease.EtcContent, osrelease.RHCOS):
+				assertRHCOS(t, nodeOSRelease, node)
+			case strings.Contains(nodeOSRelease.EtcContent, osrelease.SCOS):
+				assertSCOS(t, nodeOSRelease, node)
+			case strings.Contains(nodeOSRelease.EtcContent, osrelease.FCOS):
+				assertFCOS(t, nodeOSRelease, node)
+			default:
+				t.Fatalf("unknown OS on node %s detected: %s", node.Name, nodeOSRelease.EtcContent)
+			}
+		})
+	}
+}
+
+func assertRHCOS(t *testing.T, nodeOSRelease helpers.NodeOSRelease, node corev1.Node) {
+	assert.True(t, nodeOSRelease.OS.IsEL(), "expected IsEL() to be true: %s", nodeOSRelease.EtcContent)
+	assert.False(t, nodeOSRelease.OS.IsSCOS(), "expected IsSCOS() to be false: %s", nodeOSRelease.EtcContent)
+	assert.False(t, nodeOSRelease.OS.IsFCOS(), "expected IsFCOS() to be false: %s", nodeOSRelease.EtcContent)
+
+	rhelVersion := nodeOSRelease.OS.OSRelease().ADDITIONAL_FIELDS["RHEL_VERSION"]
+
+	if strings.Contains(nodeOSRelease.EtcContent, "RHEL_VERSION=\"8.") { // This pattern intentionally unterminated so it matches all RHCOS 8 versions
+		t.Logf("Identified %s %s on node %s", osrelease.RHCOS, rhelVersion, node.Name)
+		assert.False(t, nodeOSRelease.OS.IsEL9(), "expected < RHCOS 9.0: %s", nodeOSRelease.EtcContent)
+	}
+
+	if strings.Contains(nodeOSRelease.EtcContent, "RHEL_VERSION=\"9.") { // This pattern intentionally unterminated so it matches all RHCOS 9 versions
+		t.Logf("Identified %s %s on node %s", osrelease.RHCOS, rhelVersion, node.Name)
+		assert.True(t, nodeOSRelease.OS.IsEL9(), "expected >= RHCOS 9.0+: %s", nodeOSRelease.EtcContent)
+	}
+}
+
+func assertSCOS(t *testing.T, nodeOSRelease helpers.NodeOSRelease, node corev1.Node) {
+	t.Logf("Identified %s on node %s", osrelease.SCOS, node.Name)
+	assert.True(t, nodeOSRelease.OS.IsEL(), "expected IsEL() to be true: %s", nodeOSRelease.EtcContent)
+	assert.True(t, nodeOSRelease.OS.IsEL9(), "expected IsEL9() to be true: %s", nodeOSRelease.EtcContent)
+	assert.False(t, nodeOSRelease.OS.IsFCOS(), "expected IsFCOS() to be false: %s", nodeOSRelease.EtcContent)
+}
+
+func assertFCOS(t *testing.T, nodeOSRelease helpers.NodeOSRelease, node corev1.Node) {
+	t.Logf("Identified OS %s on node %s", osrelease.FCOS, node.Name)
+	assert.False(t, nodeOSRelease.OS.IsEL(), "expected IsEL() to be false: %s", nodeOSRelease.EtcContent)
+	assert.False(t, nodeOSRelease.OS.IsEL9(), "expected IsEL9() to be false: %s", nodeOSRelease.EtcContent)
+	assert.False(t, nodeOSRelease.OS.IsSCOS(), "expected IsSCOS() to be false: %s", nodeOSRelease.EtcContent)
+	assert.True(t, nodeOSRelease.OS.IsFCOS(), "expected IsFCOS() to be true: %s", nodeOSRelease.EtcContent)
+}

--- a/test/e2e-2of2/nodedisrupt_test.go
+++ b/test/e2e-2of2/nodedisrupt_test.go
@@ -1,0 +1,229 @@
+package e2e_2of2_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
+
+	v1 "github.com/openshift/api/machineconfiguration/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	mcoac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	mcopclientset "github.com/openshift/client-go/operator/clientset/versioned"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	constants "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/require"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// The MachineConfigPools to create for the tests.
+	testMCPFileName    string = "infra-file"
+	testMCPSSHName     string = "infra-ssh"
+	testMCPUnitName    string = "infra-unit"
+	testMCPSpecialName string = "infra-special"
+)
+
+func TestNodeDisruptionPolicies(t *testing.T) {
+
+	cs := framework.NewClientSet("")
+	nodes, err := helpers.GetNodesByRole(cs, "worker")
+	require.Nil(t, err, "error grabbing nodes from worker pool")
+	require.Greater(t, len(nodes), 0, "this test requires atleast one node in the worker pool")
+
+	// By equally(based on run-time) separating out the actions to be tested across three parallel sub-tests,
+	// the test suite can be run much faster. This still provides sufficient coverage as the calculation and
+	// execution of policies are independant of each other. Each testFunc can handle any combination of testActions.
+
+	testActionsAlpha := []opv1.NodeDisruptionPolicySpecAction{
+		{Type: opv1.NoneSpecAction}, {Type: opv1.DrainSpecAction}}
+
+	testActionsBeta := []opv1.NodeDisruptionPolicySpecAction{{Type: opv1.RebootSpecAction}}
+
+	testActionsGamma := []opv1.NodeDisruptionPolicySpecAction{{Type: opv1.DaemonReloadSpecAction},
+		{Type: opv1.RestartSpecAction, Restart: &opv1.RestartService{ServiceName: "crio.service"}},
+		{Type: opv1.ReloadSpecAction, Reload: &opv1.ReloadService{ServiceName: "crio.service"}}}
+
+	// Shuffle the three action sets so each testFunc is randomly assigned one of the above action sets.
+	testActionSets := [][]opv1.NodeDisruptionPolicySpecAction{testActionsAlpha, testActionsBeta, testActionsGamma}
+	helpers.ShuffleSlice(testActionSets)
+
+	testFuncs := []func(*testing.T, corev1.Node, []opv1.NodeDisruptionPolicySpecAction){testFilePolicy, testUnitPolicy, testSSHKeyPolicy}
+
+	for testIndex, testFunc := range testFuncs {
+		testIndex := testIndex
+		testFunc := testFunc
+		t.Run(helpers.GetFunctionName(testFunc), func(t *testing.T) {
+			// Only parallelize if there are enough nodes to run the tests individually
+			if len(nodes) >= len(testFuncs) {
+				t.Parallel()
+				testFunc(t, nodes[testIndex], testActionSets[testIndex])
+			} else {
+				testFunc(t, nodes[0], testActionSets[testIndex])
+			}
+
+		})
+	}
+
+}
+
+func testFilePolicy(t *testing.T, node corev1.Node, testActions []opv1.NodeDisruptionPolicySpecAction) {
+
+	cs := framework.NewClientSet("")
+	t.Cleanup(helpers.CreatePoolAndApplyMCToNode(t, cs, testMCPFileName, node, nil))
+
+	// Step through each action and check if it was applied correctly. This loop generates a MachineConfiguration
+	// and a MachineConfig for each testAction and verifies that the correct NodeDisruptionPolicy was applied.
+	for _, action := range testActions {
+		fileName := "/etc/test-" + string(action.Type)
+		fileApplyConfiguration := mcoac.NodeDisruptionPolicySpecFile().WithPath(fileName).WithActions(helpers.GetActionApplyConfiguration(action))
+		applyConfiguration := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed").WithNodeDisruptionPolicy(mcoac.NodeDisruptionPolicyConfig().WithFiles(fileApplyConfiguration)))
+		// Create the test MC object, derived from the action under test
+		testMC := helpers.NewMachineConfig("01-test-file", helpers.MCLabelForRole(testMCPFileName), "", []ign3types.File{ctrlcommon.NewIgnFile(fileName, "test\n")})
+		checkNodeDisruptionAction(t, cs, testMC, testMCPFileName, *applyConfiguration, node, action.Type)
+	}
+
+}
+
+func testUnitPolicy(t *testing.T, nodeUnderTest corev1.Node, testActions []opv1.NodeDisruptionPolicySpecAction) {
+
+	cs := framework.NewClientSet("")
+	t.Cleanup(helpers.CreatePoolAndApplyMCToNode(t, cs, testMCPUnitName, nodeUnderTest, nil))
+
+	// Step through each action and check if it was applied correctly. This loop generates a MachineConfiguration
+	// and a MachineConfig for each testAction and verifies that the correct NodeDisruptionPolicy was applied.
+	for _, action := range testActions {
+		serviceName := string(action.Type) + "-test.service"
+		serviceApplyConfiguration := mcoac.NodeDisruptionPolicySpecUnit().WithName(opv1.NodeDisruptionPolicyServiceName(serviceName)).WithActions(helpers.GetActionApplyConfiguration(action))
+		applyConfiguration := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed").WithNodeDisruptionPolicy(mcoac.NodeDisruptionPolicyConfig().WithUnits(serviceApplyConfiguration)))
+		testMC := helpers.NewMachineConfigExtended("01-test-unit", helpers.MCLabelForRole(testMCPUnitName), nil, nil, []ign3types.Unit{{Name: serviceName, Contents: helpers.StrToPtr("test")}}, nil, nil, false, nil, "", "")
+		checkNodeDisruptionAction(t, cs, testMC, testMCPUnitName, *applyConfiguration, nodeUnderTest, action.Type)
+	}
+}
+
+func testSSHKeyPolicy(t *testing.T, node corev1.Node, testActions []opv1.NodeDisruptionPolicySpecAction) {
+
+	cs := framework.NewClientSet("")
+	t.Cleanup(helpers.CreatePoolAndApplyMCToNode(t, cs, testMCPSSHName, node, nil))
+
+	// Step through each action and check if it was applied correctly. This loop generates a MachineConfiguration
+	// and a MachineConfig for each testAction and verifies that the correct NodeDisruptionPolicy was applied.
+	for _, action := range testActions {
+		sshApplyConfiguration := mcoac.NodeDisruptionPolicySpecSSHKey().WithActions(helpers.GetActionApplyConfiguration(action))
+		applyConfiguration := mcoac.MachineConfiguration("cluster").WithSpec(mcoac.MachineConfigurationSpec().WithManagementState("Managed").WithNodeDisruptionPolicy(mcoac.NodeDisruptionPolicyConfig().WithSSHKey(sshApplyConfiguration)))
+		testMC := helpers.NewMachineConfigExtended("01-test-ssh", helpers.MCLabelForRole(testMCPSSHName), nil, nil, nil, []ign3types.SSHAuthorizedKey{"test"}, nil, false, nil, "", "")
+		checkNodeDisruptionAction(t, cs, testMC, testMCPSSHName, *applyConfiguration, node, action.Type)
+	}
+
+}
+
+// This is a bespoke test function for the Special Action. This verifies that drain only takes
+// place when registries are removed from /etc/containers/registries.conf and no drain takes
+// place when registried are added. It also verifies that crio reloads takes place in both cases.
+func TestNodeDisruptionPolicySpecialAction(t *testing.T) {
+
+	t.Logf("Verifying Special action")
+
+	cs := framework.NewClientSet("")
+	t.Cleanup(helpers.CreatePoolAndApplyMC(t, cs, testMCPSpecialName, nil))
+	nodeUnderTest := helpers.GetSingleNodeByRole(t, cs, testMCPSpecialName)
+
+	// Grab name of MCD pod under test
+	mcdPod, err := helpers.MCDForNode(cs, &nodeUnderTest)
+	require.Nil(t, err, "determing mcd pod of node under test failed")
+
+	// Grab old rendered MC to figure out transition back
+	oldRenderedMC := helpers.GetMcName(t, cs, testMCPSpecialName)
+
+	// Modify registry file on disk by adding a new "test.io" domain
+	tomlReg := sysregistriesv2.V2RegistriesConf{}
+	_, err = toml.Decode(helpers.GetFileContentOnNode(t, cs, nodeUnderTest, constants.ContainerRegistryConfPath), &tomlReg)
+	require.Nil(t, err, "failed decoding TOML content from file %s: %w", constants.ContainerRegistryConfPath, err)
+	tomlReg.UnqualifiedSearchRegistries = append(tomlReg.UnqualifiedSearchRegistries, "test.io")
+	var newFile bytes.Buffer
+	encoder := toml.NewEncoder(&newFile)
+	err = encoder.Encode(tomlReg)
+	require.Nil(t, err, "failed encoding TOML content into file %s: %w", constants.ContainerRegistryConfPath, err)
+
+	// Create the a test machineconfig from the file in cluster
+	testMC := helpers.NewMachineConfig("01-test", helpers.MCLabelForRole(testMCPSpecialName), "", []ign3types.File{ctrlcommon.NewIgnFile(constants.ContainerRegistryConfPath, newFile.String())})
+	_, err = cs.MachineconfigurationV1Interface.MachineConfigs().Create(context.TODO(), testMC, metav1.CreateOptions{})
+	require.Nil(t, err, "creating test machine config failed")
+
+	// Wait for transition to new config
+	renderedMC := helpers.WaitForConfigAndPoolComplete(t, cs, testMCPSpecialName, testMC.Name)
+
+	// Check daemon logs to ensure drain was not executed for this case and that a crio reload took place for this MC change.
+	helpers.AssertMCDLogsContain(t, cs, mcdPod, &nodeUnderTest, fmt.Sprintf("Drain calculated for node disruption: false for config %s", renderedMC))
+	helpers.AssertMCDLogsContain(t, cs, mcdPod, &nodeUnderTest, fmt.Sprintf("Performing post config change action: Special for config %s", renderedMC))
+
+	// Remove test config, this is the equivalent of deleting a registry
+	cs.MachineconfigurationV1Interface.MachineConfigs().Delete(context.TODO(), testMC.Name, metav1.DeleteOptions{})
+	require.Nil(t, err, "deleting test machine config failed")
+
+	// Wait for pool to return to old MC before checking actions
+	helpers.WaitForPoolComplete(t, cs, testMCPSpecialName, oldRenderedMC)
+
+	// Check daemon logs to ensure drain action was executed and that a crio reload took place for this MC change.
+	helpers.AssertMCDLogsContain(t, cs, mcdPod, &nodeUnderTest, fmt.Sprintf("Drain calculated for node disruption: true for config %s", oldRenderedMC))
+	helpers.AssertMCDLogsContain(t, cs, mcdPod, &nodeUnderTest, fmt.Sprintf("Performing post config change action: Special for config %s", oldRenderedMC))
+
+	t.Logf("Successfully verified Special action")
+
+}
+
+func checkNodeDisruptionAction(t *testing.T, cs *framework.ClientSet, testMC *v1.MachineConfig, testMCP string, applyConfiguration mcoac.MachineConfigurationApplyConfiguration, nodeUnderTest corev1.Node, expectedAction opv1.NodeDisruptionPolicySpecActionType) {
+
+	t.Logf("Verifying %s", expectedAction)
+
+	// Grab the client
+	machineConfigurationClient := mcopclientset.NewForConfigOrDie(cs.GetRestConfig())
+
+	// This may be needed to verify reboot action
+	initialUptime := helpers.GetNodeUptime(t, cs, nodeUnderTest)
+
+	// Grab name of MCD pod under test
+	mcdPod, err := helpers.MCDForNode(cs, &nodeUnderTest)
+	require.Nil(t, err, "determing mcd pod of node under test failed")
+
+	// Apply the node disruption policy
+	_, err = machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), &applyConfiguration, metav1.ApplyOptions{FieldManager: "machine-config-operator" + testMCP})
+	require.Nil(t, err, "updating cluster node disruption policy failed")
+
+	// Grab old rendered MC to figure out transition back
+	oldRenderedMC := helpers.GetMcName(t, cs, testMCP)
+
+	// Create the test machineconfig in cluster
+	_, err = cs.MachineconfigurationV1Interface.MachineConfigs().Create(context.TODO(), testMC, metav1.CreateOptions{})
+	require.Nil(t, err, "creating test machine config failed")
+
+	// Wait for transition to new config
+	renderedMC := helpers.WaitForConfigAndPoolComplete(t, cs, testMCP, testMC.Name)
+
+	// Check daemon logs to ensure correct action was executed
+	if expectedAction == opv1.DrainSpecAction {
+		helpers.AssertMCDLogsContain(t, cs, mcdPod, &nodeUnderTest, fmt.Sprintf("Drain calculated for node disruption: true for config %s", renderedMC))
+	} else if expectedAction == opv1.RebootSpecAction {
+		helpers.AssertNodeReboot(t, cs, nodeUnderTest, initialUptime)
+	} else {
+		helpers.AssertMCDLogsContain(t, cs, mcdPod, &nodeUnderTest, fmt.Sprintf("Performing post config change action: %v for config %s", expectedAction, renderedMC))
+	}
+
+	// Remove test config
+	cs.MachineconfigurationV1Interface.MachineConfigs().Delete(context.TODO(), testMC.Name, metav1.DeleteOptions{})
+	require.Nil(t, err, "deleting test machine config failed")
+
+	// Wait for pool to return to old MC before running next test case
+	helpers.WaitForPoolComplete(t, cs, testMCP, oldRenderedMC)
+
+	t.Logf("Successfully verified %s", expectedAction)
+}

--- a/test/e2e-2of2/osimageurl_override_test.go
+++ b/test/e2e-2of2/osimageurl_override_test.go
@@ -1,0 +1,100 @@
+package e2e_2of2_test
+
+import (
+	"os"
+	"testing"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// This test targets the osImageURL functionality by creating a MachineConfig
+// that points to a custom OS image containing third-party content. The test
+// works like this:
+// 1. Ensure that the node does not have the third-party binaries on it.
+// 2. Create a new MachineConfig that points to a custom OS image which
+// contains those binaries.
+// 3. Wait for the node to boot into the new custom OS image.
+// 4. Assert that the node now has the binaries in place.
+// 5. Revert back to the previous state.
+// 6. Wait for the node to roll back.
+// 7. Assert that the binaries are no longer present.
+func TestOSImageURLOverride(t *testing.T) {
+	envVarName := "MCO_OS_IMAGE_URL"
+
+	osImageURL, ok := os.LookupEnv(envVarName)
+	if ok && osImageURL != "" {
+		t.Logf("%s=%q, will use as custom OS image", envVarName, osImageURL)
+	} else {
+		t.Skipf("%s not set; skipping!", envVarName)
+		return
+	}
+
+	cs := framework.NewClientSet("")
+
+	node := helpers.GetRandomNode(t, cs, "worker")
+
+	binaries := []string{
+		"/usr/bin/tailscale",
+		"/usr/bin/rg",
+		"/usr/bin/yq",
+	}
+
+	t.Logf("Node %q has not yet booted into the new OS, running pre-test assertions", node.Name)
+
+	assertNodeDoesNotHaveBinaries(t, cs, node, binaries)
+
+	undoFunc := applyCustomOSToNode(t, cs, node, osImageURL, "infra")
+	t.Cleanup(undoFunc)
+
+	assertNodeHasBinaries(t, cs, node, binaries)
+
+	// We're done with our test assertions at this point, so lets roll back.
+	undoFunc()
+
+	assertNodeDoesNotHaveBinaries(t, cs, node, binaries)
+}
+
+func assertNodeHasBinaries(t *testing.T, cs *framework.ClientSet, node corev1.Node, binaries []string) {
+	for _, binary := range binaries {
+		t.Logf("Checking for presence of: %q", binary)
+		helpers.AssertFileOnNode(t, cs, node, binary)
+	}
+}
+
+func assertNodeDoesNotHaveBinaries(t *testing.T, cs *framework.ClientSet, node corev1.Node, binaries []string) {
+	for _, binary := range binaries {
+		t.Logf("Checking for absence of: %q", binary)
+		helpers.AssertFileNotOnNode(t, cs, node, binary)
+	}
+}
+
+// Creates a new MachineConfigPool, adds the given node to it, and overrides
+// the osImageURL with the provided OS image name.
+func applyCustomOSToNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, osImageURL, poolName string) func() {
+	// Do a pre-run assertion to ensure that we are not in the new OS image.
+	helpers.AssertNodeNotBootedIntoImage(t, cs, node, osImageURL)
+
+	mc := helpers.NewMachineConfig("custom-os-image", helpers.MCLabelForRole(poolName), osImageURL, []ign3types.File{})
+
+	t.Logf("Applying custom OS image %q to node %q", osImageURL, node.Name)
+
+	undoFunc := helpers.CreatePoolAndApplyMCToNode(t, cs, poolName, node, mc)
+
+	// Assert that we've booted into the new custom OS image.
+	helpers.AssertNodeBootedIntoImage(t, cs, node, osImageURL)
+
+	t.Logf("Node %q has booted into %q", node.Name, osImageURL)
+
+	return helpers.MakeIdempotent(func() {
+		// Roll back the MachineConfig that introduced the custom OS image.
+		undoFunc()
+
+		// Assert that rpm-ostree indicates we're not running the custom OS image anymore.
+		helpers.AssertNodeNotBootedIntoImage(t, cs, node, osImageURL)
+
+		t.Logf("Node %q has returned to its previous OS image", node.Name)
+	})
+}

--- a/test/e2e-2of2/osimageurl_test.go
+++ b/test/e2e-2of2/osimageurl_test.go
@@ -1,0 +1,42 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOSImageURL(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	// grab the latest worker- MC
+	mcp, err := cs.MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	mc, err := cs.MachineConfigs().Get(context.TODO(), mcp.Status.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	if mc.Spec.OSImageURL == "" {
+		t.Fatalf("Empty OSImageURL for %s", mc.Name)
+	}
+
+	// grab the latest master- MC
+	mcp, err = cs.MachineConfigPools().Get(context.TODO(), "master", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+	mc, err = cs.MachineConfigs().Get(context.TODO(), mcp.Status.Configuration.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	if mc.Spec.OSImageURL == "" {
+		t.Fatalf("Empty OSImageURL for %s", mc.Name)
+	}
+}

--- a/test/e2e-2of2/sanity_test.go
+++ b/test/e2e-2of2/sanity_test.go
@@ -1,0 +1,26 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"testing"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test case for https://github.com/openshift/machine-config-operator/pull/288/commits/44d5c5215b5450fca32806f796b50a3372daddc2
+func TestOperatorLabel(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	d, err := cs.DaemonSets(ctrlcommon.MCONamespace).Get(context.TODO(), "machine-config-daemon", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("%#v", err)
+	}
+
+	osSelector := d.Spec.Template.Spec.NodeSelector["kubernetes.io/os"]
+	if osSelector != "linux" {
+		t.Errorf("Expected node selector 'linux', not '%s'", osSelector)
+	}
+}


### PR DESCRIPTION
**What I did:**
This PR adds two new e2e packages/targets: `test-e2e-1of2` and `test-e2e-2of2` consisting of tests from the main e2e target: `test-e2e`. The tests have been equally divided among the two new targets so they would both run for about the same amount of time. 

Once these tests have been rehearsed correctly and merged into o/release, we can then make a follow-up PR to remove the original make target. 

**How to verify:**
Existing e2es should pass. This should not need QE testing since it is only affecting test changes. 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
