### PR TITLE
MCO-2025: Report OSImageStream in MCP Status

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -266,6 +266,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
+			ctx.InformerFactory.Machineconfiguration().V1alpha1().OSImageStreams(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),
 			ctx.FeatureGatesHandler,

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -107,12 +107,14 @@ func (f *fixture) newControllerWithStopChan(stopCh <-chan struct{}) *Controller 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())
 	ci := configv1informer.NewSharedInformerFactory(f.schedulerClient, noResyncPeriodFunc())
 	c := NewWithCustomUpdateDelay(i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().MachineConfigs(), i.Machineconfiguration().V1().MachineConfigPools(), k8sI.Core().V1().Nodes(),
-		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1().MachineOSConfigs(), i.Machineconfiguration().V1().MachineOSBuilds(), i.Machineconfiguration().V1().MachineConfigNodes(), ci.Config().V1().Schedulers(), f.kubeclient, f.client, time.Millisecond, f.fgHandler)
+		k8sI.Core().V1().Pods(), i.Machineconfiguration().V1().MachineOSConfigs(), i.Machineconfiguration().V1().MachineOSBuilds(), i.Machineconfiguration().V1().MachineConfigNodes(), ci.Config().V1().Schedulers(),
+		i.Machineconfiguration().V1alpha1().OSImageStreams(), f.kubeclient, f.client, time.Millisecond, f.fgHandler)
 
 	c.ccListerSynced = alwaysReady
 	c.mcpListerSynced = alwaysReady
 	c.nodeListerSynced = alwaysReady
 	c.schedulerListerSynced = alwaysReady
+	c.osImageStreamListerSynced = alwaysReady
 	c.eventRecorder = &record.FakeRecorder{}
 
 	i.Start(stopCh)
@@ -266,7 +268,9 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "machineosconfigs") ||
 				action.Matches("watch", "machineosconfigs") ||
 				action.Matches("list", "machineconfignodes") ||
-				action.Matches("watch", "machineconfignodes")) {
+				action.Matches("watch", "machineconfignodes") ||
+				action.Matches("list", "osimagestreams") ||
+				action.Matches("watch", "osimagestreams")) {
 			continue
 		}
 		ret = append(ret, action)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -527,6 +527,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
+			ctx.InformerFactory.Machineconfiguration().V1alpha1().OSImageStreams(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),
 			ctx.FeatureGatesHandler,


### PR DESCRIPTION
**- What I did**

This adds the functionality to populate the current `OSImageStream` in the `Status` of an MCP. Here are some notes on the reasoning behind the flow to determine the pool's `OSImageStream`:
- When we are going through an update, the `OSImageStream` value in the status can remain as it was previously populated since the value should only change once the pool reaches an updated state.
- When a pool is in an updated state, we need to check the updated nodes to see what image they are pointing to to make sure we populate the status correctly. This is because there is a lag between when the `OSImageStream` is set in the MCP's spec and when the MCP is considered updating (the lag is due to the MC rendering process taking time and that new desired rendered version being set in the MCP to cause a config version mismatch).
- When a pool has no nodes (for example, when a new custom pool is created), any nodes added to the MCP will point to the default OS image version, unless a different stream is specified in the MCP's spec.

**- How to verify it**
In general, the `OSImageStream` in the `Status` of an MCP should reflect the current OS image stream the nodes in the pool are pointing to. Some cases I tested are:
- When first bringing up standard tech preview cluster with this PR enabled, the `pool.Status.OSImageStream` value should be `rhel-9` and `pool.Spec.OSImageStream` should not be set. (This represents the default case.)
- When setting `pool.Spec.OSImageStream` in a pool to `rhel-10`, the `pool.Status.OSImageStream` value should remain as `rhel-9` until the pool is updated, when the `pool.Status.OSImageStream` value should flip to `rhel-10`.
- When `pool.Spec.OSImageStream` is already set to `rhel-10` and it is then removed, the `pool.Status.OSImageStream` value should remain as `rhel-10` until the pool is updated, when the `pool.Status.OSImageStream` value should flip to `rhel-9`.

**- Description for the changelog**
[MCO-2025](https://issues.redhat.com//browse/MCO-2025): Report OSImageStream in MCP Status
