### PR TITLE
don't call os.Exit(0) in the leader election callback

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 
 	features "github.com/openshift/api/features"
 	"github.com/openshift/machine-config-operator/cmd/common"
@@ -169,11 +168,9 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			OnStartedLeading: run,
 			OnStoppedLeading: func() {
 				klog.Infof("Stopped leading. Terminating.")
-				os.Exit(0)
 			},
 		},
 	})
-	panic("unreachable")
 }
 
 func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controller {

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
@@ -145,9 +144,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			OnStartedLeading: run,
 			OnStoppedLeading: func() {
 				klog.Info("Stopped leading. Terminating.")
-				os.Exit(0)
 			},
 		},
 	})
-	panic("unreachable")
 }

--- a/cmd/machine-os-builder/start.go
+++ b/cmd/machine-os-builder/start.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
 
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
@@ -88,9 +87,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				// cleanup as well as to terminate its lease.
 				<-shutdownChan
 				klog.Infof("Stopped leading; machine-os-builder terminating.")
-				os.Exit(0)
 			},
 		},
 	})
-
 }


### PR DESCRIPTION
**- What I did**

We continue to see issues with leases not being released upon controller shutdown. This is most likely because the `os.Exit(0)` calls cause the binary to exit before the machinery that releases the lease is called.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
