### PR TITLE
[release-4.19] OCPBUGS-76920: Degrade MCPs status based on MCN `NodeDegraded` condition

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -139,6 +139,9 @@ func (ctrl *Controller) calculateStatus(fg featuregates.FeatureGate, mcs []*mcfg
 			// populate the degradedReasons from the MachineConfigNodeNodeDegraded condition
 			if mcfgv1.StateProgress(cond.Type) == mcfgv1.MachineConfigNodeNodeDegraded && cond.Status == metav1.ConditionTrue {
 				degradedMachines = append(degradedMachines, ourNode)
+				// Degraded nodes are also unavailable since they are not in a "Done" state
+				// and cannot be used for further updates (see IsUnavailableForUpdate)
+				unavailableMachines = append(unavailableMachines, ourNode)
 				degradedReasons = append(degradedReasons, fmt.Sprintf("Node %s is reporting: %q", ourNode.Name, cond.Message))
 				break
 			}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -637,15 +637,32 @@ type unreconcilableErr struct {
 	error
 }
 
+// updateErrorState calls `SetUnreconcilable` to set the node's state annotation value to
+// "Unreconcilable" and the associated reason annotation if the provided error is an unreconcilable
+// error. Otherwise it calls `updateDegradedState` to set the node's state annotation value to
+// "Degraded," populate the associated reason annotation, and set the degrade condition in the MCN.
 func (dn *Daemon) updateErrorState(err error) error {
 	var uErr *unreconcilableErr
 	if errors.As(err, &uErr) {
-		dn.nodeWriter.SetUnreconcilable(err)
-	} else {
-		if err := dn.nodeWriter.SetDegraded(err); err != nil {
-			return err
-		}
+		return dn.nodeWriter.SetUnreconcilable(err)
 	}
+	return dn.updateDegradedState(err)
+}
+
+// `updateDegradedState` calls `SetDegraded` to set the node's state annotation value to "Degraded"
+// and populate the associated reason annotation. It then sets the degrade condition in the MCN.
+func (dn *Daemon) updateDegradedState(err error) error {
+	// Set node state annotation to "Degraded"
+	if setErr := dn.nodeWriter.SetDegraded(err); setErr != nil {
+		return setErr
+	}
+	// Get MCP associated with node
+	pool, poolErr := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
+	if poolErr != nil {
+		return poolErr
+	}
+	// Set the node's MCN condition to "Degraded"
+	dn.reportMachineNodeDegradeStatus(err, pool)
 	return nil
 }
 
@@ -2390,7 +2407,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 		// NOTE: This case expects a cluster to exists already.
 		ufc, err := dn.prepUpdateFromCluster()
 		if err != nil {
-			if err := dn.nodeWriter.SetDegraded(err); err != nil {
+			if err := dn.updateDegradedState(err); err != nil {
 				return err
 			}
 			maybeReportOnMissingMC(err)
@@ -2401,7 +2418,7 @@ func (dn *Daemon) runOnceFromMachineConfig(machineConfig mcfgv1.MachineConfig, c
 		}
 		// At this point we have verified we need to update
 		if err = dn.triggerUpdateWithMachineConfig(ufc.currentConfig, &machineConfig, false); err != nil {
-			dn.nodeWriter.SetDegraded(err)
+			dn.updateDegradedState(err)
 			return err
 		}
 		return nil


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
This is a manual cherrypick of https://github.com/openshift/machine-config-operator/pull/5110 & https://github.com/openshift/machine-config-operator/pull/5649.

**- How to verify it**
See the original PRs.

**- Description for the changelog**
OCPBUGS-74433: Degrade MCPs based on the `MachineConfigNodeNodeDegraded` MCN condition