### PR TITLE
OCPBUGS-61487: Add timer for Azure VIP routes reconciliation

### DIFF
--- a/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
+++ b/templates/master/00-master/azure/files/opt-libexec-openshift-azure-routes-sh.yaml
@@ -57,15 +57,11 @@ contents:
         if [ -z "${ovnkContainerID}" ]; then
             return
         fi
-        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
         local routeVIPsV4=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip4" | awk '$8{print $8}')
-        echo "Found v4route vips: ${routeVIPsV4}"
         local host=$(hostname)
-        echo ${host}
         for route_vip in ${routeVIPsV4}; do
             if [[ ! -v v4vips[${route_vip}] ]] || [[ "${v4vips[${route_vip}]}" = down ]]; then
-                echo removing stale vip "${route_vip}" for local clients
-                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${route_vip}"
+                echo "removing stale route: ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${route_vip}"
                 crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${route_vip}"
             fi
         done
@@ -75,11 +71,9 @@ contents:
         fi
 
         local routeVIPsV6=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "ip6" | awk '$8{print $8}')
-        echo "Found v6route vips: ${routeVIPsV6}"
         for route_vip in ${routeVIPsV6}; do
             if [[ ! -v v6vips[${route_vip}] ]] || [[ "${v6vips[${route_vip}]}" = down ]]; then
-                echo removing stale vip "${route_vip}" for local clients
-                echo "ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${route_vip}"
+                echo "removing stale route: ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${route_vip}"
                 crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-del ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip6.dst == ${route_vip}"
             fi
         done
@@ -101,7 +95,6 @@ contents:
             fi
         done
 
-        echo "synchronizing IPv4 VIPs to (${v4vipset}), IPv6 VIPS to (${v6vipset})"
         {
             echo "flush chain inet ${TABLE_NAME} ${VIPS_CHAIN}"
             if [[ -n "${v4vipset}" ]]; then
@@ -119,21 +112,13 @@ contents:
             echo "OVN-Kubernetes is not running; no routes to add."
             return
         fi
-        echo "Found ovnkube-controller pod... ${ovnkContainerID}"
         local ovnK8sMp0v4=$(ip -brief address show ovn-k8s-mp0 | awk '{print $3}' | awk -F/ '{print $1}')
-        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v4}"
         local host=$(hostname)
-        echo ${host}
         for vip in "${!v4vips[@]}"; do
             if [[ "${v4vips[${vip}]}" != down ]]; then
-                echo "ensuring route for ${vip} for internal clients"
                 local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v4}")
-                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
-                if [[ "${routes}" == *"${vip}"* ]]; then
-                    echo "Route exists"
-                else
-                    echo "Route does not exist; creating it..."
-                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${vip} reroute ${ovnK8sMp0v4}"
+                if [[ "${routes}" != *"${vip}"* ]]; then
+                    echo "adding route: ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip4.dst == ${vip} reroute ${ovnK8sMp0v4}"
                     crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip4.dst == ${vip}" reroute "${ovnK8sMp0v4}"
                 fi
             fi
@@ -144,18 +129,11 @@ contents:
         fi
 
         local ovnK8sMp0v6=$(ip -brief address show ovn-k8s-mp0 | awk '{print $4}' | awk -F/ '{print $1}')
-        echo "Found ovn-k8s-mp0 interface IP ${ovnK8sMp0v6}"
-
         for vip in "${!v6vips[@]}"; do
             if [[ "${v6vips[${vip}]}" != down ]]; then
-                echo "ensuring route for ${vip} for internal clients"
                 local routes=$(crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-list ovn_cluster_router | grep "1010" | grep "${vip}" | grep "${ovnK8sMp0v6}")
-                echo "OVNK Routes on ovn-cluster-router at 1010 priority: $routes"
-                if [[ "${routes}" == *"${vip}"* ]]; then
-                    echo "Route exists"
-                else
-                    echo "Route does not exist; creating it..."
-                    echo "ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${vip} reroute ${ovnK8sMp0v6}"
+                if [[ "${routes}" != *"${vip}"* ]]; then
+                    echo "adding route: ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-${host} && ip6.dst == ${vip} reroute ${ovnK8sMp0v6}"
                     crictl exec -i ${ovnkContainerID} ovn-nbctl lr-policy-add ovn_cluster_router 1010 "inport == \"rtos-${host}\" && ip6.dst == ${vip}" reroute "${ovnK8sMp0v6}"
                 fi
             fi
@@ -195,10 +173,8 @@ contents:
                 echo "${vip} has upfile and downfile, marking as down"
             else
                 if [[ ${vip} =~ : ]]; then
-                    echo "processing v6 vip ${vip}"
                     v6vips[${vip}]="${vip}"
                 else
-                    echo "processing v4 vip ${vip}"
                     v4vips[${vip}]="${vip}"
                 fi
             fi
@@ -213,7 +189,6 @@ contents:
             sync_rules
             remove_stale_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
             add_routes # needed for OVN-Kubernetes plugin's routingViaHost=false mode
-            echo "done applying vip rules"
             ;;
         cleanup)
             clear_rules

--- a/templates/master/00-master/azure/units/openshift-azure-routes-timer-stop.service.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes-timer-stop.service.yaml
@@ -1,0 +1,10 @@
+name: openshift-azure-routes-timer-stop.service
+enabled: false
+contents: |
+  [Unit]
+  Description=Stop Azure VIP routes periodic timer after boot window
+
+  [Service]
+  Type=oneshot
+  ExecStart=/bin/systemctl stop openshift-azure-routes.timer
+  SyslogIdentifier=openshift-azure-routes-timer-stop

--- a/templates/master/00-master/azure/units/openshift-azure-routes-timer-stop.timer.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes-timer-stop.timer.yaml
@@ -1,0 +1,11 @@
+name: openshift-azure-routes-timer-stop.timer
+enabled: true
+contents: |
+  [Unit]
+  Description=Stop Azure VIP routes timer after boot window
+
+  [Timer]
+  OnBootSec=15min
+
+  [Install]
+  WantedBy=timers.target

--- a/templates/master/00-master/azure/units/openshift-azure-routes.service.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes.service.yaml
@@ -8,6 +8,6 @@ contents: |
   
   [Service]
   Type=simple
-  ExecStart=/bin/bash /opt/libexec/openshift-azure-routes.sh start
+  ExecStart=/usr/bin/flock --exclusive --nonblock /run/azure-routes.lock /bin/bash /opt/libexec/openshift-azure-routes.sh start
   User=root
   SyslogIdentifier=openshift-azure-routes

--- a/templates/master/00-master/azure/units/openshift-azure-routes.timer.yaml
+++ b/templates/master/00-master/azure/units/openshift-azure-routes.timer.yaml
@@ -1,0 +1,12 @@
+name: openshift-azure-routes.timer
+enabled: true
+contents: |
+  [Unit]
+  Description=Periodic reconciliation of Azure VIP routes
+
+  [Timer]
+  OnBootSec=30
+  OnUnitActiveSec=30
+
+  [Install]
+  WantedBy=timers.target

--- a/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
+++ b/templates/master/00-master/gcp/units/openshift-gcp-routes.service.yaml
@@ -12,6 +12,7 @@ contents: |
   ExecStart=/bin/bash /opt/libexec/openshift-gcp-routes.sh start
   ExecStopPost=/bin/bash /opt/libexec/openshift-gcp-routes.sh cleanup
   User=root
+  SyslogIdentifier=openshift-gcp-routes
   RestartSec=30
   Restart=always
 


### PR DESCRIPTION
During systemd daemon-reload (e.g., during MCO updates), the openshift-azure-routes.path unit may miss file change events from apiserver-watcher. This leaves the azure-vips nftables table empty even when the API server is back up.

Fix by adding a periodic timer that triggers reconciliation every 30 seconds as a fallback, for the first 15 minutes after boot. The path unit still provides immediate response to file changes. Also wrap the service ExecStart with flock to prevent concurrent executions when both triggers fire simultaneously.

15 minutes after boot, `openshift-azure-routes.timer`, which triggers periodic reconciliation, is inactive:
```
                                                 
  sh-5.1# systemctl status openshift-azure-routes.timer                                                                                                                                                         
  ○ openshift-azure-routes.timer - Periodic reconciliation of Azure VIP routes                                                                                                                                  
  Loaded: loaded (/etc/systemd/system/openshift-azure-routes.timer; enabled; preset: disabled)                                                                                                                  
  Active: inactive (dead) since Tue 2026-01-20 18:51:59 UTC; 33min ago          # <-------- inactive                                                                                                                        
  Duration: 14min 55.823s                        # <-------- around 15 mins                                                                                                                                                                
  Trigger: n/a                                                                                                                                                                                                  
  Triggers: ● openshift-azure-routes.service                                                                                                                                                                    
                                                                                                                                                                                                                
  Jan 20 18:37:03 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Periodic reconciliation of Azure VIP routes.                                                                                           
  Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.timer: Deactivated successfully.                                                                                        
  Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Stopped Periodic reconciliation of Azure VIP routes. 
```
The stopper **timer** (`openshift-azure-routes-timer-stop.timer`) runs once:
```
  sh-5.1# systemctl status openshift-azure-routes-timer-stop.timer                                                                                                                                              
  ● openshift-azure-routes-timer-stop.timer - Stop Azure VIP routes timer after boot window                                                                                                                     
  Loaded: loaded (/etc/systemd/system/openshift-azure-routes-timer-stop.timer; enabled; preset: disabled)                                                                                                       
  Active: active (elapsed) since Tue 2026-01-20 18:37:03 UTC; 48min ago                                                                                                                                         
  Until: Tue 2026-01-20 18:37:03 UTC; 48min ago                                                                                                                                                                 
  Trigger: n/a                                                                                                                                                                                                  
  Triggers: ● openshift-azure-routes-timer-stop.service                                                                                                                                                         
                                                                                                                                                                                                                
  Jan 20 18:37:03 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Stop Azure VIP routes timer after boot window.  
```
The stopper **service** (`openshift-azure-routes-timer-stop.service`) shows it succeeded and is now inactive:
```
  sh-5.1# systemctl status openshift-azure-routes-timer-stop.service                                                                                                                                            
  ○ openshift-azure-routes-timer-stop.service - Stop Azure VIP routes periodic timer after boot window                                                                                                          
  Loaded: loaded (/etc/systemd/system/openshift-azure-routes-timer-stop.service; static)                                                                                                                        
  Active: inactive (dead) since Tue 2026-01-20 18:51:59 UTC; 34min ago    # <----- inactive                                                                                                                                       
  TriggeredBy: ● openshift-azure-routes-timer-stop.timer                                                                                                                                                        
  Process: 17283 ExecStart=/bin/systemctl stop openshift-azure-routes.timer (code=exited, status=0/SUCCESS)                                                                                                     
  Main PID: 17283 (code=exited, status=0/SUCCESS)        # <------ SUCCESS                                                                                                                                                       
  CPU: 10ms                                                                                                                                                                                                     
                                                                                                                                                                                                                
  Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Starting Stop Azure VIP routes periodic timer after boot window...                                                                             
  Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes-timer-stop.service: Deactivated successfully.                                                                           
  Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Finished Stop Azure VIP routes periodic timer after boot window.  
```

The path unit (`openshift-azure-routes.path`), reacting to file changes in the watched directory, is still active:
```
  sh-5.1# systemctl status openshift-azure-routes.path                                                                                                                                                          
  ● openshift-azure-routes.path - Watch for downfile changes                                                                                                                                                    
  Loaded: loaded (/etc/systemd/system/openshift-azure-routes.path; enabled; preset: disabled)                                                                                                                   
  Active: active (waiting) since Tue 2026-01-20 18:37:03 UTC; 49min ago                                                                                                                                         
  Until: Tue 2026-01-20 18:37:03 UTC; 49min ago                                                                                                                                                                 
  Triggers: ● openshift-azure-routes.service    
```

In the journal, route reconciliation only happens due to changes in the watched directory, after the reconciliation timer is stopped:
```
Jan 20 18:48:16 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:48:16 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:49:03 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:49:03 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:49:35 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:49:35 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:50:06 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:50:06 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:50:55 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:50:56 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:51:28 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:51:28 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Starting Stop Azure VIP routes periodic timer after boot window...
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.timer: Deactivated successfully.
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Stopped Periodic reconciliation of Azure VIP routes.
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes-timer-stop.service: Deactivated successfully.
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Finished Stop Azure VIP routes periodic timer after boot window.
Jan 20 18:51:59 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 18:53:49 ci-ln-cstcz2t-1d09d-p76m2-master-0 kubenswrapper[2714]: E0120 18:53:49.768877    2714 controller.go:195] "Failed to update lease" err="Put \"https://api-int.ci-ln-cstcz2t-1d09d.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-ln-cstcz2t-1d09d-p76m2-master-0?timeout=10s\": context deadline exceeded"
Jan 20 18:59:30 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 18:59:30 ci-ln-cstcz2t-1d09d-p76m2-master-0 openshift-azure-routes[27591]: removing stale route: ovn-nbctl lr-policy-del ovn_cluster_router 1010 inport == rtos-ci-ln-cstcz2t-1d09d-p76m2-master-0 && ip4.dst == 10.0.0.100
Jan 20 18:59:30 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
Jan 20 19:00:38 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: Started Work around Azure load balancer hairpin.
Jan 20 19:00:38 ci-ln-cstcz2t-1d09d-p76m2-master-0 openshift-azure-routes[28364]: adding route: ovn-nbctl lr-policy-add ovn_cluster_router 1010 inport == rtos-ci-ln-cstcz2t-1d09d-p76m2-master-0 && ip4.dst == 10.0.0.100 reroute 10.130.0.2
Jan 20 19:00:38 ci-ln-cstcz2t-1d09d-p76m2-master-0 systemd[1]: openshift-azure-routes.service: Deactivated successfully.
timed out waiting for input: auto-logout
sh-5.1# date
Tue Jan 20 19:47:10 UTC 2026
sh-5.1# 
```
