### PR TITLE
OCPBUGS-57473: extract oc binary instead of pulling OS image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     if ! rpm -q util-linux; then dnf install -y util-linux; fi && \
     # We also need to install fuse-overlayfs and cpp for Buildah to work correctly.
     if ! rpm -q buildah; then dnf install -y buildah fuse-overlayfs cpp --exclude container-selinux; fi && \
+    # Install the oc binary.
+    if ! rpm -q openshift-clients; then dnf install -y openshift-clients; fi && \
     # Create the build user which will be used for doing OS image builds. We
     # use the username "build" and the uid 1000 since this matches what is in
     # the official Buildah image.

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -35,6 +35,8 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     if ! rpm -q util-linux; then dnf install -y util-linux; fi && \
     # We also need to install fuse-overlayfs and cpp for Buildah to work correctly.
     if ! rpm -q buildah; then dnf install -y buildah fuse-overlayfs cpp --exclude container-selinux; fi && \
+    # Install the oc binary.
+    if ! rpm -q openshift-clients; then dnf install -y openshift-clients; fi && \
     # Create the build user which will be used for doing OS image builds. We
     # use the username "build" and the uid 1000 since this matches what is in
     # the official Buildah image.

--- a/pkg/controller/build/buildrequest/assets/create-digest-cm.sh
+++ b/pkg/controller/build/buildrequest/assets/create-digest-cm.sh
@@ -6,7 +6,20 @@
 
 set -xeuo
 
-# Inject the contents of the digestfile into a ConfigMap.
+# Check if the oc command is available.
+if command -v "oc" &> /dev/null; then
+    echo "Using built-in oc command"
+else
+    # If the oc command is not available, check under /tmp/done/oc.
+    if [[ -x /tmp/done/oc ]]; then
+        # Add this to our PATH if found.
+        export PATH="$PATH:/tmp/done"
+    else
+        # If it cannot be found, return a non-zero exit code.
+        echo "oc command not found"
+        exit 1
+    fi
+fi
 
 # Create and label the digestfile ConfigMap
 if ! oc create configmap \

--- a/pkg/controller/build/buildrequest/buildrequest_test.go
+++ b/pkg/controller/build/buildrequest/buildrequest_test.go
@@ -211,6 +211,8 @@ func assertSecretInCorrectFormat(t *testing.T, secret *corev1.Secret) {
 }
 
 func assertBuildJobIsCorrect(t *testing.T, buildJob *batchv1.Job, opts BuildRequestOpts) {
+	t.Helper()
+
 	etcRpmGpgKeysOpts := optsForEtcRpmGpgKeys()
 	assertBuildJobMatchesExpectations(t, opts.HasEtcPkiRpmGpgKeys, buildJob,
 		etcRpmGpgKeysOpts.envVar(),
@@ -233,12 +235,7 @@ func assertBuildJobIsCorrect(t *testing.T, buildJob *batchv1.Job, opts BuildRequ
 	)
 
 	assert.Equal(t, buildJob.Spec.Template.Spec.InitContainers[0].Image, mcoImagePullspec)
-	expectedPullspecs := []string{
-		"base-os-image-from-machineosconfig",
-		fixtures.OSImageURLConfig().BaseOSContainerImage,
-	}
-
-	assert.Contains(t, expectedPullspecs, buildJob.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, buildJob.Spec.Template.Spec.Containers[0].Image, mcoImagePullspec)
 
 	assertPodHasVolume(t, buildJob.Spec.Template.Spec, corev1.Volume{
 		Name: "final-image-push-creds",


### PR DESCRIPTION
**- What I did**

The first-pass of OCL made use of the fact that the OS image has the `oc` binary so that we would always have the most appropriate version of the binary for a given OpenShift release. Unfortunately, this has the following side effects:

- Builds take much longer since the base OS image must be pulled twice; and it is a large image.
- It causes issues with garbage collection on the node after the build pod has been run there.

There are two paths forward to mitigate this:
1. Install the `openshift-clients` package into the MCO image.
2. Extract the `oc` binary from the base OS image after we've used it.

For 4.19 and 4.20, we can use the first approach. For 4.18, we must use the latter approach. Here's why:
- There were SSL verification failures whenever the DNF wrapper script tries to run `dnf install openshift-clients`. It does not work correctly in the base image we use in 4.18 (`registry.ci.openshift.org/ocp/builder:rhel-9-enterprise-base-multi-openshift-4.18`) or 4.19 (`registry.ci.openshift.org/ocp/builder:rhel-9-enterprise-base-multi-openshift-4.18`).
- The reason we chose this as the base image for development is because they are manifestlisted and have multi-arch support. Since our team has a heterogenous mix of workstations, this is a requirement for us. Luckily, the newer base images `registry.ci.openshift.org/ocp/4.19:base-rhel9` and `registry.ci.openshift.org/ocp/4.20:base-rhel9` are manifestlisted and have multi-arch support. Unfortunately, the 4.18 version of this image does not. That said, I have added some conditional logic to handle this case better.

So what we do now is install the `oc` binary in the container image where / when possible. We check if the binary is present and if not, we extract it from the base OS image after the build is complete. Otherwise, we use the `oc` binary as-is if it is indeed present.

**- How to verify it**

1. Opt into OCL and perform a build.
2. Note which node the build is running on.
3. Retrieve the base OS image pullspec: `$ oc get configmap/machine-config-osimageurl -n openshift-machine-config-operator -o json | jq -r '.data.baseOSContainerImage'`
3. oc debug into the node and run `crictl images -o json | grep "<base os image pullspec>"`. The base OS image should not be found in CRI-O's container image storage.

It is worth noting that the reason why the image should not be found there is because the Buildah pod cannot touch the host's container image storage.

**- Description for the changelog**
Extract `oc` binary after OCL build
