### PR TITLE
MCO-1924: MCO-500: Migrate direct runGetOut() to use CommandRunner in the MCD

### DIFF
--- a/pkg/daemon/bootc.go
+++ b/pkg/daemon/bootc.go
@@ -181,17 +181,6 @@ func (b *BootcClient) GetBootedAndStagedImage() (*BootEntry, *BootEntry, error) 
 	return status.Status.GetBootedImage(), status.Status.GetStagedImage(), nil
 }
 
-// // GetStatus returns multi-line human-readable text describing system status
-// // Bootc is working on status update: https://github.com/containers/bootc/issues/408
-// func (r *BootcClient) GetStatus() (string, error) {
-// 	output, err := runGetOut("bootc", "status")
-// 	if err != nil {
-// 		return "", err
-// 	}
-
-// 	return string(output), nil
-// }
-
 // GetBootedImageInfo() returns the image URL as well as the image version(for logging) and the ostree commit (for comparisons)
 func (b *BootcClient) GetBootedImageInfo() (*BootedImageInfo, error) {
 	bootedImage, _, err := b.GetBootedAndStagedImage()

--- a/pkg/daemon/command_runner.go
+++ b/pkg/daemon/command_runner.go
@@ -35,14 +35,6 @@ func (r *CommandRunnerOS) RunGetOut(command string, args ...string) ([]byte, err
 	return rawOut, nil
 }
 
-// TODO: Delete this function to always consume the interface instance
-// Tracking story: https://issues.redhat.com/browse/MCO-1924
-//
-//	Conserved the old signature to avoid a big footprint bugfix with this change
-func runGetOut(command string, args ...string) ([]byte, error) {
-	return (&CommandRunnerOS{}).RunGetOut(command, args...)
-}
-
 // MockCommandRunner is a test implementation that returns pre-configured outputs.
 type MockCommandRunner struct {
 	outputs map[string][]byte

--- a/pkg/daemon/on_disk_validation.go
+++ b/pkg/daemon/on_disk_validation.go
@@ -242,7 +242,8 @@ func checkUnitEnabled(name string, expectedEnabled *bool) error {
 	if expectedEnabled == nil {
 		return nil
 	}
-	outBytes, _ := runGetOut("systemctl", "is-enabled", name)
+	cmdRunner := &CommandRunnerOS{}
+	outBytes, _ := cmdRunner.RunGetOut("systemctl", "is-enabled", name)
 	out := strings.TrimSpace(string(outBytes))
 
 	switch {

--- a/pkg/daemon/podman.go
+++ b/pkg/daemon/podman.go
@@ -31,6 +31,8 @@ type PodmanInterface interface {
 	GetPodmanImageInfoByReference(reference string) (*PodmanImageInfo, error)
 	// GetPodmanInfo retrieves Podman system information.
 	GetPodmanInfo() (*PodmanInfo, error)
+	// CreatePodmanContainer creates a container from the specified image URL.
+	CreatePodmanContainer(additionalArgs []string, containerName, imgURL string) ([]byte, error)
 }
 
 // PodmanExecInterface is the production implementation that executes real podman commands.
@@ -86,4 +88,16 @@ func (p *PodmanExecInterface) GetPodmanInfo() (*PodmanInfo, error) {
 		return nil, fmt.Errorf("failed to decode podman system info output: %v", err)
 	}
 	return &podmanInfo, nil
+}
+
+// CreatePodmanContainer creates a container from the specified image URL.
+// It executes 'podman create <args> --name <containerName> <imgURL>'.
+func (p *PodmanExecInterface) CreatePodmanContainer(additionalArgs []string, containerName, imgURL string) ([]byte, error) {
+	args := []string{"create"}
+	if len(additionalArgs) > 0 {
+		args = append(args, additionalArgs...)
+	}
+	args = append(args, "--name", containerName, imgURL)
+
+	return p.cmdRunner.RunGetOut("podman", args...)
 }


### PR DESCRIPTION
**- What I did**
- Remove the legacy `runGetOut` function https://github.com/isabella-janssen/machine-config-operator/blob/e52120b2cded908564878b30f7e87efa4709dcd6/pkg/daemon/command_runner.go#L38-L44 and its references in favor of the `RunGetOut` function that makes use of the `CommandRunnerOS` struct https://github.com/isabella-janssen/machine-config-operator/blob/e52120b2cded908564878b30f7e87efa4709dcd6/pkg/daemon/command_runner.go#L21-L36
- Make a new `CreatePodmanContainer` function to make use of the `PodmanExecInterface` struct
- Update & create relevant tests
- General code cleanup

**- How to verify it**
This is just code refactoring and cleanup, so existing functionality should remain unchanged.

**- Description for the changelog**
[MCO-1924](https://issues.redhat.com//browse/MCO-1924): Migrate direct runGetOut() to use CommandRunner in the MCD