### PR TITLE
OCPBUGS-65544: MCO-1886: add the missing service to the expose ports 22623 and 22624

### DIFF
--- a/install/0000_80_machine-config_00_service.yaml
+++ b/install/0000_80_machine-config_00_service.yaml
@@ -63,4 +63,29 @@ spec:
   - name: health
     port: 8798
     protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: machine-config-server
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: machine-config-server
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: machine-config-server
+  ports:
+  - name: https
+    port: 22623
+    targetPort: 22623
+    protocol: TCP
+  - name: http
+    port: 22624
+    targetPort: 22624
+    protocol: TCP
 


### PR DESCRIPTION
regarding to this bug https://issues.redhat.com/browse/MCO-1886

**- What I did**
added a new ClusterIP Service machine-config-server in openshift-machine-config-operator.
Exposes TCP ports 22623 (https) and 22624 (http) used by the Machine Config Server.



