### PR TITLE
OCPBUGS-72396: use D-Bus API to list systemd units

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -260,7 +260,7 @@ require (
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb // indirect
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
-	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09
 	github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.5 // indirect

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/clarketm/json"
 	"github.com/coreos/go-semver/semver"
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2136,7 +2137,8 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 		if u.Enabled != nil {
 			// Only when a unit has contents should we attempt to enable or disable it.
 			// See: https://issues.redhat.com/browse/OCPBUGS-56648
-			if unitHasContent(u) || systemdUnits.Has(u.Name) {
+			_, unitExists := systemdUnits[u.Name]
+			if unitHasContent(u) || unitExists {
 				if *u.Enabled {
 					enabledUnits = append(enabledUnits, u.Name)
 				} else {
@@ -2170,27 +2172,26 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 	return nil
 }
 
-func (dn *Daemon) listSystemdUnits() (sets.Set[string], error) {
-	rawJSON, err := dn.cmdRunner.RunGetOut("systemctl", "list-units", "--all", "--no-pager", "--output=json")
+func (dn *Daemon) listSystemdUnits() (result map[string]systemddbus.UnitStatus, err error) {
+	conn, err := systemddbus.NewSystemdConnectionContext(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("error listing systemd units: %w", err)
+		return nil, fmt.Errorf("failed to connect to system bus to list units: %w", err)
+	}
+	defer func() {
+		conn.Close()
+	}()
+
+	units, err := conn.ListUnitsContext(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list systemd units: %w", err)
 	}
 
-	type Unit struct {
-		Unit string `json:"unit,omitempty"`
+	result = make(map[string]systemddbus.UnitStatus)
+	for _, unit := range units {
+		result[unit.Name] = unit
 	}
-	var units []Unit
-	if err := json.Unmarshal(rawJSON, &units); err != nil {
-		return nil, fmt.Errorf("error parsing systemd units: %w", err)
-	}
+	return result, nil
 
-	names := sets.New[string]()
-	for _, u := range units {
-		if u.Unit != "" {
-			names.Insert(u.Unit)
-		}
-	}
-	return names, nil
 }
 
 // writeFiles writes the given files to disk.


### PR DESCRIPTION
Fixes: [#OCPBUGS-72396](https://issues.redhat.com/browse/OCPBUGS-72396)

**- What I did**

Replace the systemctl command-line approach with direct D-Bus API calls for listing systemd units. This ensures compatibility with older OS versions that don't support the --output=json flag in systemctl.

**- How to verify it**

TBD

**- Description for the changelog**

Replace the systemctl command-line approach with direct D-Bus API calls to ensure compatibility with older OS versions that don't support the --output=json flag in systemctl.