### PR TITLE
OCPBUGS-76450: reduce MCO image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS 
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-# FIXME once we can depend on a new enough host that supports globs for COPY,
-# just use that.  For now we work around this by copying a tarball.
-ENV GOCACHE="/go/rhel9/.cache"
-ENV GOMODCACHE="/go/rhel9/pkg/mod"
-RUN make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
+RUN make install DESTDIR=./instroot-rhel9
 
 # Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.22 AS rhel8-builder
@@ -15,9 +11,7 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 # Copy the RHEL 8 machine-config-daemon binary and rename
 COPY . .
-ENV GOCACHE="/go/rhel8/.cache"
-ENV GOMODCACHE="/go/rhel8/pkg/mod"
-RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
+RUN make install DESTDIR=./instroot-rhel8
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 ARG TAGS=""
@@ -47,9 +41,10 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     if ! id -u "build" >/dev/null 2>&1; then useradd --uid 1000 build; fi && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
-# Copy the binaries *after* we install nmstate so we don't invalidate our cache for local builds.
-COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9.tar /tmp/instroot-rhel9.tar
-RUN cd / && tar xf /tmp/instroot-rhel9.tar && rm -f /tmp/instroot-rhel9.tar
+# Copy the binaries directly from their build stages into their final location.
+# Do this after package installation to avoid invalidating state for faster
+# local builds.
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9/usr/bin/* /usr/bin/
 # Copy the RHEL 8 machine-config-daemon binary and rename
 COPY --from=rhel8-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel8/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel8
 COPY templates /etc/mcc/templates

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,11 +4,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS 
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
-# FIXME once we can depend on a new enough host that supports globs for COPY,
-# just use that.  For now we work around this by copying a tarball.
-ENV GOCACHE="/go/rhel9/.cache"
-ENV GOMODCACHE="/go/rhel9/pkg/mod"
-RUN make install DESTDIR=./instroot-rhel9 && tar -C instroot-rhel9 -cf instroot-rhel9.tar .
+RUN make install DESTDIR=./instroot-rhel9
 
 # Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.22 AS rhel8-builder
@@ -16,9 +12,7 @@ ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/machine-config-operator
 # Copy the RHEL 8 machine-config-daemon binary and rename
 COPY . .
-ENV GOCACHE="/go/rhel8/.cache"
-ENV GOMODCACHE="/go/rhel8/pkg/mod"
-RUN make install DESTDIR=./instroot-rhel8 && tar -C instroot-rhel8 -cf instroot-rhel8.tar .
+RUN make install DESTDIR=./instroot-rhel8
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 ARG TAGS=""
@@ -48,9 +42,10 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     if ! id -u "build" >/dev/null 2>&1; then useradd --uid 1000 build; fi && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
-# Copy the binaries *after* we install nmstate so we don't invalidate our cache for local builds.
-COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9.tar /tmp/instroot-rhel9.tar
-RUN cd / && tar xf /tmp/instroot-rhel9.tar && rm -f /tmp/instroot-rhel9.tar
+# Copy the binaries directly from their build stages into their final location.
+# Do this after package installation to avoid invalidating state for faster
+# local builds.
+COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9/usr/bin/* /usr/bin/
 # Copy the RHEL 8 machine-config-daemon binary and rename
 COPY --from=rhel8-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel8/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel8
 COPY templates /etc/mcc/templates


### PR DESCRIPTION
**- What I did**

This ensures that the DNF package cache is clear after installing packages to reduce overall image size. This also reduces the overall image size when layer squashing is not used by eliminating the tarball extraction in the final image in favor of directly copying the files into place. Building the image locally using Podman, this yields a ~500 MB size reduction with the images output by the CI system being reduced by ~1.5 GB.

**- How to verify it**

To verify that the image size is reduced, one can build the image before and after this PR and compare the sizes. That said, there should not be any effect upon the MCO behavior itself. Therefore, a clean CI run should suffice for verification.

**- Description for the changelog**
Reduce MCO image size