### PR TITLE
OCPBUGS-59968: Cert Controller should live fetch SAN IPs during cert rotation

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -92,6 +92,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.KubeMAOSharedInformer.Core().V1().Secrets(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
+			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
 		)
 		if err != nil {
 			klog.Fatalf("unable to start cert rotation controller: %v", err)

--- a/pkg/controller/certrotation/certrotation_controller.go
+++ b/pkg/controller/certrotation/certrotation_controller.go
@@ -220,23 +220,6 @@ func (c *CertRotationController) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-// This should not be directly called; it is only to be used for unit tests.
-func (c *CertRotationController) Sync() error {
-	syncCtx := factory.NewSyncContext("mco-cert-rotation-sync", c.recorder)
-
-	if err := c.syncHostnames(); err != nil {
-		return err
-	}
-
-	for _, certRotator := range c.certRotators {
-		if err := certRotator.Sync(context.TODO(), syncCtx); err != nil {
-			return err
-		}
-	}
-	return nil
-
-}
-
 func getServerIPsFromInfra(cfg *configv1.Infrastructure) []string {
 	if cfg.Status.PlatformStatus == nil {
 		return []string{}

--- a/pkg/controller/certrotation/dynamic_serving.go
+++ b/pkg/controller/certrotation/dynamic_serving.go
@@ -1,0 +1,42 @@
+package certrotationcontroller
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// DynamicServingRotation is a threadsafe struct to provide hostname methods for certrotation.ServingRotation info.
+// This allows us to change the hostnames and get our certs regenerated.
+type DynamicServingRotation struct {
+	lock             sync.RWMutex
+	hostnames        sets.Set[string]
+	hostnamesChanged chan struct{}
+}
+
+func (r *DynamicServingRotation) setHostnames(newHostnames []string) {
+	if r.isSame(newHostnames) {
+		return
+	}
+
+	r.lock.Lock()
+	r.hostnames = sets.New(newHostnames...)
+	r.lock.Unlock()
+	select {
+	case r.hostnamesChanged <- struct{}{}:
+	default:
+	}
+}
+
+func (r *DynamicServingRotation) isSame(newHostnames []string) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	newSet := sets.New(newHostnames...)
+	return r.hostnames.Equal(newSet)
+}
+
+func (r *DynamicServingRotation) GetHostnames() []string {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.hostnames.UnsortedList()
+}

--- a/pkg/controller/certrotation/hostnames.go
+++ b/pkg/controller/certrotation/hostnames.go
@@ -1,0 +1,70 @@
+package certrotationcontroller
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+)
+
+func (c *CertRotationController) syncHostnames() error {
+	cfg, err := c.infraLister.Get("cluster")
+	if err != nil {
+		return fmt.Errorf("unable to get cluster infrastructure resource: %w", err)
+	}
+
+	serverIPs := getServerIPsFromInfra(cfg)
+
+	if cfg.Status.APIServerInternalURL == "" {
+		return fmt.Errorf("no APIServerInternalURL found in cluster infrastructure resource")
+	}
+	apiserverIntURL, err := url.Parse(cfg.Status.APIServerInternalURL)
+	if err != nil {
+		return fmt.Errorf("no APIServerInternalURL found in cluster infrastructure resource")
+	}
+
+	// Only attempt to get ARO cluster resource on Azure platform
+	if cfg.Status.PlatformStatus != nil && cfg.Status.PlatformStatus.Type == configv1.AzurePlatformType {
+		aroCluster, err := c.aroClient.AroV1alpha1().Clusters().Get(context.Background(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			klog.Infof("ARO cluster resource not found or not accessible: %v", err)
+		} else {
+			klog.Infof("ARO cluster resource found w/ IPs: %s", aroCluster.Spec.APIIntIP)
+			serverIPs = append(serverIPs, aroCluster.Spec.APIIntIP)
+		}
+	}
+
+	hostnames := append([]string{apiserverIntURL.Hostname()}, serverIPs...)
+	klog.Infof("syncing hostnames: %v", hostnames)
+	c.hostnamesRotation.setHostnames(hostnames)
+	return nil
+}
+
+func (c *CertRotationController) runHostnames() {
+	for c.processHostnames() {
+	}
+}
+
+func (c *CertRotationController) processHostnames() bool {
+	dsKey, quit := c.hostnamesQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.hostnamesQueue.Done(dsKey)
+
+	err := c.syncHostnames()
+	if err == nil {
+		c.hostnamesQueue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.hostnamesQueue.AddRateLimited(dsKey)
+
+	return true
+}


### PR DESCRIPTION
This takes inspiration from https://github.com/openshift/cluster-kube-apiserver-operator/blob/main/pkg/operator/certrotationcontroller/dynamic_serving.go. I did not want to vendor a whole package for that type, but most of the mechanism is similar to that; with a few adjustments for it to work with the MCO's cert controller. I also added a unit test for this particular case. 

I also chose not to listen on the ARO resource, although I can include it if requested. Since we want to eventually move from vendoring non openshift API, I figured it wasn't worth plumbing that through. 

**How to verify:**

Existing cert rotation mechanisms should remain unchanged. The easiest way to verify this is that installs and upgrades to this PR should be able to successfully scale up nodes. Examining the cert controller logs and the MCO cert objects should confirm this. (see https://github.com/openshift/machine-config-operator/pull/4669 for what to look for)

I'm not sure there is an easy way to test hostnames changes on a live cluster, edits to the `apiServerInternalURI` in infrastructure object is immediately stomped by the `cluster-config-operator`. If somehow we could even force an edit, it is likely to break a number of other configurations on the cluster. So I'm open to other ideas here :smile: 
