### PR TITLE
OCPBUGS-56717: enable nodeip-configuration for platform external

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -1,7 +1,7 @@
 # NOTE: When making changes to this service, be sure they are replicated in the
 # VSphere-specific service in templates/common/[vsphere|kubevirt]/units
 name: nodeip-configuration.service
-enabled: {{if or (eq .Infra.Status.PlatformStatus.Type "None") (and (eq .Infra.Status.ControlPlaneTopology "SingleReplica") (eq (cloudProvider .) "external")) }}true{{else}}false{{end}}
+enabled: {{if or (eq .Infra.Status.PlatformStatus.Type "None") (eq .Infra.Status.PlatformStatus.Type "External") (and (eq .Infra.Status.ControlPlaneTopology "SingleReplica") (eq (cloudProvider .) "external")) }}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Add a condition to the `nodeip-configuration.service` template that should enable `nodeip-configuration.service` when `PlatformStatus.Type` is set to `External`

**- How to verify it**
[According to Ross](https://issues.redhat.com/browse/OCPBUGS-56717?focusedId=27382565&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27382565) the test [upi-conf-vsphere-platform-external](https://github.com/openshift/release/blob/master/ci-operator/step-registry/upi/conf/vsphere/platform-external/upi-conf-vsphere-platform-external-ref.yaml) exists. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enable nodeip-configuration.service when `PlatformStatus.Type` is `External`.

