### PR TITLE
OCPEDGE-2216: feat: increase reserved memory for tnf masters

### DIFF
--- a/templates/master/00-master/two-node-with-fencing/files/kubelet-auto-node-sizing-enabled.yaml
+++ b/templates/master/00-master/two-node-with-fencing/files/kubelet-auto-node-sizing-enabled.yaml
@@ -1,0 +1,8 @@
+mode: 0644
+path: "/etc/node-sizing-enabled.env"
+contents:
+  inline: |
+    NODE_SIZING_ENABLED=false
+    SYSTEM_RESERVED_MEMORY=1536Mi
+    SYSTEM_RESERVED_CPU=500m
+    SYSTEM_RESERVED_ES=1Gi


### PR DESCRIPTION
during upgrades one master will take on more activity, we're noticing more of these alerts for two node fencing upgrades, we have some extra services that might be pushing more pressure on the 1GB reserved system memory, increasing to 1.5GB to account increased system load during fencing operations. Kube resources don't support decimals, so using 1536Mi.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Updated reserved memory amount for TNF to resolve https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/SystemMemoryExceedsReservation.md

**- How to verify it**

Upgrade pipeline should not result in alert firing.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
