### PR TITLE
OCPNODE-3874: Remove the dead code of setting the operator status for cgroupv1 based clusters

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -271,15 +271,6 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error 
 		Reason: asExpectedReason,
 	}
 
-	configNode, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
-	if err != nil {
-		return err
-	}
-	if configNode.Spec.CgroupMode == configv1.CgroupModeV1 {
-		coStatusCondition.Status = configv1.ConditionFalse
-		coStatusCondition.Reason = "ClusterOnCgroupV1"
-		coStatusCondition.Message = "Cluster is using deprecated cgroup v1 and is not upgradable. Please update the `CgroupMode` in the `nodes.config.openshift.io` object to 'v2'. Once upgraded, the cluster cannot be changed back to cgroup v1"
-	}
 	var degraded, interrupted bool
 	for _, pool := range pools {
 		interrupted = isPoolStatusConditionTrue(pool, mcfgv1.MachineConfigPoolBuildInterrupted)
@@ -386,14 +377,6 @@ func (optr *Operator) generateClusterFleetEvaluations() ([]string, error) {
 		evaluations = append(evaluations, "runc: transition to default crun")
 	}
 
-	enabled, err = optr.cfeEvalCgroupsV1()
-	if err != nil {
-		return evaluations, err
-	}
-	if enabled {
-		evaluations = append(evaluations, "cgroupsv1: support has been deprecated in favor of cgroupsv2")
-	}
-
 	sort.Strings(evaluations)
 
 	return evaluations, nil
@@ -442,21 +425,6 @@ func (optr *Operator) cfeEvalRunc() (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-func (optr *Operator) cfeEvalCgroupsV1() (bool, error) {
-	// check for nil so we do not have to mock within tests
-	if optr.nodeClusterLister == nil {
-		return false, nil
-	}
-	nodeClusterConfig, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return nodeClusterConfig.Spec.CgroupMode == configv1.CgroupModeV1, nil
 }
 
 // GetAllManagedNodes returns the nodes managed by MCO


### PR DESCRIPTION
- Option of configuring cgroupv1 has been [removed](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes#ocp-4-19-cgroup-v1-removed_release-notes) in OCP - 4.19
- It is safe to remove this check from the operator status for all the clusters greater than OCP - 4.19

Reference: https://github.com/openshift/machine-config-operator/pull/5397#discussion_r2504815059
