### PR TITLE
OCPBUGS-66314: Add hostIP 127.0.0.1 to machine-config-daemon port 8798

### DIFF
--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         image: {{.Images.MachineConfigOperator}}
         ports:
         - containerPort: 8798
+          hostIP: 127.0.0.1
           name: health
           protocol: TCP
         command: ["/usr/bin/machine-config-daemon"]


### PR DESCRIPTION
**- What I did**
Added `hostIP: 127.0.0.1` to the `machine-config-daemon` container port 8798 in the DaemonSet manifest. This explicitly indicates that the health port is bound only to the localhost interface and is not externally exposed.