### PR TITLE
OCPBUGS-61695: Override NMState service definition

### DIFF
--- a/templates/common/_base/units/nmstate.service.yaml
+++ b/templates/common/_base/units/nmstate.service.yaml
@@ -1,0 +1,20 @@
+# Temporary override until the fix for https://issues.redhat.com/browse/OCPBUGS-61695
+# makes it into RHCOS.
+name: nmstate.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Apply nmstate on-disk state
+  Documentation=man:nmstate.service(8) https://www.nmstate.io
+  After=NetworkManager-wait-online.service
+  Before=network-online.target
+  Wants=NetworkManager-wait-online.service
+  Requires=NetworkManager.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/bin/nmstatectl service
+  RemainAfterExit=yes
+
+  [Install]
+  WantedBy=NetworkManager.service


### PR DESCRIPTION
A bug was introduced in the NMState service definition that breaks many of our uses of it on the host. This overrides the service so the NetworkManager-wait-online service is a softer dependency because in some environments that service will fail and we don't want it to prevent NMState from running.

This is done as a complete override of the service because it is not possible to replace dependencies using a partial drop-in. Also, it is only a temporary fix until the NMState fix lands in our images.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
