### PR TITLE
OCPBUGS-74692: Write all units when forcefile exists to recover from systemd unit config drift

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1025,6 +1025,9 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 
 	var nodeDisruptionActions []opv1.NodeDisruptionPolicyStatusAction
 	var actions []string
+	// Check for forcefile before calculatePostConfigChange* functions delete it.
+	// This is needed for updateFiles to know whether to write all units (OCPBUGS-74692).
+	forceFilePresent := forceFileExists()
 	// Node Disruption Policies cannot be used during firstboot as API is not accessible.
 	if !firstBoot {
 		nodeDisruptionActions, err = dn.calculatePostConfigChangeNodeDisruptionAction(diff, diffFileSet, allChangedUnitNames)
@@ -1133,13 +1136,13 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 	}
 
 	// update files on disk that need updating
-	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, skipCertificateWrite); err != nil {
+	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, skipCertificateWrite, forceFilePresent); err != nil {
 		return err
 	}
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, skipCertificateWrite); err != nil {
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, skipCertificateWrite, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1277,15 +1280,18 @@ func (dn *Daemon) updateHypershift(oldConfig, newConfig *mcfgv1.MachineConfig, d
 	unitDiff := ctrlcommon.GetChangedConfigUnitsByType(&oldIgnConfig, &newIgnConfig)
 	addedOrChangedUnits := slices.Concat(unitDiff.Added, unitDiff.Updated)
 
+	// Check for forcefile to support config drift recovery (OCPBUGS-74692)
+	forceFilePresent := forceFileExists()
+
 	// update files on disk that need updating
 	// We should't skip the certificate write in HyperShift since it does not run the extra daemon process
-	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, false); err != nil {
+	if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, false, forceFilePresent); err != nil {
 		return err
 	}
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, false); err != nil {
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, false, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1810,12 +1816,26 @@ func (dn *CoreOSDaemon) getKernelPackagesForTargetRelease() (releaseKernelPackag
 // whatever has been written is picked up by the appropriate daemons, if
 // required. in particular, a daemon-reload and restart for any unit files
 // touched.
-func (dn *Daemon) updateFiles(oldIgnConfig, newIgnConfig ign3types.Config, addedOrChangedUnits []ign3types.Unit, skipCertificateWrite bool) error {
+func (dn *Daemon) updateFiles(oldIgnConfig, newIgnConfig ign3types.Config, addedOrChangedUnits []ign3types.Unit, skipCertificateWrite, forceFilePresent bool) error {
 	klog.Info("Updating files")
 	if err := dn.writeFiles(newIgnConfig.Storage.Files, skipCertificateWrite); err != nil {
 		return err
 	}
-	if err := dn.writeUnits(addedOrChangedUnits); err != nil {
+
+	// With OCPBUGS-58023, we updated this flow to only write units that were either added or
+	// updated. As can be seen in OCPBUGS-74692, this impacted the traditional method to recover
+	// from config drifts with systemd units. It makes the `touch /run/machine-config-daemon-force`
+	// command useless since the new flow does not rewrite all files, only the ones that have been
+	// added or changed with the latest MC. To keep the fix for OCPBUGS-58023 and allow continue
+	// supporting the traditional config drift recovery for systemd units, all units should be
+	// written when a forcefile exists.
+	unitsToWrite := addedOrChangedUnits
+	if forceFilePresent {
+		klog.Info("Forcefile exists, writing all units")
+		unitsToWrite = newIgnConfig.Systemd.Units
+	}
+
+	if err := dn.writeUnits(unitsToWrite); err != nil {
 		return err
 	}
 	return dn.deleteStaleData(oldIgnConfig, newIgnConfig)


### PR DESCRIPTION
Closes: OCPBUGS-74692

**- What I did**

This updates the flow for writing systemd units to write all units when a forcefile is present. This allows the fix introduced in https://github.com/openshift/machine-config-operator/pull/5582, which updates the flow to only write new or updated units, to persist while keeping the legacy configuration drift recovery as described in OCPBUGS-74692.

**- How to verify it**
Check that the fix for OCPBUGS-58023 still works (see https://github.com/openshift/machine-config-operator/pull/5148#issuecomment-3106598580).

For verifying OCPBUGS-74692:
1. Apply an MC to create a dropin file.
```
oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: drifted-dropins-test
spec:
  config:
    ignition:
      version: 3.5.0
    systemd:
      units:
        - dropins:
            - contents: '[Service]

                Environment="FAKE_OPTS=fake-value"'
              name: 10-chrony-drop-test.conf
          enabled: true
          name: chronyd.service
EOF
```
2. Manually edit the dropin file to force a config drift.
```
$ oc debug node/ip-10-0-106-195.us-west-2.compute.internal
  # chroot /host
  # nano /etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf
```
3. Wait for the MCP to be degraded due to the config drift.
```
$ oc get mcp
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
...
worker   rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa   False     True       True       3              2                   2                     1                      95m
$ oc describe mcp worker
Name:         worker
...
Status:
...
  Conditions:
    Last Transition Time:  2026-02-03T17:22:05Z
    Message:               
    Reason:                
    Status:                False
    Type:                  Updated
...
    Last Transition Time:  2026-02-03T17:22:05Z
    Message:               Node ip-10-0-106-195.us-west-2.compute.internal is reporting: "Node ip-10-0-106-195.us-west-2.compute.internal upgrade failure. unexpected on-disk state validating against rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\"", Node ip-10-0-106-195.us-west-2.compute.internal is reporting: "unexpected on-disk state validating against rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\""
    Reason:                1 nodes are reporting degraded status on sync
    Status:                True
    Type:                  NodeDegraded
    Last Transition Time:  2026-02-03T17:22:05Z
    Message:               Node ip-10-0-106-195.us-west-2.compute.internal is reporting: "Node ip-10-0-106-195.us-west-2.compute.internal upgrade failure. unexpected on-disk state validating against rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\"", Node ip-10-0-106-195.us-west-2.compute.internal is reporting: "unexpected on-disk state validating against rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa: content mismatch for file \"/etc/systemd/system/chronyd.service.d/10-chrony-drop-test.conf\""
    Reason:                
    Status:                True
    Type:                  Degraded
...
```
4. Run `touch /run/machine-config-daemon-force` on the node to correct the config drift.
```
$ oc debug node/ip-10-0-106-195.us-west-2.compute.internal
  # chroot /host
  # touch /run/machine-config-daemon-force
```
5. Wait for the node & MCP to return to an updated state.
```
$ oc get mcp -w                                           
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
...
worker   rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa   False     True       True       3              2                   2                     1                      100m
worker   rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa   False     True       True       3              2                   2                     1                      103m
worker   rendered-worker-fe6f3c06bdf2750d188bfca93e4f81aa   True      False      False      3              3                   3                     0                      104m
```
**- Description for the changelog**
OCPBUGS-74692: Write all units when forcefile exists to recover from systemd unit config drift