### PR TITLE
OCPBUGS-65731: Skip Azure Confidential Compute Clusters for boot image updates

### DIFF
--- a/pkg/controller/machine-set-boot-image/platform_helpers.go
+++ b/pkg/controller/machine-set-boot-image/platform_helpers.go
@@ -252,7 +252,12 @@ func reconcileVSphereProviderSpec(streamData *stream.Stream, arch string, infra 
 func reconcileAzureProviderSpec(streamData *stream.Stream, arch string, _ *osconfigv1.Infrastructure, providerSpec *machinev1beta1.AzureMachineProviderSpec, machineSetName string, secretClient clientset.Interface) (bool, *machinev1beta1.AzureMachineProviderSpec, error) {
 
 	if arch == "ppc64le" || arch == "s390x" {
-		klog.Infof("Skipping machineset %s, machinesets with arch %s are not supported for Azure", machineSetName, arch)
+		klog.Infof("Skipping update for %s, machinesets/controlplanemachinesets with arch %s are not supported for Azure", machineSetName, arch)
+		return false, nil, nil
+	}
+
+	if providerSpec.SecurityProfile != nil && providerSpec.SecurityProfile.Settings.SecurityType != "" {
+		klog.Infof("Skipping update for %s, machinesets/controlplanemachinesets with a SecurityType defined(%s in this case) is not currently supported for Azure", machineSetName, providerSpec.SecurityProfile.Settings.SecurityType)
 		return false, nil, nil
 	}
 


### PR DESCRIPTION
**- What I did**
Added an exemption for Azure `MachineSets` with a non-empty `securityType` field set. See attached bug for additional context.


**- How to verify it**
I've added a few units for this, but unsure how to launch a confidential compute cluster. The boot image controller should skip over the `machinesets` in those cases - the controller logs and `machinesets` themselves could be examined to verify this behavior.

