### PR TITLE
OCPBUGS-60704: operator: switch out VAP v1beta1 to v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openshift/api v0.0.0-20240801145124-1cd5e2993247
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
-	github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1
+	github.com/openshift/library-go v0.0.0-20250821150749-08d89313a9b1
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEco
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
 github.com/openshift/kube-openapi v0.0.0-20230816122517-ffc8f001abb0 h1:GPlAy197Jkr+D0T2FNWanamraTdzS/r9ZkT29lxvHaA=
 github.com/openshift/kube-openapi v0.0.0-20230816122517-ffc8f001abb0/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
-github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1 h1:jLERUXwvYY9+9oCz66oQ/XTZzeyH8RmCpxiImYVYnmA=
-github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
+github.com/openshift/library-go v0.0.0-20250821150749-08d89313a9b1 h1:kSg+RCw4SFj1s7qNStKGfhjZudVsfEeqCOvuNlwLYuM=
+github.com/openshift/library-go v0.0.0-20250821150749-08d89313a9b1/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
 github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b h1:oXzC1N6E9gw76/WH2gEA8GEHvuq09wuVQ9GoCuR8GF4=
 github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "machine-configuration-guards"

--- a/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "machine-configuration-guards-binding"

--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "managed-bootimages-platform-check"

--- a/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "managed-bootimages-platform-check-binding"

--- a/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "mcn-guards"

--- a/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigdaemon/mcn-guards-validatingadmissionpolicybinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "mcn-guards-binding"

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -943,33 +943,29 @@ func (optr *Operator) applyManifests(config *renderConfig, paths manifestPaths) 
 			return fmt.Errorf("received nil feature gates")
 		}
 
-		// Only sync validatingadmissionpolicy manifests if ValidatingAdmissionPolicy feature gate is enabled
-		if fg.Enabled(features.FeatureGateValidatingAdmissionPolicy) {
-
-			// These new apply functions have a resource cache in case there are duplicate CRs
-			noCache := resourceapply.NewResourceCache()
-			for _, path := range paths.validatingAdmissionPolicies {
-				vapBytes, err := renderAsset(config, path)
-				if err != nil {
-					return err
-				}
-				vap := resourceread.ReadValidatingAdmissionPolicyV1beta1OrDie(vapBytes)
-				_, _, err = resourceapply.ApplyValidatingAdmissionPolicyV1beta1(context.TODO(), optr.kubeClient.AdmissionregistrationV1beta1(), optr.libgoRecorder, vap, noCache)
-				if err != nil {
-					return err
-				}
+		// These new apply functions have a resource cache in case there are duplicate CRs
+		noCache := resourceapply.NewResourceCache()
+		for _, path := range paths.validatingAdmissionPolicies {
+			vapBytes, err := renderAsset(config, path)
+			if err != nil {
+				return err
 			}
+			vap := resourceread.ReadValidatingAdmissionPolicyV1OrDie(vapBytes)
+			_, _, err = resourceapply.ApplyValidatingAdmissionPolicyV1(context.TODO(), optr.kubeClient.AdmissionregistrationV1(), optr.libgoRecorder, vap, noCache)
+			if err != nil {
+				return err
+			}
+		}
 
-			for _, path := range paths.validatingAdmissionPolicyBindings {
-				vapbBytes, err := renderAsset(config, path)
-				if err != nil {
-					return err
-				}
-				vapb := resourceread.ReadValidatingAdmissionPolicyBindingV1beta1OrDie(vapbBytes)
-				_, _, err = resourceapply.ApplyValidatingAdmissionPolicyBindingV1beta1(context.TODO(), optr.kubeClient.AdmissionregistrationV1beta1(), optr.libgoRecorder, vapb, noCache)
-				if err != nil {
-					return err
-				}
+		for _, path := range paths.validatingAdmissionPolicyBindings {
+			vapbBytes, err := renderAsset(config, path)
+			if err != nil {
+				return err
+			}
+			vapb := resourceread.ReadValidatingAdmissionPolicyBindingV1OrDie(vapbBytes)
+			_, _, err = resourceapply.ApplyValidatingAdmissionPolicyBindingV1(context.TODO(), optr.kubeClient.AdmissionregistrationV1(), optr.libgoRecorder, vapb, noCache)
+			if err != nil {
+				return err
 			}
 		}
 		return nil

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
@@ -96,6 +96,7 @@ func (c syncContext) enqueueKeys(keys ...string) {
 // (or its tombstone) is a namespace  and it matches a name of any namespaces
 // that we are interested in
 func namespaceChecker(interestingNamespaces []string) func(obj interface{}) bool {
+	// This is used for quick lookups in informers
 	interestingNamespacesSet := sets.New(interestingNamespaces...)
 
 	return func(obj interface{}) bool {

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -41,9 +41,11 @@ type CABundleConfigMap struct {
 	EventRecorder events.Recorder
 }
 
-func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA, signingCertKeyPairLocation string) ([]*x509.Certificate, error) {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
+	modified := false
+
 	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
@@ -56,36 +58,44 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 			c.Namespace,
 			c.AdditionalAnnotations,
 		)}
+		modified = true
 	}
 
-	needsMetadataUpdate := false
+	needsOwnerUpdate := false
 	if c.Owner != nil {
-		needsMetadataUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
+		needsOwnerUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
 	}
-	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta) || needsMetadataUpdate
-	if needsMetadataUpdate && len(caBundleConfigMap.ResourceVersion) > 0 {
-		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
-		if err != nil {
-			return nil, err
-		}
-	}
+	needsMetadataUpdate := c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta)
+	modified = needsOwnerUpdate || needsMetadataUpdate || modified
 
 	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
 	if err != nil {
 		return nil, err
 	}
 	if originalCABundleConfigMap == nil || originalCABundleConfigMap.Data == nil || !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
-		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
+		reason := ""
+		if originalCABundleConfigMap == nil {
+			reason = "configmap doesn't exist"
+		} else if originalCABundleConfigMap.Data == nil {
+			reason = "configmap is empty"
+		} else if !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
+			reason = fmt.Sprintf("signer update %s", signingCertKeyPairLocation)
+		}
+		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert: %s", c.Name, c.Namespace, reason)
 		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
 
-		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
+		modified = true
+	}
+
+	if modified {
+
+		actualCABundleConfigMap, updated, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
 		if err != nil {
 			return nil, err
 		}
-		if modified {
+		if updated {
 			klog.V(2).Infof("Updated ca-bundle.crt configmap %s/%s with:\n%s", certs.CertificateBundleToString(updatedCerts), caBundleConfigMap.Namespace, caBundleConfigMap.Name)
 		}
-
 		caBundleConfigMap = actualCABundleConfigMap
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -121,13 +121,17 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 	return syncErr
 }
 
+func (c CertRotationController) getSigningCertKeyPairLocation() string {
+	return fmt.Sprintf("%s/%s", c.RotatedSelfSignedCertKeySecret.Namespace, c.RotatedSelfSignedCertKeySecret.Name)
+}
+
 func (c CertRotationController) SyncWorker(ctx context.Context) error {
 	signingCertKeyPair, _, err := c.RotatedSigningCASecret.EnsureSigningCertKeyPair(ctx)
 	if err != nil {
 		return err
 	}
 
-	cabundleCerts, err := c.CABundleConfigMap.EnsureConfigMapCABundle(ctx, signingCertKeyPair)
+	cabundleCerts, err := c.CABundleConfigMap.EnsureConfigMapCABundle(ctx, signingCertKeyPair, c.getSigningCertKeyPairLocation())
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -63,10 +63,12 @@ type RotatedSigningCASecret struct {
 // EnsureSigningCertKeyPair manages the entire lifecycle of a signer cert as a secret, from creation to continued rotation.
 // It always returns the currently used CA pair, a bool indicating whether it was created/updated within this function call and an error.
 func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, bool, error) {
+	modified := false
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, false, err
 	}
+	var signerExists = true
 	signingCertKeyPairSecret := originalSigningCertKeyPairSecret.DeepCopy()
 	if apierrors.IsNotFound(err) {
 		// create an empty one
@@ -78,6 +80,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 			),
 			Type: corev1.SecretTypeTLS,
 		}
+		signerExists = false
 	}
 
 	applyFn := resourceapply.ApplySecret
@@ -87,16 +90,15 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
-	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
-		if err != nil {
-			return nil, false, err
-		}
-		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
-	}
+	needsMetadataUpdate := ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	needsTypeChange := ensureSecretTLSTypeSet(signingCertKeyPairSecret)
+	modified = needsMetadataUpdate || needsTypeChange || modified
 
 	signerUpdated := false
-	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Refresh, c.RefreshOnlyWhenExpired); needed {
+	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret, c.Refresh, c.RefreshOnlyWhenExpired); needed || !signerExists {
+		if !signerExists {
+			reason = "secret doesn't exist"
+		}
 		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
 		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
 			return nil, false, err
@@ -104,13 +106,18 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
+		modified = true
+		signerUpdated = true
+	}
+
+	if modified {
 		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, false, err
 		}
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
-		signerUpdated = true
 	}
+
 	// at this point, the secret has the correct signer, so we should read that signer to be able to sign
 	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
 	if err != nil {
@@ -136,7 +143,8 @@ func ensureOwnerReference(meta *metav1.ObjectMeta, owner *metav1.OwnerReference)
 	return false
 }
 
-func needNewSigningCertKeyPair(annotations map[string]string, refresh time.Duration, refreshOnlyWhenExpired bool) (bool, string) {
+func needNewSigningCertKeyPair(secret *corev1.Secret, refresh time.Duration, refreshOnlyWhenExpired bool) (bool, string) {
+	annotations := secret.Annotations
 	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
 	if len(reason) > 0 {
 		return true, reason
@@ -153,7 +161,7 @@ func needNewSigningCertKeyPair(annotations map[string]string, refresh time.Durat
 	validity := notAfter.Sub(notBefore)
 	at80Percent := notAfter.Add(-validity / 5)
 	if time.Now().After(at80Percent) {
-		return true, fmt.Sprintf("past its latest possible time %v", at80Percent)
+		return true, fmt.Sprintf("past refresh time (80%% of validity): %v", at80Percent)
 	}
 
 	developerSpecifiedRefresh := notBefore.Add(refresh)

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -80,7 +80,7 @@ type TargetCertCreator interface {
 	// NewCertificate creates a new key-cert pair with the given signer.
 	NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error)
 	// NeedNewTargetCertKeyPair decides whether a new cert-key pair is needed. It returns a non-empty reason if it is the case.
-	NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string
+	NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, secretDoesntExist bool) string
 	// SetAnnotations gives an option to override or set additional annotations
 	SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string
 }
@@ -96,6 +96,9 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one
 	// TODO do the cross signing thing, but this shows the API consumers want and a very simple impl.
+
+	secretDoesntExist := false
+	modified := false
 	originalTargetCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
@@ -111,6 +114,8 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 			),
 			Type: corev1.SecretTypeTLS,
 		}
+		modified = true
+		secretDoesntExist = true
 	}
 
 	applyFn := resourceapply.ApplySecret
@@ -120,15 +125,11 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
-	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
-		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
-		if err != nil {
-			return nil, err
-		}
-		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
-	}
+	needsMetadataUpdate := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	needsSecretTypeUpdate := ensureSecretTLSTypeSet(targetCertKeyPairSecret)
+	modified = needsMetadataUpdate || needsSecretTypeUpdate || modified
 
-	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
+	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired, secretDoesntExist); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
 		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
 			return nil, err
@@ -136,6 +137,10 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
+		modified = true
+	}
+
+	if modified {
 		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return nil, err
@@ -146,7 +151,12 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 	return targetCertKeyPairSecret, nil
 }
 
-func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+func needNewTargetCertKeyPair(secret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, secretDoesntExist bool) string {
+	if secretDoesntExist {
+		return "secret doesn't exist"
+	}
+
+	annotations := secret.Annotations
 	if reason := needNewTargetCertKeyPairForTime(annotations, signer, refresh, refreshOnlyWhenExpired); len(reason) > 0 {
 		return reason
 	}
@@ -203,7 +213,7 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 	validity := notAfter.Sub(notBefore)
 	at80Percent := notAfter.Add(-validity / 5)
 	if time.Now().After(at80Percent) {
-		return fmt.Sprintf("past its latest possible time %v", at80Percent)
+		return fmt.Sprintf("past refresh time (80%% of validity): %v", at80Percent)
 	}
 
 	// If Certificate is past its refresh time, we may have action to take. We only do this if the signer is old enough.
@@ -263,8 +273,8 @@ func (r *ClientRotation) NewCertificate(signer *crypto.CA, validity time.Duratio
 	return signer.MakeClientCertificateForDuration(r.UserInfo, validity)
 }
 
-func (r *ClientRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
-	return needNewTargetCertKeyPair(currentCertSecret.Annotations, signer, caBundleCerts, refresh, refreshOnlyWhenExpired)
+func (r *ClientRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, secretDoesntExist bool) string {
+	return needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, secretDoesntExist)
 }
 
 func (r *ClientRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
@@ -288,8 +298,8 @@ func (r *ServingRotation) RecheckChannel() <-chan struct{} {
 	return r.HostnamesChanged
 }
 
-func (r *ServingRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
-	reason := needNewTargetCertKeyPair(currentCertSecret.Annotations, signer, caBundleCerts, refresh, refreshOnlyWhenExpired)
+func (r *ServingRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, secretDoesntExist bool) string {
+	reason := needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, secretDoesntExist)
 	if len(reason) > 0 {
 		return reason
 	}
@@ -334,8 +344,8 @@ func (r *SignerRotation) NewCertificate(signer *crypto.CA, validity time.Duratio
 	return crypto.MakeCAConfigForDuration(signerName, validity, signer)
 }
 
-func (r *SignerRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
-	return needNewTargetCertKeyPair(currentCertSecret.Annotations, signer, caBundleCerts, refresh, refreshOnlyWhenExpired)
+func (r *SignerRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, secretDoesntExist bool) string {
+	return needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, secretDoesntExist)
 }
 
 func (r *SignerRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -152,6 +152,18 @@ func ApplyValidatingWebhookConfigurationImproved(ctx context.Context, client adm
 	return actual, true, nil
 }
 
+func DeleteValidatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder, required *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, bool, error) {
+	err := client.ValidatingWebhookConfigurations().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
 // copyValidatingWebhookCABundle populates webhooks[].clientConfig.caBundle fields from existing resource if it was set before
 // and is not set in present. This provides upgrade compatibility with service-ca-bundle operator.
 func copyValidatingWebhookCABundle(from, to *admissionregistrationv1.ValidatingWebhookConfiguration) {
@@ -226,6 +238,65 @@ func ApplyValidatingAdmissionPolicyV1beta1(ctx context.Context, client admission
 	return actual, true, nil
 }
 
+// ApplyValidatingAdmissionPolicyV1 ensures the form of the specified
+// validatingadmissionpolicyconfiguration is present in the API. If it does not exist,
+// it will be created. If it does exist, the metadata of the required
+// validatingadmissionpolicyconfiguration will be merged with the existing validatingadmissionpolicyconfiguration
+// and an update performed if the validatingadmissionpolicyconfiguration spec and metadata differ from
+// the previously required spec and metadata based on generation change.
+func ApplyValidatingAdmissionPolicyV1(ctx context.Context, client admissionregistrationclientv1.ValidatingAdmissionPoliciesGetter, recorder events.Recorder,
+	requiredOriginal *admissionregistrationv1.ValidatingAdmissionPolicy, cache ResourceCache) (*admissionregistrationv1.ValidatingAdmissionPolicy, bool, error) {
+	if requiredOriginal == nil {
+		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
+	}
+
+	existing, err := client.ValidatingAdmissionPolicies().Get(ctx, requiredOriginal.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		required := requiredOriginal.DeepCopy()
+		actual, err := client.ValidatingAdmissionPolicies().Create(
+			ctx, resourcemerge.WithCleanLabelsAndAnnotations(required).(*admissionregistrationv1.ValidatingAdmissionPolicy), metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		if err != nil {
+			return nil, false, err
+		}
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+		return actual, true, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+
+	if cache.SafeToSkipApply(requiredOriginal, existing) {
+		return existing, false, nil
+	}
+
+	required := requiredOriginal.DeepCopy()
+	modified := false
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	specEquivalent := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if specEquivalent && !modified {
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, existingCopy)
+		return existingCopy, false, nil
+	}
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+	toWrite.Spec = required.Spec
+
+	klog.V(2).Infof("ValidatingAdmissionPolicyConfigurationV1 %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
+
+	actual, err := client.ValidatingAdmissionPolicies().Update(ctx, toWrite, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	if err != nil {
+		return nil, false, err
+	}
+	// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+	cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+	return actual, true, nil
+}
+
 // ApplyValidatingAdmissionPolicyBindingV1beta1 ensures the form of the specified
 // validatingadmissionpolicybindingconfiguration is present in the API. If it does not exist,
 // it will be created. If it does exist, the metadata of the required
@@ -274,6 +345,65 @@ func ApplyValidatingAdmissionPolicyBindingV1beta1(ctx context.Context, client ad
 	toWrite.Spec = required.Spec
 
 	klog.V(2).Infof("ValidatingAdmissionPolicyBindingConfigurationV1beta1 %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
+
+	actual, err := client.ValidatingAdmissionPolicyBindings().Update(ctx, toWrite, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	if err != nil {
+		return nil, false, err
+	}
+	// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+	cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+	return actual, true, nil
+}
+
+// ApplyValidatingAdmissionPolicyBindingV1 ensures the form of the specified
+// validatingadmissionpolicybindingconfiguration is present in the API. If it does not exist,
+// it will be created. If it does exist, the metadata of the required
+// validatingadmissionpolicybindingconfiguration will be merged with the existing validatingadmissionpolicybindingconfiguration
+// and an update performed if the validatingadmissionpolicybindingconfiguration spec and metadata differ from
+// the previously required spec and metadata based on generation change.
+func ApplyValidatingAdmissionPolicyBindingV1(ctx context.Context, client admissionregistrationclientv1.ValidatingAdmissionPolicyBindingsGetter, recorder events.Recorder,
+	requiredOriginal *admissionregistrationv1.ValidatingAdmissionPolicyBinding, cache ResourceCache) (*admissionregistrationv1.ValidatingAdmissionPolicyBinding, bool, error) {
+	if requiredOriginal == nil {
+		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
+	}
+
+	existing, err := client.ValidatingAdmissionPolicyBindings().Get(ctx, requiredOriginal.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		required := requiredOriginal.DeepCopy()
+		actual, err := client.ValidatingAdmissionPolicyBindings().Create(
+			ctx, resourcemerge.WithCleanLabelsAndAnnotations(required).(*admissionregistrationv1.ValidatingAdmissionPolicyBinding), metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		if err != nil {
+			return nil, false, err
+		}
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
+		return actual, true, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+
+	if cache.SafeToSkipApply(requiredOriginal, existing) {
+		return existing, false, nil
+	}
+
+	required := requiredOriginal.DeepCopy()
+	modified := false
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	specEquivalent := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if specEquivalent && !modified {
+		// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
+		cache.UpdateCachedResourceMetadata(requiredOriginal, existingCopy)
+		return existingCopy, false, nil
+	}
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+	toWrite.Spec = required.Spec
+
+	klog.V(2).Infof("ValidatingAdmissionPolicyBindingConfigurationV1 %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
 
 	actual, err := client.ValidatingAdmissionPolicyBindings().Update(ctx, toWrite, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -335,6 +335,12 @@ func DeleteAll(ctx context.Context, clients *ClientHolder, recorder events.Recor
 			} else {
 				_, result.Changed, result.Error = DeleteStorageClass(ctx, clients.kubeClient.StorageV1(), recorder, t)
 			}
+		case *admissionregistrationv1.ValidatingWebhookConfiguration:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/admission.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/admission.go
@@ -53,3 +53,21 @@ func ReadValidatingAdmissionPolicyBindingV1beta1OrDie(objBytes []byte) *admissio
 
 	return requiredObj.(*admissionv1beta1.ValidatingAdmissionPolicyBinding)
 }
+
+func ReadValidatingAdmissionPolicyV1OrDie(objBytes []byte) *admissionv1.ValidatingAdmissionPolicy {
+	requiredObj, err := runtime.Decode(admissionCodecs.UniversalDecoder(admissionv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*admissionv1.ValidatingAdmissionPolicy)
+}
+
+func ReadValidatingAdmissionPolicyBindingV1OrDie(objBytes []byte) *admissionv1.ValidatingAdmissionPolicyBinding {
+	requiredObj, err := runtime.Decode(admissionCodecs.UniversalDecoder(admissionv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*admissionv1.ValidatingAdmissionPolicyBinding)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1128,7 +1128,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1
+# github.com/openshift/library-go v0.0.0-20250821150749-08d89313a9b1
 ## explicit; go 1.22.0
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/cloudprovider


### PR DESCRIPTION
Backports b53b9df3b05a4d3fc0cc6a43bd0b7cccd1d757b6 to 4.17 to avoid the upgrade to 4.18 from complaining about v1beta1 usage which happens prior to the upgrade. I believe this should be safe because we enabled the featuregate in 4.17 and Kube API Server Operator upgrades prior to Machine Config Operator.

I believe this will however prevent us from cleanly downgrading back to 4.16, which is unsupported.