### PR TITLE
OCPBUGS-23418: Machine-config controller should not log about non-existent pull-secret changes

### DIFF
--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -150,10 +150,17 @@ func (ctrl *Controller) addSecret(obj interface{}) {
 	ctrl.filterSecret(secret)
 }
 
-func (ctrl *Controller) updateSecret(_, newSecret interface{}) {
-	secret := newSecret.(*corev1.Secret)
-	klog.V(4).Infof("Update Secret %v", secret)
-	ctrl.filterSecret(secret)
+func (ctrl *Controller) updateSecret(old, newObj interface{}) {
+	oldSecret := old.(*corev1.Secret)
+	newSecret := newObj.(*corev1.Secret)
+
+	klog.V(4).Infof("Update Secret %v", newSecret)
+
+	// Only trigger resync if the secret data actually changed
+	// This prevents log spam from informer resyncs and watch reconnections
+	if !reflect.DeepEqual(oldSecret.Data, newSecret.Data) {
+		ctrl.filterSecret(newSecret)
+	}
 }
 
 func (ctrl *Controller) deleteSecret(obj interface{}) {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
  Fixed false-positive log spam where MCC logged "Re-syncing ControllerConfig due to secret pull-secret change" every ~25 minutes even though the pull-secret secret hadn't actually changed.

**- How to verify it**
Check logs on a running cluster 

  1. Install a cluster with this fix
  2. Wait 1+ hours without modifying the pull-secret
  3. Check MCC logs:
  oc logs -n openshift-machine-config-operator -l k8s-app=machine-config-controller -c machine-config-controller --tail=-1 | grep -c 'Re-syncing ControllerConfig due to secret pull-secret change'
  4. Expected: Count should be 0 (no false positives)
  5. Without fix: Count would be ~7+ over a few hours

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:   Fix MCC log spam: only log pull-secret changes when data actually changes, not on informer resyncs
-->
