### PR TITLE
CORS-4170:  Fix IP address for default Azure DNS resolver

### DIFF
--- a/templates/common/azure/units/azure-update-dns.service.yaml
+++ b/templates/common/azure/units/azure-update-dns.service.yaml
@@ -13,7 +13,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=/usr/local/bin/update-dns-server 169.254.169.254
+  ExecStart=/usr/local/bin/update-dns-server 168.63.129.16
 
   [Install]
   RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
When ClusterHostedDNS (or custom-dns) is enabled on Azure, the `azure-update-dns` service running on the control plane, was incorrectly setting `169.254.169.254` as the Azure default resolver. 

Fixed this IP to `168.63.129.16`, based on Azure documentation links:
[Reverse DNS considerations](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances?tabs=redhat#reverse-dns-considerations)
and [Azure IP address 168.63.129.16 overview](https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16?tabs=linux)