### PR TITLE
NO-ISSUE: Add AMI update automation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_grap
 
 all: binaries
 
-.PHONY: clean test test-unit test-e2e verify update install-tools
+.PHONY: clean test test-unit test-e2e verify update update-amis install-tools
 
 # Remove build artifaces
 # Example:
@@ -69,6 +69,13 @@ test-unit: install-go-junit-report
 #    make update
 update:
 	hack/update-templates.sh
+
+# Update the AMI list from the OpenShift installer repository.
+# Example:
+#    make update-amis
+update-amis:
+	python3 hack/update_amis.py
+
 go-deps:
 	go mod tidy
 	go mod vendor

--- a/hack/update_amis.py
+++ b/hack/update_amis.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+Script to update AMI list in ami.go from the OpenShift installer repository.
+
+This script:
+1. Fetches the rhcos.json file from the installer repo
+2. Steps back through git history from HEAD to the last recorded commit
+3. Extracts new AMI IDs from each commit
+4. Validates that no duplicate AMIs are being added
+5. Updates ami.go with new AMIs and the latest commit hash
+"""
+
+import os
+import re
+import sys
+import json
+import tempfile
+import subprocess
+from typing import Set, Dict, List, Tuple
+from pathlib import Path
+
+
+class Color:
+    """ANSI color codes for terminal output."""
+    RED = '\033[0;31m'
+    GREEN = '\033[0;32m'
+    YELLOW = '\033[1;33m'
+    BLUE = '\033[0;34m'
+    NC = '\033[0m'  # No Color
+
+
+def log_info(message: str):
+    """Print info message in green."""
+    print(f"{Color.GREEN}[INFO]{Color.NC} {message}")
+
+
+def log_warn(message: str):
+    """Print warning message in yellow."""
+    print(f"{Color.YELLOW}[WARN]{Color.NC} {message}")
+
+
+def log_error(message: str):
+    """Print error message in red."""
+    print(f"{Color.RED}[ERROR]{Color.NC} {message}", file=sys.stderr)
+
+
+def run_command(cmd: List[str], cwd: str = None, check: bool = True) -> str:
+    """Run a shell command and return its output."""
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=check
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        if check:
+            log_error(f"Command failed: {' '.join(cmd)}")
+            log_error(f"Error: {e.stderr}")
+            raise
+        return ""
+
+
+def get_current_commit_hash(ami_go_path: Path) -> str:
+    """Extract the current source commit hash from ami.go."""
+    with open(ami_go_path, 'r') as f:
+        for line in f:
+            if 'source commit hash' in line:
+                match = re.search(r'= ([a-f0-9]+)', line)
+                if match:
+                    return match.group(1)
+    raise ValueError("Could not find source commit hash in ami.go")
+
+
+def get_existing_amis(ami_go_path: Path) -> List[str]:
+    """Extract all existing AMI IDs from ami.go in order."""
+    amis = []
+    with open(ami_go_path, 'r') as f:
+        in_ami_section = False
+        for line in f:
+            if 'AllowedAMIs = sets.New(' in line:
+                in_ami_section = True
+                continue
+            if in_ami_section:
+                if line.strip() == ')':
+                    break
+                # Extract AMI IDs from the line
+                ami_matches = re.findall(r'"(ami-[a-f0-9]+)"', line)
+                amis.extend(ami_matches)
+    return amis
+
+
+def extract_amis_from_json(json_content: str) -> Set[str]:
+    """Extract AMI IDs from rhcos.json content."""
+    amis = set()
+    try:
+        data = json.loads(json_content)
+        # Navigate through the JSON structure to find AMI IDs
+        if 'amis' in data:
+            for arch_data in data['amis']:
+                if 'hvm' in arch_data:
+                    ami = arch_data['hvm']
+                    if ami.startswith('ami-'):
+                        amis.add(ami)
+
+        # Also search for AMI patterns in the entire JSON
+        ami_matches = re.findall(r'ami-[a-f0-9]{8,}', json_content)
+        amis.update(ami_matches)
+
+    except json.JSONDecodeError as e:
+        log_warn(f"Failed to parse JSON: {e}")
+        # Fall back to regex extraction
+        ami_matches = re.findall(r'ami-[a-f0-9]{8,}', json_content)
+        amis.update(ami_matches)
+
+    return amis
+
+
+def get_commits_between(repo_path: Path, start_commit: str, file_path: str) -> List[str]:
+    """Get list of commits from start_commit to HEAD for the given file."""
+    # Get commits from start_commit (exclusive) to HEAD
+    cmd = ['git', 'log', '--pretty=format:%H', f'{start_commit}..HEAD', '--', file_path]
+    output = run_command(cmd, cwd=str(repo_path), check=False)
+
+    if not output:
+        log_warn(f"No commits found between {start_commit} and HEAD")
+        # Try getting recent commits
+        cmd = ['git', 'log', '--pretty=format:%H', '-n', '10', '--', file_path]
+        output = run_command(cmd, cwd=str(repo_path), check=False)
+
+    commits = [line.strip() for line in output.split('\n') if line.strip()]
+    # Reverse to process oldest first
+    return list(reversed(commits))
+
+
+def get_file_at_commit(repo_path: Path, commit: str, file_path: str) -> str:
+    """Get the content of a file at a specific commit."""
+    cmd = ['git', 'show', f'{commit}:{file_path}']
+    return run_command(cmd, cwd=str(repo_path), check=False)
+
+
+def update_ami_go_file(ami_go_path: Path, new_amis: Set[str], existing_amis: List[str],
+                       latest_commit: str) -> bool:
+    """Update the ami.go file with new AMIs and commit hash."""
+    # Keep existing AMIs in order, then add new AMIs sorted at the end
+    new_amis_sorted = sorted(new_amis)
+    all_amis = existing_amis + new_amis_sorted
+
+    # Read the original file
+    with open(ami_go_path, 'r') as f:
+        lines = f.readlines()
+
+    # Find the AMI section
+    start_idx = None
+    end_idx = None
+    for i, line in enumerate(lines):
+        if 'AllowedAMIs = sets.New(' in line:
+            start_idx = i
+        elif start_idx is not None and line.strip() == ')':
+            end_idx = i
+            break
+
+    if start_idx is None or end_idx is None:
+        log_error("Could not find AllowedAMIs section in ami.go")
+        return False
+
+    # Always use 5 AMIs per line
+    amis_per_line = 5
+
+    # Format AMIs for Go code (5 per line)
+    formatted_lines = []
+    for i in range(0, len(all_amis), amis_per_line):
+        chunk = all_amis[i:i+amis_per_line]
+        formatted = ', '.join(f'"{ami}"' for ami in chunk)
+        # Always add comma at the end
+        formatted += ','
+        formatted_lines.append(f'\t{formatted}\n')
+
+    # Update commit hash in the lines before the AMI section
+    for i in range(start_idx):
+        if 'source commit hash' in lines[i]:
+            lines[i] = re.sub(
+                r'(source commit hash = )[a-f0-9]+',
+                f'\\g<1>{latest_commit}',
+                lines[i]
+            )
+
+    # Reconstruct the file
+    new_lines = (
+        lines[:start_idx+1] +  # Everything up to and including "AllowedAMIs = sets.New("
+        formatted_lines +       # The formatted AMI list
+        [lines[end_idx]] +      # The closing ")"
+        lines[end_idx+1:]       # Everything after
+    )
+
+    # Write back to file
+    with open(ami_go_path, 'w') as f:
+        f.writelines(new_lines)
+
+    return True
+
+
+def main():
+    """Main function to update AMIs."""
+    # Configuration
+    REPO_URL = "https://github.com/openshift/installer"
+    FILE_PATH = "data/data/coreos/rhcos.json"
+
+    # Determine the project root (parent of hack directory)
+    script_dir = Path(__file__).parent.resolve()
+    project_root = script_dir.parent
+    AMI_GO_FILE = project_root / "pkg/controller/machine-set-boot-image/ami.go"
+
+    # Check if ami.go exists
+    if not AMI_GO_FILE.exists():
+        log_error(f"File not found: {AMI_GO_FILE}")
+        sys.exit(1)
+
+    log_info("Starting AMI update process...")
+
+    # Get current commit hash from ami.go
+    current_commit = get_current_commit_hash(AMI_GO_FILE)
+    log_info(f"Current source commit in ami.go: {current_commit}")
+
+    # Get existing AMIs
+    existing_amis = get_existing_amis(AMI_GO_FILE)
+    existing_amis_set = set(existing_amis)
+    log_info(f"Found {len(existing_amis)} existing AMI IDs in ami.go")
+
+    # Create temporary directory and clone with filter
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo_path = Path(temp_dir)
+
+        log_info(f"Cloning repository with filter for {FILE_PATH}...")
+
+        # Clone with --filter=blob:none --no-checkout for faster cloning
+        run_command([
+            'git', 'clone', '--quiet', '--filter=blob:none', '--no-checkout',
+            '--depth=100', '--single-branch', '--branch=main',
+            REPO_URL, str(repo_path)
+        ])
+
+        # Checkout only the specific file
+        run_command(['git', 'checkout', 'main', '--', FILE_PATH], cwd=str(repo_path))
+
+        # Check if current commit is up to date with remote
+        log_info("Checking if file is up to date...")
+        latest_remote_commit = run_command(
+            ['git', 'log', '-n', '1', '--pretty=format:%H', '--', FILE_PATH],
+            cwd=str(repo_path)
+        )
+
+        if latest_remote_commit == current_commit:
+            log_info("File is already up to date! No new commits to process.")
+            sys.exit(0)
+
+        # Get commits to process
+        log_info(f"Getting commit history from {current_commit[:8]} to latest...")
+        commits = get_commits_between(repo_path, current_commit, FILE_PATH)
+
+        if not commits:
+            log_warn("No new commits found")
+            sys.exit(0)
+
+        log_info(f"Found {len(commits)} commit(s) to process")
+
+        # Track new AMIs and their source commits
+        new_amis_map: Dict[str, str] = {}
+        latest_commit = None
+
+        # Process each commit
+        for commit in commits:
+            log_info(f"Processing commit: {commit[:8]}...")
+
+            # Get file content at this commit
+            content = get_file_at_commit(repo_path, commit, FILE_PATH)
+
+            if not content:
+                log_warn(f"Could not retrieve {FILE_PATH} at commit {commit[:8]}, skipping...")
+                continue
+
+            # Extract AMIs from this version
+            commit_amis = extract_amis_from_json(content)
+
+            if not commit_amis:
+                log_warn(f"No AMIs found in commit {commit[:8]}")
+                continue
+
+            log_info(f"  Found {len(commit_amis)} AMI(s) in this commit")
+            latest_commit = commit
+
+            # Check each AMI
+            for ami in commit_amis:
+                # Check if AMI already exists in ami.go
+                if ami in existing_amis_set:
+                    log_error(f"Duplicate AMI detected: {ami}")
+                    log_error(f"  This AMI already exists in ami.go")
+                    log_error(f"  Found in commit: {commit[:8]}")
+                    sys.exit(1)
+
+                # Check if AMI was already added by a previous commit in this run
+                if ami in new_amis_map:
+                    log_error(f"Duplicate AMI detected: {ami}")
+                    log_error(f"  First seen in commit: {new_amis_map[ami][:8]}")
+                    log_error(f"  Duplicate in commit: {commit[:8]}")
+                    sys.exit(1)
+
+                # Add to new AMIs map
+                new_amis_map[ami] = commit
+
+        # Check if we found any new AMIs
+        if not new_amis_map:
+            log_warn("No new AMIs found")
+            sys.exit(0)
+
+        log_info(f"Found {len(new_amis_map)} new AMI(s) to add")
+
+        if not latest_commit:
+            log_error("No valid commits were processed")
+            sys.exit(1)
+
+        log_info(f"Latest processed commit: {latest_commit[:8]}")
+
+    # Update ami.go file
+    log_info(f"Updating {AMI_GO_FILE}...")
+
+    success = update_ami_go_file(
+        AMI_GO_FILE,
+        set(new_amis_map.keys()),
+        existing_amis,
+        latest_commit
+    )
+
+    if not success:
+        log_error("Failed to update ami.go")
+        sys.exit(1)
+
+    # Print summary
+    log_info("Update complete!")
+    log_info(f"  - Updated source commit hash to: {latest_commit[:8]}")
+    log_info(f"  - Added {len(new_amis_map)} new AMI(s)")
+    log_info(f"  - Total AMI count: {len(existing_amis) + len(new_amis_map)}")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        log_warn("\nInterrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        log_error(f"Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/pkg/controller/machine-set-boot-image/ami.go
+++ b/pkg/controller/machine-set-boot-image/ami.go
@@ -4,6 +4,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// source commit hash = 28ce2c4d6557b159d0253a8f32f640b50a578798
+// source URI = https://github.com/openshift/installer/blob/main/data/data/coreos/rhcos.json
+
 // AllowedAMIs contains the set of AMI IDs that are allowed to be updated from
 var AllowedAMIs = sets.New(
 	"ami-000145e5a91e9ac22", "ami-0001c9b25b9ca6731", "ami-000277c401a2db73a", "ami-0002c5529c6fff5a4", "ami-00033b241162023da",
@@ -1417,4 +1420,32 @@ var AllowedAMIs = sets.New(
 	"ami-0ff4e932cabee6256", "ami-0ff4fdc5b214f44a9", "ami-0ff530e464d386737", "ami-0ff55f3137f7b2b90", "ami-0ff5c08957821d8ee",
 	"ami-0ff5d97cd0b6cd949", "ami-0ff609cf0a5f78f63", "ami-0ff64f495c7e977cf", "ami-0ff931d09ab1cdccd", "ami-0ffb4a883a156709a",
 	"ami-0ffdaea585a65e49f", "ami-0ffdfef19643ac7f5", "ami-0ffe01a0fb1078c6f", "ami-0ffe8d7ad8405534c", "ami-0ffec236307e00b94",
+	"ami-000abd48695e852a9", "ami-000b42519a25cacc5", "ami-001d35f0b7a38999e", "ami-004899c1b1392a416", "ami-007439e088223214a",
+	"ami-00bd76511738f7c79", "ami-00c57db622051df7b", "ami-0104db843a42a4455", "ami-012a97b7293096c47", "ami-012fa36dc30f5e43c",
+	"ami-013bd53f7db86068d", "ami-0148286cf26e84d1d", "ami-019cdefdbe8ae3f45", "ami-01e129afb49fdd7ac", "ami-020178428baa4d29d",
+	"ami-020f780ada6ae8dad", "ami-0214e803d8564e890", "ami-021b5ab76f755886f", "ami-0228c2964a198026b", "ami-023b6cb1f845e69bf",
+	"ami-024f628f2bf9dadba", "ami-025c94ec9eb0e18ff", "ami-026b8f665827ffda4", "ami-029e68d76a61871b1", "ami-02d89c98e7cb51709",
+	"ami-02e1801c5d670fc58", "ami-02f64485ccc70a4b0", "ami-030445ba8507a3ec6", "ami-033695428741399bd", "ami-038f598890a52f3c9",
+	"ami-03ec26381f6a347be", "ami-03f6525889efe953b", "ami-03f93a32298fb00fb", "ami-04332931a972c8398", "ami-045044c91f08f0141",
+	"ami-045c4882302e99352", "ami-0467b2b1a131cb070", "ami-049ef84221f8c41fb", "ami-04c3ea90e1fec5a29", "ami-04ca111133e8458c6",
+	"ami-04cd61839a245df4e", "ami-04d3462fcff665a38", "ami-04db8de6d2660d477", "ami-054cb427389152da1", "ami-056269e07d092d729",
+	"ami-05834415546b16278", "ami-05a118f475704e651", "ami-05ac23294a4ae1451", "ami-05bcd8360b8e667ba", "ami-05fce4dea56fdf75f",
+	"ami-0612e7d07f913d6da", "ami-063fdc060a1235bfd", "ami-0695977d7105dd264", "ami-06a69920498a19505", "ami-06c0dd7efd3688e89",
+	"ami-06ce6706d18914e38", "ami-06e1f97c47558c2cc", "ami-06eb65026809257f2", "ami-07079826624ddc0d3", "ami-071273656bbd5ceaf",
+	"ami-0764fc8a8a3159ee8", "ami-0774d29f6ed96935b", "ami-0788e768db7ced74d", "ami-07b9d012be3de4f52", "ami-07e7ddbe74370b8d4",
+	"ami-082a55a580d5538ed", "ami-08587b3c3e9c0b132", "ami-086c5fdb20edc12c7", "ami-0871eb73b7eba6b71", "ami-087742c9801577ca8",
+	"ami-0890ea87ff5edfe5d", "ami-08956a7d43f06c11a", "ami-089d8892ef8f88156", "ami-08a972c2bc8a15c46", "ami-08cd8521bbeef13da",
+	"ami-08f4d022a29e9eca7", "ami-08ff4ee35db1e8b29", "ami-0907a17ccca484f8a", "ami-0929268b6d28ba1e9", "ami-0934f6e7344143299",
+	"ami-09469dfe86edf2a39", "ami-0961ddf05f99aa1ac", "ami-097ddc2cc5a145e29", "ami-09a4ec979ba4d8804", "ami-09b876828c9cb81f2",
+	"ami-09c2ab0e2e7411878", "ami-09d23adad19cdb25c", "ami-09e3bf4a7e74ce7db", "ami-09f65446cd0bf6996", "ami-09f756251f513af27",
+	"ami-09fe6bcfb3cab07a7", "ami-0a3254abafd41cbda", "ami-0a7e97cb28cbb8354", "ami-0a9461ac20d4691fe", "ami-0aab399b5d22e4302",
+	"ami-0ab3d3804935c276d", "ami-0ac916d2813a7b18a", "ami-0ae438f9ab8af4459", "ami-0afe0c55043adaf0a", "ami-0aff54e74e2bf4555",
+	"ami-0b31157035ce913d5", "ami-0b4093c08d6b1e916", "ami-0b745e03468dc48d2", "ami-0b83bc614ecbb4381", "ami-0b9392304b25a1be6",
+	"ami-0ba39a0e658a28b9b", "ami-0ba6941055f037421", "ami-0bbc07f8031693f95", "ami-0bc01c2ad16fef268", "ami-0c110862155a78151",
+	"ami-0c59bfd7b7a7cc3e7", "ami-0c5e7ad0cce0b5b68", "ami-0c5f9e47b5c3e9c13", "ami-0cca0b255eebfac0d", "ami-0cd7e64385588d5af",
+	"ami-0cebb38e071808759", "ami-0d05d8687e94714da", "ami-0d191a1bffd735ebe", "ami-0d2f277e312013de9", "ami-0d3c5dedab43b8daa",
+	"ami-0db4e8c33879b1a97", "ami-0dc346212bfae9a5a", "ami-0dd67b8ff235b962c", "ami-0df908df0aad1f3b2", "ami-0e024a0bbbdf621da",
+	"ami-0e0a89efe9e4aebd8", "ami-0e0eb82f12439136c", "ami-0e62ef7268af3c2ca", "ami-0e72cf40ed8ca51f3", "ami-0e76fbd6c355a48c4",
+	"ami-0e939a03652163c23", "ami-0ed302ffd26100bbb", "ami-0f22ba0e5c926e85a", "ami-0f6dbbdd757912184", "ami-0f79de75c0bb9ea50",
+	"ami-0f7e06ef6b630d78c", "ami-0f9afa7909fa8890b", "ami-0faeee552170fef71", "ami-0ff561b9a6261fac9", "ami-0ff7e5fea2302529b",
 )


### PR DESCRIPTION
As an experiment, I asked claude to write a quick script that will sync up our hardcoded AMI list with [the installer's rhcos.json](https://github.com/openshift/installer/blob/master/data/data/coreos/rhcos.json). I opted for python for easier readability and added a make target for it. The ami.go file also now stores the last commit hash that was used to generate the list so the script knows when to stop looking while traversing.

**Sample output**
When there is no update to perform:
```
$ make update-amis 
python3 hack/update_amis.py
[INFO] Starting AMI update process...
[INFO] Current source commit in ami.go: ba4b42c8a1de5d69106769c949065977bff06e42
[INFO] Found 7055 existing AMI IDs in ami.go
[INFO] Cloning repository with filter for data/data/coreos/rhcos.json...
[INFO] Checking if file is up to date...
[INFO] Getting commit history from ba4b42c8 to latest...
[INFO] Found 2 commit(s) to process
[INFO] Processing commit: cfd47751...
[INFO]   Found 70 AMI(s) in this commit
[INFO] Processing commit: 28ce2c4d...
[INFO]   Found 70 AMI(s) in this commit
[INFO] Found 140 new AMI(s) to add
[INFO] Latest processed commit: 28ce2c4d
[INFO] Updating /home/djoshy/projects/machine-config-operator/pkg/controller/machine-set-boot-image/ami.go...
[INFO] Update complete!
[INFO]   - Updated source commit hash to: 28ce2c4d
[INFO]   - Added 140 new AMI(s)
[INFO]   - Total AMI count: 7195
```
When there is no update to perform:
```
$ make update-amis 
python3 hack/update_amis.py
[INFO] Starting AMI update process...
[INFO] Current source commit in ami.go: 28ce2c4d6557b159d0253a8f32f640b50a578798
[INFO] Found 7195 existing AMI IDs in ami.go
[INFO] Cloning repository with filter for data/data/coreos/rhcos.json...
[INFO] Checking if file is up to date...
[INFO] File is already up to date! No new commits to process.
```

**Note**: This is not meant to be a long-term solution, it is only meant to hold us over till we have figured out marketplace support for AWS. This script does not have to be run often, once per release is probably good enough. 