### PR TITLE
CORS-3849,OCPBUGS-76279: Enable hosts plugin within the CoreDNS Corefile for cloud platforms

### DIFF
--- a/manifests/cloud-platform-alt-dns/coredns-corefile.tmpl
+++ b/manifests/cloud-platform-alt-dns/coredns-corefile.tmpl
@@ -33,4 +33,7 @@
         match ^api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
+    hosts {
+        fallthrough
+    }
 }

--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -55,6 +55,9 @@ spec:
     - name: manifests
       mountPath: "/opt/openshift/manifests"
       mountPropagation: HostToContainer
+    - name: hosts-dir
+      mountPath: "/etc/hosts"
+      mountPropagation: HostToContainer
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns
@@ -71,6 +74,8 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
+    - name: hosts-dir
+      mountPath: "/etc/hosts"
     livenessProbe:
       httpGet:
         path: /health

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -28,6 +28,9 @@ contents:
       - name: nm-resolv
         hostPath:
           path: "/var/run/NetworkManager"
+      - name: hosts-dir
+        hostPath:
+          path: "/etc/hosts"
       initContainers:
       - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -59,6 +62,9 @@ contents:
         - name: conf-dir
           mountPath: "/etc/coredns"
           mountPropagation: HostToContainer
+        - name: hosts-dir
+          mountPath: "/etc/hosts"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
       containers:
@@ -74,6 +80,8 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
+        - name: hosts-dir
+          mountPath: "/etc/hosts"
         livenessProbe:
           httpGet:
             path: /health
@@ -120,6 +128,9 @@ contents:
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
           mountPropagation: HostToContainer 
+        - name: hosts-dir
+          mountPath: "/etc/hosts"
+          mountPropagation: HostToContainer
         imagePullPolicy: IfNotPresent        
       hostNetwork: true
       tolerations:


### PR DESCRIPTION
Update the CoreDNS Corefile for cloud platforms to enable the hosts plugin. This change enables all entries within the /etc/hosts file to be loaded and served via the DNS service provided by the cluster's coreDNS instance on both the bootstrap and control plane nodes. Used CoreDNS documentation [0] for reference.

This feature was requested by ARO but we feel that the hosts plugin should be enabled on all cloud platforms (GCP, AWS and Azure) at all times and not just when run within ARO.

[0] - https://coredns.io/plugins/hosts/#examples