### PR TITLE
OCPBUGS-62095: CRI-O: set hard/soft file descriptor ulimits to `1048576`

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,9 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    default_ulimits = [
+      "nofile=1048576",
+    ]
 
     [crio.runtime.runtimes.runc]
     runtime_root = "/run/runc"

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,9 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    default_ulimits = [
+      "nofile=1048576",
+    ]
 
     [crio.runtime.runtimes.runc]
     runtime_root = "/run/runc"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,9 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    default_ulimits = [
+      "nofile=1048576",
+    ]
 
     [crio.runtime.runtimes.runc]
     runtime_root = "/run/runc"


### PR DESCRIPTION
Change the default ulimits for CRI-O to resolve the mentioned issue in https://issues.redhat.com/browse/OCPBUGS-62095