### PR TITLE
NO-ISSUE: Fix-up AMI update script to work from CI image

### DIFF
--- a/hack/update_amis.py
+++ b/hack/update_amis.py
@@ -238,7 +238,7 @@ def main():
     log_info("Walking through entire git history to collect all AMIs...")
 
     # Create temporary directory and clone with filter
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         repo_path = Path(temp_dir)
 
         log_info(f"Cloning repository with full history for {FILE_PATH}...")


### PR DESCRIPTION
This recent change seems to break rehearsals on https://github.com/openshift/release/pull/74400/ due to a python dependency: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/74400/rehearse-74400-periodic-ci-openshift-machine-config-operator-release-4.22-periodics-update-amis/2019422845095907328#1:build-log.txt%3A36-42 
