### PR TITLE
MCO-1961: Rework MC's OSImageURL merge logic

### DIFF
--- a/devex/cmd/onclustertesting/helpers.go
+++ b/devex/cmd/onclustertesting/helpers.go
@@ -181,7 +181,7 @@ func deleteAllMachineConfigsForPool(cs *framework.ClientSet, mcp *mcfgv1.Machine
 	for _, mc := range machineConfigs.Items {
 		mc := mc
 		eg.Go(func() error {
-			if _, ok := mc.Annotations[helpers.MCPNameToRole(mcp.Name)]; ok && !strings.HasPrefix(mc.Name, "rendered-") {
+			if _, ok := mc.Annotations[helpers.MCPNameToRole(mcp.Name)]; ok && !strings.HasPrefix(mc.Name, ctrlcommon.RenderedMachineConfigPrefix) {
 				if err := cs.MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil {
 					return err
 				}

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -30,6 +30,9 @@ const (
 	// OSImageURLOverriddenKey is used to tag a rendered machineconfig when OSImageURL has been overridden from default using machineconfig
 	OSImageURLOverriddenKey = "machineconfiguration.openshift.io/os-image-url-overridden"
 
+	// RenderedMachineConfigPrefix is the name prefix for rendered MachineConfigs
+	RenderedMachineConfigPrefix = "rendered-"
+
 	// ControllerConfigName is the name of the ControllerConfig object that controllers use
 	ControllerConfigName = "machine-config-controller"
 

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -189,6 +189,10 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.Contro
 	// so the only way we get an override here is if the user adds something different
 	osImageURL := GetDefaultBaseImageContainer(&cconfig.Spec)
 	for _, cfg := range configs {
+		// Ignore generated MCs, only the rendered MC or a user provided MC can set this field
+		if cfg.Annotations[GeneratedByControllerVersionAnnotationKey] != "" {
+			continue
+		}
 		if cfg.Spec.OSImageURL != "" {
 			osImageURL = cfg.Spec.OSImageURL
 		}
@@ -197,6 +201,10 @@ func MergeMachineConfigs(configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.Contro
 	// Allow overriding the extensions container
 	baseOSExtensionsContainerImage := cconfig.Spec.BaseOSExtensionsContainerImage
 	for _, cfg := range configs {
+		// Ignore generated MCs, only the rendered MC or a user provided MC can set this field
+		if cfg.Annotations[GeneratedByControllerVersionAnnotationKey] != "" {
+			continue
+		}
 		if cfg.Spec.BaseOSExtensionsContainerImage != "" {
 			baseOSExtensionsContainerImage = cfg.Spec.BaseOSExtensionsContainerImage
 		}

--- a/pkg/controller/render/hash.go
+++ b/pkg/controller/render/hash.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 )
 
 var (
@@ -37,7 +38,7 @@ func getMachineConfigHashedName(pool *mcfgv1.MachineConfigPool, config *mcfgv1.M
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("rendered-%s-%x", pool.GetName(), h), nil
+	return fmt.Sprintf("%s%s-%x", ctrlcommon.RenderedMachineConfigPrefix, pool.GetName(), h), nil
 }
 
 func hashData(data []byte) ([]byte, error) {

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -361,13 +361,12 @@ func generateMachineConfigForName(config *RenderConfig, role, name, templateDir,
 
 	mcfg.Spec.Extensions = append(mcfg.Spec.Extensions, slices.Sorted(maps.Keys(extensions))...)
 
-	// TODO(jkyros): you might think you can remove this since we override later when we merge
-	// config, but resourcemerge doesn't blank this field out once it's populated
-	// so if you end up on a cluster where it was ever populated in this machineconfig, it
-	// will keep that last value forever once you upgrade...which is a problen now that we allow OSImageURL overrides
-	// because it will look like an override when it shouldn't be. So don't take this out until you've solved that.
-	// And inject the osimageurl here
-	mcfg.Spec.OSImageURL = ctrlcommon.GetDefaultBaseImageContainer(config.ControllerConfigSpec)
+	// Note: Previously, the OSImageURL was set here (as well as in the rendered MC) to facilitate
+	// overrides. Now, all the OSImageURL's from generated MCs are ignored and only user provided
+	// MCs with the OSImageURL set are considered during the merge process.
+	// Now the image URL is explicitly cleared to avoid confusion. Its content is never consumed.
+	mcfg.Spec.OSImageURL = ""
+	mcfg.Spec.BaseOSExtensionsContainerImage = ""
 
 	return mcfg, nil
 }


### PR DESCRIPTION
**- What I did**

Template-generated MachineConfigs (e.g., 01-master-kubelet, 01-master-container-runtime) were setting OSImageURL on the final rendered MachineConfig, even though only user-provided MachineConfigs should be able to override this field.

The root cause was that template generation explicitly sets OSImageURL on all generated MCs, and the merge logic (MergeMachineConfigs) was treating all MCs equally when determining the final OSImageURL value. This meant template-generated MCs would always propagate the base OS image URL to the rendered MC, making it impossible for the system to distinguish between a default value and an intentional override.

This commit fixes the issue by modifying MergeMachineConfigs to skip any MachineConfig with the
machineconfiguration.openshift.io/generated-by-controller-version annotation when evaluating OSImageURL and BaseOSExtensionsContainerImage overrides. This ensures that only user-provided MachineConfigs can override these fields, while still allowing template-generated MCs to have the field populated (which is necessary due to resourcemerge not blanking out previously-set values during upgrades).

The same logic is applied to BaseOSExtensionsContainerImage for consistency.

**- How to verify it**

Ideally, we would like to test that running clusters:

1. A freshly deployed cluster with this change should not have MCs with the osImageURL field set. A test-provided MC to override the URL should do what's expected that is to trigger a rendered-MC rollout with the image for the nodes.
2. A running cluster deployed without this change properly updates to an image with this change. The MCs of both worker and master pool should not have the osImageURL field set (only the render MCs should have it). A test-provided MC to override the URL should do what's expected that is to trigger a rendered-MC rollout with the image for the nodes.
3. A running cluster deployed without this image, with a test-provided MC to override the osImageURL already rolledout should preserve the image after upgrading the cluster to a cluster with this image.

**- Description for the changelog**

Prevent template MachineConfigs from overriding OSImageURL
