### PR TITLE
MCO-1911: Use the right naming in migrated test cases

### DIFF
--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		skipTestIfOCBIsEnabled(oc)
 	})
 
-	g.It("PolarionID:83141-A valid MachineOSConfig leads to a successful MachineOSBuild and cleanup of its associated resources", func() {
+	g.It("[PolarionID:83141][OTP] A valid MachineOSConfig leads to a successful MachineOSBuild and cleanup of its associated resources", func() {
 		var (
 			mcpAndMoscName = "infra"
 		)
@@ -53,7 +53,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	})
 
-	g.It("PolarionID:83138-A MachineOSConfig fails to apply or degrades if invalid inputs are given", func() {
+	g.It("[PolarionID:83138][OTP] A MachineOSConfig fails to apply or degrades if invalid inputs are given", func() {
 		var (
 			mcpAndMoscName = "infra"
 			pushSpec       = fmt.Sprintf("%s/openshift-machine-config-operator/ocb-%s-image:latest", InternalRegistrySvcURL, mcpAndMoscName)
@@ -106,7 +106,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!")
 	})
 
-	g.It("PolarionID:83140-A MachineOSConfig with custom containerfile definition can be successfully applied", func() {
+	g.It("[PolarionID:83140][OTP] A MachineOSConfig with custom containerfile definition can be successfully applied", func() {
 		var (
 			mcp = GetCompactCompatiblePool(oc.AsAdmin())
 
@@ -145,7 +145,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		testContainerFile([]ContainerFile{{Content: containerFileContent}}, MachineConfigNamespace, mcp, checkers, false)
 	})
 
-	g.It("PolarionID:77781-A successfully built MachineOSConfig can be re-build", func() {
+	g.It("[PolarionID:77781][OTP] A successfully built MachineOSConfig can be re-build", func() {
 
 		var (
 			mcp = GetCompactCompatiblePool(oc.AsAdmin())
@@ -167,7 +167,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	g.It("PolarionID:77782-A MachineOSConfig with an unfinished build can be re-build", func() {
+	g.It("[PolarionID:77782][OTP] A MachineOSConfig with an unfinished build can be re-build", func() {
 
 		var (
 			mcp = GetCompactCompatiblePool(oc.AsAdmin())

--- a/test/extended-priv/mco_password.go
+++ b/test/extended-priv/mco_password.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		preChecks(oc)
 	})
 
-	g.It("PolarionID:59417-MCD create/update password with MachineConfig in CoreOS nodes", func() {
+	g.It("[PolarionID:59417][OTP] MCD create/update password with MachineConfig in CoreOS nodes", func() {
 		var (
 			mcName   = "tc-59417-test-core-passwd"
 			mcc      = NewController(oc.AsAdmin()).IgnoreLogsBeforeNowOrFail()
@@ -129,7 +129,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	})
 
-	g.It("PolarionID:72137-Create a password for a user different from 'core' user", func() {
+	g.It("[PolarionID:72137][OTP] Create a password for a user different from 'core' user", func() {
 		var (
 			mcName       = "mco-tc-59900-wrong-user-password"
 			wrongUser    = "root"
@@ -149,7 +149,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	})
 
 	// https://issues.redhat.com/browse/MCO-1696
-	g.It("PolarionID:59424-ssh keys can be found in new dir on RHCOS9 node", func() {
+	g.It("[PolarionID:59424][OTP] ssh keys can be found in new dir on RHCOS9 node", func() {
 		var (
 			allCoreOsNodes = wMcp.GetCoreOsNodesOrFail()
 			allMasters     = mMcp.GetNodesOrFail()
@@ -191,7 +191,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		}
 	})
 
-	g.It("PolarionID:59426-ssh keys can be updated in new dir on RHCOS9 node", func() {
+	g.It("[PolarionID:59426][LEVEL0][OTP] ssh keys can be updated in new dir on RHCOS9 node", func() {
 
 		var (
 			mcName            = "tc-59426-add-ssh-key"
@@ -276,7 +276,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	})
 
-	g.It("PolarionID:62533-Passwd login must not work with ssh", func() {
+	g.It("[PolarionID:62533][OTP] Passwd login must not work with ssh", func() {
 		var (
 			mcName       = "tc-62533-test-passwd-ssh-login"
 			password     = exutil.GetRandomString()
@@ -312,7 +312,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	g.It("PolarionID:64986-Remove all ssh keys", func() {
+	g.It("[PolarionID:64986][OTP] Remove all ssh keys", func() {
 		var (
 			sshMCName    = "99-" + mcp.GetName() + "-ssh"
 			backupMCFile = filepath.Join(e2e.TestContext.OutputDir, "tc-64986-"+sshMCName+".backup.json")
@@ -373,7 +373,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	g.It("PolarionID:75552-apply ssh keys when root owns .ssh", func() {
+	g.It("[PolarionID:75552][OTP] apply ssh keys when root owns .ssh", func() {
 		var (
 			node         = mcp.GetSortedNodesOrFail()[0]
 			authKeysdDir = NewRemoteFile(node, "/home/core/.ssh/authorized_keys.d")

--- a/test/extended-priv/util.go
+++ b/test/extended-priv/util.go
@@ -419,7 +419,7 @@ func IsCapabilityEnabled(oc *exutil.CLI, capability string) bool {
 func GetCurrentTestPolarionIDNumber() string {
 	name := g.CurrentSpecReport().FullText()
 
-	r := regexp.MustCompile(`PolarionID:(?P<id>\d+)`)
+	r := regexp.MustCompile(`\[PolarionID:(?P<id>\d+)\]`)
 
 	matches := r.FindStringSubmatch(name)
 	number := r.SubexpIndex("id")


### PR DESCRIPTION
**- What I did**

Change the name of the test cases to add the necessary labels to track the migrated test cases.

Add the LEVEL0 label too.

All changes were made according to the suggestions made by the extended framework team in https://redhat-internal.slack.com/archives/C07RDCVEYJG/p1761566081582099?thread_ts=1761564227.897439&cid=C07RDCVEYJG


**- How to verify it**

**- Description for the changelog**
