### PR TITLE
OCPBUGS-60559: Update the OnClusterBuild payload tests to reflect the validation rule requiring MCP & MOSC names to match

### DIFF
--- a/test/extended/mco_ocb.go
+++ b/test/extended/mco_ocb.go
@@ -24,19 +24,18 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	g.It("PolarionID:83141-A valid MachineOSConfig leads to a successful MachineOSBuild and cleanup of its associated resources", func() {
 		var (
-			infraMcpName = "infra"
-			moscName     = fmt.Sprintf("tc-%s-infra", GetCurrentTestPolarionIDNumber())
+			mcpAndMoscName = "infra"
 		)
 
 		exutil.By("Create custom infra MCP")
 		// We add no workers to the infra pool, it is not necessary
-		infraMcp, err := CreateCustomMCP(oc.AsAdmin(), infraMcpName, 0)
+		infraMcp, err := CreateCustomMCP(oc.AsAdmin(), mcpAndMoscName, 0)
 		defer infraMcp.delete()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a new custom pool: %s", infraMcpName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a new custom pool: %s", mcpAndMoscName)
 		logger.Infof("OK!\n")
 
 		exutil.By("Configure OCB functionality for the new infra MCP")
-		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, moscName, infraMcpName, nil)
+		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcpAndMoscName, nil)
 		defer mosc.CleanupAndDelete()
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource")
 		logger.Infof("OK!\n")
@@ -56,17 +55,16 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	g.It("PolarionID:83138-A MachineOSConfig fails to apply or degrades if invalid inputs are given", func() {
 		var (
-			infraMcpName = "infra"
-			moscName     = fmt.Sprintf("tc-%s-infra", GetCurrentTestPolarionIDNumber())
-			pushSpec     = fmt.Sprintf("%s/openshift-machine-config-operator/ocb-%s-image:latest", InternalRegistrySvcURL, infraMcpName)
-			pullSecret   = NewSecret(oc.AsAdmin(), "openshift-config", "pull-secret")
+			mcpAndMoscName = "infra"
+			pushSpec       = fmt.Sprintf("%s/openshift-machine-config-operator/ocb-%s-image:latest", InternalRegistrySvcURL, mcpAndMoscName)
+			pullSecret     = NewSecret(oc.AsAdmin(), "openshift-config", "pull-secret")
 
 			fakePullSecretName         = "fake-pull-secret"
 			expectedWrongPullSecretMsg = fmt.Sprintf(`could not validate baseImagePullSecret "%s" for MachineOSConfig %s: secret %s from %s is not found. Did you use the right secret name?`,
-				fakePullSecretName, moscName, fakePullSecretName, moscName)
+				fakePullSecretName, mcpAndMoscName, fakePullSecretName, mcpAndMoscName)
 			fakePushSecretName         = "fake-push-secret"
 			expectedWrongPushSecretMsg = fmt.Sprintf(`could not validate renderedImagePushSecret "%s" for MachineOSConfig %s: secret %s from %s is not found. Did you use the right secret name?`,
-				fakePushSecretName, moscName, fakePushSecretName, moscName)
+				fakePushSecretName, mcpAndMoscName, fakePushSecretName, mcpAndMoscName)
 
 			fakeBuilderType             = "FakeBuilderType"
 			expectedWrongBuilderTypeMsg = fmt.Sprintf(`Unsupported value: "%s": supported values: "Job"`, fakeBuilderType)
@@ -74,9 +72,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 		exutil.By("Create custom infra MCP")
 		// We add no workers to the infra pool, it is not necessary
-		infraMcp, err := CreateCustomMCP(oc.AsAdmin(), infraMcpName, 0)
+		infraMcp, err := CreateCustomMCP(oc.AsAdmin(), mcpAndMoscName, 0)
 		defer infraMcp.delete()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a new custom pool: %s", infraMcpName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a new custom pool: %s", mcpAndMoscName)
 		logger.Infof("OK!\n")
 
 		exutil.By("Clone the pull-secret in MCO namespace")
@@ -86,19 +84,19 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 
 		// Check behaviour when wrong pullSecret
-		checkMisconfiguredMOSC(oc.AsAdmin(), moscName, infraMcpName, fakePullSecretName, clonedSecret.GetName(), pushSpec, nil,
+		checkMisconfiguredMOSC(oc.AsAdmin(), mcpAndMoscName, fakePullSecretName, clonedSecret.GetName(), pushSpec, nil,
 			expectedWrongPullSecretMsg,
 			"Check that MOSC using wrong pull secret are failing as expected")
 
 		// Check behaviour when wrong pushSecret
-		checkMisconfiguredMOSC(oc.AsAdmin(), moscName, infraMcpName, clonedSecret.GetName(), fakePushSecretName, pushSpec, nil,
+		checkMisconfiguredMOSC(oc.AsAdmin(), mcpAndMoscName, clonedSecret.GetName(), fakePushSecretName, pushSpec, nil,
 			expectedWrongPushSecretMsg,
 			"Check that MOSC using wrong push secret are failing as expected")
 
 		// Try to create a MOSC with a wrong pushSpec
 		logger.Infof("Create a MachineOSConfig resource with a wrong builder type")
 
-		err = NewMCOTemplate(oc, "generic-machine-os-config.yaml").Create("-p", "NAME="+moscName, "POOL="+infraMcpName, "PULLSECRET="+clonedSecret.GetName(),
+		err = NewMCOTemplate(oc, "generic-machine-os-config.yaml").Create("-p", "NAME="+mcpAndMoscName, "POOL="+mcpAndMoscName, "PULLSECRET="+clonedSecret.GetName(),
 			"PUSHSECRET="+clonedSecret.GetName(), "PUSHSPEC="+pushSpec, "IMAGEBUILDERTYPE="+fakeBuilderType)
 		o.Expect(err).To(o.HaveOccurred(), "Expected oc command to fail, but it didn't")
 		o.Expect(err).To(o.BeAssignableToTypeOf(&exutil.ExitError{}), "Unexpected error while creating the new MOSC")
@@ -150,12 +148,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	g.It("PolarionID:77781-A successfully built MachineOSConfig can be re-build", func() {
 
 		var (
-			mcp      = GetCompactCompatiblePool(oc.AsAdmin())
-			moscName = "test-" + mcp.GetName() + "-" + GetCurrentTestPolarionIDNumber()
+			mcp = GetCompactCompatiblePool(oc.AsAdmin())
 		)
 
 		exutil.By("Configure OCB functionality for the new worker MCP")
-		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, moscName, mcp.GetName(), nil)
+		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcp.GetName(), nil)
 		defer DisableOCL(mosc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource")
 		logger.Infof("OK!\n")
@@ -173,12 +170,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	g.It("PolarionID:77782-A MachineOSConfig with an unfinished build can be re-build", func() {
 
 		var (
-			mcp      = GetCompactCompatiblePool(oc.AsAdmin())
-			moscName = "test-" + mcp.GetName() + "-" + GetCurrentTestPolarionIDNumber()
+			mcp = GetCompactCompatiblePool(oc.AsAdmin())
 		)
 
 		exutil.By("Configure OCB functionality for the new worker MCP")
-		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, moscName, mcp.GetName(), nil)
+		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcp.GetName(), nil)
 		defer DisableOCL(mosc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource")
 		logger.Infof("OK!\n")
@@ -223,16 +219,15 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 func testContainerFile(containerFiles []ContainerFile, imageNamespace string, mcp *MachineConfigPool, checkers []Checker, defaultPullSecret bool) {
 	var (
-		oc       = mcp.GetOC().AsAdmin()
-		mcpList  = NewMachineConfigPoolList(oc.AsAdmin())
-		moscName = "test-" + GetCurrentTestPolarionIDNumber()
-		mosc     *MachineOSConfig
-		err      error
+		oc      = mcp.GetOC().AsAdmin()
+		mcpList = NewMachineConfigPoolList(oc.AsAdmin())
+		mosc    *MachineOSConfig
+		err     error
 	)
 	switch imageNamespace {
 	case MachineConfigNamespace:
 		exutil.By("Configure OCB functionality for the new infra MCP. Create MOSC")
-		mosc, err = createMachineOSConfigUsingExternalOrInternalRegistry(oc, MachineConfigNamespace, moscName, mcp.GetName(), containerFiles, defaultPullSecret)
+		mosc, err = createMachineOSConfigUsingExternalOrInternalRegistry(oc, MachineConfigNamespace, mcp.GetName(), containerFiles, defaultPullSecret)
 	default:
 		SkipTestIfCannotUseInternalRegistry(mcp.GetOC())
 
@@ -262,7 +257,7 @@ func testContainerFile(containerFiles []ContainerFile, imageNamespace string, mc
 		logger.Infof("OK!\n")
 
 		exutil.By("Configure OCB functionality for the new infra MCP. Create MOSC")
-		mosc, err = CreateMachineOSConfigUsingInternalRegistry(oc, tmpNamespace.GetName(), moscName, mcp.GetName(), containerFiles, defaultPullSecret)
+		mosc, err = CreateMachineOSConfigUsingInternalRegistry(oc, tmpNamespace.GetName(), mcp.GetName(), containerFiles, defaultPullSecret)
 	}
 	defer DisableOCL(mosc)
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource")
@@ -461,7 +456,7 @@ func ValidateMOSCIsGarbageCollected(mosc *MachineOSConfig, mcp *MachineConfigPoo
 
 }
 
-func checkMisconfiguredMOSC(oc *exutil.CLI, moscName, poolName, baseImagePullSecret, renderedImagePushSecret, pushSpec string, containerFile []ContainerFile,
+func checkMisconfiguredMOSC(oc *exutil.CLI, moscAndMcpName, baseImagePullSecret, renderedImagePushSecret, pushSpec string, containerFile []ContainerFile,
 	expectedMsg, stepMgs string) {
 	var (
 		machineConfigCO = NewResource(oc.AsAdmin(), "co", "machine-config")
@@ -471,7 +466,7 @@ func checkMisconfiguredMOSC(oc *exutil.CLI, moscName, poolName, baseImagePullSec
 	defer logger.Infof("OK!\n")
 
 	logger.Infof("Create a misconfiugred MOSC")
-	mosc, err := CreateMachineOSConfig(oc, moscName, poolName, baseImagePullSecret, renderedImagePushSecret, pushSpec, containerFile)
+	mosc, err := CreateMachineOSConfig(oc, moscAndMcpName, baseImagePullSecret, renderedImagePushSecret, pushSpec, containerFile)
 	defer mosc.Delete()
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating MOSC with wrong pull secret")
 	logger.Infof("OK!")


### PR DESCRIPTION
Closes: OCPBUGS-60559

**- What I did**
Update the MOSC-related functions in the `test/extended/` directory to take in one parameter representing both the MOSC and MCP names to align with the API validation introduced in https://github.com/openshift/api/pull/2399 requiring the names to be identical.

**- How to verify it**
The on-cluster image mode tests in the MCO disruptive test suite should not fail with the following error.

```
MachineOSConfig name must match the referenced MachineConfigPool name; can only have one MachineOSConfig per MachineConfigPool
```

**- Description for the changelog**
OCPBUGS-60559: Update the OnClusterBuild tests to reflect validation rule requiring the MOSC and MCP names to match