### PR TITLE
OCPBUGS-54682: Fix - NetworkManager restart or crash renders br-ex unusable

### DIFF
--- a/templates/common/_base/files/ofport-request.yaml
+++ b/templates/common/_base/files/ofport-request.yaml
@@ -59,9 +59,13 @@ contents:
     fi
 
     # Get the bridge name
-    BRIDGE_NAME=$(nmcli -t -f connection.interface-name conn show "${BRIDGE_ID}" | awk -F ':' '{print $NF}')
+    BRIDGE_NAME=$(nmcli -t -f connection.interface-name conn show "${BRIDGE_ID}" | awk -F ':' '{print $NF}') || true
     # Limit this to br-ex and br-ex1 only. If one wanted to enable this for all OVS bridges,
     # the condition would be: if [ "$BRIDGE_NAME" == "" ]; then
+    # OCPBUGS-54682: If the condition is not met the first time it will check for br-ex-br to see if there is a K-NMS managed br-ex.
+    if [ "${BRIDGE_NAME}" != "br-ex" ] && [ "${BRIDGE_NAME}" != "br-ex1" ]; then
+        BRIDGE_NAME=$(nmcli -t -f connection.interface-name conn show "br-ex-br" | awk -F ':' '{print $NF}')
+    fi
     if [ "${BRIDGE_NAME}" != "br-ex" ] && [ "${BRIDGE_NAME}" != "br-ex1" ]; then
         exit 0
     fi


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Restarting Network Manager on a node will lead to the node losing connection if the nodes `br-ex` interface is being managed by nmstate. This is happening because the ofport dispatcher script does not take into account that the `br-ex` bridge ID is `br-ex-br` instead of `br-ex`. This PR is adding a check to fall back to check for nmstate managed `br-ex` if no bridge ID can be found.

**- How to verify it**
Deploy a nmstate managed br-ex cluster.
Restart NetworkManager using `systemctl restart NetworkManager`.
Node will lose connection if fix was unsuccessful. 
Node will retain connection if fix was successful.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed an issue where restarting or crashing NetworkManager on nodes with a `br-ex` interface managed by nmstate would cause the node to lose network connectivity.

* Root Cause:
The ofport dispatcher script did not account for nmstate-managed `br-ex` bridges, which use the bridge ID `br-ex-br` instead of `br-ex` This caused the script to fail when NetworkManager was restarted.
* Solution:
Added a fallback check in the ofport dispatcher script to properly detect nmstate-managed `br-ex` interfaces by checking for the `br-ex-br` bridge ID when the standard `br-ex` bridge ID is not found.