### PR TITLE
NO-ISSUE: Fix Failure Status condition to True when kubeletconfig or container runtime config validation fails

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -350,7 +350,7 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.ContainerRunt
 	if err != nil {
 		condition = apihelpers.NewContainerRuntimeConfigCondition(
 			mcfgv1.ContainerRuntimeConfigFailure,
-			corev1.ConditionFalse,
+			corev1.ConditionTrue,
 			fmt.Sprintf("Error: %v", err),
 		)
 	} else {

--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -398,7 +398,7 @@ func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.KubeletConfig
 	if err != nil {
 		condition = apihelpers.NewKubeletConfigCondition(
 			mcfgv1.KubeletConfigFailure,
-			corev1.ConditionFalse,
+			corev1.ConditionTrue,
 			fmt.Sprintf("Error: %v", err),
 		)
 	} else {

--- a/pkg/controller/kubelet-config/helpers_test.go
+++ b/pkg/controller/kubelet-config/helpers_test.go
@@ -1,0 +1,71 @@
+package kubeletconfig
+
+import (
+	"fmt"
+	"testing"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestWrapErrorWithCondition(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		args            []interface{}
+		expectedType    mcfgv1.KubeletConfigStatusConditionType
+		expectedStatus  corev1.ConditionStatus
+		expectedMessage string
+	}{
+		{
+			name:            "error without args produces Failure condition with status True",
+			err:             fmt.Errorf("KubeletConfiguration: swapBehavior is not allowed to be set, but contains: LimitedSwap"),
+			args:            nil,
+			expectedType:    mcfgv1.KubeletConfigFailure,
+			expectedStatus:  corev1.ConditionTrue,
+			expectedMessage: "Error: KubeletConfiguration: swapBehavior is not allowed to be set, but contains: LimitedSwap",
+		},
+		{
+			name:            "error with formatted args produces Failure condition with status True",
+			err:             fmt.Errorf("validation failed"),
+			args:            []interface{}{"Failed to validate %s: %v", "kubelet config", "invalid field"},
+			expectedType:    mcfgv1.KubeletConfigFailure,
+			expectedStatus:  corev1.ConditionTrue,
+			expectedMessage: "Failed to validate kubelet config: invalid field",
+		},
+		{
+			name:            "nil error produces Success condition with status True",
+			err:             nil,
+			args:            nil,
+			expectedType:    mcfgv1.KubeletConfigSuccess,
+			expectedStatus:  corev1.ConditionTrue,
+			expectedMessage: "Success",
+		},
+		{
+			name:            "nil error with args still produces Success condition",
+			err:             nil,
+			args:            []interface{}{"Custom success message"},
+			expectedType:    mcfgv1.KubeletConfigSuccess,
+			expectedStatus:  corev1.ConditionTrue,
+			expectedMessage: "Custom success message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := wrapErrorWithCondition(tt.err, tt.args...)
+
+			if condition.Type != tt.expectedType {
+				t.Errorf("expected condition type %v, got %v", tt.expectedType, condition.Type)
+			}
+
+			if condition.Status != tt.expectedStatus {
+				t.Errorf("expected condition status %v, got %v", tt.expectedStatus, condition.Status)
+			}
+
+			if condition.Message != tt.expectedMessage {
+				t.Errorf("expected message %q, got %q", tt.expectedMessage, condition.Message)
+			}
+		})
+	}
+}

--- a/test/extended-priv/kubeletconfig.go
+++ b/test/extended-priv/kubeletconfig.go
@@ -48,7 +48,7 @@ func (kc KubeletConfig) waitUntilSuccess(timeout string) {
 func (kc KubeletConfig) waitUntilFailure(expectedMsg, timeout string) {
 	logger.Infof("wait for %s to report failure", kc.name)
 	o.EventuallyWithOffset(1, &kc, timeout, "2s").Should(o.SatisfyAll(
-		HaveConditionField("Failure", "status", "False"),
+		HaveConditionField("Failure", "status", "True"),
 		HaveConditionField("Failure", "message", o.ContainSubstring(expectedMsg)),
 	), "KubeletConfig '%s' should report Failure in status.conditions and report failure message %s. But it doesn't.", kc.GetName(), expectedMsg)
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the `wrapErrorWithCondition` function in both `kubelet-config` and `container-runtime-config` controllers to correctly report failure status as `True` instead of `False` when validation errors occur.

The function was incorrectly setting Failure condition status to False when errors occurred. According to Kubernetes condition semantics, a condition type should be True when that condition is present. So `Failure=True` means a failure has occurred, not `Failure=False`.


**- How to verify it**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix KubeletConfig and ContainerRuntimeConfig Failure condition status to correctly report True when validation errors occur.