### PR TITLE
OCPBUGS-58023: Prevent unnecessary systemd unit disable

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -945,12 +945,25 @@ func CalculateConfigFileDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) []st
 	return diffFileSet
 }
 
-// CalculateConfigUnitDiffs compares the units present in two ignition configurations and returns the list of units
-// that are different between them
-//
-//nolint:dupl
-func CalculateConfigUnitDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) []string {
-	// Go through the units and see what is new or different
+type UnitDiff struct {
+	Added   []ign3types.Unit
+	Removed []ign3types.Unit
+	Updated []ign3types.Unit
+}
+
+// GetChangedConfigUnitsByType compares the units present in two ignition configurations, one
+// old config and the other new, a struct with units mapped to the type of change:
+//   - New unit added: "Added"
+//   - Unit previously existing removed: "Removed"
+//   - Existing unit changed in some way: "Updated"
+func GetChangedConfigUnitsByType(oldIgnConfig, newIgnConfig *ign3types.Config) (unitDiffs UnitDiff) {
+	diffUnit := UnitDiff{
+		Added:   []ign3types.Unit{},
+		Removed: []ign3types.Unit{},
+		Updated: []ign3types.Unit{},
+	}
+
+	// Get the sets of the old and new units from the ignition configurations
 	oldUnitSet := make(map[string]ign3types.Unit)
 	for _, u := range oldIgnConfig.Systemd.Units {
 		oldUnitSet[u.Name] = u
@@ -959,26 +972,25 @@ func CalculateConfigUnitDiffs(oldIgnConfig, newIgnConfig *ign3types.Config) []st
 	for _, u := range newIgnConfig.Systemd.Units {
 		newUnitSet[u.Name] = u
 	}
-	diffUnitSet := []string{}
 
 	// First check if any units were removed
 	for unit := range oldUnitSet {
 		_, ok := newUnitSet[unit]
 		if !ok {
-			diffUnitSet = append(diffUnitSet, unit)
+			diffUnit.Removed = append(diffUnit.Removed, oldUnitSet[unit])
 		}
 	}
 
-	// Now check if any units were added/changed
+	// Now check if any units were added or updated
 	for name, newUnit := range newUnitSet {
 		oldUnit, ok := oldUnitSet[name]
 		if !ok {
-			diffUnitSet = append(diffUnitSet, name)
+			diffUnit.Added = append(diffUnit.Added, newUnitSet[name])
 		} else if !reflect.DeepEqual(oldUnit, newUnit) {
-			diffUnitSet = append(diffUnitSet, name)
+			diffUnit.Updated = append(diffUnit.Updated, newUnitSet[name])
 		}
 	}
-	return diffUnitSet
+	return diffUnit
 }
 
 // NewIgnFile returns a simple ignition3 file from just path and file contents.

--- a/pkg/daemon/on_disk_validation.go
+++ b/pkg/daemon/on_disk_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
@@ -101,7 +102,12 @@ func checkV3Unit(unit ign3types.Unit, systemdPath string) error {
 		return nil
 	}
 
-	return checkFileContentsAndMode(path, []byte(*unit.Contents), defaultFilePermissions)
+	err := checkFileContentsAndMode(path, []byte(*unit.Contents), defaultFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	return checkUnitEnabled(unit.Name, unit.Enabled)
 }
 
 // checkV3Units validates the contents of all the units in the
@@ -227,6 +233,29 @@ func checkV2Files(files []ign2types.File) error {
 			return err
 		}
 		checkedFiles[f.Path] = true
+	}
+	return nil
+}
+
+// checkUnitEnabled checks whether a systemd unit is enabled as expected.
+func checkUnitEnabled(name string, expectedEnabled *bool) error {
+	if expectedEnabled == nil {
+		return nil
+	}
+	outBytes, _ := runGetOut("systemctl", "is-enabled", name)
+	out := strings.TrimSpace(string(outBytes))
+
+	switch {
+	case *expectedEnabled:
+		// If expected to be enabled, reject known "not enabled" states
+		if out == "disabled" || out == "masked" || out == "masked-runtime" || out == "not-found" {
+			return fmt.Errorf("unit %q expected enabled=true, but systemd reports %q", name, out)
+		}
+	case !*expectedEnabled:
+		// If expected to be disabled, reject any of the enabled-like states
+		if out == "enabled" || out == "enabled-runtime" {
+			return fmt.Errorf("unit %q expected enabled=false, but systemd reports %q", name, out)
+		}
 	}
 	return nil
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	goruntime "runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1012,13 +1013,20 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	logSystem("Starting update from %s to %s: %+v", oldConfigName, newConfigName, diff)
 
 	diffFileSet := ctrlcommon.CalculateConfigFileDiffs(&oldIgnConfig, &newIgnConfig)
-	diffUnitSet := ctrlcommon.CalculateConfigUnitDiffs(&oldIgnConfig, &newIgnConfig)
+	// Get the added and updated units
+	unitDiff := ctrlcommon.GetChangedConfigUnitsByType(&oldIgnConfig, &newIgnConfig)
+	addedOrChangedUnits := slices.Concat(unitDiff.Added, unitDiff.Updated)
+	// Get the names of all units changed in some way (added, removed, or updated)
+	var allChangedUnitNames []string
+	for _, unit := range append(addedOrChangedUnits, unitDiff.Removed...) {
+		allChangedUnitNames = append(allChangedUnitNames, unit.Name)
+	}
 
 	var nodeDisruptionActions []opv1.NodeDisruptionPolicyStatusAction
 	var actions []string
 	// Node Disruption Policies cannot be used during firstboot as API is not accessible.
 	if !firstBoot {
-		nodeDisruptionActions, err = dn.calculatePostConfigChangeNodeDisruptionAction(diff, diffFileSet, diffUnitSet)
+		nodeDisruptionActions, err = dn.calculatePostConfigChangeNodeDisruptionAction(diff, diffFileSet, allChangedUnitNames)
 	} else {
 		actions, err = calculatePostConfigChangeAction(diff, diffFileSet)
 		klog.Infof("Skipping node disruption polciies as node is executing first boot.")
@@ -1124,13 +1132,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}
 
 	// update files on disk that need updating
-	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, skipCertificateWrite); err != nil {
+	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, skipCertificateWrite); err != nil {
 		return err
 	}
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, skipCertificateWrite); err != nil {
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, skipCertificateWrite); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1265,15 +1273,18 @@ func (dn *Daemon) updateHypershift(oldConfig, newConfig *mcfgv1.MachineConfig, d
 		return fmt.Errorf("parsing new Ignition config failed: %w", err)
 	}
 
+	unitDiff := ctrlcommon.GetChangedConfigUnitsByType(&oldIgnConfig, &newIgnConfig)
+	addedOrChangedUnits := slices.Concat(unitDiff.Added, unitDiff.Updated)
+
 	// update files on disk that need updating
 	// We should't skip the certificate write in HyperShift since it does not run the extra daemon process
-	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, false); err != nil {
+	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, false); err != nil {
 		return err
 	}
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, false); err != nil {
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1782,12 +1793,12 @@ func (dn *CoreOSDaemon) getKernelPackagesForRelease() releaseKernelPackages {
 // whatever has been written is picked up by the appropriate daemons, if
 // required. in particular, a daemon-reload and restart for any unit files
 // touched.
-func (dn *Daemon) updateFiles(oldIgnConfig, newIgnConfig ign3types.Config, skipCertificateWrite bool) error {
+func (dn *Daemon) updateFiles(oldIgnConfig, newIgnConfig ign3types.Config, addedOrChangedUnits []ign3types.Unit, skipCertificateWrite bool) error {
 	klog.Info("Updating files")
 	if err := dn.writeFiles(newIgnConfig.Storage.Files, skipCertificateWrite); err != nil {
 		return err
 	}
-	if err := dn.writeUnits(newIgnConfig.Systemd.Units); err != nil {
+	if err := dn.writeUnits(addedOrChangedUnits); err != nil {
 		return err
 	}
 	return dn.deleteStaleData(oldIgnConfig, newIgnConfig)


### PR DESCRIPTION
Closes: OCPBUGS-58023

**- What I did**
This takes inspiration from the proposed fix for OCPBUGS-58023 in https://github.com/openshift/machine-config-operator/pull/5225 and updates some of the changes to be clearer and more maintainable per review suggestions. It includes cherry-picks of the following two commits
- https://github.com/openshift/machine-config-operator/commit/4512ec46f7b13a6e85588bbf480c4d029990724a - This was the original work for fixing the bug.
- https://github.com/openshift/machine-config-operator/pull/5225/commits/40304ebef36233e3eb9ae1fc0d32a6e2e65381f5 - This was the commit that introduced a fix to address the test failures called out in [TRT-2232](https://issues.redhat.com//browse/TRT-2232).

and some cleanup.

**- How to verify it**
[OCPBUGS-58023](https://issues.redhat.com//browse/OCPBUGS-58023): See https://github.com/openshift/machine-config-operator/pull/5148#issuecomment-3106598580 for previous verification steps.
[TRT-2232](https://issues.redhat.com//browse/TRT-2232): Payload tests previously impacted by this bug fix should pass.
- Blocking payloads should pass
- Informing payloads should pass consistent with historic rates
- PR e2es should pass

**- Description for the changelog**
OCPBUGS-58023: Prevent unnecessary systemd unit disable