### PR TITLE
OCPBUGS-57364: Fix IP address for default AWS DNS resolver

### DIFF
--- a/templates/common/aws/units/aws-update-dns.service.yaml
+++ b/templates/common/aws/units/aws-update-dns.service.yaml
@@ -13,7 +13,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=/usr/local/bin/update-dns-server 169.254.169.254
+  ExecStart=/usr/local/bin/update-dns-server 169.254.169.253
 
   [Install]
   RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
When ClusterHostedDNS (or custom-dns) is enabled on AWS, the aws-update-dns service running on the control plane, was incorrectly setting 169.254.169.254 as the AWS default Nameserver.

Fixed this IP to 169.254.169.253 , based on [Understanding Amazon DNS](https://docs.aws.amazon.com/vpc/latest/userguide/AmazonDNS-concepts.html)
