### PR TITLE
[release-4.20] OCPBUGS-64656: Update the OCP base image in Dockerfile to 4.20 reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/go/rhel8/.cache,z \
     --mount=type=cache,target=/go/rhel8/pkg/mod,z \
     make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-enterprise-base-multi-openshift-4.19
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 ARG TAGS=""
 COPY install /manifests
 RUN --mount=type=cache,target=/var/cache/dnf,z \


### PR DESCRIPTION
**- What I did**
This updates the OCP base image to reference a 4.20 multi-arch variant instead of the currently referenced 4.19 image.

**- How to verify it**
_To verify locally:_
MCO should continue to build properly.

_To verify with CI:_
All existing tests should continue to pass.

**- Description for the changelog**
OCPBUGS-64656: Update the OCP base image in Dockerfile to 4.20 reference
