### PR TITLE
MCO-1714: MCO-1715: MCO-1716: MCO-1717: MCO-1718: Add regression tests for the ImageModeStatusReporting FeatureGate

### DIFF
--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -17,9 +17,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	)
 
 	g.JustBeforeEach(func() {
-		preChecks(oc)
-
-		skipTestIfOCBIsEnabled(oc)
+		PreChecks(oc)
+		SkipTestIfOCBIsEnabled(oc)
 	})
 
 	g.It("PolarionID:83141-A valid MachineOSConfig leads to a successful MachineOSBuild and cleanup of its associated resources", func() {
@@ -274,7 +273,7 @@ func testContainerFile(containerFiles []ContainerFile, imageNamespace string, mc
 	ValidateMOSCIsGarbageCollected(mosc, mcp)
 }
 
-func skipTestIfOCBIsEnabled(oc *exutil.CLI) {
+func SkipTestIfOCBIsEnabled(oc *exutil.CLI) {
 	moscl := NewMachineOSConfigList(oc)
 	allMosc := moscl.GetAllOrFail()
 	if len(allMosc) != 0 {

--- a/test/extended-priv/mco_password.go
+++ b/test/extended-priv/mco_password.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		mMcp = NewMachineConfigPool(oc.AsAdmin(), MachineConfigPoolMaster)
 		mcp = GetCompactCompatiblePool(oc.AsAdmin())
 
-		preChecks(oc)
+		PreChecks(oc)
 	})
 
 	g.It("PolarionID:59417-MCD create/update password with MachineConfig in CoreOS nodes", func() {

--- a/test/extended-priv/testdata/files/machineconfigs/infra-extension-mc.yaml
+++ b/test/extended-priv/testdata/files/machineconfigs/infra-extension-mc.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: infra-extension-mc
+objects:
+- apiVersion: machineconfiguration.openshift.io/v1
+  kind: MachineConfig
+  metadata:
+    labels:
+      machineconfiguration.openshift.io/role: infra
+    name: 90-infra-extension
+  spec:
+    config:
+      ignition:
+        version: 3.2.0
+    extensions:
+      - usbguard

--- a/test/extended-priv/testdata/files/machineconfigs/infra-testfile-mc.yaml
+++ b/test/extended-priv/testdata/files/machineconfigs/infra-testfile-mc.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: infra-extension-mc
+objects:
+- apiVersion: machineconfiguration.openshift.io/v1
+  kind: MachineConfig
+  metadata:
+    labels:
+      machineconfiguration.openshift.io/role: infra
+    name: 90-infra-testfile
+  spec:
+    config:
+      ignition:
+        version: 3.2.0
+      storage:
+        files:
+        - contents:
+            source: data:,hello%20world%0A
+          mode: 420
+          path: /home/core/test

--- a/test/extended-priv/testdata/files/machineconfigs/master-testfile-mc.yaml
+++ b/test/extended-priv/testdata/files/machineconfigs/master-testfile-mc.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: master-extension-mc
+objects:
+- apiVersion: machineconfiguration.openshift.io/v1
+  kind: MachineConfig
+  metadata:
+    labels:
+      machineconfiguration.openshift.io/role: master
+    name: 90-master-testfile
+  spec:
+    config:
+      ignition:
+        version: 3.2.0
+      storage:
+        files:
+        - contents:
+            source: data:,hello%20world%0A
+          mode: 420
+          path: /home/core/test

--- a/test/extended-priv/testdata/files/machineconfigurations/nodedisruptionpolicy-rebootless-path.yaml
+++ b/test/extended-priv/testdata/files/machineconfigurations/nodedisruptionpolicy-rebootless-path.yaml
@@ -1,0 +1,16 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: node-disruption-policy
+objects:
+- apiVersion: operator.openshift.io/v1
+  kind: MachineConfiguration
+  metadata:
+    name: cluster
+    namespace: openshift-machine-config-operator
+  spec:
+    nodeDisruptionPolicy:
+      files:
+        - path: /home/core/test
+          actions:
+            - type: None

--- a/test/extended-priv/util.go
+++ b/test/extended-priv/util.go
@@ -185,8 +185,8 @@ func sortMasterNodeList(oc *exutil.CLI, nodes []Node) ([]Node, error) {
 	return masterSortedNodes, nil
 }
 
-// preChecks executes some basic checks to make sure the the cluster is healthy enough to run MCO test cases
-func preChecks(oc *exutil.CLI) {
+// PreChecks executes some basic checks to make sure the the cluster is healthy enough to run MCO test cases
+func PreChecks(oc *exutil.CLI) {
 	exutil.By("MCO Preconditions Checks")
 
 	allMCPs, err := NewMachineConfigPoolList(oc.AsAdmin()).GetAll()

--- a/test/extended/const.go
+++ b/test/extended/const.go
@@ -24,4 +24,23 @@ const (
 	TrueString = "True"
 	// FalseString string for false value
 	FalseString = "False"
+
+	// CurrentMachineConfigAnnotationKey is used to fetch current MachineConfig for a machine
+	CurrentMachineConfigAnnotationKey = "machineconfiguration.openshift.io/currentConfig"
+	// DesiredMachineConfigAnnotationKey is used to specify the desired MachineConfig for a machine
+	DesiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
+	// CurrentImageAnnotationKey is used to get the current OS image pullspec for a machine
+	CurrentImageAnnotationKey = "machineconfiguration.openshift.io/currentImage"
+	// DesiredImageAnnotationKey is used to specify the desired OS image pullspec for a machine
+	DesiredImageAnnotationKey = "machineconfiguration.openshift.io/desiredImage"
+	// MachineConfigDaemonStateAnnotationKey is used to fetch the state of the daemon on the machine.
+	MachineConfigDaemonStateAnnotationKey = "machineconfiguration.openshift.io/state"
+
+	// MachineConfigDaemonStateDone is set by daemon when it is done applying an update.
+	MachineConfigDaemonStateDone = "Done"
+	// MachineConfigDaemonStateDegraded is set by daemon when an error not caused by a bad MachineConfig
+	// is thrown during an update.
+	MachineConfigDaemonStateDegraded = "Degraded"
+	// MachineConfigDaemonStateUnreconcilable is set by the daemon when a MachineConfig cannot be applied.
+	MachineConfigDaemonStateUnreconcilable = "Unreconcilable"
 )

--- a/test/extended/image_mode_status_reporting.go
+++ b/test/extended/image_mode_status_reporting.go
@@ -1,0 +1,417 @@
+package extended
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	extpriv "github.com/openshift/machine-config-operator/test/extended-priv"
+	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	mcNameToFixtureMap = map[string]string{
+		"90-infra-extension": filepath.Join("machineconfigs", "infra-extension-mc.yaml"),
+		"90-infra-testfile":  filepath.Join("machineconfigs", "infra-testfile-mc.yaml"),
+		"90-master-testfile": filepath.Join("machineconfigs", "master-testfile-mc.yaml"),
+	}
+	nodeDisruptionFixture      = filepath.Join("machineconfigurations", "nodedisruptionpolicy-rebootless-path.yaml")
+	nodeDisruptionEmptyFixture = filepath.Join("machineconfigurations", "managedbootimages-empty.yaml")
+)
+
+// These tests verify ImageModeStatusReporting feature gate functionality.
+// They are [Serial] and [Disruptive] because they modify cluster state and interact with custom MCPs.
+var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting]", g.Ordered, func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLI("mco-image-mode-status", exutil.KubeConfigPath()).AsAdmin()
+	)
+
+	g.JustBeforeEach(func() {
+		extpriv.PreChecks(oc)
+		extpriv.SkipTestIfOCBIsEnabled(oc)
+	})
+
+	g.It("MachineConfigNode properties should match the associated node properties when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]", func() {
+		// Create machine config client for test
+		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+
+		// Skip this test if there are no machines in the worker MCP, as this will mean we cannot
+		// create a custom MCP.
+		if !DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
+			g.Skip(fmt.Sprintf("Skipping this test since the cluster does not have nodes in the `worker` MCP."))
+		}
+
+		// Run the standard image mode MCN test for a custom MCP named `infra` with no MC to apply
+		runImageModeMCNTest(oc, machineConfigClient, "infra", "", false)
+	})
+
+	g.It("MachineConfigNode conditions should properly transition on an image based update when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]", func() {
+		// Create machine config client for test
+		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+
+		// Skip this test if there are no machines in the worker MCP, as this will mean we cannot
+		// create a custom MCP.
+		if !DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
+			g.Skip(fmt.Sprintf("Skipping this test since the cluster does not have nodes in the `worker` MCP."))
+		}
+
+		// Run the standard image mode MCN test for a custom MCP named `infra` with no MC to apply
+		runImageModeMCNTest(oc, machineConfigClient, "infra", "90-infra-extension", true)
+	})
+
+	g.It("MachineConfigNode conditions should properly transition on a non-image based update when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]", func() {
+		// Create machine config client for test
+		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+
+		// Skip this test if there are no machines in the worker MCP, as this will mean we cannot
+		// create a custom MCP.
+		if !DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
+			g.Skip(fmt.Sprintf("Skipping this test since the cluster does not have nodes in the `worker` MCP."))
+		}
+
+		// Run the standard image mode MCN test for a custom MCP named `infra` with no MC to apply
+		runImageModeMCNTest(oc, machineConfigClient, "infra", "90-infra-testfile", false)
+	})
+
+	g.It("MachineConfigPool machine counts should transition correctly on an update in a default MCP [apigroup:machineconfiguration.openshift.io]", func() {
+		// Create machine config client for test
+		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+
+		// Run the machine count test for a default MCP when applying a standard MachineConfig
+		runMachineCountTest(machineConfigClient, oc, "90-master-testfile", "master")
+	})
+
+	g.It("MachineConfigPool machine counts should transition when OCB is enabled in a default MCP [apigroup:machineconfiguration.openshift.io]", func() {
+		// Create machine config client for test
+		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+
+		// Run this test against the `worker` MCP if it has machines, otherwise default to `master`
+		mcpName := "master"
+		if DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
+			logger.Infof("`worker` MCP has machines, running test in against that MCP.")
+			mcpName = "worker"
+		}
+
+		// Run the machine count test for the master MCP when enabling on-cluster image mode
+		runMachineCountTest(machineConfigClient, oc, "", mcpName)
+	})
+})
+
+// `runImageModeMCNTest` runs through the general flow of validating the MCN of a node for image
+// mode enabled workflows. The steps for the test are as follows:
+//  1. Select a worker node to use throughout the test
+//  2. Validate the starting properties of te MCN associated with the test node
+//  3. Create a custom MCP named the value of `mcpAndMoscName` and add the test node to it
+//  4. Validate the properties of the MCN associated with the test node
+//  5. Configure on cluster image mode in the custom MCP & validate the MOSC applied successfully
+//  6. Validate the properties of the MCN associated with the test node
+//  7. If a MachineConfig has been provided, apply it, validate the MCN conditions trasnition
+//     throughout the update, then remove the MC
+//  8. Disable on cluster image mode in the custom MCP & validate the MOSC removal was successful
+//  9. Validate the properties of the MCN associated with the test node
+//  10. Remove the custom MCP
+//  11. Validate the properties of the MCN associated with the test node
+func runImageModeMCNTest(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, mcpAndMoscName, mcName string, isImageUpdate bool) {
+	exutil.By("Select a node to follow in this test")
+	workerNodes, err := GetNodesByRole(oc, "worker")
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting worker nodes: %s", err)
+	o.Expect(len(workerNodes)).To(o.BeNumerically(">=", 1), "Less than one worker node in pool")
+	nodeToTestName := workerNodes[0].Name
+	logger.Infof("Using `%s` as node for test", nodeToTestName)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate node's starting MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, "worker")
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+
+	exutil.By("Create custom `infra` MCP and add the test node to it")
+	// Create MCP
+	infraMcp, err := extpriv.CreateCustomMCP(oc.AsAdmin(), mcpAndMoscName, 0)
+	defer CleanupCustomMCP(oc, machineConfigClient, mcpAndMoscName, nodeToTestName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a new custom pool `%s`: %s", mcpAndMoscName, err)
+	// Label node
+	err = oc.AsAdmin().Run("label").Args(fmt.Sprintf("node/%s", nodeToTestName), fmt.Sprintf("node-role.kubernetes.io/%s=", mcpAndMoscName)).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error labeing node `%s` for MCP `%s`: %s", nodeToTestName, mcpAndMoscName, err)
+	// Wait for the new `infra` MCP to be ready
+	WaitForMCPToBeReady(machineConfigClient, mcpAndMoscName, 1, "")
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate node's custom MCP MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, mcpAndMoscName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+
+	exutil.By("Configure OCB functionality for the new `infra` MCP")
+	mosc, err := extpriv.CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcpAndMoscName, nil)
+	defer extpriv.DisableOCL(mosc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource: %s", err)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validating the `infra` MOSC applied successfully")
+	extpriv.ValidateSuccessfulMOSC(mosc, nil)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate the node in `infra` MCP has correct MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, mcpAndMoscName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+
+	// If an MC has been provided, apply it and validate the MCN conditions transition correctly
+	// throughout the update.
+	if mcName != "" {
+		exutil.By("Applying the MC")
+		err = ApplyMachineConfigFixture(oc, mcNameToFixtureMap[mcName])
+		defer DeleteMCAndWaitForMCPUpdate(oc, machineConfigClient, mcName, mcpAndMoscName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error applying MC `%s`: %s", mcName, err)
+		logger.Infof("OK!\n")
+
+		exutil.By("Validating the MCN condition transitions")
+		validateMCNTransitions(machineConfigClient, nodeToTestName, isImageUpdate)
+		logger.Infof("OK!\n")
+
+		exutil.By("Removing the MC")
+		DeleteMCAndWaitForMCPUpdate(oc, machineConfigClient, mcName, mcpAndMoscName)
+		logger.Infof("OK!\n")
+	}
+
+	exutil.By("Remove the MachineOSConfig resource")
+	o.Expect(extpriv.DisableOCL(mosc)).To(o.Succeed(), "Error cleaning up MOSC `%s`", mosc)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validating the `infra` MOSC was removed successfully")
+	extpriv.ValidateMOSCIsGarbageCollected(mosc, infraMcp)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate the node in `infra` MCP has correct MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, mcpAndMoscName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+
+	exutil.By("Delete the `infra` MCP")
+	err = CleanupCustomMCP(oc, machineConfigClient, mcpAndMoscName, nodeToTestName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error deleting `%s` MCP: %s", mcpAndMoscName, err)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate the test node has correct MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, "worker")
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+}
+
+// `validateMCNTransitions` applies a MC, validates that the MCN conditions properly
+// transition during the update, removes the MC, then validates that the MCN conditions properly
+// transition during the update.
+func validateMCNTransitions(machineConfigClient *machineconfigclient.Clientset, nodeToTestName string, isImageUpdate bool) {
+	// Validate transition through conditions for MCN
+	exutil.By("Validating the transitions through MCN conditions")
+	ValidateTransitionThroughConditions(machineConfigClient, nodeToTestName, false, isImageUpdate)
+	logger.Infof("OK!\n")
+
+	// When an update is complete, all conditions other than `Updated` must be false
+	logger.Infof("Checking all conditions other than 'Updated' are False.")
+	o.Expect(ConfirmUpdatedMCNStatus(machineConfigClient, nodeToTestName)).Should(o.BeTrue(), "Error, all conditions must be 'False' when Updated=True.")
+	logger.Infof("OK!\n")
+
+	return
+}
+
+// `runMachineCountTest` runs through the general flow of validating machine count transitions in
+// MCPs after an update has been triggered and on the subsequent cleanup. The steps are as follows:
+//  1. Get the starting rendered MC version to track the update completion
+//  2. Trigger the MCP updating process
+//     - If a MC is provided, apply a node disruption policy to limit reboots then apply the MC
+//     - If an MC is not provided, enable on-cluster image mode
+//  3. Validate the machine counts transition as expected throughout the update
+//  4. Get the updated rendered MC version to track the cleanup completion
+//  5. Cleanup the update triggered in step 2
+//     - For the MC apply case, delete the MC
+//     - For the on-cluster image mode case, delete the created MOSC
+//  6. Validate the machine counts transition as expected throughout the cleanup
+func runMachineCountTest(machineConfigClient *machineconfigclient.Clientset, oc *exutil.CLI, mcName, mcpName string) {
+	// Get the starting time of the test
+	startTime := metav1.Now()
+
+	var mosc *extpriv.MachineOSConfig
+	var err error
+	var layered bool
+	if mcName != "" { // Handle a standard MC apply case
+		// Apply a node disruption policy to allow for a rebootless update
+		exutil.By("Applying the NodeDisruptionPolicy")
+		err = ApplyMachineConfigFixture(oc, nodeDisruptionFixture)
+		defer ApplyMachineConfigFixture(oc, nodeDisruptionEmptyFixture)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error applying the NodeDisruptionPolicy: %s", err)
+		logger.Infof("OK!\n")
+
+		// Apply machine config
+		exutil.By("Applying the MC")
+		err = ApplyMachineConfigFixture(oc, mcNameToFixtureMap[mcName])
+		defer DeleteMCAndWaitForMCPUpdate(oc, machineConfigClient, mcName, mcpName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error applying MC `%s`: %s", mcName, err)
+		logger.Infof("OK!\n")
+	} else { // Handle the layered MCP case
+		layered = true
+		// Enable image mode in the desired pool
+		exutil.By("Configure OCB functionality in the `master` MCP")
+		mosc, err = extpriv.CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcpName, nil)
+		defer extpriv.DisableOCL(mosc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource: %s", err)
+		logger.Infof("OK!\n")
+	}
+
+	// Track that the machine counts transition properly
+	validateMCPMachineCountTransitions(machineConfigClient, oc, mcpName, startTime, mosc, layered)
+
+	// Get the starting time of the cleanup
+	startTime = metav1.Now()
+
+	if mcName != "" { // Handle a standard MC apply case
+		// Delete the machine config
+		exutil.By("Removing the MC")
+		_, mcErr := DeleteMCByName(oc, machineConfigClient, mcName)
+		o.Expect(mcErr).NotTo(o.HaveOccurred(), "Error deleting MC `%s`: %s", mcName, mcErr)
+		logger.Infof("OK!\n")
+	} else { // Handle the layered MCP case
+		// Disable image mode
+		exutil.By("Remove the MachineOSConfig resource")
+		err = mosc.CleanupAndDelete()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error deleting MOSC: %s", err)
+		logger.Infof("OK!\n")
+	}
+
+	// Track that the machine counts transition properly during cleanup
+	validateMCPMachineCountTransitions(machineConfigClient, oc, mcpName, startTime, nil, layered)
+}
+
+// `validateMCPMachineCountTransitions` validates the actual machine counts reported in a MCP's
+// status matches the expected machine counts determined by checking the node annotations of the
+// targeted nodes. This function runs until one of the following termination conditions is met:
+//   - The expected and actual machine counts do not match within a 8 second tolerance window
+//   - The MCP is fully updated
+//   - The overall timeout for this function has been met
+//   - Some other error has occurred in a step of the function
+func validateMCPMachineCountTransitions(machineConfigClient *machineconfigclient.Clientset, oc *exutil.CLI, mcpName string, startTime metav1.Time, mosc *extpriv.MachineOSConfig, layered bool) {
+	timeout := 15 * time.Minute
+	interval := 10 * time.Second
+	// For on-cluster image mode updates, set the timeout to be longer
+	if layered {
+		logger.Infof("Layered update, setting longer update timeout.")
+		timeout = 45 * time.Minute
+		interval = 30 * time.Second
+	}
+	o.Eventually(func() bool {
+		// Check if the MCP machine counts match what is expected from the pool's node annotation
+		// values. Note that there is some latency between when the node annotations are set and
+		// when the MCP machine counts are updates, so we'll try this a few times to make sure we
+		// don't fail just because of unlucky timing.
+		for i := 0; i < 3; i++ {
+			logger.Infof("Checking if the MCP machine counts match the expected values...")
+
+			// Handle success case
+			if mcnAndNodeAnnotationMachineCountsMatch(machineConfigClient, oc, mcpName, mosc) {
+				break
+			}
+
+			// Handle case when the counts are not as expected. If we reach this point in the third
+			// itteration, we've exhausted our attempts and are likely seeing a true discrepancy
+			// between the expected and actual machine counts.
+			o.Expect(i).NotTo(o.BeNumerically("==", 2), "The actual MCP machine counts did not match the expected machine counts")
+			// If we have not exhausted our attempts, wait a few seconds and check again
+			if i != 2 {
+				logger.Infof("The MCP machine counts did match the expected values. Waiting 4 seconds then trying again.")
+				time.Sleep(4 * time.Second)
+			}
+		}
+
+		// Check if the MCP is updated
+		// TODO: check if this properly handles the OCL case
+		return MCPIsUpdatedToNewConfig(machineConfigClient, mcpName, startTime)
+	}, timeout, interval).Should(o.BeTrue(), "Timed out waiting for MCP '%v' to complete update.", mcpName)
+
+}
+
+// `mcnAndNodeAnnotationMachineCountsMatch` checks whether the updated and degraded machine counts
+// in the desired MCP match the expected machine counts calculated by checking the annotations of
+// each node in the pool. It returns `true` if the counts match and false otherwise.
+func mcnAndNodeAnnotationMachineCountsMatch(machineConfigClient *machineconfigclient.Clientset, oc *exutil.CLI, mcpName string, mosc *extpriv.MachineOSConfig) bool {
+	// Get machine counts from MCP
+	mcp, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
+	o.Expect(mcpErr).NotTo(o.HaveOccurred(), "Error getting MCP `%v`: %s", mcpName, mcpErr)
+	actualUpdatedCount := mcp.Status.UpdatedMachineCount
+	actualDegradedCount := mcp.Status.DegradedMachineCount
+
+	// Get the expected machine counts from the node annotation values
+	nodes, nodesErr := GetNodesByRole(oc, mcpName)
+	o.Expect(nodesErr).NotTo(o.HaveOccurred(), "Error getting nodes in MCP `%v`: %s", mcpName, nodesErr)
+	var expectedUpdatedCount int32
+	var expectedDegradedCount int32
+	for _, node := range nodes {
+		desiredConfig := node.Annotations[DesiredMachineConfigAnnotationKey]
+		currentConfig := node.Annotations[CurrentMachineConfigAnnotationKey]
+		desiredImage := node.Annotations[DesiredImageAnnotationKey]
+		currentImage := node.Annotations[CurrentImageAnnotationKey]
+		mcdState := node.Annotations[MachineConfigDaemonStateAnnotationKey]
+
+		// Check if node is degraded Note that a node is considered degraded when the
+		// MachineConfigDaemon state is either "Degraded" or "Unreconcilable"
+		if mcdState == MachineConfigDaemonStateDegraded || mcdState == MachineConfigDaemonStateUnreconcilable {
+			expectedDegradedCount++
+		}
+
+		// Check if node is updated. Note that a node is considered updated when the following
+		// annotation conditions are met:
+		// 	- The current and desired config versions match
+		// 	- The current and desired images match
+		// 	- The MachineConfigDaemon state is "Done"
+		// 	- The node's desired config version matches the config version in the MCP's `Spec`
+		// 	- (non-layered MCP) The node's desired image is empty
+		// 	- (layered MCP) The node's desired image should not be empty
+		// 	- (layered MCP) The node's desired image matches the CurrentImagePullSpec in the MOSC's `Status`
+		// 	- (layered MCP) The node's desired config matches the config version in the MOSB's `Spec`
+		if desiredConfig == currentConfig && desiredImage == currentImage &&
+			mcdState == MachineConfigDaemonStateDone && desiredConfig == mcp.Spec.Configuration.Name {
+			if mosc == nil && desiredImage == "" { // Handle updated non-layered MCP case
+				expectedUpdatedCount++
+			} else if mosc != nil { // Handle the layered MCP case
+				// Get the config version from the MOSB for the MCP
+				mosb, mosbErr := mosc.GetCurrentMachineOSBuild()
+				// If the MOSB DNE yet, the node is not updated
+				if mosbErr != nil || mosb == nil {
+					continue
+				}
+				mosbConfigName, mosbErr := mosb.GetMachineConfigName()
+				o.Expect(mosbErr).NotTo(o.HaveOccurred(), "Error getting machine config from MOSB `%v`: %s", mosb.GetName(), mosbErr)
+
+				// Get the config image from the MOSC
+				moscConfigImage, moscErr := mosc.GetStatusCurrentImagePullSpec()
+				o.Expect(moscErr).NotTo(o.HaveOccurred(), "Error getting config image from MOSC `%v`: %s", mosc.GetName(), moscErr)
+
+				// Check if the node is updated
+				if desiredImage != "" && desiredImage == moscConfigImage && desiredConfig == mosbConfigName {
+					expectedUpdatedCount++
+				}
+			}
+		}
+	}
+
+	// Check that actual and expected degraded and updated machine counts match
+	if actualUpdatedCount != expectedUpdatedCount || actualDegradedCount != expectedDegradedCount {
+		// Log when the counts are not the same so debugging is easier
+		logger.Infof("actualUpdatedCount: %v; expectedUpdatedCount: %v; actualDegradedCount: %v; expectedDegradedCount: %v", actualUpdatedCount, expectedUpdatedCount, actualDegradedCount, expectedDegradedCount)
+		return false
+	}
+	return true
+}

--- a/test/extended/machineconfig.go
+++ b/test/extended/machineconfig.go
@@ -1,0 +1,38 @@
+// TODO (MCO-1960): Deduplicate these functions with the helpers defined in /extended-priv/machineconfig.go.
+package extended
+
+import (
+	"context"
+
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	extpriv "github.com/openshift/machine-config-operator/test/extended-priv"
+	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// `ApplyMachineConfigFixture` applies a MachineConfig fixture
+func ApplyMachineConfigFixture(oc *exutil.CLI, fixture string) error {
+	err := extpriv.NewMCOTemplate(oc, fixture).Apply()
+	return err
+}
+
+// `DeleteMCByName` deletes the MC with the provided name if it exists in the cluster
+func DeleteMCByName(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, mcName string) (mcDeleted bool, err error) {
+	// Check if the MC still exists
+	_, getMCErr := machineConfigClient.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mcName, metav1.GetOptions{})
+	if getMCErr != nil {
+		// If the MC does not exist in the cluster, we have nothing to delete
+		if apierrs.IsNotFound(getMCErr) {
+			logger.Infof("MC `%s` does not exist so no deletion is necessary.", mcName)
+			return false, nil
+		}
+		return false, getMCErr
+	}
+
+	// Delete the desired MC
+	deleteMCErr := oc.AsAdmin().Run("delete").Args("machineconfig", mcName).Execute()
+	return true, deleteMCErr
+}

--- a/test/extended/machineconfignode.go
+++ b/test/extended/machineconfignode.go
@@ -1,0 +1,356 @@
+// TODO (MCO-1960): Deduplicate these functions with the helpers defined in /extended-priv/machineconfignode.go.
+package extended
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	o "github.com/onsi/gomega"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// `ValidateMCNForNode` validates the MCN of a provided node by checking the following:
+//   - Check that `mcn.Spec.Pool.Name` matches provided `poolName`
+//   - Check that `mcn.Name` matches the node name
+//   - Check that `mcn.Spec.ConfigVersion.Desired` matches the node desired config version
+//   - Check that `nmcn.Status.ConfigVersion.Current` matches the node current config version
+//   - Check that `mcn.Status.ConfigVersion.Desired` matches the node desired config version
+//   - Check that `mcn.Spec.ConfigImage.DesiredImage` matches the node desired image
+//   - Check that `nmcn.Status.ConfigImage.CurrentImage` matches the node current image
+//   - Check that `mcn.Status.ConfigImage.DesiredImage` matches the node desired image
+func ValidateMCNForNode(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, nodeName, poolName string) error {
+	// Get updated node
+	node, nodeErr := oc.AsAdmin().KubeClient().CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if nodeErr != nil {
+		logger.Errorf("Could not get node `%v`", nodeName)
+		return nodeErr
+	}
+
+	// Get node's desired and current config versions and images
+	nodeCurrentConfig := node.Annotations[constants.CurrentMachineConfigAnnotationKey]
+	nodeDesiredConfig := node.Annotations[constants.DesiredMachineConfigAnnotationKey]
+	nodeCurrentImage := mcfgv1.ImageDigestFormat(node.Annotations[constants.CurrentImageAnnotationKey])
+	nodeDesiredImage := mcfgv1.ImageDigestFormat(node.Annotations[constants.DesiredImageAnnotationKey])
+
+	// Get node's MCN
+	logger.Infof("Getting MCN for node `%v`.", nodeName)
+	mcn, mcnErr := machineConfigClient.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if mcnErr != nil {
+		logger.Errorf("Could not get MCN for node `%v`", nodeName)
+		return mcnErr
+	}
+
+	// Check MCN pool name value for default MCPs
+	logger.Infof("Checking MCN pool name for node `%v` matches pool association `%v`.", nodeName, poolName)
+	if mcn.Spec.Pool.Name != poolName {
+		logger.Errorf("MCN pool name `%v` does not match node MCP association `%v`.", mcn.Spec.Pool.Name, poolName)
+		return fmt.Errorf("the MCN pool name does not match expected node MCP association")
+	}
+
+	// Check MCN name matches node name
+	logger.Infof("Checking MCN name matches node name `%v`.", nodeName)
+	if mcn.Name != nodeName {
+		logger.Errorf("MCN name `%v` does not match node name `%v`.", mcn.Name, nodeName)
+		return fmt.Errorf("the MCN name does not match node name")
+	}
+
+	// Check desired config version in MCN spec matches desired config on node
+	logger.Infof("Checking node `%v` desired config version `%v` matches desired config version in MCN spec.", nodeName, nodeDesiredConfig)
+	if mcn.Spec.ConfigVersion.Desired != nodeDesiredConfig {
+		logger.Errorf("MCN spec desired config version `%v` does not match node desired config version `%v`.", mcn.Spec.ConfigVersion.Desired, nodeDesiredConfig)
+		return fmt.Errorf("MCN spec desired config version does not match node desired config version")
+	}
+
+	// Check current config version in MCN status matches current config on node
+	logger.Infof("Checking node `%v` current config version `%v` matches current version in MCN status.", nodeName, nodeCurrentConfig)
+	if mcn.Status.ConfigVersion.Current != nodeCurrentConfig {
+		logger.Infof("MCN status current config version `%v` does not match node current config version `%v`.", mcn.Status.ConfigVersion.Current, nodeCurrentConfig)
+		return fmt.Errorf("MCN status current config version does not match node current config version")
+	}
+
+	// Check desired config version in MCN status matches desired config on node
+	logger.Infof("Checking node `%v` desired config version `%v` matches desired version in MCN status.", nodeName, nodeDesiredConfig)
+	if mcn.Status.ConfigVersion.Desired != nodeDesiredConfig {
+		logger.Infof("MCN status desired config version `%v` does not match node desired config version `%v`.", mcn.Status.ConfigVersion.Desired, nodeDesiredConfig)
+		return fmt.Errorf("MCN status desired config version does not match node desired config version")
+	}
+
+	// Check desired image in MCN spec matches desired image on node
+	logger.Infof("Checking node `%v` desired image `%v` matches desired image in MCN spec.", nodeName, nodeDesiredImage)
+	if mcn.Spec.ConfigImage.DesiredImage != nodeDesiredImage {
+		logger.Errorf("MCN spec desired image `%v` does not match node desired image `%v`.", mcn.Spec.ConfigImage.DesiredImage, nodeDesiredImage)
+		return fmt.Errorf("MCN spec desired image does not match node desired image")
+	}
+
+	// Check current image in MCN status matches current image on node
+	logger.Infof("Checking node `%v` current image `%v` matches current image in MCN status.", nodeName, nodeCurrentImage)
+	if mcn.Status.ConfigImage.CurrentImage != nodeCurrentImage {
+		logger.Infof("MCN status current image `%v` does not match node current image `%v`.", mcn.Status.ConfigImage.CurrentImage, nodeCurrentImage)
+		return fmt.Errorf("MCN status current image does not match node current image")
+	}
+
+	// Check desired image in MCN status matches desired image on node
+	logger.Infof("Checking node `%v` desired image `%v` matches desired image in MCN status.", nodeName, nodeDesiredImage)
+	if mcn.Status.ConfigImage.DesiredImage != nodeDesiredImage {
+		logger.Infof("MCN status desired image `%v` does not match node desired image `%v`.", mcn.Status.ConfigImage.DesiredImage, nodeDesiredImage)
+		return fmt.Errorf("MCN status desired image does not match node desired image")
+	}
+
+	return nil
+}
+
+// `getMCNCondition` returns the queried condition or nil if the condition does not exist
+func getMCNCondition(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress) *metav1.Condition {
+	// Loop through conditions and return the status of the desired condition type
+	conditions := mcn.Status.Conditions
+	for _, condition := range conditions {
+		if condition.Type == string(conditionType) {
+			return &condition
+		}
+	}
+	return nil
+}
+
+// `getMCNConditionStatus` returns the status of the desired condition type for MCN, or
+// an empty string if the condition does not exist
+func getMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress) metav1.ConditionStatus {
+	// Loop through conditions and return the status of the desired condition type
+	condition := getMCNCondition(mcn, conditionType)
+	if condition == nil {
+		return ""
+	}
+
+	logger.Infof("MCN '%s' %s condition status is %s", mcn.Name, conditionType, condition.Status)
+	return condition.Status
+}
+
+// `checkMCNConditionStatus` checks that an MCN condition matches the desired status (ex.
+// confirm "Updated" is "False")
+func checkMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress, status metav1.ConditionStatus) bool {
+	conditionStatus := getMCNConditionStatus(mcn, conditionType)
+	if conditionStatus != status && conditionType == mcfgv1.MachineConfigNodeResumed {
+		condition := getMCNCondition(mcn, conditionType)
+		logger.Infof("LastTransitionTime: %v, Message: %v, ObservedGeneration: %v, Reason: %v, Status: %v, Type: %v", condition.LastTransitionTime, condition.Message, condition.ObservedGeneration, condition.Reason, condition.Status, condition.Type)
+	}
+	return conditionStatus == status
+}
+
+// `waitForMCNConditionStatus` waits up to a specified timeout for the desired MCN
+// condition to match the desired status (ex. wait until "Updated" is "False")
+func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientset, mcnName string, conditionType mcfgv1.StateProgress, status metav1.ConditionStatus,
+	timeout time.Duration, interval time.Duration) (bool, error) {
+
+	conditionMet := false
+	var conditionErr error
+	var workerNodeMCN *mcfgv1.MachineConfigNode
+	if err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(_ context.Context) (bool, error) {
+		logger.Infof("Waiting for MCN '%v' %v condition to be %v.", mcnName, conditionType, status)
+
+		workerNodeMCN, conditionErr = machineConfigClient.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), mcnName, metav1.GetOptions{})
+		// Record if an error occurs when getting the MCN resource
+		if conditionErr != nil {
+			logger.Infof("Error getting MCN for node '%v': %v", mcnName, conditionErr)
+			return false, nil
+		}
+
+		// Check if the MCN status is as desired
+		conditionMet = checkMCNConditionStatus(workerNodeMCN, conditionType, status)
+		return conditionMet, nil
+	}); err != nil {
+		logger.Infof("The desired MCN condition was never met: %v", err)
+		// Handle the situation where there were errors getting the MCN resource
+		if conditionErr != nil {
+			logger.Infof("An error occurred waiting for MCN '%v' %v condition to be %v: %v", mcnName, conditionType, status, conditionErr)
+			return conditionMet, fmt.Errorf("MCN '%v' %v condition was not %v: %v", mcnName, conditionType, status, conditionErr)
+		}
+		// Handle case when no errors occur grabbing the MCN, but we time out waiting for the condition to be in the desired state
+		logger.Infof("A timeout occurred waiting for MCN '%v' %v condition was not %v.", mcnName, conditionType, status)
+		return conditionMet, nil
+	}
+
+	return conditionMet, conditionErr
+}
+
+// `ValidateTransitionThroughConditions` validates the condition trasnitions in the MCN
+// during a node update. Note that some conditions are passed through quickly in a node update, so
+// the test can "miss" catching the phases. For test stability, if we fail to catch an "Unknown"
+// status, a warning will be logged instead of erroring out the test.
+func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclient.Clientset, updatingNodeName string, isRebootless, isImageMode bool) {
+	// Get the start time of the update
+	updateStartTime := metav1.Now()
+
+	// Set the expected wait time for the MCN condition of a working node to flip to Updated=False.
+	// For image-based updates, this condition flip can take a while since an image needs to build
+	// and push before the nodes uppdate, but we want to make sure non-image updates do not take as
+	// long for the condition to flip (that would mean something is wrong and would waste time).
+	updatingWaitTime := 1 * time.Minute
+	updatingWaitInterval := 1 * time.Second
+	if isImageMode {
+		updatingWaitTime = 15 * time.Minute
+		updatingWaitInterval = 5 * time.Second
+	}
+
+	// Test the condition transitions.
+	logger.Infof("Waiting for Updated=False")
+	conditionMet, err := waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionFalse, updatingWaitTime, updatingWaitInterval)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Updated=False: %v", err))
+	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Updated=False.")
+
+	logger.Infof("Waiting for UpdatePrepared=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePrepared, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdatePrepared=True: %v", err))
+	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdatePrepared=True.")
+
+	logger.Infof("Waiting for UpdateExecuted=Unknown")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateExecuted=Unknown: %v", err))
+	if !conditionMet {
+		logger.Infof("Warning, could not detect UpdateExecuted=Unknown.")
+	}
+
+	// On standard, non-rebootless, update, check that node transitions through "Cordoned" and "Drained" phases
+	if !isRebootless {
+		logger.Infof("Waiting for Cordoned=True")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateCordoned, metav1.ConditionTrue, 30*time.Second, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Cordoned=True: %v", err))
+		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Cordoned=True.")
+
+		logger.Infof("Waiting for Drained=Unknown")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionUnknown, 15*time.Second, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Drained=Unknown: %v", err))
+		if !conditionMet {
+			logger.Infof("Warning, could not detect Drained=Unknown.")
+		}
+
+		logger.Infof("Waiting for Drained=True")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionTrue, 4*time.Minute, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Drained=True: %v", err))
+		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Drained=True.")
+	}
+
+	logger.Infof("Waiting for AppliedFilesAndOS=Unknown")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFilesAndOS, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedFilesAndOS=Unknown: %v", err))
+	if !conditionMet {
+		logger.Infof("Warning, could not detect AppliedFilesAndOS=Unknown.")
+	}
+
+	// On image mode update, check that node transitions through the "ImagePulledFromRegistry" phase
+	if isImageMode {
+		logger.Infof("Waiting for ImagePulledFromRegistry=Unknown")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for ImagePulledFromRegistry=Unknown: %v", err))
+		if !conditionMet {
+			logger.Infof("Warning, could not detect ImagePulledFromRegistry=Unknown.")
+		}
+	}
+
+	logger.Infof("Waiting for AppliedFilesAndOS=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFilesAndOS, metav1.ConditionTrue, 3*time.Minute, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedFilesAndOS=True: %v", err))
+	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedFilesAndOS=True.")
+
+	logger.Infof("Waiting for UpdateExecuted=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionTrue, 20*time.Second, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateExecuted=True: %v", err))
+	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateExecuted=True.")
+
+	// On image mode update, check that node transitions through the "ImagePulledFromRegistry" phase
+	if isImageMode {
+		logger.Infof("Waiting for ImagePulledFromRegistry=True")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for ImagePulledFromRegistry=True: %v", err))
+		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect ImagePulledFromRegistry=True.")
+	}
+
+	// On rebootless update, check that node transitions through "UpdatePostActionComplete" phase
+	if isRebootless {
+		logger.Infof("Waiting for UpdatePostActionComplete=True")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePostActionComplete, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdatePostActionComplete=True: %v", err))
+		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdatePostActionComplete=True.")
+	} else { // On standard, non-rebootless, update, check that node transitions through "RebootedNode" phase
+		logger.Infof("Waiting for RebootedNode=Unknown")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionUnknown, 15*time.Second, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=Unknown: %v", err))
+		if !conditionMet {
+			logger.Infof("Warning, could not detect RebootedNode=Unknown.")
+		}
+
+		logger.Infof("Waiting for RebootedNode=True")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionTrue, 10*time.Minute, 1*time.Second)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=True: %v", err))
+		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=True.")
+	}
+
+	// The final steps of the update happen quickly, so sometimes we can miss the final condition
+	// transitions. If we do, we will not error out, but record that the condition was missed.
+	logger.Infof("Waiting for Resumed=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeResumed, metav1.ConditionTrue, 5*time.Second, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Resumed=True: %v", err))
+	if !conditionMet {
+		logger.Infof("Warning, could not detect Resumed=True.")
+	}
+	logger.Infof("Waiting for UpdateComplete=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateComplete, metav1.ConditionTrue, 10*time.Second, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
+	if !conditionMet {
+		logger.Infof("Warning, could not detect UpdateComplete=True.")
+	}
+	logger.Infof("Waiting for Uncordoned=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateUncordoned, metav1.ConditionTrue, 10*time.Second, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
+	if !conditionMet {
+		logger.Infof("Warning, could not detect UpdateComplete=True.")
+	}
+
+	logger.Infof("Waiting for Updated=True")
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Updated=True: %v", err))
+	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Updated=True.")
+
+	// When the update is not an image mode update, we need to check that the
+	// "ImagePulledFromRegistry" condition did not transition during the updates
+	if !isImageMode {
+		mcn, mcnErr := machineConfigClient.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), updatingNodeName, metav1.GetOptions{})
+		o.Expect(mcnErr).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while trying to get MCN for node `%v`: %v", updatingNodeName, mcnErr))
+
+		for _, condition := range mcn.Status.Conditions {
+			if condition.Type == string(mcfgv1.MachineConfigNodeImagePulledFromRegistry) {
+				logger.Infof("Checking that %v was not updated during this update.", condition.Type)
+				o.Expect(condition.LastTransitionTime.Before(&updateStartTime)).To(o.BeTrue(), "Expected last transition time of %v condition to be before %v.", condition.Type, updateStartTime)
+			}
+		}
+	}
+}
+
+// `ConfirmUpdatedMCNStatus` confirms that an MCN is in a fully updated state, which requires:
+//  1. "Updated" = True
+//  2. All other conditions = False
+func ConfirmUpdatedMCNStatus(clientSet *machineconfigclient.Clientset, mcnName string) bool {
+	// Get MCN
+	workerNodeMCN, workerErr := clientSet.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), mcnName, metav1.GetOptions{})
+	o.Expect(workerErr).NotTo(o.HaveOccurred())
+
+	// Loop through conditions and return the status of the desired condition type
+	conditions := workerNodeMCN.Status.Conditions
+	for _, condition := range conditions {
+		if condition.Type == string(mcfgv1.MachineConfigNodeUpdated) && condition.Status != metav1.ConditionTrue {
+			logger.Infof("Node '%s' update is not complete; 'Updated' condition status is '%v'", mcnName, condition.Status)
+			return false
+		} else if condition.Type != string(mcfgv1.MachineConfigNodeUpdated) && condition.Status != metav1.ConditionFalse {
+			logger.Infof("Node '%s' is updated but MCN is invalid; '%v' codition status is '%v'", mcnName, condition.Type, condition.Status)
+			return false
+		}
+	}
+
+	logger.Infof("Node '%s' update is complete and corresponding MCN is valid.", mcnName)
+	return true
+}

--- a/test/extended/machineconfigpool.go
+++ b/test/extended/machineconfigpool.go
@@ -1,0 +1,155 @@
+// TODO (MCO-1960): Deduplicate these functions with the helpers defined in /extended-priv/machineconfigpool.go.
+package extended
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	o "github.com/onsi/gomega"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// `DoesMachineConfigPoolHaveMachines` returns true if the desired MCP, defined by the
+// `mcpName` parameter has machines and false otherwise. It also returns an error if one occurs
+// when getting the MCP.
+func DoesMachineConfigPoolHaveMachines(machineConfigClient *machineconfigclient.Clientset, mcpName string) bool {
+	// Get desired MCP
+	mcp, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
+	o.Expect(mcpErr).NotTo(o.HaveOccurred(), "Error checking for compatible MCPs: %s", mcpErr)
+
+	// Check if desired MCP has machines
+	return mcp.Status.MachineCount > 0
+}
+
+// `WaitForMCPToBeReady` waits up to 5 minutes for a pool to be in an updated state with
+// a specified number of ready machines
+func WaitForMCPToBeReady(machineConfigClient *machineconfigclient.Clientset, poolName string, readyMachineCount int32, oldRenderedMC string) {
+	o.Eventually(func() bool {
+		mcp, err := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+		if err != nil {
+			logger.Infof("Failed to grab MCP '%v', error :%v", poolName, err)
+			return false
+		}
+		// Check if the pool is in an updated state with the correct number of ready machines
+		if IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) &&
+			(oldRenderedMC != "" || mcp.Status.UpdatedMachineCount == readyMachineCount) {
+			logger.Infof("MCP '%v' has the desired %v ready machines.", poolName, mcp.Status.UpdatedMachineCount)
+			// If an old rendered MC has been provided, make sure the MCP has been updated to a new rendered MC
+			if oldRenderedMC != "" {
+				// If the MC in the MCP is not equal to the old rendered MC, it meas we have updated to a new MC
+				if mcp.Spec.Configuration.Name != oldRenderedMC {
+					logger.Infof("MCP '%v' has updated to a new rendered MC: %v.", poolName, mcp.Spec.Configuration.Name)
+					return true
+				}
+				logger.Infof("MCP '%v' is still targeting the old rendered MC: %v. Waiting for the MCP to target a new rendered MC.", poolName, mcp.Spec.Configuration.Name)
+				return false
+			}
+			return true
+		}
+		// Log details of what is outstanding for the pool to be considered ready
+		if mcp.Status.UpdatedMachineCount == readyMachineCount {
+			logger.Infof("MCP '%v' has the desired %v ready machines, but is not in an 'Updated' state.", poolName, mcp.Status.UpdatedMachineCount)
+		} else {
+			logger.Infof("MCP '%v' has %v ready machines. Waiting for the desired ready machine count of %v.", poolName, mcp.Status.UpdatedMachineCount, readyMachineCount)
+		}
+		return false
+	}, 5*time.Minute, 10*time.Second).Should(o.BeTrue(), "Timed out waiting for MCP '%v' to be in 'Updated' state with %v ready machines.", poolName, readyMachineCount)
+}
+
+// `CleanupCustomMCP` cleans up a custom MCP if it exists through the following steps:
+//  1. Remove the custom MCP role label from the node
+//  2. Wait for the custom MCP to be updated with no ready machines
+//  3. Wait for the node to have a current config version equal to the config version of the worker MCP
+//  4. Remove the custom MCP
+func CleanupCustomMCP(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, customMCPName, nodeName string) error {
+	// Skip this if the custom MCP is already deleted
+	logger.Infof("Checking if MCP `%v` still exists", customMCPName)
+	customMcp, customMcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), customMCPName, metav1.GetOptions{})
+	if customMcpErr != nil {
+		if apierrors.IsNotFound(customMcpErr) {
+			logger.Infof("Custom MCP `%v` no longer exists, no cleanup is required", customMCPName)
+			return nil
+		}
+		return fmt.Errorf("error checking existence of %v MCP", customMCPName)
+	}
+
+	// Unlabel node if one is in the MCP
+	if customMcp.Status.MachineCount > 0 {
+		logger.Infof("Removing label node-role.kubernetes.io/%v from node %v", customMCPName, nodeName)
+		unlabelErr := oc.AsAdmin().Run("label").Args(fmt.Sprintf("node/%s", nodeName), fmt.Sprintf("node-role.kubernetes.io/%s-", customMCPName)).Execute()
+		if unlabelErr != nil {
+			return fmt.Errorf("could not remove label 'node-role.kubernetes.io/%v' from node '%v'; err: %v", customMCPName, nodeName, unlabelErr)
+		}
+	}
+
+	// Wait for custom MCP to report no ready nodes
+	logger.Infof("Waiting for %v MCP to be updated with %v ready machines.", customMCPName, 0)
+	WaitForMCPToBeReady(machineConfigClient, customMCPName, 0, "")
+
+	// Wait for node to have a current config version equal to the worker MCP's config version
+	workerMcp, workerMcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), "worker", metav1.GetOptions{})
+	if workerMcpErr != nil {
+		return fmt.Errorf("could not get worker MCP; err: %v", workerMcpErr)
+	}
+	workerMcpConfig := workerMcp.Spec.Configuration.Name
+	logger.Infof("Waiting for %v node to be updated with %v config version.", nodeName, workerMcpConfig)
+	WaitForNodeCurrentConfig(oc, nodeName, workerMcpConfig)
+
+	// Delete custom MCP
+	logger.Infof("Deleting MCP %v", customMCPName)
+	deleteMCPErr := oc.AsAdmin().Run("delete").Args("mcp", customMCPName).Execute()
+	if deleteMCPErr != nil {
+		return fmt.Errorf("error deleting MCP '%v': %v", customMCPName, deleteMCPErr)
+	}
+
+	return nil
+}
+
+// `DeleteMCAndWaitForMCPUpdate` deletes the desired MC and waits for the associated MCP
+// to return to an updated state
+func DeleteMCAndWaitForMCPUpdate(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, mcName, mcpName string) {
+	oldRenderedMC := ""
+	// Get the rendered config of the MCP before the MC deletion, if the MCP still exists
+	mcp, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
+	if mcpErr == nil {
+		oldRenderedMC = mcp.Spec.Configuration.Name
+	}
+
+	// Delete the provided MC
+	logger.Infof("Deleting MC `%v`.", mcName)
+	mcDeleted, deleteMCErr := DeleteMCByName(oc, machineConfigClient, mcName)
+	o.Expect(deleteMCErr).NotTo(o.HaveOccurred(), fmt.Sprintf("Could not delete MachineConfig `%v`: %v.", mcName, deleteMCErr))
+
+	// Only wait for the MCP to return to an updated state if the MC existed and needed deletion
+	// and if the targeted MCP still exists
+	if mcDeleted && mcpErr == nil {
+		logger.Infof("Waiting for %v MCP to be updated with %v ready machines.", mcpName, 1)
+		WaitForMCPToBeReady(machineConfigClient, mcpName, 1, oldRenderedMC)
+	}
+}
+
+// `MCPIsUpdatedToNewConfig` checks whether a MCP has been updated to a new config version by
+// checking if the "Updated" condition in the pool's `Status` is true and if the last update time
+// of the condition is from after the update start time.
+func MCPIsUpdatedToNewConfig(machineConfigClient *machineconfigclient.Clientset, mcpName string, startTime metav1.Time) bool {
+	// Get MCP
+	mcp, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
+	o.Expect(mcpErr).NotTo(o.HaveOccurred(), "Error getting MCP `%v`: %s", mcpName, mcpErr)
+
+	// Check that the MCP is in an "Updated" condition that was set after the update started
+	for _, condition := range mcp.Status.Conditions {
+		if condition.Type == mcfgv1.MachineConfigPoolUpdated {
+			return condition.Status == corev1.ConditionTrue && condition.LastTransitionTime.After(startTime.Time)
+		}
+	}
+
+	return false
+}

--- a/test/extended/node.go
+++ b/test/extended/node.go
@@ -1,9 +1,20 @@
+// TODO (MCO-1960): Deduplicate these functions with the helpers defined in /extended-priv/node.go.
 package extended
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	o "github.com/onsi/gomega"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	extpriv "github.com/openshift/machine-config-operator/test/extended-priv"
 	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -20,4 +31,37 @@ func getReadyNodes(oc *exutil.CLI) (sets.Set[string], error) {
 		nodeSet.Insert(node.GetName())
 	}
 	return nodeSet, nil
+}
+
+// `GetNodesByRole` gets all nodes labeled with the desired role
+func GetNodesByRole(oc *exutil.CLI, role string) ([]corev1.Node, error) {
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{fmt.Sprintf("node-role.kubernetes.io/%s", role): ""}).String(),
+	}
+	nodes, err := oc.AsAdmin().KubeClient().CoreV1().Nodes().List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Items, nil
+}
+
+// `WaitForNodeCurrentConfig` waits up to 5 minutes for a input node to have a current
+// config equal to the `config` parameter
+func WaitForNodeCurrentConfig(oc *exutil.CLI, nodeName, config string) {
+	o.Eventually(func() bool {
+		node, nodeErr := oc.AsAdmin().KubeClient().CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if nodeErr != nil {
+			logger.Infof("Failed to get node '%v', error :%v", nodeName, nodeErr)
+			return false
+		}
+
+		// Check if the node's current config matches the input config version
+		nodeCurrentConfig := node.Annotations[constants.CurrentMachineConfigAnnotationKey]
+		if nodeCurrentConfig == config {
+			logger.Infof("Node '%v' has successfully updated and has a current config version of '%v'.", nodeName, nodeCurrentConfig)
+			return true
+		}
+		logger.Infof("Node '%v' has a current config version of '%v'. Waiting for the node's current config version to be '%v'.", nodeName, nodeCurrentConfig, config)
+		return false
+	}, 5*time.Minute, 10*time.Second).Should(o.BeTrue(), "Timed out waiting for node '%v' to have a current config version of '%v'.", nodeName, config)
 }


### PR DESCRIPTION
**- What I did**
This adds 5 regression tests to use for the component readiness of the `ImageModeStatusReporting` feature gate.

| Jira | Test Name | Description | Execution Time |
|---|---|---|---|
| [MCO-1716](https://issues.redhat.com//browse/MCO-1716) | MachineConfigNode properties should match the associated node properties when OCB is enabled in a custom MCP | This test checks that the new image mode status reporting fields, namely the desired and current config image values, are set when on-cluster image mode is enabled in a custom MCP. | 19 min |
| [MCO-1715](https://issues.redhat.com//browse/MCO-1715) | MachineConfigNode conditions should properly transition on an image based update when OCB is enabled in a custom MCP | This test checks that all MCN conditions, including the `ImagePulledFromRegistry` condition added for image mode status reporting, transition as expected when an update requiring a new image to build (as defined in #4996) is triggered in a custom MCP with on-cluster image mode enabled. | 28 min |
| [MCO-1714](https://issues.redhat.com//browse/MCO-1714) | MachineConfigNode conditions should properly transition on a non-image based update when OCB is enabled in a custom MCP | This test checks that all MCN conditions transition as expected when an update _not_ requiring a new image to build (as defined in #4996) is triggered in a custom MCP with on-cluster image mode enabled. | __ min |
| [MCO-1717](https://issues.redhat.com//browse/MCO-1717) | MachineConfigPool machine counts should transition correctly on an update in a default MCP | This test checks that the updated and degraded machine counts are correctly populated throughout the application and cleanup of a MC in a default MCP. | __ min |
| [MCO-1718](https://issues.redhat.com//browse/MCO-1718) | MachineConfigPool machine counts should transition when OCB is enabled in a default MCP | This test checks that the updated and degraded machine counts are correctly populated throughout the enabling and disabling of on-cluster image mode in a default MCP. | __ min |

** Note that the recorded execution time is an approximate base on running the tests locally on a standard 3x3 cluster.

**- How to verify it**
_To test locally:_
```
$ make all
$ <path_to_machine-config-tests-ext> run-test "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting] MachineConfigNode properties should match the associated node properties when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]"
$ <path_to_machine-config-tests-ext> run-test "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting] MachineConfigNode conditions should properly transition on an image based update when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]"
$ <path_to_machine-config-tests-ext> run-test "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting] MachineConfigNode conditions should properly transition on a non-image based update when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]"
$ <path_to_machine-config-tests-ext> run-test "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting] MachineConfigPool machine counts should transition correctly on an update in a default MCP [apigroup:machineconfiguration.openshift.io]"
$ <path_to_machine-config-tests-ext> run-test "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting] MachineConfigPool machine counts should transition when OCB is enabled in a default MCP [apigroup:machineconfiguration.openshift.io]"
```

_To test in a payload rehearsal:_
Check the results of the tech preview MCO disruptive suite runs:
- [periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-vsphere-mco-disruptive-techpreview](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-machine-config-operator-5363-periodics-e2e-vsphere-mco-disruptive-techpreview/1981789195609313280)
- [periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-metal-ipi-ovn-ipv4-mco-disruptive-techpreview](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-machine-config-operator-5363-periodics-e2e-metal-ipi-ovn-ipv4-mco-disruptive-techpreview/1981789196167155712)
- periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-metal-ipi-ovn-ipv6-mco-disruptive-techpreview
- periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-metal-ipi-ovn-dualstack-mco-disruptive-techpreview
- periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-aws-mco-disruptive-techpreview
- periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-gcp-mco-disruptive-techpreview
- periodic-ci-openshift-machine-config-operator-release-4.21-periodics-e2e-azure-mco-disruptive-techpreview

**- Description for the changelog**
[MCO-1714](https://issues.redhat.com//browse/MCO-1714): [MCO-1715](https://issues.redhat.com//browse/MCO-1715): [MCO-1716](https://issues.redhat.com//browse/MCO-1716): [MCO-1717](https://issues.redhat.com//browse/MCO-1717): [MCO-1718](https://issues.redhat.com//browse/MCO-1718): Add regression tests for ImageModeStatusReporting FeatureGate