### PR TITLE
OCPBUGS-65556: [release-4.20] Backport: Add delays to reduce TestOSBuildController failures

### DIFF
--- a/pkg/controller/build/osbuildcontroller_test.go
+++ b/pkg/controller/build/osbuildcontroller_test.go
@@ -291,7 +291,7 @@ func TestOSBuildController(t *testing.T) {
 		// new MachineOSBuild is produced from it. We'll do this 10 times.
 		for i := 0; i <= 5; i++ {
 			apiMosc := testhelpers.SetContainerfileContentsOnMachineOSConfig(ctx, t, mcfgclient, mosc, "FROM configs AS final"+fmt.Sprintf("%d", i))
-
+			time.Sleep(time.Millisecond * 200)
 			apiMCP, err := mcfgclient.MachineconfigurationV1().MachineConfigPools().Get(ctx, apiMosc.Spec.MachineConfigPool.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 
@@ -306,6 +306,7 @@ func TestOSBuildController(t *testing.T) {
 			// Set the successful status on the job.
 			fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Succeeded: 1})
 			// The MachineOSBuild should be successful.
+			time.Sleep(time.Millisecond * 200)
 			kubeassert.MachineOSBuildIsSuccessful(mosb, "Expected the MachineOSBuild %s status to be successful", mosb.Name)
 			// And the build job should be deleted.
 			assertBuildObjectsAreDeleted(ctx, t, kubeassert, mosb)
@@ -333,6 +334,7 @@ func TestOSBuildController(t *testing.T) {
 			require.NoError(t, err)
 
 			apiMCP := insertNewRenderedMachineConfigAndUpdatePool(ctx, t, mcfgclient, mosc.Spec.MachineConfigPool.Name, getConfigNameForPool(i+2))
+			time.Sleep(time.Millisecond * 200)
 
 			mosb := buildrequest.NewMachineOSBuildFromAPIOrDie(ctx, kubeclient, apiMosc, apiMCP)
 			buildJobName := utils.GetBuildJobName(mosb)
@@ -342,6 +344,7 @@ func TestOSBuildController(t *testing.T) {
 			kubeassert.JobExists(buildJobName, "Build job did not get created for MachineConfigPool %q change", mcp.Name)
 			// Set the successful status on the job.
 			fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Succeeded: 1})
+			time.Sleep(time.Millisecond * 200)
 			// The MachineOSBuild should be successful.
 			kubeassert.MachineOSBuildIsSuccessful(mosb, "Expected the MachineOSBuild %s status to be successful", mosb.Name)
 			// And the build job should be deleted.
@@ -660,7 +663,7 @@ func setupOSBuildControllerForTestWithRunningBuild(ctx context.Context, t *testi
 	t.Helper()
 
 	kubeclient, mcfgclient, imageclient, routeclient, mosc, mosb, mcp, kubeassert, ctrl := setupOSBuildControllerForTestWithBuild(ctx, t, poolName)
-
+	time.Sleep(time.Millisecond * 200)
 	initialBuildJobName := utils.GetBuildJobName(mosb)
 
 	// After creating the new MachineOSConfig, a MachineOSBuild should be created.
@@ -671,7 +674,7 @@ func setupOSBuildControllerForTestWithRunningBuild(ctx context.Context, t *testi
 
 	// Set the running status on the job.
 	fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Active: 1})
-
+	time.Sleep(time.Millisecond * 200)
 	// The MachineOSBuild should be running.
 	kubeassert.Eventually().WithContext(ctx).MachineOSBuildIsRunning(mosb, "Expected the MachineOSBuild %s status to be running", mosb.Name)
 
@@ -682,10 +685,11 @@ func setupOSBuildControllerForTestWithSuccessfulBuild(ctx context.Context, t *te
 	t.Helper()
 
 	kubeclient, mcfgclient, imageclient, routeclient, mosc, mosb, mcp, kubeassert, _ := setupOSBuildControllerForTestWithRunningBuild(ctx, t, poolName)
-
+	time.Sleep(time.Millisecond * 200)
 	kubeassert.MachineOSBuildExists(mosb)
 	kubeassert.JobExists(utils.GetBuildJobName(mosb))
 	fixtures.SetJobStatus(ctx, t, kubeclient, mosb, fixtures.JobStatus{Succeeded: 1})
+	time.Sleep(time.Millisecond * 200)
 	kubeassert.MachineOSBuildIsSuccessful(mosb)
 	kubeassert.JobDoesNotExist(utils.GetBuildJobName(mosb))
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
## Description

   Backport of #5239 to release-4.20

My PR saw a similar failure https://github.com/openshift/machine-config-operator/pull/5387 hence needed to backport

   ### Summary
   This PR backports the test timing fixes from PR #5239 to the release-4.20 branch.

   ### Problem
   The test `TestOSBuildController/MachineConfig_changes_creates_a_new_MachineOSBuild` is failing in CI on release-4.20 with a timeout error (`context deadline
    exceeded`). The test completes in ~24.73 seconds but times out at the 25-second limit.

   ### Root Cause
   - Commit 97cecaed0 introduced MOSB reuse logic which added more complex reconciliation
   - This increased test execution time beyond the 25-second timeout in CI environments
   - PR #5239 added 200ms delays to fix this issue on main/4.21/4.22
   - However, these fixes were not backported to release-4.20

   ### Solution
   Cherry-pick commit fd87e53af from PR #5239 which adds `time.Sleep(200ms)` delays at critical points in the test to allow the controller's reconciliation
   loops to complete before assertions are checked.

   ### Testing
   - ✅ Test passes locally with delays (3.22s)
   - ✅ Test was timing out before this fix
   ### Original PR
   https://github.com/openshift/machine-config-operator/pull/5239

   cc: @djoshy (original author)

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
