### PR TITLE
OCPBUGS-67229: Set `NodeDegraded` MCN condition when node state annotation is set to `Degraded`

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -649,15 +649,32 @@ type unreconcilableErr struct {
 	error
 }
 
+// updateErrorState calls `SetUnreconcilable` to set the node's state annotation value to
+// "Unreconcilable" and the associated reason annotation if the provided error is an unreconcilable
+// error. Otherwise it calls `updateDegradedState` to set the node's state annotation value to
+// "Degraded," populate the associated reason annotation, and set the degrade condition in the MCN.
 func (dn *Daemon) updateErrorState(err error) error {
 	var uErr *unreconcilableErr
 	if errors.As(err, &uErr) {
-		dn.nodeWriter.SetUnreconcilable(err)
-	} else {
-		if err := dn.nodeWriter.SetDegraded(err); err != nil {
-			return err
-		}
+		return dn.nodeWriter.SetUnreconcilable(err)
 	}
+	return dn.updateDegradedState(err)
+}
+
+// `updateDegradedState` calls `SetDegraded` to set the node's state annotation value to "Degraded"
+// and populate the associated reason annotation. It then sets the degrade condition in the MCN.
+func (dn *Daemon) updateDegradedState(err error) error {
+	// Set node state annotation to "Degraded"
+	if setErr := dn.nodeWriter.SetDegraded(err); setErr != nil {
+		return setErr
+	}
+	// Get MCP associated with node
+	pool, poolErr := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if poolErr != nil {
+		return poolErr
+	}
+	// Set the node's MCN condition to "Degraded"
+	dn.reportMachineNodeDegradeStatus(err, pool)
 	return nil
 }
 
@@ -2419,7 +2436,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 		// NOTE: This case expects a cluster to exists already.
 		ufc, err := dn.prepUpdateFromCluster()
 		if err != nil {
-			if err := dn.nodeWriter.SetDegraded(err); err != nil {
+			if err := dn.updateDegradedState(err); err != nil {
 				return err
 			}
 			return err
@@ -2429,7 +2446,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 		}
 		// At this point we have verified we need to update
 		if err = dn.triggerUpdateWithMachineConfig(ufc.currentConfig, &machineConfig, false); err != nil {
-			dn.nodeWriter.SetDegraded(err)
+			dn.updateDegradedState(err)
 			return err
 		}
 		return nil


### PR DESCRIPTION
Closes: OCPBUGS-67229

**- What I did**
This updates the set degraded flow to include populating the degrade condition in the MCN of a node. This prevents discrepancies in the degrades being reported in node annotations and the conditions in the MCN resource and further discrepancies in the MCP reporting in TechPreview where degraded machine counts are determined by MCN conditions.

**- How to verify it**
1. Launch a TechPreview cluster with this PR enabled.
```
launch 4.22 gcp,techpreview
```
2. Force a config drift to degrade a node. I did this through the following flow outlined in the original bug:
   a. Create a MC to deploy a dropin file
```
$ oc apply -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  creationTimestamp: "2025-12-11T15:09:37Z"
  generation: 1
  labels:
    machineconfiguration.openshift.io/role: worker
  name: drifted-dropins-test
  resourceVersion: "190655"
  uid: 63ecfe84-8149-40cb-82e3-9a35a3b37954
spec:
  config:
    ignition:
      version: 3.5.0
    passwd:
      users: []
    storage:
      files: []
    systemd:
      units:
      - dropins:
        - contents: |-
            [Service]
            Environment="FAKE_OPTS=fake-value"
          name: 10-chrony-drop-test.conf
        enabled: true
        name: chronyd.service
  extensions: []
  kernelArguments: []
  osImageURL: ""
EOF
```
   b. When the update has completed, manually modify the deployed dropin file to force a configuration drift.
```
$ oc debug node/ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz
  # chroot /host
  # nano /etc/systemd/system/chronyd.servt /etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf
  # cat /etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf
[Service]
Environment="FAKE_OPTS=fake-value-new"
```
3. Check that the MCP correctly reports as degraded.
```
$ oc get mcp worker
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
worker   rendered-worker-dd3f981617fd37b167db506d3a2cfd84   False     True       True       3              2                   2                     1                      112m
$ oc describe mcp worker
Name:         worker
...
Status:
...
  Conditions:
    Last Transition Time:  2025-12-19T14:32:56Z
    Message:               
    Reason:                
    Status:                False
    Type:                  Updated
    Last Transition Time:  2025-12-19T14:32:56Z
    Message:               All nodes are updating to MachineConfig rendered-worker-dd3f981617fd37b167db506d3a2cfd84
    Reason:                
    Status:                True
    Type:                  Updating
    Last Transition Time:  2025-12-19T14:32:56Z
    Message:               Node ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz is reporting: "Node ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz upgrade failure. unexpected on-disk state validating against rendered-worker-dd3f981617fd37b167db506d3a2cfd84: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\"", Node ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz is reporting: "unexpected on-disk state validating against rendered-worker-dd3f981617fd37b167db506d3a2cfd84: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\""
    Reason:                1 nodes are reporting degraded status on sync
    Status:                True
    Type:                  NodeDegraded
    Last Transition Time:  2025-12-19T14:32:56Z
    Message:               Node ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz is reporting: "Node ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz upgrade failure. unexpected on-disk state validating against rendered-worker-dd3f981617fd37b167db506d3a2cfd84: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\"", Node ci-ln-tgf5wlt-72292-5l6mx-worker-a-jgwqz is reporting: "unexpected on-disk state validating against rendered-worker-dd3f981617fd37b167db506d3a2cfd84: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\""
    Reason:                
    Status:                True
    Type:                  Degraded
...
  Degraded Machine Count:  1
  Machine Count:           3
...
  Ready Machine Count:          2
  Unavailable Machine Count:    1
  Updated Machine Count:        2
...
```

**- Description for the changelog**
OCPBUGS-67229: Update the flow to set a node's state annotation to `Degraded` to also set the `NodeDegraded` condition in the MCN