### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/test/e2e-ocl/helpers_test.go
+++ b/test/e2e-ocl/helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -813,7 +812,7 @@ func convertFilesFromContainerImageToBytesMap(t *testing.T, pullspec, containerF
 			return nil
 		}
 
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52