### PR TITLE
OCPBUGS-63006: Ensure MOSC updates rolls out new image built to nodes

### DIFF
--- a/test/e2e-ocl/Containerfile.simple
+++ b/test/e2e-ocl/Containerfile.simple
@@ -1,0 +1,3 @@
+FROM configs AS final
+RUN touch /etc/simple-test-file.txt && \
+    ostree container commit


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/OCPBUGS-63006
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
When an MOSC is edited, ensure that the new image that is built is rolled out onto the nodes in the pool by ensuring that the node_controller is able to pick the correct and most recent MOSB even if the rendered-MC used for the new image build hasn't changed.

**- How to verify it**
Enable a pool into OCL and then update the MOSC, which will trigger a new image build but not a new rendered-MC and ensure that the new image is rolled out onto the nodes.

**- Description for the changelog**
Ensure node_controller is able to point to the most recent successful image build even when the rendered-MC hasn't changed.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
