### PR TITLE
MCO-1999: align extended tests code with private repo. Pointers and pe…

### DIFF
--- a/test/extended-priv/configmap.go
+++ b/test/extended-priv/configmap.go
@@ -71,24 +71,24 @@ func (cm *ConfigMap) GetDataValueOrFail(key string) string {
 	return value
 }
 
-// GetAll returns a []ConfigMap list with all existing pinnedimageset sorted by creation timestamp
-func (cml *ConfigMapList) GetAll() ([]ConfigMap, error) {
+// GetAll returns a []*ConfigMap list with all existing pinnedimageset sorted by creation timestamp
+func (cml *ConfigMapList) GetAll() ([]*ConfigMap, error) {
 	cml.ResourceList.SortByTimestamp()
 	allResources, err := cml.ResourceList.GetAll()
 	if err != nil {
 		return nil, err
 	}
-	all := make([]ConfigMap, 0, len(allResources))
+	all := make([]*ConfigMap, 0, len(allResources))
 
 	for _, res := range allResources {
-		all = append(all, *NewConfigMap(cml.oc, res.namespace, res.name))
+		all = append(all, NewConfigMap(cml.oc, res.namespace, res.name))
 	}
 
 	return all, nil
 }
 
-// GetAllOrFail returns a []ConfigMap list with all existing pinnedimageset sorted by creation time, if any error happens it fails the test
-func (cml *ConfigMapList) GetAllOrFail() []ConfigMap {
+// GetAllOrFail returns a []*ConfigMap list with all existing pinnedimageset sorted by creation time, if any error happens it fails the test
+func (cml *ConfigMapList) GetAllOrFail() []*ConfigMap {
 	all, err := cml.GetAll()
 	o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred(), "Error getting the list of existing ConfigMap in the cluster")
 	return all

--- a/test/extended-priv/controlplanemachineset.go
+++ b/test/extended-priv/controlplanemachineset.go
@@ -263,7 +263,7 @@ func (cpms ControlPlaneMachineSet) SetUserDataSecret(userDataSecretName string) 
 }
 
 // GetMachines returns a slice with the machines created for this ControlPlaneMachineSet
-func (cpms ControlPlaneMachineSet) GetMachines() ([]Machine, error) {
+func (cpms ControlPlaneMachineSet) GetMachines() ([]*Machine, error) {
 	ml := NewMachineList(cpms.oc, cpms.GetNamespace())
 	ml.ByLabel("machine.openshift.io/cluster-api-machine-role=master")
 	ml.ByLabel("machine.openshift.io/cluster-api-machine-type=master")
@@ -272,7 +272,7 @@ func (cpms ControlPlaneMachineSet) GetMachines() ([]Machine, error) {
 }
 
 // GetMachinesOrFail get machines from ControlPlaneMachineSet or fail the test if any error occurred
-func (cpms ControlPlaneMachineSet) GetMachinesOrFail() []Machine {
+func (cpms ControlPlaneMachineSet) GetMachinesOrFail() []*Machine {
 	ml, err := cpms.GetMachines()
 	o.Expect(err).NotTo(o.HaveOccurred(), "Get machines of ControlPlaneMachineSet %s failed", cpms.GetName())
 	return ml
@@ -304,23 +304,23 @@ func (cpms ControlPlaneMachineSet) GetNodesOrFail() []*Node {
 	return nodes
 }
 
-// GetAll returns a []ControlPlaneMachineSet list with all existing ControlPlaneMachineSets
-func (cpmsl *ControlPlaneMachineSetList) GetAll() ([]ControlPlaneMachineSet, error) {
+// GetAll returns a []*ControlPlaneMachineSet list with all existing ControlPlaneMachineSets
+func (cpmsl *ControlPlaneMachineSetList) GetAll() ([]*ControlPlaneMachineSet, error) {
 	allCPMSResources, err := cpmsl.ResourceList.GetAll()
 	if err != nil {
 		return nil, err
 	}
-	allCPMS := make([]ControlPlaneMachineSet, 0, len(allCPMSResources))
+	allCPMS := make([]*ControlPlaneMachineSet, 0, len(allCPMSResources))
 
 	for _, cpmsRes := range allCPMSResources {
-		allCPMS = append(allCPMS, *NewControlPlaneMachineSet(cpmsl.oc, cpmsRes.GetNamespace(), cpmsRes.GetName()))
+		allCPMS = append(allCPMS, NewControlPlaneMachineSet(cpmsl.oc, cpmsRes.GetNamespace(), cpmsRes.GetName()))
 	}
 
 	return allCPMS, nil
 }
 
-// GetAllOrFail returns a []ControlPlaneMachineSet list with all existing ControlPlaneMachineSets and fail the test if it is not possible
-func (cpmsl *ControlPlaneMachineSetList) GetAllOrFail() []ControlPlaneMachineSet {
+// GetAllOrFail returns a []*ControlPlaneMachineSet list with all existing ControlPlaneMachineSets and fail the test if it is not possible
+func (cpmsl *ControlPlaneMachineSetList) GetAllOrFail() []*ControlPlaneMachineSet {
 	allCpms, err := cpmsl.GetAll()
 	o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred(), "Error getting the list of existing ControlPlaneMachineSets")
 

--- a/test/extended-priv/generic_behaviour_validation.go
+++ b/test/extended-priv/generic_behaviour_validation.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Checker interface {
-	Check(checkedNodes ...Node)
+	Check(checkedNodes ...*Node)
 }
 
 type CommandOutputChecker struct {
@@ -21,7 +21,7 @@ type CommandOutputChecker struct {
 	Desc     string
 }
 
-func (cOutChecker CommandOutputChecker) Check(checkedNodes ...Node) {
+func (cOutChecker CommandOutputChecker) Check(checkedNodes ...*Node) {
 	msg := "Executing verification commands"
 	if cOutChecker.Desc != "" {
 		msg = cOutChecker.Desc
@@ -47,7 +47,7 @@ type RemoteFileChecker struct {
 	Desc         string
 }
 
-func (rfc RemoteFileChecker) Check(checkedNodes ...Node) {
+func (rfc RemoteFileChecker) Check(checkedNodes ...*Node) {
 	msg := fmt.Sprintf("Checking file: %s", rfc.FileFullPath)
 	if rfc.Desc != "" {
 		msg = rfc.Desc
@@ -65,12 +65,12 @@ func (rfc RemoteFileChecker) Check(checkedNodes ...Node) {
 }
 
 // checkDrainAction checks that the drain action in the node is the expected one (drainSkipped)
-func checkDrainAction(drainSkipped bool, node Node, controller *Controller) {
+func checkDrainAction(drainSkipped bool, node *Node, controller *Controller) {
 	checkDrainActionWithGomega(drainSkipped, node, controller, o.Default)
 }
 
 // checkDrainActionWithGomega checks that the drain action in the node is the expected one (drainSkipped). It accepts an extra Gomega parameter that allows the function to be used in the Eventually gomega matchers
-func checkDrainActionWithGomega(drainExecuted bool, node Node, controller *Controller, gm o.Gomega) {
+func checkDrainActionWithGomega(drainExecuted bool, node *Node, controller *Controller, gm o.Gomega) {
 	var (
 		execDrainLogMsg = "initiating drain"
 	)
@@ -97,12 +97,12 @@ func checkDrainActionWithGomega(drainExecuted bool, node Node, controller *Contr
 }
 
 // checkRebootAction checks that the reboot action in the node is the expected one (rebootSkipped)
-func checkRebootAction(rebootExecuted bool, node Node, startTime time.Time) {
+func checkRebootAction(rebootExecuted bool, node *Node, startTime time.Time) {
 	checkRebootActionWithGomega(rebootExecuted, node, startTime, o.Default)
 }
 
 // checkRebootActionWithGomega checks that the reboot action in the node is the expected one (rebootSkipped). It accepts an extra Gomega parameter that allows the function to be used in the Eventually gomega matchers
-func checkRebootActionWithGomega(rebootExecuted bool, node Node, startTime time.Time, gm o.Gomega) {
+func checkRebootActionWithGomega(rebootExecuted bool, node *Node, startTime time.Time, gm o.Gomega) {
 	if rebootExecuted {
 		logger.Infof("Checking that node %s was rebooted", node.GetName())
 		gm.Expect(node.GetUptime()).Should(o.BeTemporally(">", startTime),

--- a/test/extended-priv/machine.go
+++ b/test/extended-priv/machine.go
@@ -41,7 +41,7 @@ func (m Machine) GetNode() (*Node, error) {
 		return nil, fmt.Errorf("No node linked to this Machine. Machine: %s", m.GetName())
 	}
 
-	return &(nodes[0]), nil
+	return nodes[0], nil
 }
 
 // GetNodeOrFail, call GetNode, fail the test if any error occurred
@@ -75,16 +75,16 @@ func NewMachineList(oc *exutil.CLI, namespace string) *MachineList {
 	return &MachineList{*NewNamespacedResourceList(oc, MachineFullName, namespace)}
 }
 
-// GetAll returns a []Machine slice with all existing nodes
-func (ml MachineList) GetAll() ([]Machine, error) {
+// GetAll returns a []*Machine slice with all existing nodes
+func (ml MachineList) GetAll() ([]*Machine, error) {
 	allMResources, err := ml.ResourceList.GetAll()
 	if err != nil {
 		return nil, err
 	}
-	allMs := make([]Machine, 0, len(allMResources))
+	allMs := make([]*Machine, 0, len(allMResources))
 
 	for _, mRes := range allMResources {
-		allMs = append(allMs, *NewMachine(ml.oc, mRes.GetNamespace(), mRes.GetName()))
+		allMs = append(allMs, NewMachine(ml.oc, mRes.GetNamespace(), mRes.GetName()))
 	}
 
 	return allMs, nil

--- a/test/extended-priv/machineosbuild.go
+++ b/test/extended-priv/machineosbuild.go
@@ -68,17 +68,17 @@ func (mosb MachineOSBuild) GetJob() (*Job, error) {
 	return NewJob(mosb.GetOC(), jobNamespace, jobName), nil
 }
 
-// GetAll returns a []MachineOSBuild list with all existing pinnedimageset sorted by creation timestamp
-func (mosbl *MachineOSBuildList) GetAll() ([]MachineOSBuild, error) {
+// GetAll returns a []*MachineOSBuild list with all existing pinnedimageset sorted by creation timestamp
+func (mosbl *MachineOSBuildList) GetAll() ([]*MachineOSBuild, error) {
 	mosbl.ResourceList.SortByTimestamp()
 	allResources, err := mosbl.ResourceList.GetAll()
 	if err != nil {
 		return nil, err
 	}
-	all := make([]MachineOSBuild, 0, len(allResources))
+	all := make([]*MachineOSBuild, 0, len(allResources))
 
 	for _, res := range allResources {
-		all = append(all, *NewMachineOSBuild(mosbl.oc, res.name))
+		all = append(all, NewMachineOSBuild(mosbl.oc, res.name))
 	}
 
 	return all, nil

--- a/test/extended-priv/machineosconfig.go
+++ b/test/extended-priv/machineosconfig.go
@@ -299,7 +299,7 @@ func (mosc MachineOSConfig) GetMachineConfigPool() (*MachineConfigPool, error) {
 }
 
 // GetMachineOSBuildList returns a list of all MOSB linked to this MOSC
-func (mosc MachineOSConfig) GetMachineOSBuildList() ([]MachineOSBuild, error) {
+func (mosc MachineOSConfig) GetMachineOSBuildList() ([]*MachineOSBuild, error) {
 	mosbList := NewMachineOSBuildList(mosc.GetOC())
 	mosbList.SetItemsFilter(fmt.Sprintf(`?(@.spec.machineOSConfig.name=="%s")`, mosc.GetName()))
 	return mosbList.GetAll()
@@ -345,24 +345,24 @@ func (mosc MachineOSConfig) Rebuild() error {
 	return mosc.Patch("json", `[{"op": "add", "path": "/metadata/annotations/machineconfiguration.openshift.io~1rebuild", "value":""}]`)
 }
 
-// GetAll returns a []MachineOSConfig list with all existing pinnedimageset sorted by creation timestamp
-func (moscl *MachineOSConfigList) GetAll() ([]MachineOSConfig, error) {
+// GetAll returns a []*MachineOSConfig list with all existing pinnedimageset sorted by creation timestamp
+func (moscl *MachineOSConfigList) GetAll() ([]*MachineOSConfig, error) {
 	moscl.ResourceList.SortByTimestamp()
 	allMOSCResources, err := moscl.ResourceList.GetAll()
 	if err != nil {
 		return nil, err
 	}
-	allMOSCs := make([]MachineOSConfig, 0, len(allMOSCResources))
+	allMOSCs := make([]*MachineOSConfig, 0, len(allMOSCResources))
 
 	for _, moscRes := range allMOSCResources {
-		allMOSCs = append(allMOSCs, *NewMachineOSConfig(moscl.oc, moscRes.name))
+		allMOSCs = append(allMOSCs, NewMachineOSConfig(moscl.oc, moscRes.name))
 	}
 
 	return allMOSCs, nil
 }
 
-// GetAllOrFail returns a []MachineOSConfig list with all existing pinnedimageset sorted by creation time, if any error happens it fails the test
-func (moscl *MachineOSConfigList) GetAllOrFail() []MachineOSConfig {
+// GetAllOrFail returns a []*MachineOSConfig list with all existing pinnedimageset sorted by creation time, if any error happens it fails the test
+func (moscl *MachineOSConfigList) GetAllOrFail() []*MachineOSConfig {
 	moscs, err := moscl.GetAll()
 	o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred(), "Error getting the list of existing MachineOSConfig in the cluster")
 	return moscs

--- a/test/extended-priv/machineset.go
+++ b/test/extended-priv/machineset.go
@@ -29,16 +29,16 @@ func NewMachineSetList(oc *exutil.CLI, namespace string) *MachineSetList {
 	return &MachineSetList{*NewNamespacedResourceList(oc, MachineSetFullName, namespace)}
 }
 
-// GetAll returns a []MachineSet list with all existing MachineSets
-func (msl *MachineSetList) GetAll() ([]MachineSet, error) {
+// GetAll returns a []*MachineSet list with all existing MachineSets
+func (msl *MachineSetList) GetAll() ([]*MachineSet, error) {
 	allMachineSetResources, err := msl.ResourceList.GetAll()
 	if err != nil {
 		return nil, err
 	}
-	allMachineSets := make([]MachineSet, 0, len(allMachineSetResources))
+	allMachineSets := make([]*MachineSet, 0, len(allMachineSetResources))
 
 	for _, msRes := range allMachineSetResources {
-		allMachineSets = append(allMachineSets, *NewMachineSet(msl.oc, msRes.GetNamespace(), msRes.GetName()))
+		allMachineSets = append(allMachineSets, NewMachineSet(msl.oc, msRes.GetNamespace(), msRes.GetName()))
 	}
 
 	return allMachineSets, nil

--- a/test/extended-priv/mco.go
+++ b/test/extended-priv/mco.go
@@ -72,7 +72,7 @@ func checkDegraded(mcp *MachineConfigPool, expectedMessage, expectedReason, degr
 	logger.Infof("OK!\n")
 }
 
-func skipTestIfRHELVersion(node Node, operator, constraintVersion string) {
+func skipTestIfRHELVersion(node *Node, operator, constraintVersion string) {
 	actualVersion, err := node.GetRHELVersion()
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting RHEL version from node %s", node.GetName())
 

--- a/test/extended-priv/mco_controlplanemachineset.go
+++ b/test/extended-priv/mco_controlplanemachineset.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		oc = exutil.NewCLI("mco-controlplanemachineset", exutil.KubeConfigPath())
 		// Common variables
 		cpms                 *ControlPlaneMachineSet
-		machines             []Machine
+		machines             []*Machine
 		machineConfiguration *MachineConfiguration
 	)
 

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -274,7 +274,7 @@ func testContainerFile(containerFiles []ContainerFile, imageNamespace string, mc
 }
 
 func SkipTestIfOCBIsEnabled(oc *exutil.CLI) {
-	moscl := NewMachineOSConfigList(oc)
+	moscl := NewMachineOSConfigList(oc.AsAdmin())
 	allMosc := moscl.GetAllOrFail()
 	if len(allMosc) != 0 {
 		moscl.PrintDebugCommand()

--- a/test/extended-priv/mco_password.go
+++ b/test/extended-priv/mco_password.go
@@ -495,7 +495,7 @@ func GenerateSSHKeyPairOrFail() (privateKey, publicKey string) {
 	return privKey, pubKey
 }
 
-func checkSSHAccessInNode(node Node, user, privKey string) {
+func checkSSHAccessInNode(node *Node, user, privKey string) {
 	tmpPrivKeyPath := "/tmp/tmp-" + exutil.GetRandomString()
 	remotePrivSSH := NewRemoteFile(node, tmpPrivKeyPath)
 	defer func() {
@@ -510,7 +510,7 @@ func checkSSHAccessInNode(node Node, user, privKey string) {
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error in the login process using ssh key in node %s:\n %s", node.GetName(), bresp)
 }
 
-func checkAuthorizedKeyInNode(node Node, keys []string) {
+func checkAuthorizedKeyInNode(node *Node, keys []string) {
 	logger.Infof("Checking old file /home/core/.ssh/authorized_keys")
 	rOldAuthorizedFile := NewRemoteFile(node, "/home/core/.ssh/authorized_keys")
 	o.Expect(rOldAuthorizedFile.Fetch()).ShouldNot(o.Succeed(),

--- a/test/extended-priv/remotefile.go
+++ b/test/extended-priv/remotefile.go
@@ -29,14 +29,14 @@ const (
 
 // RemoteFile handles files located remotely in a node
 type RemoteFile struct {
-	node     Node
+	node     *Node
 	fullPath string
 	statData map[string]string
 	content  string
 }
 
 // NewRemoteFile creates a new instance of RemoteFile
-func NewRemoteFile(node Node, fullPath string) *RemoteFile {
+func NewRemoteFile(node *Node, fullPath string) *RemoteFile {
 	return &RemoteFile{node: node, fullPath: fullPath}
 }
 

--- a/test/extended-priv/resource.go
+++ b/test/extended-priv/resource.go
@@ -434,12 +434,12 @@ type ResourceList struct {
 
 // NewResourceList constructs a ResourceList struct for not-namespaced resources
 func NewResourceList(oc *exutil.CLI, kind string) *ResourceList {
-	return &ResourceList{ocGetter{oc.AsAdmin(), kind, "", ""}, []string{}, ""}
+	return &ResourceList{ocGetter{oc, kind, "", ""}, []string{}, ""}
 }
 
 // NewNamespacedResourceList constructs a ResourceList struct for namespaced resources
 func NewNamespacedResourceList(oc *exutil.CLI, kind, namespace string) *ResourceList {
-	return &ResourceList{ocGetter{oc.AsAdmin(), kind, namespace, ""}, []string{}, ""}
+	return &ResourceList{ocGetter{oc, kind, namespace, ""}, []string{}, ""}
 }
 
 // CleanParams removes the extraparams added by methods like "ByLabel" or "SorBy..."

--- a/test/extended-priv/util.go
+++ b/test/extended-priv/util.go
@@ -111,7 +111,7 @@ func generateTemplateAbsolutePath(fileName string) string {
 	return filepath.Join(fixturesPath, fileName)
 }
 
-func sortNodeList(nodes []Node) []Node {
+func sortNodeList(nodes []*Node) []*Node {
 	sort.Slice(nodes, func(l, r int) bool {
 		lMetadata := JSON(nodes[l].GetOrFail("{.metadata}"))
 		rMetadata := JSON(nodes[r].GetOrFail("{.metadata}"))
@@ -159,8 +159,8 @@ func sortNodeList(nodes []Node) []Node {
 // sortMasterNodeList returns the list of nodes sorted by the order used to updated them in MCO master pool.
 //
 //	Master pool will use the same order as the rest of the pools, but the node running the operator pod will be the last one to be updated.
-func sortMasterNodeList(oc *exutil.CLI, nodes []Node) ([]Node, error) {
-	masterSortedNodes := []Node{}
+func sortMasterNodeList(oc *exutil.CLI, nodes []*Node) ([]*Node, error) {
+	masterSortedNodes := []*Node{}
 	operatorNode, err := GetOperatorNode(oc)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func sortMasterNodeList(oc *exutil.CLI, nodes []Node) ([]Node, error) {
 
 	logger.Infof("MCO operator pod running in node: %s", operatorNode)
 
-	var latestNode Node
+	var latestNode *Node
 	for _, item := range sortNodeList(nodes) {
 		node := item
 		if node.GetName() == operatorNode.GetName() {


### PR DESCRIPTION
…rmissions in lists

**- What I did**

Modify the extended tests code so that it is aligned with the private tests code.

Modifications:

- The lists should return a slice of pointers. 
- The resource lists should not override the oc user with oc.AsAdmin(), they should use the provided user.


**- How to verify it**

All tests should pass

**- Description for the changelog**
