### PR TITLE
OCPBUGS-62295: Shorten HAProxy timeouts

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -17,6 +17,8 @@ contents:
       timeout client       86400s
       timeout server       86400s
       timeout tunnel       86400s
+      timeout client-fin   1s
+      timeout server-fin   1s
     {{`{{- if gt (len .LBConfig.Backends) 0 }}`}}
     frontend  main
       bind :::{{`{{ .LBConfig.LbPort }}`}} v4v6

--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -14,9 +14,9 @@ contents:
       timeout http-request 30s
       timeout queue        1m
       timeout connect      10s
-      timeout client       86400s
-      timeout server       86400s
-      timeout tunnel       86400s
+      timeout client       1m
+      timeout server       1m
+      timeout tunnel       5m
       timeout client-fin   1s
       timeout server-fin   1s
     {{`{{- if gt (len .LBConfig.Backends) 0 }}`}}


### PR DESCRIPTION
I'm not sure why we set these to 24 hours in the first place, but
it doesn't match what we document in our sample UPI HAProxy config,
nor can I find any justification for why one would want such long
timeouts. This changes our client and server timeouts to be 1m,
matching the documented values. It also sets the tunnel timeout to
5m, which is not covered at all in the documentation but according
to HAProxy docs should generally be longer than other timeouts since
tunnel connection tend to be longer lived.

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
