### PR TITLE
[release-4.19] OCPBUGS-64922: Update timing of MCN desired config spec update to align with node annotation setting

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	helpers "github.com/openshift/machine-config-operator/pkg/helpers"
+	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
 
 	configv1 "github.com/openshift/api/config/v1"
 	features "github.com/openshift/api/features"
@@ -1240,14 +1241,16 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1.MachineOSConfig, mosb *
 		}
 
 		lns := ctrlcommon.NewLayeredNodeState(oldNode)
+		desiredConfig := ""
 		if !layered {
 			lns.SetDesiredStateFromPool(pool)
+			desiredConfig = pool.Spec.Configuration.Name
 		} else {
 			lns.SetDesiredStateFromMachineOSConfig(mosc, mosb)
+			desiredConfig = mosb.Spec.MachineConfig.Name
 		}
 
 		// Set the desired state to match the pool.
-
 		newData, err := json.Marshal(lns.Node())
 		if err != nil {
 			return err
@@ -1256,6 +1259,12 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1.MachineOSConfig, mosb *
 		// Don't make a patch call if no update is needed.
 		if reflect.DeepEqual(newData, oldData) {
 			return nil
+		}
+
+		// Populate the desired config version and image annotations in the node's MCN
+		err = upgrademonitor.UpdateMachineConfigNodeSpecDesiredAnnotation(ctrl.fgAcessor, ctrl.client, nodeName, desiredConfig)
+		if err != nil {
+			klog.Errorf("error populating MCN for desired config version and image updates: %v", err)
 		}
 
 		klog.V(4).Infof("Pool %s: layered=%v node %s update is needed", pool.Name, layered, nodeName)

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -91,7 +91,7 @@ func newFixtureWithFeatureGates(t *testing.T, enabled, disabled []configv1.Featu
 }
 
 func newFixture(t *testing.T) *fixture {
-	return newFixtureWithFeatureGates(t, []configv1.FeatureGateName{features.FeatureGatePinnedImages, features.FeatureGateOnClusterBuild}, []configv1.FeatureGateName{})
+	return newFixtureWithFeatureGates(t, []configv1.FeatureGateName{features.FeatureGatePinnedImages, features.FeatureGateOnClusterBuild, features.FeatureGateMachineConfigNodes}, []configv1.FeatureGateName{})
 }
 
 func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller {
@@ -260,7 +260,10 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "machineosbuilds") ||
 				action.Matches("watch", "machineosbuilds") ||
 				action.Matches("list", "machineosconfigs") ||
-				action.Matches("watch", "machineosconfigs")) {
+				action.Matches("watch", "machineosconfigs") ||
+				action.Matches("list", "machineconfignodes") ||
+				action.Matches("watch", "machineconfignodes") ||
+				action.Matches("get", "machineconfignodes")) {
 			continue
 		}
 		ret = append(ret, action)


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/5367 because the automated cherry-pick was resulting in build failures in the CI test runs.