### PR TITLE
MCO-1961: OSImageStream follow up

### DIFF
--- a/pkg/controller/osimagestream/helpers.go
+++ b/pkg/controller/osimagestream/helpers.go
@@ -2,12 +2,12 @@ package osimagestream
 
 import (
 	"fmt"
-	"strings"
 
 	v1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/api/machineconfiguration/v1alpha1"
 	"github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // GetStreamSetsNames extracts the names from a slice of OSImageStreamSets.
@@ -35,7 +35,7 @@ func GetOSImageStreamSetByName(osImageStream *v1alpha1.OSImageStream, name strin
 		}
 	}
 
-	return nil, fmt.Errorf("requested OSImageStream %s does not exist. Existing: %s", name, strings.Join(GetStreamSetsNames(osImageStream.Status.AvailableStreams), ","))
+	return nil, k8serrors.NewNotFound(v1alpha1.GroupVersion.WithResource("osimagestreams").GroupResource(), name)
 }
 
 // TryGetOSImageStreamSetByName retrieves an OSImageStreamSet by name, returning nil if not found.

--- a/pkg/controller/osimagestream/image_data_test.go
+++ b/pkg/controller/osimagestream/image_data_test.go
@@ -127,82 +127,72 @@ func TestGroupOSContainerImageMetadataToStream_MultipleStreams(t *testing.T) {
 	assert.Equal(t, v1alpha1.ImageDigestFormat("quay.io/openshift/ext-10@sha256:ddd444"), rhel10.OSExtensionsImage)
 }
 
-func TestGroupOSContainerImageMetadataToStream_OSImageOnly(t *testing.T) {
-	imagesMetadata := []*ImageData{
+func TestGroupOSContainerImageMetadataToStream_PartialURLs(t *testing.T) {
+	// This test ensures that GroupOSContainerImageMetadataToStream only returns
+	// OSImageStreamSet that have both URLs
+
+	tests := []struct {
+		name      string
+		imageData []*ImageData
+	}{
 		{
-			Image:  "quay.io/openshift/os@sha256:abc123",
-			Type:   ImageTypeOS,
-			Stream: "rhel-9",
+			name: "OS only",
+			imageData: []*ImageData{
+				{
+					Image:  "quay.io/openshift/os@sha256:abc123",
+					Type:   ImageTypeOS,
+					Stream: "rhel-9",
+				},
+			},
+		},
+		{
+			name: "Extensions only",
+			imageData: []*ImageData{
+				{
+					Image:  "quay.io/openshift/ext@sha256:def456",
+					Type:   ImageTypeExtensions,
+					Stream: "rhel-9",
+				},
+			},
+		},
+		{
+			name: "OS Duplicated",
+			imageData: []*ImageData{
+				{
+					Image:  "quay.io/openshift/os-old@sha256:111",
+					Type:   ImageTypeOS,
+					Stream: "rhel-9",
+				},
+				{
+					Image:  "quay.io/openshift/os-new@sha256:222",
+					Type:   ImageTypeOS,
+					Stream: "rhel-9",
+				},
+			},
+		},
+		{
+			name: "Extensions Duplicated",
+			imageData: []*ImageData{
+				{
+					Image:  "quay.io/openshift/ext-old@sha256:333",
+					Type:   ImageTypeExtensions,
+					Stream: "rhel-9",
+				},
+				{
+					Image:  "quay.io/openshift/ext-new@sha256:444",
+					Type:   ImageTypeExtensions,
+					Stream: "rhel-9",
+				},
+			},
 		},
 	}
 
-	result := GroupOSContainerImageMetadataToStream(imagesMetadata)
-
-	require.Len(t, result, 1)
-	assert.Equal(t, "rhel-9", result[0].Name)
-	assert.Equal(t, v1alpha1.ImageDigestFormat("quay.io/openshift/os@sha256:abc123"), result[0].OSImage)
-	assert.Empty(t, result[0].OSExtensionsImage)
-}
-
-func TestGroupOSContainerImageMetadataToStream_ExtensionsImageOnly(t *testing.T) {
-	imagesMetadata := []*ImageData{
-		{
-			Image:  "quay.io/openshift/ext@sha256:def456",
-			Type:   ImageTypeExtensions,
-			Stream: "rhel-9",
-		},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GroupOSContainerImageMetadataToStream(tt.imageData)
+			require.Empty(t, result, "result should be empty")
+		})
 	}
-
-	result := GroupOSContainerImageMetadataToStream(imagesMetadata)
-
-	require.Len(t, result, 1)
-	assert.Equal(t, "rhel-9", result[0].Name)
-	assert.Empty(t, result[0].OSImage)
-	assert.Equal(t, v1alpha1.ImageDigestFormat("quay.io/openshift/ext@sha256:def456"), result[0].OSExtensionsImage)
-}
-
-func TestGroupOSContainerImageMetadataToStream_DuplicateOSImage(t *testing.T) {
-	imagesMetadata := []*ImageData{
-		{
-			Image:  "quay.io/openshift/os-old@sha256:111",
-			Type:   ImageTypeOS,
-			Stream: "rhel-9",
-		},
-		{
-			Image:  "quay.io/openshift/os-new@sha256:222",
-			Type:   ImageTypeOS,
-			Stream: "rhel-9",
-		},
-	}
-
-	result := GroupOSContainerImageMetadataToStream(imagesMetadata)
-
-	require.Len(t, result, 1)
-	assert.Equal(t, "rhel-9", result[0].Name)
-	// Last one wins
-	assert.Equal(t, v1alpha1.ImageDigestFormat("quay.io/openshift/os-new@sha256:222"), result[0].OSImage)
-}
-
-func TestGroupOSContainerImageMetadataToStream_DuplicateExtensionsImage(t *testing.T) {
-	imagesMetadata := []*ImageData{
-		{
-			Image:  "quay.io/openshift/ext-old@sha256:333",
-			Type:   ImageTypeExtensions,
-			Stream: "rhel-9",
-		},
-		{
-			Image:  "quay.io/openshift/ext-new@sha256:444",
-			Type:   ImageTypeExtensions,
-			Stream: "rhel-9",
-		},
-	}
-
-	result := GroupOSContainerImageMetadataToStream(imagesMetadata)
-
-	require.Len(t, result, 1)
-	assert.Equal(t, "rhel-9", result[0].Name)
-	// Last one wins
-	assert.Equal(t, v1alpha1.ImageDigestFormat("quay.io/openshift/ext-new@sha256:444"), result[0].OSExtensionsImage)
 }
 
 func TestGroupOSContainerImageMetadataToStream_EmptyInput(t *testing.T) {

--- a/pkg/controller/osimagestream/imagestream_source_test.go
+++ b/pkg/controller/osimagestream/imagestream_source_test.go
@@ -133,6 +133,16 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 								"io.openshift.build.source-location": "https://github.com/openshift/os",
 							},
 						},
+						{
+							Name: "custom-os-extensions",
+							From: &corev1.ObjectReference{
+								Kind: "DockerImage",
+								Name: "quay.io/openshift/custom-os-extensions:latest",
+							},
+							Annotations: map[string]string{
+								"io.openshift.build.source-location": "https://github.com/openshift/os",
+							},
+						},
 					},
 				},
 			},
@@ -142,6 +152,15 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
 							labelStreamClass: "custom-stream",
+						},
+					},
+				},
+				{
+					Image: "quay.io/openshift/custom-os-extensions:latest",
+					InspectInfo: &types.ImageInspectInfo{
+						Labels: map[string]string{
+							labelStreamClass: "custom-stream",
+							labelOSTreeLinux: labelValuePresent,
 						},
 					},
 				},
@@ -179,14 +198,23 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 			providerImageStream: createTestImageStream(),
 			inspectorResults: []imageutils.BulkInspectResult{
 				{
-					Image: testRHELCoreosImage,
+					Image: "invalid-image",
 					Error: errors.New("failed to inspect"),
+				},
+				{
+					Image: testRHELCoreosImage,
+					InspectInfo: &types.ImageInspectInfo{
+						Labels: map[string]string{
+							labelStreamClass: streamNameRHELCoreos,
+						},
+					},
 				},
 				{
 					Image: testRHELCoreosExtensionsImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
 							labelStreamClass: streamNameRHELCoreos,
+							labelOSTreeLinux: labelValuePresent,
 						},
 					},
 				},
@@ -224,10 +252,10 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 							},
 						},
 						{
-							Name: "stream-coreos-10.0",
+							Name: "stream-coreos-10-extensions",
 							From: &corev1.ObjectReference{
 								Kind: "DockerImage",
-								Name: "quay.io/openshift/stream-coreos:10.0",
+								Name: "quay.io/openshift/stream-coreos-extensions:10.0",
 							},
 						},
 					},
@@ -239,12 +267,28 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
 							labelStreamClass: streamNameRHELCoreos,
+						},
+					},
+				},
+				{
+					Image: testRHELCoreosExtensionsImage,
+					InspectInfo: &types.ImageInspectInfo{
+						Labels: map[string]string{
+							labelStreamClass: streamNameRHELCoreos,
 							labelOSTreeLinux: labelValuePresent,
 						},
 					},
 				},
 				{
 					Image: "quay.io/openshift/stream-coreos:10.0",
+					InspectInfo: &types.ImageInspectInfo{
+						Labels: map[string]string{
+							labelStreamClass: "stream-coreos",
+						},
+					},
+				},
+				{
+					Image: "quay.io/openshift/stream-coreos-extensions:10.0",
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
 							labelStreamClass: "stream-coreos",

--- a/pkg/controller/osimagestream/osimagestream.go
+++ b/pkg/controller/osimagestream/osimagestream.go
@@ -21,6 +21,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	ErrorNoOSImageStreamAvailable = errors.New("unable to retrieve any OSImageStream from the configured sources")
+)
+
 // StreamSource represents a source that can provide OS image stream sets.
 type StreamSource interface {
 	FetchStreams(ctx context.Context) ([]*v1alpha1.OSImageStreamSet, error)
@@ -114,7 +118,7 @@ func BuildOsImageStreamRuntime(
 func BuildOSImageStreamFromSources(ctx context.Context, sources []StreamSource) (*v1alpha1.OSImageStream, error) {
 	streams := collect(ctx, sources)
 	if len(streams) == 0 {
-		return nil, fmt.Errorf("could not find any OS stream")
+		return nil, ErrorNoOSImageStreamAvailable
 	}
 
 	// TODO: This logic is temporal till we make an agreement on

--- a/pkg/controller/osimagestream/osimagestream_controller.go
+++ b/pkg/controller/osimagestream/osimagestream_controller.go
@@ -101,12 +101,8 @@ func (ctrl *Controller) Run(stopCh <-chan struct{}) {
 		err := ctrl.boot()
 		if err != nil {
 			klog.Errorf("Error booting OSImageStreamController: %v", err)
-		}
-
-		if err != nil {
-			defer klog.Errorf("OSImageStreamController failed to boot: %v", err)
 		} else {
-			defer klog.Infof(
+			klog.Infof(
 				"OSImageStreamController booted successfully. Available streams: %s. Default stream: %s",
 				GetStreamSetsNames(ctrl.osImageStream.Status.AvailableStreams),
 				ctrl.osImageStream.Status.DefaultStream,


### PR DESCRIPTION
**- What I did**

Minor improvement to:

- Ensure that `pkg/controller/osimagestream/helpers_test.go`  testing data is created once per test case and not shared between test cases.
- Make the `GetOSImageStreamSetByName` function return a k8s NotFound error in case the requested OSImageStreamSet does not exist.
- Bugfix to ensure that URL based sources don't pass empty ImageDatas to  the GroupOSContainerImageMetadataToStream function in case one or both images don't have enough labels to determine the stream. The same patch is applied to the ImageStream source.
- Ensure that GroupOSContainerImageMetadataToStream never returns  partial OSImageStreamSets with only one of the URLs filled.

**- How to verify it**

Unit tests are enough to test the functionality.

**- Description for the changelog**

Improved OSImageStreamSet retrieval error handling and fixed bugs with URL-based image source metadata grouping
