### PR TITLE
OCPBUGS-69910: Bump OpenShift builder images to 4.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.21
+  tag: rhel-9-release-golang-1.24-openshift-4.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use RHEL 9 as the primary builder base for the Machine Config Operator
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS rhel9-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS rhel9-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
@@ -10,7 +10,7 @@ ENV GOMODCACHE="/go/rhel9/pkg/mod"
 RUN make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
 
 # Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS rhel8-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.22 AS rhel8-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 # Copy the RHEL 8 machine-config-daemon binary and rename
@@ -19,7 +19,7 @@ ENV GOCACHE="/go/rhel8/.cache"
 ENV GOMODCACHE="/go/rhel8/pkg/mod"
 RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
 
-FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 ARG TAGS=""
 COPY install /manifests
 RUN if [ "${TAGS}" = "fcos" ]; then \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,6 +1,6 @@
 # THIS FILE IS GENERATED FROM Dockerfile DO NOT EDIT
 # Use RHEL 9 as the primary builder base for the Machine Config Operator
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS rhel9-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS rhel9-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
@@ -11,7 +11,7 @@ ENV GOMODCACHE="/go/rhel9/pkg/mod"
 RUN make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
 
 # Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS rhel8-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.22 AS rhel8-builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 # Copy the RHEL 8 machine-config-daemon binary and rename
@@ -20,7 +20,7 @@ ENV GOCACHE="/go/rhel8/.cache"
 ENV GOMODCACHE="/go/rhel8/pkg/mod"
 RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
 
-FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 ARG TAGS=""
 COPY install /manifests
 RUN if [ "${TAGS}" = "fcos" ]; then \


### PR DESCRIPTION
**- What I did**

Update Dockerfile and generated Dockerfile.rhel7 to use OpenShift 4.22 builder images and base image instead of 4.21.

**- How to verify it**

Automated pre-submit e2e is enough.

**- Description for the changelog**

Update Dockerfile and generated Dockerfile.rhel7 to use OpenShift 4.22 builder images and base image instead of 4.21.