### PR TITLE
OCPBUGS-62671: [release-4.18] Networking: reset ovn-remote config and allow ovnkube controller to set it

### DIFF
--- a/templates/common/_base/files/configure-ovs-network.yaml
+++ b/templates/common/_base/files/configure-ovs-network.yaml
@@ -5,6 +5,13 @@ contents:
     #!/bin/bash
     set -x
 
+    # Clear ovn-remote config to connect to OVN DBs.
+    # ovnkube controller will set it on startup.
+    # May remove when https://issues.redhat.com/browse/FDP-1537 is availabe
+    # However it may also be a good idea to leave this because we don't want
+    # ovn-controller syncing to a stale OVN southbound database.
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-remote=" "
+
     if [ -e /etc/nmstate/openshift/applied ]; then
       echo "Skipping configure-ovs due to manual network configuration"
       exit 0


### PR DESCRIPTION
…et it

This fixes the issue where ovn-remote is set
prior to reboot and when boot occurs, ovn-controller syncs quickly with a stale SB DB.

This PR is part of the EIP GARP issue fix.
Its required because when ovnkube-controller and
ovn-controller container start on boot, there
is no order to which container will start first,
and we dont want ovn-controller to connect to SB DB before ovnkube controller has added the drop flows.

Ideally, we would only allow ovn-controller to sync with SB DB when ovnkube controller has concluded
syncing and the changes are available in SB DB.
That maybe future work.


(cherry picked from commit 567a191e7d8a67fb371c15c9a5e350d18add9a03) (cherry picked from commit 98291f7de333d83f5eafce2c11ea33e250c882e2)


/hold

Depends on https://github.com/openshift/machine-config-operator/pull/5324