### PR TITLE
OCPBUGS-65959: Revert "OCPBUGS-50492: Add kube_rbac_proxy service"

### DIFF
--- a/install/0000_80_machine-config_00_service.yaml
+++ b/install/0000_80_machine-config_00_service.yaml
@@ -88,24 +88,4 @@ spec:
     port: 22624
     targetPort: 22624
     protocol: TCP
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kube-rbac-proxy
-  namespace: openshift-machine-config-operator
-  labels:
-    k8s-app: kube-rbac-proxy
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    service.beta.openshift.io/serving-cert-secret-name: proxy-tls
-spec:
-  type: ClusterIP
-  selector:
-    k8s-app: kube-rbac-proxy
-  ports:
-  - name: secure-listen
-    port: 9637
-    protocol: TCP
+


### PR DESCRIPTION
This reverts commit 3ccd953f60b209012762f41efc0266153b08caf3, as it broke the rbac-proxy pod entirely. See bug for details