### PR TITLE
OCPBUGS-75916: crio: disable short_name_mode until we introduce ctrcfg api for it

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -67,6 +67,7 @@ contents:
     pause_image_auth_file = "/var/lib/kubelet/config.json"
     pause_command = "/usr/bin/pod"
     oci_artifact_mount_support = false
+    short_name_mode = "disabled"
 
     [crio.network]
     network_dir = "/etc/kubernetes/cni/net.d/"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -67,6 +67,7 @@ contents:
     pause_image_auth_file = "/var/lib/kubelet/config.json"
     pause_command = "/usr/bin/pod"
     oci_artifact_mount_support = false
+    short_name_mode = "disabled"
 
     [crio.network]
     network_dir = "/etc/kubernetes/cni/net.d/"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
disable for 4.22 (and eventually 4.21) until we get a proper fix in
alternative to https://github.com/openshift/machine-config-operator/pull/5622
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
