### PR TITLE
RHEL-97088: set slaves down before bond reactivation

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -574,6 +574,9 @@ contents:
       for conn in "${connections[@]}"; do
         local slave_type=$($NMCLI_GET_VALUE connection.slave-type connection show "$conn")
         if [ "$slave_type" = "team" ] || [ "$slave_type" = "bond" ]; then
+          # Some Cisco switches mishandle LACP with agg=0; set slave down to
+          # avoid sending such packets during reactivation.
+          ip link set $(nmcli -g connection.interface-name connection show "$conn") down
           mod_nm_conn "$conn" connection.autoconnect yes
         fi
       done


### PR DESCRIPTION
Some Cisco switches disable peer ports upon receiving LACP packets with agg=0 during negotiation, disrupting the network. Cisco attributes this behavior to ambiguity in the IEEE spec.

Such packets are sent when slaves are removed during NetworkManager bond reactivation. To prevent this, set slaves down before reactivation. This is a safe change, as NetworkManager bond reactivation will re-add and bring them up.
