### PR TITLE
OCPBUGS-59723: Exclude cronjob that deletes MCN v1alpha1 CRD from hypershift

### DIFF
--- a/install/0000_80_machine-config_00_v1alpha1-mcn-cleanup-job.yaml
+++ b/install/0000_80_machine-config_00_v1alpha1-mcn-cleanup-job.yaml
@@ -6,7 +6,8 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
+    # exclude from hypershift
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     release.openshift.io/feature-set: Default
     # This prevent an update of this cronjob once the child job suspends on a successful run
     release.openshift.io/create-only: "true"


### PR DESCRIPTION
Follow-up to https://github.com/openshift/machine-config-operator/pull/5215. 

This PR removes an annotation(include.release.openshift.io/ibm-cloud-managed) and adds an annotation (exclude.release.openshift.io/internal-openshift-hosted). This is how our [current MCO deployments](https://github.com/openshift/machine-config-operator/blob/main/install/0000_80_machine-config_04_deployment.yaml#L9-L11) are defined, and is what prevents them from being deployed on Hypershift clusters.