### PR TITLE
OCPBUGS-62232: Set -fin timeouts in HAProxy config

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -17,6 +17,8 @@ contents:
       timeout client       86400s
       timeout server       86400s
       timeout tunnel       86400s
+      timeout client-fin   1s
+      timeout server-fin   1s
     {{`{{- if gt (len .LBConfig.Backends) 0 }}`}}
     frontend  main
       bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6


### PR DESCRIPTION
We have a bug where misbehaved clients are exhausting the connection limits by starting a connection and abandoning it before it is even established. Setting the client-fin timeout is a recommended option to address this sort of situation. This patch also sets server-fin in the interest of symmetry and avoiding any similar issues on the server side.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
