### PR TITLE
MCO-2120: Rework OS Image Stream label classification

### DIFF
--- a/pkg/osimagestream/image_data.go
+++ b/pkg/osimagestream/image_data.go
@@ -3,6 +3,7 @@ package osimagestream
 import (
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/openshift/api/machineconfiguration/v1alpha1"
 	"k8s.io/klog/v2"
@@ -11,8 +12,15 @@ import (
 const (
 	// coreOSLabelStreamClass is the container image label that identifies the OS stream name.
 	coreOSLabelStreamClass = "io.openshift.os.streamclass"
-	// coreOSLabelDiscriminator is the container image label that distinguishes OS images from Extensions images.
-	coreOSLabelDiscriminator = "ostree.linux"
+
+	// coreOSLabelExtension is the container image label that identifies an extensions image.
+	coreOSLabelExtension      = "io.openshift.os.extensions"
+	coreOSLabelExtensionValue = "true"
+
+	// coreOSLabelBootc is the container image label present on bootc-based OS images.
+	coreOSLabelBootc             = "containers.bootc"
+	coreOSLabelBootcValueBool    = "true"
+	coreOSLabelBootcValueInteger = "1"
 )
 
 // ImageType indicates whether a container image is an OS image or an extensions image.
@@ -40,12 +48,16 @@ type ImageData struct {
 	Stream string    // OS stream name
 }
 
+// ImageLabelMatcher is a function that checks whether a set of container image
+// labels matches a specific criterion.
+type ImageLabelMatcher func(labels map[string]string) bool
+
 // ImageStreamExtractorImpl implements ImageDataExtractor using container image labels
 // to identify and classify OS and extensions images.
 type ImageStreamExtractorImpl struct {
-	imagesInspector      ImagesInspector
-	streamLabels         []string
-	osImageDiscriminator string
+	streamLabels            []string
+	osImageMatchers         []ImageLabelMatcher
+	extensionsImageMatchers []ImageLabelMatcher
 }
 
 // NewImageStreamExtractor creates a new ImageDataExtractor configured to recognize
@@ -54,14 +66,19 @@ func NewImageStreamExtractor() ImageDataExtractor {
 	// The type is thought to allow future extra label addition for
 	// i.e. Allow a customer to bring their own images with their own labels (defining a selector)
 	return &ImageStreamExtractorImpl{
-		streamLabels:         []string{coreOSLabelStreamClass},
-		osImageDiscriminator: coreOSLabelDiscriminator,
+		streamLabels: []string{coreOSLabelStreamClass},
+		osImageMatchers: []ImageLabelMatcher{
+			labelEquals(coreOSLabelBootc, coreOSLabelBootcValueBool, coreOSLabelBootcValueInteger),
+		},
+		extensionsImageMatchers: []ImageLabelMatcher{
+			labelEquals(coreOSLabelExtension, coreOSLabelExtensionValue),
+		},
 	}
 }
 
 // GetImageData analyzes container image labels to extract OS stream metadata.
-// Returns nil if the image does not have the required stream label.
-// Distinguishes between OS and extensions images based on the presence of the ostree discriminator label.
+// Returns nil if the image does not have the required stream label or if it
+// cannot be classified as either an OS or extensions image.
 func (e *ImageStreamExtractorImpl) GetImageData(image string, labels map[string]string) *ImageData {
 	imageData := &ImageData{
 		Image:  image,
@@ -72,10 +89,14 @@ func (e *ImageStreamExtractorImpl) GetImageData(image string, labels map[string]
 		return nil
 	}
 
-	if findLabelValue(labels, e.osImageDiscriminator) != "" {
+	// Determine the type of image. OS or extensions.
+	switch {
+	case matchesAny(labels, e.osImageMatchers):
 		imageData.Type = ImageTypeOS
-	} else {
+	case matchesAny(labels, e.extensionsImageMatchers):
 		imageData.Type = ImageTypeExtensions
+	default:
+		return nil
 	}
 
 	return imageData
@@ -149,4 +170,30 @@ func NewOSImageStreamURLSetFromImageMetadata(imageMetadata *ImageData) *v1alpha1
 		urlSet.OSExtensionsImage = imageName
 	}
 	return urlSet
+}
+
+// labelEquals returns a matcher that checks whether a label has the expected value (case-insensitive).
+func labelEquals(key string, values ...string) ImageLabelMatcher {
+	return func(labels map[string]string) bool {
+		v, ok := labels[key]
+		if !ok {
+			return false
+		}
+		for _, value := range values {
+			if strings.EqualFold(v, value) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// matchesAny returns true if any of the matchers match the given labels.
+func matchesAny(labels map[string]string, matchers []ImageLabelMatcher) bool {
+	for _, m := range matchers {
+		if m(labels) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/osimagestream/imagestream_source_test.go
+++ b/pkg/osimagestream/imagestream_source_test.go
@@ -25,11 +25,6 @@ const (
 	testRHELCoreosTagName    = "rhel-coreos-9.4"
 	testRHELCoreosExtTagName = "rhel-coreos-extensions-9.4"
 
-	labelStreamClass = "io.openshift.os.streamclass"
-	labelOSTreeLinux = "ostree.linux"
-
-	labelValuePresent = "present"
-
 	streamNameRHELCoreos = "rhel-coreos"
 )
 
@@ -87,8 +82,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: testRHELCoreosImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: streamNameRHELCoreos,
-							labelOSTreeLinux: labelValuePresent,
+							testCoreOSLabelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 						},
 					},
 				},
@@ -96,7 +91,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: testRHELCoreosExtensionsImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 						},
 					},
 				},
@@ -151,7 +147,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: "quay.io/openshift/custom-os:latest",
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: "custom-stream",
+							testCoreOSLabelStreamClass: "custom-stream",
+							testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 						},
 					},
 				},
@@ -159,8 +156,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: "quay.io/openshift/custom-os-extensions:latest",
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: "custom-stream",
-							labelOSTreeLinux: labelValuePresent,
+							testCoreOSLabelStreamClass: "custom-stream",
+							testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 						},
 					},
 				},
@@ -205,7 +202,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: testRHELCoreosImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 						},
 					},
 				},
@@ -213,8 +211,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: testRHELCoreosExtensionsImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: streamNameRHELCoreos,
-							labelOSTreeLinux: labelValuePresent,
+							testCoreOSLabelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 						},
 					},
 				},
@@ -266,7 +264,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: testRHELCoreosImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 						},
 					},
 				},
@@ -274,8 +273,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: testRHELCoreosExtensionsImage,
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: streamNameRHELCoreos,
-							labelOSTreeLinux: labelValuePresent,
+							testCoreOSLabelStreamClass: streamNameRHELCoreos,
+							testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 						},
 					},
 				},
@@ -283,7 +282,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: "quay.io/openshift/stream-coreos:10.0",
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: "stream-coreos",
+							testCoreOSLabelStreamClass: "stream-coreos",
+							testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 						},
 					},
 				},
@@ -291,8 +291,8 @@ func TestImageStreamStreamSource_FetchStreams(t *testing.T) {
 					Image: "quay.io/openshift/stream-coreos-extensions:10.0",
 					InspectInfo: &types.ImageInspectInfo{
 						Labels: map[string]string{
-							labelStreamClass: "stream-coreos",
-							labelOSTreeLinux: labelValuePresent,
+							testCoreOSLabelStreamClass: "stream-coreos",
+							testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 						},
 					},
 				},

--- a/pkg/osimagestream/osimagestream_test.go
+++ b/pkg/osimagestream/osimagestream_test.go
@@ -233,25 +233,27 @@ spec:
 			// ConfigMap source images
 			"quay.io/openshift/os-cm@sha256:111": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-cm@sha256:222": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 			// Network source images
 			"quay.io/openshift/os-net@sha256:333": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-net@sha256:444": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},
@@ -301,13 +303,14 @@ func TestDefaultStreamSourceFactory_CreateRuntimeSources_ConfigMapOnly(t *testin
 		inspectData: map[string]*types.ImageInspectInfo{
 			"quay.io/openshift/os@sha256:abc123": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext@sha256:def456": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},
@@ -395,25 +398,27 @@ spec:
 			// ConfigMap source images (rhel-9)
 			"quay.io/openshift/os@sha256:abc123": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext@sha256:def456": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 			// Network source images (rhel-10)
 			"quay.io/openshift/os-10@sha256:aaa111": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-10",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-10",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-10@sha256:bbb222": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-10",
+					testCoreOSLabelStreamClass: "rhel-10",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},
@@ -489,24 +494,26 @@ func TestDefaultStreamSourceFactory_CreateBootstrapSources_MultipleStreams(t *te
 		inspectData: map[string]*types.ImageInspectInfo{
 			"quay.io/openshift/os-9@sha256:aaa111": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-9@sha256:bbb222": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 			"quay.io/openshift/os-10@sha256:ccc333": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-10",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-10",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-10@sha256:ddd444": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-10",
+					testCoreOSLabelStreamClass: "rhel-10",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},
@@ -546,13 +553,14 @@ func TestDefaultStreamSourceFactory_CreateBootstrapSources_CliImagesOnly(t *test
 		inspectData: map[string]*types.ImageInspectInfo{
 			"quay.io/openshift/os@sha256:abc123": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext@sha256:def456": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},
@@ -608,13 +616,14 @@ func TestDefaultStreamSourceFactory_CreateBootstrapSources_ImageStreamOnly(t *te
 		inspectData: map[string]*types.ImageInspectInfo{
 			"quay.io/openshift/os@sha256:abc123": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext@sha256:def456": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},
@@ -674,24 +683,26 @@ func TestDefaultStreamSourceFactory_CreateBootstrapSources_BothSources(t *testin
 		inspectData: map[string]*types.ImageInspectInfo{
 			"quay.io/openshift/os-cli@sha256:111": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-cli@sha256:222": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 			"quay.io/openshift/os-stream@sha256:333": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
-					"ostree.linux":                "present",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 				},
 			},
 			"quay.io/openshift/ext-stream@sha256:444": {
 				Labels: map[string]string{
-					"io.openshift.os.streamclass": "rhel-9",
+					testCoreOSLabelStreamClass: "rhel-9",
+					testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 				},
 			},
 		},

--- a/pkg/osimagestream/urls_source_test.go
+++ b/pkg/osimagestream/urls_source_test.go
@@ -86,8 +86,8 @@ func TestOSImagesURLStreamSource_FetchStreams_Success(t *testing.T) {
 				Image: dummyOSImageName,
 				InspectInfo: &types.ImageInspectInfo{
 					Labels: map[string]string{
-						"io.openshift.os.streamclass": "rhel-coreos",
-						"ostree.linux":                "present",
+						testCoreOSLabelStreamClass: "rhel-coreos",
+						testCoreOSLabelBootc:       testCoreOSLabelBootcValue1,
 					},
 				},
 				Error: nil,
@@ -96,7 +96,8 @@ func TestOSImagesURLStreamSource_FetchStreams_Success(t *testing.T) {
 				Image: dummyOSExtensionsImageName,
 				InspectInfo: &types.ImageInspectInfo{
 					Labels: map[string]string{
-						"io.openshift.os.streamclass": "rhel-coreos",
+						testCoreOSLabelStreamClass: "rhel-coreos",
+						testCoreOSLabelExtension:   testCoreOSLabelExtensionValue,
 					},
 				},
 				Error: nil,


### PR DESCRIPTION
**- What I did**

Replace the single ostree.linux discriminator with configurable label matchers that explicitly classify OS images ostree.bootable, containers.bootc) and extensions images (io.openshift.os.extensions).
Images that match no discriminator now return nil instead of defaulting to extensions.

**- How to verify it**

Regular CI tests are enough to verify this change.

**- Description for the changelog**

OS image streams now use explicit label matchers (ostree.bootable, containers.bootc, io.openshift.os.extensions) instead of a single ostree.linux discriminator to classify OS and extensions images
