### PR TITLE
[DO-NOT-MERGE] test custom dns on azure platform

### DIFF
--- a/templates/common/aws/units/aws-update-dns.service.yaml
+++ b/templates/common/aws/units/aws-update-dns.service.yaml
@@ -13,7 +13,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=/usr/local/bin/update-dns-server 169.254.169.253
+  ExecStart=/usr/local/bin/update-dns-server 169.254.169.253,169.254.169.254
 
   [Install]
   RequiredBy=kubelet-dependencies.target

--- a/templates/common/azure/units/azure-update-dns.service.yaml
+++ b/templates/common/azure/units/azure-update-dns.service.yaml
@@ -13,7 +13,7 @@ contents: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=/usr/local/bin/update-dns-server 168.63.129.16
+  ExecStart=/usr/local/bin/update-dns-server 168.63.129.16,169.254.169.254
 
   [Install]
   RequiredBy=kubelet-dependencies.target

--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -7,6 +7,7 @@ contents:
         bufsize 512
         health :18080
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
+            force_tcp
             policy sequential
         }
         cache 30

--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -9,11 +9,7 @@ contents:
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
             policy sequential
         }
-        cache 900 {
-            success 10000 900
-            denial 5000 30
-            prefetch 1 10m
-        }
+        cache 30
         reload
         template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match .*[.]apps.{{ .DNS.Spec.BaseDomain }}

--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -7,10 +7,13 @@ contents:
         bufsize 512
         health :18080
         forward . {{`{{- range $upstream := .DNSUpstreams}} {{$upstream}}{{- end}}`}} {
-            force_tcp
             policy sequential
         }
-        cache 30
+        cache 900 {
+            success 10000 900
+            denial 5000 30
+            prefetch 1 10m
+        }
         reload
         template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match .*[.]apps.{{ .DNS.Spec.BaseDomain }}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
just for test purpose, don't merge it.
We found that some i/o timeout error in coredns log when enabling customer dns on azure platform.
Asked Gemini, check if force TCP can fix the issue

>### The Root Cause: Azure UDP Throttling & Conntrack
>1. UDP Conntrack Race Condition: DNS uses UDP. On Linux (and Azure's underlying networking), sending many UDP packets in parallel via the same socket can cause race conditions in the kernel's connection tracking (conntrack) table.
>2. Azure's SNAT Limits: Azure Load Balancers (which sit in front of the recursive resolvers) have stricter SNAT port limits and aggressive timeouts. If CoreDNS makes many outbound queries, it can exhaust the available ephemeral ports or hit rate limits that GCP handles more gracefully.
>3. Packet Drops: When these limits are hit, Azure silently drops the UDP packets. CoreDNS waits for a reply that never comes, resulting in `i/o timeout`.
>### Solution 1: Force TCP (The Quick Fix)
>TCP is connection-oriented. Azure's networking stack tracks TCP connections much more reliably than UDP flows, and it avoids the specific UDP conntrack race conditions.
>Modify your `forward` block in the Corefile to force TCP for upstream connections.
>```corefile
>forward . /etc/resolv.conf {
>    force_tcp
>}
>```
>*This is the most common fix for Azure-specific DNS flakiness.*

/uncc