### PR TITLE
 AGENT-1443: IRI Add certificate regeneration to MCS cert rotation controller

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -109,6 +109,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().Secrets(),
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
+			ctrlctx.FeatureGatesHandler,
 		)
 		if err != nil {
 			klog.Fatalf("unable to start cert rotation controller: %v", err)

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -110,6 +110,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.KubeNamespacedInformerFactory.Core().V1().ConfigMaps(),
 			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
 			ctrlctx.FeatureGatesHandler,
+			ctrlctx.ClientBuilder.MachineConfigClientOrDie("cert-rotation-controller"),
 		)
 		if err != nil {
 			klog.Fatalf("unable to start cert rotation controller: %v", err)

--- a/pkg/controller/certrotation/certrotation_controller.go
+++ b/pkg/controller/certrotation/certrotation_controller.go
@@ -10,10 +10,12 @@ import (
 	"github.com/vincent-petithory/dataurl"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -28,6 +30,7 @@ import (
 	machineclientset "github.com/openshift/client-go/machine/clientset/versioned"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
 
@@ -46,6 +49,7 @@ const (
 	mcsCARefresh     = 8 * oneYear
 	mcsTLSKeyExpiry  = mcsCAExpiry
 	mcsTLSKeyRefresh = mcsCARefresh
+	iriTLSKeyExpiry  = mcsCAExpiry
 	workQueueKey     = "key"
 )
 
@@ -336,6 +340,9 @@ func (c *CertRotationController) addConfigMap(obj interface{}) {
 	go func() {
 		c.reconcileUserDataSecrets()
 	}()
+	go func() {
+		c.reconcileIRICertificate()
+	}()
 }
 
 func (c *CertRotationController) updateConfigMap(oldCM, newCM interface{}) {
@@ -358,6 +365,9 @@ func (c *CertRotationController) updateConfigMap(oldCM, newCM interface{}) {
 	// Reconcile all user data secrets
 	go func() {
 		c.reconcileUserDataSecrets()
+	}()
+	go func() {
+		c.reconcileIRICertificate()
 	}()
 }
 
@@ -466,4 +476,85 @@ func (c *CertRotationController) reconcileSecret(secret corev1.Secret) error {
 
 	klog.Infof("Successfully modified %s secret \n", secret.Name)
 	return nil
+}
+
+func (c *CertRotationController) reconcileIRICertificate() {
+	klog.Infof("Reconciling IRI certificate")
+
+	// Get the MCS CA secret (fresh get, not from lister)
+	caSecret, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.MachineConfigServerCAName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Cannot get MCS CA secret for IRI cert reconciliation: %v", err)
+		return
+	}
+
+	caCert := caSecret.Data[corev1.TLSCertKey]
+	caKey := caSecret.Data[corev1.TLSPrivateKeyKey]
+	if len(caCert) == 0 || len(caKey) == 0 {
+		klog.Errorf("MCS CA secret %s is missing cert or key data", ctrlcommon.MachineConfigServerCAName)
+		return
+	}
+
+	// Load the CA
+	ca, err := crypto.GetCAFromBytes(caCert, caKey)
+	if err != nil {
+		klog.Errorf("Cannot load MCS CA for IRI cert generation: %v", err)
+		return
+	}
+
+	// Get hostnames from the dynamic serving rotation
+	hostnames := c.hostnamesRotation.GetHostnames()
+	if len(hostnames) == 0 {
+		klog.Errorf("No hostnames available for IRI cert generation")
+		return
+	}
+
+	// Generate a new IRI TLS certificate signed by the MCS CA
+	certConfig, err := ca.MakeServerCert(sets.New(hostnames...), iriTLSKeyExpiry)
+	if err != nil {
+		klog.Errorf("Cannot generate IRI TLS certificate: %v", err)
+		return
+	}
+
+	certPEM, keyPEM, err := certConfig.GetPEMBytes()
+	if err != nil {
+		klog.Errorf("Cannot get PEM bytes for IRI TLS certificate: %v", err)
+		return
+	}
+
+	// Check if the IRI TLS secret already exists
+	iriSecret, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// Create new secret
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ctrlcommon.InternalReleaseImageTLSSecretName,
+				Namespace: ctrlcommon.MCONamespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				corev1.TLSCertKey:       certPEM,
+				corev1.TLSPrivateKeyKey: keyPEM,
+			},
+		}
+		if _, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); err != nil {
+			klog.Errorf("Cannot create IRI TLS secret: %v", err)
+			return
+		}
+		klog.Infof("Successfully created IRI TLS secret %s", ctrlcommon.InternalReleaseImageTLSSecretName)
+		return
+	} else if err != nil {
+		klog.Errorf("Cannot get IRI TLS secret: %v", err)
+		return
+	}
+
+	// Update existing secret
+	updatedSecret := iriSecret.DeepCopy()
+	updatedSecret.Data[corev1.TLSCertKey] = certPEM
+	updatedSecret.Data[corev1.TLSPrivateKeyKey] = keyPEM
+	if _, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(context.TODO(), updatedSecret, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Cannot update IRI TLS secret: %v", err)
+		return
+	}
+	klog.Infof("Successfully updated IRI TLS secret %s", ctrlcommon.InternalReleaseImageTLSSecretName)
 }

--- a/pkg/controller/certrotation/certrotation_controller.go
+++ b/pkg/controller/certrotation/certrotation_controller.go
@@ -3,16 +3,18 @@ package certrotationcontroller
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/vincent-petithory/dataurl"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -23,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -31,6 +34,7 @@ import (
 	"github.com/openshift/api/features"
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	machineclientset "github.com/openshift/client-go/machine/clientset/versioned"
+	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -59,6 +63,7 @@ const (
 type CertRotationController struct {
 	kubeClient   kubernetes.Interface
 	configClient configclientset.Interface
+	mcfgClient   mcfgclientset.Interface
 	aroClient    aroclientset.Interface
 
 	mcoConfigMapInfomer coreinformersv1.ConfigMapInformer
@@ -92,6 +97,7 @@ func New(
 	mcoConfigMapInfomer coreinformersv1.ConfigMapInformer,
 	infraInformer configinformers.InfrastructureInformer,
 	featureGatesHandler ctrlcommon.FeatureGatesHandler,
+	mcfgClient mcfgclientset.Interface,
 ) (*CertRotationController, error) {
 
 	recorder := events.NewLoggingEventRecorder(componentName, clock.RealClock{})
@@ -99,6 +105,7 @@ func New(
 	c := &CertRotationController{
 		kubeClient:          kubeClient,
 		configClient:        configClient,
+		mcfgClient:          mcfgClient,
 		aroClient:           aroClient,
 		recorder:            recorder,
 		maoSecretInformer:   maoSecretInformer,
@@ -346,8 +353,6 @@ func (c *CertRotationController) addConfigMap(obj interface{}) {
 
 	go func() {
 		c.reconcileUserDataSecrets()
-	}()
-	go func() {
 		c.reconcileIRICertificate()
 	}()
 }
@@ -369,11 +374,8 @@ func (c *CertRotationController) updateConfigMap(oldCM, newCM interface{}) {
 
 	klog.Infof("configMap %s updated, reconciling user data secrets and IRI certificate", oldConfigMap.Name)
 
-	// Reconcile all user data secrets
 	go func() {
 		c.reconcileUserDataSecrets()
-	}()
-	go func() {
 		c.reconcileIRICertificate()
 	}()
 }
@@ -490,101 +492,130 @@ func (c *CertRotationController) reconcileIRICertificate() {
 		klog.V(4).Infof("Skipping IRI certificate reconciliation: %s feature gate is not enabled", features.FeatureGateNoRegistryClusterInstall)
 		return
 	}
+
+	// Check that the IRI cluster resource exists to confirm the feature is actually enabled
+	if _, err := c.mcfgClient.MachineconfigurationV1alpha1().InternalReleaseImages().Get(context.TODO(), ctrlcommon.InternalReleaseImageInstanceName, metav1.GetOptions{}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.V(4).Infof("Skipping IRI certificate reconciliation: InternalReleaseImage %q not found", ctrlcommon.InternalReleaseImageInstanceName)
+		} else {
+			klog.Errorf("Error checking InternalReleaseImage %q resource: %v", ctrlcommon.InternalReleaseImageInstanceName, err)
+		}
+		return
+	}
+
 	klog.Infof("Reconciling IRI certificate")
 
-	// Get the MCS CA secret (fresh get, not from lister)
-	caSecret, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.MachineConfigServerCAName, metav1.GetOptions{})
+	ca, err := c.loadMCSCA()
 	if err != nil {
-		klog.Errorf("Cannot get MCS CA secret for IRI cert reconciliation: %v", err)
+		klog.Errorf("Cannot load MCS CA for IRI cert reconciliation: %v", err)
 		return
 	}
 
-	caCert := caSecret.Data[corev1.TLSCertKey]
-	caKey := caSecret.Data[corev1.TLSPrivateKeyKey]
-	if len(caCert) == 0 || len(caKey) == 0 {
-		klog.Errorf("MCS CA secret %s is missing cert or key data", ctrlcommon.MachineConfigServerCAName)
-		return
-	}
-
-	// Load the CA
-	ca, err := crypto.GetCAFromBytes(caCert, caKey)
+	hostnames, err := c.getIRIHostnames()
 	if err != nil {
-		klog.Errorf("Cannot load MCS CA for IRI cert generation: %v", err)
+		klog.Errorf("Cannot determine IRI hostnames: %v", err)
 		return
 	}
 
-	// Check if the existing IRI cert is already valid under the current CA
 	iriSecret, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
-	secretExists := err == nil
-	if secretExists {
-		if c.isIRICertValid(iriSecret, ca) {
-			klog.Infof("IRI TLS certificate is still valid under the current MCS CA, skipping rotation")
-			return
-		}
-	} else if !errors.IsNotFound(err) {
-		klog.Errorf("Cannot get IRI TLS secret: %v", err)
+	if err != nil {
+		klog.Errorf("Cannot get IRI TLS secret %s: %v", ctrlcommon.InternalReleaseImageTLSSecretName, err)
 		return
 	}
 
-	// Get hostnames from the dynamic serving rotation (includes api-int hostname and platform VIPs)
-	hostnames := c.hostnamesRotation.GetHostnames()
-	if len(hostnames) == 0 {
-		klog.Errorf("No hostnames available for IRI cert generation")
+	if c.isIRICertValid(iriSecret, ca, hostnames) {
+		klog.Infof("IRI TLS certificate is still valid under the current MCS CA, skipping rotation")
 		return
 	}
-	// IRI registry also serves locally on each master node, matching the installer's SANs
-	hostnames = append(hostnames, "localhost", "127.0.0.1", "::1")
 
-	// Generate a new IRI TLS certificate signed by the MCS CA
-	certConfig, err := ca.MakeServerCert(sets.New(hostnames...), iriTLSKeyExpiry)
+	certPEM, keyPEM, err := c.generateIRICert(ca, hostnames)
 	if err != nil {
 		klog.Errorf("Cannot generate IRI TLS certificate: %v", err)
 		return
 	}
 
-	certPEM, keyPEM, err := certConfig.GetPEMBytes()
-	if err != nil {
-		klog.Errorf("Cannot get PEM bytes for IRI TLS certificate: %v", err)
-		return
-	}
-
-	if !secretExists {
-		// Create new secret
-		newSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ctrlcommon.InternalReleaseImageTLSSecretName,
-				Namespace: ctrlcommon.MCONamespace,
-			},
-			Type: corev1.SecretTypeTLS,
-			Data: map[string][]byte{
-				corev1.TLSCertKey:       certPEM,
-				corev1.TLSPrivateKeyKey: keyPEM,
-			},
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
 		}
-		if _, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); err != nil {
-			klog.Errorf("Cannot create IRI TLS secret: %v", err)
-			return
+		updated := current.DeepCopy()
+		if updated.Data == nil {
+			updated.Data = map[string][]byte{}
 		}
-		klog.Infof("Successfully created IRI TLS secret %s", ctrlcommon.InternalReleaseImageTLSSecretName)
-		return
-	}
-
-	// Update existing secret
-	updatedSecret := iriSecret.DeepCopy()
-	updatedSecret.Data[corev1.TLSCertKey] = certPEM
-	updatedSecret.Data[corev1.TLSPrivateKeyKey] = keyPEM
-	if _, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(context.TODO(), updatedSecret, metav1.UpdateOptions{}); err != nil {
+		updated.Data[corev1.TLSCertKey] = certPEM
+		updated.Data[corev1.TLSPrivateKeyKey] = keyPEM
+		_, err = c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(context.TODO(), updated, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
 		klog.Errorf("Cannot update IRI TLS secret: %v", err)
 		return
 	}
 	klog.Infof("Successfully updated IRI TLS secret %s", ctrlcommon.InternalReleaseImageTLSSecretName)
 }
 
-// isIRICertValid checks whether the existing IRI certificate is signed by the given CA
-// and has not expired.
-func (c *CertRotationController) isIRICertValid(iriSecret *corev1.Secret, ca *crypto.CA) bool {
+// loadMCSCA retrieves the MCS CA secret and returns the parsed CA.
+func (c *CertRotationController) loadMCSCA() (*crypto.CA, error) {
+	caSecret, err := c.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.MachineConfigServerCAName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get MCS CA secret: %w", err)
+	}
+
+	caCert := caSecret.Data[corev1.TLSCertKey]
+	caKey := caSecret.Data[corev1.TLSPrivateKeyKey]
+	if len(caCert) == 0 || len(caKey) == 0 {
+		return nil, fmt.Errorf("MCS CA secret %s is missing cert or key data", ctrlcommon.MachineConfigServerCAName)
+	}
+
+	return crypto.GetCAFromBytes(caCert, caKey)
+}
+
+// getIRIHostnames returns the SANs for the IRI TLS certificate: apiInt hostname + localhost.
+func (c *CertRotationController) getIRIHostnames() ([]string, error) {
+	cfg, err := c.infraLister.Get("cluster")
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster infrastructure resource: %w", err)
+	}
+
+	if cfg.Status.APIServerInternalURL == "" {
+		return nil, fmt.Errorf("no APIServerInternalURL found in cluster infrastructure resource")
+	}
+
+	apiserverIntURL, err := url.Parse(cfg.Status.APIServerInternalURL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse APIServerInternalURL: %w", err)
+	}
+
+	return []string{apiserverIntURL.Hostname(), "localhost", "127.0.0.1", "::1"}, nil
+}
+
+// generateIRICert generates a new IRI TLS certificate signed by the given CA.
+func (c *CertRotationController) generateIRICert(ca *crypto.CA, hostnames []string) (certPEM, keyPEM []byte, err error) {
+	certConfig, err := ca.MakeServerCert(sets.New(hostnames...), iriTLSKeyExpiry)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot generate IRI TLS certificate: %w", err)
+	}
+
+	certPEM, keyPEM, err = certConfig.GetPEMBytes()
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot get PEM bytes for IRI TLS certificate: %w", err)
+	}
+
+	return certPEM, keyPEM, nil
+}
+
+// isIRICertValid checks whether the existing IRI certificate is signed by the given CA,
+// has not expired, and covers all expected hostnames in its SANs.
+func (c *CertRotationController) isIRICertValid(iriSecret *corev1.Secret, ca *crypto.CA, expectedHostnames []string) bool {
 	certPEM := iriSecret.Data[corev1.TLSCertKey]
-	if len(certPEM) == 0 {
+	keyPEM := iriSecret.Data[corev1.TLSPrivateKeyKey]
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		return false
+	}
+
+	// Verify cert and key form a valid keypair before doing anything else
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		klog.Infof("Existing IRI TLS secret has an invalid keypair: %v", err)
 		return false
 	}
 
@@ -615,6 +646,19 @@ func (c *CertRotationController) isIRICertValid(iriSecret *corev1.Secret, ca *cr
 	})
 	if err != nil {
 		klog.Infof("Existing IRI TLS certificate is not valid under current MCS CA: %v", err)
+		return false
+	}
+
+	// Verify the cert SANs exactly match the expected hostname set; any drift
+	// (missing or extra SANs) means the cert must be rotated.
+	// MakeServerCert adds all hostnames to DNSNames and also adds IP strings to
+	// IPAddresses, so compare a unified set of all SAN strings.
+	certSANs := sets.New(iriCert.DNSNames...)
+	for _, ip := range iriCert.IPAddresses {
+		certSANs.Insert(ip.String())
+	}
+	if !certSANs.Equal(sets.New(expectedHostnames...)) {
+		klog.Infof("IRI TLS certificate SANs differ from expected set, rotation needed")
 		return false
 	}
 

--- a/pkg/controller/certrotation/certrotation_controller.go
+++ b/pkg/controller/certrotation/certrotation_controller.go
@@ -586,7 +586,12 @@ func (c *CertRotationController) getIRIHostnames() ([]string, error) {
 		return nil, fmt.Errorf("cannot parse APIServerInternalURL: %w", err)
 	}
 
-	return []string{apiserverIntURL.Hostname(), "localhost", "127.0.0.1", "::1"}, nil
+	// Include platform VIPs to match the SANs the installer generates for the IRI cert.
+	// The installer adds platform VIPs as both DNS names and IP addresses; we include
+	// them here so isIRICertValid passes for the installer-generated cert without
+	// triggering a spurious rotation during cluster installation.
+	hostnames := append([]string{apiserverIntURL.Hostname(), "localhost", "127.0.0.1", "::1"}, getServerIPsFromInfra(cfg)...)
+	return hostnames, nil
 }
 
 // generateIRICert generates a new IRI TLS certificate signed by the given CA.

--- a/pkg/controller/certrotation/certrotation_controller_test.go
+++ b/pkg/controller/certrotation/certrotation_controller_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/openshift/api/features"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -28,6 +30,7 @@ import (
 	fakearoclientset "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	fakeconfigv1client "github.com/openshift/client-go/config/clientset/versioned/fake"
 	fakemachineclientset "github.com/openshift/client-go/machine/clientset/versioned/fake"
+	fakemcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned/fake"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 )
@@ -42,6 +45,7 @@ type fixture struct {
 	kubeClient    *fake.Clientset
 	configClient  *fakeconfigv1client.Clientset
 	machineClient *fakemachineclientset.Clientset
+	mcfgClient    *fakemcfgclientset.Clientset
 	aroClient     *fakearoclientset.Clientset
 
 	maoSecretLister    []*corev1.Secret
@@ -52,6 +56,7 @@ type fixture struct {
 	objects        []runtime.Object
 	configObjects  []runtime.Object
 	machineObjects []runtime.Object
+	mcfgObjects    []runtime.Object
 	aroObjects     []runtime.Object
 	k8sI           kubeinformers.SharedInformerFactory
 	infraInformer  configinformers.SharedInformerFactory
@@ -65,6 +70,7 @@ func newFixture(t *testing.T) *fixture {
 	f.objects = []runtime.Object{}
 	f.configObjects = []runtime.Object{}
 	f.machineObjects = []runtime.Object{}
+	f.mcfgObjects = []runtime.Object{}
 	f.aroObjects = []runtime.Object{}
 	return f
 }
@@ -92,6 +98,7 @@ func (f *fixture) newController() *CertRotationController {
 	f.kubeClient = fake.NewSimpleClientset(f.objects...)
 	f.configClient = fakeconfigv1client.NewSimpleClientset(f.configObjects...)
 	f.machineClient = fakemachineclientset.NewSimpleClientset(f.machineObjects...)
+	f.mcfgClient = fakemcfgclientset.NewSimpleClientset(f.mcfgObjects...)
 	f.aroClient = fakearoclientset.NewSimpleClientset(f.aroObjects...)
 	f.k8sI = kubeinformers.NewSharedInformerFactory(f.kubeClient, noResyncPeriodFunc())
 	f.infraInformer = configinformers.NewSharedInformerFactory(f.configClient, noResyncPeriodFunc())
@@ -117,7 +124,7 @@ func (f *fixture) newController() *CertRotationController {
 		[]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall},
 		nil,
 	)
-	c, err := New(f.kubeClient, f.configClient, f.machineClient, f.aroClient, f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().ConfigMaps(), f.infraInformer.Config().V1().Infrastructures(), fgHandler)
+	c, err := New(f.kubeClient, f.configClient, f.machineClient, f.aroClient, f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().ConfigMaps(), f.infraInformer.Config().V1().Infrastructures(), fgHandler, f.mcfgClient)
 	require.NoError(f.t, err)
 
 	c.StartInformers()
@@ -312,7 +319,6 @@ func TestMCSCARotation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("case %s", test.name), func(t *testing.T) {
 			t.Parallel()
 			f := newFixture(t)
@@ -356,80 +362,48 @@ func TestMCSCARotation(t *testing.T) {
 }
 
 func TestIRICertificateRotation(t *testing.T) {
-	tests := []struct {
-		name                 string
-		iriSecretAlreadyExists bool
-		forceRotation        bool
-	}{
-		{
-			// Covers the case where the IRI secret has been manually deleted
-			// (e.g., accidental "oc delete secret internal-release-image-tls")
-			// and the controller recreates it.
-			name:                 "IRI secret is created when it does not already exist",
-			iriSecretAlreadyExists: false,
-			forceRotation:        false,
-		},
-		{
-			name:                 "IRI secret is updated on CA rotation",
-			iriSecretAlreadyExists: true,
-			forceRotation:        true,
-		},
-	}
+	t.Run("IRI secret is updated on CA rotation", func(t *testing.T) {
+		t.Parallel()
+		f := newFixture(t)
+		maoSecret := getGoodMAOSecret("test-user-data")
+		f.machineObjects = append(f.machineObjects, getMachineSet("test-machine"))
+		f.mcfgObjects = append(f.mcfgObjects, getIRIClusterResource())
+		f.objects = append(f.objects, maoSecret)
+		f.maoSecretLister = append(f.maoSecretLister, maoSecret)
+		f.controller = f.newController()
 
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			f := newFixture(t)
-			maoSecret := getGoodMAOSecret("test-user-data")
-			f.machineObjects = append(f.machineObjects, getMachineSet("test-machine"))
-			f.objects = append(f.objects, maoSecret)
-			f.maoSecretLister = append(f.maoSecretLister, maoSecret)
-			f.controller = f.newController()
+		// Initial sync to create CA and MCS TLS cert
+		f.runController()
 
-			// Initial sync to create CA and MCS TLS cert
-			f.runController()
+		// Create the IRI cert under the current CA
+		f.createIRISecret(t)
+		f.controller.reconcileIRICertificate()
+		existingSecret, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
+		require.NoError(t, err, "IRI TLS secret should exist after initial reconciliation")
+		originalCertData := existingSecret.Data[corev1.TLSCertKey]
 
-			var originalCertData []byte
-			if test.iriSecretAlreadyExists {
-				// Create the IRI cert under the current CA
-				f.controller.reconcileIRICertificate()
-				existingSecret, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
-				require.NoError(t, err, "IRI TLS secret should exist after initial reconciliation")
-				originalCertData = existingSecret.Data[corev1.TLSCertKey]
-			} else {
-				_, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
-				require.True(t, errors.IsNotFound(err), "IRI TLS secret should not exist before reconciliation")
-			}
+		// Force CA rotation
+		t.Log("Forcing CA rotation")
+		secret, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.MachineConfigServerCAName, metav1.GetOptions{})
+		require.NoError(t, err)
+		newSecret := secret.DeepCopy()
+		newSecret.Annotations[certrotation.CertificateNotAfterAnnotation] = time.Now().Add(-time.Hour).Format(time.RFC3339)
+		_, err = f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(context.TODO(), newSecret, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		f.syncListers(t)
+		f.runController()
 
-			if test.forceRotation {
-				t.Log("Forcing CA rotation")
-				secret, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.MachineConfigServerCAName, metav1.GetOptions{})
-				require.NoError(t, err)
-				newSecret := secret.DeepCopy()
-				newSecret.Annotations[certrotation.CertificateNotAfterAnnotation] = time.Now().Add(-time.Hour).Format(time.RFC3339)
-				_, err = f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Update(context.TODO(), newSecret, metav1.UpdateOptions{})
-				require.NoError(t, err)
-				f.syncListers(t)
-				f.runController()
-			}
+		// Reconcile the IRI certificate
+		f.controller.reconcileIRICertificate()
 
-			// Reconcile the IRI certificate
-			f.controller.reconcileIRICertificate()
+		// Verify the IRI TLS secret was updated
+		iriSecret, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
+		require.NoError(t, err, "IRI TLS secret should exist after reconciliation")
+		require.Equal(t, corev1.SecretTypeTLS, iriSecret.Type, "IRI secret should be of type TLS")
+		require.NotEqual(t, originalCertData, iriSecret.Data[corev1.TLSCertKey], "IRI certificate data should have changed after CA rotation")
 
-			// Verify the IRI TLS secret was created/updated
-			iriSecret, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
-			require.NoError(t, err, "IRI TLS secret should exist after reconciliation")
-			require.Equal(t, corev1.SecretTypeTLS, iriSecret.Type, "IRI secret should be of type TLS")
-
-			// If the IRI secret existed before, verify the cert data actually changed
-			if test.iriSecretAlreadyExists {
-				require.NotEqual(t, originalCertData, iriSecret.Data[corev1.TLSCertKey], "IRI certificate data should have changed after CA rotation")
-			}
-
-			f.verifyIRICertificate(t)
-		})
-	}
+		f.verifyIRICertificate(t)
+	})
 
 	// Verifies idempotency: if the IRI cert is already valid under the
 	// current CA, reconcileIRICertificate should skip regeneration.
@@ -438,6 +412,7 @@ func TestIRICertificateRotation(t *testing.T) {
 		f := newFixture(t)
 		maoSecret := getGoodMAOSecret("test-user-data")
 		f.machineObjects = append(f.machineObjects, getMachineSet("test-machine"))
+		f.mcfgObjects = append(f.mcfgObjects, getIRIClusterResource())
 		f.objects = append(f.objects, maoSecret)
 		f.maoSecretLister = append(f.maoSecretLister, maoSecret)
 		f.controller = f.newController()
@@ -445,7 +420,8 @@ func TestIRICertificateRotation(t *testing.T) {
 		// Initial sync to create CA and MCS TLS cert
 		f.runController()
 
-		// First reconciliation creates the IRI cert
+		// Create the IRI secret and reconcile to populate it
+		f.createIRISecret(t)
 		f.controller.reconcileIRICertificate()
 
 		// Get the IRI secret after first reconciliation
@@ -467,8 +443,105 @@ func TestIRICertificateRotation(t *testing.T) {
 	})
 }
 
+func TestIRICertificateReconcileSkippedWhenFeatureGateDisabled(t *testing.T) {
+	f := newFixture(t)
+	f.mcfgObjects = append(f.mcfgObjects, getIRIClusterResource())
+	f.machineObjects = append(f.machineObjects, getMachineSet("test-machine"))
+
+	// Build a controller with the feature gate disabled.
+	f.kubeClient = fake.NewSimpleClientset(f.objects...)
+	f.configClient = fakeconfigv1client.NewSimpleClientset(f.configObjects...)
+	f.machineClient = fakemachineclientset.NewSimpleClientset(f.machineObjects...)
+	f.mcfgClient = fakemcfgclientset.NewSimpleClientset(f.mcfgObjects...)
+	f.aroClient = fakearoclientset.NewSimpleClientset(f.aroObjects...)
+	f.k8sI = kubeinformers.NewSharedInformerFactory(f.kubeClient, noResyncPeriodFunc())
+	f.infraInformer = configinformers.NewSharedInformerFactory(f.configClient, noResyncPeriodFunc())
+
+	fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler(
+		nil,
+		[]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall},
+	)
+	c, err := New(f.kubeClient, f.configClient, f.machineClient, f.aroClient,
+		f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().Secrets(),
+		f.k8sI.Core().V1().ConfigMaps(), f.infraInformer.Config().V1().Infrastructures(),
+		fgHandler, f.mcfgClient)
+	require.NoError(t, err)
+
+	// reconcileIRICertificate must be a no-op when the feature gate is disabled.
+	c.reconcileIRICertificate()
+
+	// Verify no IRI TLS secret was created.
+	_, err = f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
+	require.Error(t, err, "IRI TLS secret should not exist when feature gate is disabled")
+	require.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestIsIRICertValid(t *testing.T) {
+	caConfig, err := crypto.MakeSelfSignedCAConfig("test-ca", 24*time.Hour)
+	require.NoError(t, err)
+	certBytes, keyBytes, err := caConfig.GetPEMBytes()
+	require.NoError(t, err)
+	ca, err := crypto.GetCAFromBytes(certBytes, keyBytes)
+	require.NoError(t, err)
+
+	makeSecret := func(hostnames []string) *corev1.Secret {
+		certCfg, err := ca.MakeServerCert(sets.New(hostnames...), time.Hour)
+		require.NoError(t, err)
+		certPEM, keyPEM, err := certCfg.GetPEMBytes()
+		require.NoError(t, err)
+		return &corev1.Secret{
+			Data: map[string][]byte{
+				corev1.TLSCertKey:       certPEM,
+				corev1.TLSPrivateKeyKey: keyPEM,
+			},
+		}
+	}
+
+	ctrl := &CertRotationController{}
+
+	tests := []struct {
+		name              string
+		certHostnames     []string
+		expectedHostnames []string
+		expectValid       bool
+	}{
+		{
+			name:              "matching SANs",
+			certHostnames:     []string{"api-int.example.com", "localhost", "127.0.0.1", "::1"},
+			expectedHostnames: []string{"api-int.example.com", "localhost", "127.0.0.1", "::1"},
+			expectValid:       true,
+		},
+		{
+			name:              "missing expected DNS SAN",
+			certHostnames:     []string{"localhost", "127.0.0.1", "::1"},
+			expectedHostnames: []string{"api-int.example.com", "localhost", "127.0.0.1", "::1"},
+			expectValid:       false,
+		},
+		{
+			name:              "missing expected IP SAN",
+			certHostnames:     []string{"api-int.example.com", "localhost", "::1"},
+			expectedHostnames: []string{"api-int.example.com", "localhost", "127.0.0.1", "::1"},
+			expectValid:       false,
+		},
+		{
+			name:              "cert has extra SANs beyond expected",
+			certHostnames:     []string{"api-int.example.com", "extra.host", "localhost", "127.0.0.1", "::1"},
+			expectedHostnames: []string{"api-int.example.com", "localhost", "127.0.0.1", "::1"},
+			expectValid:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := makeSecret(tt.certHostnames)
+			got := ctrl.isIRICertValid(secret, ca, tt.expectedHostnames)
+			require.Equal(t, tt.expectValid, got)
+		})
+	}
+}
+
 // verifyIRICertificate checks that the IRI TLS certificate is signed by the current
-// MCS CA and contains the expected SANs (hostnames from hostnamesRotation + localhost SANs).
+// MCS CA and contains the expected SANs (apiInt hostname + localhost SANs).
 func (f *fixture) verifyIRICertificate(t *testing.T) {
 	t.Helper()
 
@@ -498,10 +571,9 @@ func (f *fixture) verifyIRICertificate(t *testing.T) {
 	err = iriCert.CheckSignatureFrom(caCert)
 	require.NoError(t, err, "IRI certificate should be signed by the MCS CA")
 
-	// Verify the IRI cert has the correct SANs (hostnames from hostnamesRotation + localhost SANs)
-	expectedHostnames := f.controller.hostnamesRotation.GetHostnames()
-	require.NotEmpty(t, expectedHostnames, "Expected hostnames should not be empty")
-	expectedHostnames = append(expectedHostnames, "localhost", "127.0.0.1", "::1")
+	// Verify the IRI cert has the correct SANs (apiInt hostname + localhost SANs)
+	expectedHostnames, err := f.controller.getIRIHostnames()
+	require.NoError(t, err, "Should be able to get IRI hostnames")
 
 	for _, hostname := range expectedHostnames {
 		ip := net.ParseIP(hostname)

--- a/pkg/controller/certrotation/helpers_test.go
+++ b/pkg/controller/certrotation/helpers_test.go
@@ -1,7 +1,13 @@
 package certrotationcontroller
 
 import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,4 +53,30 @@ func getAROCluster(apiIntIP string) *arov1alpha1.Cluster {
 			APIIntIP: apiIntIP,
 		},
 	}
+}
+
+func getIRIClusterResource() *mcfgv1alpha1.InternalReleaseImage {
+	return &mcfgv1alpha1.InternalReleaseImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ctrlcommon.InternalReleaseImageInstanceName,
+		},
+	}
+}
+
+// createIRISecret creates an empty IRI TLS secret, simulating what the IRI controller
+// would create during cluster bootstrap.
+func (f *fixture) createIRISecret(t *testing.T) {
+	t.Helper()
+	_, err := f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ctrlcommon.InternalReleaseImageTLSSecretName,
+			Namespace: ctrlcommon.MCONamespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       {},
+			corev1.TLSPrivateKeyKey: {},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
 }

--- a/pkg/controller/certrotation/hostnames.go
+++ b/pkg/controller/certrotation/hostnames.go
@@ -60,6 +60,7 @@ func (c *CertRotationController) processHostnames() bool {
 	err := c.syncHostnames()
 	if err == nil {
 		c.hostnamesQueue.Forget(dsKey)
+		go c.reconcileIRICertificate()
 		return true
 	}
 

--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -1,10 +1,12 @@
 package e2e_iri_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"os"

--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -374,3 +374,57 @@ func TestIRIController_ShouldRestoreMachineConfigsWhenModified(t *testing.T) {
 		})
 	}
 }
+
+// TestCertRotation_IRICertIsRegeneratedOnCARotation verifies that when the MCS CA
+// rotates, the cert rotation controller regenerates the IRI TLS certificate and
+// signs it with the new CA.
+func TestCertRotation_IRICertIsRegeneratedOnCARotation(t *testing.T) {
+	skipIfNoBaremetal(t)
+
+	cs := framework.NewClientSet("")
+	ctx := context.Background()
+
+	// Record the current IRI TLS cert so we can detect when it changes.
+	iriSecret, err := cs.Secrets(ctrlcommon.MCONamespace).Get(ctx, ctrlcommon.InternalReleaseImageTLSSecretName, v1.GetOptions{})
+	require.NoError(t, err)
+	originalCert := iriSecret.Data[corev1.TLSCertKey]
+	require.NotEmpty(t, originalCert, "IRI TLS cert should be present before rotation")
+
+	// Trigger MCS CA rotation by deleting the CA secret. library-go's
+	// CertRotationController recreates the secret with a new keypair and then
+	// reconciles the machine-config-server-ca ConfigMap (the CA bundle). The
+	// configmap update event fires updateConfigMap(), which calls
+	// reconcileIRICertificate() to regenerate the IRI TLS cert.
+	err = cs.Secrets(ctrlcommon.MCONamespace).Delete(ctx, ctrlcommon.MachineConfigServerCAName, v1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// Wait for the IRI TLS cert to be replaced.
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		updated, err := cs.Secrets(ctrlcommon.MCONamespace).Get(ctx, ctrlcommon.InternalReleaseImageTLSSecretName, v1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return !bytes.Equal(updated.Data[corev1.TLSCertKey], originalCert), nil
+	})
+	require.NoError(t, err, "IRI TLS cert should have been rotated after MCS CA rotation")
+
+	// Verify the new cert is signed by the new MCS CA bundle.
+	cm, err := cs.ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, ctrlcommon.MachineConfigServerCAName, v1.GetOptions{})
+	require.NoError(t, err)
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM([]byte(cm.Data["ca-bundle.crt"])))
+
+	iriSecret, err = cs.Secrets(ctrlcommon.MCONamespace).Get(ctx, ctrlcommon.InternalReleaseImageTLSSecretName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(iriSecret.Data[corev1.TLSCertKey])
+	require.NotNil(t, block, "Should be able to decode rotated IRI TLS cert PEM")
+	iriCert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	_, err = iriCert.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.NoError(t, err, "Rotated IRI TLS cert should be signed by the new MCS CA")
+}


### PR DESCRIPTION
**- What I did**

- Updated certrotation_controller to generate new IRI TLS certificates when the MCS CA rotates
- Created reconcileIRICertificate function to update the IRI TLS certificates
- The function only runs if the NoRegistryClusterInstall feature gate is enabled and the InternalReleaseImage CR is present
- IRI cert SANs match the installer: api-int hostname + localhost/127.0.0.1/::1
- Add idempotency check (isIRICertValid) that verifies the existing IRI cert against the current MCS CA and expected SANs before regenerating, preventing unnecessary Secret updates on controller restarts
- Call reconcileIRICertificate from the hostname queue worker so that an APIServerInternalURL change triggers rotation even without a concurrent CA rotation
- Add unit tests for isIRICertValid SAN validation logic
- Add e2e test: TestCertRotation_IRICertIsRegeneratedOnCARotation

**- How to verify it**

Force the MCS CA to rotate by deleting the secret:
```
oc delete secret machine-config-server-ca -n openshift-machine-config-operator
```
Verify the IRI TLS certificates have been updated at /etc/iri-registry/certs/tls.crt
Verify the IRI registry continues to work with the new certificates:
```
curl --cacert /etc/iri-registry/certs/tls.crt https://api-int.<cluster>:22625/v2/_catalog
```

**- Description for the changelog**

When the MCS CA rotates, the IRI TLS certificate (internal-release-image-tls) was not being regenerated, leaving it signed by the old CA. This adds a reconcileIRICertificate() method that generates a new IRI server cert signed by the current MCS CA and creates/updates the secret, triggered on CA configmap events and APIServerInternalURL changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IRI TLS certificate rotation: automatic regeneration/validation of Internal Release Image TLS certs when the machine-config-server CA changes; gated by a feature flag and requires the InternalReleaseImage resource.

* **Improvements**
  * Remote registry fallback uses kubelet auth and fixed command quoting for correct image pulling.

* **Tests**
  * Added unit and e2e tests for IRI cert rotation, SAN validation, idempotency, and CA-sync verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->