### PR TITLE
WIP: Configure kubelet GracefulNodeShutdown

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_shutdown_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_shutdown_test.go
@@ -1,0 +1,117 @@
+package kubeletconfig
+
+import (
+	"testing"
+	"time"
+
+	osev1 "github.com/openshift/api/config/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestShutdownGracePeriodConfiguration verifies that shutdownGracePeriod and
+// shutdownGracePeriodCriticalPods are correctly configured in kubelet templates.
+// This test ensures that:
+// - Master and arbiter nodes get 270s/240s
+// - Worker nodes get 90s/60s
+// - SNO (SingleReplica) topology gets no shutdownGracePeriod (zero value)
+func TestShutdownGracePeriodConfiguration(t *testing.T) {
+	testCases := []struct {
+		name                                string
+		platform                            osev1.PlatformType
+		topology                            osev1.TopologyMode
+		nodeRole                            string
+		expectedShutdownGracePeriod         time.Duration
+		expectedShutdownGracePeriodCritical time.Duration
+	}{
+		{
+			name:                                "AWS master",
+			platform:                            osev1.AWSPlatformType,
+			nodeRole:                            "master",
+			expectedShutdownGracePeriod:         270 * time.Second,
+			expectedShutdownGracePeriodCritical: 240 * time.Second,
+		},
+		{
+			name:                                "AWS arbiter",
+			platform:                            osev1.AWSPlatformType,
+			nodeRole:                            "arbiter",
+			expectedShutdownGracePeriod:         270 * time.Second,
+			expectedShutdownGracePeriodCritical: 240 * time.Second,
+		},
+		{
+			name:                                "AWS worker",
+			platform:                            osev1.AWSPlatformType,
+			nodeRole:                            "worker",
+			expectedShutdownGracePeriod:         90 * time.Second,
+			expectedShutdownGracePeriodCritical: 60 * time.Second,
+		},
+		{
+			name:                                "GCP master",
+			platform:                            osev1.GCPPlatformType,
+			nodeRole:                            "master",
+			expectedShutdownGracePeriod:         270 * time.Second,
+			expectedShutdownGracePeriodCritical: 240 * time.Second,
+		},
+		{
+			name:                                "None master",
+			platform:                            osev1.NonePlatformType,
+			nodeRole:                            "master",
+			expectedShutdownGracePeriod:         270 * time.Second,
+			expectedShutdownGracePeriodCritical: 240 * time.Second,
+		},
+		{
+			name:                                "None worker",
+			platform:                            osev1.NonePlatformType,
+			nodeRole:                            "worker",
+			expectedShutdownGracePeriod:         90 * time.Second,
+			expectedShutdownGracePeriodCritical: 60 * time.Second,
+		},
+		{
+			name:                                "SNO master",
+			platform:                            osev1.NonePlatformType,
+			topology:                            osev1.SingleReplicaTopologyMode,
+			nodeRole:                            "master",
+			expectedShutdownGracePeriod:         0,
+			expectedShutdownGracePeriodCritical: 0,
+		},
+		{
+			name:                                "SNO worker",
+			platform:                            osev1.NonePlatformType,
+			topology:                            osev1.SingleReplicaTopologyMode,
+			nodeRole:                            "worker",
+			expectedShutdownGracePeriod:         0,
+			expectedShutdownGracePeriodCritical: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler([]osev1.FeatureGateName{"Example"}, nil)
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, tc.platform)
+			if tc.topology != "" {
+				cc.Spec.Infra.Status.ControlPlaneTopology = tc.topology
+			}
+			f.ccLister = append(f.ccLister, cc)
+
+			ctrl := f.newController(fgHandler)
+
+			kubeletConfig, err := generateOriginalKubeletConfigIgn(cc, ctrl.templatesDir, tc.nodeRole, &osev1.APIServer{})
+			require.NoError(t, err, "Failed to generate kubelet config for %s", tc.name)
+
+			contents, err := ctrlcommon.DecodeIgnitionFileContents(kubeletConfig.Contents.Source, kubeletConfig.Contents.Compression)
+			require.NoError(t, err, "Failed to decode ignition file contents for %s", tc.name)
+
+			originalKubeConfig, err := DecodeKubeletConfig(contents)
+			require.NoError(t, err, "Failed to decode kubelet config for %s", tc.name)
+
+			assert.Equal(t, metav1.Duration{Duration: tc.expectedShutdownGracePeriod}, originalKubeConfig.ShutdownGracePeriod,
+				"shutdownGracePeriod mismatch for %s", tc.name)
+			assert.Equal(t, metav1.Duration{Duration: tc.expectedShutdownGracePeriodCritical}, originalKubeConfig.ShutdownGracePeriodCriticalPods,
+				"shutdownGracePeriodCriticalPods mismatch for %s", tc.name)
+		})
+	}
+}

--- a/templates/arbiter/01-arbiter-kubelet/_base/files/kubelet.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/kubelet.yaml
@@ -31,6 +31,10 @@ contents:
     nodeStatusUpdateFrequency: 10s
     nodeStatusReportFrequency: 5m
     serverTLSBootstrap: true
+    {{- if ne .Infra.Status.ControlPlaneTopology "SingleReplica" }}
+    shutdownGracePeriod: 270s
+    shutdownGracePeriodCriticalPods: 240s
+    {{- end }}
     tlsMinVersion: {{.TLSMinVersion}}
     tlsCipherSuites:
       {{- range .TLSCipherSuites }}

--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -31,6 +31,10 @@ contents:
     nodeStatusUpdateFrequency: 10s
     nodeStatusReportFrequency: 5m
     serverTLSBootstrap: true
+    {{- if ne .Infra.Status.ControlPlaneTopology "SingleReplica" }}
+    shutdownGracePeriod: 270s
+    shutdownGracePeriodCriticalPods: 240s
+    {{- end }}
     tlsMinVersion: {{.TLSMinVersion}}
     tlsCipherSuites:
       {{- range .TLSCipherSuites }}

--- a/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml
@@ -31,6 +31,10 @@ contents:
     nodeStatusUpdateFrequency: 10s
     nodeStatusReportFrequency: 5m
     serverTLSBootstrap: true
+    {{- if ne .Infra.Status.ControlPlaneTopology "SingleReplica" }}
+    shutdownGracePeriod: 90s
+    shutdownGracePeriodCriticalPods: 60s
+    {{- end }}
     tlsMinVersion: {{.TLSMinVersion}}
     tlsCipherSuites:
       {{- range .TLSCipherSuites }}


### PR DESCRIPTION
**- What I did**

OpenShift never configures kubelet's `shutdownGracePeriod` in KubeletConfiguration, making GracefulNodeShutdown a no-op. During MCO-triggered reboots:

1. MCO drains regular pods (static pods like kube-apiserver are skipped)
2. MCO calls `systemctl reboot` via logind
3. Kubelet exits immediately on SIGTERM without terminating pods
4. kube-apiserver needs up to 194s for graceful shutdown (platform-dependent) but systemd's `DefaultTimeoutStopSec` is 90s
5. kube-apiserver gets SIGKILLed, watch-termination detects non-graceful termination

This is a latent bug exposed by new MCO changes introducing additional master reboots:
- https://github.com/openshift/machine-config-operator/pull/5460 (drop `--pod-infra-container-image`, all node reboots)
- https://github.com/openshift/machine-config-operator/pull/5491 (re-enable `autoSizingReserved`, worker reboots)
- New OCL day1 job (Dec 2025, multiple master reboots)

Configures `shutdownGracePeriod` and `shutdownGracePeriodCriticalPods` in kubelet templates:
- Master/arbiter: 270s total, 240s for critical pods (covers the worst-case kube-apiserver `terminationGracePeriodSeconds` of 194s on AWS with headroom)
- Worker: 90s total, 60s for critical pods
- SNO: disabled

Kubelet automatically overrides logind's `InhibitDelayMaxSec` and acquires a delay inhibitor lock so that `systemctl reboot` waits for graceful pod termination.

**- How to verify it**

- `go test ./pkg/controller/kubelet-config/... -run TestShutdownGracePeriod -v`
- `go test ./pkg/controller/template/... -v`
- Deploy to a cluster and verify kubelet config on nodes contains `shutdownGracePeriod`
- Run `[sig-api-machinery][Feature:APIServer][Late] kubelet terminates kube-apiserver gracefully extended` test

**- Payload test results**

| Test | Result | Details |
|------|--------|---------|
| AWS e2e (`e2e-aws-ovn`) | PASS | `kubelet terminates kube-apiserver gracefully` + `extended` both passed |
| GCP e2e (`e2e-gcp-ovn`) | PASS | `kubelet terminates kube-apiserver gracefully` + `extended` both passed |
| OCL (`e2e-aws-ovn-ocl`) | INFRA FAILURE | Unrelated test harness bug: `oc wait --for=create` not supported |

**- Description for the changelog**

Configure kubelet GracefulNodeShutdown with generous grace periods to prevent kube-apiserver from being SIGKILLed during node reboots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage validating shutdown grace period configuration for kubelet across multiple platform scenarios and node roles.

* **New Features**
  * Kubelet graceful shutdown settings now configured for multi-replica control plane topologies on master, arbiter, and worker nodes, with configuration excluded for single-replica setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->