### PR TITLE
NO-ISSUE: Add rhel-10-coreos{,-extensions} to image-references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,15 @@ COPY install /manifests
 RUN if [ "${TAGS}" = "fcos" ]; then \
     # comment out non-base/extensions image-references entirely for fcos
     sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
+    # comment out rhel-coreos-10 entirely for fcos
+    sed -i '/- name: rhel-coreos-10/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config_05_osimageurl.yaml && \
     # rewrite image names for fcos
     sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then \
+    # comment out rhel-coreos-10 for scos
+    sed -i '/- name: rhel-coreos-10/,+3 s/^/#/' /manifests/* && \
     # rewrite image names for scos
     sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi && \
     dnf --setopt=keepcache=true -y install 'nmstate >= 2.2.10' && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -26,11 +26,15 @@ COPY install /manifests
 RUN if [ "${TAGS}" = "fcos" ]; then \
     # comment out non-base/extensions image-references entirely for fcos
     sed -i '/- name: rhel-coreos-/,+3 s/^/#/' /manifests/image-references && \
+    # comment out rhel-coreos-10 entirely for fcos
+    sed -i '/- name: rhel-coreos-10/,+3 s/^/#/' /manifests/image-references && \
     # also remove extensions from the osimageurl configmap (if we don't, oc won't rewrite it, and the placeholder value will survive and get used)
     sed -i '/baseOSExtensionsContainerImage:/ s/^/#/' /manifests/0000_80_machine-config_05_osimageurl.yaml && \
     # rewrite image names for fcos
     sed -i 's/rhel-coreos/fedora-coreos/g' /manifests/*; \
     elif [ "${TAGS}" = "scos" ]; then \
+    # comment out rhel-coreos-10 for scos
+    sed -i '/- name: rhel-coreos-10/,+3 s/^/#/' /manifests/* && \
     # rewrite image names for scos
     sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi && \
     dnf --setopt=keepcache=true -y install 'nmstate >= 2.2.10' && \

--- a/install/image-references
+++ b/install/image-references
@@ -28,6 +28,14 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-extensions
+  - name: rhel-coreos-10
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel10-coreos
+  - name: rhel-coreos-10-extensions
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel10-coreos-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage


### PR DESCRIPTION
Handle FCOS and SCOS where those aren't relevant by commenting them out.

**- What I did**
Added rhel-10-coreos and rhel-10-coreos-extensions making sure that they're commented out for fcos and scos tags

**- How to verify it**
Build the images, the images should show up in the release payload

**- Description for the changelog**
Add rhel-10-coreos and rhel-10-coreos-extensions to the MCO image-references on OCP.