### PR TITLE
MCO-1844: Remove MissingMachineConfig Alert

### DIFF
--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -168,22 +168,4 @@ spec:
               If this happens on container level, the descheduler will not be able to detect it, as it works on the pod level.
               To fix this, increase memory of the affected node of control plane nodes.
             runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneMemory.md
-    - name: mcd-missing-mc
-      rules:
-        - alert: MissingMachineConfig
-          expr: |
-            mcd_missing_mc > 0
-          labels:
-            namespace: openshift-machine-config-operator
-            severity: warning
-          annotations:
-            summary: "This keeps track of Machine Config failures. Specifically a common failure on install when a rendered Machine Config is missing. Triggered when this error happens once."
-            description: >-
-              Could not find config {{ $labels.mc }} in-cluster, this likely indicates the MachineConfigs in-cluster has changed during the install process. 
-              If you are seeing this when installing the cluster, please compare the in-cluster rendered machineconfigs to /etc/mcs-machine-config-content.json
-    - name: telemetry.rules
-      rules:
-      - expr: count(mcd_local_unsupported_packages > 0)
-        record: cluster:mcd_nodes_with_unsupported_packages:count
-      - expr: sum(mcd_local_unsupported_packages)
-        record: cluster:mcd_total_unsupported_packages:sum
+

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -57,12 +57,6 @@ var (
 			Name: "mcd_config_drift",
 			Help: "timestamp for config drift",
 		})
-	// mcdMissingMC tracks the missing machine config error
-	mcdMissingMC = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "mcd_missing_mc",
-			Help: "total number of times a MC was reported missing",
-		}, []string{"mc"})
 
 	// unsupportedPackages counts the number of unsupported packages installed on the node, categorized by vendor
 	unsupportedPackages = prometheus.NewGaugeVec(


### PR DESCRIPTION
Please provide the following information:
-->

**- What I did**

Removed the MissingMachineConfig Alert , metric gauge, and related code.

Due to the work done in

https://github.com/openshift/machine-config-operator/pull/4594

and the fix having been backported to 4.16

https://github.com/openshift/machine-config-operator/pull/4655

It is defunct and can no longer fire 

**- How to verify it**

1. Build openshift cluster with image

2.  Check prometheusrules for machine-config-daemon and see alert is no longer present. Due to previous commits the alert no longer functioned anyways. 

$ oc get prometheusrule machine-config-daemon -o yaml

**- Description for the changelog**

Removed the MissingMachineConfig Alert from PrometheusRules as it can no longer fire. 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
