### PR TITLE
OCPBUGS-73884: pkg/controller/container-runtime-config: admin_ack handling for 4.20-to-4.21 OCI mirror requirement

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -102,6 +102,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		ctrlctx.InformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
@@ -214,6 +215,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.ConfigInformerFactory.Config().V1().Images(),
 			ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
 			ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),
+			ctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
 			ctx.ConfigInformerFactory,
 			ctx.OperatorInformerFactory.Operator().V1alpha1().ImageContentSourcePolicies(),
 			ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),

--- a/pkg/controller/container-runtime-config/admin_ack.go
+++ b/pkg/controller/container-runtime-config/admin_ack.go
@@ -1,0 +1,68 @@
+package containerruntimeconfig
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	SigstoreKey = "ack-4.20-sigstore-in-4.21"
+	SigstoreMsg = "This cluster has mirrors configured. 4.21 will require Sigstore signatures for quay.io/openshift-release-dev/ocp-release release verification. Please ensure that any registries configured as mirrors of quay.io/openshift-release-dev/ocp-release images contain the Sigstore signature images associated with any release images before updating to 4.21. See https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/nodes-sigstore-using.html#nodes-sigstore-prepare-for-4.21_nodes-sigstore-using for more details."
+
+	AdminAckGatesConfigMapName = "admin-gates"
+)
+
+// Syncs the admin-ack configmap in the openshift-config-managed namespace, and adds MCO specific keys if needed.
+func (ctrl *Controller) syncAdminAckConfigMap(ctx context.Context, hasMirrorConfig bool) error {
+	cm, err := ctrl.ocManagedConfigMapLister.ConfigMaps(ctrlcommon.OpenshiftConfigManagedNamespace).Get(AdminAckGatesConfigMapName)
+	if err != nil {
+		return fmt.Errorf("error fetching configmap %s during sync: %w", AdminAckGatesConfigMapName, err)
+	}
+
+	newCM := cm.DeepCopy()
+
+	updateGuardKeyIfNeeded(hasMirrorConfig, SigstoreKey, SigstoreMsg, newCM)
+
+	// Only send an API request if an update is needed
+	if !reflect.DeepEqual(cm.Data, newCM.Data) {
+		_, err = ctrl.kubeClient.CoreV1().ConfigMaps(ctrlcommon.OpenshiftConfigManagedNamespace).Update(ctx, newCM, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("error updating configmap %s during sync: %w", AdminAckGatesConfigMapName, err)
+		}
+		klog.Infof("%s configmap update successful", newCM.Name)
+	}
+
+	return nil
+}
+
+// updateGuardKeyIfNeeded adds a key with a message depending on:
+// If guard is needed, the key exists, and the message diverges from the expected message => update the message
+// If guard is needed and key exists, and the message matches the expected message => nothing to do
+// If guard is needed and key doesn't exist => create it
+// If guard is not needed and key exists => delete it
+// If guard is not needed and key doesn't exist => nothing to do
+func updateGuardKeyIfNeeded(guardNeeded bool, key, msg string, cm *corev1.ConfigMap) {
+	keyExists := cm.Data != nil && cm.Data[key] != ""
+	if guardNeeded {
+		if keyExists && msg != cm.Data[key] {
+			klog.Infof("Updating key %s in configmap %s from %q to %q", key, cm.Name, cm.Data[key], msg)
+			cm.Data[key] = msg
+		} else if !keyExists {
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+			cm.Data[key] = msg
+			klog.Infof("Adding key %s to configmap %s", key, cm.Name)
+		}
+	} else if keyExists {
+		delete(cm.Data, key)
+		klog.Infof("Deleting key %s from configmap %s", key, cm.Name)
+	}
+}

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -22,7 +22,7 @@ func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
 				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
 			}
 			// ctrcfg for bootstrap mode
-			cm := newConfigMap("crio-default-ulimits")
+			cm := newConfigMap(ctrlcommon.MCONamespace, "crio-default-ulimits")
 			ctrcfg := newContainerRuntimeConfig("log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 
 			f.ccLister = append(f.ccLister, cc)

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -468,6 +468,7 @@ func newTestFixture(t *testing.T, cfg *rest.Config, objs []runtime.Object) *fixt
 	ctrlctx.InformerFactory.Start(ctrlctx.Stop)
 	ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
 	ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+	ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
 	ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
 	ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
 
@@ -522,6 +523,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.ConfigInformerFactory.Config().V1().Images(),
 			ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
 			ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),
+			ctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
 			ctx.ConfigInformerFactory,
 			ctx.OperatorInformerFactory.Operator().V1alpha1().ImageContentSourcePolicies(),
 			ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),


### PR DESCRIPTION
Similar to #5027's boot-image handling, but in the machine-config controller that handles mirror management this time, instead of 4.18's guard which lived in the machine-config operator.

## What I did

Added a new admin-ack gate to 4.20 clusters that configure mirroring, to warn them about 4.21's requirement for `quay.io/openshift-release-dev/ocp-release` release image Sigstore signatures (openshift/cluster-update-keys#89).

## How to test

Configure any ImageContentSourcePolicy or ImageDigestMirrorSet.  See that the machine-config controller injects an `ack-4.20-oci-registry-in-4.21` gate into the `admin-gates` ConfigMap in the `openshift-config-managed` Namespace.  Eventually existing cluster-version-operator logic will propagate that gate into ClusterVersion's `Upgradeable` condition.

While the `ack-4.20-oci-registry-in-4.21` gate is set in the ConfigMap, bump the message.  The machine-config controller should stomp it back to the canonical message.

Remove all ImageContentSourcePolicy and ImageDigestMirrorSets.  See that the machine-config controller removes the `ack-4.20-oci-registry-in-4.21` from the ConfigMap.  Same CVO propagation, although if there are no other `Upgradeable` concerns, the CVO will report that by removing the `Upgradeable` condition from ClusterVersion (sometimes folks are confused that it isn't explicitly set `Upgradeable=True` there).

While the `ack-4.20-oci-registry-in-4.21` gate not set in the ConfigMap, manually inject it.  The machine-config controller should stomp it back off by removing the gate.

##  Description for the changelog

The 4.20 machine-config controller now manages an admin ack to warn cluster administrators with mirror configurations about OCI mirror requirements coming in 4.21.
