### PR TITLE
OCPBUGS-62984: MCP is not correctly degraded when a pivotError happens

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -926,7 +926,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}
 
 	if dn.nodeWriter != nil {
-		state, err := getNodeAnnotationExt(dn.node, constants.MachineConfigDaemonStateAnnotationKey, true)
+		// Refetch node from lister to get fresh state before checking guard.
+		// This prevents overwriting Degraded/Unreconcilable states that were just set.
+		freshNode, err := dn.nodeLister.Get(dn.name)
+		if err != nil {
+			return fmt.Errorf("error fetching fresh node state: %w", err)
+		}
+		state, err := getNodeAnnotationExt(freshNode, constants.MachineConfigDaemonStateAnnotationKey, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
  Fixed a bug where nodes would flip between Degraded and Working states when a pivot (OS upgrade) operation failed. The issue was in `pkg/daemon/update.go:928-944` where the guard condition checked stale cached node state (`dn.node`) instead of fetching fresh state from the lister. This caused the MCD to overwrite a just-set Degraded state back to Working, resulting in continuous flapping between states for ~15 minutes.
  
**- How to verify it**
  1. Create a test MachineConfigPool: `oc create -f <pool-yaml>`
  2. Label a worker node into the pool: `oc label node <node-name> node-role.kubernetes.io/pivot-test=""`
  3. Break rpm-ostree on the node to make pivot operations fail:
```
$ oc debug/node ....
chroot /host
.....
# Create a wrapper of rpm-ostree in /tmp/rpm-ostree.broken
$ vi  /tmp/rpm-ostree.broken

The content of the new rpm-ostree.broken file should be:
#!/bin/bash
if [ "$1" == "rebase" ];
then
exit -1
else
/tmp/rpm-ostree $@
fi
exit $?

$ chmod +x /tmp/rpm-ostree.broken
$ cp /usr/bin/rpm-ostree /tmp/rpm-ostree
$ nsenter --mount=/proc/1/ns/mnt mount --bind /tmp/rpm-ostree.broken /usr/bin/rpm-ostree
Make sure that the new file has the right selinux type
$ restorecon -v /usr/bin/rpm-ostree
Relabeled /usr/bin/rpm-ostree from system_u:object_r:tmp_t:s0 to system_u:object_r:install_exec_t:s0
```

  4. Create a MachineConfig with a fake osImageURL to trigger the pivot:
```
  oc apply -f - <<EOF
  apiVersion: machineconfiguration.openshift.io/v1
  kind: MachineConfig
  metadata:
    name: pivot-error-test
    labels:
      machineconfiguration.openshift.io/role: pivot-test
  spec:
    osImageURL: quay.io/test/fake-image:will-fail
    config:
      ignition:
        version: 3.5.0
  EOF
```
  5. Monitor node state continuously: 
`oc get node <node-name> -o jsonpath='{.metadata.annotations.machineconfiguration\.openshift\.io/state}{"\n"}'
`  

or with this script

`while true; do STATE=$(oc get node <node-name> -o jsonpath='{.metadata.annotations.machineconfiguration\.openshift\.io/state}'); echo "$(date +%H:%M:%S) - State: $STATE"; sleep 5; done`

  7. With the fix: Node transitions to Degraded and stays Degraded
  8. Without the fix: Node flips between Degraded and Working states repeatedly
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog: Fix node state flapping between Degraded and Working when pivot operations fail by refetching fresh node state before guard condition check
-->
