### PR TITLE
[release-4.20] OCPBUGS-59766: Update timing of MCN desired config spec update to align with node annotation setting

### DIFF
--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -335,6 +335,42 @@ func isSingletonCondition(singletonConditionTypes []mcfgv1.StateProgress, condit
 	return false
 }
 
+// UpdateMachineConfigNodeSpecDesiredAnnotation sets the desired config version in the `Spec` of an
+// existing MachineConfigNode resource
+func UpdateMachineConfigNodeSpecDesiredAnnotation(fgHandler ctrlcommon.FeatureGatesHandler, mcfgClient mcfgclientset.Interface, nodeName, desiredConfig string) error {
+	if fgHandler == nil {
+		return nil
+	}
+
+	// Check that the MachineConfigNode feature gate is enabled
+	if !fgHandler.Enabled(features.FeatureGateMachineConfigNodes) {
+		klog.Infof("MachineConfigNode FeatureGate is not enabled.")
+		return nil
+	}
+
+	// Get the existing MCN
+	mcn, mcnErr := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	// Note that this function is only intended to update the Spec of an existing MCN. We should
+	// not reach this point if there is not an existing MCN for a node, but we need to handle the
+	// DNE and other potential error situations just in case.
+	if mcnErr != nil {
+		return mcnErr
+	}
+
+	// Set the desired config annotation
+	mcn.Spec.ConfigVersion.Desired = NotYetSet
+	if desiredConfig != "" {
+		mcn.Spec.ConfigVersion.Desired = desiredConfig
+	}
+
+	// Update the MCN resource
+	if _, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Update(context.TODO(), mcn, metav1.UpdateOptions{FieldManager: "machine-config-operator"}); err != nil {
+		return fmt.Errorf("failed to update the %s mcn spec with the new desired config value: %w", nodeName, err)
+	}
+
+	return nil
+}
+
 // GenerateAndApplyMachineConfigNodeSpec generates and applies a new MCN spec based off the node state
 func GenerateAndApplyMachineConfigNodeSpec(fgHandler ctrlcommon.FeatureGatesHandler, pool string, node *corev1.Node, mcfgClient mcfgclientset.Interface) error {
 	if fgHandler == nil || node == nil {


### PR DESCRIPTION
Closes: OCPBUGS-59766

**- What I did**
This is a manual backport of the bug fix included in the larger scoped PR #5282 into 4.21.

**- How to verify it**
1. Launch a 4.20 cluster with this PR build included.
```
launch 4.20,openshift/machine-config-operator#5367 aws
```

2. Apply a MachineConfig to trigger a node update. Track how the desired config is updated in the MCN's spec and status. The desired config value in the spec should update before the UpdatePrepared condition is True and before the desired config version is updated in the status.
_Example grep to see the necessary fields:_
```
oc describe machineconfignode/<node-name> | grep -E "Config Version|UpdatePrepared" -A 2
```

**- Description for the changelog**
OCPBUGS-59766: Update timing of desired config version update in MCN to align with node annotation setting