### PR TITLE
OCPBUGS-63709: templates/on-prem/haproxy: Add POD_NAMESPACE

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -133,6 +133,11 @@ contents:
           capabilities:
             add: ["NET_ADMIN", "SYS_CHROOT"]
         image: {{ .Images.baremetalRuntimeCfgImage }}
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         command:
         - monitor
         - "/var/lib/kubelet/kubeconfig"


### PR DESCRIPTION
**- What I did**

I added `POD_NAMESPACE` to `haproxy.yaml`.

This is not strictly speaking needed currently, but I need it for https://github.com/openshift/baremetal-runtimecfg/pull/371

**- How to verify it**

There is not much to verify, just adding an env variable to the manifest.

**- Description for the changelog**

Added missing POD_NAMESPACE environment variable to the monitor container in haproxy.yaml
