### PR TITLE
MCO-1966: Filter extended tests by platform

### DIFF
--- a/test/extended/boot_image_update_azure.go
+++ b/test/extended/boot_image_update_azure.go
@@ -18,7 +18,7 @@ import (
 )
 
 // These tests are [Serial] because it modifies the cluster/machineconfigurations.operator.openshift.io object in each test.
-var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure]", g.Ordered, func() {
+var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure]", g.Label("Platform:azure"), g.Ordered, func() {
 	defer g.GinkgoRecover()
 	var (
 		AllMachineSetFixture     = filepath.Join("machineconfigurations", "managedbootimages-all.yaml")


### PR DESCRIPTION
**- What I did**
Add the functionality to exclude test cases from an execution depending on the platform using env flags.

Included labels:

- PLatform:PLATFORM_NAME:  the test runs only in this platform
- NotPlatform:PLATFORM_NAME: the test doesn't run in this platform
- Exclude:REASON: the test is never executed

**- How to verify it**

Azure test cases are not listed if aws platform is required



```
$ ./_output/linux/amd64/machine-config-tests-ext list --platform aws |grep name
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:83141][OTP] A valid MachineOSConfig leads to a successful MachineOSBuild and cleanup of its associated resources",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:83138][OTP] A MachineOSConfig fails to apply or degrades if invalid inputs are given",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:83140][OTP] A MachineOSConfig with custom containerfile definition can be successfully applied",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:77781][OTP] A successfully built MachineOSConfig can be re-build",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:77782][OTP] A MachineOSConfig with an unfinished build can be re-build",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:59417][OTP] MCD create/update password with MachineConfig in CoreOS nodes",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:72137][OTP] Create a password for a user different from 'core' user",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:59424][OTP] ssh keys can be found in new dir on RHCOS9 node",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:59426][LEVEL0][OTP] ssh keys can be updated in new dir on RHCOS9 node",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:62533][OTP] Passwd login must not work with ssh",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:64986][OTP] Remove all ssh keys",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:75552][OTP] apply ssh keys when root owns .ssh",
```


Azure test cases are listed if platform azure is required

```
$ ./_output/linux/amd64/machine-config-tests-ext list --platform azure |grep name
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:83141][OTP] A valid MachineOSConfig leads to a successful MachineOSBuild and cleanup of its associated resources",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:83138][OTP] A MachineOSConfig fails to apply or degrades if invalid inputs are given",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:83140][OTP] A MachineOSConfig with custom containerfile definition can be successfully applied",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:77781][OTP] A successfully built MachineOSConfig can be re-build",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:77782][OTP] A MachineOSConfig with an unfinished build can be re-build",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:59417][OTP] MCD create/update password with MachineConfig in CoreOS nodes",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:72137][OTP] Create a password for a user different from 'core' user",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:59424][OTP] ssh keys can be found in new dir on RHCOS9 node",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:59426][LEVEL0][OTP] ssh keys can be updated in new dir on RHCOS9 node",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:62533][OTP] Passwd login must not work with ssh",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:64986][OTP] Remove all ssh keys",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO password [PolarionID:75552][OTP] apply ssh keys when root owns .ssh",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure] Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure] Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure] Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure] Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]",
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][OCPFeatureGate:ManagedBootImagesAzure] [Disruptive] Should update boot images on an Azure MachineSets with a legacy boot image and scale successfully [apigroup:machineconfiguration.openshift.io]",
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
