### PR TITLE
OCPBUGS-64822: remove check for conflicting ClusterImagePolicy in syncUpgradeableStatus

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -280,16 +280,6 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error 
 		coStatusCondition.Reason = "ClusterOnCgroupV1"
 		coStatusCondition.Message = "Cluster is using deprecated cgroup v1 and is not upgradable. Please update the `CgroupMode` in the `nodes.config.openshift.io` object to 'v2'. Once upgraded, the cluster cannot be changed back to cgroup v1"
 	}
-
-	// Check for ClusterImagePolicy named "openshift" which conflicts with the cluster default ClusterImagePolicy object
-	if _, err = optr.configClient.ConfigV1().ClusterImagePolicies().Get(context.TODO(), "openshift", metav1.GetOptions{}); err == nil {
-		coStatusCondition.Status = configv1.ConditionFalse
-		coStatusCondition.Reason = "ConflictingClusterImagePolicy"
-		coStatusCondition.Message = "ClusterImagePolicy resource named 'openshift' conflicts with the cluster default ClusterImagePolicy object and blocks upgrades. Please delete the 'openshift' ClusterImagePolicy resource and reapply it with a different name if needed"
-	} else if !apierrors.IsNotFound(err) {
-		return err
-	}
-
 	var degraded, interrupted bool
 	for _, pool := range pools {
 		interrupted = isPoolStatusConditionTrue(pool, mcfgv1.MachineConfigPoolBuildInterrupted)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
remove check for conflicting ClusterImagePolicy in syncUpgradeableStatus
revert https://github.com/openshift/machine-config-operator/pull/5397
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
