### PR TITLE
OCPBUGS-74101: Fixes the issue in the test TestKubeletConfigMaxPods when AutoNodeSizing is enabled by default

### DIFF
--- a/test/e2e-2of2/kubeletcfg_test.go
+++ b/test/e2e-2of2/kubeletcfg_test.go
@@ -162,16 +162,6 @@ func runTestWithKubeletCfg(t *testing.T, testName string, regexKey []string, str
 		}
 	}
 
-	// Get the new node object which should reflect new values for the allocatables
-	if *kc1.Spec.AutoSizingReserved {
-		refreshedNode := helpers.GetSingleNodeByRole(t, cs, poolName)
-
-		// The value for the allocatable should have changed because of the auto node sizing.
-		// We cannot predict if the values of the allocatables will increase or decrease,
-		// as it depends on the configuration of the system under test.
-		require.NotEqual(t, refreshedNode.Status.Allocatable.Memory().Value(), node.Status.Allocatable.Memory().Value(), "value of the allocatable should have changed")
-	}
-
 	if kc2 != nil {
 		// create our second kubelet config and attach it to our created node pool
 		cleanupKcFunc2 := createKcWithConfig(t, cs, kcName2, poolName, &kc2.Spec, "1")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Reported by @djoshy : https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1768319412897509

The TestKubeletConfigMaxPods test has been failing intermittently since PR #5491 merged. The failure occurs at the allocatable memory assertion:
```
  kubeletcfg_test.go:172:
      Error:      	Should not be: 13435936768
      Test:       	TestKubeletConfigMaxPods
      Messages:   	value of the allocatable should have changed
```
PR #5491 changed the default behavior for worker nodes:

  Before PR #5491:
  - NODE_SIZING_ENABLED=false (autosizing disabled by default)
  - System reserved memory: 1GB (static)

  After PR #5491:
  - NODE_SIZING_ENABLED=true (autosizing enabled by default for non-Hypershift clusters)
  - System reserved memory: ~2GB (dynamically calculated)

  The test at kubeletcfg_test.go:165-173 made an invalid assumption:
  1. It assumed nodes start with autosizing disabled
  2. It expected applying AutoSizingReserved: true to enable autosizing for the first time
  3. It expected this state change to alter allocatable memory

**What actually happens now:**
  1. Worker nodes already have autosizing enabled by default
  2. Test applies AutoSizingReserved: true → no state change (already enabled)
  3. Allocatable memory stays the same → assertion fails ❌

**Solution**
  I removed the allocatable memory assertion
 

Related: https://github.com/openshift/machine-config-operator/pull/5491

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
