### PR TITLE
OCPBUGS-66403: Remove log exposing kubeconfig

### DIFF
--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -221,7 +221,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							}
 
 							pathToData[kubeConfigPath] = newData
-							klog.Infof("Writing new Data to /etc/kubernetes/kubeconfig: %s", string(newData))
+							klog.Infof("Writing new Data to /etc/kubernetes/kubeconfig")
 						}
 					} else {
 						klog.Info("Could not read kubeconfig file, or data does not need to be changed")


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-66403

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
MCD log on master nodes was exposing the kubeconfig in the logs. Remove that log so we are not accidentally leaking sensitive information.

**- How to verify it**
Ensure the MCD logs no longer have the kubeconfig text showing up in the log.

**- Description for the changelog**
Remove log exposing kubeconfig in MCD logs
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
