### PR TITLE
OCPBUGS-64822: Implement upgrade blocking for conflicting ClusterImagePolicy named "openshift"

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -280,6 +280,16 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error 
 		coStatusCondition.Reason = "ClusterOnCgroupV1"
 		coStatusCondition.Message = "Cluster is using deprecated cgroup v1 and is not upgradable. Please update the `CgroupMode` in the `nodes.config.openshift.io` object to 'v2'. Once upgraded, the cluster cannot be changed back to cgroup v1"
 	}
+
+	// Check for ClusterImagePolicy named "openshift" which conflicts with the cluster default ClusterImagePolicy object
+	if _, err = optr.configClient.ConfigV1().ClusterImagePolicies().Get(context.TODO(), "openshift", metav1.GetOptions{}); err == nil {
+		coStatusCondition.Status = configv1.ConditionFalse
+		coStatusCondition.Reason = "ConflictingClusterImagePolicy"
+		coStatusCondition.Message = "ClusterImagePolicy resource named 'openshift' conflicts with the cluster default ClusterImagePolicy object and blocks upgrades. Please delete the 'openshift' ClusterImagePolicy resource and reapply it with a different name if needed"
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	var degraded, interrupted bool
 	for _, pool := range pools {
 		interrupted = isPoolStatusConditionTrue(pool, mcfgv1.MachineConfigPoolBuildInterrupted)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added logic to check if the resource `openshift` is customer-created and update the cluster operator status Upgradeable=False  accordingly. The `openshift` CIP is cluster-managed reserved for release payload verification. This prevents upgrades when a conflicting policy is detected. 

This check needs to be backported to 4.20.z as we plan to GA `openshift` ClusterImagePolicy (https://github.com/openshift/cluster-update-keys/pull/85) in 4.21.

**- How to verify it**

1. launch cluster with this patch

```
4.21.0-0.nightly-2025-11-05-234508, openshift/machine-config-operator#5395 (gcp)
```

2. apply a ClusterImagePolicy name: openshift

```
oc create -f clusterimgpolicycr.yaml
```

```yaml
# clusterimgpolicycr.yaml

apiVersion: config.openshift.io/v1
kind: ClusterImagePolicy
metadata:
  name: openshift
spec:
  scopes:
  - "example.com/test"
  policy:
    rootOfTrust:
      policyType: PublicKey
      publicKey:
        keyData: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFVW9GVW9ZQVJlS1hHeTU5eGU1U1FPazJhSjhvKwoyL1l6NVk4R2NOM3pGRTZWaUl2a0duSGhNbEFoWGFYL2JvME05UjYyczAvNnErK1Q3dXdORnVPZzhBPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t
    signedIdentity:
      matchPolicy: RemapIdentity
      remapIdentity:
        prefix: example.com
        signedPrefix: mirror.com
```

```
$ oc get clusterimagepolicy
NAME        AGE
openshift   3m11s
```

3. Check the upgrade status has `Upgradeable=False`

```
$ oc adm upgrade
Cluster version is 4.21.0-0-2025-11-07-142257-test-ci-ln-6zj1wdt-latest

Upgradeable=False

  Reason: ConflictingClusterImagePolicy
  Message: Cluster operator machine-config should not be upgraded between minor versions: ClusterImagePolicy resource named 'openshift' conflicts with the cluster default ClusterImagePolicy object and blocks upgrades. Please delete the 'openshift' ClusterImagePolicy resource and reapply it with a different name if needed

warning: Cannot display available updates:
  Reason: NoChannel
  Message: The update channel has not been configured.
```

```
oc describe co

Name:         machine-config
Namespace:    
Labels:       <none>
Annotations:  exclude.release.openshift.io/internal-openshift-hosted: true
              include.release.openshift.io/self-managed-high-availability: true
              include.release.openshift.io/single-node-developer: true
API Version:  config.openshift.io/v1
Kind:         ClusterOperator
Metadata:
  Creation Timestamp:  2025-11-07T14:38:17Z
  Generation:          1
  Owner References:
    API Version:     config.openshift.io/v1
    Controller:      true
    Kind:            ClusterVersion
    Name:            version
    UID:             ca29e303-4d5f-4199-b400-5af02af7c412
  Resource Version:  36347
  UID:               b83c6e38-f19f-452a-a5cb-711c91b056ae
Spec:
Status:
  Conditions:
    ...
    Last Transition Time:  2025-11-07T15:20:35Z
    Message:               ClusterImagePolicy resource named 'openshift' conflicts with the cluster default ClusterImagePolicy object and blocks upgrades. Please delete the 'openshift' ClusterImagePolicy resource and reapply it with a different name if needed
    Reason:                ConflictingClusterImagePolicy
    Status:                False
    Type:                  Upgradeable
    ...
```


**- Description for the changelog**

Implement upgrade blocking for conflicting ClusterImagePolicy named "openshift"
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
