### PR TITLE
MCO-1536: Add new ImageBuildDegraded status option to MCP

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -239,6 +239,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSConfigs(),
+			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/pkg/controller/build/helpers.go
+++ b/pkg/controller/build/helpers.go
@@ -289,3 +289,15 @@ func extractNSAndNameWithTag(imageRef string) (string, string, error) {
 
 	return parts[1], parts[2], nil
 }
+
+var errUnknownBuildFailure = fmt.Errorf("build failed for unknown reason")
+
+// Extracts meaningful error from MachineOSBuild
+func getBuildErrorFromMOSB(mosb *mcfgv1.MachineOSBuild) error {
+	for _, condition := range mosb.Status.Conditions {
+		if condition.Type == "Failed" && condition.Status == metav1.ConditionTrue {
+			return fmt.Errorf("%s: %s", condition.Reason, condition.Message)
+		}
+	}
+	return errUnknownBuildFailure
+}

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -107,7 +107,7 @@ func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.schedulerClient, noResyncPeriodFunc())
 	c := NewWithCustomUpdateDelay(i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), i.Machineconfiguration().V1().MachineConfigPools(), k8sI.Core().V1().Nodes(),
-		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1().MachineOSConfigs(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgHandler)
+		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1().MachineOSConfigs(), i.Machineconfiguration().V1().MachineOSBuilds(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgHandler)
 
 	c.ccListerSynced = alwaysReady
 	c.mcpListerSynced = alwaysReady

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -522,6 +522,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
 			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineOSConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/MCO-1536
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add a new status type called ImageBuildDegraded that is used to track build failures and successes for the image mode use case.
When a build fails, ImageBuildDegraded is set to True and the overall Degraded status of the pool is also set to True. If the failed build is modified/fixed, a new build starts and both the ImageBuildDegraded and overall Degraded statuses are cleared for the pool. This ensures that we don't block the pool on a build failure and that a retry attempt is possible.

**- How to verify it**
1. Start a build with a wrong Containerfile so it fails
2. Check that the ImageBuildDegraded status is set to True with the appropriate message for the MCP
3. Fix the Containerfile in the MOSC
4. Wait for new build to start - old failed build and build resources should be cleared and the ImageBuildDegraded status on the pool should be set to False

**- Description for the changelog**
Add new ImageBuildDegraded status option for MCP
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
