### PR TITLE
OCPBUGS-62301: enable kernel psi at install time

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -152,7 +152,7 @@ func updateMachineConfigwithCgroup(node *osev1.Node, mc *mcfgv1.MachineConfig) e
 	// updating the Machine Config resource with the relevant cgroup config
 	var (
 		kernelArgsv1                                            = []string{"systemd.unified_cgroup_hierarchy=0", "systemd.legacy_systemd_cgroup_controller=1"}
-		kernelArgsv2                                            = []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=0"}
+		kernelArgsv2                                            = []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"}
 		kernelArgsToAdd, kernelArgsToRemove, adjustedKernelArgs []string
 	)
 	switch node.Spec.CgroupMode {

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -90,13 +90,13 @@ func TestBootstrapNodeConfigDefault(t *testing.T) {
 	}{
 		configNodeCgroupDefault: {
 			Name:             "Default",
-			MasterKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=0"},
-			WorkerKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=0"},
+			MasterKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"},
+			WorkerKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"},
 		},
 		configNodeCgroupV2: {
 			Name:             "Cgroupv2",
-			MasterKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=0"},
-			WorkerKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=0"},
+			MasterKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"},
+			WorkerKernelArgs: []string{"systemd.unified_cgroup_hierarchy=1", "cgroup_no_v1=\"all\"", "psi=1"},
 		},
 	}
 


### PR DESCRIPTION
**- What I did**

I have changed the default kernel argument for the Pressure Stall Information from 0 to 1. This enables the psi at the Kernel level so we can evaluate if we have any sort of performance degradation.

**- Description for the changelog**
```
Kernel Pressure Stall Information is now enabled by default.
```
