### PR TITLE
[release-4.21] OCPBUGS-71196: Enable existing units without content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -260,7 +260,7 @@ require (
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb // indirect
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
-	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09
 	github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.5 // indirect

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/clarketm/json"
 	"github.com/coreos/go-semver/semver"
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2111,6 +2112,10 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 	var disabledUnits []string
 
 	isCoreOSVariant := dn.os.IsCoreOSVariant()
+	systemdUnits, err := dn.listSystemdUnits()
+	if err != nil {
+		return err
+	}
 
 	for _, u := range units {
 		if err := writeUnit(u, pathSystemd, isCoreOSVariant); err != nil {
@@ -2132,7 +2137,8 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 		if u.Enabled != nil {
 			// Only when a unit has contents should we attempt to enable or disable it.
 			// See: https://issues.redhat.com/browse/OCPBUGS-56648
-			if unitHasContent(u) {
+			_, unitExists := systemdUnits[u.Name]
+			if unitHasContent(u) || unitExists {
 				if *u.Enabled {
 					enabledUnits = append(enabledUnits, u.Name)
 				} else {
@@ -2164,6 +2170,28 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 		}
 	}
 	return nil
+}
+
+func (dn *Daemon) listSystemdUnits() (result map[string]systemddbus.UnitStatus, err error) {
+	conn, err := systemddbus.NewSystemdConnectionContext(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to system bus to list units: %w", err)
+	}
+	defer func() {
+		conn.Close()
+	}()
+
+	units, err := conn.ListUnitsContext(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list systemd units: %w", err)
+	}
+
+	result = make(map[string]systemddbus.UnitStatus)
+	for _, unit := range units {
+		result[unit.Name] = unit
+	}
+	return result, nil
+
 }
 
 // writeFiles writes the given files to disk.


### PR DESCRIPTION
Fixed: [OCPBUGS-71196](https://issues.redhat.com/browse/OCPBUGS-71196)

**- What I did**

This is a manual cherry-pick of the fixes introduced for OCPBUGS-72396  and OCPBUGS-70259.

Check if a systemd unit exists on the system before attempting to enable or disable it, even when the unit has no content in the MachineConfig. This prevents errors when managing pre-existing system units.

**- How to verify it**

1. Deploy a 4.21 cluster with this change.
2. Ensure the kdump service is disabled in the worker nodes (it's disabled by default).
3. Apply the following MC:
```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 99-worker-custom-enable-kdump
spec:
  config:
    ignition:
      version: 3.1.0
    systemd:
      units:
      - enabled: true
        name: kdump.service  
```
4. Wait for the worker MCP to finish the update.
5. Check on a worker node that the kdump service is now enabled.

**- Description for the changelog**

Ensure OS provided units can be enabled with empty Ignition units.
