### PR TITLE
AGENT-1412: Prevent deletion of InternalReleaseImage when in use

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -143,6 +143,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				ctrlctx.InformerFactory.Machineconfiguration().V1alpha1().InternalReleaseImages(),
 				ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 				ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
+				ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 				ctrlctx.ClientBuilder.KubeClientOrDie("internalreleaseimage-controller"),
 				ctrlctx.ClientBuilder.MachineConfigClientOrDie("internalreleaseimage-controller"))
 

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	features "github.com/openshift/api/features"
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -66,6 +67,13 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			klog.Fatal(fmt.Errorf("failed to connect to feature gates %w", fgErr))
 		}
 
+		// Only pass IRI informer when the feature gate is enabled to avoid
+		// watching for a CRD that may not exist
+		var iriInformer = ctrlctx.InformerFactory.Machineconfiguration().V1alpha1().InternalReleaseImages()
+		if !ctrlctx.FeatureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
+			iriInformer = nil
+		}
+
 		controller := operator.New(
 			ctrlcommon.MCONamespace, componentName,
 			startOpts.imagesFile,
@@ -108,6 +116,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.NamespacedInformerFactory.Machineconfiguration().V1().MachineOSConfigs(),
 			ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 			ctrlctx.InformerFactory.Machineconfiguration().V1alpha1().OSImageStreams(),
+			iriInformer,
 			ctrlctx,
 		)
 

--- a/manifests/machineconfigcontroller/internalreleaseimage-deletion-guard-validatingadmissionpolicy.yaml
+++ b/manifests/machineconfigcontroller/internalreleaseimage-deletion-guard-validatingadmissionpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "internalreleaseimage-deletion-guard"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: config.openshift.io/v1
+    kind: ClusterVersion
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
+    resourceRules:
+    - apiGroups:   ["machineconfiguration.openshift.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["DELETE"]
+      resources:   ["internalreleaseimages"]
+      scope: "*"
+  validations:
+    - expression: "!oldObject.status.releases.exists(r, has(r.image) && r.image == params.status.desired.image)"
+      message: "Cannot delete InternalReleaseImage while the cluster is using a release bundle from this resource. The current cluster release image matches a release stored in this InternalReleaseImage. Please upgrade or downgrade to a different release before deletion."

--- a/manifests/machineconfigcontroller/internalreleaseimage-deletion-guard-validatingadmissionpolicybinding.yaml
+++ b/manifests/machineconfigcontroller/internalreleaseimage-deletion-guard-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,10 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "internalreleaseimage-deletion-guard-binding"
+spec:
+  policyName: "internalreleaseimage-deletion-guard"
+  validationActions: [Deny]
+  paramRef:
+    name: "version"
+    parameterNotFoundAction: "Deny"


### PR DESCRIPTION
Add ValidatingAdmissionPolicy to block deletion of the InternalReleaseImage singleton resource if any of its release bundles are currently in use by the cluster. This prevents accidental deletion of IRI while the cluster is running a release version that is stored in the InternalReleaseImage resource.

The policy checks the ClusterVersion's current version against all release bundle names in the IRI status. If a match is found, deletion is blocked with a clear error message instructing the user to upgrade or downgrade before deletion.

This is part of the NoRegistryClusterInstall feature, where deletion of IRI is the default opt-out mechanism, and this guard ensures safe operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
