### PR TITLE
MCO-1685: Add mco-sanitize file processing logic

### DIFF
--- a/devex/cmd/mco-sanitize/config.go
+++ b/devex/cmd/mco-sanitize/config.go
@@ -1,0 +1,22 @@
+package main
+
+// ConfigRedact defines the configuration for redacting specific fields in Kubernetes resources.
+// It specifies which resources to target and which fields within those resources should be sanitized.
+type ConfigRedact struct {
+	// APIVersion specifies the API version of the Kubernetes resource to target.
+	// If empty, all API versions of the specified Kind will be redacted.
+	APIVersion string `yaml:"apiVersion"`
+
+	// Kind specifies the Kubernetes resource type to target (e.g., "Pod", "Secret", "ConfigMap").
+	// This field is required and cannot be empty.
+	Kind string `yaml:"kind"`
+
+	// Namespaces specifies a list of namespaces to limit redaction to.
+	// If empty or nil, resources from all namespaces will be considered for redaction.
+	Namespaces []string `yaml:"namespaces"`
+
+	// Paths contains a list of dot-separated field paths to redact within the targeted resources.
+	// For example: "spec.containers.0.env.0.value" or "data.password".
+	// Array elements can be referenced by index or all elements will be processed if * is given.
+	Paths []string `yaml:"paths"`
+}

--- a/devex/cmd/mco-sanitize/main.go
+++ b/devex/cmd/mco-sanitize/main.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	// Mock function till mco-sanitize fully lands
+	// https://issues.redhat.com/browse/MCO-1685 covers the whole binary development and testing
+}

--- a/devex/cmd/mco-sanitize/processor.go
+++ b/devex/cmd/mco-sanitize/processor.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3" // v3 is required. v2 doesn't handle map/array key/index types properly
+	"k8s.io/klog/v2"
+)
+
+// FileProcessorImpl implements the FileProcessor interface and handles
+// the processing of individual files for sanitization.
+type FileProcessorImpl struct {
+	redactor Redactor
+}
+
+// NewFileProcessor creates a new FileProcessorImpl instance with the provided redactor.
+func NewFileProcessor(redactor Redactor) *FileProcessorImpl {
+	return &FileProcessorImpl{redactor: redactor}
+}
+
+// Process handles the sanitization of a single file at the given path.
+// Returns true if the file was modified, false otherwise, along with any error encountered.
+func (p *FileProcessorImpl) Process(_ context.Context, path string) (changed bool, err error) {
+	unmarshaller, marshaller := getMarshaller(path)
+	if unmarshaller == nil || marshaller == nil {
+		// Unsupported file format
+		// Ignore the file
+		return false, nil
+	}
+
+	inputData, resources := fetchInput(path, unmarshaller)
+	if inputData == nil || resources == nil {
+		// Turned out that the file extension was not matching the file content
+		// or the file is corrupt/cannot read
+		// Ignore the file
+		return false, err
+	}
+
+	changed, err = p.redactor.Redact(inputData, resources, marshaller)
+	if !changed || err != nil {
+		// If the file didn't change or an error occurred do not touch the original file
+		return changed, err
+	}
+
+	outFile, _ := os.Create(path)
+	defer func() {
+		if closeErr := outFile.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	err = writeOutput(outFile, inputData, marshaller)
+	return changed, err
+}
+
+// writeOutput encodes the sanitized content and writes it to the provided writer
+func writeOutput(outputWriter io.Writer, outputContent interface{}, marshaller contentMarshaler) error {
+	encoded, err := marshaller(outputContent)
+	if err != nil {
+		return fmt.Errorf("could not encode redacted data back to the original format: %v", err)
+	}
+
+	if _, err = outputWriter.Write(encoded); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getMarshaller returns the appropriate unmarshaller and marshaller functions
+// based on the file extension. Returns nil for unsupported formats.
+func getMarshaller(path string) (contentUnmarshaller, contentMarshaler) {
+	if strings.HasSuffix(path, ".json") {
+		return json.Unmarshal, json.Marshal
+	} else if strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml") {
+		return yaml.Unmarshal, yaml.Marshal
+	}
+	return nil, nil
+}
+
+// fetchInput reads and parses a file, returning the parsed content and metadata.
+// Handles both individual resources and Kubernetes List types.
+func fetchInput(path string, unmarshaler contentUnmarshaller) (interface{}, []KubernetesMetaResource) {
+	inFile, err := os.Open(path)
+	if err != nil {
+		return nil, nil
+	}
+	defer func() {
+		if closeErr := inFile.Close(); closeErr != nil {
+			klog.Errorf("error closing input file %q: %v", path, closeErr)
+		}
+	}()
+
+	inputBytes, err := io.ReadAll(inFile)
+	if err != nil {
+		return nil, nil
+	}
+
+	var resource KubernetesMetaResource
+	err = unmarshaler(inputBytes, &resource)
+	if err != nil || resource.Kind == "" || resource.APIVersion == "" {
+		return nil, nil
+	}
+
+	// check if the input was a list type
+	if strings.HasSuffix(resource.Kind, "List") && resource.APIVersion == "v1" {
+		var kubernetesList KubernetesMetaListInterface
+		err = unmarshaler(inputBytes, &kubernetesList)
+		if err != nil {
+			return nil, nil
+		}
+		return kubernetesList.Items, resource.Items
+	}
+	var inputData map[string]interface{}
+	err = unmarshaler(inputBytes, &inputData)
+	if err != nil {
+		return nil, nil
+	}
+	return inputData, []KubernetesMetaResource{resource}
+}

--- a/devex/cmd/mco-sanitize/processor_test.go
+++ b/devex/cmd/mco-sanitize/processor_test.go
@@ -1,0 +1,284 @@
+// Assisted-by: Claude
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRedactor for testing
+type mockRedactor struct {
+	shouldRedact bool
+	shouldError  bool
+	errorMsg     string
+}
+
+func (m *mockRedactor) Redact(_ interface{}, _ []KubernetesMetaResource, _ contentMarshaler) (bool, error) {
+	if m.shouldError {
+		return false, &mockError{m.errorMsg}
+	}
+	return m.shouldRedact, nil
+}
+
+type mockError struct {
+	msg string
+}
+
+func (e *mockError) Error() string {
+	return e.msg
+}
+
+func TestFileProcessor_Process_ValidYAML(t *testing.T) {
+	// Create temp directory
+	tempDir := t.TempDir()
+
+	// Create test YAML file
+	testFile := filepath.Join(tempDir, "test.yaml")
+	yamlContent := `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: test-config
+  namespace: default
+spec:
+  config:
+    storage:
+      files:
+        - contents: "sensitive data"
+`
+	require.NoError(t, os.WriteFile(testFile, []byte(yamlContent), 0644))
+
+	// Test with redactor that returns true (content changed)
+	redactor := &mockRedactor{shouldRedact: true}
+	processor := NewFileProcessor(redactor)
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err)
+	assert.True(t, changed, "Process() should return true when redactor makes changes")
+
+	// Verify file still exists and is readable
+	assert.FileExists(t, testFile)
+}
+
+func TestFileProcessor_Process_ValidJSON(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.json")
+	jsonContent := `{
+  "apiVersion": "machineconfiguration.openshift.io/v1",
+  "kind": "MachineConfig",
+  "metadata": {
+    "name": "test-config",
+    "namespace": "default"
+  },
+  "spec": {
+    "config": {
+      "storage": {
+        "files": [
+          {"contents": "sensitive data"}
+        ]
+      }
+    }
+  }
+}`
+	require.NoError(t, os.WriteFile(testFile, []byte(jsonContent), 0644))
+
+	redactor := &mockRedactor{shouldRedact: true}
+	processor := NewFileProcessor(redactor)
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err)
+	assert.True(t, changed, "Process() should return true when redactor makes changes")
+}
+
+func TestFileProcessor_Process_NoChanges(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.yaml")
+	yamlContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+`
+	require.NoError(t, os.WriteFile(testFile, []byte(yamlContent), 0644))
+
+	// Redactor returns false (no changes)
+	redactor := &mockRedactor{shouldRedact: false}
+	processor := NewFileProcessor(redactor)
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err)
+	assert.False(t, changed, "Process() should return false when redactor makes no changes")
+}
+
+func TestFileProcessor_Process_RedactorError(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.yaml")
+	yamlContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+`
+	require.NoError(t, os.WriteFile(testFile, []byte(yamlContent), 0644))
+
+	redactor := &mockRedactor{shouldError: true, errorMsg: "redaction failed"}
+	processor := NewFileProcessor(redactor)
+
+	_, err := processor.Process(context.Background(), testFile)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "redaction failed")
+}
+
+func TestFileProcessor_Process_InvalidFile(t *testing.T) {
+	processor := NewFileProcessor(&mockRedactor{})
+
+	// Test non-existent file
+	changed, err := processor.Process(context.Background(), "/non/existent/file.yaml")
+	assert.NoError(t, err, "Process() should handle non-existent files gracefully")
+	assert.False(t, changed, "Process() should return false for non-existent files")
+}
+
+func TestFileProcessor_Process_UnsupportedExtension(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("some text"), 0644))
+
+	processor := NewFileProcessor(&mockRedactor{shouldRedact: true})
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err, "Process() should handle unsupported files gracefully")
+	assert.False(t, changed, "Process() should return false for unsupported file types")
+}
+
+func TestFileProcessor_Process_CorruptYAML(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.yaml")
+	corruptYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  invalid: [unclosed bracket
+`
+	require.NoError(t, os.WriteFile(testFile, []byte(corruptYAML), 0644))
+
+	processor := NewFileProcessor(&mockRedactor{shouldRedact: true})
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err, "Process() should handle corrupt files gracefully")
+	assert.False(t, changed, "Process() should return false for corrupt files")
+}
+
+func TestFileProcessor_Process_ListResource(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "list.yaml")
+	// Create a List resource with multiple items
+	yamlContent := `apiVersion: v1
+kind: ConfigMapList
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: test-config-1
+    namespace: default
+  data:
+    key1: value1
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: test-config-2
+    namespace: default
+  data:
+    key2: value2
+`
+	require.NoError(t, os.WriteFile(testFile, []byte(yamlContent), 0644))
+
+	// Test with redactor that returns true (content changed)
+	redactor := &mockRedactor{shouldRedact: true}
+	processor := NewFileProcessor(redactor)
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err)
+	assert.True(t, changed, "Process() should return true when redactor processes List resources")
+
+	// Verify file still exists
+	assert.FileExists(t, testFile)
+}
+
+func TestFileProcessor_Process_ListResourceNoChanges(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "list.json")
+	// Create a JSON List resource
+	jsonContent := `{
+  "apiVersion": "v1",
+  "kind": "SecretList",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "secret-1",
+        "namespace": "default"
+      },
+      "data": {
+        "key": "dmFsdWU="
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "secret-2",
+        "namespace": "kube-system"
+      },
+      "data": {
+        "token": "dG9rZW4="
+      }
+    }
+  ]
+}`
+	require.NoError(t, os.WriteFile(testFile, []byte(jsonContent), 0644))
+
+	// Test with redactor that returns false (no changes needed)
+	redactor := &mockRedactor{shouldRedact: false}
+	processor := NewFileProcessor(redactor)
+
+	changed, err := processor.Process(context.Background(), testFile)
+	assert.NoError(t, err)
+	assert.False(t, changed, "Process() should return false when redactor makes no changes to List resources")
+}
+
+func TestFileProcessor_Process_ListResourceMalformed(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "malformed-list.yaml")
+	// Create a List resource that will fail during KubernetesMetaListInterface unmarshaling
+	yamlContent := `apiVersion: v1
+kind: ConfigMapList
+items:
+  - this is not a valid kubernetes resource structure
+  - neither is this: [invalid, yaml, structure
+  - completely: broken
+`
+	require.NoError(t, os.WriteFile(testFile, []byte(yamlContent), 0644))
+
+	// Even with a redactor that would normally make changes
+	redactor := &mockRedactor{shouldRedact: true}
+	processor := NewFileProcessor(redactor)
+
+	changed, err := processor.Process(context.Background(), testFile)
+	// Should handle malformed List structure gracefully
+	assert.NoError(t, err, "Process() should handle malformed List structure gracefully")
+	// The processor should return false for malformed content since it can't be properly processed
+	assert.False(t, changed, "Process() should return false for malformed List resources")
+}

--- a/devex/cmd/mco-sanitize/redactor.go
+++ b/devex/cmd/mco-sanitize/redactor.go
@@ -8,6 +8,18 @@ import (
 	"strings"
 )
 
+// Redactor defines the interface for sanitizing sensitive data in Kubernetes resources.
+// Implementations should redact specified fields while preserving the structure and
+// metadata necessary for analysis and debugging purposes.
+type Redactor interface {
+	// Redact sanitizes the given inputData based on the provided Kubernetes resource metadata.
+	// The inputData should be the unmarshalled representation of the k8sResources.
+	// A content marshaler is required to calculate the length of redacted content.
+	// Returns true if any redaction was performed, false otherwise.
+	// Returns an error if the redaction process encounters any issues.
+	Redact(inputData interface{}, k8sResources []KubernetesMetaResource, marshaler contentMarshaler) (bool, error)
+}
+
 // redactTargetConfig holds redaction configuration for a specific Kubernetes resource type
 type redactTargetConfig struct {
 	namespaces []string

--- a/devex/cmd/mco-sanitize/redactor.go
+++ b/devex/cmd/mco-sanitize/redactor.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// redactTargetConfig holds redaction configuration for a specific Kubernetes resource type
+type redactTargetConfig struct {
+	namespaces []string
+	apiVersion string
+	paths      []string
+}
+
+// KubernetesRedactor sanitizes Kubernetes resources by redacting sensitive fields configured
+// by a given ConfigRedact
+type KubernetesRedactor struct {
+	targetConfigs map[string]redactTargetConfig
+}
+
+// NewKubernetesRedactor creates a new KubernetesRedactor based on a given
+// set of ConfigRedact. Returns an error if configs is nil or if any config
+// has an empty Kind field.
+func NewKubernetesRedactor(configs []ConfigRedact) (*KubernetesRedactor, error) {
+	if configs == nil {
+		return nil, errors.New("invalid redact configuration")
+	}
+	targetConfigs := make(map[string]redactTargetConfig)
+	for _, cfg := range configs {
+		if cfg.Kind == "" {
+			return nil, errors.New("invalid redact configuration. Empty kind")
+		}
+		targetConfigs[cfg.Kind] = redactTargetConfig{
+			paths:      cfg.Paths,
+			apiVersion: cfg.APIVersion,
+			namespaces: cfg.Namespaces,
+		}
+	}
+	return &KubernetesRedactor{targetConfigs: targetConfigs}, nil
+}
+
+// Redact sanitizes the given inputData, that corresponds to the unmarshalled representation of the given
+// k8sResources.
+// To perform the sanitization length calculation, a content marshaller is required. The marshaller should match
+// with the unmarshaller used to retrieve the inputData.
+// Only kubernetes resources targeted by the redactor configuration will be sanitized, others won't be touched.
+// This function returns a true boolean indicating if at least one sanitization was done, otherwise it returns false.
+// If any error is encountered while processing the input data, an error will be returned.
+func (r *KubernetesRedactor) Redact(inputData interface{}, k8sResources []KubernetesMetaResource, marshaler contentMarshaler) (bool, error) {
+	if len(k8sResources) == 0 {
+		return false, nil
+	}
+
+	switch value := inputData.(type) {
+	case map[string]interface{}:
+		return r.redactResource(inputData, &k8sResources[0], marshaler)
+
+	case []map[string]interface{}:
+		if len(value) != len(k8sResources) {
+			return false, fmt.Errorf("mismatch between input data length (%d) and resources length (%d)",
+				len(value), len(k8sResources))
+		}
+
+		changed := false
+		for idx, item := range k8sResources {
+			var resourceChanged bool
+			resourceChanged, err := r.redactResource(value[idx], &item, marshaler)
+			if err != nil {
+				return changed, err
+			}
+			if resourceChanged {
+				changed = true
+			}
+		}
+		return changed, nil
+	}
+	return false, nil
+}
+
+// redactResource processes a single Kubernetes resource for redaction based on the redactor's configuration.
+// It checks if the resource matches any configured redaction rules and applies redaction to all matching paths.
+// Returns true if any changes were made to the input data, false otherwise.
+func (r *KubernetesRedactor) redactResource(inputData interface{}, k8sResource *KubernetesMetaResource, marshaler contentMarshaler) (bool, error) {
+	targetConfig := r.getRedactConfig(k8sResource)
+	if targetConfig == nil {
+		return false, nil
+	}
+	changed := false
+	for _, path := range targetConfig.paths {
+		iterChanged, err := recursiveWalk(&visitorNode{value: inputData, marshaler: marshaler}, strings.Split(path, "."))
+		if err != nil {
+			return changed, fmt.Errorf("error visiting resource %#v with path %s: %w", k8sResource, path, err)
+		}
+		if iterChanged {
+			changed = true
+		}
+	}
+	return changed, nil
+}
+
+// getRedactConfig retrieves the redaction configuration for a given Kubernetes resource.
+// It matches the resource against configured rules based on Kind, APIVersion, and Namespace.
+// Returns nil if no matching configuration is found or if the resource doesn't meet the criteria.
+func (r *KubernetesRedactor) getRedactConfig(k8sResource *KubernetesMetaResource) *redactTargetConfig {
+	targetConfig, ok := r.targetConfigs[k8sResource.Kind]
+	if !ok {
+		return nil
+	}
+	if targetConfig.apiVersion != "" && targetConfig.apiVersion != k8sResource.APIVersion {
+		return nil
+	}
+	if targetConfig.namespaces != nil && len(targetConfig.namespaces) > 0 && !slices.Contains(targetConfig.namespaces, k8sResource.Metadata.Namespace) {
+		return nil
+	}
+	return &targetConfig
+}
+
+// recursiveWalk traverses the data structure following the specified path and performs redaction.
+// It handles three types of nodes: arrays, maps and primitives.
+// Returns true if any redaction was performed, false otherwise.
+func recursiveWalk(node *visitorNode, path []string) (bool, error) {
+	if len(path) == 0 {
+		return true, node.redact()
+	}
+	key := path[0]
+	switch value := node.value.(type) {
+	case []interface{}:
+		// The current node value is an array
+		// In arrays we only support * (give me all) or indexing (give me a zero base index)
+		if key == "*" {
+			// Easy case, sanitize everything inside the array
+			changed := false
+			for idx := range value {
+				iterChanged, err := recursiveWalk(node.newArrayChild(idx), path[1:])
+				if err != nil {
+					return false, err
+				}
+				if iterChanged {
+					changed = true
+				}
+			}
+			return changed, nil
+		} else {
+			// The path provides the index to pick. Transverse only that index
+			pathIndex, err := strconv.Atoi(key)
+			if err != nil {
+				return false, errors.New("redact path uses array indexing at a path level that is not an array")
+			}
+			newNode := node.newArrayChild(pathIndex)
+			if newNode == nil {
+				return false, nil
+			}
+			return recursiveWalk(newNode, path[1:])
+		}
+	case map[string]interface{}:
+		// Map case. newObjectChild returns nil if the key doesn't exist which should make us
+		// break the transversing path
+		newNode := node.newObjectChild(key)
+		if newNode == nil {
+			return false, nil
+		}
+		return recursiveWalk(newNode, path[1:])
+	default:
+		// It's not possible to reach this path unless the user configures a path
+		// that enforces the sanitized to continue transversing through something
+		// that is not an array neither a map
+		return false, fmt.Errorf("invalid query path. A path cannot traverse a primitive type")
+	}
+}
+
+// visitorNode represents a node in the object graph traversal during redaction.
+type visitorNode struct {
+	value     interface{}      // The current value at this node
+	key       string           // The key name if this node is a map value
+	index     int              // The array index if this node is an array element
+	parent    *visitorNode     // Reference to the parent node
+	marshaler contentMarshaler // Marshaler function
+}
+
+// newArrayChild creates a new visitorNode for an array element at the specified index.
+// This method assumes the current node's value is an array and returns a new node
+// representing the child element at the given index. Returns nil if the index is
+// out of bounds (greater than or equal to the array length).
+func (n *visitorNode) newArrayChild(index int) *visitorNode {
+	if len(n.value.([]interface{})) <= index {
+		// No matching element, skip
+		return nil
+	}
+	return &visitorNode{
+		value:     n.value.([]interface{})[index],
+		index:     index,
+		parent:    n,
+		marshaler: n.marshaler,
+	}
+}
+
+// newObjectChild creates a new visitorNode for a map value with the specified key.
+// This method assumes the current node's value is a map and returns a new node
+// representing the child value for the given key. Returns nil if the key doesn't
+// exist or the value is nil.
+func (n *visitorNode) newObjectChild(key string) *visitorNode {
+	val, ok := n.value.(map[string]interface{})[key]
+	if !ok || val == nil {
+		// No matching key, skip
+		return nil
+	}
+	return &visitorNode{
+		value:     val,
+		key:       key,
+		parent:    n,
+		marshaler: n.marshaler,
+	}
+}
+
+// replace replaces the current node's value in its parent data structure.
+// If the node has no parent (root level), it updates its own value.
+// For array elements, it updates the value at the node's index.
+// For map values, it updates the value for the node's key.
+func (n *visitorNode) replace(value interface{}) error {
+	// If no parent we are replacing at root level
+	if n.parent == nil {
+		n.value = value
+		return nil
+	}
+
+	switch val := n.parent.value.(type) {
+	case []interface{}:
+		val[n.index] = value
+		return nil
+	case map[string]interface{}:
+		val[n.key] = value
+		return nil
+	default:
+		// Unreachable condition: It's not possible to reach this condition
+		// cause unmarshalling takes care of making child elements child of
+		// a map or slice in yaml/json
+		return fmt.Errorf("error redacting kubernetes resource")
+	}
+}
+
+// redact replaces the current node's value with redaction information.
+// For complex types (arrays/maps), it marshals the value to determine its length.
+// For strings, it uses the string directly. For other primitives, it converts to string.
+// The redacted value is replaced with a map containing a redaction message and the
+// original data length for audit purposes.
+func (n *visitorNode) redact() error {
+	if n.value == nil {
+		return nil
+	}
+
+	var redactSource string
+	switch val := n.value.(type) {
+	case []interface{}, map[string]interface{}:
+		rawBytes, err := n.marshaler(val)
+		if err != nil {
+			return err
+		}
+		redactSource = string(rawBytes)
+	case string:
+		redactSource = val
+	default:
+		redactSource = fmt.Sprintf("%v", val)
+	}
+	redactInfo := map[string]interface{}{
+		"_REDACTED": "This field has been redacted",
+		"length":    len(redactSource),
+	}
+	return n.replace(redactInfo)
+}

--- a/devex/cmd/mco-sanitize/redactor_test.go
+++ b/devex/cmd/mco-sanitize/redactor_test.go
@@ -1,0 +1,955 @@
+// Assisted-by: Claude
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestNewKubernetesRedactor_ValidConfig(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+			Namespaces: []string{"default", "openshift-machine-config-operator"},
+			Paths:      []string{"spec.config.storage.files.contents", "spec.config.systemd.units.contents"},
+		},
+		{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "ControllerConfig",
+			Paths:      []string{"spec.internalRegistryPullSecret", "spec.kubeAPIServerServingCAData"},
+		},
+	}
+
+	redactor, err := NewKubernetesRedactor(configs)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, redactor)
+}
+
+func TestNewKubernetesRedactor_NilConfig(t *testing.T) {
+	redactor, err := NewKubernetesRedactor(nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, redactor)
+	assert.EqualError(t, err, "invalid redact configuration")
+}
+
+func TestNewKubernetesRedactor_EmptyKind(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			APIVersion: "v1",
+			Kind:       "", // Empty kind should cause error
+			Paths:      []string{"data.secret"},
+		},
+	}
+
+	redactor, err := NewKubernetesRedactor(configs)
+
+	assert.Error(t, err)
+	assert.Nil(t, redactor)
+	assert.EqualError(t, err, "invalid redact configuration. Empty kind")
+}
+
+func TestNewKubernetesRedactor_EmptySlice(t *testing.T) {
+	configs := []ConfigRedact{}
+
+	redactor, err := NewKubernetesRedactor(configs)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, redactor)
+}
+
+func TestKubernetesRedactor_Redact_EmptyResources(t *testing.T) {
+	configs := []ConfigRedact{
+		{Kind: "MachineConfig", Paths: []string{"spec.config"}},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "machineconfiguration.openshift.io/v1",
+		"kind":       "MachineConfig",
+		"spec":       map[string]interface{}{"config": "sensitive"},
+	}
+
+	changed, err := redactor.Redact(inputData, []KubernetesMetaResource{}, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestKubernetesRedactor_Redact_SingleResource_Match(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "MachineConfig",
+			Paths: []string{"spec.config"},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "machineconfiguration.openshift.io/v1",
+		"kind":       "MachineConfig",
+		"metadata": map[string]interface{}{
+			"name":      "test-config",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"config": "sensitive configuration",
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	// Verify the content was actually redacted
+	spec := inputData["spec"].(map[string]interface{})
+	redactedInfo, ok := spec["config"].(map[string]interface{})["_REDACTED"]
+	assert.True(t, ok)
+	assert.Equal(t, "This field has been redacted", redactedInfo)
+}
+
+func TestKubernetesRedactor_Redact_SingleResource_NoMatch(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "Secret", // Different kind
+			Paths: []string{"data.password"},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap", // Different kind, shouldn't match
+		"data": map[string]interface{}{
+			"config": "not sensitive",
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestKubernetesRedactor_Redact_ApiVersionMismatch(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Paths:      []string{"data.secret"},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v2", // Different API version
+		"kind":       "ConfigMap",
+		"data": map[string]interface{}{
+			"secret": "sensitive",
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v2",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestKubernetesRedactor_Redact_NamespaceFilter(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:       "Secret",
+			Namespaces: []string{"openshift-machine-config-operator"}, // Only specific namespace
+			Paths:      []string{"data.token"},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"data": map[string]interface{}{
+			"token": "sensitive-token",
+		},
+	}
+
+	// Test with non-matching namespace
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Metadata:   KubernetesMetadata{Namespace: "default"}, // Different namespace
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+	assert.NoError(t, err)
+	assert.False(t, changed, "Should not redact resource in non-matching namespace")
+
+	// Test with matching namespace
+	k8sResources[0].Metadata.Namespace = "openshift-machine-config-operator"
+	changed, err = redactor.Redact(inputData, k8sResources, yaml.Marshal)
+	assert.NoError(t, err)
+	assert.True(t, changed, "Should redact resource in matching namespace")
+}
+
+func TestKubernetesRedactor_Redact_ListResources(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap",
+			Paths: []string{"data"},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := []map[string]interface{}{
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"data": map[string]interface{}{
+				"config": "sensitive config 1",
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"data": map[string]interface{}{
+				"config": "sensitive config 2",
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, json.Marshal)
+
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	// Verify both items were redacted
+	for i, item := range inputData {
+		redactedInfo, ok := item["data"].(map[string]interface{})["_REDACTED"]
+		assert.True(t, ok, "Item %d should be redacted", i)
+		assert.Equal(t, "This field has been redacted", redactedInfo)
+	}
+}
+
+func TestKubernetesRedactor_Redact_ListResources_LengthMismatch(t *testing.T) {
+	configs := []ConfigRedact{
+		{Kind: "ConfigMap", Paths: []string{"data.config"}},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := []map[string]interface{}{
+		{"apiVersion": "v1", "kind": "ConfigMap"},
+		{"apiVersion": "v1", "kind": "ConfigMap"},
+	}
+
+	// Mismatched lengths
+	k8sResources := []KubernetesMetaResource{
+		{APIVersion: "v1", Kind: "ConfigMap"},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, json.Marshal)
+
+	assert.Error(t, err)
+	assert.False(t, changed)
+	assert.Contains(t, err.Error(), "mismatch between input data length")
+}
+
+func TestKubernetesRedactor_Redact_ListResources_PartialMatch(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap", // Only ConfigMaps will be redacted
+			Paths: []string{"data"},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := []map[string]interface{}{
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"data": map[string]interface{}{
+				"secret": "redact this",
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "Secret", // Different kind, won't be redacted
+			"data": map[string]interface{}{
+				"secret": "don't redact this",
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{APIVersion: "v1", Kind: "ConfigMap"},
+		{APIVersion: "v1", Kind: "Secret"},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.True(t, changed, "Should return true since at least one item was redacted")
+
+	// Verify only the first item was redacted
+	_, configMapRedacted := inputData[0]["data"].(map[string]interface{})["_REDACTED"]
+	assert.True(t, configMapRedacted, "ConfigMap should be redacted")
+
+	secretData, secretExists := inputData[1]["data"].(map[string]interface{})["secret"]
+	assert.True(t, secretExists, "Secret data should still exist")
+	assert.Equal(t, "don't redact this", secretData, "Secret should not be redacted")
+}
+
+func TestKubernetesRedactor_Redact_UnsupportedInputType(t *testing.T) {
+	configs := []ConfigRedact{
+		{Kind: "ConfigMap", Paths: []string{"data.config"}},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	// Unsupported input type (string instead of map or slice)
+	inputData := "this is not a supported input type"
+
+	k8sResources := []KubernetesMetaResource{
+		{APIVersion: "v1", Kind: "ConfigMap"},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestKubernetesRedactor_Redact_ArrayTraversal(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "MachineConfig",
+			Paths: []string{"spec.config.storage.files.*.contents"}, // Path that goes through an array
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "machineconfiguration.openshift.io/v1",
+		"kind":       "MachineConfig",
+		"metadata": map[string]interface{}{
+			"name":      "test-config",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"config": map[string]interface{}{
+				"storage": map[string]interface{}{
+					"files": []interface{}{ // Array of files
+						map[string]interface{}{
+							"path":     "/etc/test1.conf",
+							"contents": "sensitive file content 1",
+						},
+						map[string]interface{}{
+							"path":     "/etc/test2.conf",
+							"contents": "sensitive file content 2",
+						},
+						map[string]interface{}{
+							"path":     "/etc/test3.conf",
+							"contents": "sensitive file content 3",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	// Verify that all files in the array had their contents redacted
+	files := inputData["spec"].(map[string]interface{})["config"].(map[string]interface{})["storage"].(map[string]interface{})["files"].([]interface{})
+
+	for i, file := range files {
+		fileMap := file.(map[string]interface{})
+
+		// Check that contents was redacted
+		redactedInfo, ok := fileMap["contents"].(map[string]interface{})["_REDACTED"]
+		assert.True(t, ok, "File %d contents should be redacted", i)
+		assert.Equal(t, "This field has been redacted", redactedInfo)
+
+		// Check that path field is unchanged
+		assert.Contains(t, fileMap["path"], "/etc/test", "Path should remain unchanged for file %d", i)
+	}
+}
+
+func TestKubernetesRedactor_Redact_ArrayIndexPaths(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap",
+			Paths: []string{"data.items.0", "data.items.2"}, // Target specific array elements by index
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "test-config",
+			"namespace": "default",
+		},
+		"data": map[string]interface{}{
+			"items": []interface{}{
+				"first-item-sensitive", // Index 0 - should be redacted
+				"second-item-safe",     // Index 1 - should not be redacted
+				"third-item-sensitive", // Index 2 - should be redacted
+				"fourth-item-safe",     // Index 3 - should not be redacted
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	// Check that specific array elements were redacted
+	items := inputData["data"].(map[string]interface{})["items"].([]interface{})
+
+	// Element 0 should be redacted
+	redactedInfo0, ok0 := items[0].(map[string]interface{})["_REDACTED"]
+	assert.True(t, ok0, "Element 0 should be redacted")
+	assert.Equal(t, "This field has been redacted", redactedInfo0)
+
+	// Element 1 should remain unchanged
+	assert.Equal(t, "second-item-safe", items[1], "Element 1 should not be redacted")
+
+	// Element 2 should be redacted
+	redactedInfo2, ok2 := items[2].(map[string]interface{})["_REDACTED"]
+	assert.True(t, ok2, "Element 2 should be redacted")
+	assert.Equal(t, "This field has been redacted", redactedInfo2)
+
+	// Element 3 should remain unchanged
+	assert.Equal(t, "fourth-item-safe", items[3], "Element 3 should not be redacted")
+}
+
+func TestKubernetesRedactor_Redact_UnsupportedArrayIndexInPath(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap",
+			Paths: []string{"data.my-array.1.element"}, // Path with array index in middle
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"data": map[string]interface{}{
+			"my-array": []interface{}{
+				map[string]interface{}{
+					"element": "first-value-should-not-be-touched",
+				},
+				map[string]interface{}{
+					"element": "second-value-should-be-redacted",
+				},
+				map[string]interface{}{
+					"element": "third-value-should-not-be-touched",
+				},
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	// Verify that ONLY the element at index 1 was redacted
+	myArray := inputData["data"].(map[string]interface{})["my-array"].([]interface{})
+
+	// Element 0 should be unchanged
+	element0 := myArray[0].(map[string]interface{})
+	assert.Equal(t, "first-value-should-not-be-touched", element0["element"],
+		"Element at index 0 should not be redacted")
+
+	// Element 1 should be redacted
+	element1 := myArray[1].(map[string]interface{})
+	redactedInfo, ok := element1["element"].(map[string]interface{})
+	require.True(t, ok, "Element at index 1 should be redacted")
+	assert.Equal(t, "This field has been redacted", redactedInfo["_REDACTED"])
+	assert.Equal(t, len("second-value-should-be-redacted"), redactedInfo["length"])
+
+	// Element 2 should be unchanged
+	element2 := myArray[2].(map[string]interface{})
+	assert.Equal(t, "third-value-should-not-be-touched", element2["element"],
+		"Element at index 2 should not be redacted")
+}
+
+func TestKubernetesRedactor_Redact_ArrayIndexOutOfRange(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap",
+			Paths: []string{"data.my-array.5.element"}, // Index 5 is out of range (array has only 3 elements)
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"data": map[string]interface{}{
+			"my-array": []interface{}{
+				map[string]interface{}{
+					"element": "value-0",
+				},
+				map[string]interface{}{
+					"element": "value-1",
+				},
+				map[string]interface{}{
+					"element": "value-2",
+				},
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	// Should not error and should return false (no changes made)
+	require.NoError(t, err)
+	assert.False(t, changed, "Should return false when no redaction occurs due to out-of-range index")
+
+	// Verify all elements remain unchanged
+	myArray := inputData["data"].(map[string]interface{})["my-array"].([]interface{})
+
+	for i, expectedValue := range []string{"value-0", "value-1", "value-2"} {
+		element := myArray[i].(map[string]interface{})
+		assert.Equal(t, expectedValue, element["element"],
+			"Element at index %d should remain unchanged when target index is out of range", i)
+	}
+}
+
+func TestKubernetesRedactor_Redact_InvalidArrayPathElement(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap",
+			Paths: []string{"data.my-array.invalid-key.element"}, // "invalid-key" is not "*" or a number
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"data": map[string]interface{}{
+			"my-array": []interface{}{
+				map[string]interface{}{
+					"element": "value-0",
+				},
+				map[string]interface{}{
+					"element": "value-1",
+				},
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	// Should return an error because "invalid-key" is not a valid array path element
+	require.Error(t, err)
+	assert.False(t, changed, "Should return false when an error occurs")
+	assert.Contains(t, err.Error(), "redact path uses array indexing at a path level that is not an array",
+		"Error should indicate invalid array path element")
+}
+
+func TestKubernetesRedactor_Redact_NonExistentIntermediateKeys(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind: "ConfigMap",
+			Paths: []string{
+				"data.existing.password",          // Valid path - should be redacted
+				"data.nonexistent.secret",         // Invalid path - intermediate key doesn't exist
+				"data.existing.nonexistent.value", // Invalid path - deeper intermediate key doesn't exist
+			},
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"data": map[string]interface{}{
+			"existing": map[string]interface{}{
+				"password": "secret-password",
+				"username": "admin",
+			},
+			"other": map[string]interface{}{
+				"config": "some-config",
+			},
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	// Should not error and should return true (only the valid path was redacted)
+	require.NoError(t, err)
+	assert.True(t, changed, "Should return true when at least one path is successfully redacted")
+
+	// Verify that only the existing path was redacted
+	existing := inputData["data"].(map[string]interface{})["existing"].(map[string]interface{})
+
+	// The password should be redacted
+	redactedPassword, ok := existing["password"].(map[string]interface{})
+	require.True(t, ok, "Password should be redacted")
+	assert.Equal(t, "This field has been redacted", redactedPassword["_REDACTED"])
+	assert.Equal(t, len("secret-password"), redactedPassword["length"])
+
+	// The username should remain unchanged
+	assert.Equal(t, "admin", existing["username"], "Username should not be redacted")
+
+	// Other data should remain unchanged
+	other := inputData["data"].(map[string]interface{})["other"].(map[string]interface{})
+	assert.Equal(t, "some-config", other["config"], "Other data should remain unchanged")
+
+	// Verify the structure hasn't been modified by non-existent paths
+	_, hasNonexistent := inputData["data"].(map[string]interface{})["nonexistent"]
+	assert.False(t, hasNonexistent, "Non-existent keys should not be created")
+}
+
+func TestKubernetesRedactor_Redact_RootPath(t *testing.T) {
+	configs := []ConfigRedact{
+		{
+			Kind:  "ConfigMap",
+			Paths: []string{"data"}, // Root-level path
+		},
+	}
+	redactor, err := NewKubernetesRedactor(configs)
+	require.NoError(t, err)
+
+	inputData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "test-config",
+			"namespace": "default",
+		},
+		"data": map[string]interface{}{
+			"config":   "sensitive configuration",
+			"password": "secret-password",
+			"token":    "access-token",
+		},
+	}
+
+	k8sResources := []KubernetesMetaResource{
+		{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Metadata:   KubernetesMetadata{Namespace: "default"},
+		},
+	}
+
+	changed, err := redactor.Redact(inputData, k8sResources, yaml.Marshal)
+
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	// Verify the entire "data" field was redacted
+	redactedInfo, ok := inputData["data"].(map[string]interface{})["_REDACTED"]
+	assert.True(t, ok, "Data field should be redacted")
+	assert.Equal(t, "This field has been redacted", redactedInfo)
+
+	// Verify that metadata was not affected
+	metadata := inputData["metadata"].(map[string]interface{})
+	assert.Equal(t, "test-config", metadata["name"])
+	assert.Equal(t, "default", metadata["namespace"])
+}
+
+func TestKubernetesRedactor_Redact_LengthMetadata(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputData      map[string]interface{}
+		pathToRedact   string
+		expectedLength int
+		description    string
+	}{
+		{
+			name: "String primitive",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"password": "secret123",
+				},
+			},
+			pathToRedact:   "data.password",
+			expectedLength: 9, // len("secret123")
+			description:    "String length should match character count",
+		},
+		{
+			name: "Integer primitive",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": map[string]interface{}{
+					"port": 8080,
+				},
+			},
+			pathToRedact:   "data.port",
+			expectedLength: 4, // len("8080")
+			description:    "Integer length should match string representation",
+		},
+		{
+			name: "Boolean primitive",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			pathToRedact:   "data.enabled",
+			expectedLength: 4, // len("true")
+			description:    "Boolean length should match string representation",
+		},
+		{
+			name: "Map object",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"config": map[string]interface{}{
+						"host": "localhost",
+						"port": 5432,
+					},
+				},
+			},
+			pathToRedact:   "data.config",
+			expectedLength: -1, // Will be calculated based on YAML marshaling
+			description:    "Map length should match YAML marshaled representation",
+		},
+		{
+			name: "Array object",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": map[string]interface{}{
+					"servers": []interface{}{
+						"server1.example.com",
+						"server2.example.com",
+					},
+				},
+			},
+			pathToRedact:   "data.servers",
+			expectedLength: -1, // Will be calculated based on YAML marshaling
+			description:    "Array length should match YAML marshaled representation",
+		},
+		{
+			name: "Empty string",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"empty": "",
+				},
+			},
+			pathToRedact:   "data.empty",
+			expectedLength: 0, // len("")
+			description:    "Empty string should have length 0",
+		},
+		{
+			name: "Array of primitives",
+			inputData: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": map[string]interface{}{
+					"keys": []interface{}{
+						"key1",
+						"key2",
+						"key3",
+					},
+				},
+			},
+			pathToRedact:   "data.keys",
+			expectedLength: -1, // Will be calculated based on YAML marshaling
+			description:    "Array of primitives length should match YAML representation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configs := []ConfigRedact{
+				{
+					Kind:  tc.inputData["kind"].(string),
+					Paths: []string{tc.pathToRedact},
+				},
+			}
+			redactor, err := NewKubernetesRedactor(configs)
+			require.NoError(t, err)
+
+			k8sResources := []KubernetesMetaResource{
+				{
+					APIVersion: tc.inputData["apiVersion"].(string),
+					Kind:       tc.inputData["kind"].(string),
+					Metadata:   KubernetesMetadata{},
+				},
+			}
+
+			// Calculate expected length if not provided (before redaction)
+			expectedLength := tc.expectedLength
+			if expectedLength == -1 {
+				// Get original value and calculate length the same way the redactor does
+				pathParts := strings.Split(tc.pathToRedact, ".")
+				var originalValue interface{} = tc.inputData
+				for _, part := range pathParts {
+					originalValue = originalValue.(map[string]interface{})[part]
+				}
+
+				var redactSource string
+				switch originalValue.(type) {
+				case []interface{}, map[string]interface{}:
+					rawBytes, err := yaml.Marshal(originalValue)
+					require.NoError(t, err)
+					redactSource = string(rawBytes)
+				case string:
+					redactSource = originalValue.(string)
+				default:
+					redactSource = fmt.Sprintf("%v", originalValue)
+				}
+				expectedLength = len(redactSource)
+			}
+
+			changed, err := redactor.Redact(tc.inputData, k8sResources, yaml.Marshal)
+
+			require.NoError(t, err, "Redaction should not error")
+			require.True(t, changed, "Data should be changed after redaction")
+
+			// Navigate to the redacted field
+			pathParts := strings.Split(tc.pathToRedact, ".")
+			var redactedField interface{} = tc.inputData
+			for _, part := range pathParts {
+				redactedField = redactedField.(map[string]interface{})[part]
+			}
+
+			// Verify redaction structure
+			redactInfo, ok := redactedField.(map[string]interface{})
+			require.True(t, ok, "Redacted field should be a map")
+
+			redactMsg, ok := redactInfo["_REDACTED"].(string)
+			require.True(t, ok, "Should have _REDACTED field")
+			assert.Equal(t, "This field has been redacted", redactMsg)
+
+			lengthField, ok := redactInfo["length"]
+			require.True(t, ok, "Should have length field")
+			actualLength, ok := lengthField.(int)
+			require.True(t, ok, "Length should be an integer")
+
+			assert.Equal(t, expectedLength, actualLength,
+				"Length field should match expected value: %s", tc.description)
+		})
+	}
+}

--- a/devex/cmd/mco-sanitize/redactor_test.go
+++ b/devex/cmd/mco-sanitize/redactor_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewKubernetesRedactor_ValidConfig(t *testing.T) {

--- a/devex/cmd/mco-sanitize/types.go
+++ b/devex/cmd/mco-sanitize/types.go
@@ -1,0 +1,31 @@
+package main
+
+// contentMarshaler is a function type that converts an interface{} value to its byte representation.
+// Abstraction of JSON/YAML marshaller/unmarshaller.
+type contentMarshaler func(interface{}) ([]byte, error)
+
+// KubernetesMetadata represents the metadata section of a Kubernetes resource.
+// It contains essential identification information for the resource.
+type KubernetesMetadata struct {
+	// Namespace specifies the namespace where the Kubernetes resource is located.
+	// For cluster-scoped resources, this field may be empty.
+	Namespace string `yaml:"namespace" json:"namespace"`
+}
+
+// KubernetesMetaResource represents the minimal metadata structure of a Kubernetes resource
+// required for redaction operations. It contains only the fields necessary to identify
+// and process resources during sanitization.
+type KubernetesMetaResource struct {
+	// APIVersion specifies the API version of the Kubernetes resource.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+
+	// Kind specifies the type of Kubernetes resource.
+	Kind string `yaml:"kind" json:"kind"`
+
+	// Metadata contains the resource's metadata information, primarily the namespace.
+	Metadata KubernetesMetadata `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+
+	// Items is used when the resource represents a List type.
+	// It contains the individual resources within the list that need to be processed.
+	Items []KubernetesMetaResource `yaml:"items,omitempty" json:"items,omitempty"`
+}

--- a/devex/cmd/mco-sanitize/types.go
+++ b/devex/cmd/mco-sanitize/types.go
@@ -4,6 +4,16 @@ package main
 // Abstraction of JSON/YAML marshaller/unmarshaller.
 type contentMarshaler func(interface{}) ([]byte, error)
 
+// contentUnmarshaller is a function type that a byte representation to an interface{}.
+// Abstraction of JSON/YAML unmarshaller.
+type contentUnmarshaller func([]byte, interface{}) error
+
+// KubernetesMetaListInterface represents a generic Kubernetes List resource structure.
+// It contains a collection of items that can be any type of Kubernetes resource.
+type KubernetesMetaListInterface struct {
+	Items []map[string]interface{} `yaml:"items,omitempty" json:"items,omitempty"`
+}
+
 // KubernetesMetadata represents the metadata section of a Kubernetes resource.
 // It contains essential identification information for the resource.
 type KubernetesMetadata struct {

--- a/devex/cmd/mco-sanitize/walker.go
+++ b/devex/cmd/mco-sanitize/walker.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/klog/v2"
+)
+
+// FileFilter defines an interface for filtering files during filesystem transversing.
+type FileFilter interface {
+	// Filter returns true if the file at the given path should be processed,
+	// false otherwise.
+	Filter(path string) bool
+}
+
+// DefaultStaticFileFilter is a file filter that accepts files based on their extension.
+// It filters for YAML (.yaml, .yml) and JSON (.json) files.
+type DefaultStaticFileFilter struct{}
+
+// NewDefaultStaticFileFilter creates a new instance of DefaultStaticFileFilter.
+func NewDefaultStaticFileFilter() *DefaultStaticFileFilter {
+	return &DefaultStaticFileFilter{}
+}
+
+// Filter returns true if the file has a YAML (.yaml, .yml) or JSON (.json) extension.
+func (fp *DefaultStaticFileFilter) Filter(path string) bool {
+	return strings.HasSuffix(path, ".yaml") ||
+		strings.HasSuffix(path, ".yml") ||
+		strings.HasSuffix(path, ".json")
+}
+
+// FileProcessor defines an interface for processing individual files.
+// Implementations handle the actual work to be performed on each file,
+// such as sanitization, validation, or transformation.
+type FileProcessor interface {
+	// Process performs the required operation on the file at the given path.
+	// Returns true if the file was modified, false otherwise.
+	// Returns an error if the processing operation fails.
+	Process(ctx context.Context, path string) (bool, error)
+}
+
+// FsWalker provides concurrent filesystem traversal and processing capabilities.
+// It walks through a directory tree, applies filtering criteria, and processes
+// matching files using a configurable number of worker goroutines.
+type FsWalker struct {
+	workerCount   int           // Number of concurrent workers for file processing
+	inputPath     string        // Root path to start traversal from
+	filter        FileFilter    // Filter to determine which files to process
+	fileProcessor FileProcessor // Processor to handle individual files
+}
+
+// fsWalkerTaskResult represents the result of processing a single file.
+// It contains information about any errors encountered, whether the file
+// was modified, and the path of the processed file.
+type fsWalkerTaskResult struct {
+	error   error  // Error encountered during processing, if any
+	changed bool   // Whether the file was modified during processing
+	path    string // Path of the processed file
+}
+
+// NewFsWalker creates a new filesystem walker with the specified configuration.
+// The walker will traverse the inputPath directory tree, apply the given filter
+// to determine which files to process, and use the specified number of workers
+// to process files concurrently.
+func NewFsWalker(inputPath string, workers int, filter FileFilter, processor FileProcessor) *FsWalker {
+	return &FsWalker{
+		workerCount:   workers,
+		inputPath:     inputPath,
+		filter:        filter,
+		fileProcessor: processor,
+	}
+}
+
+// Walk traverses the filesystem starting from the configured input path,
+// processing files that match the filter criteria using concurrent workers.
+// Files are processed concurrently using the configured number of goroutines.
+// Returns an error if the processing operation fails.
+func (fw *FsWalker) Walk(ctx context.Context) error {
+	reportChan := make(chan fsWalkerTaskResult)
+	workerChan := make(chan string)
+	var wg sync.WaitGroup
+	var reportWg sync.WaitGroup
+
+	var shouldExit atomic.Bool
+	shouldExit.Store(false)
+
+	// Create the worker routines
+	for range fw.workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case path, ok := <-workerChan:
+					if !ok {
+						return
+					}
+					changed, err := fw.fileProcessor.Process(ctx, path)
+					if err != nil || changed {
+						// Ignore tasks without errors or unchanged
+						reportChan <- fsWalkerTaskResult{
+							error:   err,
+							changed: changed,
+							path:    path,
+						}
+					}
+				case <-ctx.Done():
+					shouldExit.Store(true)
+					return
+				}
+			}
+
+		}()
+	}
+
+	// Create the reporting routine
+	reportWg.Add(1)
+	go func() {
+		defer reportWg.Done()
+		for report := range reportChan {
+			if report.error != nil {
+				klog.Errorf("error while processing file %q: %v", report.path, report.error)
+			} else if report.changed && report.path != "" {
+				path, err := filepath.Rel(fw.inputPath, report.path)
+				if err != nil {
+					path = report.path
+				}
+				klog.Infof("file %s redacted", path)
+			}
+		}
+	}()
+	err := filepath.WalkDir(fw.inputPath, func(path string, dirEntry fs.DirEntry, err error) error {
+		if shouldExit.Load() {
+			return filepath.SkipAll
+		}
+		if err != nil {
+			return err
+		}
+		if dirEntry.IsDir() {
+			return nil
+		}
+
+		if fw.filter.Filter(path) {
+			select {
+			case workerChan <- path:
+				// Successfully sent
+			case <-ctx.Done():
+				// Context cancelled, exit immediately
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+
+	// Wait for workers and report routines to exit
+	close(workerChan)
+	wg.Wait()
+
+	close(reportChan)
+	reportWg.Wait()
+	return err
+}

--- a/devex/cmd/mco-sanitize/walker_test.go
+++ b/devex/cmd/mco-sanitize/walker_test.go
@@ -1,0 +1,350 @@
+// Assisted-by: Claude
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock implementations for testing
+type mockFileFilter struct {
+	filterFunc func(path string) bool
+}
+
+func (m *mockFileFilter) Filter(path string) bool {
+	if m.filterFunc != nil {
+		return m.filterFunc(path)
+	}
+	return true
+}
+
+type mockFileProcessor struct {
+	processFunc    func(ctx context.Context, path string) (bool, error)
+	processedFiles []string
+	mu             sync.Mutex
+}
+
+func (m *mockFileProcessor) Process(ctx context.Context, path string) (bool, error) {
+	m.mu.Lock()
+	m.processedFiles = append(m.processedFiles, path)
+	m.mu.Unlock()
+
+	if m.processFunc != nil {
+		return m.processFunc(ctx, path)
+	}
+	return false, nil
+}
+
+func (m *mockFileProcessor) getProcessedFiles() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]string, len(m.processedFiles))
+	copy(result, m.processedFiles)
+	return result
+}
+
+func TestDefaultStaticFileFilter_Filter(t *testing.T) {
+	filter := NewDefaultStaticFileFilter()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"YAML file", "/path/to/file.yaml", true},
+		{"YML file", "/path/to/file.yml", true},
+		{"JSON file", "/path/to/file.json", true},
+		{"Go file", "/path/to/file.go", false},
+		{"Text file", "/path/to/file.txt", false},
+		{"No extension", "/path/to/file", false},
+		{"Hidden YAML", "/path/to/.hidden.yaml", true},
+		{"Nested YAML", "/very/deep/path/config.yml", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filter.Filter(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewFsWalker(t *testing.T) {
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+
+	walker := NewFsWalker("/test/path", 5, filter, processor)
+
+	assert.NotNil(t, walker)
+	assert.Equal(t, 5, walker.workerCount)
+	assert.Equal(t, "/test/path", walker.inputPath)
+	assert.Equal(t, filter, walker.filter)
+	assert.Equal(t, processor, walker.fileProcessor)
+}
+
+func TestFsWalker_Walk_EmptyDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker(tempDir, 2, filter, processor)
+
+	ctx := context.Background()
+	err := walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	assert.Empty(t, processor.getProcessedFiles())
+}
+
+func TestFsWalker_Walk_SingleFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	err := os.WriteFile(testFile, []byte("test content"), 0644)
+	require.NoError(t, err)
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker(tempDir, 1, filter, processor)
+
+	ctx := context.Background()
+	err = walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, 1)
+	assert.Equal(t, testFile, processedFiles[0])
+}
+
+func TestFsWalker_Walk_MultipleFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	files := []string{"file1.txt", "file2.yaml", "file3.json"}
+	for _, filename := range files {
+		testFile := filepath.Join(tempDir, filename)
+		err := os.WriteFile(testFile, []byte("test content"), 0644)
+		require.NoError(t, err)
+	}
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker(tempDir, 2, filter, processor)
+
+	ctx := context.Background()
+	err := walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, 3)
+
+	// Check all files were processed
+	processedMap := make(map[string]bool)
+	for _, file := range processedFiles {
+		processedMap[filepath.Base(file)] = true
+	}
+	for _, filename := range files {
+		assert.True(t, processedMap[filename], "File %s should have been processed", filename)
+	}
+}
+
+func TestFsWalker_Walk_WithSubdirectories(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create subdirectory
+	subDir := filepath.Join(tempDir, "subdir")
+	err := os.Mkdir(subDir, 0755)
+	require.NoError(t, err)
+
+	// Create files in root and subdirectory
+	rootFile := filepath.Join(tempDir, "root.txt")
+	subFile := filepath.Join(subDir, "sub.txt")
+
+	err = os.WriteFile(rootFile, []byte("root content"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(subFile, []byte("sub content"), 0644)
+	require.NoError(t, err)
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker(tempDir, 1, filter, processor)
+
+	ctx := context.Background()
+	err = walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, 2)
+
+	processedPaths := make(map[string]bool)
+	for _, file := range processedFiles {
+		processedPaths[file] = true
+	}
+	assert.True(t, processedPaths[rootFile])
+	assert.True(t, processedPaths[subFile])
+}
+
+func TestFsWalker_Walk_FilterFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create different file types
+	yamlFile := filepath.Join(tempDir, "config.yaml")
+	txtFile := filepath.Join(tempDir, "readme.txt")
+	jsonFile := filepath.Join(tempDir, "data.json")
+
+	for _, file := range []string{yamlFile, txtFile, jsonFile} {
+		err := os.WriteFile(file, []byte("content"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Filter only YAML files
+	filter := &mockFileFilter{
+		filterFunc: func(path string) bool {
+			return filepath.Ext(path) == ".yaml"
+		},
+	}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker(tempDir, 1, filter, processor)
+
+	ctx := context.Background()
+	err := walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, 1)
+	assert.Equal(t, yamlFile, processedFiles[0])
+}
+
+func TestFsWalker_Walk_ProcessorError(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	err := os.WriteFile(testFile, []byte("content"), 0644)
+	require.NoError(t, err)
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{
+		processFunc: func(ctx context.Context, path string) (bool, error) {
+			return false, errors.New("processor error")
+		},
+	}
+	walker := NewFsWalker(tempDir, 1, filter, processor)
+
+	ctx := context.Background()
+	err = walker.Walk(ctx)
+
+	// The walker should not return processor errors, they should be logged
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, 1)
+}
+
+func TestFsWalker_Walk_ContextCancellation(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create several files
+	for i := 0; i < 5; i++ {
+		testFile := filepath.Join(tempDir, "test"+string(rune('0'+i))+".txt")
+		err := os.WriteFile(testFile, []byte("content"), 0644)
+		require.NoError(t, err)
+	}
+
+	var processStarted atomic.Bool
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{
+		processFunc: func(ctx context.Context, path string) (bool, error) {
+			processStarted.Store(true)
+			// Simulate slow processing
+			time.Sleep(100 * time.Millisecond)
+			return false, nil
+		},
+	}
+	walker := NewFsWalker(tempDir, 1, filter, processor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start walking in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- walker.Walk(ctx)
+	}()
+
+	// Wait for processing to start then cancel
+	for !processStarted.Load() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+
+	// Wait for completion with timeout
+	select {
+	case err := <-errChan:
+		// Should complete without error (cancellation is handled gracefully)
+		assert.NoError(t, err)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Test timed out - walker didn't respond to cancellation within 1 second")
+	}
+}
+
+func TestFsWalker_Walk_MultipleWorkers(t *testing.T) {
+	tempDir := t.TempDir()
+
+	fileCount := 10
+	for i := 0; i < fileCount; i++ {
+		testFile := filepath.Join(tempDir, "file"+string(rune('0'+i))+".txt")
+		err := os.WriteFile(testFile, []byte("content"), 0644)
+		require.NoError(t, err)
+	}
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker(tempDir, 3, filter, processor) // 3 workers
+
+	ctx := context.Background()
+	err := walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, fileCount)
+}
+
+func TestFsWalker_Walk_ProcessorReturnsChanged(t *testing.T) {
+	tempDir := t.TempDir()
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	err := os.WriteFile(testFile, []byte("content"), 0644)
+	require.NoError(t, err)
+
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{
+		processFunc: func(ctx context.Context, path string) (bool, error) {
+			return true, nil // Return changed=true
+		},
+	}
+	walker := NewFsWalker(tempDir, 1, filter, processor)
+
+	ctx := context.Background()
+	err = walker.Walk(ctx)
+
+	assert.NoError(t, err)
+	processedFiles := processor.getProcessedFiles()
+	assert.Len(t, processedFiles, 1)
+}
+
+func TestFsWalker_Walk_NonexistentDirectory(t *testing.T) {
+	filter := &mockFileFilter{}
+	processor := &mockFileProcessor{}
+	walker := NewFsWalker("/nonexistent/path", 1, filter, processor)
+
+	ctx := context.Background()
+	err := walker.Walk(ctx)
+
+	assert.Error(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -401,7 +401,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.5.1 // indirect
 	k8s.io/apiserver v0.33.2
 	k8s.io/klog/v2 v2.130.1


### PR DESCRIPTION
**- What I did**

This change adds a sub-piece of the mco-sanitizer, the utility binary that takes a must-gather directory and removes/sanitizes the content based on some given configuration.
This change is limited to the file walker and processor components of  the tool.

**- How to verify it**

UT testing is enough to test this sub-component of mco-sanitize.

**- Description for the changelog**

Implements a sub-component of the mco-sanitizer that is responsible of walk and process a FS directory.