### PR TITLE
Remove escape chars when installing extensions in OCL Containerfile

### DIFF
--- a/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
+++ b/pkg/controller/build/buildrequest/assets/Containerfile.on-cluster-build-template
@@ -41,8 +41,8 @@ chmod 644 /etc/yum.repos.d/coreos-extensions.repo
 {{if .ExtensionsPackages}}
 # Install extension packages
 extensions="{{- range $index, $item := .ExtensionsPackages }}{{- if $index }} {{ end }}{{$item}}{{- end }}"
-echo "Installing extension packages: \$extensions"
-rpm-ostree install \$extensions
+echo "Installing extension packages: $extensions"
+rpm-ostree install $extensions
 {{end}}
 
 {{if and .KernelType .KernelPackages}}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Containerfile.ocb-template: Remove escape chars when installing ext

**- How to verify it**
Install extensions through OCL should succeed

**- Description for the changelog**
<!--
Remove escape chars when installing ext
-->
