### PR TITLE
AGENT-1411: Preload the registry image when starting the iri-service

### DIFF
--- a/pkg/controller/internalreleaseimage/internalreleaseimage_helpers_test.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_helpers_test.go
@@ -34,10 +34,11 @@ func verifyInternalReleaseMasterMachineConfig(t *testing.T, mc *mcfgv1.MachineCo
 	assert.Len(t, ignCfg.Systemd.Units, 1)
 	assert.Contains(t, *ignCfg.Systemd.Units[0].Contents, "docker-registry-image-pullspec")
 
-	assert.Len(t, ignCfg.Storage.Files, 3)
+	assert.Len(t, ignCfg.Storage.Files, 4, "Found an unexpected file")
 	verifyIgnitionFile(t, &ignCfg, "/etc/pki/ca-trust/source/anchors/root-ca.crt", "root-ca-data")
 	verifyIgnitionFile(t, &ignCfg, "/etc/iri-registry/certs/tls.key", "iri-tls-key")
 	verifyIgnitionFile(t, &ignCfg, "/etc/iri-registry/certs/tls.crt", "iri-tls-crt")
+	verifyIgnitionFileContains(t, &ignCfg, "/usr/local/bin/load-registry-image.sh", "docker-registry-image-pullspec")
 }
 
 func verifyInternalReleaseWorkerMachineConfig(t *testing.T, mc *mcfgv1.MachineConfig) {
@@ -57,6 +58,12 @@ func verifyIgnitionFile(t *testing.T, ignCfg *ign3types.Config, path string, exp
 	data, err := ctrlcommon.GetIgnitionFileDataByPath(ignCfg, path)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedContent, string(data), path)
+}
+
+func verifyIgnitionFileContains(t *testing.T, ignCfg *ign3types.Config, path string, expectedContent string) {
+	data, err := ctrlcommon.GetIgnitionFileDataByPath(ignCfg, path)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), expectedContent, path)
 }
 
 // objs is an helper func to improve the test readability.

--- a/pkg/controller/internalreleaseimage/templates/master/files/usr-local-bin-load-registry-image-sh.yaml
+++ b/pkg/controller/internalreleaseimage/templates/master/files/usr-local-bin-load-registry-image-sh.yaml
@@ -1,0 +1,46 @@
+mode: 0644
+path: "/usr/local/bin/load-registry-image.sh"
+contents:
+  inline: |-
+    #!/bin/bash
+    set -euo pipefail
+
+    # The image used for the InternalReleaseImage registry, specified by digest.
+    registryImage="{{ .DockerRegistryImage }}"
+
+    imageBase="${registryImage%@*}"   
+    imageDigest="${registryImage#*@}"
+
+    # If the registry is already available in the local container storage then
+    # there's no need to preload it.
+    echo "Checking if ${registryImage} is locally available..."
+    imageId=$(podman images --digests --filter "digest=${imageDigest}" --format '{{"{{"}}.ID{{"}}"}}')
+
+    if [[ -n "$imageId" ]]; then
+        echo "Registry image ${registryImage} found"
+        exit 0
+    fi
+
+    localRegistryImageDir="${REGISTRY_DIR}/images/registry"
+    
+    if [[ -d "${localRegistryImageDir}" ]]; then
+        # Load registry image into the local container storage
+        echo "Loading registry image from local cache (digest: ${imageDigest})"
+        imageId=$(podman pull -q "dir:${localRegistryImageDir}")
+        
+        # Tag the pulled image with :latest using the image ID. Even though not directly used, the tag is
+        # required to allow podman running the container by using the image digest.
+        echo "Tagging registry image $imageId as ${imageBase}:latest"
+        podman tag "$imageId" "${imageBase}:latest"
+        exit 0
+    fi
+        
+    # As a fallback, let's try to fetch the registry image remotely
+    echo "Trying to pull ${registryImage} from remote registry..."
+    if podman pull '${registryImage}'; then
+        echo "Successfully pulled ${registryImage} from remote registry"
+        exit 0
+    fi
+
+    echo "Unable to retrieve ${registryImage}, cannot start the InternalReleaseImage registry"
+    exit 1

--- a/pkg/controller/internalreleaseimage/templates/master/units/iri-registry.service.yaml
+++ b/pkg/controller/internalreleaseimage/templates/master/units/iri-registry.service.yaml
@@ -4,12 +4,14 @@ contents: |
   [Unit]
   Description=InternalReleaseImage Registry
   Wants=network.target
+  ConditionPathIsDirectory=/var/lib/iri-registry
 
   [Service]
+  Environment=REGISTRY_DIR=/var/lib/iri-registry
   Environment=PODMAN_SYSTEMD_UNIT=%n
-  ExecStartPre=mkdir -p /var/lib/iri-registry
+  ExecStartPre=/usr/local/bin/load-registry-image.sh
   ExecStartPre=/bin/rm -f %t/%n.ctr-id
-  ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --log-driver=journald --replace --name=iri-registry -v /var/lib/iri-registry:/var/lib/registry:ro -v /etc/iri-registry/certs:/certs:ro -e REGISTRY_HTTP_ADDR=0.0.0.0:22625 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key -u 0 --entrypoint=/usr/bin/distribution {{ .DockerRegistryImage }} serve /etc/registry/config.yaml
+  ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --log-driver=journald --replace --name=iri-registry -v ${REGISTRY_DIR}:/var/lib/registry:ro,Z -v /etc/iri-registry/certs:/certs:ro -e REGISTRY_HTTP_ADDR=0.0.0.0:22625 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key -u 0 --entrypoint=/usr/bin/distribution {{ .DockerRegistryImage }} serve /etc/registry/config.yaml
   ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
   ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 


### PR DESCRIPTION
**- What I did**

Added a script to load the registry image from the current cache before starting the InternalReleaseImage registry service on each control plane node.

Requires: https://github.com/openshift/appliance/pull/631/