### PR TITLE
OCPBUGS-56558: Recheck `generatedByControllerVersion` annotation prior to deleting a degraded MC

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -779,8 +779,13 @@ func (ctrl *Controller) cleanUpDuplicatedMC() error {
 		if !strings.Contains(mc.Name, generatedCtrCfg) {
 			continue
 		}
+		// Recheck to ensure nothing changed in between
+		mcToBeDeleted, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mc.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		// delete the containerruntime mc if its degraded
-		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+		if mcToBeDeleted.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
 			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 				return fmt.Errorf("error deleting degraded containerruntime machine config %s: %w", mc.Name, err)
 			}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -658,6 +658,7 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg1)
 			f.expectCreateMachineConfigAction(mcs1)
 			f.expectPatchContainerRuntimeConfig(ctrcfg1, ctrcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs2)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 
 			f.run(getKey(ctrcfg1, t))
@@ -698,6 +699,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchContainerRuntimeConfig(ctrcfg1, ctrcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 
 			c := f.newController()
@@ -740,6 +742,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfig(ctrcfgUpdate)
 			f.expectUpdateMachineConfigAction(mcsUpdate)
 			f.expectPatchContainerRuntimeConfig(ctrcfgUpdate, ctrcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectUpdateContainerRuntimeConfig(ctrcfgUpdate)
 
 			f.validateActions()
@@ -1651,6 +1654,7 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 				f.expectUpdateContainerRuntimeConfigRoot(ccr)
 				f.expectCreateMachineConfigAction(mcs)
 				f.expectPatchContainerRuntimeConfig(ccr, []byte(expectedPatch))
+				f.expectGetMachineConfigAction(mcs)
 				f.expectUpdateContainerRuntimeConfig(ccr)
 				f.run(poolName)
 			}
@@ -1760,6 +1764,7 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfigRoot(ctrc)
 			f.expectUpdateMachineConfigAction(ctrcfgMC)
 			f.expectPatchContainerRuntimeConfig(ctrc, []byte("{}"))
+			f.expectGetMachineConfigAction(ctrcfgMC)
 			f.expectUpdateContainerRuntimeConfig(ctrc)
 
 			c := f.newController()

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -751,8 +751,13 @@ func (ctrl *Controller) cleanUpDuplicatedMC(prefix string) error {
 		if !strings.HasPrefix(mc.Name, prefix) {
 			continue
 		}
+		// Recheck to ensure nothing changed in between
+		mcToBeDeleted, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mc.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		// delete the mc if its degraded
-		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+		if mcToBeDeleted.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
 			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !macherrors.IsNotFound(err) {
 				return fmt.Errorf("error deleting degraded kubelet machine config %s: %w", mc.Name, err)
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -464,6 +464,7 @@ func TestKubeletConfigCreate(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -510,6 +511,7 @@ func TestKubeletConfigMultiCreate(t *testing.T) {
 				f.expectUpdateKubeletConfigRoot(kc)
 				f.expectCreateMachineConfigAction(mcs)
 				f.expectPatchKubeletConfig(kc, []byte(expectedPatch))
+				f.expectGetMachineConfigAction(mcs)
 				f.expectUpdateKubeletConfig(kc)
 				f.run(poolName)
 			}
@@ -558,6 +560,7 @@ func TestKubeletConfigAutoSizingReserved(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -601,6 +604,7 @@ func TestKubeletConfiglogFile(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -638,6 +642,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			c := f.newController(fgHandler)
@@ -696,6 +701,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateMachineConfigAction(mcUpdate)
 			f.expectPatchKubeletConfig(kcUpdate, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kcUpdate)
 
 			f.validateActions()
@@ -742,6 +748,7 @@ func TestMachineConfigUpdateUponFeatureGateUpdate(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			c := f.newController(fgHandler)
@@ -787,6 +794,7 @@ func TestMachineConfigUpdateUponFeatureGateUpdate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateMachineConfigAction(mcUpdate)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.validateActions()
@@ -834,6 +842,7 @@ func TestMachineConfigSkipUpdate(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			c := f.newController(fgHandler)
@@ -981,6 +990,7 @@ func TestKubeletFeatureExists(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -1200,6 +1210,7 @@ func TestAddAnnotationExistingKubeletConfig(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc)
 			f.expectUpdateMachineConfigAction(kcMC)
 			f.expectPatchKubeletConfig(kc, []byte("{}"))
+			f.expectGetMachineConfigAction(kcMC)
 			f.expectUpdateKubeletConfig(kc)
 
 			c := f.newController(fgHandler)

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -97,6 +97,8 @@ func TestFeaturesDefault(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2Deprecated)
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2Deprecated)
+			f.expectGetMachineConfigAction(mcs2)
 
 			f.runFeature(getKeyFromFeatureGate(features, t), fgHandler)
 		})
@@ -153,6 +155,8 @@ func TestFeaturesCustomNoUpgrade(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2Deprecated)
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2Deprecated)
+			f.expectGetMachineConfigAction(mcs2)
 			f.runFeature(getKeyFromFeatureGate(features, t), fgHandler)
 		})
 	}


### PR DESCRIPTION
<!--
Closes: OCPBUGS-56558
-->

**- What I did**
crc & kcc: Before deleting a degraded MC, ensure that the annotations have not been updated since the last check

**- How to verify it**
Check OCPBUGS-56558

**- Description for the changelog**
<!--
Recheck generatedByControllerVersion annotation prior to deleting a degraded MC
-->
