### PR TITLE
TRT-2232: Revert #5148 "OCPBUGS-58023: Prevent unnecessary systemd unit disable"

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -926,7 +926,7 @@ func CalculateConfigFileDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) []st
 // that are different between them
 //
 //nolint:dupl
-func CalculateConfigUnitDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) ([]string, []ign3types.Unit) {
+func CalculateConfigUnitDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) []string {
 	// Go through the units and see what is new or different
 	oldUnitSet := make(map[string]ign3types.Unit)
 	for _, u := range oldIgnConfig.Systemd.Units {
@@ -946,19 +946,16 @@ func CalculateConfigUnitDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) ([]s
 		}
 	}
 
-	addedOrChangedUnits := []ign3types.Unit{}
 	// Now check if any units were added/changed
 	for name, newUnit := range newUnitSet {
 		oldUnit, ok := oldUnitSet[name]
 		if !ok {
 			diffUnitSet = append(diffUnitSet, name)
-			addedOrChangedUnits = append(addedOrChangedUnits, newUnit)
 		} else if !reflect.DeepEqual(oldUnit, newUnit) {
 			diffUnitSet = append(diffUnitSet, name)
-			addedOrChangedUnits = append(addedOrChangedUnits, newUnit)
 		}
 	}
-	return diffUnitSet, addedOrChangedUnits
+	return diffUnitSet
 }
 
 // NewIgnFile returns a simple ignition3 file from just path and file contents.

--- a/pkg/daemon/on_disk_validation.go
+++ b/pkg/daemon/on_disk_validation.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
@@ -103,12 +101,7 @@ func checkV3Unit(unit ign3types.Unit, systemdPath string) error {
 		return nil
 	}
 
-	err := checkFileContentsAndMode(path, []byte(*unit.Contents), defaultFilePermissions)
-	if err != nil {
-		return err
-	}
-
-	return checkUnitEnabled(unit.Name, unit.Enabled)
+	return checkFileContentsAndMode(path, []byte(*unit.Contents), defaultFilePermissions)
 }
 
 // checkV3Units validates the contents of all the units in the
@@ -235,24 +228,6 @@ func checkV2Files(files []ign2types.File) error {
 		}
 		checkedFiles[f.Path] = true
 	}
-	return nil
-}
-
-// checkUnitEnabled checks whether a systemd unit is enabled as expected.
-func checkUnitEnabled(name string, expectedEnabled *bool) error {
-	if expectedEnabled == nil {
-		return nil
-	}
-	cmd := exec.Command("systemctl", "is-enabled", name)
-	outBytes, err := cmd.CombinedOutput()
-	out := strings.TrimSpace(string(outBytes))
-
-	// units types considered not enabled (linked, linked-runtime, masked, masked-runtime, disabled, bad)
-	isEnabled := err == nil
-	if isEnabled != *expectedEnabled {
-		return fmt.Errorf("unit %q expected enabled=%t, but systemd reports %q", name, *expectedEnabled, out)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION

Reverts #5148 ; tracked by [TRT-2232](https://issues.redhat.com//browse/TRT-2232)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

machine-config operator causing azure, metal and other platforms to fail to install

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Verify azure and metal-ovn-ipv6 jobs succeed
```

CC: @RishabhSaini

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
