### PR TITLE
MCO-2037: Fix timeout during configMap cleanup

### DIFF
--- a/test/e2e-ocl/helpers_test.go
+++ b/test/e2e-ocl/helpers_test.go
@@ -313,7 +313,7 @@ func cleanupEphemeralBuildObjects(t *testing.T, cs *framework.ClientSet) {
 	moscList, err := cs.MachineconfigurationV1Interface.MachineOSConfigs().List(context.TODO(), metav1.ListOptions{})
 	require.NoError(t, err)
 
-	kubeassert := helpers.AssertClientSet(t, cs).WithContext(context.TODO())
+	kubeassert := helpers.AssertClientSet(t, cs)
 
 	if len(secretList.Items) == 0 {
 		t.Logf("No build-time secrets to clean up")


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MCO-2037

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
The configMap cleanup would end up stuck due to
the way the timeout was specified, this fixes that.

**- How to verify it**
Run the e2e-ocl test suite

**- Description for the changelog**
Fix ocl test suite configmap cleanup workflow
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
