### PR TITLE
MCO-2049: Validate MCP osImageStream reference

### DIFF
--- a/manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "machineconfigpool-osimagestream-reference-validation"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: machineconfiguration.openshift.io/v1alpha1
+    kind: OSImageStream
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
+    resourceRules:
+    - apiGroups:   ["machineconfiguration.openshift.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE","UPDATE"]
+      resources:   ["machineconfigpools"]
+      scope: "*"
+  validations:
+    - expression: "!has(object.spec.osImageStream) || object.spec.osImageStream.name in params.status.availableStreams.map(s, s.name)"
+      message: "The specified osImageStream name must reference a valid stream from the cluster OSImageStream resource"

--- a/manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,10 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "machineconfigpool-osimagestream-reference-validation-binding"
+spec:
+  policyName: "machineconfigpool-osimagestream-reference-validation"
+  validationActions: [Deny]
+  paramRef:
+    name: "cluster"
+    parameterNotFoundAction: "Deny"

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -85,21 +85,23 @@ type manifestPaths struct {
 
 const (
 	// Machine Config Controller manifest paths
-	mccClusterRoleManifestPath                                        = "manifests/machineconfigcontroller/clusterrole.yaml"
-	mccEventsClusterRoleManifestPath                                  = "manifests/machineconfigcontroller/events-clusterrole.yaml"
-	mccEventsRoleBindingDefaultManifestPath                           = "manifests/machineconfigcontroller/events-rolebinding-default.yaml"
-	mccEventsRoleBindingTargetManifestPath                            = "manifests/machineconfigcontroller/events-rolebinding-target.yaml"
-	mccClusterRoleBindingManifestPath                                 = "manifests/machineconfigcontroller/clusterrolebinding.yaml"
-	mccServiceAccountManifestPath                                     = "manifests/machineconfigcontroller/sa.yaml"
-	mccKubeRbacProxyConfigMapPath                                     = "manifests/machineconfigcontroller/kube-rbac-proxy-config.yaml"
-	mccKubeRbacProxyPrometheusRolePath                                = "manifests/machineconfigcontroller/prometheus-rbac.yaml"
-	mccKubeRbacProxyPrometheusRoleBindingPath                         = "manifests/machineconfigcontroller/prometheus-rolebinding-target.yaml"
-	mccMachineConfigurationGuardsValidatingAdmissionPolicyPath        = "manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml"
-	mccMachineConfigurationGuardsValidatingAdmissionPolicyBindingPath = "manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml"
-	mccMachineConfigPoolSelectorValidatingAdmissionPolicyPath         = "manifests/machineconfigcontroller/custom-machine-config-pool-selector-validatingadmissionpolicy.yaml"
-	mccMachineConfigPoolSelectorValidatingAdmissionPolicyBindingPath  = "manifests/machineconfigcontroller/custom-machine-config-pool-selector-validatingadmissionpolicybinding.yaml"
-	mccUpdateBootImagesValidatingAdmissionPolicyPath                  = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml"
-	mccUpdateBootImagesValidatingAdmissionPolicyBindingPath           = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml"
+	mccClusterRoleManifestPath                                            = "manifests/machineconfigcontroller/clusterrole.yaml"
+	mccEventsClusterRoleManifestPath                                      = "manifests/machineconfigcontroller/events-clusterrole.yaml"
+	mccEventsRoleBindingDefaultManifestPath                               = "manifests/machineconfigcontroller/events-rolebinding-default.yaml"
+	mccEventsRoleBindingTargetManifestPath                                = "manifests/machineconfigcontroller/events-rolebinding-target.yaml"
+	mccClusterRoleBindingManifestPath                                     = "manifests/machineconfigcontroller/clusterrolebinding.yaml"
+	mccServiceAccountManifestPath                                         = "manifests/machineconfigcontroller/sa.yaml"
+	mccKubeRbacProxyConfigMapPath                                         = "manifests/machineconfigcontroller/kube-rbac-proxy-config.yaml"
+	mccKubeRbacProxyPrometheusRolePath                                    = "manifests/machineconfigcontroller/prometheus-rbac.yaml"
+	mccKubeRbacProxyPrometheusRoleBindingPath                             = "manifests/machineconfigcontroller/prometheus-rolebinding-target.yaml"
+	mccMachineConfigurationGuardsValidatingAdmissionPolicyPath            = "manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicy.yaml"
+	mccMachineConfigurationGuardsValidatingAdmissionPolicyBindingPath     = "manifests/machineconfigcontroller/machineconfiguration-guards-validatingadmissionpolicybinding.yaml"
+	mccMachineConfigPoolSelectorValidatingAdmissionPolicyPath             = "manifests/machineconfigcontroller/custom-machine-config-pool-selector-validatingadmissionpolicy.yaml"
+	mccMachineConfigPoolSelectorValidatingAdmissionPolicyBindingPath      = "manifests/machineconfigcontroller/custom-machine-config-pool-selector-validatingadmissionpolicybinding.yaml"
+	mccUpdateBootImagesValidatingAdmissionPolicyPath                      = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicy.yaml"
+	mccUpdateBootImagesValidatingAdmissionPolicyBindingPath               = "manifests/machineconfigcontroller/update-bootimages-validatingadmissionpolicybinding.yaml"
+	mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyPath        = "manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicy.yaml"
+	mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyBindingPath = "manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicybinding.yaml"
 
 	// Machine OS Builder manifest paths
 	mobClusterRoleManifestPath                      = "manifests/machineosbuilder/clusterrole.yaml"
@@ -1171,6 +1173,12 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig, _ *confi
 			mccMachineConfigPoolSelectorValidatingAdmissionPolicyBindingPath,
 		},
 	}
+
+	if optr.fgHandler.Enabled(features.FeatureGateOSStreams) {
+		paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyPath)
+		paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyBindingPath)
+	}
+
 	if err := optr.applyManifests(config, paths); err != nil {
 		return fmt.Errorf("failed to apply machine config controller manifests: %w", err)
 	}


### PR DESCRIPTION
**- What I did**

Add a VAP and the associated binding to validate at the API that, if given, the MCP `.spec.osImageStream.name` points to a valid OS Image Stream defined in the OSImageStream `.status.availableStreams`.

**- How to verify it**

1. Deploy a TP cluster with this change
2. Try to make the worker MCP to point to `rhel-11` by setting `.spec.osImageStream.name` to `rhel-11`
3. The edit/apply should fail with the descriptive error message `The specified osImageStream name must reference a valid stream from the cluster OSImageStream resource`.
4. Now point the worker MCP to rhel-10 by setting `.spec.osImageStream.name` to `rhel-10`. It should succeed.

**- Description for the changelog**

Add a VAP to ensure the MCP `.spec.osImageStream.name` field is always aligned with the values of the OSImageStream cluster resource.