### PR TITLE
OCPBUGS-43633: fix(security): disable SELinux execstack for stack protection

### DIFF
--- a/templates/common/_base/units/kubelet-selinux-bools.yaml
+++ b/templates/common/_base/units/kubelet-selinux-bools.yaml
@@ -1,0 +1,14 @@
+name: kubelet-selinux-bools.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Adjust selinux bools for kubelet.
+  Before=kubelet-dependencies.target
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  User=root
+  ExecStart=-/usr/sbin/setsebool selinuxuser_execstack off
+  TimeoutSec=20
+  [Install]
+  RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
**- What I did**
Add new `kubelet-selinux-bools` service to disable `selinuxuser_execstack` at node level

**- How to verify it**
Once deploy a new OCP Cluster, check the booleans at the node level following this steps:
```
# semanage boolean -l | grep -e execmem -e execstack | grep selinuxuser_execstack
```

That boolean should be `(off,  off)`

**- Description for the changelog**
Add kubelet-selinux-bools service to disable selinuxuser_execstack boolean, preventing potential stack-based code execution attacks. This enhances security by ensuring users cannot execute code on the stack through SELinux policies.

- Fixes: [OCPBUGS-43633](https://issues.redhat.com/browse/OCPBUGS-43633)
