### PR TITLE
OCPBUGS-20561: machine-config-daemon: openshift: Exposure of Sensitive Data in Log Files in the Machine Configuration Daemon. [openshift-4]

### DIFF
--- a/pkg/daemon/on_disk_validation.go
+++ b/pkg/daemon/on_disk_validation.go
@@ -8,7 +8,6 @@ import (
 
 	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
-	"github.com/google/go-cmp/cmp"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -248,7 +247,9 @@ func checkFileContentsAndMode(filePath string, expectedContent []byte, mode os.F
 		return fmt.Errorf("could not read file %q: %w", filePath, err)
 	}
 	if !bytes.Equal(contents, expectedContent) {
-		klog.Errorf("content mismatch for file %q (-want +got):\n%s", filePath, cmp.Diff(expectedContent, contents))
+		// Removing file contents logs to prevent accidental exposure of secrets.
+		klog.Errorf("content mismatch for file %q (expected %d bytes, got %d bytes)",
+			filePath, len(expectedContent), len(contents))
 		return fmt.Errorf("content mismatch for file %q", filePath)
 	}
 	return nil


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

- What I did

Fixed a security vulnerability where MCD logs exposed sensitive file contents during config drift detection.

When checkFileContentsAndMode() detected a content mismatch, it logged the full diff using cmp.Diff(expectedContent, contents). This exposed sensitive data in pod logs, including:

Pull secrets (/var/lib/kubelet/config.json)
Kubelet certificates (/var/lib/kubelet/pki/*.pem)
CA certificates (/etc/kubernetes/kubelet-ca.crt)
SSH keys
Any other secrets managed by MachineConfig

- How to verify it

Admins can still identify which file has drift and manually inspect it on the node if needed, but secrets never appear in logs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
