### PR TITLE
[release-4.20] OCPBUGS-73776: Fix timeout during configMap cleanup

### DIFF
--- a/test/e2e-ocl/helpers_test.go
+++ b/test/e2e-ocl/helpers_test.go
@@ -313,7 +313,7 @@ func cleanupEphemeralBuildObjects(t *testing.T, cs *framework.ClientSet) {
 	moscList, err := cs.MachineconfigurationV1Interface.MachineOSConfigs().List(context.TODO(), metav1.ListOptions{})
 	require.NoError(t, err)
 
-	kubeassert := helpers.AssertClientSet(t, cs).WithContext(context.TODO())
+	kubeassert := helpers.AssertClientSet(t, cs).WithTimeout(10 * time.Minute)
 
 	if len(secretList.Items) == 0 {
 		t.Logf("No build-time secrets to clean up")

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -903,7 +903,7 @@ func getRPMOStreeStatusForNode(cs *framework.ClientSet, node corev1.Node) (*rpmo
 func getBootedRPMOstreeDeployment(cs *framework.ClientSet, node corev1.Node) (*rpmostreeclient.Deployment, error) {
 	var status *rpmostreeclient.Status
 
-	backoff := wait.Backoff{Duration: 10 * time.Second, Steps: 36} // ~6 min
+	backoff := wait.Backoff{Duration: 10 * time.Second, Steps: 60} // ~10 min
 	// retry until rpm-ostree status succeeds
 	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		var err error


### PR DESCRIPTION
The configMap cleanup would end up stuck due to
the way the timeout was specified, this fixes that.

Also update timeout for rpm-ostree status check.

This is a cherrypick of https://github.com/openshift/machine-config-operator/pull/5544 with an additional timeout bump needed to make the e2e-ocl test suite pass.
