### PR TITLE
MCO-1976: [Dev] Fix RHEL9-specific MCD Logic for RHEL10/CentOS10 Compatibility

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -535,10 +535,19 @@ func ReexecuteForTargetRoot(target string) error {
 	if sourceOsVersion.IsLikeRHEL() && targetOsVersion.IsLikeRHEL() {
 		sourceMajor := sourceOsVersion.BaseVersionMajor()
 		targetMajor := targetOsVersion.BaseVersionMajor()
-		if sourceMajor == "9" && targetMajor == "8" {
+
+		// When container is newer than target, use target-compatible binary
+		switch {
+		case sourceMajor == "10" && targetMajor == "9":
+			sourceBinarySuffix = ".rhel9"
+			klog.Info("container is rhel10, target is rhel9")
+		case sourceMajor == "10" && targetMajor == "8":
+			sourceBinarySuffix = ".rhel8"
+			klog.Info("container is rhel10, target is rhel8")
+		case sourceMajor == "9" && targetMajor == "8":
 			sourceBinarySuffix = ".rhel8"
 			klog.Info("container is rhel9, target is rhel8")
-		} else {
+		default:
 			klog.Infof("using appropriate binary for source=rhel-%s target=rhel-%s", sourceMajor, targetMajor)
 		}
 	} else {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2288,7 +2288,7 @@ func (dn *Daemon) updateKubeConfigPermission() error {
 // (/home/core/.ssh/authorized_keys.d/ignition) or the old SSH key path
 // (/home/core/.ssh/authorized_keys)
 func (dn *Daemon) useNewSSHKeyPath() bool {
-	return dn.os.IsEL9() || dn.os.IsFCOS() || dn.os.IsSCOS()
+	return dn.os.IsEL9() || dn.os.IsEL10() || dn.os.IsFCOS() || dn.os.IsSCOS()
 }
 
 // Update a given PasswdUser's SSHKey


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added RHEL10 support to the MCD for SSH key path selection and binary compatibility across RHEL versions.

  Changes made:
  1. **SSH Key Path Selection** (`pkg/daemon/update.go:2291`): Added `IsEL10()` check to `useNewSSHKeyPath()` so RHEL10 correctly uses the new SSH key path (`/home/core/.ssh/authorized_keys.d/ignition`) instead of the legacy path (`/home/core/.ssh/authorized_keys`).

  2. **Binary Selection** (`pkg/daemon/daemon.go:540-548`): Extended `ReexecuteForTargetRoot()` to handle RHEL10 containers managing RHEL8 or RHEL9 hosts by selecting the appropriate binary suffix (`.rhel8` or `.rhel9`).

  This addresses items [2] and [4] from the RHEL10 MCD compatibility spike, ensuring the MCD works correctly on RHEL10 and can manage older RHEL versions during dual-stream operations.

**- How to verify it**
**For SSH Key Path (Item 2):**

  On a RHEL10 cluster:
  1. Deploy the updated MCO image
  2. Debug into a node and check MCD logs:
     ```bash
     oc logs -n openshift-machine-config-operator -l k8s-app=machine-config-daemon | grep "ssh"
  3. Should see: Writing SSH keys to "/home/core/.ssh/authorized_keys.d/ignition"
  4. Should NOT see: Writing SSH keys to "/home/core/.ssh/authorized_keys"
  5. Verify SSH keys are written to the correct location:
  oc debug node/<node-name>
  chroot /host
  ls -la /home/core/.ssh/authorized_keys.d/ignition

  For Binary Selection (Item 4):

  When RHEL10 container images are available:
  1. Deploy RHEL10 MCO container to a cluster with RHEL9 or RHEL8 nodes
  2. Check MCD logs during re-execution:
  oc logs -n openshift-machine-config-operator -l k8s-app=machine-config-daemon | grep "container is rhel10"
  3. Should see appropriate log:
    - "container is rhel10, target is rhel9" (for RHEL9 nodes)
    - "container is rhel10, target is rhel8" (for RHEL8 nodes)

  Note: Item 4 also requires Dockerfile updates to include compiled .rhel9 binary when building RHEL10 container images. When the MCO team builds RHEL10-based container images, we will be able to see this change.
**- Description for the changelog**
<!--
  Add RHEL10 support for SSH key path selection and cross-version binary compatibility in MCD
-->
