### PR TITLE
NO-ISSUE: Fix cleanup verification timeouts in e2e-ocl tests

### DIFF
--- a/test/e2e-ocl/helpers_test.go
+++ b/test/e2e-ocl/helpers_test.go
@@ -313,7 +313,12 @@ func cleanupEphemeralBuildObjects(t *testing.T, cs *framework.ClientSet) {
 	moscList, err := cs.MachineconfigurationV1Interface.MachineOSConfigs().List(context.TODO(), metav1.ListOptions{})
 	require.NoError(t, err)
 
-	kubeassert := helpers.AssertClientSet(t, cs)
+	// Create a dedicated context for cleanup verification with reasonable timeout.
+	// Cleanup should complete quickly - if verification takes >2 minutes, something is wrong.
+	// Use a slower poll interval (3s instead of 1s) to reduce API call rate and avoid rate limiting.
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cleanupCancel()
+	kubeassert := helpers.AssertClientSet(t, cs).WithContext(cleanupCtx).WithPollInterval(3 * time.Second).Eventually()
 
 	if len(secretList.Items) == 0 {
 		t.Logf("No build-time secrets to clean up")


### PR DESCRIPTION
The cleanupEphemeralBuildObjects function was experiencing intermittent timeout failures during cleanup verification, even though deletions were succeeding.

Each verification used 5-minute default timeout with 1s poll interval which could exhaust rate limits leading to the "context deadline exceeded" error.

Create a dedicated 2-minute timeout context for cleanup verification and increase poll interval from 1s to 3s to reduce API call rate which should be about 40 attempts per resource.

