### PR TITLE
OCPBUGS-72555: Restrict CPMS boot image configuration to only AWS, GCP and Azure platforms

### DIFF
--- a/manifests/machineconfigcontroller/update-bootimages-cpms-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-cpms-validatingadmissionpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "managed-bootimages-cpms-platform-check"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
+    resourceRules:
+    - apiGroups:   ["operator.openshift.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE","UPDATE"]
+      resources:   ["machineconfigurations"]
+      scope: "*"
+  validations:
+    - expression: "!has(object.spec.managedBootImages) || !has(object.spec.managedBootImages.machineManagers) || !object.spec.managedBootImages.machineManagers.exists(m, m.resource == 'controlplanemachinesets') || params.status.platformStatus.type in ['GCP','AWS','Azure']"
+      message: "The control plane machineset boot image update feature is only supported on these platforms: GCP, AWS, Azure"

--- a/manifests/machineconfigcontroller/update-bootimages-cpms-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/update-bootimages-cpms-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,10 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "managed-bootimages-cpms-platform-check-binding"
+spec:
+  policyName: "managed-bootimages-cpms-platform-check"
+  validationActions: [Deny]
+  paramRef:
+    name: "cluster"
+    parameterNotFoundAction: "Deny"

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -104,6 +104,8 @@ const (
 	mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyBindingPath = "manifests/machineconfigcontroller/machineconfigpool-osimagestream-reference-validatingadmissionpolicybinding.yaml"
 	mccIRIDeletionGuardValidatingAdmissionPolicyPath                      = "manifests/machineconfigcontroller/internalreleaseimage-deletion-guard-validatingadmissionpolicy.yaml"
 	mccIRIDeletionGuardValidatingAdmissionPolicyBindingPath               = "manifests/machineconfigcontroller/internalreleaseimage-deletion-guard-validatingadmissionpolicybinding.yaml"
+	mccUpdateBootImagesCPMSValidatingAdmissionPolicyPath                  = "manifests/machineconfigcontroller/update-bootimages-cpms-validatingadmissionpolicy.yaml"
+	mccUpdateBootImagesCPMSValidatingAdmissionPolicyBindingPath           = "manifests/machineconfigcontroller/update-bootimages-cpms-validatingadmissionpolicybinding.yaml"
 
 	// Machine OS Builder manifest paths
 	mobClusterRoleManifestPath                      = "manifests/machineosbuilder/clusterrole.yaml"
@@ -1187,6 +1189,10 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig, _ *confi
 	if optr.fgHandler.Enabled(features.FeatureGateOSStreams) {
 		paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyPath)
 		paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccMachineConfigPoolOSImageStreamValidatingAdmissionPolicyBindingPath)
+	}
+	if optr.fgHandler.Enabled(features.FeatureGateManagedBootImagesCPMS) {
+		paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccUpdateBootImagesCPMSValidatingAdmissionPolicyPath)
+		paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccUpdateBootImagesCPMSValidatingAdmissionPolicyBindingPath)
 	}
 
 	if optr.fgHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {


### PR DESCRIPTION
**- What I did**
This PR adds a ValidatingAdmissionPolicy that limits addition of the CPMS MachineManager to the boot image configuration only for the AWS, GCP, Azure platforms.

**- How to verify it**
Note that this feature is still under techpreview, so it will need a cluster launched with that TP enabled. Attempt to add a boot image configuration for controlplanemachinesets:
```
apiVersion: operator.openshift.io/v1
kind: MachineConfiguration
metadata:
  name: cluster
  namespace: openshift-machine-config-operator
spec:
  logLevel: Normal
  operatorLogLevel: Normal
  managedBootImages:
    machineManagers:
      - resource: controlplanemachinesets
        apiGroup: machine.openshift.io
        selection:
          mode: All
```
The APIServer should permit this for the platforms mentioned above and reject it for any other platforms, including vsphere with an error message like:
```
The machineconfigurations "cluster" is invalid: : ValidatingAdmissionPolicy 'managed-bootimages-cpms-platform-check' with binding 'managed-bootimages-cpms-platform-check-binding' denied request: The control plane machineset boot image update feature is only supported on these platforms: GCP, AWS, Azure
```