### PR TITLE
NO-JIRA: Pass TAGS argument to the machine-config-controller image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export GOPROXY=https://proxy.golang.org
 # this is necessary for running golangci-lint in a container
 export GOLANGCI_LINT_CACHE=$(shell echo $${GOLANGCI_LINT_CACHE:-$$GOPATH/cache})
 
-GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
+GOTAGS = "containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub $(TAGS)"
 
 all: binaries
 

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -37,9 +37,5 @@ fi
 
 mkdir -p ${BIN_PATH}
 
-if [[ $WHAT == "machine-config-controller" ]]; then
-    GOTAGS="containers_image_openpgp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
-fi
-
 echo "Building ${REPO}/${WHAT_PATH} (${VERSION_OVERRIDE}, ${HASH}) for $GOOS/$GOARCH"
 GOOS=${GOOS} GOARCH=${GOARCH} go build -mod=vendor -tags="${GOTAGS}" -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${WHAT} ${REPO}/${WHAT_PATH}

--- a/hack/build-image
+++ b/hack/build-image
@@ -41,6 +41,10 @@ else:
 
 print(f"HEAD commit: {gitrev}")
 args = [podman, 'build', '-t', imgname, '--no-cache', '.']
+# Check if TAGS environment variable is set and pass it as a build argument
+tags = os.environ.get('TAGS')
+if tags:
+    args.extend(['--build-arg', f'TAGS={tags}'])
 # Check if AUTHFILE environment variable is set. Setting this allows the user to specify which file to use
 # for the authentication when building the image
 authfile = os.environ.get('AUTHFILE')


### PR DESCRIPTION
TechPreview jobs for OKD are failing with:

```
error running MCC[BOOTSTRAP]: error inspecting available OSImageStreams: unable to retrieve any OSImageStream from the configured sources
```
which shouldn't be the case as the OSImageStreams feature should not be enabled for OKD

Turns out the TAGS=scos wasn't passed in for the machine-config-controller build