### PR TITLE
OCPNODE-4106: Propagate KubeletConfig TLS min version to CRI-O via ContainerRuntime 

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -232,6 +232,8 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
+			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ConfigInformerFactory.Config().V1().Images(),
 			ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
 			ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -259,6 +259,12 @@ func (b *Bootstrap) Run(destDir string) error {
 
 	configs = append(configs, rconfigs...)
 
+	tlsConfigs, err := containerruntimeconfig.RunTLSBootstrap(pools, kconfigs, apiServer)
+	if err != nil {
+		return err
+	}
+	configs = append(configs, tlsConfigs...)
+
 	if len(crconfigs) > 0 {
 		containerRuntimeConfigs, err := containerruntimeconfig.RunContainerRuntimeBootstrap(b.templatesDir, crconfigs, cconfig, pools, fgHandler)
 		if err != nil {

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap.go
@@ -3,6 +3,7 @@ package containerruntimeconfig
 import (
 	"fmt"
 
+	apicfgv1 "github.com/openshift/api/config/v1"
 	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -81,6 +82,50 @@ func RunContainerRuntimeBootstrap(templateDir string, crconfigs []*mcfgv1.Contai
 			mc.SetOwnerReferences([]metav1.OwnerReference{oref})
 			res = append(res, mc)
 		}
+	}
+
+	return res, nil
+}
+
+// RunTLSBootstrap creates one CRI-O TLS MachineConfig per pool at bootstrap.
+// This is separate from RunContainerRuntimeBootstrap so that TLS is propagated
+// even when there are no ContainerRuntimeConfig CRs.
+func RunTLSBootstrap(mcpPools []*mcfgv1.MachineConfigPool, kubeletConfigs []*mcfgv1.KubeletConfig, apiServer *apicfgv1.APIServer) ([]*mcfgv1.MachineConfig, error) {
+	// Validate KubeletConfig selectors upfront.
+	for _, kc := range kubeletConfigs {
+		if kc.Spec.MachineConfigPoolSelector != nil {
+			if _, err := metav1.LabelSelectorAsSelector(kc.Spec.MachineConfigPoolSelector); err != nil {
+				return nil, fmt.Errorf("invalid MachineConfigPoolSelector in KubeletConfig %s: %w", kc.Name, err)
+			}
+		}
+	}
+
+	// Iterate pools (not kubeletConfigs) because every pool needs a TLS MC,
+	// even when no KubeletConfig matches — the APIServer profile is the fallback.
+	var res []*mcfgv1.MachineConfig
+	for _, pool := range mcpPools {
+		tlsMinVersion, tlsCipherSuites := tlsConfigFromKubeletConfigs(kubeletConfigs, pool)
+		if tlsMinVersion == "" {
+			tlsMinVersion, tlsCipherSuites = ctrlcommon.GetSecurityProfileCiphersFromAPIServer(apiServer)
+		}
+		tlsDropinFiles, err := createCRIOTLSDropinFile(tlsMinVersion, tlsCipherSuites)
+		if err != nil {
+			return nil, fmt.Errorf("could not create TLS drop-in for pool %s: %w", pool.Name, err)
+		}
+		tlsIgn := createNewIgnition(tlsDropinFiles)
+
+		managedKey, err := getManagedKeyTLS(pool)
+		if err != nil {
+			return nil, fmt.Errorf("could not get TLS managed key for pool %s: %w", pool.Name, err)
+		}
+		mc, err := ctrlcommon.MachineConfigFromIgnConfig(pool.Name, managedKey, tlsIgn)
+		if err != nil {
+			return nil, fmt.Errorf("could not create TLS MachineConfig for pool %s: %w", pool.Name, err)
+		}
+		mc.SetAnnotations(map[string]string{
+			ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,
+		})
+		res = append(res, mc)
 	}
 	return res, nil
 }

--- a/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_bootstrap_test.go
@@ -1,15 +1,37 @@
 package containerruntimeconfig
 
 import (
+	"strings"
 	"testing"
 
 	apicfgv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// decodeTLSDropinFromMC parses the ignition config from a MachineConfig and
+// returns the decoded contents of the CRI-O TLS drop-in file.
+func decodeTLSDropinFromMC(t *testing.T, mc *mcfgv1.MachineConfig) string {
+	t.Helper()
+	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
+	require.NoError(t, err, "failed to parse ignition config")
+	for _, f := range ignCfg.Storage.Files {
+		if f.Path != CRIODropInFilePathTLS {
+			continue
+		}
+		if f.Contents.Source == nil {
+			return ""
+		}
+		data, err := ctrlcommon.DecodeIgnitionFileContents(f.Contents.Source, f.Contents.Compression)
+		require.NoError(t, err, "failed to decode ignition file contents")
+		return string(data)
+	}
+	return ""
+}
 
 func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
 	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType, "unrecognized"} {
@@ -29,9 +51,14 @@ func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
 			f.mccrLister = append(f.mccrLister, ctrcfg)
 			f.objects = append(f.objects, ctrcfg)
 
-			mcs, err := RunContainerRuntimeBootstrap("../../../templates", []*mcfgv1.ContainerRuntimeConfig{ctrcfg}, cc, pools, nil)
+			mcs, err := RunContainerRuntimeBootstrap("../../../templates", []*mcfgv1.ContainerRuntimeConfig{ctrcfg}, cc, pools, nil /* fgHandler */)
 			require.NoError(t, err)
 			require.Len(t, mcs, 1)
+
+			// TLS bootstrap is now a separate function
+			tlsMCs, tlsErr := RunTLSBootstrap(pools, nil /* kubeletConfigs */, nil /* apiServer */)
+			require.NoError(t, tlsErr)
+			require.Len(t, tlsMCs, 1)
 
 			// add ctrcfg1 after bootstrap
 			ctrcfg1 := newContainerRuntimeConfig("log-level-master", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
@@ -54,4 +81,126 @@ func TestAddKubeletCfgAfterBootstrapKubeletCfg(t *testing.T) {
 			require.Equal(t, "", val)
 		})
 	}
+}
+
+func TestRunTLSBootstrap(t *testing.T) {
+	workerPool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "worker",
+			Labels: map[string]string{"pools.operator.machineconfiguration.openshift.io/worker": ""},
+		},
+	}
+	masterPool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "master",
+			Labels: map[string]string{"pools.operator.machineconfiguration.openshift.io/master": ""},
+		},
+	}
+
+	t.Run("NilKubeletConfigsAndNilAPIServer_FallsBackToIntermediate", func(t *testing.T) {
+		pools := []*mcfgv1.MachineConfigPool{workerPool, masterPool}
+		mcs, err := RunTLSBootstrap(pools, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, mcs, 2)
+
+		for _, mc := range mcs {
+			assert.Contains(t, mc.Name, "generated-containerruntime-tls")
+			content := decodeTLSDropinFromMC(t, mc)
+			assert.Contains(t, content, "VersionTLS12", "nil APIServer should fall back to Intermediate (TLS 1.2)")
+		}
+		assert.True(t, strings.HasPrefix(mcs[0].Name, "99-worker-"))
+		assert.True(t, strings.HasPrefix(mcs[1].Name, "99-master-"))
+	})
+
+	t.Run("KubeletConfigCustomTLS13_OverridesAPIServer", func(t *testing.T) {
+		kc := &mcfgv1.KubeletConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "custom-tls",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: mcfgv1.KubeletConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"pools.operator.machineconfiguration.openshift.io/worker": ""},
+				},
+				TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+					Type: apicfgv1.TLSProfileCustomType,
+					Custom: &apicfgv1.CustomTLSProfile{
+						TLSProfileSpec: apicfgv1.TLSProfileSpec{
+							MinTLSVersion: apicfgv1.VersionTLS13,
+						},
+					},
+				},
+			},
+		}
+		apiServer := &apicfgv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec: apicfgv1.APIServerSpec{
+				TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+					Type: apicfgv1.TLSProfileIntermediateType,
+				},
+			},
+		}
+		pools := []*mcfgv1.MachineConfigPool{workerPool, masterPool}
+		mcs, err := RunTLSBootstrap(pools, []*mcfgv1.KubeletConfig{kc}, apiServer)
+		require.NoError(t, err)
+		require.Len(t, mcs, 2)
+
+		var workerMC, masterMC *mcfgv1.MachineConfig
+		for _, mc := range mcs {
+			if strings.Contains(mc.Name, "worker") {
+				workerMC = mc
+			} else {
+				masterMC = mc
+			}
+		}
+		require.NotNil(t, workerMC)
+		require.NotNil(t, masterMC)
+		workerContent := decodeTLSDropinFromMC(t, workerMC)
+		masterContent := decodeTLSDropinFromMC(t, masterMC)
+		assert.Contains(t, workerContent, "VersionTLS13", "worker should get KubeletConfig TLS 1.3")
+		assert.Contains(t, masterContent, "VersionTLS12", "master should fall back to APIServer Intermediate (TLS 1.2)")
+	})
+
+	t.Run("CustomProfileWithCiphers_PropagatesCipherSuites", func(t *testing.T) {
+		kc := &mcfgv1.KubeletConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "custom-ciphers",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: mcfgv1.KubeletConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"pools.operator.machineconfiguration.openshift.io/worker": ""},
+				},
+				TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+					Type: apicfgv1.TLSProfileCustomType,
+					Custom: &apicfgv1.CustomTLSProfile{
+						TLSProfileSpec: apicfgv1.TLSProfileSpec{
+							MinTLSVersion: apicfgv1.VersionTLS12,
+							Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+						},
+					},
+				},
+			},
+		}
+		pools := []*mcfgv1.MachineConfigPool{workerPool}
+		mcs, err := RunTLSBootstrap(pools, []*mcfgv1.KubeletConfig{kc}, nil)
+		require.NoError(t, err)
+		require.Len(t, mcs, 1)
+
+		content := decodeTLSDropinFromMC(t, mcs[0])
+		assert.Contains(t, content, "VersionTLS12")
+		assert.Contains(t, content, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "cipher suites should be converted to IANA names")
+		assert.Contains(t, content, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "cipher suites should be converted to IANA names")
+	})
+
+	t.Run("MCNameAndAnnotations", func(t *testing.T) {
+		pools := []*mcfgv1.MachineConfigPool{workerPool}
+		mcs, err := RunTLSBootstrap(pools, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, mcs, 1)
+
+		mc := mcs[0]
+		assert.Equal(t, "99-worker-generated-containerruntime-tls", mc.Name)
+		assert.NotEmpty(t, mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey])
+	})
 }

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -1,6 +1,7 @@
 package containerruntimeconfig
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -94,6 +95,7 @@ type Controller struct {
 	syncHandler                   func(mcp string) error
 	syncImgHandler                func(mcp string) error
 	syncCRIOCPHandler             func(key string) error
+	syncTLSHandler                func(key string) error
 	enqueueContainerRuntimeConfig func(*mcfgv1.ContainerRuntimeConfig)
 
 	ccLister       mcfglistersv1.ControllerConfigLister
@@ -129,6 +131,12 @@ type Controller struct {
 	mcpLister       mcfglistersv1.MachineConfigPoolLister
 	mcpListerSynced cache.InformerSynced
 
+	kcLister       mcfglistersv1.KubeletConfigLister
+	kcListerSynced cache.InformerSynced
+
+	apiserverLister       cligolistersv1.APIServerLister
+	apiserverListerSynced cache.InformerSynced
+
 	clusterVersionLister       cligolistersv1.ClusterVersionLister
 	clusterVersionListerSynced cache.InformerSynced
 
@@ -137,6 +145,7 @@ type Controller struct {
 	queue       workqueue.TypedRateLimitingInterface[string]
 	imgQueue    workqueue.TypedRateLimitingInterface[string]
 	criocpQueue workqueue.TypedRateLimitingInterface[string]
+	tlsQueue    workqueue.TypedRateLimitingInterface[string]
 }
 
 // New returns a new container runtime config controller
@@ -145,6 +154,8 @@ func New(
 	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	ccInformer mcfginformersv1.ControllerConfigInformer,
 	mcrInformer mcfginformersv1.ContainerRuntimeConfigInformer,
+	kcInformer mcfginformersv1.KubeletConfigInformer,
+	apiserverInformer cligoinformersv1.APIServerInformer,
 	imgInformer cligoinformersv1.ImageInformer,
 	idmsInformer cligoinformersv1.ImageDigestMirrorSetInformer,
 	itmsInformer cligoinformersv1.ImageTagMirrorSetInformer,
@@ -171,6 +182,7 @@ func New(
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "machineconfigcontroller-containerruntimeconfigcontroller"}),
 		imgQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		criocpQueue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		tlsQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 	}
 
 	mcrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -203,9 +215,42 @@ func New(
 		DeleteFunc: ctrl.itmsConfDeleted,
 	})
 
+	mcpInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(_ interface{}) {
+			ctrl.tlsQueue.Add("mcp-change")
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldMCP := oldObj.(*mcfgv1.MachineConfigPool)
+			newMCP := newObj.(*mcfgv1.MachineConfigPool)
+			// Only re-sync TLS when labels change, since labels determine
+			// which KubeletConfigs match this pool. Skip status-only updates.
+			if !reflect.DeepEqual(oldMCP.Labels, newMCP.Labels) {
+				ctrl.tlsQueue.Add("mcp-change")
+			}
+		},
+		DeleteFunc: func(_ interface{}) {
+			ctrl.tlsQueue.Add("mcp-change")
+		},
+	})
+
+	kcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    ctrl.kubeletConfigAdded,
+		UpdateFunc: ctrl.kubeletConfigUpdated,
+		DeleteFunc: ctrl.kubeletConfigDeleted,
+	})
+
+	// Re-sync CRI-O TLS config when the cluster APIServer changes, e.g.:
+	//   oc patch apiserver cluster --type=merge -p '{"spec":{"tlsSecurityProfile":{"type":"Modern"}}}'
+	apiserverInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    ctrl.apiserverAdded,
+		UpdateFunc: ctrl.apiserverUpdated,
+		DeleteFunc: ctrl.apiserverDeleted,
+	})
+
 	ctrl.syncHandler = ctrl.syncContainerRuntimeConfig
 	ctrl.syncImgHandler = ctrl.syncImageConfig
 	ctrl.syncCRIOCPHandler = ctrl.syncCRIOCredentialProviderConfig
+	ctrl.syncTLSHandler = ctrl.syncTLSConfig
 	ctrl.enqueueContainerRuntimeConfig = ctrl.enqueue
 
 	ctrl.mcpLister = mcpInformer.Lister()
@@ -216,6 +261,12 @@ func New(
 
 	ctrl.mccrLister = mcrInformer.Lister()
 	ctrl.mccrListerSynced = mcrInformer.Informer().HasSynced
+
+	ctrl.kcLister = kcInformer.Lister()
+	ctrl.kcListerSynced = kcInformer.Informer().HasSynced
+
+	ctrl.apiserverLister = apiserverInformer.Lister()
+	ctrl.apiserverListerSynced = apiserverInformer.Informer().HasSynced
 
 	ctrl.imgLister = imgInformer.Lister()
 	ctrl.imgListerSynced = imgInformer.Informer().HasSynced
@@ -246,8 +297,9 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer ctrl.queue.ShutDown()
 	defer ctrl.imgQueue.ShutDown()
 	defer ctrl.criocpQueue.ShutDown()
+	defer ctrl.tlsQueue.ShutDown()
 	listerCaches := []cache.InformerSynced{ctrl.mcpListerSynced, ctrl.mccrListerSynced, ctrl.ccListerSynced,
-		ctrl.imgListerSynced, ctrl.icspListerSynced, ctrl.idmsListerSynced, ctrl.itmsListerSynced, ctrl.clusterVersionListerSynced}
+		ctrl.kcListerSynced, ctrl.apiserverListerSynced, ctrl.imgListerSynced, ctrl.icspListerSynced, ctrl.idmsListerSynced, ctrl.itmsListerSynced, ctrl.clusterVersionListerSynced}
 
 	if ctrl.sigstoreAPIEnabled() {
 		ctrl.addImagePolicyObservers()
@@ -287,6 +339,12 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 	// Just need one worker for the CRIOCredentialProviderConfig
 	go wait.Until(ctrl.criocpWorker, time.Second, stopCh)
+
+	// One worker for TLS config propagation from KubeletConfig/APIServer to CRI-O
+	go wait.Until(ctrl.tlsWorker, time.Second, stopCh)
+
+	// Seed the TLS queue on startup so every pool gets a TLS MC
+	ctrl.tlsQueue.Add("initial-sync")
 
 	<-stopCh
 }
@@ -370,6 +428,88 @@ func (ctrl *Controller) criocpConfUpdated(_, _ interface{}) {
 
 func (ctrl *Controller) criocpConfDeleted(_ interface{}) {
 	ctrl.criocpQueue.Add("openshift-config")
+}
+
+func (ctrl *Controller) kubeletConfigAdded(obj interface{}) {
+	kc := obj.(*mcfgv1.KubeletConfig)
+	if kc.DeletionTimestamp != nil {
+		ctrl.kubeletConfigDeleted(kc)
+		return
+	}
+	klog.V(4).Infof("Add KubeletConfig %s", kc.Name)
+	ctrl.tlsQueue.Add("kubeletconfig-change")
+}
+
+func (ctrl *Controller) kubeletConfigUpdated(oldObj, newObj interface{}) {
+	oldKC := oldObj.(*mcfgv1.KubeletConfig)
+	newKC := newObj.(*mcfgv1.KubeletConfig)
+	if !reflect.DeepEqual(oldKC.Spec, newKC.Spec) {
+		klog.V(4).Infof("Update KubeletConfig: %s", newKC.Name)
+		ctrl.tlsQueue.Add("kubeletconfig-change")
+	}
+}
+
+func (ctrl *Controller) kubeletConfigDeleted(obj interface{}) {
+	kc, ok := obj.(*mcfgv1.KubeletConfig)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		kc, ok = tombstone.Obj.(*mcfgv1.KubeletConfig)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a KubeletConfig %#v", obj))
+			return
+		}
+	}
+	klog.V(4).Infof("Delete KubeletConfig %s", kc.Name)
+	ctrl.tlsQueue.Add("kubeletconfig-change")
+}
+
+func (ctrl *Controller) filterAPIServer(apiServer *apicfgv1.APIServer) {
+	if apiServer.Name != ctrlcommon.APIServerInstanceName {
+		return
+	}
+	klog.Infof("Re-syncing CRI-O TLS config due to APIServer %s change", apiServer.Name)
+	ctrl.tlsQueue.Add("apiserver-change")
+}
+
+func (ctrl *Controller) apiserverAdded(obj interface{}) {
+	apiServer := obj.(*apicfgv1.APIServer)
+	if apiServer.DeletionTimestamp != nil {
+		ctrl.apiserverDeleted(apiServer)
+		return
+	}
+	klog.V(4).Infof("Add APIServer %v", apiServer)
+	ctrl.filterAPIServer(apiServer)
+}
+
+func (ctrl *Controller) apiserverUpdated(old, cur interface{}) {
+	oldAPIServer := old.(*apicfgv1.APIServer)
+	newAPIServer := cur.(*apicfgv1.APIServer)
+	if !reflect.DeepEqual(oldAPIServer.Spec, newAPIServer.Spec) {
+		klog.V(4).Infof("Update APIServer: %s", newAPIServer.Name)
+		ctrl.filterAPIServer(newAPIServer)
+	}
+}
+
+func (ctrl *Controller) apiserverDeleted(obj interface{}) {
+	apiServer, ok := obj.(*apicfgv1.APIServer)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		apiServer, ok = tombstone.Obj.(*apicfgv1.APIServer)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an APIServer %#v", obj))
+			return
+		}
+	}
+	klog.V(4).Infof("Delete APIServer %v", apiServer)
+	ctrl.filterAPIServer(apiServer)
 }
 
 func (ctrl *Controller) addImagePolicyObservers() {
@@ -511,6 +651,11 @@ func (ctrl *Controller) criocpWorker() {
 	}
 }
 
+func (ctrl *Controller) tlsWorker() {
+	for ctrl.processNextTLSWorkItem() {
+	}
+}
+
 func (ctrl *Controller) processNextWorkItem() bool {
 	key, quit := ctrl.queue.Get()
 	if quit {
@@ -546,6 +691,19 @@ func (ctrl *Controller) processNextCRIOCPWorkItem() bool {
 
 	err := ctrl.syncCRIOCPHandler(key)
 	ctrl.handleQueueErr(ctrl.criocpQueue, "CRIOCredentialProviderConfig", err, key)
+
+	return true
+}
+
+func (ctrl *Controller) processNextTLSWorkItem() bool {
+	key, quit := ctrl.tlsQueue.Get()
+	if quit {
+		return false
+	}
+	defer ctrl.tlsQueue.Done(key)
+
+	err := ctrl.syncTLSHandler(key)
+	ctrl.handleQueueErr(ctrl.tlsQueue, "CRI-O TLS config", err, key)
 
 	return true
 }
@@ -850,8 +1008,8 @@ func (ctrl *Controller) syncContainerRuntimeConfig(key string) error {
 			return ctrl.syncStatusOnly(cfg, err, "could not find MachineConfig: %v", managedKey)
 		}
 		// If we have seen this generation and the sync didn't fail, then skip
+		// But we still need to compare the generated controller version because during an upgrade we need a new one
 		if !isNotFound && cfg.Status.ObservedGeneration >= cfg.Generation && cfg.Status.Conditions[len(cfg.Status.Conditions)-1].Type == mcfgv1.ContainerRuntimeConfigSuccess {
-			// But we still need to compare the generated controller version because during an upgrade we need a new one
 			mcCtrlVersion := mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey]
 			if mcCtrlVersion == version.Hash {
 				return nil
@@ -1569,6 +1727,154 @@ func (ctrl *Controller) addFinalizerToContainerRuntimeConfig(ctrCfg *mcfgv1.Cont
 		}
 		return ctrl.patchContainerRuntimeConfigs(ctrCfg.Name, patch)
 	})
+}
+
+// syncTLSConfig creates or updates a dedicated CRI-O TLS MachineConfig for each
+// MachineConfigPool. This runs independently of ContainerRuntimeConfig CRs, so
+// every pool gets TLS propagation regardless of whether a CTRCFG exists.
+// This follows the same pattern as kubelet_config_nodes.go syncNodeConfigHandler.
+func (ctrl *Controller) syncTLSConfig(key string) error {
+	startTime := time.Now()
+	klog.V(4).Infof("Started syncing CRI-O TLS config %q", key)
+	defer func() {
+		klog.V(4).Infof("Finished syncing CRI-O TLS config %q (%v)", key, time.Since(startTime))
+	}()
+
+	pools, err := ctrl.mcpLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("error listing MachineConfigPools for TLS sync: %w", err)
+	}
+
+	for _, pool := range pools {
+		role := pool.Name
+		managedKey, err := getManagedKeyTLS(pool)
+		if err != nil {
+			return fmt.Errorf("could not get TLS managed key for pool %s: %w", role, err)
+		}
+
+		tlsMinVersion, tlsCipherSuites, err := ctrl.getTLSConfigForPool(pool)
+		if err != nil {
+			return fmt.Errorf("could not get TLS config for pool %s: %w", role, err)
+		}
+		tlsDropinFiles, err := createCRIOTLSDropinFile(tlsMinVersion, tlsCipherSuites)
+		if err != nil {
+			return fmt.Errorf("could not create TLS drop-in for pool %s: %w", role, err)
+		}
+		tlsIgn := createNewIgnition(tlsDropinFiles)
+		rawIgn, err := json.Marshal(tlsIgn)
+		if err != nil {
+			return fmt.Errorf("could not encode TLS Ignition config: %w", err)
+		}
+
+		if err := retry.RetryOnConflict(updateBackoff, func() error {
+			mc, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), managedKey, metav1.GetOptions{})
+			isNotFound := errors.IsNotFound(err)
+			if err != nil && !isNotFound {
+				return fmt.Errorf("could not get MachineConfig %s: %w", managedKey, err)
+			}
+			if isNotFound {
+				ignConfig := ctrlcommon.NewIgnConfig()
+				mc, err = ctrlcommon.MachineConfigFromIgnConfig(role, managedKey, ignConfig)
+				if err != nil {
+					return fmt.Errorf("could not create MachineConfig from Ignition config: %w", err)
+				}
+			}
+
+			if !isNotFound && bytes.Equal(mc.Spec.Config.Raw, rawIgn) &&
+				mc.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] == version.Hash {
+				return nil
+			}
+
+			mc.Spec.Config.Raw = rawIgn
+			if mc.ObjectMeta.Annotations == nil {
+				mc.ObjectMeta.Annotations = map[string]string{}
+			}
+			mc.ObjectMeta.Annotations[ctrlcommon.GeneratedByControllerVersionAnnotationKey] = version.Hash
+
+			if isNotFound {
+				_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Create(context.TODO(), mc, metav1.CreateOptions{})
+			} else {
+				_, err = ctrl.client.MachineconfigurationV1().MachineConfigs().Update(context.TODO(), mc, metav1.UpdateOptions{})
+			}
+			return err
+		}); err != nil {
+			return fmt.Errorf("could not Create/Update MachineConfig: %w", err)
+		}
+		klog.Infof("Applied CRI-O TLS config %s on MachineConfigPool %s (TLS min version: %s)", managedKey, role, tlsMinVersion)
+		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync TLS Config", role)
+	}
+
+	// Clean up orphaned TLS MachineConfigs for pools that no longer exist
+	if err := ctrl.cleanupOrphanedTLSMachineConfigs(pools); err != nil {
+		return fmt.Errorf("error cleaning up orphaned TLS MachineConfigs: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupOrphanedTLSMachineConfigs deletes TLS MachineConfigs that belong to
+// pools which have been deleted.
+func (ctrl *Controller) cleanupOrphanedTLSMachineConfigs(activePools []*mcfgv1.MachineConfigPool) error {
+	expectedMCs := make(map[string]bool)
+	for _, pool := range activePools {
+		key, err := getManagedKeyTLS(pool)
+		if err != nil {
+			return err
+		}
+		expectedMCs[key] = true
+	}
+
+	mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing MachineConfigs for TLS cleanup: %w", err)
+	}
+	for _, mc := range mcList.Items {
+		if !strings.Contains(mc.Name, "generated-"+managedTLSConfigKeySuffix) {
+			continue
+		}
+		if expectedMCs[mc.Name] {
+			continue
+		}
+		if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mc.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("error deleting orphaned TLS MachineConfig %s: %w", mc.Name, err)
+		}
+		klog.Infof("Deleted orphaned TLS MachineConfig %s", mc.Name)
+	}
+	return nil
+}
+
+// getTLSConfigFromKubeletConfigs finds the TLS minimum version and cipher suites from
+// KubeletConfig CRs that match the given MachineConfigPool.
+func (ctrl *Controller) getTLSConfigFromKubeletConfigs(pool *mcfgv1.MachineConfigPool) (string, []string, error) {
+	kubeletConfigs, err := ctrl.kcLister.List(labels.Everything())
+	if err != nil {
+		return "", nil, fmt.Errorf("error listing KubeletConfigs for TLS propagation: %w", err)
+	}
+	v, c := tlsConfigFromKubeletConfigs(kubeletConfigs, pool)
+	return v, c, nil
+}
+
+// getTLSConfigForPool returns the TLS minimum version and cipher suites for the given pool.
+// It first checks KubeletConfig CRs targeting the pool; if none specify TLS,
+// it falls back to the cluster APIServer config.
+func (ctrl *Controller) getTLSConfigForPool(pool *mcfgv1.MachineConfigPool) (string, []string, error) {
+	v, c, err := ctrl.getTLSConfigFromKubeletConfigs(pool)
+	if err != nil {
+		return "", nil, err
+	}
+	if v != "" {
+		return v, c, nil
+	}
+	apiServer, err := ctrl.apiserverLister.Get(ctrlcommon.APIServerInstanceName)
+	if err != nil && !errors.IsNotFound(err) {
+		return "", nil, fmt.Errorf("error getting APIServer for TLS fallback: %w", err)
+	}
+	var apiServerObj *apicfgv1.APIServer
+	if err == nil {
+		apiServerObj = apiServer
+	}
+	v, c = ctrlcommon.GetSecurityProfileCiphersFromAPIServer(apiServerObj)
+	return v, c, nil
 }
 
 func (ctrl *Controller) getPoolsForContainerRuntimeConfig(config *mcfgv1.ContainerRuntimeConfig) ([]*mcfgv1.MachineConfigPool, error) {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -215,6 +215,21 @@ func newClusterVersionConfig(name, desiredImage string) *apicfgv1.ClusterVersion
 	}
 }
 
+func newAPIServerConfig(name string) *apicfgv1.APIServer {
+	return &apicfgv1.APIServer{
+		TypeMeta:   metav1.TypeMeta{APIVersion: apicfgv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(utilrand.String(5)), Generation: 1},
+		Spec: apicfgv1.APIServerSpec{
+			TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+				Type: apicfgv1.TLSProfileCustomType,
+				Custom: &apicfgv1.CustomTLSProfile{
+					TLSProfileSpec: apicfgv1.TLSProfileSpec{MinTLSVersion: ""},
+				},
+			},
+		},
+	}
+}
+
 func newClusterImagePolicyWithPublicKey(name string, scopes []string, keyData []byte) *apicfgv1.ClusterImagePolicy {
 	imgScopes := []apicfgv1.ImageScope{}
 	for _, scope := range scopes {
@@ -261,7 +276,9 @@ func newImagePolicyWithPublicKey(name, namespace string, scopes []string, keyDat
 
 func (f *fixture) newController() *Controller {
 	f.client = fake.NewSimpleClientset(f.objects...)
-	f.imgClient = fakeconfigv1client.NewSimpleClientset(f.imgObjects...)
+	imgObjs := append([]runtime.Object{}, f.imgObjects...)
+	imgObjs = append(imgObjs, newAPIServerConfig(ctrlcommon.APIServerInstanceName))
+	f.imgClient = fakeconfigv1client.NewSimpleClientset(imgObjs...)
 	f.operatorClient = fakeoperatorclient.NewSimpleClientset(f.operatorObjects...)
 
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
@@ -271,6 +288,8 @@ func (f *fixture) newController() *Controller {
 		i.Machineconfiguration().V1().MachineConfigPools(),
 		i.Machineconfiguration().V1().ControllerConfigs(),
 		i.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+		i.Machineconfiguration().V1().KubeletConfigs(),
+		ci.Config().V1().APIServers(),
 		ci.Config().V1().Images(),
 		ci.Config().V1().ImageDigestMirrorSets(),
 		ci.Config().V1().ImageTagMirrorSets(),
@@ -283,6 +302,8 @@ func (f *fixture) newController() *Controller {
 
 	c.mcpListerSynced = alwaysReady
 	c.mccrListerSynced = alwaysReady
+	c.kcListerSynced = alwaysReady
+	c.apiserverListerSynced = alwaysReady
 	c.ccListerSynced = alwaysReady
 	c.imgListerSynced = alwaysReady
 	c.icspListerSynced = alwaysReady
@@ -396,7 +417,11 @@ func filterInformerActions(actions []core.Action) []core.Action {
 				action.Matches("list", "containerruntimeconfigs") ||
 				action.Matches("watch", "containerruntimeconfigs") ||
 				action.Matches("list", "machineconfigs") ||
-				action.Matches("watch", "machineconfigs")) {
+				action.Matches("watch", "machineconfigs") ||
+				action.Matches("list", "kubeletconfigs") ||
+				action.Matches("watch", "kubeletconfigs") ||
+				action.Matches("list", "apiservers") ||
+				action.Matches("watch", "apiservers")) {
 			continue
 		}
 		ret = append(ret, action)

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -51,19 +51,24 @@ const (
 	registriesConfigPath                   = "/etc/containers/registries.conf"
 	searchRegDropInFilePath                = "/etc/containers/registries.conf.d/01-image-searchRegistries.conf"
 	policyConfigPath                       = "/etc/containers/policy.json"
-	// CRIODropInFilePathLogLevel is the path at which changes to the crio config for log-level
-	// will be dropped in this is exported so that we can use it in the e2e-tests
-	CRIODropInFilePathLogLevel   = "/etc/crio/crio.conf.d/01-ctrcfg-logLevel"
-	crioDropInFilePathPidsLimit  = "/etc/crio/crio.conf.d/01-ctrcfg-pidsLimit"
-	crioDropInFilePathLogSizeMax = "/etc/crio/crio.conf.d/01-ctrcfg-logSizeMax"
-	// CRIODropInFilePathDefaultRuntime is the path at which changes to the crio config for default-runtime
-	// will be dropped in this is exported so that we can use it in the e2e-tests
-	CRIODropInFilePathDefaultRuntime           = "/etc/crio/crio.conf.d/01-ctrcfg-defaultRuntime"
 	crioDropInFilePathAdditionalArtifactStores = "/etc/crio/crio.conf.d/01-ctrcfg-additionalArtifactStores"
 	imagepolicyType                            = "sigstoreSigned"
 	sigstoreRegistriesConfigFilePath           = "/etc/containers/registries.d/sigstore-registries.yaml"
 	crioCredentialProviderName                 = "crio-credential-provider"
 	credentialProviderAPIVersion               = "credentialprovider.kubelet.k8s.io/v1"
+	// CRIODropInFilePathLogLevel is the path at which changes to the crio config for log-level
+	// will be dropped in. This is exported so that we can use it in the e2e-tests.
+	CRIODropInFilePathLogLevel       = "/etc/crio/crio.conf.d/01-ctrcfg-logLevel"
+	crioDropInFilePathPidsLimit      = "/etc/crio/crio.conf.d/01-ctrcfg-pidsLimit"
+	crioDropInFilePathLogSizeMax     = "/etc/crio/crio.conf.d/01-ctrcfg-logSizeMax"
+	// CRIODropInFilePathDefaultRuntime is the path at which changes to the crio config for default-runtime
+	// will be dropped in. This is exported so that we can use it in the e2e-tests.
+	CRIODropInFilePathDefaultRuntime = "/etc/crio/crio.conf.d/01-ctrcfg-defaultRuntime"
+	// CRIODropInFilePathTLS is the path at which TLS settings (min version and cipher suites)
+	// will be dropped in. This is exported so that we can use it in the e2e-tests.
+	CRIODropInFilePathTLS = "/etc/crio/crio.conf.d/01-ctrcfg-tls"
+	managedTLSConfigKeyPrefix       = "99"
+	managedTLSConfigKeySuffix       = "containerruntime-tls"
 )
 
 var (
@@ -142,6 +147,17 @@ type tomlConfigCRIOAdditionalArtifactStores struct {
 		Runtime struct {
 			AdditionalArtifactStores []string `toml:"additional_artifact_stores,omitempty"`
 		} `toml:"runtime"`
+	} `toml:"crio"`
+}
+
+// tomlConfigCRIOTLS is used for conversions when TLS settings are changed.
+// This sets the minimum TLS version and cipher suites for CRI-O's streaming and metrics servers.
+type tomlConfigCRIOTLS struct {
+	Crio struct {
+		API struct {
+			TLSMinVersion   string   `toml:"tls_min_version,omitempty"`
+			TLSCipherSuites []string `toml:"tls_cipher_suites,omitempty"`
+		} `toml:"api"`
 	} `toml:"crio"`
 }
 
@@ -387,6 +403,10 @@ func getManagedKeyCRIOCredentialProvider(pool *mcfgv1.MachineConfigPool) (string
 	return ctrlcommon.GetManagedKey(pool, nil, "97", "credentialproviderconfig", "")
 }
 
+func getManagedKeyTLS(pool *mcfgv1.MachineConfigPool) (string, error) {
+	return ctrlcommon.GetManagedKey(pool, nil, managedTLSConfigKeyPrefix, managedTLSConfigKeySuffix, "")
+}
+
 // Deprecated: use getManagedKeyReg
 func getManagedKeyRegDeprecated(pool *mcfgv1.MachineConfigPool) string {
 	return fmt.Sprintf("99-%s-%s-registries", pool.Name, pool.ObjectMeta.UID)
@@ -534,6 +554,49 @@ func createCRIODropinFiles(cfg *mcfgv1.ContainerRuntimeConfig, additionalStorage
 		}
 	}
 	return generatedConfigFileList
+}
+
+// tlsConfigFromKubeletConfigs finds the TLS minimum version and cipher suites from the
+// KubeletConfig CRs that match the given MachineConfigPool. When multiple KubeletConfigs
+// match, the most recently created one wins for deterministic behavior.
+// Used by both the controller and bootstrap paths.
+func tlsConfigFromKubeletConfigs(kubeletConfigs []*mcfgv1.KubeletConfig, pool *mcfgv1.MachineConfigPool) (string, []string) {
+	var newest *mcfgv1.KubeletConfig
+	for _, kc := range kubeletConfigs {
+		if kc.Spec.TLSSecurityProfile == nil {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(kc.Spec.MachineConfigPoolSelector)
+		if err != nil {
+			klog.Warningf("invalid label selector in KubeletConfig %s: %v", kc.Name, err)
+			continue
+		}
+		if selector.Empty() || !selector.Matches(labels.Set(pool.Labels)) {
+			continue
+		}
+		if newest == nil || kc.CreationTimestamp.After(newest.CreationTimestamp.Time) {
+			newest = kc
+		}
+	}
+	if newest == nil {
+		return "", nil
+	}
+	return ctrlcommon.GetSecurityProfileCiphers(newest.Spec.TLSSecurityProfile)
+}
+
+func createCRIOTLSDropinFile(tlsMinVersion string, tlsCipherSuites []string) ([]generatedConfigFile, error) {
+	if tlsMinVersion == "" {
+		return nil, fmt.Errorf("tlsMinVersion must not be empty: the controller should always resolve a TLS profile")
+	}
+
+	tomlConf := tomlConfigCRIOTLS{}
+	tomlConf.Crio.API.TLSMinVersion = tlsMinVersion
+	tomlConf.Crio.API.TLSCipherSuites = tlsCipherSuites
+	generatedConfigFileList, err := addTOMLgeneratedConfigFile(nil, CRIODropInFilePathTLS, tomlConf)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CRI-O TLS drop-in config: %w", err)
+	}
+	return generatedConfigFileList, nil
 }
 
 // updateSearchRegistriesConfig gets the ContainerRuntimeSearchRegistries data from the Image CRD

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -1293,6 +1293,262 @@ func TestCreateCRIODropinFiles(t *testing.T) {
 	}
 }
 
+func TestCreateCRIOTLSDropinFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		tlsMinVersion  string
+		cipherSuites   []string
+		expectError    bool
+		expectContains string
+	}{
+		{
+			name:           "TLS 1.2 generates drop-in",
+			tlsMinVersion:  "VersionTLS12",
+			cipherSuites:   nil,
+			expectContains: "VersionTLS12",
+		},
+		{
+			name:           "TLS 1.3 generates drop-in",
+			tlsMinVersion:  "VersionTLS13",
+			cipherSuites:   nil,
+			expectContains: "VersionTLS13",
+		},
+		{
+			name:        "Empty version returns error",
+			tlsMinVersion: "",
+			cipherSuites:  nil,
+			expectError: true,
+		},
+		{
+			name:           "TLS 1.2 with cipher suites",
+			tlsMinVersion:  "VersionTLS12",
+			cipherSuites:   []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+			expectContains: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files, err := createCRIOTLSDropinFile(tc.tlsMinVersion, tc.cipherSuites)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, files)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, files, 1)
+			assert.Equal(t, CRIODropInFilePathTLS, files[0].filePath)
+			assert.Contains(t, string(files[0].data), tc.expectContains)
+			assert.Contains(t, string(files[0].data), "tls_min_version")
+		})
+	}
+}
+
+func TestTLSConfigFromKubeletConfigs(t *testing.T) {
+	workerPool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "worker",
+			Labels: map[string]string{"pools.operator.machineconfiguration.openshift.io/worker": ""},
+		},
+	}
+	masterPool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "master",
+			Labels: map[string]string{"pools.operator.machineconfiguration.openshift.io/master": ""},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		kubeletConfigs  []*mcfgv1.KubeletConfig
+		pool            *mcfgv1.MachineConfigPool
+		expectedVersion string
+		expectCiphers   bool
+	}{
+		{
+			name:            "No KubeletConfigs returns empty",
+			kubeletConfigs:  nil,
+			pool:            workerPool,
+			expectedVersion: "",
+			expectCiphers:   false,
+		},
+		{
+			name: "KubeletConfig without TLS returns empty",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "no-tls"},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""),
+					},
+				},
+			},
+			pool:            workerPool,
+			expectedVersion: "",
+			expectCiphers:   false,
+		},
+		{
+			name: "KubeletConfig with TLS 1.3 matching worker pool",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "tls13"},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileCustomType,
+							Custom: &apicfgv1.CustomTLSProfile{
+								TLSProfileSpec: apicfgv1.TLSProfileSpec{
+									MinTLSVersion: apicfgv1.VersionTLS13,
+								},
+							},
+						},
+					},
+				},
+			},
+			pool:            workerPool,
+			expectedVersion: "VersionTLS13",
+			expectCiphers:   false,
+		},
+		{
+			name: "KubeletConfig with TLS targeting different pool returns empty",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "tls13-master"},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileCustomType,
+							Custom: &apicfgv1.CustomTLSProfile{
+								TLSProfileSpec: apicfgv1.TLSProfileSpec{
+									MinTLSVersion: apicfgv1.VersionTLS13,
+								},
+							},
+						},
+					},
+				},
+			},
+			pool:            workerPool,
+			expectedVersion: "",
+			expectCiphers:   false,
+		},
+		{
+			name: "KubeletConfig with TLS matching master pool",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "tls13-master"},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileCustomType,
+							Custom: &apicfgv1.CustomTLSProfile{
+								TLSProfileSpec: apicfgv1.TLSProfileSpec{
+									MinTLSVersion: apicfgv1.VersionTLS13,
+								},
+							},
+						},
+					},
+				},
+			},
+			pool:            masterPool,
+			expectedVersion: "VersionTLS13",
+			expectCiphers:   false,
+		},
+		{
+			name: "Multiple matching KubeletConfigs: newest wins",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "tls13-newer",
+						CreationTimestamp: metav1.NewTime(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)),
+					},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileCustomType,
+							Custom: &apicfgv1.CustomTLSProfile{
+								TLSProfileSpec: apicfgv1.TLSProfileSpec{
+									MinTLSVersion: apicfgv1.VersionTLS13,
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "tls12-older",
+						CreationTimestamp: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+					},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileCustomType,
+							Custom: &apicfgv1.CustomTLSProfile{
+								TLSProfileSpec: apicfgv1.TLSProfileSpec{
+									MinTLSVersion: apicfgv1.VersionTLS12,
+								},
+							},
+						},
+					},
+				},
+			},
+			pool:            workerPool,
+			expectedVersion: "VersionTLS13",
+			expectCiphers:   false,
+		},
+		{
+			name: "Custom profile with ciphers returns ciphers",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-ciphers"},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileCustomType,
+							Custom: &apicfgv1.CustomTLSProfile{
+								TLSProfileSpec: apicfgv1.TLSProfileSpec{
+									MinTLSVersion: apicfgv1.VersionTLS12,
+									Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+								},
+							},
+						},
+					},
+				},
+			},
+			pool:            workerPool,
+			expectedVersion: "VersionTLS12",
+			expectCiphers:   true,
+		},
+		{
+			name: "Intermediate profile returns ciphers",
+			kubeletConfigs: []*mcfgv1.KubeletConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "intermediate"},
+					Spec: mcfgv1.KubeletConfigSpec{
+						MachineConfigPoolSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/worker", ""),
+						TLSSecurityProfile: &apicfgv1.TLSSecurityProfile{
+							Type: apicfgv1.TLSProfileIntermediateType,
+						},
+					},
+				},
+			},
+			pool:            workerPool,
+			expectedVersion: "VersionTLS12",
+			expectCiphers:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			version, ciphers := tlsConfigFromKubeletConfigs(tc.kubeletConfigs, tc.pool)
+			assert.Equal(t, tc.expectedVersion, version)
+			if tc.expectCiphers {
+				assert.NotEmpty(t, ciphers, "expected cipher suites to be non-empty")
+			} else {
+				assert.Empty(t, ciphers)
+			}
+		})
+	}
+}
+
 func TestUpdateStorageConfig(t *testing.T) {
 	templateStorageConfig := tomlConfigStorage{}
 	buf := bytes.Buffer{}

--- a/test/e2e-2of2/ctrcfg_test.go
+++ b/test/e2e-2of2/ctrcfg_test.go
@@ -9,16 +9,20 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	ctrcfg "github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config"
+	kcfg "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
 const (
@@ -159,10 +163,15 @@ func runTestWithCtrcfg(t *testing.T, testName, regexKey, expectedConfVal1, expec
 	// Verify that the override file doesn't exist in crio.conf.d anymore
 	arr := strings.Split(ctrcfg.CRIODropInFilePathLogLevel, "/")
 	overrideFileName := arr[len(arr)-1]
-	if fileExists(t, cs, node, overrideFileName) {
-		err := fmt.Errorf("override file still exists in crio.conf.d")
-		require.Nil(t, err)
-	}
+	err = wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+		exists, fErr := fileExists(t, cs, node, overrideFileName)
+		if fErr != nil {
+			t.Logf("retrying fileExists check: %v", fErr)
+			return false, nil
+		}
+		return !exists, nil
+	})
+	require.NoError(t, err, "override file still exists in crio.conf.d after rollback")
 }
 
 // createCtrcfgWithConfig takes a config spec and creates a ContainerRuntimeConfig object
@@ -239,13 +248,16 @@ func getValueFromCrioConfig(t *testing.T, cs *framework.ClientSet, node corev1.N
 	return matches[1]
 }
 
-// fileExists checks whether overrideFile exists in /etc/crio/crio.conf.d
-func fileExists(t *testing.T, cs *framework.ClientSet, node corev1.Node, overrideFile string) bool {
-	// get the contents of the crio drop in directory
-	out := helpers.ExecCmdOnNode(t, cs, node, "ls", filepath.Join("/rootfs", crioDropinDir))
-
-	// Check if the overrideFile name exists in the output
-	return strings.Contains(string(out), overrideFile)
+// fileExists checks whether overrideFile exists in /etc/crio/crio.conf.d.
+// Returns (false, err) on exec errors (e.g. connection refused during node reboot)
+// so callers using wait.Poll can retry.
+func fileExists(t *testing.T, cs *framework.ClientSet, node corev1.Node, overrideFile string) (bool, error) {
+	out, err := helpers.ExecCmdOnNodeWithError(cs, node, "ls", filepath.Join("/rootfs", crioDropinDir))
+	if err != nil {
+		t.Logf("fileExists: exec failed on node %s (may be transient during node reboot): %v, output: %q", node.Name, err, out)
+		return false, err
+	}
+	return strings.Contains(string(out), overrideFile), nil
 }
 
 func runTestWithICSP(t *testing.T, testName, expectedVal string, icspRule *apioperatorsv1alpha1.ImageContentSourcePolicy) {
@@ -329,4 +341,235 @@ func getValueFromRegistriesConfig(t *testing.T, cs *framework.ClientSet, node co
 		return searchKey
 	}
 	return ""
+}
+
+// TestKubeletConfigTLSPropagationToCRIO verifies that setting a TLSSecurityProfile
+// in a KubeletConfig CR causes the ContainerRuntimeConfig controller to generate a
+// CRI-O drop-in config file with the corresponding tls_min_version in the MachineConfig.
+//
+// This is an API-level test: it inspects MachineConfig ignition content directly
+// without SSHing into nodes or causing node reboots. An isolated MCP with no
+// matching nodes is used so that no rollouts are triggered.
+func TestKubeletConfigTLSPropagationToCRIO(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	const (
+		testPoolName = "tls-api-test"
+		kcName       = "kc-tls-api-test"
+	)
+	testPoolLabel := "pools.operator.machineconfiguration.openshift.io/" + testPoolName
+
+	// Clean up any leftovers from previous failed runs
+	_ = cs.KubeletConfigs().Delete(context.TODO(), kcName, metav1.DeleteOptions{})
+	_ = cs.MachineConfigPools().Delete(context.TODO(), testPoolName, metav1.DeleteOptions{})
+	time.Sleep(5 * time.Second)
+
+	// Deferred cleanup
+	defer func() {
+		_ = cs.KubeletConfigs().Delete(context.TODO(), kcName, metav1.DeleteOptions{})
+		time.Sleep(5 * time.Second)
+		_ = cs.MachineConfigPools().Delete(context.TODO(), testPoolName, metav1.DeleteOptions{})
+	}()
+
+	// Create an MCP that targets no nodes (label won't match any real node),
+	// so the controller creates MachineConfigs without triggering rollouts.
+	mcp := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testPoolName,
+			Labels: map[string]string{testPoolLabel: ""},
+		},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "machineconfiguration.openshift.io/role",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"worker", testPoolName},
+					},
+				},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-role.kubernetes.io/" + testPoolName: "",
+				},
+			},
+		},
+	}
+	_, err := cs.MachineConfigPools().Create(context.TODO(), mcp, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create test MCP")
+	t.Logf("Created empty MCP %q (no matching nodes)", testPoolName)
+
+	// The TLS MC name follows the pattern: 99-<pool>-generated-containerruntime-tls
+	tlsMCName := fmt.Sprintf("99-%s-generated-containerruntime-tls", testPoolName)
+
+	// Wait for the dedicated TLS MC to appear (the controller creates it for every pool)
+	err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
+		_, getErr := cs.MachineConfigs().Get(context.TODO(), tlsMCName, metav1.GetOptions{})
+		return getErr == nil, nil
+	})
+	require.NoError(t, err, "timed out waiting for TLS MC %s", tlsMCName)
+	t.Logf("Found dedicated TLS MC %q", tlsMCName)
+
+	// Helper: read the raw CRI-O TLS drop-in content from the dedicated TLS MC
+	getTLSDropInContent := func() string {
+		mc, getErr := cs.MachineConfigs().Get(context.TODO(), tlsMCName, metav1.GetOptions{})
+		if getErr != nil {
+			t.Logf("getTLSDropInContent: error getting MC: %v", getErr)
+			return ""
+		}
+		if len(mc.Spec.Config.Raw) == 0 {
+			return ""
+		}
+		ignCfg, parseErr := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
+		if parseErr != nil {
+			t.Logf("getTLSDropInContent: error parsing ignition: %v", parseErr)
+			return ""
+		}
+		for _, f := range ignCfg.Storage.Files {
+			if f.Path != ctrcfg.CRIODropInFilePathTLS {
+				continue
+			}
+			if f.Contents.Source == nil {
+				return ""
+			}
+			data, decErr := ctrlcommon.DecodeIgnitionFileContents(f.Contents.Source, f.Contents.Compression)
+			if decErr != nil {
+				t.Logf("getTLSDropInContent: error decoding file contents: %v", decErr)
+				return ""
+			}
+			return string(data)
+		}
+		return ""
+	}
+
+	getTLSVersionFromMC := func() string {
+		content := getTLSDropInContent()
+		if content == "" {
+			return ""
+		}
+		re := regexp.MustCompile(`tls_min_version = "([^"]+)"`)
+		matches := re.FindStringSubmatch(content)
+		if len(matches) == 2 {
+			return matches[1]
+		}
+		return ""
+	}
+
+	hasCipherSuites := func() bool {
+		content := getTLSDropInContent()
+		return strings.Contains(content, "tls_cipher_suites")
+	}
+
+	createOrUpdateKC := func(profile *configv1.TLSSecurityProfile) {
+		t.Helper()
+		existing, getErr := cs.KubeletConfigs().Get(context.TODO(), kcName, metav1.GetOptions{})
+		if getErr != nil {
+			kcRaw, encErr := kcfg.EncodeKubeletConfig(
+				&kubeletconfigv1beta1.KubeletConfiguration{},
+				kubeletconfigv1beta1.SchemeGroupVersion,
+				runtime.ContentTypeJSON,
+			)
+			require.NoError(t, encErr, "failed to encode kubelet config")
+			kcObj := &mcfgv1.KubeletConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: kcName},
+				Spec: mcfgv1.KubeletConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{testPoolLabel: ""},
+					},
+					KubeletConfig:      &runtime.RawExtension{Raw: kcRaw},
+					TLSSecurityProfile: profile,
+				},
+			}
+			_, createErr := cs.KubeletConfigs().Create(context.TODO(), kcObj, metav1.CreateOptions{})
+			require.NoError(t, createErr, "failed to create KubeletConfig")
+			return
+		}
+		existing.Spec.TLSSecurityProfile = profile
+		_, updateErr := cs.KubeletConfigs().Update(context.TODO(), existing, metav1.UpdateOptions{})
+		require.NoError(t, updateErr, "failed to update KubeletConfig")
+	}
+
+	waitForTLS := func(expected string) {
+		t.Helper()
+		pollErr := wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
+			return getTLSVersionFromMC() == expected, nil
+		})
+		require.NoError(t, pollErr, "expected TLS MC to contain tls_min_version %q", expected)
+	}
+
+	t.Run("APIServerFallback", func(t *testing.T) {
+		waitForTLS("VersionTLS12")
+		pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+			return hasCipherSuites(), nil
+		})
+		require.NoError(t, pollErr, "APIServer fallback (Intermediate) should include cipher suites")
+		t.Logf("Verified: APIServer fallback includes cipher suites from Intermediate profile")
+	})
+
+	t.Run("CustomProfileTLS12WithCiphers", func(t *testing.T) {
+		createOrUpdateKC(&configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS12,
+					Ciphers: []string{
+						"ECDHE-RSA-AES128-GCM-SHA256",
+						"ECDHE-RSA-AES256-GCM-SHA384",
+					},
+				},
+			},
+		})
+		waitForTLS("VersionTLS12")
+		pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+			content := getTLSDropInContent()
+			return strings.Contains(content, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256") &&
+				strings.Contains(content, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"), nil
+		})
+		require.NoError(t, pollErr, "Custom profile cipher suites (IANA names) should appear in the drop-in")
+		t.Logf("Verified: Custom profile with TLS 1.2 + specific ciphers propagated to CRI-O")
+	})
+
+	t.Run("CustomProfileTLS13", func(t *testing.T) {
+		createOrUpdateKC(&configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS13,
+				},
+			},
+		})
+		waitForTLS("VersionTLS13")
+		t.Logf("Verified: Custom profile with TLS 1.3 propagated to CRI-O")
+	})
+
+	t.Run("IntermediateProfile", func(t *testing.T) {
+		createOrUpdateKC(&configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileIntermediateType,
+		})
+		waitForTLS("VersionTLS12")
+		pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+			return hasCipherSuites(), nil
+		})
+		require.NoError(t, pollErr, "Intermediate profile should include cipher suites in the drop-in")
+		t.Logf("Verified: Intermediate profile propagated TLS 1.2 + cipher suites to CRI-O")
+	})
+
+	t.Run("ModernProfile", func(t *testing.T) {
+		createOrUpdateKC(&configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileModernType,
+		})
+		waitForTLS("VersionTLS13")
+		t.Logf("Verified: Modern profile propagated TLS 1.3 to CRI-O")
+	})
+
+	t.Run("RevertOnKubeletConfigDeletion", func(t *testing.T) {
+		delErr := cs.KubeletConfigs().Delete(context.TODO(), kcName, metav1.DeleteOptions{})
+		require.NoError(t, delErr, "failed to delete KubeletConfig")
+		waitForTLS("VersionTLS12")
+		pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+			return hasCipherSuites(), nil
+		})
+		require.NoError(t, pollErr, "After KubeletConfig deletion, fallback should include cipher suites")
+		t.Logf("Verified: Reverted to APIServer fallback with cipher suites after KubeletConfig deletion")
+	})
 }

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -589,6 +589,8 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().ContainerRuntimeConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
+			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ConfigInformerFactory.Config().V1().Images(),
 			ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
 			ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),


### PR DESCRIPTION
## What this PR does
This PR is part of the [OCPSTRAT-2748](https://redhat.atlassian.net/browse/OCPSTRAT-2748) and epic [OCPNODE-3916](https://redhat.atlassian.net/browse/OCPNODE-3916) initiative to enforce consistent TLS security policies across all OpenShift components. Today, when a cluster administrator sets a TLS security profile (via KubeletConfig or the cluster APIServer), the kubelet does it but CRI-O does not — leaving CRI-O's streaming and metrics servers with default TLS settings that may not meet the organization's security requirements.

The CRI-O side of this work has already been done and PR has been merged : https://github.com/cri-o/cri-o/pull/9723 , which added support for reading tls_min_version and tls_cipher_suites from CRI-O's drop-in configuration. Both PRs target OpenShift 4.22.
Right now, when an admin sets a TLS profile in KubeletConfig, the kubelet picks it up but CRI-O doesn't. This PR fixes that by generating a CRI-O drop-in file (/etc/crio/crio.conf.d/01-ctrcfg-tls) with the matching TLS version and ciphers. If no KubeletConfig sets TLS, it falls back to the cluster APIServer profile (default: Intermediate/TLS 1.2).


## Reference: [OCPNODE-4106](https://issues.redhat.com/browse/OCPNODE-4106)

## Background:
The ContainerRuntimeConfig controller now has a dedicated tlsQueue and syncTLSConfig handler, following the same pattern as kubelet_config_nodes.go. It watches KubeletConfig, APIServer, and MCP events, and for each pool generates a 99-<pool>-generated-containerruntime-tls MachineConfig with the CRI-O drop-in containing both tls_min_version and tls_cipher_suites .
This runs independently of ContainerRuntimeConfig CRs, so every pool gets TLS config even without any CTRCFGs defined. KubeletConfig takes priority; if none is set, it falls back to the APIServer profile (default: Intermediate/TLS 1.2). When multiple KubeletConfigs target the same pool, the most recently created one (greatertimestamp) wins.
At bootstrap, a separate RunTLSBootstrap function generates TLS MachineConfigs for all pools, called outside the ContainerRuntimeConfig block so TLS is propagated from the start.

The controller writes a TOML drop-in at /etc/crio/crio.conf.d/01-ctrcfg-tls containing the [crio.api] section with tls_min_version and tls_cipher_suites. CRI-O reads this on startup (or reload) and applies the settings to its streaming and metrics servers. For example, an Intermediate profile produces tls_min_version = "VersionTLS12" with the full set of IANA cipher suites, while a Modern profile produces tls_min_version = "VersionTLS13" with only TLS 1.3 ciphers.

## Output
Locally tested all the unit test cases are Passing : 
`--- PASS: TestRunTLSBootstrap (0.00s)
    --- PASS: TestRunTLSBootstrap/NilKubeletConfigsAndNilAPIServer_FallsBackToIntermediate
    --- PASS: TestRunTLSBootstrap/KubeletConfigCustomTLS13_OverridesAPIServer
    --- PASS: TestRunTLSBootstrap/CustomProfileWithCiphers_PropagatesCipherSuites
    --- PASS: TestRunTLSBootstrap/MCNameAndAnnotations
--- PASS: TestCreateCRIOTLSDropinFile (0.00s)
    --- PASS: TestCreateCRIOTLSDropinFile/TLS_1.2_generates_drop-in
    --- PASS: TestCreateCRIOTLSDropinFile/TLS_1.3_generates_drop-in
    --- PASS: TestCreateCRIOTLSDropinFile/Empty_version_returns_error
    --- PASS: TestCreateCRIOTLSDropinFile/TLS_1.2_with_cipher_suites
--- PASS: TestTLSConfigFromKubeletConfigs (0.00s)
    --- PASS: TestTLSConfigFromKubeletConfigs/No_KubeletConfigs_returns_empty
    --- PASS: TestTLSConfigFromKubeletConfigs/KubeletConfig_without_TLS_returns_empty
    --- PASS: TestTLSConfigFromKubeletConfigs/KubeletConfig_with_TLS_1.3_matching_worker_pool
    --- PASS: TestTLSConfigFromKubeletConfigs/KubeletConfig_with_TLS_targeting_different_pool_returns_empty
    --- PASS: TestTLSConfigFromKubeletConfigs/KubeletConfig_with_TLS_matching_master_pool
    --- PASS: TestTLSConfigFromKubeletConfigs/Multiple_matching_KubeletConfigs:_newest_wins
    --- PASS: TestTLSConfigFromKubeletConfigs/Custom_profile_with_ciphers_returns_ciphers
    --- PASS: TestTLSConfigFromKubeletConfigs/Intermediate_profile_returns_ciphers
--- PASS: TestKubeletConfigTLSPropagationToCRIO (20.30s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/APIServerFallback
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/CustomProfileTLS12WithCiphers
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/CustomProfileTLS13
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/IntermediateProfile
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/ModernProfile
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/RevertOnKubeletConfigDeletion`

e2e test result
`asahay@asahay-ubuntu:~/crio-test/machine-config-operator$ go test -v -timeout 30m -run TestKubeletConfigTLSPropagationToCRIO ./test/e2e-2of2/...
=== RUN   TestKubeletConfigTLSPropagationToCRIO
    ctrcfg_test.go:400: Created empty MCP "tls-api-test" (no matching nodes)
    ctrcfg_test.go:411: Found dedicated TLS MC "99-tls-api-test-generated-containerruntime-tls"
=== RUN   TestKubeletConfigTLSPropagationToCRIO/APIServerFallback
    ctrcfg_test.go:506: Verified: APIServer fallback includes cipher suites from Intermediate profile
=== RUN   TestKubeletConfigTLSPropagationToCRIO/CustomProfileTLS12WithCiphers
    ctrcfg_test.go:529: Verified: Custom profile with TLS 1.2 + specific ciphers propagated to CRI-O
=== RUN   TestKubeletConfigTLSPropagationToCRIO/CustomProfileTLS13
    ctrcfg_test.go:542: Verified: Custom profile with TLS 1.3 propagated to CRI-O
=== RUN   TestKubeletConfigTLSPropagationToCRIO/IntermediateProfile
    ctrcfg_test.go:554: Verified: Intermediate profile propagated TLS 1.2 + cipher suites to CRI-O
=== RUN   TestKubeletConfigTLSPropagationToCRIO/ModernProfile
    ctrcfg_test.go:562: Verified: Modern profile propagated TLS 1.3 to CRI-O
=== RUN   TestKubeletConfigTLSPropagationToCRIO/RevertOnKubeletConfigDeletion
    ctrcfg_test.go:573: Verified: Reverted to APIServer fallback with cipher suites after KubeletConfig deletion
--- PASS: TestKubeletConfigTLSPropagationToCRIO (20.34s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/APIServerFallback (0.02s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/CustomProfileTLS12WithCiphers (0.03s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/CustomProfileTLS13 (2.04s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/IntermediateProfile (2.05s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/ModernProfile (2.03s)
    --- PASS: TestKubeletConfigTLSPropagationToCRIO/RevertOnKubeletConfigDeletion (2.03s)
PASS
ok  	github.com/openshift/machine-config-operator/test/e2e-2of2	20.415s`

Pre-Merge Testing : https://issues.redhat.com/browse/OCPNODE-4113
Upgrade Testing : https://redhat.atlassian.net/browse/OCPNODE-4220
Functionality Testing : https://redhat.atlassian.net/browse/OCPNODE-4222


cc @ngopalak-redhat @bitoku @haircommander 