### PR TITLE
WIP: OCPBUGS-59995: remove unqualified search registries

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/container-registries.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/container-registries.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/containers/registries.conf"
-contents:
-  inline: |
-    unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']

--- a/templates/master/01-master-container-runtime/_base/files/container-registries.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/container-registries.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/containers/registries.conf"
-contents:
-  inline: |
-    unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']

--- a/templates/worker/01-worker-container-runtime/_base/files/container-registries.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/container-registries.yaml
@@ -1,5 +1,0 @@
-mode: 0644
-path: "/etc/containers/registries.conf"
-contents:
-  inline: |
-    unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Openshift should require all search registries be fully qualified. short names have security risks (domain squatting being the primary). Users should be specifying FQDN and ideally SHA to pull an image, though tag is acceptable if the stream is trusted. Help enforce this by disabling unqualified search registries

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
