### PR TITLE
OCPBUGS-62714: Temporary policy.json for PIS rpm-ostree rebasing

### DIFF
--- a/pkg/daemon/command_runner.go
+++ b/pkg/daemon/command_runner.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// CommandRunner abstracts command execution for testing and flexibility.
+type CommandRunner interface {
+	// RunGetOut executes a command and returns its stdout output.
+	// On error, stderr is included in the error message.
+	RunGetOut(command string, args ...string) ([]byte, error)
+}
+
+// CommandRunnerOS is the production implementation that executes real OS commands.
+type CommandRunnerOS struct{}
+
+// RunGetOut executes a command, logs it, and returns stdout.
+// On error, stderr is included in the error message (truncated to 256 chars).
+func (r *CommandRunnerOS) RunGetOut(command string, args ...string) ([]byte, error) {
+	klog.Infof("Running captured: %s %s", command, strings.Join(args, " "))
+	cmd := exec.Command(command, args...)
+	rawOut, err := cmd.Output()
+	if err != nil {
+		errtext := ""
+		if e, ok := err.(*exec.ExitError); ok {
+			// Trim to max of 256 characters
+			errtext = fmt.Sprintf("\n%s", truncate(string(e.Stderr), 256))
+		}
+		return nil, fmt.Errorf("error running %s %s: %s%s", command, strings.Join(args, " "), err, errtext)
+	}
+	return rawOut, nil
+}
+
+// TODO: Delete this function to always consume the interface instance
+// Tracking story: https://issues.redhat.com/browse/MCO-1924
+//
+//	Conserved the old signature to avoid a big footprint bugfix with this change
+func runGetOut(command string, args ...string) ([]byte, error) {
+	return (&CommandRunnerOS{}).RunGetOut(command, args...)
+}
+
+// MockCommandRunner is a test implementation that returns pre-configured outputs.
+type MockCommandRunner struct {
+	outputs map[string][]byte
+	errors  map[string]error
+}
+
+// RunGetOut returns pre-configured output or error based on the command string.
+// It matches commands using "command arg1 arg2..." as the key.
+// Returns an error if no matching output or error is found.
+func (m *MockCommandRunner) RunGetOut(command string, args ...string) ([]byte, error) {
+	key := command + " " + strings.Join(args, " ")
+	if out, ok := m.outputs[key]; ok {
+		return out, nil
+	}
+	if err, ok := m.errors[key]; ok {
+		return nil, err
+	}
+	return nil, fmt.Errorf("no output for command %s found", command)
+}

--- a/pkg/daemon/command_runner_test.go
+++ b/pkg/daemon/command_runner_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandRunnerOS_RunGetOut(t *testing.T) {
+	runner := &CommandRunnerOS{}
+
+	// Test successful command with no output
+	o, err := runner.RunGetOut("true")
+	assert.Nil(t, err)
+	assert.Equal(t, len(o), 0)
+
+	// Test failed command
+	o, err = runner.RunGetOut("false")
+	assert.NotNil(t, err)
+
+	// Test successful command with output
+	o, err = runner.RunGetOut("echo", "hello")
+	assert.Nil(t, err)
+	assert.Equal(t, string(o), "hello\n")
+
+	// Test command that outputs to stderr and exits with error
+	// base64 encode "oops" so we can't match on the command arguments
+	o, err = runner.RunGetOut("/bin/sh", "-c", "echo hello; echo b29vcwo== | base64 -d 1>&2; exit 1")
+	assert.Error(t, err)
+	errtext := err.Error()
+	assert.Contains(t, errtext, "exit status 1\nooos\n")
+
+	// Test command that doesn't exist
+	o, err = runner.RunGetOut("/usr/bin/test-failure-to-exec-this-should-not-exist", "arg")
+	assert.Error(t, err)
+}
+
+func TestMockCommandRunner_RunGetOut(t *testing.T) {
+	// Test mock with pre-configured output
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"echo hello":        []byte("hello\n"),
+			"rpm-ostree status": []byte("State: idle\n"),
+		},
+		errors: map[string]error{},
+	}
+
+	o, err := mock.RunGetOut("echo", "hello")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("hello\n"), o)
+
+	o, err = mock.RunGetOut("rpm-ostree", "status")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("State: idle\n"), o)
+
+	// Test mock with pre-configured error
+	mock = &MockCommandRunner{
+		outputs: map[string][]byte{},
+		errors: map[string]error{
+			"cmd --fail": assert.AnError,
+		},
+	}
+
+	o, err = mock.RunGetOut("cmd", "--fail")
+	assert.Error(t, err)
+	assert.Equal(t, assert.AnError, err)
+
+	// Test mock with no matching command (should return error)
+	mock = &MockCommandRunner{
+		outputs: map[string][]byte{},
+		errors:  map[string]error{},
+	}
+
+	o, err = mock.RunGetOut("unknown", "command")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no output for command")
+}
+
+func TestMockCommandRunner_Priority(t *testing.T) {
+	// Test that outputs take priority over errors
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"test cmd": []byte("output\n"),
+		},
+		errors: map[string]error{
+			"test cmd": assert.AnError,
+		},
+	}
+
+	o, err := mock.RunGetOut("test", "cmd")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("output\n"), o)
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -165,6 +165,12 @@ type Daemon struct {
 
 	// Ensures that only a single syncOSImagePullSecrets call can run at a time.
 	osImageMux *sync.Mutex
+
+	// Abstraction for running commands against the OS
+	cmdRunner CommandRunner
+
+	// Bare minimal podman client
+	podmanInterface PodmanInterface
 }
 
 // CoreOSDaemon protects the methods that should only be called on CoreOS variants
@@ -307,10 +313,11 @@ func New(
 	}
 
 	var nodeUpdaterClient *RpmOstreeClient
-
+	cmdRunner := &CommandRunnerOS{}
+	podmanInterface := NewPodmanExec(cmdRunner)
 	// Only pull the osImageURL from OSTree when we are on RHCOS or FCOS
 	if hostos.IsCoreOSVariant() {
-		nodeUpdaterClientVal := NewNodeUpdaterClient()
+		nodeUpdaterClientVal := NewNodeUpdaterClient(cmdRunner, podmanInterface)
 		nodeUpdaterClient = &nodeUpdaterClientVal
 		err := nodeUpdaterClient.Initialize()
 		if err != nil {
@@ -348,6 +355,8 @@ func New(
 		configDriftMonitor:     NewConfigDriftMonitor(),
 		osImageMux:             &sync.Mutex{},
 		irreconcilableReporter: NewNoOpIrreconcilableReporterImpl(),
+		cmdRunner:              cmdRunner,
+		podmanInterface:        podmanInterface,
 	}, nil
 }
 

--- a/pkg/daemon/image_manager_helper.go
+++ b/pkg/daemon/image_manager_helper.go
@@ -5,13 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
-	"time"
 
-	"github.com/opencontainers/go-digest"
-	pivotutils "github.com/openshift/machine-config-operator/pkg/daemon/pivot/utils"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
@@ -33,74 +28,11 @@ const (
 
 type imageSystem string
 
-// imageInspection is a public implementation of
-// https://github.com/containers/skopeo/blob/82186b916faa9c8c70cfa922229bafe5ae024dec/cmd/skopeo/inspect.go#L20-L31
-type imageInspection struct {
-	Name          string `json:",omitempty"`
-	Tag           string `json:",omitempty"`
-	Digest        digest.Digest
-	RepoDigests   []string
-	Created       *time.Time
-	DockerVersion string
-	Labels        map[string]string
-	Architecture  string
-	Os            string
-	Layers        []string
-}
-
 // BootedImageInfo stores MCO interested bootec image info
 type BootedImageInfo struct {
 	OSImageURL   string
 	ImageVersion string
 	BaseChecksum string
-}
-
-func podmanInspect(imgURL string) (imgdata *imageInspection, err error) {
-	// Pull the container image if not already available
-	var authArgs []string
-	if _, err := os.Stat(kubeletAuthFile); err == nil {
-		authArgs = append(authArgs, "--authfile", kubeletAuthFile)
-	}
-	args := []string{"pull", "-q"}
-	args = append(args, authArgs...)
-	args = append(args, imgURL)
-	_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
-	if err != nil {
-		return
-	}
-
-	inspectArgs := []string{"inspect", "--type=image"}
-	inspectArgs = append(inspectArgs, fmt.Sprintf("%s", imgURL))
-	var output []byte
-	output, err = runGetOut("podman", inspectArgs...)
-	if err != nil {
-		return
-	}
-	var imagedataArray []imageInspection
-	err = json.Unmarshal(output, &imagedataArray)
-	if err != nil {
-		err = fmt.Errorf("unmarshaling podman inspect: %w", err)
-		return
-	}
-	imgdata = &imagedataArray[0]
-	return
-
-}
-
-// runGetOut executes a command, logging it, and return the stdout output.
-func runGetOut(command string, args ...string) ([]byte, error) {
-	klog.Infof("Running captured: %s %s", command, strings.Join(args, " "))
-	cmd := exec.Command(command, args...)
-	rawOut, err := cmd.Output()
-	if err != nil {
-		errtext := ""
-		if e, ok := err.(*exec.ExitError); ok {
-			// Trim to max of 256 characters
-			errtext = fmt.Sprintf("\n%s", truncate(string(e.Stderr), 256))
-		}
-		return nil, fmt.Errorf("error running %s %s: %s%s", command, strings.Join(args, " "), err, errtext)
-	}
-	return rawOut, nil
 }
 
 // truncate a string using runes/codepoints as limits.

--- a/pkg/daemon/podman.go
+++ b/pkg/daemon/podman.go
@@ -1,0 +1,89 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PodmanStorageConfig contains storage configuration from Podman.
+type PodmanStorageConfig struct {
+	GraphDriverName string `json:"graphDriverName"`
+	GraphRoot       string `json:"graphRoot"`
+}
+
+// PodmanInfo contains system information from Podman.
+type PodmanInfo struct {
+	Store PodmanStorageConfig `json:"store"`
+}
+
+// PodmanImageInfo contains image metadata from Podman.
+type PodmanImageInfo struct {
+	ID          string   `json:"Id"`
+	Digest      string   `json:"Digest"`
+	RepoDigests []string `json:"RepoDigests"`
+	RepoDigest  string   `json:"-"` // Filled with matching digest from RepoDigests
+}
+
+// PodmanInterface abstracts podman operations for testing and flexibility.
+type PodmanInterface interface {
+	// GetPodmanImageInfoByReference retrieves image info for the given reference.
+	// Returns nil if no image is found.
+	GetPodmanImageInfoByReference(reference string) (*PodmanImageInfo, error)
+	// GetPodmanInfo retrieves Podman system information.
+	GetPodmanInfo() (*PodmanInfo, error)
+}
+
+// PodmanExecInterface is the production implementation that executes real podman commands.
+type PodmanExecInterface struct {
+	cmdRunner CommandRunner
+}
+
+// NewPodmanExec creates a new PodmanExecInterface with the given command runner.
+func NewPodmanExec(commandRunner CommandRunner) *PodmanExecInterface {
+	return &PodmanExecInterface{cmdRunner: commandRunner}
+}
+
+// GetPodmanImageInfoByReference retrieves image info for the given reference.
+// It executes 'podman images --format=json --filter reference=<reference>'.
+// Returns nil if no image is found.
+// The RepoDigest field is populated if the reference matches one of the RepoDigests.
+func (p *PodmanExecInterface) GetPodmanImageInfoByReference(reference string) (*PodmanImageInfo, error) {
+	output, err := p.cmdRunner.RunGetOut("podman", "images", "--format=json", "--filter", "reference="+reference)
+	if err != nil {
+		return nil, err
+	}
+	var podmanInfos []PodmanImageInfo
+	if err := json.Unmarshal(output, &podmanInfos); err != nil {
+		return nil, fmt.Errorf("failed to decode podman image ls output: %v", err)
+	}
+	if len(podmanInfos) == 0 {
+
+		return nil, nil
+	}
+
+	info := &podmanInfos[0]
+	// Fill the custom RepoDigest field with the digest that matches the
+	// requested reference as it's convenient to be used by the caller
+	for _, digest := range info.RepoDigests {
+		if digest == reference {
+			info.RepoDigest = digest
+			break
+		}
+	}
+
+	return info, nil
+}
+
+// GetPodmanInfo retrieves Podman system information.
+// It executes 'podman system info --format=json'.
+func (p *PodmanExecInterface) GetPodmanInfo() (*PodmanInfo, error) {
+	output, err := p.cmdRunner.RunGetOut("podman", "system", "info", "--format=json")
+	if err != nil {
+		return nil, err
+	}
+	var podmanInfo PodmanInfo
+	if err := json.Unmarshal(output, &podmanInfo); err != nil {
+		return nil, fmt.Errorf("failed to decode podman system info output: %v", err)
+	}
+	return &podmanInfo, nil
+}

--- a/pkg/daemon/podman_test.go
+++ b/pkg/daemon/podman_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPodmanImageInfoByReference_Success(t *testing.T) {
+	reference := "quay.io/openshift/test:latest"
+	imageInfo := []PodmanImageInfo{
+		{
+			ID:     "abc123",
+			Digest: "sha256:1234567890abcdef",
+			RepoDigests: []string{
+				"quay.io/openshift/test@sha256:1234567890abcdef",
+				reference,
+			},
+		},
+	}
+
+	jsonOutput, err := json.Marshal(imageInfo)
+	require.Nil(t, err)
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman images --format=json --filter reference=" + reference: jsonOutput,
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanImageInfoByReference(reference)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, "abc123", info.ID)
+	assert.Equal(t, "sha256:1234567890abcdef", info.Digest)
+	assert.Equal(t, reference, info.RepoDigest)
+	assert.Len(t, info.RepoDigests, 2)
+}
+
+func TestGetPodmanImageInfoByReference_NoMatch(t *testing.T) {
+	reference := "quay.io/openshift/nonexistent:latest"
+	// If there are no matches podman returns an empty string
+	jsonOutput := []byte("[]")
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman images --format=json --filter reference=" + reference: jsonOutput,
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanImageInfoByReference(reference)
+
+	assert.Nil(t, err)
+	assert.Nil(t, info)
+}
+
+func TestGetPodmanImageInfoByReference_CommandError(t *testing.T) {
+	reference := "quay.io/openshift/test:latest"
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{},
+		errors: map[string]error{
+			"podman images --format=json --filter reference=" + reference: fmt.Errorf("podman command failed"),
+		},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanImageInfoByReference(reference)
+
+	assert.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "podman command failed")
+}
+
+func TestGetPodmanImageInfoByReference_InvalidJSON(t *testing.T) {
+	reference := "quay.io/openshift/test:latest"
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman images --format=json --filter reference=" + reference: []byte("invalid json"),
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanImageInfoByReference(reference)
+
+	assert.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "failed to decode podman image ls output")
+}
+
+func TestGetPodmanImageInfoByReference_RepoDigestMatching(t *testing.T) {
+	reference := "quay.io/openshift/test@sha256:specific"
+	imageInfo := []PodmanImageInfo{
+		{
+			ID:     "xyz789",
+			Digest: "sha256:specific",
+			RepoDigests: []string{
+				"quay.io/openshift/test@sha256:other",
+				reference,
+				"quay.io/openshift/test@sha256:another",
+			},
+		},
+	}
+
+	jsonOutput, err := json.Marshal(imageInfo)
+	require.Nil(t, err)
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman images --format=json --filter reference=" + reference: jsonOutput,
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanImageInfoByReference(reference)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, reference, info.RepoDigest)
+}
+
+func TestGetPodmanImageInfoByReference_NoRepoDigestMatch(t *testing.T) {
+	reference := "quay.io/openshift/test:tag"
+	imageInfo := []PodmanImageInfo{
+		{
+			ID:     "xyz789",
+			Digest: "sha256:specific",
+			RepoDigests: []string{
+				"quay.io/openshift/test@sha256:other",
+			},
+		},
+	}
+
+	jsonOutput, err := json.Marshal(imageInfo)
+	require.Nil(t, err)
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman images --format=json --filter reference=" + reference: jsonOutput,
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanImageInfoByReference(reference)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	// RepoDigest should be empty since reference doesn't match any RepoDigests
+	assert.Equal(t, "", info.RepoDigest)
+}
+
+func TestGetPodmanInfo_Success(t *testing.T) {
+	podmanInfo := PodmanInfo{
+		Store: PodmanStorageConfig{
+			GraphDriverName: "overlay",
+			GraphRoot:       "/var/lib/containers/storage",
+		},
+	}
+
+	jsonOutput, err := json.Marshal(podmanInfo)
+	require.Nil(t, err)
+
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman system info --format=json": jsonOutput,
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanInfo()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, "overlay", info.Store.GraphDriverName)
+	assert.Equal(t, "/var/lib/containers/storage", info.Store.GraphRoot)
+}
+
+func TestGetPodmanInfo_CommandError(t *testing.T) {
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{},
+		errors: map[string]error{
+			"podman system info --format=json": fmt.Errorf("podman system info failed"),
+		},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanInfo()
+
+	assert.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "podman system info failed")
+}
+
+func TestGetPodmanInfo_InvalidJSON(t *testing.T) {
+	mock := &MockCommandRunner{
+		outputs: map[string][]byte{
+			"podman system info --format=json": []byte("not valid json"),
+		},
+		errors: map[string]error{},
+	}
+
+	podman := NewPodmanExec(mock)
+	info, err := podman.GetPodmanInfo()
+
+	assert.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "failed to decode podman system info output")
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -447,47 +447,29 @@ func podmanRemove(cid string) {
 	exec.Command("podman", "rm", "-f", cid).Run()
 }
 
-// return true if the image is present
-func isImagePresent(imgURL string) (bool, error) {
-	// search the image
-	var imageSearch []byte
-	imageSearch, err := runGetOut("podman", "images", "-q", "--filter", fmt.Sprintf("reference=%s", imgURL))
-	if err != nil {
-		return false, fmt.Errorf("error searching the image: %w", err)
+func pullExtensionsImage(podmanInterface PodmanInterface, imgURL string) error {
+	// Check if the image is present
+	podmanImageInfo, err := podmanInterface.GetPodmanImageInfoByReference(imgURL)
+	if err != nil || podmanImageInfo != nil {
+		// The image exists (ok) or an error happened
+		return err
 	}
-	if strings.TrimSpace(string(imageSearch)) == "" {
-		return false, nil
+
+	// The image is not present, pull it
+	var authArgs []string
+	if _, err := os.Stat(kubeletAuthFile); err == nil {
+		authArgs = append(authArgs, "--authfile", kubeletAuthFile)
 	}
-	return true, nil
+	args := []string{"pull", "-q"}
+	args = append(args, authArgs...)
+	args = append(args, imgURL)
+	_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
+	return err
 }
 
 func podmanCopy(imgURL, osImageContentDir string) (err error) {
-	// arguments used in external commands
-	var args []string
-
 	// make sure that osImageContentDir doesn't exist
 	os.RemoveAll(osImageContentDir)
-
-	// Check if the image is present
-	imagePresent, err := isImagePresent(imgURL)
-	if err != nil {
-		return
-	}
-
-	// Pull the container image
-	if !imagePresent {
-		var authArgs []string
-		if _, err := os.Stat(kubeletAuthFile); err == nil {
-			authArgs = append(authArgs, "--authfile", kubeletAuthFile)
-		}
-		args = []string{"pull", "-q"}
-		args = append(args, authArgs...)
-		args = append(args, imgURL)
-		_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
-		if err != nil {
-			return
-		}
-	}
 
 	// create a container
 	var cidBuf []byte
@@ -502,7 +484,7 @@ func podmanCopy(imgURL, osImageContentDir string) (err error) {
 
 	// copy the content from create container locally into a temp directory under /run/
 	cid := strings.TrimSpace(string(cidBuf))
-	args = []string{"cp", fmt.Sprintf("%s:/", cid), osImageContentDir}
+	args := []string{"cp", fmt.Sprintf("%s:/", cid), osImageContentDir}
 	_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
 	if err != nil {
 		return
@@ -520,7 +502,7 @@ func podmanCopy(imgURL, osImageContentDir string) (err error) {
 
 // ExtractExtensionsImage extracts the OS extensions content in a temporary directory under /run/machine-os-extensions
 // and returns the path on successful extraction
-func ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, err error) {
+func (dn *CoreOSDaemon) ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, err error) {
 	if err = os.MkdirAll(osExtensionsContentBaseDir, 0o755); err != nil {
 		err = fmt.Errorf("error creating directory %s: %w", osExtensionsContentBaseDir, err)
 		return
@@ -529,7 +511,9 @@ func ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, 
 	if osExtensionsImageContentDir, err = os.MkdirTemp(osExtensionsContentBaseDir, "os-extensions-content-"); err != nil {
 		return
 	}
-
+	if err := pullExtensionsImage(dn.podmanInterface, imgURL); err != nil {
+		return osExtensionsImageContentDir, fmt.Errorf("error pulling extensions image %s: %w", imgURL, err)
+	}
 	// Extract the image using `podman cp`
 	return osExtensionsImageContentDir, podmanCopy(imgURL, osExtensionsImageContentDir)
 }
@@ -2586,9 +2570,9 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 
 	// If PIS is configured check if the image is locally present. If so, rebase using
 	// the local image
-	isOsImagePresent := false
+	var podmanImageInfo *PodmanImageInfo
 	if isPisConfigured {
-		if isOsImagePresent, err = isImagePresent(newURL); err != nil {
+		if podmanImageInfo, err = dn.podmanInterface.GetPodmanImageInfoByReference(newURL); err != nil {
 			return err
 		}
 	}
@@ -2603,8 +2587,8 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 		}
 	}
 
-	if isOsImagePresent {
-		if err := dn.NodeUpdaterClient.RebaseLayeredFromContainerStorage(newURL); err != nil {
+	if podmanImageInfo != nil {
+		if err := dn.NodeUpdaterClient.RebaseLayeredFromContainerStorage(podmanImageInfo); err != nil {
 			return fmt.Errorf("failed to update OS from local storage: %s: %w", newURL, err)
 		}
 	} else {
@@ -2704,6 +2688,11 @@ func (dn *Daemon) isPinnedImageSetConfigured() (bool, error) {
 	return false, nil
 }
 
+// TODO: Delete this function to always consume the CommandRunner interface instance
+// Tracking story: https://issues.redhat.com/browse/MCO-1925
+//
+//	Conserved the old signature to avoid a big footprint bugfix with this change
+//
 // Synchronously invoke a command, writing its stdout to our stdout,
 // and gathering stderr into a buffer which will be returned in err
 // in case of error.
@@ -2880,7 +2869,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 			}
 		}
 
-		if osExtensionsContentDir, err = ExtractExtensionsImage(newConfig.Spec.BaseOSExtensionsContainerImage); err != nil {
+		if osExtensionsContentDir, err = dn.ExtractExtensionsImage(newConfig.Spec.BaseOSExtensionsContainerImage); err != nil {
 			// Report ImagePulledFromRegistry condition as false (failed)
 			if imageModeStatusReportingEnabled {
 				err := upgrademonitor.GenerateAndApplyMachineConfigNodes(

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -737,45 +737,6 @@ func TestOriginalFileBackupRestore(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestIsImagePresent(t *testing.T) {
-	// Create a temporary directory for the mock "podman" command.
-	tmpDir, err := os.MkdirTemp("", "*.test")
-	require.Nil(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	// Create the script that mocks the "podman" command:
-	podmanScript := filepath.Join(tmpDir, "podman")
-	err = os.WriteFile(
-		podmanScript,
-		[]byte(
-			"#!/bin/bash\n"+
-				"if [[ \"$4\" =~ test-true ]]; then\n"+
-				"  echo '1b57f04f6da8'\n"+
-				"else\n"+
-				"  echo ''\n"+
-				"fi\n"+
-				"exit 0\n",
-		),
-		0700,
-	)
-	require.Nil(t, err)
-
-	// Change the "PATH" environment variable for the execution of the rest of the test:
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-	newPath := fmt.Sprintf("%s%c%s", tmpDir, os.PathListSeparator, oldPath)
-	os.Setenv("PATH", newPath)
-
-	// Test the function:
-	imagePresent, err := isImagePresent("quay.io/openshift-release-dev/test-true")
-	assert.Nil(t, err)
-	assert.True(t, imagePresent)
-
-	imagePresent, err = isImagePresent("quay.io/openshift-release-dev/test-false")
-	assert.Nil(t, err)
-	assert.False(t, imagePresent)
-}
-
 func TestFindClosestFilePolicyPathMatch(t *testing.T) {
 
 	policyActions := map[string][]opv1.NodeDisruptionPolicyStatusAction{


### PR DESCRIPTION
Closes: OCPBUGS-62714

**- What I did**

  This commit addresses OCPBUGS-61714 by implementing a temporary container image policy override for rpm-ostree operations when pulling images from local container storage.

  **The Problem:**
  When using PinnedImageSets with restrictive container image policies, rpm-ostree fails to pull OS images from local storage during updates. The issue occurs because:
  - PinnedImageSets pre-pull images into local container storage
  - Restrictive policies (where users removed the default "insecureAcceptAnything" policy) don't explicitly allow the containers-storage transport
  - rpm-ostree is blocked by the policy when attempting to rebase from the locally stored image

  **The Solution:**
  Create a temporary, non-invasive policy override mechanism:
  - Generates a temporary policy file (/run/tmp-rpm-ostree-policy.json) that includes an insecureAcceptAnything rule specifically for the target image in containers-storage
  - Uses a systemd drop-in to bind-mount this temporary policy over /etc/containers/policy.json for the rpm-ostreed service only
  - Automatically cleans up both the temporary policy and drop-in after the rebase operation completes
  - Skips the override entirely when existing policies are already permissive enough

  This ensures rpm-ostree can always pull from local storage when using PinnedImageSets without permanently modifying the system's security policies.

**- How to verify it**
1. Spin-up a 4.21 cluster that is not using the latest available version (just for the shake of making the update). Important: To truly test the change, select an install version with a CoreOS image different from the one you will use for the update.
2. Pin the CoreOS image of the update
```bash
# Get the CoreOS digest
COREOS_DIGEST=$(oc adm release info <update-release-image-pullspec> -o=jsonpath='{.references.spec.tags[?(@.name=="rhel-coreos")].from.name}')

# Apply the PIS resource and ensure the image is pulled in master nodes
cat <<EOF | oc apply -f - 
  apiVersion: machineconfiguration.openshift.io/v1
  kind: PinnedImageSet
  metadata:
    labels:
      machineconfiguration.openshift.io/role: master
    name: master-pinned-images
  spec:
    pinnedImages:
     - name: $COREOS_DIGEST
EOF
```
3. Wait for the image to be pulled in all the master nodes
```bash
oc get node -l node-role.kubernetes.io/master -o name | \
xargs -I {} oc debug {} -- chroot /host podman images --filter reference=$COREOS_DIGEST

Starting pod/pabrodri-test-c4w4f-master-0-debug-hj8b6 ...
To use host binaries, run `chroot /host`. Instead, if you need to access host namespaces, run `nsenter -a -t 1`.
REPOSITORY                                      TAG         IMAGE ID      CREATED     SIZE
quay.io/openshift-release-dev/ocp-v4.0-art-dev  <none>      f590b495c6cd  4 days ago  2.64 GB
### OUTPUT CROPPED FOR BREVITY. SAME OUTPUT FOR ALL MASTER NODES ###
 ```
5. Apply a restrictive pull policy:
```bash
oc patch image.config.openshift.io/cluster --type=merge -p '
{                                                 
  "spec": {
    "allowedRegistriesForImport": [
      {
        "domainName": "registry.ci.openshift.org",
        "insecure": false
      },
      {
        "domainName": "quay.io",
        "insecure": false
      },
      {
        "domainName": "registry.redhat.io",
        "insecure": false
      },
      {
        "domainName": "registry.connect.redhat.com",
        "insecure": false
      },
      {
        "domainName": "registry.access.redhat.com",
        "insecure": false
      },
      {
        "domainName": "registry-proxy.engineering.redhat.com",
        "insecure": false
      },
      {
        "domainName": "registry.stage.redhat.io",
        "insecure": false
      },
      {
        "domainName": "ghcr.io",
        "insecure": false
      }
    ],
    "registrySources": {
      "allowedRegistries": [
        "registry.ci.openshift.org",
        "quay.io",
        "registry.redhat.io",
        "registry.connect.redhat.com",
        "registry.access.redhat.com",
        "registry-proxy.engineering.redhat.com",
        "registry.stage.redhat.io",
        "ghcr.io"
      ]
    }
  }
}
'
```
6. Wait for the MCPs to rollout the change
7. Ensure the policy has been deployed. It should look like this in all nodes:
```bash
oc get node -l node-role.kubernetes.io/master -o name | \
xargs -I {} oc debug {} -- chroot /host cat /etc/containers/policy.json
Starting pod/pabrodri-test-c4w4f-master-0-debug-xv7c5 ...
To use host binaries, run `chroot /host`. Instead, if you need to access host namespaces, run `nsenter -a -t 1`.
{
  "default": [
    {
      "type": "reject"
    }
  ],
  "transports": {
    "atomic": {
      "ghcr.io": [
        {
          "type": "insecureAcceptAnything"
        }
      ],
      "quay.io": [
        {
          "type": "insecureAcceptAnything"
        }
      ],
      "registry-proxy.engineering.redhat.com": [
        {
          "type": "insecureAcceptAnything"
        }
      ],
      "registry.access.redhat.com": [
        {
          "type": "insecureAcceptAnything"
        }
      ],
      "registry.ci.openshift.org": [
        {
          "type": "insecureAcceptAnything"
        }
### OUTPUT CROPPED FOR BREVITY ###
```
9. Trigger the cluster update
```bash
oc adm upgrade --to-image=<update-release-image-pullspec>
```
10. Wait for the update to finish


**- Description for the changelog**

Fix rpm-ostree rebase failures from local container storage when using PinnedImageSets with restrictive image policies
