### PR TITLE
OCPBUGS-59958: Remove cleanUpDuplicatedMC call in node.config handling

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -72,9 +72,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
-	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
-		return err
-	}
 
 	// Fetch the controllerconfig
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)


### PR DESCRIPTION
This function was originally intended to remove duplicate MCs that somehow was no longer tracked by the controller. I don't think it should be used in general, and this removal here was causing the controller to be confused and deleting valid 97-POOL-generated-kubeletconfig machineconfig objects, since the new controller hasn't yet had a chance to sync and stamp its controller version, causing multiple reboots.

Looks like we did this change in
https://github.com/openshift/machine-config-operator/pull/3563#issue-1589711695, and the behaviour seems to have changed since then, so I would expect this to be a safe change as the cgroups config is always being generated now. I would lean towards removing cleanUpDuplicatedMC entirely, but based on the comment, it looks like it is catching some unmanaged MC scenarios (e.g. deletion of a custom MCP), so will not do that for a backporting fix until we can sort that out. Note that 97-generated only applies for master/worker/arbiter pools, so I think that shouldn't be a problem.

cc @sairameshv in case I am missing something from the original context