### PR TITLE
OCPBUGS-60805: configure-ovs: work around a Cisco switch issue

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -574,6 +574,16 @@ contents:
       for conn in "${connections[@]}"; do
         local slave_type=$($NMCLI_GET_VALUE connection.slave-type connection show "$conn")
         if [ "$slave_type" = "team" ] || [ "$slave_type" = "bond" ]; then
+          # Work around a Cisco switch issue: if a slave is detached from a bond
+          # (e.g. during NM reactivation) before LACP negotiation completes, the
+          # switch may mishandle LACP packets with agg=0. To avoid this, wait for
+          # LACP to finish (only applies to LACP bonds in state UP).
+          slave=$(nmcli -g connection.interface-name connection show "$conn")
+          if ip -d link show "$slave" | tr '\n' ' ' | grep -q 'state UP.*ad_aggregator_id'; then
+            if ! timeout 5 bash -c "while [ \$(ip -d link show \"$slave\" | grep -o \"collecting,distributing\" | wc -l) -lt 2 ]; do sleep 1; done"; then
+              echo "WARNING: LACP negotiation is not yet done on slave $conn."
+            fi
+          fi
           mod_nm_conn "$conn" connection.autoconnect yes
         fi
       done


### PR DESCRIPTION
When a slave is detached from a bond (e.g. during NetworkManager reactivation) before LACP negotiation completes, some Cisco switches mishandle LACP packets with agg=0, and disable the port.

To work around this, if a bond slave is UP and LACP is enabled, wait up to 5 seconds for both ends to reach the "collecting,distributing" state before reattaching the interface. If negotiation does not complete within this window, a warning is logged but configuration continues.

Note: This is a switch error, and sending agg=0 is valid. This is a workaround that only hides the issue on affected hardware and may reduce system's fault tolerance.
