### PR TITLE
OCPBUGS-62828: MCO degraded when an empty pull-secret is configured

### DIFF
--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -180,6 +180,16 @@ type: kubernetes.io/dockercfg`
 			expected: &DockerConfigJSON{Auths: DockerConfig{}},
 		},
 		{
+			name:     "Empty JSON object without auths key",
+			bytes:    []byte(`{}`),
+			expected: &DockerConfigJSON{Auths: nil},
+		},
+		{
+			name:        "JSON null literal",
+			bytes:       []byte(`null`),
+			errExpected: true,
+		},
+		{
 			name:        "Invalid K8s object bytes",
 			bytes:       []byte(`{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"configmap"},"data":{"key":"value"}}`),
 			errExpected: true,


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #[62828](https://issues.redhat.com/browse/OCPBUGS-62828)"

Please provide the following information:
-->

**- What I did**
  Fixed a bug where MCO becomes degraded when an empty pull-secret is configured in the cluster. Modified
  `getImageRegistryPullSecrets()` in `pkg/operator/sync.go` to gracefully handle empty pull-secrets by
  checking if the pull-secret data is empty or contains only `{}` before attempting to convert and merge
  it. When an empty pull-secret is detected, the operator now skips the merge operation instead of
  erroring out. Also added test coverage in `pkg/secrets/secrets_test.go` for empty JSON object and null
  literal edge cases.
**- How to verify it**
    1. Configure an empty pull-secret in the cluster 

$ oc -n openshift-config set data secret/pull-secret '.dockerconfigjson={}'

and verify MCO is not degraded. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:   Handle empty pull-secrets gracefully to prevent MCO degradation when global pull-secret is configured as empty
-->
