### PR TITLE
[release-4.19] OCPBUGS-61738: Recheck generatedByControllerVersion annotation prior to deleting a degraded MC

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -787,8 +787,13 @@ func (ctrl *Controller) cleanUpDuplicatedMC() error {
 		if !strings.Contains(mc.Name, generatedCtrCfg) {
 			continue
 		}
+		// Recheck to ensure nothing changed in between
+		mcToBeDeleted, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mc.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		// delete the containerruntime mc if its degraded
-		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+		if mcToBeDeleted.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
 			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 				return fmt.Errorf("error deleting degraded containerruntime machine config %s: %w", mc.Name, err)
 			}

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -660,6 +660,7 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg1)
 			f.expectCreateMachineConfigAction(mcs1)
 			f.expectPatchContainerRuntimeConfig(ctrcfg1, ctrcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs2)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 
 			f.run(getKey(ctrcfg1, t))
@@ -700,6 +701,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchContainerRuntimeConfig(ctrcfg1, ctrcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 
 			c := f.newController()
@@ -742,6 +744,7 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfig(ctrcfgUpdate)
 			f.expectUpdateMachineConfigAction(mcsUpdate)
 			f.expectPatchContainerRuntimeConfig(ctrcfgUpdate, ctrcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectUpdateContainerRuntimeConfig(ctrcfgUpdate)
 
 			f.validateActions()
@@ -1653,6 +1656,7 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 				f.expectUpdateContainerRuntimeConfigRoot(ccr)
 				f.expectCreateMachineConfigAction(mcs)
 				f.expectPatchContainerRuntimeConfig(ccr, []byte(expectedPatch))
+				f.expectGetMachineConfigAction(mcs)
 				f.expectUpdateContainerRuntimeConfig(ccr)
 				f.run(poolName)
 			}
@@ -1762,6 +1766,7 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 			f.expectUpdateContainerRuntimeConfigRoot(ctrc)
 			f.expectUpdateMachineConfigAction(ctrcfgMC)
 			f.expectPatchContainerRuntimeConfig(ctrc, []byte("{}"))
+			f.expectGetMachineConfigAction(ctrcfgMC)
 			f.expectUpdateContainerRuntimeConfig(ctrc)
 
 			c := f.newController()

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -750,8 +750,13 @@ func (ctrl *Controller) cleanUpDuplicatedMC(prefix string) error {
 		if !strings.HasPrefix(mc.Name, prefix) {
 			continue
 		}
+		// Recheck to ensure nothing changed in between
+		mcToBeDeleted, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mc.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		// delete the mc if its degraded
-		if mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
+		if mcToBeDeleted.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] != version.Hash {
 			if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !macherrors.IsNotFound(err) {
 				return fmt.Errorf("error deleting degraded kubelet machine config %s: %w", mc.Name, err)
 			}

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -443,6 +443,7 @@ func TestKubeletConfigCreate(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -489,6 +490,7 @@ func TestKubeletConfigMultiCreate(t *testing.T) {
 				f.expectUpdateKubeletConfigRoot(kc)
 				f.expectCreateMachineConfigAction(mcs)
 				f.expectPatchKubeletConfig(kc, []byte(expectedPatch))
+				f.expectGetMachineConfigAction(mcs)
 				f.expectUpdateKubeletConfig(kc)
 				f.run(poolName)
 			}
@@ -537,6 +539,7 @@ func TestKubeletConfigAutoSizingReserved(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -580,6 +583,7 @@ func TestKubeletConfiglogFile(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -615,6 +619,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			c := f.newController(fgAccess)
@@ -665,6 +670,7 @@ func TestKubeletConfigUpdates(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kcUpdate, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kcUpdate)
 
 			f.validateActions()
@@ -775,6 +781,7 @@ func TestKubeletFeatureExists(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchKubeletConfig(kc1, kcfgPatchBytes)
+			f.expectGetMachineConfigAction(mcs)
 			f.expectUpdateKubeletConfig(kc1)
 
 			f.run(getKey(kc1, t))
@@ -992,6 +999,7 @@ func TestAddAnnotationExistingKubeletConfig(t *testing.T) {
 			f.expectUpdateKubeletConfigRoot(kc)
 			f.expectUpdateMachineConfigAction(kcMC)
 			f.expectPatchKubeletConfig(kc, []byte("{}"))
+			f.expectGetMachineConfigAction(kcMC)
 			f.expectUpdateKubeletConfig(kc)
 
 			c := f.newController(fgAccess)

--- a/pkg/controller/kubelet-config/kubelet_config_features_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_features_test.go
@@ -99,6 +99,8 @@ func TestFeaturesDefault(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2Deprecated)
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2Deprecated)
+			f.expectGetMachineConfigAction(mcs2)
 
 			f.runFeature(getKeyFromFeatureGate(features, t), fgAccess)
 		})
@@ -155,6 +157,8 @@ func TestFeaturesCustomNoUpgrade(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2Deprecated)
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
+			f.expectGetMachineConfigAction(mcs2Deprecated)
+			f.expectGetMachineConfigAction(mcs2)
 			f.runFeature(getKeyFromFeatureGate(features, t), fgAccess)
 		})
 	}


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/5259

/assign RishabhSaini