### PR TITLE
OCPBUGS-61384: Fix scheduling for keepalived

### DIFF
--- a/templates/arbiter/00-arbiter/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/arbiter/00-arbiter/on-prem/files/keepalived-keepalived.yaml
@@ -5,8 +5,19 @@ contents:
     global_defs {
         enable_script_security
         script_user root
-        max_auto_priority -1
         vrrp_garp_master_refresh 60
+
+        # These settings are fine tuning scheduling of the process. They are to
+        # avoid split-brain caused by not getting enough CPU to run vrrp fast enough.
+        # Values are coming from multiple online resources combined together, e.g.
+        # * https://groups.io/g/keepalived-users/topic/a_thread_timer_expired/94707560
+        # * https://forge.puppet.com/modules/puppet/keepalived/readme
+        max_auto_priority 99
+        vrrp_rt_priority 50
+        vrrp_no_swap
+        vrrp_rlimit_rttime 100000
+        bfd_rlimit_rttime 100000
+        checker_rlimit_rttime 100000
     }
 
     # These are separate checks to provide the following behavior:

--- a/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml
@@ -5,8 +5,19 @@ contents:
     global_defs {
         enable_script_security
         script_user root
-        max_auto_priority -1
         vrrp_garp_master_refresh 60
+
+        # These settings are fine tuning scheduling of the process. They are to
+        # avoid split-brain caused by not getting enough CPU to run vrrp fast enough.
+        # Values are coming from multiple online resources combined together, e.g.
+        # * https://groups.io/g/keepalived-users/topic/a_thread_timer_expired/94707560
+        # * https://forge.puppet.com/modules/puppet/keepalived/readme
+        max_auto_priority 99
+        vrrp_rt_priority 50
+        vrrp_no_swap
+        vrrp_rlimit_rttime 100000
+        bfd_rlimit_rttime 100000
+        checker_rlimit_rttime 100000
     }
 
     # These are separate checks to provide the following behavior:

--- a/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
+++ b/templates/worker/00-worker/on-prem/files/keepalived-keepalived.yaml
@@ -5,8 +5,19 @@ contents:
     global_defs {
         enable_script_security
         script_user root
-        max_auto_priority -1
         vrrp_garp_master_refresh 60
+
+        # These settings are fine tuning scheduling of the process. They are to
+        # avoid split-brain caused by not getting enough CPU to run vrrp fast enough.
+        # Values are coming from multiple online resources combined together, e.g.
+        # * https://groups.io/g/keepalived-users/topic/a_thread_timer_expired/94707560
+        # * https://forge.puppet.com/modules/puppet/keepalived/readme
+        max_auto_priority 99
+        vrrp_rt_priority 50
+        vrrp_no_swap
+        vrrp_rlimit_rttime 100000
+        bfd_rlimit_rttime 100000
+        checker_rlimit_rttime 100000
     }
 
     # TODO: Improve this check. The port is assumed to be alive.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Modified scheduling configuration of keepalived. It is supposed to give more resources/priority so that keepalived is less prone to miss its healtchecks in a scenario where it gets less CPU than it needs.

**- How to verify it**
Deploy a cluster using metal platform. Confirm installation succeeds. Use dev-scripts or any other test environment of your choice.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Scheduling configuration for keepalived process has been changed. As a result, the process should be more robust and unnecessary VIP failovers should be happening less often.

Fixes: OCPBUGS-61384