### PR TITLE
NO-ISSUE: CPMS test should account for skew API

### DIFF
--- a/test/extended-priv/machineconfiguration.go
+++ b/test/extended-priv/machineconfiguration.go
@@ -82,3 +82,39 @@ func (mc MachineConfiguration) GetAllManagedBootImagesResources() ([]string, err
 	}
 	return strings.Fields(result), nil
 }
+
+// SetManualSkew configures bootImageSkewEnforcement to Manual mode with the specified mode type and version.
+// mode should be "RHCOSVersion" or "OCPVersion", version is the corresponding version string.
+func (mc MachineConfiguration) SetManualSkew(mode, version string) error {
+	logger.Infof("Setting .spec.bootImageSkewEnforcement to Manual mode (%s: %s) on %s", mode, version, mc)
+	var versionField string
+	switch mode {
+	case "RHCOSVersion":
+		versionField = `"rhcosVersion":"` + version + `"`
+	case "OCPVersion":
+		versionField = `"ocpVersion":"` + version + `"`
+	default:
+		versionField = `"rhcosVersion":"` + version + `"`
+	}
+	return mc.Patch("merge", `{"spec":{"bootImageSkewEnforcement":{"mode":"Manual","manual":{"mode":"`+mode+`",`+versionField+`}}}}`)
+}
+
+// SetNoneSkew configures bootImageSkewEnforcement to None mode, effectively disabling skew enforcement
+func (mc MachineConfiguration) SetNoneSkew() error {
+	logger.Infof("Setting .spec.bootImageSkewEnforcement to None mode on %s", mc)
+	return mc.Patch("merge", `{"spec":{"bootImageSkewEnforcement":{"mode":"None"}}}`)
+}
+
+// RemoveSkew removes the bootImageSkewEnforcement config from MachineConfiguration
+func (mc MachineConfiguration) RemoveSkew() error {
+	logger.Infof("Removing .spec.bootImageSkewEnforcement from %s", mc)
+	skewConfig, err := mc.Get(`{.spec.bootImageSkewEnforcement}`)
+	if err != nil {
+		return err
+	}
+	if skewConfig == "" {
+		logger.Infof(".spec.bootImageSkewEnforcement does not exist. No need to remove it")
+		return nil
+	}
+	return mc.Patch("json", `[{ "op": "remove", "path": "/spec/bootImageSkewEnforcement"}]`)
+}

--- a/test/extended-priv/mco_controlplanemachineset.go
+++ b/test/extended-priv/mco_controlplanemachineset.go
@@ -410,6 +410,23 @@ func testMachineConfigurationStatusUpdate(mc *MachineConfiguration, patchConfig 
 
 	originalSpec := mc.GetSpecOrFail()
 	defer mc.SetSpec(originalSpec)
+
+	// Disable skew enforcement for the test to avoid boot image configurations causing conflicts
+	o.Expect(mc.SetNoneSkew()).To(o.Succeed(), "Error disabling skew enforcement on %s", mc)
+
+	// Wait for the controller to observe and process the spec change
+	o.Eventually(func() (bool, error) {
+		generation, err := mc.Get(`{.metadata.generation}`)
+		if err != nil {
+			return false, err
+		}
+		observedGeneration, err := mc.Get(`{.status.observedGeneration}`)
+		if err != nil {
+			return false, err
+		}
+		return generation == observedGeneration, nil
+	}, "2m", "10s").Should(o.BeTrue(), "MachineConfiguration observedGeneration did not catch up to generation")
+
 	originalStatus, err := mc.GetManagedBootImagesStatus()
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting original status from %s", mc)
 	logger.Infof("Original status: %s", originalStatus)


### PR DESCRIPTION
**- What I did**
Added a skew enforcement disable call prior to running the actual test case. This is so that when status population lands via the MVP(https://github.com/openshift/machine-config-operator/pull/5428), this test would not break.

**- How to verify it**
The mco disruptive suite for this test should continue to pass.

