### PR TITLE
OCPBUGS-64825: Add MachineConfigNode informer to trigger MCP machine count syncs

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -244,6 +244,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSConfigs(),
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
+			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -107,7 +107,7 @@ func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.schedulerClient, noResyncPeriodFunc())
 	c := NewWithCustomUpdateDelay(i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), i.Machineconfiguration().V1().MachineConfigPools(), k8sI.Core().V1().Nodes(),
-		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1().MachineOSConfigs(), i.Machineconfiguration().V1().MachineOSBuilds(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgHandler)
+		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1().MachineOSConfigs(), i.Machineconfiguration().V1().MachineOSBuilds(), i.Machineconfiguration().V1().MachineConfigNodes(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgHandler)
 
 	c.ccListerSynced = alwaysReady
 	c.mcpListerSynced = alwaysReady
@@ -264,7 +264,9 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "machineosbuilds") ||
 				action.Matches("watch", "machineosbuilds") ||
 				action.Matches("list", "machineosconfigs") ||
-				action.Matches("watch", "machineosconfigs")) {
+				action.Matches("watch", "machineosconfigs") ||
+				action.Matches("list", "machineconfignodes") ||
+				action.Matches("watch", "machineconfignodes")) {
 			continue
 		}
 		ret = append(ret, action)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -525,6 +525,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.KubeInformerFactory.Core().V1().Pods(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineOSConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
+			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),


### PR DESCRIPTION
Closes: OCPBUGS-64825

**- What I did**
This adds a MachineConfigNode informer in the node controller so that changes to a node's MCN trigger syncs of the MachineConfigPool machine counts. This change is necessary with the introduction of #5141, which calculates the updated and degraded machine counts with MCN conditions instead of node annotations. It also adds a `TestCalculateStatusWithImageModeReporting` test, which tests the same cases as the previously existing `TestCalculateStatus` test, but in a tech preview situation.

**- How to verify it**
This can be tested locally by launching a 4.21 tech preview cluster with this PR included. It can also be tested by ensuring that all existing `MachineConfigNode` and `ImageModeStatusReporting` pass--specifically the `Should properly report MCN conditions on node degrade` test mentioned in the attached bug.

**- Description for the changelog**
OCPBUGS-64825: Add MachineConfigNode informer to trigger MCP machine count syncs