### PR TITLE
MCO-1956: Stream image utils

### DIFF
--- a/pkg/imageutils/image_inspect.go
+++ b/pkg/imageutils/image_inspect.go
@@ -1,0 +1,174 @@
+package imageutils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containers/common/pkg/retry"
+	"github.com/containers/image/v5/image"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// GetImage retrieves a container image by name using the provided system context.
+// The returned ImageSource must be closed by the caller.
+func GetImage(ctx context.Context, sysCtx *types.SystemContext, imageName string, retryOpts *retry.RetryOptions) (types.Image, types.ImageSource, error) {
+	ref, err := ParseImageName(imageName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing image name %q: %w", imageName, err)
+	}
+
+	source, err := GetImageSourceFromReference(ctx, sysCtx, ref, retryOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting image source for %s: %w", imageName, err)
+	}
+
+	img, err := image.FromUnparsedImage(ctx, sysCtx, image.UnparsedInstance(source, nil))
+	if err != nil {
+		return nil, nil, errors.Join(err, source.Close())
+	}
+
+	return img, source, nil
+}
+
+// GetDigestFromImage computes and returns the manifest digest for the given image.
+// It includes retry logic to handle transient network errors.
+func GetDigestFromImage(ctx context.Context, image types.Image, retryOpts *retry.RetryOptions) (digest.Digest, error) {
+	var (
+		rawManifest []byte
+		err         error
+	)
+	if err = retry.IfNecessary(ctx, func() error {
+		rawManifest, _, err = image.Manifest(ctx)
+		return err
+	}, retryOpts); err != nil {
+		return "", fmt.Errorf("error retrieving manifest for image: %w", err)
+	}
+	return manifest.Digest(rawManifest)
+}
+
+// GetInspectInfoFromImage retrieves detailed inspection information for the given image.
+// It includes retry logic to handle transient network errors.
+func GetInspectInfoFromImage(ctx context.Context, image types.Image, retryOpts *retry.RetryOptions) (*types.ImageInspectInfo, error) {
+	var (
+		imgInspect *types.ImageInspectInfo
+		err        error
+	)
+	return imgInspect, retry.IfNecessary(ctx, func() error {
+		imgInspect, err = image.Inspect(ctx)
+		return err
+	}, retryOpts)
+}
+
+// BulkInspectResult represents the result of inspecting a single image in a bulk operation.
+// It contains either the inspection information or an error if the inspection failed.
+type BulkInspectResult struct {
+	Image       string
+	InspectInfo *types.ImageInspectInfo
+	Error       error
+}
+
+// BulkInspectorOptions configures the behavior of a BulkInspector.
+// RetryOpts specifies retry behavior for transient network errors.
+// FailOnErr determines whether to return immediately on the first error (true)
+// or to continue inspecting all images and collect all results (false).
+// Count limits the number of concurrent image inspections. If Count is 0 or
+// negative, no limit is applied and all images are inspected concurrently.
+type BulkInspectorOptions struct {
+	RetryOpts *retry.RetryOptions
+	FailOnErr bool
+	Count     int
+}
+
+// BulkInspector performs concurrent image inspections with optional rate limiting
+// and configurable error handling.
+type BulkInspector struct {
+	retryOpts *retry.RetryOptions
+	failOnErr bool
+	count     int
+}
+
+// NewBulkInspector creates a new BulkInspector with the provided options.
+// If opts is nil or RetryOpts is nil, sensible defaults are applied:
+// - RetryOpts.MaxRetry defaults to 2
+// - FailOnErr defaults to false
+// - Count defaults to 0 (unlimited concurrency)
+func NewBulkInspector(opts *BulkInspectorOptions) *BulkInspector {
+	if opts == nil {
+		opts = &BulkInspectorOptions{}
+	}
+	if opts.RetryOpts == nil {
+		opts.RetryOpts = &retry.RetryOptions{MaxRetry: 2}
+	}
+	return &BulkInspector{
+		retryOpts: opts.RetryOpts,
+		failOnErr: opts.FailOnErr,
+		count:     opts.Count,
+	}
+}
+
+// Inspect concurrently inspects multiple container images and returns their inspection results.
+// The inspection is performed with optional rate limiting based on the Count configuration.
+// If FailOnErr is true, the method returns immediately upon encountering the first error.
+// Otherwise, it inspects all images and returns results for all of them, with errors
+// recorded in individual BulkInspectResult entries.
+// Results are returned in completion order, not input order. Use the Image field to
+// correlate results with the input image names.
+func (i *BulkInspector) Inspect(ctx context.Context, sysCtx *types.SystemContext, images ...string) ([]BulkInspectResult, error) {
+	imagesCount := len(images)
+	if imagesCount == 0 {
+		return []BulkInspectResult{}, nil
+	}
+
+	results := make(chan BulkInspectResult, imagesCount)
+	var rateLimiterChannel chan struct{}
+	if i.count > 0 {
+		rateLimiterChannel = make(chan struct{}, min(i.count, imagesCount))
+	} else {
+		// No rate limiting - use a channel that never blocks
+		rateLimiterChannel = make(chan struct{}, imagesCount)
+	}
+
+	childContext, cancel := context.WithCancel(ctx)
+	// The deferred cancellation of the context will kill the tasks when exiting
+	// Useful in case of error
+	defer cancel()
+	for _, imageName := range images {
+		go func(img string) {
+			select {
+			case rateLimiterChannel <- struct{}{}:
+				defer func() { <-rateLimiterChannel }()
+
+				inspectInfo, err := i.inspectImage(childContext, sysCtx, img)
+				results <- BulkInspectResult{Image: img, InspectInfo: inspectInfo, Error: err}
+			case <-childContext.Done():
+				results <- BulkInspectResult{Error: childContext.Err(), Image: img, InspectInfo: nil}
+			}
+		}(imageName)
+	}
+
+	inspectInfos := make([]BulkInspectResult, imagesCount)
+	for idx := range imagesCount {
+		res := <-results
+		if res.Error != nil && i.failOnErr {
+			return nil, res.Error
+		}
+		inspectInfos[idx] = res
+	}
+	return inspectInfos, nil
+}
+
+func (i *BulkInspector) inspectImage(ctx context.Context, sysCtx *types.SystemContext, image string) (inspectInfo *types.ImageInspectInfo, err error) {
+	img, imgSource, err := GetImage(ctx, sysCtx, image, i.retryOpts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if imgSourceErr := imgSource.Close(); imgSourceErr != nil {
+			err = errors.Join(err, imgSourceErr)
+		}
+	}()
+	return GetInspectInfoFromImage(ctx, img, i.retryOpts)
+}

--- a/pkg/imageutils/layer_reader.go
+++ b/pkg/imageutils/layer_reader.go
@@ -1,0 +1,106 @@
+package imageutils
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"slices"
+
+	"github.com/containers/common/pkg/retry"
+	"github.com/containers/image/v5/pkg/blobinfocache/none"
+	"github.com/containers/image/v5/types"
+)
+
+// ReadImageFileContentFn is a predicate function that returns true when
+// the tar header matches the desired file to extract from the image layer.
+type ReadImageFileContentFn func(*tar.Header) bool
+
+// ReadImageFileContent searches for and extracts a file from a container image.
+// It iterates through the image layers (starting from the last) and uses matcherFn
+// to identify the target file. When found, the file content is returned as a byte slice.
+// If no matching file is found, (nil, nil) is returned.
+func ReadImageFileContent(ctx context.Context, sysCtx *types.SystemContext, imageName string, matcherFn ReadImageFileContentFn) (content []byte, err error) {
+	ref, err := ParseImageName(imageName)
+	if err != nil {
+		return nil, err
+	}
+	img, err := ref.NewImage(ctx, sysCtx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := img.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	src, err := GetImageSourceFromReference(ctx, sysCtx, ref, &retry.Options{MaxRetry: 2})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := src.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	layerInfos := img.LayerInfos()
+
+	// Small optimization: Usually user defined content is
+	// at the very end layers so start searching backwards
+	// may result in finding the file sooner.
+	slices.Reverse(layerInfos)
+	for _, info := range layerInfos {
+		if content, err = searchLayerForFile(ctx, src, info, matcherFn); err != nil || content != nil {
+			return content, err
+		}
+	}
+	return nil, nil
+
+}
+
+func searchLayerForFile(ctx context.Context, imgSrc types.ImageSource, blobInfo types.BlobInfo, matcherFn ReadImageFileContentFn) (content []byte, err error) {
+	layerStream, _, err := imgSrc.GetBlob(ctx, blobInfo, none.NoCache)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := layerStream.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	// The layer content is just a gzip tar file. Create both readers
+	gzr, err := gzip.NewReader(layerStream)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := gzr.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	// Open the tar and search for the target file till
+	// we find it or no more files are present in the tar
+	tr := tar.NewReader(gzr)
+	for {
+		var header *tar.Header
+		header, err = tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if matcherFn(header) {
+			content, err = io.ReadAll(tr)
+			return content, err
+		}
+	}
+
+	// The target file wasn't found
+	return nil, nil
+}

--- a/test/e2e-2of2/imageutils_test.go
+++ b/test/e2e-2of2/imageutils_test.go
@@ -1,0 +1,287 @@
+package e2e_2of2
+
+import (
+	"archive/tar"
+	"context"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containers/common/pkg/retry"
+	"github.com/containers/image/v5/types"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var testRetryOpts = retry.Options{MaxRetry: 2}
+
+func releaseManifestsMatcher(header *tar.Header) bool {
+	return strings.TrimLeft(header.Name, "./") == "release-manifests/image-references"
+}
+
+// setupSysContext creates and returns a SysContext from the cluster's controller config.
+// The caller is responsible for calling Cleanup() on the returned SysContext.
+func setupSysContext(t *testing.T, cs *framework.ClientSet) *imageutils.SysContext {
+	t.Helper()
+
+	controllerConfig, err := cs.ControllerConfigs().Get(context.TODO(), "machine-config-controller", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, controllerConfig.Spec.PullSecret)
+
+	secret, err := cs.Secrets(controllerConfig.Spec.PullSecret.Namespace).Get(context.TODO(), controllerConfig.Spec.PullSecret.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+
+	sysContext, err := imageutils.NewSysContextFromControllerConfig(secret, controllerConfig)
+	require.NoError(t, err)
+	require.NotNil(t, sysContext)
+
+	return sysContext
+}
+
+// getMCOImageReference retrieves the machine-config-operator container image from the MCO deployment.
+func getMCOImageReference(t *testing.T, cs *framework.ClientSet) string {
+	t.Helper()
+
+	mcoDeployment, err := cs.Deployments("openshift-machine-config-operator").Get(context.TODO(), "machine-config-operator", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, mcoDeployment)
+
+	for _, container := range mcoDeployment.Spec.Template.Spec.Containers {
+		if container.Name == "machine-config-operator" {
+			return container.Image
+		}
+	}
+
+	require.FailNow(t, "machine-config-operator container not found in deployment")
+	return "" // unreachable, but keeps compiler happy
+}
+
+// getMCOImage retrieves the MCO container image with retry logic and performs standard assertions.
+// The caller is responsible for closing the returned ImageSource.
+func getMCOImage(t *testing.T, ctx context.Context, sysCtx *types.SystemContext, cs *framework.ClientSet) (types.Image, types.ImageSource) {
+	t.Helper()
+
+	image, source, err := imageutils.GetImage(ctx, sysCtx, getMCOImageReference(t, cs), &testRetryOpts)
+	require.NoError(t, err)
+	require.NotNil(t, source)
+	require.NotNil(t, image)
+
+	return image, source
+}
+
+// getControllerConfigImages retrieves the deduplicated list of container images from the
+// machine-config-controller ControllerConfig, returning them in sorted order.
+func getControllerConfigImages(t *testing.T, cs *framework.ClientSet) []string {
+	t.Helper()
+
+	controllerConfig, err := cs.ControllerConfigs().Get(context.TODO(), "machine-config-controller", metav1.GetOptions{})
+	require.NoError(t, err)
+	// Remove duplicate images
+	ccImages := make(map[string]struct{})
+	for _, image := range controllerConfig.Spec.Images {
+		ccImages[image] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(ccImages))
+}
+
+// TestReadImageFileContent validates the ability to extract a specific file from a container image.
+// It tests the ReadImageFileContent function by retrieving the image-references manifest from
+// the cluster's payload image.
+func TestReadImageFileContent(t *testing.T) {
+	cs := framework.NewClientSet("")
+	sysContext := setupSysContext(t, cs)
+	defer func() {
+		require.NoError(t, sysContext.Cleanup())
+	}()
+
+	clusterVersion, err := cs.ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, clusterVersion)
+
+	timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+	defer timedCtxCancelFn()
+	content, err := imageutils.ReadImageFileContent(timedCtx, sysContext.SysContext, clusterVersion.Status.Desired.Image, releaseManifestsMatcher)
+	require.NoError(t, err)
+
+	// Note: The test file is a file used in the MCO to fetch OSImageStreams, and it's
+	// used here only as an example. This test should limit itself to the image
+	// manipulation logic to grab a file from an image reference.
+	// The file points to the Payload ImageStream
+	// Note: If at some point in the future the file doesn't exist pick
+	// any other file in that image (or change the image too). The specific file
+	// to test against is not important.
+	require.NotNil(t, content, "the Payload Image must contain the image-references file")
+	imageStream := resourceread.ReadImageStreamV1OrDie(content)
+	require.NotNil(t, imageStream)
+}
+
+// TestGetImage validates the ability to fetch and inspect a container image.
+// It tests the GetImage function by retrieving the MCO container image from the cluster,
+// ensuring both the image and its source are properly initialized.
+func TestGetImage(t *testing.T) {
+	cs := framework.NewClientSet("")
+	sysContext := setupSysContext(t, cs)
+	defer func() {
+		require.NoError(t, sysContext.Cleanup())
+	}()
+
+	timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+	defer timedCtxCancelFn()
+
+	image, source := getMCOImage(t, timedCtx, sysContext.SysContext, cs)
+	defer func() {
+		require.NoError(t, source.Close())
+	}()
+	require.NotNil(t, image)
+	require.NotNil(t, source)
+}
+
+// TestGetImageHelpers validates the image inspection helper functions.
+// It tests GetDigestFromImage and GetInspectInfoFromImage by retrieving the MCO image's
+// digest and metadata, ensuring the returned information is valid and complete.
+func TestGetImageHelpers(t *testing.T) {
+	cs := framework.NewClientSet("")
+	sysContext := setupSysContext(t, cs)
+	defer func() {
+		require.NoError(t, sysContext.Cleanup())
+	}()
+
+	timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+	defer timedCtxCancelFn()
+
+	image, source := getMCOImage(t, timedCtx, sysContext.SysContext, cs)
+	defer func() {
+		require.NoError(t, source.Close())
+	}()
+
+	digest, err := imageutils.GetDigestFromImage(timedCtx, image, &testRetryOpts)
+	require.NoError(t, err)
+	require.NotEmpty(t, digest)
+
+	inspectInfo, err := imageutils.GetInspectInfoFromImage(timedCtx, image, &testRetryOpts)
+	require.NoError(t, err)
+	require.NotNil(t, inspectInfo)
+
+	// Perform a simple assertion to ensure the inspect info is not empty
+	require.NotEmpty(t, inspectInfo.Labels)
+
+	// Test known label
+	label, ok := inspectInfo.Labels["io.openshift.release.operator"]
+	require.True(t, ok)
+	require.Equal(t, "true", strings.ToLower(label))
+}
+
+// TestBulkInspector validates the BulkInspector functionality for concurrent image inspection.
+// It tests the NewBulkInspector and Inspect methods across multiple scenarios including
+// default behavior with unlimited concurrency, rate-limited inspection, error handling with
+// FailOnErr=false (soft errors), and FailOnErr=true (hard errors with early termination).
+func TestBulkInspector(t *testing.T) {
+	// Common setup for all subtests
+	cs := framework.NewClientSet("")
+	sysContext := setupSysContext(t, cs)
+	defer func() {
+		require.NoError(t, sysContext.Cleanup())
+	}()
+
+	testImages := getControllerConfigImages(t, cs)
+	require.NotEmpty(t, testImages, "ControllerConfig requires to have some images to test the BulkInspector")
+
+	t.Run("Default", func(t *testing.T) {
+		timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+		defer timedCtxCancelFn()
+
+		bulkInspector := imageutils.NewBulkInspector(nil)
+		results, err := bulkInspector.Inspect(timedCtx, sysContext.SysContext, testImages...)
+		require.NoError(t, err)
+		require.Equal(t, len(testImages), len(results))
+
+		resultsByImage := make(map[string]imageutils.BulkInspectResult)
+		for _, result := range results {
+			resultsByImage[result.Image] = result
+		}
+
+		// Test that all images were inspected
+		for _, image := range testImages {
+			result, found := resultsByImage[image]
+			require.True(t, found, "image %s not found in results", image)
+			require.NoError(t, result.Error)
+			require.NotNil(t, result.InspectInfo)
+		}
+	})
+
+	t.Run("RateLimited", func(t *testing.T) {
+		timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+		defer timedCtxCancelFn()
+
+		// This inspection is slower, test with fewer images
+		caseImages := testImages[:min(1, len(testImages))]
+		bulkInspector := imageutils.NewBulkInspector(&imageutils.BulkInspectorOptions{Count: 1, RetryOpts: &testRetryOpts})
+		results, err := bulkInspector.Inspect(timedCtx, sysContext.SysContext, caseImages...)
+		require.NoError(t, err)
+		require.Equal(t, len(caseImages), len(results))
+
+		resultsByImage := make(map[string]imageutils.BulkInspectResult)
+		for _, result := range results {
+			resultsByImage[result.Image] = result
+		}
+
+		// Test that all images were inspected
+		for _, image := range caseImages {
+			result, found := resultsByImage[image]
+			require.True(t, found, "image %s not found in results", image)
+			require.NoError(t, result.Error)
+			require.NotNil(t, result.InspectInfo)
+		}
+	})
+
+	t.Run("DefaultSoftError", func(t *testing.T) {
+		timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+		defer timedCtxCancelFn()
+
+		// Append an image that will make the BulkInspector report and error
+		invalidImage := testImages[0] + "0"
+		caseImages := append(slices.Clone(testImages), invalidImage)
+
+		bulkInspector := imageutils.NewBulkInspector(nil)
+		results, err := bulkInspector.Inspect(timedCtx, sysContext.SysContext, caseImages...)
+		require.NoError(t, err)
+		require.Equal(t, len(caseImages), len(results))
+
+		resultsByImage := make(map[string]imageutils.BulkInspectResult)
+		for _, result := range results {
+			resultsByImage[result.Image] = result
+		}
+
+		// Test that all images were inspected
+		for _, image := range caseImages {
+			result, found := resultsByImage[image]
+			require.True(t, found, "image %s not found in results", image)
+			if image == invalidImage {
+				require.Error(t, result.Error)
+			} else {
+				require.NoError(t, result.Error)
+				require.NotNil(t, result.InspectInfo)
+			}
+
+		}
+	})
+
+	t.Run("FailOnErr", func(t *testing.T) {
+		timedCtx, timedCtxCancelFn := context.WithTimeout(context.Background(), time.Minute)
+		defer timedCtxCancelFn()
+
+		// Append an image that will make it fail
+		failImages := append(slices.Clone(testImages), testImages[0]+"0")
+
+		bulkInspector := imageutils.NewBulkInspector(&imageutils.BulkInspectorOptions{FailOnErr: true, Count: 0})
+		results, err := bulkInspector.Inspect(timedCtx, sysContext.SysContext, failImages...)
+		require.Nil(t, results)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
**- What I did**

Build common helpers to manipulate and work with images. The helpers have been introduced in the image builder to replace part of the logic and will be the base of the OSImageStream logic.

**- How to verify it**

Verified by the new test file `imageutils_test.go`, part of e2e-2of2

**- Description for the changelog**

Add container image utilities for file extraction and inspection with e2e tests

