### PR TITLE
AGENT-1424: add initial e2e tests for the InternalReleaseImage controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,9 @@ test-e2e-ocl: install-go-junit-report install-skopeo
 	# Temporarily include /tmp/skopeo/bin in our PATH variable so that the test suite can find skopeo.
 	set -o pipefail; PATH="$(PATH):/tmp/skopeo/bin" go test -tags=$(GOTAGS) -failfast -timeout 190m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-ocl/ | ./hack/test-with-junit.sh $(@)
 
+test-e2e-iri: install-go-junit-report
+	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-iri/ | ./hack/test-with-junit.sh $(@)
+
 bootstrap-e2e: install-go-junit-report install-setup-envtest
 	@echo "Setting up KUBEBUILDER_ASSETS"
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --index https://raw.githubusercontent.com/openshift/api/master/envtest-releases.yaml --bin-dir $(PROJECT_DIR)/bin -p path)" && \

--- a/test/e2e-iri/README.md
+++ b/test/e2e-iri/README.md
@@ -1,0 +1,5 @@
+# e2e IRI tests
+
+This test package should be used for testing the behaviors of the InternalReleaseImage controller.
+Currently it is deployed as part of the Agent Installer for OpenShift-Virt (OVE) - and specifically for the NoRegistryClusterInstall feature.
+To run the tests, deploy first a baremetal cluster using the OVE ISO.

--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -1,0 +1,190 @@
+package e2e_iri_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/test/framework"
+)
+
+func TestIRIResource_Available(t *testing.T) {
+	cs := framework.NewClientSet("")
+	ctx := context.Background()
+
+	// Check that the initial InternalReleaseImage resource has been installed.
+	_, err := cs.InternalReleaseImages().Get(ctx, "cluster", v1.GetOptions{})
+	require.NoError(t, err)
+
+	// Verify that the expected MachineConfigs have been created.
+	_, err = cs.MachineConfigs().Get(ctx, "02-master-internalreleaseimage", v1.GetOptions{})
+	require.NoError(t, err)
+	_, err = cs.MachineConfigs().Get(ctx, "02-worker-internalreleaseimage", v1.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestIRIController_VerifyIRIRegistryOnAllTheMasterNodes_NoCert(t *testing.T) {
+	masterNodes, err := framework.NewClientSet("").CoreV1Interface.Nodes().List(context.TODO(), v1.ListOptions{LabelSelector: "node-role.kubernetes.io/master="})
+	require.NoError(t, err)
+
+	// For every control plane node, ping the IRI registry at port 22625,
+	// using directly the node IP.
+	for _, node := range masterNodes.Items {
+		nodeAddr := ""
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				nodeAddr = addr.Address
+				break
+			}
+		}
+		require.NotEmpty(t, nodeAddr)
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+			Timeout: 30 * time.Second,
+		}
+		pingIRIRegistry(t, client, nodeAddr)
+	}
+}
+
+func skipIfNoBaremetal(t *testing.T) {
+	infra, err := framework.NewClientSet("").Infrastructures().Get(context.Background(), "cluster", v1.GetOptions{})
+	require.NoError(t, err)
+	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
+		t.Skip("Skipping non-baremetal platforms")
+	}
+}
+
+func TestIRIController_VerifyIRIRegistryOnApiInt_WithCert(t *testing.T) {
+	cs := framework.NewClientSet("")
+	ctx := context.Background()
+
+	skipIfNoBaremetal(t)
+
+	// Retrieve the root CA (same of MCS).
+	cm, err := cs.ConfigMaps("openshift-machine-config-operator").Get(ctx, "machine-config-server-ca", v1.GetOptions{})
+	require.NoError(t, err)
+	rootCA := []byte(cm.Data["ca-bundle.crt"])
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM(rootCA))
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: roots,
+			},
+		},
+		Timeout: 30 * time.Second,
+	}
+
+	// The api-int DNS entry may be not resolvable in the current environment.
+	// Let's fetch directly the related IP address.
+	infra, err := cs.Infrastructures().Get(ctx, "cluster", v1.GetOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs)
+
+	pingIRIRegistry(t, client, infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs[0])
+}
+
+func pingIRIRegistry(t *testing.T, client *http.Client, ipAddr string) {
+	iriRegistryUrl := fmt.Sprintf("https://%s:%d/v2/", ipAddr, 22625)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, iriRegistryUrl, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, resp.StatusCode, http.StatusOK)
+	apiVersion := resp.Header.Get("Docker-Distribution-Api-Version")
+	require.Equal(t, apiVersion, "registry/2.0")
+}
+
+func TestIRIController_ShouldRestoreMachineConfigsWhenModified(t *testing.T) {
+	cases := []struct {
+		name       string
+		userAction func(t *testing.T, ctx context.Context, cs *framework.ClientSet, configs []*mcfgv1.MachineConfig)
+	}{
+		{
+			name: "user deletes all the IRI machine configs",
+			userAction: func(t *testing.T, ctx context.Context, cs *framework.ClientSet, configs []*mcfgv1.MachineConfig) {
+				// Delete all the IRI MachineConfigs found.
+				for _, mc := range configs {
+					err := cs.MachineConfigs().Delete(ctx, mc.Name, v1.DeleteOptions{})
+					require.NoError(t, err)
+				}
+			},
+		},
+		{
+			name: "user patches all the IRI machine configs",
+			userAction: func(t *testing.T, ctx context.Context, cs *framework.ClientSet, configs []*mcfgv1.MachineConfig) {
+				// Update all the IRI MachineConfigs found.
+				for _, mc := range configs {
+					updatedMC := mc.DeepCopy()
+					updatedMC.Spec.OSImageURL = "some-unused-value"
+					_, err := cs.MachineConfigs().Update(ctx, updatedMC, v1.UpdateOptions{})
+					require.NoError(t, err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := framework.NewClientSet("")
+			ctx := context.Background()
+
+			// Check that initially IRI MachineConfigs are defined.
+			machineConfigs, err := cs.MachineConfigs().List(ctx, v1.ListOptions{})
+			require.NoError(t, err)
+			iriMachineConfigs := []*mcfgv1.MachineConfig{}
+			for _, mc := range machineConfigs.Items {
+				if len(mc.OwnerReferences) != 0 && mc.OwnerReferences[0].Kind == "InternalReleaseImage" && mc.OwnerReferences[0].Name == "cluster" {
+					iriMachineConfigs = append(iriMachineConfigs, mc.DeepCopy())
+				}
+			}
+			require.NotEmpty(t, iriMachineConfigs)
+
+			// Apply the user action.
+			tc.userAction(t, ctx, cs, iriMachineConfigs)
+
+			// Wait until all of them will be restored.
+			err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+				for _, oldMC := range iriMachineConfigs {
+					newMC, err := cs.MachineConfigs().Get(ctx, oldMC.Name, v1.GetOptions{})
+					if k8serrors.IsNotFound(err) {
+						return false, nil
+					}
+					if err != nil {
+						return true, err
+					}
+					// Check that the ignition is really the same.
+					oldIgn, err := ctrlcommon.ParseAndConvertConfig(oldMC.Spec.Config.Raw)
+					require.NoError(t, err)
+					newIgn, err := ctrlcommon.ParseAndConvertConfig(newMC.Spec.Config.Raw)
+					require.NoError(t, err)
+					if !reflect.DeepEqual(oldIgn, newIgn) {
+						return true, fmt.Errorf("newer version of MachineConfig %s is different from the original one.", oldMC.Name)
+					}
+				}
+				return true, nil
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/test/e2e-iri/main_test.go
+++ b/test/e2e-iri/main_test.go
@@ -1,0 +1,44 @@
+package e2e_iri_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/openshift/api/features"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/machine-config-operator/test/framework"
+)
+
+func TestMain(m *testing.M) {
+	skip, err := skipIRITests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "skip IRI check failed: %v\n", err)
+		os.Exit(1)
+	}
+	if skip {
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func skipIRITests() (bool, error) {
+	cs := framework.NewClientSet("")
+	ctx := context.Background()
+
+	// Check if NoRegistryClusterInstall feature is enabled.
+	fg, err := cs.FeatureGates().Get(ctx, "cluster", v1.GetOptions{})
+	if err != nil {
+		return true, err
+	}
+	// Assume only one version has been installed.
+	for _, d := range fg.Status.FeatureGates[0].Disabled {
+		if d.Name == features.FeatureGateNoRegistryClusterInstall {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
**- What I did**
Added new set of e2e tests for the InternalReleaseImage controller

**- How to verify it**
- Deploy an OVE ISO based cluster. 
- Run `make e2e-iri` to run the tests

**- Description for the changelog**
-