### PR TITLE
MCO-2035: Add a prometheus alert to indicate scaling risk

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -274,6 +274,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
+			ctx.OperatorInformerFactory.Operator().V1().MachineConfigurations(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),
 			ctx.FeatureGatesHandler,

--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -38,7 +38,18 @@ spec:
           annotations:
             summary: "Triggers when nodes in a pool have overlapping labels such as master, worker, and a custom label therefore a choice must be made as to which is honored."
             description: "Node {{ $labels.exported_node }} has triggered a pool alert due to a label change. For more details check MachineConfigController pod logs: oc logs -f -n {{ $labels.namespace }} machine-config-controller-xxxxx -c machine-config-controller"
-            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/MachineConfigControllerPoolAlert.md 
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/MachineConfigControllerPoolAlert.md
+    - name: mcc-boot-image-skew-enforcement-none
+      rules:
+        - alert: MCCBootImageSkewEnforcementNone
+          expr: |
+            mcc_boot_image_skew_enforcement_none == 1
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: info
+          annotations:
+            summary: "Boot image skew enforcement is disabled. Scaling operations may not be successful."
+            description: "Boot image skew enforcement mode is set to None. When scaling up, new nodes may be provisioned with older boot images that could introduce compatibility issues. Consider manually updating boot images to match the cluster version. Please refer to docs at [TODO-INSERTLINK] for additional details."            
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -25,6 +25,15 @@ var (
 			Help: "state of OS image override",
 		}, []string{"pool"})
 
+	// MCCBootImageSkewEnforcementNone indicates when boot image skew enforcement is disabled.
+	// Set to 1 when mode is "None", 0 otherwise. A value of 1 indicates scaling operations may
+	// not be successful
+	MCCBootImageSkewEnforcementNone = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mcc_boot_image_skew_enforcement_none",
+			Help: "Set to 1 when boot image skew enforcement mode is None, indicating scaling may not be successful as bootimages are out of date",
+		})
+
 	// MCCDrainErr logs failed drain
 	MCCDrainErr = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -94,6 +103,7 @@ func RegisterMCCMetrics() error {
 		MCCUpdatedMachineCount,
 		MCCDegradedMachineCount,
 		MCCUnavailableMachineCount,
+		MCCBootImageSkewEnforcementNone,
 	})
 
 	if err != nil {

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -624,6 +624,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
 			ctx.ConfigInformerFactory.Config().V1().Schedulers(),
+			ctx.OperatorInformerFactory.Operator().V1().MachineConfigurations(),
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),
 			ctx.FeatureGatesHandler,


### PR DESCRIPTION
**- What I did**
This PR adds a new Prometheus alert to indicate that scaling may be risky when skew enforcement is set to `None` mode. Node controller seemed to be the logical place to do this since:
  - It runs on all platforms unconditionally unlike the boot image controller                                                                                                                                                                                                              
  - It relates to node scaling operations   

**- How to verify it**
- Launch this PR in `TechPreview` mode. 
- Set skew mode to `None`. A Prometheus alert should appear shortly, indicating scaling risk.
- Set skew mode to `Manual`. The alert should disappear.
 
The following "Automatic" mode portions are only relevant to GCP & AWS at time of writing.
- Set skew mode to `None` so that the alert is triggered again.
- Remove the `None` mode from spec; the controller should now auto-select `Automatic` mode. The alert should disappear.