### PR TITLE
OCPBUGS-74431: CVE-2025-58183 ose-machine-config-operator-container: Unbounded allocation when parsing GNU sparse map [openshift-4.21]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/machine-config-operator
 
-go 1.24.0
+go 1.24.8
 
 require (
 	github.com/Azure/ARO-RP v0.0.0-20250602035759-0693f32d5ccc


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
  Upgraded Go from 1.24.0 to 1.24.8 in go.mod to address CVE-2025-58183, an unbounded memory allocation vulnerability in the archive/tar package used by MCO's image inspection code (pkg/imageutils/layer_reader.go).
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
