### PR TITLE
MON-4512: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/install/0000_90_machine-config_00_servicemonitor.yaml
+++ b/install/0000_90_machine-config_00_servicemonitor.yaml
@@ -33,6 +33,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: machine-config-controller
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -69,3 +70,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: machine-config-daemon
+  serviceDiscoveryRole: EndpointSlice

--- a/manifests/machineconfigcontroller/prometheus-rbac.yaml
+++ b/manifests/machineconfigcontroller/prometheus-rbac.yaml
@@ -24,3 +24,11 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - get
+    - list
+    - watch

--- a/manifests/machineconfigdaemon/prometheus-rbac.yaml
+++ b/manifests/machineconfigdaemon/prometheus-rbac.yaml
@@ -24,3 +24,11 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.
