### PR TITLE
OCPBUGS-75917: ctrcfg: set ShortNameMode disabled when ugprading from 4.20 to 4.21

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -196,6 +196,12 @@ func (b *Bootstrap) Run(destDir string) error {
 	}
 	configs = append(configs, defaultUlimitsConfigs...)
 
+	shortNameModeConfigs, err := containerruntimeconfig.RunShortNameModeBootstrap(pools)
+	if err != nil {
+		return err
+	}
+	configs = append(configs, shortNameModeConfigs...)
+
 	if len(crconfigs) > 0 {
 		containerRuntimeConfigs, err := containerruntimeconfig.RunContainerRuntimeBootstrap(b.templatesDir, crconfigs, cconfig, pools)
 		if err != nil {

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
@@ -22,14 +23,14 @@ func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
 				helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0"),
 			}
 			// ctrcfg for bootstrap mode
-			cm := newConfigMap(ctrlcommon.MCONamespace, "crio-default-ulimits")
+			cms := []runtime.Object{newConfigMap(ctrlcommon.MCONamespace, "crio-default-ulimits"), newConfigMap(ctrlcommon.MCONamespace, "crio-short-name-mode")}
 			ctrcfg := newContainerRuntimeConfig("log-level", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, pools[0])
 			f.mccrLister = append(f.mccrLister, ctrcfg)
 			f.objects = append(f.objects, ctrcfg)
-			f.k8sObjects = append(f.k8sObjects, cm)
+			f.k8sObjects = append(f.k8sObjects, cms...)
 
 			mcs, err := RunContainerRuntimeBootstrap("../../../templates", []*mcfgv1.ContainerRuntimeConfig{ctrcfg}, cc, pools)
 			require.NoError(t, err)

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -464,6 +464,13 @@ func (f *fixture) expectCreateMachineConfigAction(config *mcfgv1.MachineConfig) 
 	f.actions = append(f.actions, core.NewRootCreateAction(schema.GroupVersionResource{Resource: "machineconfigs"}, config))
 }
 
+func (f *fixture) expectGetAndCreateMachineConfigAction(config *mcfgv1.MachineConfig) {
+	f.actions = append(f.actions,
+		core.NewRootGetAction(schema.GroupVersionResource{Resource: "machineconfigs"}, config.Name),
+		core.NewRootCreateAction(schema.GroupVersionResource{Resource: "machineconfigs"}, config),
+	)
+}
+
 func (f *fixture) expectDeleteMachineConfigAction(config *mcfgv1.MachineConfig) {
 	f.actions = append(f.actions, core.NewRootDeleteAction(schema.GroupVersionResource{Resource: "machineconfigs"}, config.Name))
 }
@@ -664,6 +671,8 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			mcs1 := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 			mcs2 := mcs1.DeepCopy()
 			mcs2.Name = ctrCfgKey
 			cm := newConfigMap(ctrlcommon.MCONamespace, defaultContainerRuntimeCMName)
@@ -676,10 +685,10 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			f.objects = append(f.objects, ctrcfg1)
 			f.k8sObjects = append(f.k8sObjects, cm, adminAckGateConfigMap)
 
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectGetMachineConfigAction(mcs1)
@@ -715,6 +724,8 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			mcs := helpers.NewMachineConfig(getManagedKeyCtrCfgDeprecated(mcp), map[string]string{"node-role": "master"}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 			mcsUpdate := mcs.DeepCopy()
 			mcsUpdate.Name = keyCtrCfg
 			cm := newConfigMap(ctrlcommon.MCONamespace, defaultContainerRuntimeCMName)
@@ -727,10 +738,10 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.objects = append(f.objects, ctrcfg1)
 			f.k8sObjects = append(f.k8sObjects, cm, adminAckGateConfigMap)
 
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectGetMachineConfigAction(mcs)
@@ -778,10 +789,10 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 				t.Errorf("syncHandler returned: %v", err)
 			}
 
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectGetMachineConfigAction(mcsUpdate)
@@ -824,6 +835,8 @@ func TestImageConfigCreate(t *testing.T) {
 			mcs2 := helpers.NewMachineConfig(keyReg2, map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 
 			f.ccLister = append(f.ccLister, cc)
 			f.mcpLister = append(f.mcpLister, mcp)
@@ -841,10 +854,10 @@ func TestImageConfigCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectCreateMachineConfigAction(mcs2)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.run("cluster")
 
@@ -1821,6 +1834,8 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 			ctrcfgMC := helpers.NewMachineConfig(ctrMCKey, map[string]string{"node-role/master": ""}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 			cm := newConfigMap(ctrlcommon.MCONamespace, defaultContainerRuntimeCMName)
 			adminAckGateConfigMap := newConfigMap(ctrlcommon.OpenshiftConfigManagedNamespace, AdminAckGatesConfigMapName)
 
@@ -1839,10 +1854,10 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 			require.Equal(t, "1", val)
 
 			// no new machine config will be created
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.expectGetMachineConfigAction(ctrcfgMC)
 			f.expectGetMachineConfigAction(ctrcfgMC)
@@ -1977,6 +1992,8 @@ func TestClusterImagePolicyCreate(t *testing.T) {
 			mcs2 := helpers.NewMachineConfig(keyReg2, map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 
 			clusterimgPolicy := newClusterImagePolicyWithPublicKey("image-policy", []string{"example.com"}, []byte("foo bar"))
 			f.ccLister = append(f.ccLister, cc)
@@ -1998,10 +2015,10 @@ func TestClusterImagePolicyCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 
 			f.expectCreateMachineConfigAction(mcs2)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.run("")
 
@@ -2037,6 +2054,8 @@ func TestSigstoreRegistriesConfigIDMSandCIPCreate(t *testing.T) {
 			mcs2 := helpers.NewMachineConfig(keyReg2, map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 
 			// idms source is the same as cip scope
 			idms := newIDMS("built-in", []apicfgv1.ImageDigestMirrors{
@@ -2063,10 +2082,10 @@ func TestSigstoreRegistriesConfigIDMSandCIPCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 
 			f.expectCreateMachineConfigAction(mcs2)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.run("")
 
@@ -2104,6 +2123,8 @@ func TestImagePolicyCreate(t *testing.T) {
 			mcs2 := helpers.NewMachineConfig(keyReg2, map[string]string{"node-role": "worker"}, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
 			defaultUlimitsmcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-default-ulimits", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs1 := helpers.NewMachineConfig("00-override-master-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
+			shortNameModemcs2 := helpers.NewMachineConfig("00-override-worker-generated-crio-short-name-mode", nil, "dummy://", []ign3types.File{{}})
 
 			imgPolicy := newImagePolicyWithPublicKey("image-policy", "testnamespace", []string{"example.com"}, []byte("namespace foo bar"))
 			f.ccLister = append(f.ccLister, cc)
@@ -2125,10 +2146,10 @@ func TestImagePolicyCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 
 			f.expectCreateMachineConfigAction(mcs2)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs1)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs1)
-			f.expectGetMachineConfigAction(defaultUlimitsmcs2)
-			f.expectCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs1)
+			f.expectGetAndCreateMachineConfigAction(defaultUlimitsmcs2)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs1)
+			f.expectGetAndCreateMachineConfigAction(shortNameModemcs2)
 
 			f.run("")
 


### PR DESCRIPTION
in cri-o 1.33, a change cri-o/cri-o#9401 was made to the short name mode for CRI-O. Now, CRI-O is enforcing short names, which means when an image is unqualified (short name) and has an ambiguous pull path (multiple different names returned), cri-o fails to pull the image.

This may break users however, and so we shouldn't upgrade with it.

We should drop-in an ignition file on upgrades from 4.20 to 4.21 to make sure existing clusters don't get this change, but new clusters started in 4.21 do.

This was entirely based on #5516, which has its own inspiration history

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
