### PR TITLE
AGENT-1411: fix IRI registry setup file

### DIFF
--- a/pkg/controller/internalreleaseimage/templates/master/files/usr-local-bin-load-registry-image-sh.yaml
+++ b/pkg/controller/internalreleaseimage/templates/master/files/usr-local-bin-load-registry-image-sh.yaml
@@ -1,4 +1,4 @@
-mode: 0644
+mode: 0755
 path: "/usr/local/bin/load-registry-image.sh"
 contents:
   inline: |-


### PR DESCRIPTION
**- What I did**
make executable  load-registry-image.sh file, since it is required by the IRI registry service

**- How to verify it**
Use dev-scriptst to deploy an OVE based cluster
