### PR TITLE
CORS-4208: set default KUBELET_NODE_IPS for dualstack nodes

### DIFF
--- a/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
@@ -11,10 +11,12 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
-{{- if eq .IPFamilies "IPv6"}}
+{{- if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") }}
   Environment="KUBELET_NODE_IP=::"
+  Environment="KUBELET_NODE_IPS=::"
 {{- else}}
   Environment="KUBELET_NODE_IP=0.0.0.0"
+  Environment="KUBELET_NODE_IPS=0.0.0.0"
 {{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -11,10 +11,12 @@ contents: |
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
-{{- if eq .IPFamilies "IPv6"}}
+{{- if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") }}
   Environment="KUBELET_NODE_IP=::"
+  Environment="KUBELET_NODE_IPS=::"
 {{- else}}
   Environment="KUBELET_NODE_IP=0.0.0.0"
+  Environment="KUBELET_NODE_IPS=0.0.0.0"
 {{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -12,10 +12,12 @@ contents: |
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
   ExecStartPre=/bin/mkdir --parents /etc/openshift/kubelet.conf.d
   ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
-{{- if eq .IPFamilies "IPv6"}}
+{{- if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") }}
   Environment="KUBELET_NODE_IP=::"
+  Environment="KUBELET_NODE_IPS=::"
 {{- else}}
   Environment="KUBELET_NODE_IP=0.0.0.0"
+  Environment="KUBELET_NODE_IPS=0.0.0.0"
 {{- end}}
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

This updates the master and worker kubelet service templates to set the defaults `KUBELET_NODE_IPS`.
- DualStack: default to `0.0.0.0`
- DualStackIPv6Primary: default to `::`

This set the `--node-ip` (i.e. to `0.0.0.0` or `::`) kubelet argument when enabling dualstack support on cloud providers, where node ip is not beforehand.

**- Why I did**

When investigating failures related to dual-stack support on AWS, I noticed `kubelet` ran without the `--node-ip=<any-id>` argument. As a result, CNI never came online, while complaining that node was missing the `InternalIP` address. For example, results from a failed attempt returned the following errors:

| Component | Failed log | 
|:--|:--|
|`ovnkube-controller` container|`F0903 17:41:46.149835    5622 ovnkube.go:138] failed to run ovnkube: [failed to start network controller: failed to start default network controller - while waiting for any node to have zone: "i-041d879bce674db11.ec2.internal", error: context canceled, failed to start node network controller: failed to init default node network controller: i-041d879bce674db11.ec2.internal doesn't have an address with type InternalIP or ExternalIP]`|
|`kubelet`|`Error syncing pod, skipping" err="network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: no CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?"`|
|`kube-rbac-proxy-crio` container|`failed to initialize certificate reloader: error loading certificates: error loading certificate: open /var/lib/kubelet/pki/kubelet-server-current.pem: no such file or directory`|

After some research and trial, I determined that the kubelet `--node-ip` is necessary. It must be set to `0.0.0.0` or `::` (ipv6-primary) in case of dualstack. After ensuring the argument is set, node was assigned `InternalIP` address and CNI progressed successfully. 

**- How to verify it**

Tested with https://github.com/openshift/installer/pull/9930. Alternatively, the installer can lay down a environment file to set the env var (for example, https://github.com/openshift/installer/commit/9fa264dae2b11a7b11b111e9be7d2cfdac119fa7), but I think it seems quite hacky :disappointed: 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update the master and worker kubelet service templates to set the defaults `KUBELET_NODE_IPS` (i.e.  `0.0.0.0` for Dualstack and `::` for DualStackIPv6Primary)

