### PR TITLE
MCO-2032: Avoid MCPs duplication at install time

### DIFF
--- a/manifests/manifests_pools.go
+++ b/manifests/manifests_pools.go
@@ -1,0 +1,56 @@
+package manifests
+
+import (
+	"fmt"
+	"reflect"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/machine-config-operator/lib/resourceread"
+)
+
+const (
+	ManifestFileNameMCPMaster  ManifestMachineConfigPool = "master.machineconfigpool.yaml"
+	ManifestFileNameMCPWorker  ManifestMachineConfigPool = "worker.machineconfigpool.yaml"
+	ManifestFileNameMCPArbiter ManifestMachineConfigPool = "arbiter.machineconfigpool.yaml"
+)
+
+// ManifestMachineConfigPool represents the filename of a built-in MachineConfigPool manifest
+// embedded in the operator.
+type ManifestMachineConfigPool string
+
+// GetMachineConfigPool reads and parses the given built-in MachineConfigPool manifest.
+func GetMachineConfigPool(pool ManifestMachineConfigPool) (*mcfgv1.MachineConfigPool, error) {
+	content, err := ReadFile(string(pool))
+	if err != nil {
+		return nil, fmt.Errorf("error reading pool manifest %s: %v", string(pool), err)
+	}
+	return resourceread.ReadMachineConfigPoolV1OrDie(content), nil
+}
+
+// GetMachineConfigPools reads and parses all built-in MachineConfigPool manifests
+// (master, worker, and arbiter)
+func GetMachineConfigPools() ([]*mcfgv1.MachineConfigPool, error) {
+	var pools []*mcfgv1.MachineConfigPool
+	for _, pool := range []ManifestMachineConfigPool{ManifestFileNameMCPMaster, ManifestFileNameMCPWorker, ManifestFileNameMCPArbiter} {
+		poolObj, err := GetMachineConfigPool(pool)
+		if err != nil {
+			return nil, err
+		}
+		pools = append(pools, poolObj)
+	}
+	return pools, nil
+}
+
+// ContainsMachineConfigPool reports whether pool is identical (via reflect.DeepEqual) to any
+// of the pools in generatedPools.
+func ContainsMachineConfigPool(generatedPools []*mcfgv1.MachineConfigPool, pool *mcfgv1.MachineConfigPool) bool {
+	if pool == nil || generatedPools == nil {
+		return false
+	}
+	for _, generated := range generatedPools {
+		if reflect.DeepEqual(generated, pool) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**- What I did**

Allow the installer to provide MachineConfigPool manifests at bootstrap time. When present, the operator uses them as-is instead of generating its own. 
For any managed pool not provided by the installer, the operator generates one with the OSImageStream from the install-config.

On the sync path, if a managed MCP is missing (e.g. deleted by the user), the operator recreates it using the original install-config.

**- How to verify it**

For all tests, be sure to have a recent openshift-installer, one that contains [this](https://github.com/openshift/installer/pull/10192) change.

#### Case 1
Automated CI tests for regular installer deployments and hypershift should pass to make sure the default MCPs are still propery generated and consumed.

#### Case 2
Apply a user given MCP for the worker pool that doesn't use the filename of the MCO builtins

```bash
export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=<build-with-this-change>
mkdir installer-dir
# Call the installer to generate the install-config. Follow the instructions
./openshift-install --dir installer-dir create manifests

# Enable TechPreview
yq -i '.spec.featureSet = "TechPreviewNoUpgrade"' installer-dir/openshift/99_feature-gate.yaml

# Add a single MCP that doesn't match the filename we use to see if the MCO properly applies only the user given MCP
curl -s https://raw.githubusercontent.com/openshift/machine-config-operator/refs/heads/main/manifests/worker.machineconfigpool.yaml | yq '.spec.osImageStream.name = "rhel-10"' > installer-dir/openshift/worker-mcp.yaml

# Run the cluster installation
./openshift-install --dir installer-dir create cluster
```
#### Case 3
Apply a user given MCP for the worker pool that uses the same filename the MCO uses
```bash
export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=<build-with-this-change>
mkdir installer-dir
# Call the installer to generate the install-config. Follow the instructions
./openshift-install --dir installer-dir create manifests

# Add a pool CR to just use rhel-10 in workers
curl -s https://raw.githubusercontent.com/openshift/machine-config-operator/refs/heads/main/manifests/worker.machineconfigpool.yaml | yq '.spec.osImageStream.name = "rhel-10"' > installer-dir/openshift/worker.machineconfigpool.yaml 

# Enable TechPreview
yq -i '.spec.featureSet = "TechPreviewNoUpgrade"' installer-dir/openshift/99_feature-gate.yaml

# Run the cluster installation
./openshift-install --dir installer-dir create cluster
```

**- Description for the changelog**

Allow user/installer-provided MachineConfigPool manifests by removing duplicated manifests and ensure the user can reset builtin MCP specs.
