### PR TITLE
add container port to the container under the server pods

### DIFF
--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -27,6 +27,13 @@ spec:
           - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
           - "--tls-min-version={{.TLSMinVersion}}"
           - "--v={{.LogLevel}}"
+        ports:
+        - containerPort: 22623
+          name: https
+          protocol: TCP
+        - containerPort: 22624
+          name: http
+          protocol: TCP
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
add container port to the container under the server pods
 machine-config-server daemonset was missing the containerport filed
 its just info for the ports that its need