### PR TITLE
[release-4.20] OCPBUGS-70349: Remove the dead code of setting the operator status for cgroupv1 based clusters

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -271,16 +271,6 @@ func (optr *Operator) syncUpgradeableStatus(co *configv1.ClusterOperator) error 
 		Reason: asExpectedReason,
 	}
 
-	configNode, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
-	if err != nil {
-		return err
-	}
-	if configNode.Spec.CgroupMode == configv1.CgroupModeV1 {
-		coStatusCondition.Status = configv1.ConditionFalse
-		coStatusCondition.Reason = "ClusterOnCgroupV1"
-		coStatusCondition.Message = "Cluster is using deprecated cgroup v1 and is not upgradable. Please update the `CgroupMode` in the `nodes.config.openshift.io` object to 'v2'. Once upgraded, the cluster cannot be changed back to cgroup v1"
-	}
-
 	// Check for ClusterImagePolicy named "openshift" which conflicts with the cluster default ClusterImagePolicy object
 	// Only check for Default featureSet clusters allowing 4.20 ci techpreview builds upgrades
 	// Use SigstoreImageVerificationPKI as an featureset indicator: if it's disabled, the cluster is on Default feature set
@@ -402,14 +392,6 @@ func (optr *Operator) generateClusterFleetEvaluations() ([]string, error) {
 		evaluations = append(evaluations, "runc: transition to default crun")
 	}
 
-	enabled, err = optr.cfeEvalCgroupsV1()
-	if err != nil {
-		return evaluations, err
-	}
-	if enabled {
-		evaluations = append(evaluations, "cgroupsv1: support has been deprecated in favor of cgroupsv2")
-	}
-
 	sort.Strings(evaluations)
 
 	return evaluations, nil
@@ -458,21 +440,6 @@ func (optr *Operator) cfeEvalRunc() (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-func (optr *Operator) cfeEvalCgroupsV1() (bool, error) {
-	// check for nil so we do not have to mock within tests
-	if optr.nodeClusterLister == nil {
-		return false, nil
-	}
-	nodeClusterConfig, err := optr.nodeClusterLister.Get(ctrlcommon.ClusterNodeInstanceName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return nodeClusterConfig.Spec.CgroupMode == configv1.CgroupModeV1, nil
 }
 
 // GetAllManagedNodes returns the nodes managed by MCO


### PR DESCRIPTION
Manual backport of https://github.com/openshift/machine-config-operator/pull/5399