### PR TITLE
MCO-1953: Refactor functionality to grab machines by state for calculating MCP status

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -51,7 +51,6 @@ import (
 	"github.com/openshift/client-go/machineconfiguration/clientset/versioned/scheme"
 	"github.com/openshift/library-go/pkg/crypto"
 	buildconstants "github.com/openshift/machine-config-operator/pkg/controller/build/constants"
-	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 )
 
 // strToPtr converts the input string to a pointer to itself
@@ -1286,42 +1285,51 @@ func RequiresRebuild(oldMC, newMC *mcfgv1.MachineConfig) bool {
 		!reflect.DeepEqual(oldMC.Spec.KernelArguments, newMC.Spec.KernelArguments)
 }
 
-// GetUpdatedMachines filters the provided nodes to return the nodes whose
-// current config matches its desired config and target config in the
-// associated MCP and has the "done" flag set.
-func GetUpdatedMachines(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node, mosc *mcfgv1.MachineOSConfig, mosb *mcfgv1.MachineOSBuild, layered bool) []*corev1.Node {
+type MachinesByStatus struct {
+	Updated     []*corev1.Node
+	Degraded    []*corev1.Node
+	Ready       []*corev1.Node
+	Unavailable []*corev1.Node
+}
+
+// GetMachinesByState takes a list of nodes and returns lists of nodes filtered by state. The
+// states and their requirements are:
+//   - Updated: A node's current config matches its desired config and the target config in the
+//     associated MCP and the node has the "done" flag set
+//   - Degraded: The node's `machineconfiguration.openshift.io/state` annotation has a value of
+//     "Degraded" or "Unreconcilable"
+//   - Ready: The node is "Updated" and marked ready
+//   - Unavailable: The node is either marked unscheduleable or has a MCD actively working. If the
+//     MCD is actively working (or hasn't started) then the node *may* go unschedulable in the
+//     future, so the node is considered "unavailable" so another node update does not exceed
+//     the desired maxUnavailable. (Somewhat the opposite of a "Ready" node)
+func GetMachinesByState(pool *mcfgv1.MachineConfigPool, nodes []*corev1.Node, mosc *mcfgv1.MachineOSConfig, mosb *mcfgv1.MachineOSBuild, layered bool) MachinesByStatus {
 	var updated []*corev1.Node
+	var degraded []*corev1.Node
+	var ready []*corev1.Node
+	var unavail []*corev1.Node
 	for _, node := range nodes {
 		lns := NewLayeredNodeState(node)
 		if lns.IsDone(pool, layered, mosc, mosb) {
 			updated = append(updated, node)
+			// A node must be updated to be considered "Ready"
+			if lns.IsNodeReady() {
+				ready = append(ready, node)
+			}
 		}
-	}
-	return updated
-}
-
-// GetDegradedMachines filters the provided nodes to return the nodes that
-// are considered in a degraded state.
-func GetDegradedMachines(nodes []*corev1.Node) []*corev1.Node {
-	var degraded []*corev1.Node
-	for _, node := range nodes {
-		if node.Annotations == nil {
-			continue
-		}
-		dconfig, ok := node.Annotations[daemonconsts.DesiredMachineConfigAnnotationKey]
-		if !ok || dconfig == "" {
-			continue
-		}
-		dstate, ok := node.Annotations[daemonconsts.MachineConfigDaemonStateAnnotationKey]
-		if !ok || dstate == "" {
-			continue
-		}
-
-		if dstate == daemonconsts.MachineConfigDaemonStateDegraded || dstate == daemonconsts.MachineConfigDaemonStateUnreconcilable {
+		if lns.IsNodeDegraded() || lns.IsNodeUnreconcilable() {
 			degraded = append(degraded, node)
 		}
+		if lns.IsUnavailableForUpdate() {
+			unavail = append(unavail, node)
+		}
 	}
-	return degraded
+	return MachinesByStatus{
+		Updated:     updated,
+		Degraded:    degraded,
+		Ready:       ready,
+		Unavailable: unavail,
+	}
 }
 
 // `IsMachineUpdatedMCN` checks if a machine (node) is "updated" by checking the associated MCN's

--- a/pkg/controller/common/layered_node_state.go
+++ b/pkg/controller/common/layered_node_state.go
@@ -337,3 +337,13 @@ func (l *LayeredNodeState) GetDesiredAnnotationsFromMachineOSConfig(mosc *mcfgv1
 
 	return mosb.Spec.MachineConfig.Name, desiredImage
 }
+
+// IsNodeDegraded checks if the node is reporting a MCD state of "Degraded"
+func (l *LayeredNodeState) IsNodeDegraded() bool {
+	return l.isNodeMCDState(daemonconsts.MachineConfigDaemonStateDegraded)
+}
+
+// IsNodeUnreconcilable checks if the node is reporting a MCD state of "Unreconcilable"
+func (l *LayeredNodeState) IsNodeUnreconcilable() bool {
+	return l.isNodeMCDState(daemonconsts.MachineConfigDaemonStateUnreconcilable)
+}

--- a/pkg/controller/common/layered_node_state_test.go
+++ b/pkg/controller/common/layered_node_state_test.go
@@ -21,11 +21,24 @@ func newNode(current, desired string) *corev1.Node {
 	return helpers.NewNodeBuilder("").WithCurrentConfig(current).WithDesiredConfig(desired).Node()
 }
 
+func newNodeWithState(current, desired, state string) *corev1.Node {
+	return helpers.NewNodeBuilder("").WithCurrentConfig(current).WithDesiredConfig(desired).WithMCDState(state).Node()
+}
+
 func newLayeredNode(currentConfig, desiredConfig, currentImage, desiredImage string) *corev1.Node {
 	nb := helpers.NewNodeBuilder("")
 	nb.WithCurrentConfig(currentConfig).WithDesiredConfig(desiredConfig)
 	nb.WithCurrentImage(currentImage).WithDesiredImage(desiredImage)
 	nb.WithNodeReady()
+	return nb.Node()
+}
+
+func newLayeredNodeWithState(currentConfig, desiredConfig, currentImage, desiredImage, state string) *corev1.Node {
+	nb := helpers.NewNodeBuilder("")
+	nb.WithCurrentConfig(currentConfig).WithDesiredConfig(desiredConfig)
+	nb.WithCurrentImage(currentImage).WithDesiredImage(desiredImage)
+	nb.WithNodeReady()
+	nb.WithMCDState(state)
 	return nb.Node()
 }
 

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -1441,7 +1441,7 @@ func (ctrl *Controller) updateCandidateNode(mosc *mcfgv1.MachineOSConfig, mosb *
 // getAllCandidateMachines returns all possible nodes which can be updated to the target config, along with a maximum
 // capacity.  It is the reponsibility of the caller to choose a subset of the nodes given the capacity.
 func getAllCandidateMachines(layered bool, config *mcfgv1.MachineOSConfig, build *mcfgv1.MachineOSBuild, pool *mcfgv1.MachineConfigPool, nodesInPool []*corev1.Node, maxUnavailable int) ([]*corev1.Node, uint) {
-	unavail := getUnavailableMachines(nodesInPool, pool)
+	unavail := getUnavailableMachines(nodesInPool)
 	if len(unavail) >= maxUnavailable {
 		klog.V(4).Infof("getAllCandidateMachines: No capacity left for pool %s (unavail=%d >= maxUnavailable=%d)",
 			pool.Name, len(unavail), maxUnavailable)


### PR DESCRIPTION
**- What I did**

- Create `IsNodeDegraded` and `IsNodeUnreconcilable` layered node state helpers to check if a node's state annotation is set to "Degraded" or "Unreconcilable" respectively.
- Move `GetDegradedMachines` functionality into the new `GetMachinesByState` function and remove the unnecessary empty desired config and state annotation checks.
- Pull the `getReadyMachines`, `getUnavailableMachines`, and `GetUpdatedMachines` functionality into the new `GetMachinesByState` function. 
- Clean up the main `calculateStatus` function to reflect the function updates.
- Update the corresponding unit tests.

**- How to verify it**

The machine counts in the MCP status should being populated as before.

**- Description for the changelog**
[MCO-1953](https://issues.redhat.com//browse/MCO-1953): Refactor functions used to calculate the number of update, ready, degraded, and unavailable machines