### PR TITLE
[release-4.20] OCPBUGS-50492: Add kube_rbac_proxy service

### DIFF
--- a/install/0000_80_machine-config_00_service.yaml
+++ b/install/0000_80_machine-config_00_service.yaml
@@ -63,4 +63,25 @@ spec:
   - name: health
     port: 8798
     protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-rbac-proxy
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: kube-rbac-proxy
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    service.beta.openshift.io/serving-cert-secret-name: proxy-tls
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: kube-rbac-proxy
+  ports:
+  - name: secure-listen
+    port: 9637
+    protocol: TCP
 


### PR DESCRIPTION
This PR adds a service to port 9637. As for now since it does not have a service, an endpointslice is not created and it is not included in the communication matrix. Adding a service should solve this issue.

(cherry picked from commit 3ccd953f60b209012762f41efc0266153b08caf3)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
