### PR TITLE
OCPBUGS-63734: Fix error reporting on OS image failure

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2627,7 +2627,7 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 		}); err != nil {
 			// Report ImagePulledFromRegistry condition as false (failed)
 			if imageModeStatusReportingEnabled {
-				err = upgrademonitor.GenerateAndApplyMachineConfigNodes(
+				mcnErr := upgrademonitor.GenerateAndApplyMachineConfigNodes(
 					&upgrademonitor.Condition{State: mcfgv1.MachineConfigNodeImagePulledFromRegistry, Reason: string(mcfgv1.MachineConfigNodeImagePulledFromRegistry), Message: fmt.Sprintf("Failed to pull OS image %s from registry: %v", newURL, err)},
 					nil,
 					metav1.ConditionFalse,
@@ -2637,8 +2637,8 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 					dn.fgHandler,
 					pool,
 				)
-				if err != nil {
-					klog.Errorf("Error setting ImagePulledFromRegistry condition to false: %v", err)
+				if mcnErr != nil {
+					klog.Errorf("Error setting ImagePulledFromRegistry condition to false: %v", mcnErr)
 				}
 			}
 			return fmt.Errorf("Failed to update OS to %s after retries: %w", newURL, err)


### PR DESCRIPTION
**- What I did**
This updates the error handling of the MCN status update in the case of a failed OS image so that it is not overridden.

**- How to verify it**
1. Launch a 4.21 tech preview cluster with this PR included.
```
launch 4.21,openshift/machine-config-operator#5385 gcp,techpreview
```
2. Apply a MC with an invalid custom OS image, to force an OS image failure.
```
$ cat << EOF | oc create -f -
 kind: MachineConfig
 apiVersion: machineconfiguration.openshift.io/v1
 metadata:
   labels:
     machineconfiguration.openshift.io/role: "worker"
   name: "not-bootable-image-tc54052"
 spec:
   osImageURL: "quay.io/openshifttest/hello-openshift:1.2.0"
EOF
```
3. Wait for the `worker` MCP to degrade.
```
$ oc get mcp/worker
worker   rendered-worker-2996b083442ff3c9b9456218a648514f   False     True       True       3              0                   0                     1                      51m
```
4. Check that the `Failed to update OS to quay.io/openshifttest/hello-openshift:1.2.0 after retries:` error is reporting the proper error.
```
$ oc get mcp/worker -oyaml
...
- lastTransitionTime: "2025-11-03T15:09:13Z"
    message: 'Node ci-ln-615zw32-72292-c9mvb-worker-a-n4n94 is reporting: "Node ci-ln-615zw32-72292-c9mvb-worker-a-n4n94
      upgrade failure. Failed to update OS to quay.io/openshifttest/hello-openshift:1.2.0
      after retries: timed out waiting for the condition", Node ci-ln-615zw32-72292-c9mvb-worker-a-n4n94
      is reporting: "Failed to update OS to quay.io/openshifttest/hello-openshift:1.2.0
      after retries: timed out waiting for the condition"'
    reason: 1 nodes are reporting degraded status on sync
    status: "True"
    type: NodeDegraded
...
```

**- Description for the changelog**
OCPBUGS-63734: Fix error reporting on OS image failure