### PR TITLE
OCPBUGS-74368: Stale operator metrics Service and ServiceMonitor resources need to be deleted

### DIFF
--- a/install/0000_90_machine-config_90_deletion.yaml
+++ b/install/0000_90_machine-config_90_deletion.yaml
@@ -28,3 +28,28 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: Default
     release.openshift.io/delete: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: machine-config-operator
+  namespace: openshift-machine-config-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/feature-set: Default
+    release.openshift.io/delete: "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: machine-config-operator
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: machine-config-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
**- What I did**
Added deletion manifests for the following resources:
  - Service/machine-config-operator in openshift-machine-config-operator namespace                                                                                                      
  - ServiceMonitor/machine-config-operator in namespace openshift-machine-config-operator namespace    

**- How to verify it**

- Create a cluster on 4.20. 
- Verify that these resources exist. 
- Then, upgrade to this PR(based on release-4.21 or main). 
- These resources should be now deleted.
