### PR TITLE
MCO-1747: Dump install-time MC to disk

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -366,6 +366,24 @@ func (dn *Daemon) performPostConfigChangeAction(postConfigChangeActions []string
 	return dn.finishRebootlessUpdate()
 }
 
+func (dn *Daemon) writeInstallConfigFile(config *mcfgv1.MachineConfig) error {
+
+	configPath := filepath.Join(filepath.Dir(dn.currentConfigPath), "installconfig")
+	if _, err := os.Stat(configPath); err == nil || !os.IsNotExist(err) {
+		return err
+	}
+	// If the logic reached this far it means the installconfig file does not exist
+	jsonConfig, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("error creating the installtime config json content. %w", err)
+	}
+	if err := writeFileAtomicallyWithDefaults(configPath, jsonConfig); err != nil {
+		return fmt.Errorf("error writting the installtime config json file. %w", err)
+	}
+
+	return nil
+}
+
 func setRunningKargsWithCmdline(config *mcfgv1.MachineConfig, requestedKargs []string, cmdline []byte) error {
 	splits := splitKernelArguments(strings.TrimSpace(string(cmdline)))
 	config.Spec.KernelArguments = nil


### PR DESCRIPTION
For further usage in the irreconcilable fields diff calculation we need to store the MC used to boot each node.
In case the node already exists (node upgraded from a previous version) we take the current MC as the install-time one, as the fields that are used to compute the irreconcilable changes shouldn't have changed.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
