### PR TITLE
OCPBUGS-63750: fix Go build tag behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export GOPROXY=https://proxy.golang.org
 # this is necessary for running golangci-lint in a container
 export GOLANGCI_LINT_CACHE=$(shell echo $${GOLANGCI_LINT_CACHE:-$$GOPATH/cache})
 
-GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub $(TAGS)"
+GOTAGS = "$(TAGS)"
 
 all: binaries
 
@@ -43,11 +43,11 @@ clean:
 # Example:
 #    make _build-component-machine-config-operator
 _build-component-%:
-	WHAT_PATH=cmd/$* WHAT=$(basename $*) hack/build-go.sh
+	WHAT_PATH=cmd/$* WHAT=$(basename $*) GOTAGS=$(GOTAGS) hack/build-go.sh
 
 # Build the helpers under devex/cmd.
 _build-helper-%:
-	WHAT_PATH=devex/cmd/$* WHAT=$(basename $*) hack/build-go.sh
+	WHAT_PATH=devex/cmd/$* WHAT=$(basename $*) GOTAGS=$(GOTAGS) hack/build-go.sh
 
 # Verify that an e2e test is valid Golang by doing a trial compilation.
 _verify-e2e-%:

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -5,7 +5,7 @@ set -eu
 REPO=github.com/openshift/machine-config-operator
 WHAT=${WHAT:-machine-config-operator}
 WHAT_PATH="${WHAT_PATH:-cmd/${WHAT}}"
-GOTAGS="${GOTAGS:-} ${TAGS:-}"
+GOTAGS="${GOTAGS:-}"
 GLDFLAGS=${GLDFLAGS:-}
 
 eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")

--- a/hack/build-image
+++ b/hack/build-image
@@ -51,7 +51,13 @@ authfile = os.environ.get('AUTHFILE')
 if authfile:
     args.extend(['--authfile', authfile])
 for k in openshift_keys:
-    args.append(f'--label={k}=')
-args.extend([f'--label=vcs-ref={gitrev}', '--label=vcs-type=git', '--label=vcs-url='])
+    args.append(f"--label={k}=")
+args.extend([f"--label=vcs-ref={gitrev}", "--label=vcs-type=git", "--label=vcs-url="])
+
+# Check if TAGS env var is set. Setting this allows Go build tags to be passed
+# into the image build process as a build argument.
+tags = os.environ.get("TAGS")
+if tags:
+    args.extend(["--build-arg", f"TAGS={tags}"])
 print(subprocess.list2cmdline(args))
 os.execlp(podman, *args)

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -13,11 +13,6 @@ GOTAGS="${1:-""}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-""}"
 TIMEOUT="${2:-"10m"}" # Default timeout to 10 minutes if not provided
 
-if [ ! -n "$GOTAGS" ]; then
-  echo "No Go tags provided"
-  exit 1
-fi
-
 cd "$REPO_ROOT"
 
 retval=0

--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -17,7 +17,7 @@ COVERAGE_REPORT="mco-unit-test-coverage.out"
 
 function run_tests() {
   test_opts=("$@")
-  CGO_ENABLED=0 go test "${test_opts[@]}" -tags="$GOTAGS" './devex/...' './cmd/...' './pkg/...' './lib/...' './test/helpers/...' | ./hack/test-with-junit.sh "$MAKEFILE_TARGET"
+  go test "${test_opts[@]}" -tags="${GOTAGS}" './devex/...' './cmd/...' './pkg/...' './lib/...' './test/helpers/...' | ./hack/test-with-junit.sh "$MAKEFILE_TARGET"
 }
 
 function run_tests_with_coverage() {
@@ -38,11 +38,6 @@ function run_tests_with_coverage() {
 
 if [ ! -n "$MAKEFILE_TARGET" ]; then
   echo "No Makefile target provided"
-  exit 1
-fi
-
-if [ ! -n "$GOTAGS" ]; then
-  echo "No GOTAGS provided"
   exit 1
 fi
 


### PR DESCRIPTION
**- What I did**

The MCO was being built with the Go build tag `containers_image_openpgp` which specifically uses the OpenPGP implementation. According to the [containers/image](https://github.com/containers/image/blob/29bbd0ee0e58ec1b379a38c5e1bdc3d251ebe34d/signature/mechanism_openpgp.go#L18-L24) repo, the gpgme implementation for working with image signatures is the preferred implementation.

While investigating this, I thought to search throughout our vendored dependencies for each of the Go build tags (`containers_image_openpgp` `exclude_graphdriver_devicemapper` `exclude_graphdriver_btrfs` `containers_image_ostree_stub`) that the MCO uses to determine whether they were still needed. As it turns out, the only build tag we were using was the OpenPGP one referenced above. This means that we can mostly remove all of the currently-used build tags and consolidate where and how they are being set.

To do that, this PR does the following:
1. Removes all hard-coded Go build tags from the `Makefile`.
2. Ensures that `hack/build-go.sh` uses the tags provided to it from the `Makefile`.
3. Ensures that if `TAGS=scos` is set for building the MCO for OKD, that the tag is passed through from the Makefile into the `hack/build-go.sh` script and honored.
4. Ensures that if `TAGS=scos` is set, that the `make image` target passes the tags into the image build process and that the tags are consumed.

**- How to verify it**

There should be no changes in the MCOs behavior or function that I am aware of. Our test suite should be able to confirm this.

To verify that the MCO is being built with the correct implementation, one can do the following:
1. Clone this PR to your local system.
2. Run `make image` to build the MCO image.
3. Exfiltrate the binaries from the image to your host by doing something like `podman run -it --rm -v "$PWD:/host:z" localhost/machine-config-operator:latest cp /usr/bin/machine-config* /host`.
5. Use the Go toolchain and ensure that the following output is found for the two binaries which require it (these are the machine-config-controller and the machine-config-daemon; the other MCO binaries do not use this dependency and thus, will not be built with it):

```console
$ go version -m machine-config-controller | grep -E '(pgp|gpg)'
        dep     github.com/proglottis/gpgme     v0.1.4

$ go version -m machine-config-daemon | grep -E '(pgp|gpg)'
        dep     github.com/proglottis/gpgme     v0.1.4
```

**Note:** Ensure that you have the `gpgme-devel` library installed in your development environment. You can do this by running `make binaries`. If the build mysteriously fails, then ensure the package is installed. See: https://github.com/containers/container-libs/tree/main/image#building for more info. The OCP Go builder image already includes this library.

**- Description for the changelog**
Ensure the MCO uses gpgme
