### PR TITLE
OCPBUGS-58198: Fix MCP updated machine count for image mode disabling case

### DIFF
--- a/pkg/controller/common/layered_node_state.go
+++ b/pkg/controller/common/layered_node_state.go
@@ -26,14 +26,16 @@ func NewLayeredNodeState(n *corev1.Node) *LayeredNodeState {
 	return &LayeredNodeState{node: n}
 }
 
-// Checks if the node is done "working" and that the node is targeting is MachineConfig
-// determined by the pool. If in layered mode, the image annotations are also checked
-// checked against the OCL objects.
+// Checks if the node is done "working." For a node in both layered and non-layered MCPs, the
+// node's state annotation must be "Done" and it must be targeting the correct MachineConfig. For
+// `layered` MCPs, the node's desired image annotation must match the image defined in the
+// MachineOsConfig and the desired MachineConfig must match the config version defined in the
+// MachineOSBuild. For non-layered MCPs, the node must not have a desired image annotation value.
 func (l *LayeredNodeState) IsDone(mcp *mcfgv1.MachineConfigPool, layered bool, mosc *mcfgv1.MachineOSConfig, mosb *mcfgv1.MachineOSBuild) bool {
 	if layered {
 		return l.IsNodeDone() && l.IsDesiredMachineConfigEqualToPool(mcp) && l.IsDesiredEqualToBuild(mosc, mosb)
 	}
-	return l.IsNodeDone() && l.IsDesiredMachineConfigEqualToPool(mcp)
+	return l.IsNodeDone() && l.IsDesiredMachineConfigEqualToPool(mcp) && !l.IsDesiredImageAnnotationPresentOnNode()
 }
 
 // The original behavior of getUnavailableMachines is: getUnavailableMachines

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -287,6 +287,28 @@ func TestGetUpdatedMachines(t *testing.T) {
 			newNode("node-1", machineConfigV1, machineConfigV1),
 			newNodeWithReady("node-2", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
 		},
+	}, {
+		name: "Pool with image mode disabling, one node updating, 2 nodes not not acted upon",
+		nodes: []*corev1.Node{
+			newLayeredNode("node-0", machineConfigV0, machineConfigV0, imageV1, ""),
+			newLayeredNode("node-1", machineConfigV0, machineConfigV0, imageV1, imageV1),
+			newLayeredNode("node-2", machineConfigV0, machineConfigV0, imageV1, imageV1),
+		},
+		currentConfig: machineConfigV0,
+		updated:       nil,
+		layered:       false,
+	}, {
+		name: "Pool with image mode disabling, one node updated, 1 node updating, 1 node not acted upon",
+		nodes: []*corev1.Node{
+			newNode("node-0", machineConfigV0, machineConfigV0),
+			newLayeredNode("node-1", machineConfigV0, machineConfigV0, imageV1, ""),
+			newLayeredNode("node-2", machineConfigV0, machineConfigV0, imageV1, imageV1),
+		},
+		currentConfig: machineConfigV0,
+		updated: []*corev1.Node{
+			newNode("node-0", machineConfigV0, machineConfigV0),
+		},
+		layered: false,
 	},
 	}
 


### PR DESCRIPTION
Closes: OCPBUGS-58198

**- What I did**
This updates the layered node state `IsDone` function to properly handle the image mode disabling case. When image mode is disabling, the `layered` boolean flips to `false` and, in that case, we need to make sure the node does not have a desired image annotation value. It also adds two unit test cases to cover the image mode disabling scenario.

**- How to verify it**
1. Launch a 4.21 cluster with this PR included.
```
launch 4.21,openshift/machine-config-operator#5271 aws
```
2. Enable image mode in the worker MCP.
```
$ oc create -f - << EOF 
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineOSConfig
metadata:
  name: worker
spec:
  machineConfigPool:
    name: worker
  imageBuilder:
    imageBuilderType: Job
  renderedImagePushSecret:
    name: $(oc get -n openshift-machine-config-operator sa builder -ojsonpath='{.secrets[0].name}')
  renderedImagePushSpec: "image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image:latest"
EOF
```
3. Once image mode has fully rolled out to the worker MCP, disable image mode by deleting the MachineOSConfig.
```
$ oc delete machineosconfig/worker
```
4. Watch the worker MCP machine counts to ensure they are properly 
```
$ oc get mcp -w
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
worker   rendered-worker-2e189c0d0e49e7c6f573a58781bab8cd   True      False      False      3              3                   3                     0                      3h55m
worker   rendered-worker-2e189c0d0e49e7c6f573a58781bab8cd   False     True       False      3              0                   0                     0                      3h55m
worker   rendered-worker-2e189c0d0e49e7c6f573a58781bab8cd   False     True       False      3              1                   1                     0                      4h1m
worker   rendered-worker-2e189c0d0e49e7c6f573a58781bab8cd   False     True       False      3              2                   2                     0                      4h6m
worker   rendered-worker-2e189c0d0e49e7c6f573a58781bab8cd   True      False      False      3              3                   3                     0                      4h12m
```

**- Description for the changelog**
OCPBUGS-58198: Update the node done check to properly calculate the updated machine count when image mode is being disabled