### PR TITLE
OCPBUGS-73802: Fix up bootstrap-e2e

### DIFF
--- a/pkg/controller/bootstrap/testdata/bootstrap/cluster-image-policy.yaml
+++ b/pkg/controller/bootstrap/testdata/bootstrap/cluster-image-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterImagePolicy
+metadata:
+  creationTimestamp: null
+  name: openshift
+spec:
+  policy:
+    rootOfTrust:
+      policyType: PublicKey
+      publicKey: #using public key from https://docs.sigstore.dev/cosign/verifying/verify
+        keyData: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFTGlnQ25sTE5LZ09nbFJUeDFEN0poSTdlUnc5OQpRb2xFOUpvNFFVeG5iTXk1blV1QkwrVVpGOXFxZm0vRGcxQk5lSFJUaEh6V2gya2k5dkFFZ1dFRE93PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==
+  scopes:
+  - quay.io/openshift-release-dev/ocp-release


### PR DESCRIPTION
  This PR improves the bootstrap e2e test framework with several fixes and enhancements:                                                                              
                                                                                                                                                                     
  Test Framework (test/framework/envtest.go)                                                                                                                          
  - Add -p path flag to setup-envtest command to correctly output the binary assets path                                                                              
  - Clean up CRD paths, removing redundant entries                                                                                                                    
  - Add support for ClusterImagePolicy and MachineOSConfig resources in CheckCleanEnvironment, CleanEnvironment, and CreateObjects functions                          
                                                                                                                                                                      
  Bootstrap Test (test/e2e-bootstrap/bootstrap_test.go)                                                                                                               
  - Add mcfgv1alpha1 scheme registration for MachineOSConfig support                                                                                                  
  - Rename verifyNodeSizingEnabled to verifyNodeSizing with an enabled parameter to support testing both enabled and disabled states                                  
  - Explicitly disable OSStreams feature gate in tests (requires RHEL images with specific metadata that are not publicly accessible)                                 
  - Add proper error handling for ignition config unmarshalling                                                                                                       
                                                                                                                                                                      
  Test Fixtures                                                                                                                                                       
  - Add cluster-image-policy.yaml test fixture with a valid public key from https://docs.sigstore.dev/cosign/verifying/verify                                         
