### PR TITLE
[release-4.20] OCPBUGS-74433: Set `NodeDegraded` MCN condition when node state annotation is set to `Degraded`

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -131,6 +131,9 @@ func (ctrl *Controller) calculateStatus(mcs []*mcfgv1.MachineConfigNode, cconfig
 			// populate the degradedReasons from the MachineConfigNodeNodeDegraded condition
 			if mcfgv1.StateProgress(cond.Type) == mcfgv1.MachineConfigNodeNodeDegraded && cond.Status == metav1.ConditionTrue {
 				degradedMachines = append(degradedMachines, ourNode)
+				// Degraded nodes are also unavailable since they are not in a "Done" state
+				// and cannot be used for further updates (see IsUnavailableForUpdate)
+				unavailableMachines = append(unavailableMachines, ourNode)
 				degradedReasons = append(degradedReasons, fmt.Sprintf("Node %s is reporting: %q", ourNode.Name, cond.Message))
 				break
 			}


### PR DESCRIPTION
Closes: OCPBUGS-74433

**- What I did**
This is a manual cherry pick of https://github.com/openshift/machine-config-operator/pull/5554 that also includes a fix to how consider a machine unavailable when it is degraded.

**- How to verify it**
See details in https://github.com/openshift/machine-config-operator/pull/5509.

**- Description for the changelog**
OCPBUGS-74433: Update the flow to set a node's state annotation to `Degraded` to also set the `NodeDegraded` condition in the MCN