### PR TITLE
NO-ISSUE: Add delays to reduce TestOSBuildController failures

### DIFF
--- a/pkg/controller/build/osbuildcontroller_test.go
+++ b/pkg/controller/build/osbuildcontroller_test.go
@@ -291,7 +291,7 @@ func TestOSBuildController(t *testing.T) {
 		// new MachineOSBuild is produced from it. We'll do this 10 times.
 		for i := 0; i <= 5; i++ {
 			apiMosc := testhelpers.SetContainerfileContentsOnMachineOSConfig(ctx, t, mcfgclient, mosc, "FROM configs AS final"+fmt.Sprintf("%d", i))
-
+			time.Sleep(time.Millisecond * 200)
 			apiMCP, err := mcfgclient.MachineconfigurationV1().MachineConfigPools().Get(ctx, apiMosc.Spec.MachineConfigPool.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 
@@ -306,6 +306,7 @@ func TestOSBuildController(t *testing.T) {
 			// Set the successful status on the job.
 			fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Succeeded: 1})
 			// The MachineOSBuild should be successful.
+			time.Sleep(time.Millisecond * 200)
 			kubeassert.MachineOSBuildIsSuccessful(mosb, "Expected the MachineOSBuild %s status to be successful", mosb.Name)
 			// And the build job should be deleted.
 			assertBuildObjectsAreDeleted(ctx, t, kubeassert, mosb)
@@ -333,6 +334,7 @@ func TestOSBuildController(t *testing.T) {
 			require.NoError(t, err)
 
 			apiMCP := insertNewRenderedMachineConfigAndUpdatePool(ctx, t, mcfgclient, mosc.Spec.MachineConfigPool.Name, getConfigNameForPool(i+2))
+			time.Sleep(time.Millisecond * 200)
 
 			mosb := buildrequest.NewMachineOSBuildFromAPIOrDie(ctx, kubeclient, apiMosc, apiMCP)
 			buildJobName := utils.GetBuildJobName(mosb)
@@ -342,6 +344,7 @@ func TestOSBuildController(t *testing.T) {
 			kubeassert.JobExists(buildJobName, "Build job did not get created for MachineConfigPool %q change", mcp.Name)
 			// Set the successful status on the job.
 			fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Succeeded: 1})
+			time.Sleep(time.Millisecond * 200)
 			// The MachineOSBuild should be successful.
 			kubeassert.MachineOSBuildIsSuccessful(mosb, "Expected the MachineOSBuild %s status to be successful", mosb.Name)
 			// And the build job should be deleted.
@@ -660,7 +663,7 @@ func setupOSBuildControllerForTestWithRunningBuild(ctx context.Context, t *testi
 	t.Helper()
 
 	kubeclient, mcfgclient, imageclient, routeclient, mosc, mosb, mcp, kubeassert, ctrl := setupOSBuildControllerForTestWithBuild(ctx, t, poolName)
-
+	time.Sleep(time.Millisecond * 200)
 	initialBuildJobName := utils.GetBuildJobName(mosb)
 
 	// After creating the new MachineOSConfig, a MachineOSBuild should be created.
@@ -671,7 +674,7 @@ func setupOSBuildControllerForTestWithRunningBuild(ctx context.Context, t *testi
 
 	// Set the running status on the job.
 	fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Active: 1})
-
+	time.Sleep(time.Millisecond * 200)
 	// The MachineOSBuild should be running.
 	kubeassert.Eventually().WithContext(ctx).MachineOSBuildIsRunning(mosb, "Expected the MachineOSBuild %s status to be running", mosb.Name)
 
@@ -682,10 +685,11 @@ func setupOSBuildControllerForTestWithSuccessfulBuild(ctx context.Context, t *te
 	t.Helper()
 
 	kubeclient, mcfgclient, imageclient, routeclient, mosc, mosb, mcp, kubeassert, _ := setupOSBuildControllerForTestWithRunningBuild(ctx, t, poolName)
-
+	time.Sleep(time.Millisecond * 200)
 	kubeassert.MachineOSBuildExists(mosb)
 	kubeassert.JobExists(utils.GetBuildJobName(mosb))
 	fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Succeeded: 1})
+	time.Sleep(time.Millisecond * 200)
 	kubeassert.MachineOSBuildIsSuccessful(mosb)
 	kubeassert.JobDoesNotExist(utils.GetBuildJobName(mosb))
 


### PR DESCRIPTION
This test has been flakey in the past, and we opened https://issues.redhat.com/browse/OCPBUGS-48526 to track it, but its [failure count](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-machine-config-operator-main-unit) has gotten frequent enough to warrant further investigation. Unsure if some recent changes have made its failure more prevalent.

I've added my conclusions from testing in the jira ticket, please check [this comment](https://issues.redhat.com/browse/OCPBUGS-48526?focusedId=28057945&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28057945) for more context.
