### PR TITLE
OCPBUGS-63131: Fix cleanup in `TestInstallRPMAndCheckMCDMetrics` to decrease risk of test failures due to interference

### DIFF
--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -1210,6 +1210,13 @@ func TestInstallRPMAndCheckMCDMetrics(t *testing.T) {
 			return false, nil
 		}
 
+		// Wait for the node to return to a ready state
+		lns := ctrlcommon.NewLayeredNodeState(&node)
+		if !lns.IsNodeReady() {
+			t.Logf("Node %s is not ready yet.", node.Name)
+			return false, nil
+		}
+
 		// Check for the metric
 		metricName := "mcd_local_unsupported_packages"
 		if !strings.Contains(out, metricName) {


### PR DESCRIPTION
Closes: OCPBUGS-63131

**- What I did**
This updates the `TestInstallRPMAndCheckMCDMetrics` test to wait for the test node to return to a "Ready" state before considering it complete. This ensures that tests running after it that rely on nodes to be in a health state are not adversely affected.

**- How to verify it**
Previously, when `TestMCNScopeSadPath` was run after `TestInstallRPMAndCheckMCDMetrics`, the following error would occur:
```
$ go test -v -count=1 -run TestInstallRPMAndCheckMCDMetrics ./test/e2e-1of2/ && go test -v -count=1 -run TestMCNScopeSadPath ./test/e2e-2of2/
=== RUN   TestInstallRPMAndCheckMCDMetrics
...
--- PASS: TestInstallRPMAndCheckMCDMetrics (355.50s)
PASS
ok  	github.com/openshift/machine-config-operator/test/e2e-1of2	356.915s
=== RUN   TestMCNScopeSadPath
...
E1208 14:57:38.175938   15278 exec.go:468] cmd: /usr/local/bin/oc rsh -n openshift-machine-config-operator -c machine-config-daemon machine-config-daemon-d74xt chroot /rootfs oc patch machineconfignodes ci-ln-4t070jt-72292-b4n86-master-0 --type=merge -p {"spec":{"configVersion":{"desired":"rendered-worker-test"}}}
    mcn_test.go:28: 
        	Error Trace:	/Users/ijanssen/Documents/mco/testing/mco-836/machine-config-operator/test/e2e-2of2/mcn_test.go:28
        	Error:      	"Error from server: error dialing backend: dial tcp 10.0.128.4:10250: connect: connection refused\n" does not contain "updates to MCN ci-ln-4t070jt-72292-b4n86-master-0 can only be done from the MCN's owner node"
        	Test:       	TestMCNScopeSadPath
--- FAIL: TestMCNScopeSadPath (0.66s)
FAIL
FAIL	github.com/openshift/machine-config-operator/test/e2e-2of2	1.831s
FAIL
```

To verify this works, run `` directly after `` and check that both tests pass:
```
$ go test -v -count=1 -run TestInstallRPMAndCheckMCDMetrics ./test/e2e-1of2/ && go test -v -count=1 -run TestMCNScopeSadPath ./test/e2e-2of2/
=== RUN   TestInstallRPMAndCheckMCDMetrics
...
PASS: TestInstallRPMAndCheckMCDMetrics (326.75s)
PASS
ok  	github.com/openshift/machine-config-operator/test/e2e-1of2	327.795s
=== RUN   TestMCNScopeSadPath
...
--- PASS: TestMCNScopeSadPath (1.48s)
PASS
ok  	github.com/openshift/machine-config-operator/test/e2e-2of2	2.673s
```

**- Description for the changelog**
OCPBUGS-63131: Fix cleanup in `TestInstallRPMAndCheckMCDMetrics` to wait for test node to return to "Ready" state