### PR TITLE
MCO-1877: MCO-1879: MCO-1882: MCO-1884: Implement boot image skew enforcement MVP

### DIFF
--- a/pkg/apihelpers/apihelpers.go
+++ b/pkg/apihelpers/apihelpers.go
@@ -554,3 +554,31 @@ func MergeMachineManager(status *opv1.MachineConfigurationStatus, manager opv1.M
 
 	status.ManagedBootImagesStatus = result
 }
+
+// GetSkewEnforcementStatusAutomaticWithOCPVersion returns a BootImageSkewEnforcementStatus with Automatic mode and the given OCP version.
+func GetSkewEnforcementStatusAutomaticWithOCPVersion(ocpVersion string) opv1.BootImageSkewEnforcementStatus {
+	return opv1.BootImageSkewEnforcementStatus{
+		Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+		Automatic: opv1.ClusterBootImageAutomatic{
+			OCPVersion: ocpVersion,
+		},
+	}
+}
+
+// GetSkewEnforcementStatusManualWithOCPVersion returns a BootImageSkewEnforcementStatus with Manual mode and the given OCP version.
+func GetSkewEnforcementStatusManualWithOCPVersion(ocpVersion string) opv1.BootImageSkewEnforcementStatus {
+	return opv1.BootImageSkewEnforcementStatus{
+		Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+		Manual: opv1.ClusterBootImageManual{
+			Mode:       opv1.ClusterBootImageSpecModeOCPVersion,
+			OCPVersion: ocpVersion,
+		},
+	}
+}
+
+// GetSkewEnforcementStatusNone returns a BootImageSkewEnforcementStatus with None mode.
+func GetSkewEnforcementStatusNone() opv1.BootImageSkewEnforcementStatus {
+	return opv1.BootImageSkewEnforcementStatus{
+		Mode: opv1.BootImageSkewEnforcementModeStatusNone,
+	}
+}

--- a/pkg/controller/bootimage/boot_image_controller_test.go
+++ b/pkg/controller/bootimage/boot_image_controller_test.go
@@ -813,7 +813,7 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				testStreamData = tt.streamData
 			}
 
-			patchRequired, updatedProviderSpec, err := reconcileAzureProviderSpec(
+			patchRequired, _, updatedProviderSpec, err := reconcileAzureProviderSpec(
 				testStreamData,
 				tt.arch,
 				infra,

--- a/pkg/controller/bootimage/cpms_helpers.go
+++ b/pkg/controller/bootimage/cpms_helpers.go
@@ -257,7 +257,7 @@ func reconcilePlatformCPMS[T any](
 	configMap *corev1.ConfigMap,
 	arch string,
 	secretClient clientset.Interface,
-	reconcileProviderSpec func(*stream.Stream, string, *osconfigv1.Infrastructure, *T, string, clientset.Interface) (bool, *T, error),
+	reconcileProviderSpec func(*stream.Stream, string, *osconfigv1.Infrastructure, *T, string, clientset.Interface) (bool, bool, *T, error),
 ) (patchRequired bool, newCPMS *machinev1.ControlPlaneMachineSet, err error) {
 	klog.Infof("Reconciling controlplanemachineset %s on %s, with arch %s", cpms.Name, string(infra.Status.PlatformStatus.Type), arch)
 
@@ -274,7 +274,7 @@ func reconcilePlatformCPMS[T any](
 	}
 
 	// Reconcile the provider spec
-	patchRequired, newProviderSpec, err := reconcileProviderSpec(streamData, arch, infra, providerSpec, cpms.Name, secretClient)
+	patchRequired, _, newProviderSpec, err := reconcileProviderSpec(streamData, arch, infra, providerSpec, cpms.Name, secretClient)
 	if err != nil {
 		return false, nil, err
 	}

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -157,6 +157,7 @@ const (
 	NodeSizingEnabledEnvPath = "/etc/node-sizing-enabled.env"
 
 	// Current Boot Image Skew Limits
+	// Note: Update units in status_test.go when the following are bumped
 	RHCOSVersionBootImageSkewLimit = "9.2"
 	OCPVersionBootImageSkewLimit   = "4.13.0"
 )

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -155,6 +155,10 @@ const (
 
 	// NodeSizingEnabledEnvPath is the file path for the node sizing enabled environment file
 	NodeSizingEnabledEnvPath = "/etc/node-sizing-enabled.env"
+
+	// Current Boot Image Skew Limits
+	RHCOSVersionBootImageSkewLimit = "9.2"
+	OCPVersionBootImageSkewLimit   = "4.13.0"
 )
 
 // Commonly-used MCO ConfigMap names

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -146,6 +146,7 @@ type Operator struct {
 	idmsListerSynced                 cache.InformerSynced
 	itmsListerSynced                 cache.InformerSynced
 	icspListerSynced                 cache.InformerSynced
+	clusterVersionListerSynced       cache.InformerSynced
 	mcoSAListerSynced                cache.InformerSynced
 	mcoSecretListerSynced            cache.InformerSynced
 	ocCmListerSynced                 cache.InformerSynced
@@ -278,6 +279,7 @@ func New(
 		dnsInformer.Informer(),
 		maoSecretInformer.Informer(),
 		imgInformer.Informer(),
+		clusterVersionInformer.Informer(),
 		mcoSAInformer.Informer(),
 		mcoSecretInformer.Informer(),
 		ocSecretInformer.Informer(),
@@ -306,6 +308,7 @@ func New(
 	optr.icspLister = icspInformer.Lister()
 	optr.icspListerSynced = icspInformer.Informer().HasSynced
 
+	optr.clusterVersionLister = clusterVersionInformer.Lister()
 	optr.clusterCmLister = clusterCmInfomer.Lister()
 	optr.clusterCmListerSynced = clusterCmInfomer.Informer().HasSynced
 	optr.mcpLister = mcpInformer.Lister()
@@ -323,6 +326,8 @@ func New(
 	optr.nodeClusterLister = nodeClusterInformer.Lister()
 	optr.nodeClusterListerSynced = nodeClusterInformer.Informer().HasSynced
 
+	optr.imgListerSynced = imgInformer.Informer().HasSynced
+	optr.clusterVersionListerSynced = clusterVersionInformer.Informer().HasSynced
 	optr.maoSecretInformerSynced = maoSecretInformer.Informer().HasSynced
 	optr.serviceAccountInformerSynced = serviceAccountInfomer.Informer().HasSynced
 	optr.clusterRoleInformerSynced = clusterRoleInformer.Informer().HasSynced
@@ -417,6 +422,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 		optr.idmsListerSynced,
 		optr.itmsListerSynced,
 		optr.icspListerSynced,
+		optr.clusterVersionListerSynced,
 		optr.mcoSAListerSynced,
 		optr.mcoSecretListerSynced,
 		optr.ocCmListerSynced,

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -23,8 +23,10 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	opv1 "github.com/openshift/api/operator/v1"
 	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	mcoplistersv1 "github.com/openshift/client-go/operator/listers/operator/v1"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/test/helpers"
@@ -794,4 +796,379 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 	assert.Nil(t, err, "expected syncAll to pass")
 
 	assert.False(t, optr.inClusterBringup)
+}
+
+func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
+	tests := []struct {
+		name               string
+		featureGateEnabled bool
+		mcop               *opv1.MachineConfiguration
+		mcopNotFound       bool
+		mcopGetError       error
+		expectUpgradeBlock bool
+		expectMessage      string
+		expectError        bool
+	}{
+		{
+			name:               "feature gate disabled",
+			featureGateEnabled: false,
+			mcop:               nil,
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "MachineConfiguration not found",
+			featureGateEnabled: true,
+			mcopNotFound:       true,
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is None",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusNone,
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is unset",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: "",
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		// OCP version tests in automatic mode
+		{
+			name:               "mode is Automatic with OCP version within limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							OCPVersion: "4.17.0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Automatic with OCP version below limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							OCPVersion: "4.12.0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: true,
+			expectMessage:      "Upgrades have been disabled because the cluster is using OCP boot image version 4.12.0, which is below the minimum required version " + ctrlcommon.OCPVersionBootImageSkewLimit + ". To enable upgrades, please update your boot images following the documentation at [TODO: insert link], or disable boot image skew enforcement at [TODO: insert link]",
+			expectError:        false,
+		},
+		// OCP version tests in manual mode
+		{
+			name:               "mode is Manual with OCP version within limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:       opv1.ClusterBootImageSpecModeOCPVersion,
+							OCPVersion: "4.16.0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Manual with OCP version below limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:       opv1.ClusterBootImageSpecModeOCPVersion,
+							OCPVersion: "4.10.0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: true,
+			expectMessage:      "Upgrades have been disabled because the cluster is using OCP boot image version 4.10.0, which is below the minimum required version " + ctrlcommon.OCPVersionBootImageSkewLimit + ". To enable upgrades, please update your boot images following the documentation at [TODO: insert link], or disable boot image skew enforcement at [TODO: insert link]",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Automatic with exact minimum OCP version",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							OCPVersion: ctrlcommon.OCPVersionBootImageSkewLimit,
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		// RHCOS version tests in Automatic mode
+		{
+			name:               "mode is Automatic with modern RHCOS version within limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							RHCOSVersion: "9.4.20251023-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Automatic with modern RHCOS version below limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							RHCOSVersion: "9.0.20251023-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: true,
+			expectMessage:      "Upgrades have been disabled because the cluster is using RHCOS boot image version 9.0.20251023-0(RHEL version: 9.0), which is below the minimum required RHEL version " + ctrlcommon.RHCOSVersionBootImageSkewLimit + ". To enable upgrades, please update your boot images following the documentation at [TODO: insert link], or disable boot image skew enforcement at [TODO: insert link]",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Automatic with legacy RHCOS version within limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							RHCOSVersion: "416.94.202510081640-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Automatic with legacy RHCOS version below limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							RHCOSVersion: "411.86.202308081056-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: true,
+			expectMessage:      "Upgrades have been disabled because the cluster is using RHCOS boot image version 411.86.202308081056-0(RHEL version: 8.6), which is below the minimum required RHEL version " + ctrlcommon.RHCOSVersionBootImageSkewLimit + ". To enable upgrades, please update your boot images following the documentation at [TODO: insert link], or disable boot image skew enforcement at [TODO: insert link]",
+			expectError:        false,
+		},
+
+		{
+			name:               "mode is Automatic with exact minimum RHCOS version",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusAutomatic,
+						Automatic: opv1.ClusterBootImageAutomatic{
+							RHCOSVersion: "413.92.202402131523-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		// RHCOS version tests in manual mode
+		{
+			name:               "mode is Manual with modern RHCOS version within limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:         opv1.ClusterBootImageSpecModeRHCOSVersion,
+							RHCOSVersion: "9.6.20251023-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Manual with modern RHCOS version below limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:         opv1.ClusterBootImageSpecModeRHCOSVersion,
+							RHCOSVersion: "9.1.20251023-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: true,
+			expectMessage:      "Upgrades have been disabled because the cluster is using RHCOS boot image version 9.1.20251023-0(RHEL version: 9.1), which is below the minimum required RHEL version " + ctrlcommon.RHCOSVersionBootImageSkewLimit + ". To enable upgrades, please update your boot images following the documentation at [TODO: insert link], or disable boot image skew enforcement at [TODO: insert link]",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Manual with legacy RHCOS version within limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:         opv1.ClusterBootImageSpecModeRHCOSVersion,
+							RHCOSVersion: "416.94.202510081640-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+		{
+			name:               "mode is Manual with legacy RHCOS version below limit",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:         opv1.ClusterBootImageSpecModeRHCOSVersion,
+							RHCOSVersion: "411.86.202308081056-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: true,
+			expectMessage:      "Upgrades have been disabled because the cluster is using RHCOS boot image version 411.86.202308081056-0(RHEL version: 8.6), which is below the minimum required RHEL version " + ctrlcommon.RHCOSVersionBootImageSkewLimit + ". To enable upgrades, please update your boot images following the documentation at [TODO: insert link], or disable boot image skew enforcement at [TODO: insert link]",
+			expectError:        false,
+		},
+		{
+			name:               "mode is manual with exact minimum RHCOS version",
+			featureGateEnabled: true,
+			mcop: &opv1.MachineConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
+				Status: opv1.MachineConfigurationStatus{
+					BootImageSkewEnforcementStatus: opv1.BootImageSkewEnforcementStatus{
+						Mode: opv1.BootImageSkewEnforcementModeStatusManual,
+						Manual: opv1.ClusterBootImageManual{
+							Mode:         opv1.ClusterBootImageSpecModeRHCOSVersion,
+							RHCOSVersion: "413.92.202402131523-0",
+						},
+					},
+				},
+			},
+			expectUpgradeBlock: false,
+			expectMessage:      "",
+			expectError:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up feature gate handler
+			enabledFeatures := []configv1.FeatureGateName{}
+			if tc.featureGateEnabled {
+				enabledFeatures = append(enabledFeatures, features.FeatureGateBootImageSkewEnforcement)
+			}
+			fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler(enabledFeatures, []configv1.FeatureGateName{})
+
+			// Set up mcopLister
+			mcopIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			if tc.mcop != nil && !tc.mcopNotFound {
+				mcopIndexer.Add(tc.mcop)
+			}
+			mcopLister := mcoplistersv1.NewMachineConfigurationLister(mcopIndexer)
+
+			optr := &Operator{
+				fgHandler:  fgHandler,
+				mcopLister: mcopLister,
+			}
+
+			upgradeBlock, message, err := optr.checkBootImageSkewUpgradeableGuard()
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectUpgradeBlock, upgradeBlock, "upgrade block mismatch")
+			assert.Equal(t, tc.expectMessage, message, "message mismatch")
+		})
+	}
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -30,6 +30,7 @@ import (
 	kubeErrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8sversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
@@ -2343,6 +2344,9 @@ func (optr *Operator) syncMachineConfiguration(_ *renderConfig, _ *configv1.Clus
 		defaultOptInEvent = optr.syncManagedBootImagesStatus(mcop, newMachineConfigurationStatus, isDefaultOnPlatform, supportCPMSBootImageUpdates)
 	}
 
+	// Update skew enforcement status if needed
+	optr.syncBootImageSkewEnforcementStatus(mcop, newMachineConfigurationStatus, supportsBootImageUpdates)
+
 	newMachineConfigurationStatus.ObservedGeneration = mcop.GetGeneration()
 	// Check if any changes are required in the Status before making the API call.
 	if !reflect.DeepEqual(mcop.Status, *newMachineConfigurationStatus) {
@@ -2503,4 +2507,76 @@ func (optr *Operator) syncPreBuiltImageMachineConfigs() error {
 	}
 
 	return nil
+}
+
+// syncBootImageSkewEnforcementStatus determines the appropriate BootImageSkewEnforcementStatus based on
+// the MachineConfiguration spec, platform defaults, and cluster version information.
+func (optr *Operator) syncBootImageSkewEnforcementStatus(mcop *opv1.MachineConfiguration, newMachineConfigurationStatus *opv1.MachineConfigurationStatus, supportsBootImageUpdates bool) {
+	// React to any changes in boot image skew enforcement configuration
+	if !optr.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
+		return
+	}
+
+	// First, estimate an OCPVersion from ClusterVersion.
+	ocpVersionAtInstall := optr.getOCPVersionFromClusterVersion()
+	// If BootImageSkewEnforcement spec is defined, reflect that to status
+	//nolint:gocritic
+	if mcop.Spec.BootImageSkewEnforcement != (opv1.BootImageSkewEnforcementConfig{}) {
+		if mcop.Spec.BootImageSkewEnforcement.Mode == opv1.BootImageSkewEnforcementConfigModeManual {
+			newMachineConfigurationStatus.BootImageSkewEnforcementStatus = opv1.BootImageSkewEnforcementStatus{
+				Mode:   opv1.BootImageSkewEnforcementModeStatusManual,
+				Manual: mcop.Spec.BootImageSkewEnforcement.Manual,
+			}
+		} else { // only other possible opinion is "None"
+			newMachineConfigurationStatus.BootImageSkewEnforcementStatus = apihelpers.GetSkewEnforcementStatusNone()
+		}
+	} else if supportsBootImageUpdates {
+		// If an "All" option is specified and BootImageSkewEnforcementStatus is empty or not set to Automatic => set Mode to Automatic.
+		if apihelpers.HasMAPIMachineSetManagerWithMode(newMachineConfigurationStatus.ManagedBootImagesStatus.MachineManagers, opv1.MachineSets, opv1.All) {
+			if (newMachineConfigurationStatus.BootImageSkewEnforcementStatus.Mode != opv1.BootImageSkewEnforcementModeStatusAutomatic ||
+				mcop.Status.BootImageSkewEnforcementStatus == opv1.BootImageSkewEnforcementStatus{}) {
+				newMachineConfigurationStatus.BootImageSkewEnforcementStatus = apihelpers.GetSkewEnforcementStatusAutomaticWithOCPVersion(ocpVersionAtInstall)
+			}
+		} else { // For any other opinion i.e. admin has overridden boot image opinion to Partial/None => set Mode to Manual.
+			newMachineConfigurationStatus.BootImageSkewEnforcementStatus = apihelpers.GetSkewEnforcementStatusManualWithOCPVersion(ocpVersionAtInstall)
+		}
+	} else { // For platforms that do not support automated boot image updates => set Mode to Manual.
+		newMachineConfigurationStatus.BootImageSkewEnforcementStatus = apihelpers.GetSkewEnforcementStatusManualWithOCPVersion(ocpVersionAtInstall)
+	}
+}
+
+// getOCPVersionFromClusterVersion extracts the OCP version from ClusterVersion history.
+// It finds the last completed update in history (install version) and parses it to a clean version string.
+// Returns an empty string if ClusterVersion cannot be retrieved or parsed.
+func (optr *Operator) getOCPVersionFromClusterVersion() string {
+	clusterVersion, err := optr.clusterVersionLister.Get("version")
+	if err != nil {
+		klog.Warningf("Failed to get ClusterVersion: %v, skipping boot image skew enforcement configuration", err)
+		return ""
+	}
+	if len(clusterVersion.Status.History) == 0 {
+		klog.Warningf("ClusterVersion has no history, skipping boot image skew enforcement configuration")
+		return ""
+	}
+
+	// History is ordered by recency (newest first), so find the last completed entry (install version)
+	var installVersion string
+	for i := len(clusterVersion.Status.History) - 1; i >= 0; i-- {
+		if clusterVersion.Status.History[i].State == configv1.CompletedUpdate {
+			installVersion = clusterVersion.Status.History[i].Version
+			break
+		}
+	}
+	// ClusterVersion has no completed updates in history(install likely on-going), default to last value
+	if installVersion == "" {
+		klog.Warningf("ClusterVersion has no completed updates in history(install likely on-going), default to last value")
+		installVersion = clusterVersion.Status.History[len(clusterVersion.Status.History)-1].Version
+	}
+	// Scrape away CI/nightly tags if needed
+	parsedVersion, err := k8sversion.ParseGeneric(installVersion)
+	if err != nil {
+		klog.Warningf("Failed to parse install version %q: %v, use a placeholder for now", installVersion, err)
+		return "0.0.0"
+	}
+	return fmt.Sprintf("%d.%d.%d", parsedVersion.Major(), parsedVersion.Minor(), parsedVersion.Patch())
 }


### PR DESCRIPTION
This PR integrates the boot image skew enforcement API introduced in https://github.com/openshift/api/pull/2357.  This involves the following changes:
- The operator now populates the `bootImageSkewEnforcementStatus` field in the `MachineConfiguration` object based on `spec.bootImageSkewEnforcement`, platform defaults and cluster version. 
- The boot image controller will now update the current boot image value in `bootImageSkewEnforcementStatus` on a successful boot image update. Note that this requires the skew enforcement to be set to `Automatic` mode, and all machinesets to be opt-ed in for boot image updates.
- The operator sets Upgradeable=False when it detects the cluster is out of skew, determined by comparing the boot image values in bootImageSkewEnforcementStatus against the MCO's hardcoded skew limits. Before performing this check, the operator first verifies that the controller is neither in an error state nor currently performing boot image updates. If the controller is in an error state, the operator sets Upgradeable=False and propagates that error instead of proceeding with the skew check. If the controller is mid-update, the operator defers the skew check until later; this is to avoid race conditions.
- Some unit tests have been added to `sync_test.go` and `status_test.go` to verify the above mechanisms.

### Verifying API behavior
This verification will have to be done based on the platform. If the platform:

- **supports boot image updates and it is on by default(AWS and GCP at the time of writing)**, i.e. `status.managedBootImagesStatus` is set to `All` if `spec.managedBootImages` is empty. Then, skew enforcement status will be set to `Automatic`, with a boot image version estimated from cluster version. Then, the boot image controller will perform a sync which will update the boot image(if required) and after all resources have been successfully updated, it will update the boot image value stored in the skew enforcement status. The value set will be the OCP `releaseVersion` described by the `coreos-bootimages` configmap. Here's an example:
```
  spec:
    logLevel: Normal
    managementState: Managed
    operatorLogLevel: Normal
  status:
    bootImageSkewEnforcementStatus:
      automatic:
        ocpVersion: 4.21.0
      mode: Automatic
    conditions:
    - lastTransitionTime: "2025-11-19T22:06:06Z"
      message: Reconciled 3 of 3 MAPI MachineSets | Reconciled 0 of 0 ControlPlaneMachineSets
        | Reconciled 0 of 0 CAPI MachineSets | Reconciled 0 of 0 CAPI MachineDeployments
      reason: BootImageConfigMapAdded
      status: "False"
      type: BootImageUpdateProgressing
    - lastTransitionTime: "2025-11-19T22:06:07Z"
      message: 0 Degraded MAPI MachineSets | 0 Degraded ControlPlaneMachineSets |
        0 Degraded CAPI MachineSets | 0 CAPI MachineDeployments
      reason: BootImageConfigMapAdded
      status: "False"
      type: BootImageUpdateDegraded
    managedBootImagesStatus:
      machineManagers:
      - apiGroup: machine.openshift.io
        resource: machinesets
        selection:
          mode: All
```

- **supports boot image updates, but is not on by default(vsphere and Azure at the time of writing)** i.e. `status.managedBootImagesStatus` is set to `None` if `spec.managedBootImages` is empty. Then, skew enforcement status will be set to `Manual`, with a boot image version estimated from cluster version. The object would now look like this:
```
  spec:
    logLevel: Normal
    managementState: Managed
    operatorLogLevel: Normal
  status:
    bootImageSkewEnforcementStatus:
      manual:
        mode: OCPVersion
        ocpVersion: 4.21.0
      mode: Manual
    conditions:
    - lastTransitionTime: "2025-11-19T22:06:06Z"
      message: Reconciled 0 of 0 MAPI MachineSets | Reconciled 0 of 0 ControlPlaneMachineSets
        | Reconciled 0 of 0 CAPI MachineSets | Reconciled 0 of 0 CAPI MachineDeployments
      reason: BootImageConfigMapAdded
      status: "False"
      type: BootImageUpdateProgressing
    - lastTransitionTime: "2025-11-19T22:06:07Z"
      message: 0 Degraded MAPI MachineSets | 0 Degraded ControlPlaneMachineSets |
        0 Degraded CAPI MachineSets | 0 CAPI MachineDeployments
      reason: BootImageConfigMapAdded
      status: "False"
      type: BootImageUpdateDegraded
    managedBootImagesStatus:
      machineManagers:
      - apiGroup: machine.openshift.io
        resource: machinesets
        selection:
          mode: None
```
The admin can choose to opt-in for boot image updates in this case(set `spec.ManagedBootImages` to `All`), and the operator should automatically switch the skew enforcement status to `Automatic`, with the appropriate boot image version. This would mean the object would finally look like this:
```
  spec:
    logLevel: Normal
    managementState: Managed
    operatorLogLevel: Normal
    managedBootImages:
      machineManagers:
      - apiGroup: machine.openshift.io
        resource: machinesets
        selection:
          mode: All
  status:
    bootImageSkewEnforcementStatus:
      automatic:
        ocpVersion: 4.21.0
      mode: Automatic
    conditions:
    - lastTransitionTime: "2025-11-19T22:06:06Z"
      message: Reconciled 3 of 3 MAPI MachineSets | Reconciled 0 of 0 ControlPlaneMachineSets
        | Reconciled 0 of 0 CAPI MachineSets | Reconciled 0 of 0 CAPI MachineDeployments
      reason: BootImageConfigMapAdded
      status: "False"
      type: BootImageUpdateProgressing
    - lastTransitionTime: "2025-11-19T22:06:07Z"
      message: 0 Degraded MAPI MachineSets | 0 Degraded ControlPlaneMachineSets |
        0 Degraded CAPI MachineSets | 0 CAPI MachineDeployments
      reason: BootImageConfigMapAdded
      status: "False"
      type: BootImageUpdateDegraded
    managedBootImagesStatus:
      machineManagers:
      - apiGroup: machine.openshift.io
        resource: machinesets
        selection:
          mode: All
```
- **does not support boot image updates(all other platforms at the time of writing)**  i.e. `status.managedBootImagesStatus` is empty and `spec.managedBootImages` cannot be set by the admin. Then, skew enforcement status will be set to `Manual`, with a boot image version estimated from cluster version. The object would now look like this:
```
  spec:
    logLevel: Normal
    managementState: Managed
    operatorLogLevel: Normal
  status:
    bootImageSkewEnforcementStatus:
      manual:
        mode: OCPVersion
        ocpVersion: 4.21.0
      mode: Manual
```
In this case, the admin is expected to manually perform boot image updates and then add a spec field like so:
```
spec:
  bootImageSkewEnforcement:
    mode: Manual
    manual:
      mode: OCPVersion
      ocpVersion: 4.21.2
```
The operator should then update the status to include this:
```
spec:
  bootImageSkewEnforcement:
    mode: Manual
    manual:
      mode: OCPVersion
      ocpVersion: 4.21.2
status:
  bootImageSkewEnforcementStatus:
      mode: OCPVersion
      ocpVersion: 4.21.2
```
The above snippet is if an admin had chosen to record the `OCPVersion`. In manual mode, the admin can also choose to to store the `RHCOSVersion`, like so:
```
spec:
  bootImageSkewEnforcement:
    mode: Manual
    manual:
      mode: RHCOSVersion
      rhcosVersion: 9.0.20251023-0
status:
  bootImageSkewEnforcementStatus:
    mode: Manual
    manual:
      mode: RHCOSVersion
      rhcosVersion: 9.0.20251023-0
```
Note that only one of RHCOSVersion or OCPVersion is permitted in `Manual` mode. 

The admin can also choose to disable skew enforcement altogether by setting it `None` mode in spec.
```
spec:
  bootImageSkewEnforcement:
    mode: None
status:
  bootImageSkewEnforcementStatus:
    mode: None
```

### Verifying upgrade block

Upgrades will be blocked when the cluster is to determined out of skew. This mechanism works the same way in manual and automatic mode, although it is likely easier to verify in manual mode. The current thresholds for a skew violation is set to when OCP first moved to RHEL9, which corresponds to RHEL version 9.2 and OCP version 4.13.0. The operator will perform semver comparisons of these thresholds against the boot image versions stored in `bootImageSkewEnforcementStatus` and set `Upgradeable=False` if necessary. To verify this, first set the mode to Manual with an out of skew boot image version like so:
```
  spec:
    bootImageSkewEnforcement:
      manual:
	mode: RHCOSVersion
        rhcosVersion: 9.0.20251023-0
      mode: Manual
```
Now, examine the `machine-config` CO object's conditions field, it should indicate an issue preventing upgrades like so:
```
$ oc get co machine-config -o yaml
...
  - lastTransitionTime: "2025-11-20T15:15:12Z"
    message: 'Upgrades have been disabled because the cluster is using RHCOS boot
      image version 9.0.20251023-0(RHEL version: 9.0), which is below the minimum
      required RHEL version 9.2. To enable upgrades, please update your boot images
      following the documentation at [TODO: insert link], or disable boot image skew
      enforcement at [TODO: insert link]'
    reason: ClusterBootImageSkewError
    status: "False"
    type: Upgradeable
```
Next, set the boot image to one within the skew limits:
```
  spec:
    bootImageSkewEnforcement:
      manual:
	mode: RHCOSVersion
        rhcosVersion: 9.2.20251023-0
      mode: Manual
```
Then, the `Upgradeable`  condition should be restored back to `True`
```
  - lastTransitionTime: "2025-11-20T15:19:25Z"
    reason: AsExpected
    status: "True"
    type: Upgradeable
```

These set of steps can be repeated with the OCPVersion specified too. This comparison should only take place in `Automatic` and `Manual` mode however, as `Automatic` is only permitted on the status side, I don't think there is an easy way to test that(other than the units I've included). 

In `None` mode, this version check should not take place.

Some caveats to note about `Automatic` mode: 

1. The admin is not permitted to use `Automatic` mode within the spec. This is in an intentional choice because only the MCO will always be able to self determine if a platform is eligible for automatic skew enforcement. 
2. In `Automatic` mode, API validations will prevent changing the boot image configuration to a setting other than `All`. To change the boot image configuration, the admin is first expected to go to `Manual` skew enforcement mode and then attempt to change the boot image configuration of the cluster.
3. In `Automatic` mode, if any machinesets are skipped for boot image updates(for example a marketplace or an unknown boot image was detected in any of the machinesets), the boot image controller will not update the boot image value stored in bootImageEnforcementStatus. This is because the cluster cannot be considered up to date on boot image if even one of the machine resources are out of skew. 
4. In `Automatic` mode, the operator will only populate the OCPVersion. This is because each platform may not have the same RHCOS version of the boot image(for example, across marketplace streams) in a given release, and it would involve a lot of per-platform piping to correctly track the RHCOS version per machineset within the boot image controller. I did not deem this to be worth the effort, but am open to implementing that later if the need arises. 