### PR TITLE
OCPBUGS-65726: Remove --mount directives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 ENV GOCACHE="/go/rhel9/.cache"
 ENV GOMODCACHE="/go/rhel9/pkg/mod"
-RUN --mount=type=cache,target=/go/rhel9/.cache,z \
-    --mount=type=cache,target=/go/rhel9/pkg/mod,z \
-    make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
+RUN make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
 
 # Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS rhel8-builder
@@ -19,15 +17,12 @@ WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 ENV GOCACHE="/go/rhel8/.cache"
 ENV GOMODCACHE="/go/rhel8/pkg/mod"
-RUN --mount=type=cache,target=/go/rhel8/.cache,z \
-    --mount=type=cache,target=/go/rhel8/pkg/mod,z \
-    make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
+RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 ARG TAGS=""
 COPY install /manifests
-RUN --mount=type=cache,target=/var/cache/dnf,z \
-    if [ "${TAGS}" = "fcos" ]; then \
+RUN if [ "${TAGS}" = "fcos" ]; then \
     # comment out non-base/extensions image-references entirely for fcos
     sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,9 +8,7 @@ COPY . .
 # just use that.  For now we work around this by copying a tarball.
 ENV GOCACHE="/go/rhel9/.cache"
 ENV GOMODCACHE="/go/rhel9/pkg/mod"
-RUN --mount=type=cache,target=/go/rhel9/.cache,z \
-    --mount=type=cache,target=/go/rhel9/pkg/mod,z \
-    make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
+RUN make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
 
 # Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS rhel8-builder
@@ -20,15 +18,12 @@ WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 ENV GOCACHE="/go/rhel8/.cache"
 ENV GOMODCACHE="/go/rhel8/pkg/mod"
-RUN --mount=type=cache,target=/go/rhel8/.cache,z \
-    --mount=type=cache,target=/go/rhel8/pkg/mod,z \
-    make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
+RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 ARG TAGS=""
 COPY install /manifests
-RUN --mount=type=cache,target=/var/cache/dnf,z \
-    if [ "${TAGS}" = "fcos" ]; then \
+RUN if [ "${TAGS}" = "fcos" ]; then \
     # comment out non-base/extensions image-references entirely for fcos
     sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
@@ -45,7 +40,8 @@ RUN --mount=type=cache,target=/var/cache/dnf,z \
     # Create the build user which will be used for doing OS image builds. We
     # use the username "build" and the uid 1000 since this matches what is in
     # the official Buildah image.
-    useradd --uid 1000 build
+    # Conditional checks if "build" user does not exist before adding user.
+    if ! id -u "build" >/dev/null 2>&1; then useradd --uid 1000 build; fi
 # Copy the binaries *after* we install nmstate so we don't invalidate our cache for local builds.
 COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9.tar /tmp/instroot-rhel9.tar
 RUN cd / && tar xf /tmp/instroot-rhel9.tar && rm -f /tmp/instroot-rhel9.tar


### PR DESCRIPTION
**- What I did**

This removes the `--mount` directives from the `RUN` stages of our Dockerfiles to resolve a build issue. See: https://issues.redhat.com/browse/RHEL-129120 for additional info. We should revert this PR once the issue is resolved.

**- How to verify it**

The Dockerfiles should build in CI as usual. No special verification should be necessary.

**- Description for the changelog**
Remove --mount directives from MCO Dockerfiles
