### PR TITLE
OCPBUGS-59723: Delete MCN v1alpha1 CRD on upgrade

### DIFF
--- a/install/0000_90_machine-config_90_deletion.yaml
+++ b/install/0000_90_machine-config_90_deletion.yaml
@@ -1,5 +1,6 @@
 # keep default for upgrading purposes, need to delete the existing role:
 # https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/object-deletion.md
+# Remove default service account
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,3 +18,12 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+---
+# Remove unneeded v1alpha1 MCN CRD if it exists
+apiVersion: machineconfiguration.openshift.io/v1alpha1
+kind: MachineConfigNode
+metadata:
+  name: machineconfignodes.machineconfiguration.openshift.io
+  namespace: openshift-machine-config-operator
+  annotations:
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
Closes: OCPBUGS-59723

**- What I did**
Add delete annotation for MCN v1alpha1 CRD on update to remove unnecessary CRD that causes conflicts when updating to version with MCN GAed.

**- How to verify it**
There are a few ways to verify this change, but this is how I've tested the fix.
1. Launch 4.15 cluster without techpreview enabled. You'll see that the MCN v1alpha1 CRD is in the cluster even though the feature should be behind a tech preview feature gate.
```console
$ oc get clusterversion
NAME      VERSION                              AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.15.0-0.nightly-2025-07-29-112846   True        False         6m14s   Cluster version is 4.15.0-0.nightly-2025-07-29-112846
$ oc get crd | grep machineconfignode                                                 
machineconfignodes.machineconfiguration.openshift.io              2025-07-29T19:21:54Z
```

2. Chain upgrades to the cluster up to an image built from this PR as the 4.20 version.
_Clusterbot command to make image with this PR:_ `build openshift/machine-config-operator#5198,4.20`
```console
$ oc adm upgrade --to-latest
# upgrades to 4.15
$ oc adm upgrade --to-latest
# upgrades to 4.16
$ oc adm upgrade --to-latest
# upgrades to 4.17
$ oc adm upgrade --to-latest
# upgrades to 4.18
$ oc adm upgrade --to-latest
# upgrades to 4.19
$ oc adm upgrade --to-image=<image-build-from-pr> --allow-explicit-upgrade --force
# upgrades to 4.20
```

3. Check that upgrade was successful, that v1alpha1 MCN CRD no longer exists in cluster, and that the v1 MCN CRDs are present in the cluster.

```

```

It is also worth confirming that no adverse changes to the current install pattern occur due to this change. This can be confirmed by launching a 4.20 cluster with this PR included (both with and without techpreview enabled) and confirming that the V1 MCN CRDs are present in the cluster.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
