### PR TITLE
OCPBUGS-76444: pkg/daemon/update: Remove kernel-rt-kvm

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1735,10 +1735,7 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 		logSystem("Re-applying kernel type %s", newKtype)
 	}
 
-	kernelPackages, err := dn.getKernelPackagesForTargetRelease()
-	if err != nil {
-		return fmt.Errorf("failed to get kernel packages for target release: %w", err)
-	}
+	kernelPackages := dn.getKernelPackagesForTargetRelease()
 	if newKtype == ctrlcommon.KernelTypeRealtime {
 		// Switch to RT kernel
 		args := []string{"override", "remove"}
@@ -1762,20 +1759,8 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 }
 
 // getKernelPackagesForTargetRelease returns the list of kernel packaged for the running OS release.
-func (dn *CoreOSDaemon) getKernelPackagesForTargetRelease() (releaseKernelPackages, error) {
+func (dn *CoreOSDaemon) getKernelPackagesForTargetRelease() releaseKernelPackages {
 	// TODO: Drop this code and use https://github.com/coreos/rpm-ostree/issues/2542 instead
-
-	// Fetch the OS deployments to infer the target OS version from them
-	booted, staged, err := dn.NodeUpdaterClient.GetBootedAndStagedDeployment()
-	if err != nil {
-		return releaseKernelPackages{}, fmt.Errorf("error fetching OS deployments : %v", err)
-	}
-
-	// If there's a staged deployment the packages will be installed in it instead of in the current booted deployment
-	targetDeployment := booted
-	if staged != nil {
-		targetDeployment = staged
-	}
 
 	kernelPackages := releaseKernelPackages{
 		defaultKernel:   []string{"kernel", "kernel-core", "kernel-modules", "kernel-modules-core", "kernel-modules-extra"},
@@ -1784,14 +1769,7 @@ func (dn *CoreOSDaemon) getKernelPackagesForTargetRelease() (releaseKernelPackag
 		// of other dependencies we don't want for historical reasons.
 		realtimeKernel: []string{"kernel-rt-core", "kernel-rt-modules", "kernel-rt-modules-extra"},
 	}
-
-	// RHEL10 early bugfix of OCPBUGS-62925
-	// RHEL10 doesn't ship with kernel-rt-kvm
-	targetVersion := NewTargetOSVersionFromDeployment(targetDeployment)
-	if !targetVersion.IsEL10() {
-		kernelPackages.realtimeKernel = append(kernelPackages.realtimeKernel, "kernel-rt-kvm")
-	}
-	return kernelPackages, nil
+	return kernelPackages
 }
 
 // updateFiles writes files specified by the nodeconfig to disk. it also writes


### PR DESCRIPTION
This package no longer exists in 9.8 therefore we can just remove it. This is not a revert of earlier commits because other pieces of code depend on the new isEL10 function.

Fixes: OCPBUGS-76444