### PR TITLE
OCPBUGS-10431: allow worker pools to set staticPodPath by relaxing validation to only block control plane pools

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -377,9 +377,6 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 	if len(kcDecoded.FeatureGates) > 0 {
 		return fmt.Errorf("KubeletConfiguration: featureGates is not allowed to be set, but contains: %v", kcDecoded.FeatureGates)
 	}
-	if kcDecoded.StaticPodPath != "" {
-		return fmt.Errorf("KubeletConfiguration: staticPodPath is not allowed to be set, but contains: %s", kcDecoded.StaticPodPath)
-	}
 	if kcDecoded.FailSwapOn != nil {
 		return fmt.Errorf("KubeletConfiguration: failSwapOn is not allowed to be set, but contains: %v", *kcDecoded.FailSwapOn)
 	}
@@ -391,6 +388,51 @@ func validateUserKubeletConfig(cfg *mcfgv1.KubeletConfig) error {
 		return fmt.Errorf("KubeletConfiguration: autoSizingReserved and systemdReserved cannot be set together")
 	}
 	return nil
+}
+
+// validateStaticPodPathGivenPool validates staticPodPath based on the target pool.
+// Control plane pools cannot have staticPodPath set at all.
+// Worker and custom pools may only set staticPodPath to "" to disable static pods.
+func validateStaticPodPathGivenPool(cfg *mcfgv1.KubeletConfig, pool *mcfgv1.MachineConfigPool) error {
+	if cfg.Spec.KubeletConfig == nil || cfg.Spec.KubeletConfig.Raw == nil {
+		return nil
+	}
+	if isControlPlanePool(pool) {
+		if strings.Contains(string(cfg.Spec.KubeletConfig.Raw), "\"staticPodPath\"") {
+			return fmt.Errorf("KubeletConfiguration: staticPodPath is not allowed to be set for control plane pool %q", pool.Name)
+		}
+		return nil
+	}
+	kcDecoded, err := DecodeKubeletConfig(cfg.Spec.KubeletConfig.Raw)
+	if err != nil {
+		return fmt.Errorf("KubeletConfig could not be unmarshalled, err: %w", err)
+	}
+	if kcDecoded.StaticPodPath != "" {
+		return fmt.Errorf("KubeletConfiguration: staticPodPath must be empty for pool %q, but contains: %s", pool.Name, kcDecoded.StaticPodPath)
+	}
+	return nil
+}
+
+// isControlPlanePool returns true if the pool targets control plane nodes,
+// either by name (master, arbiter) or by selecting nodes with the master label.
+func isControlPlanePool(pool *mcfgv1.MachineConfigPool) bool {
+	if pool.Name == ctrlcommon.MachineConfigPoolMaster || pool.Name == ctrlcommon.MachineConfigPoolArbiter {
+		return true
+	}
+	if pool.Spec.NodeSelector == nil {
+		return false
+	}
+	if pool.Spec.NodeSelector.MatchLabels != nil {
+		if _, ok := pool.Spec.NodeSelector.MatchLabels[ctrlcommon.MasterLabel]; ok {
+			return true
+		}
+	}
+	for _, expr := range pool.Spec.NodeSelector.MatchExpressions {
+		if expr.Key == ctrlcommon.MasterLabel && (expr.Operator == metav1.LabelSelectorOpExists || expr.Operator == metav1.LabelSelectorOpIn) {
+			return true
+		}
+	}
+	return false
 }
 
 func wrapErrorWithCondition(err error, args ...interface{}) mcfgv1.KubeletConfigCondition {

--- a/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
+++ b/pkg/controller/kubelet-config/kubelet_config_bootstrap.go
@@ -40,6 +40,10 @@ func RunKubeletBootstrap(templateDir string, kubeletConfigs []*mcfgv1.KubeletCon
 			}
 			role := pool.Name
 
+			if err := validateStaticPodPathGivenPool(kubeletConfig, pool); err != nil {
+				return nil, err
+			}
+
 			originalKubeConfig, err := generateOriginalKubeletConfigWithFeatureGates(controllerConfig, templateDir, role, fgHandler, apiServer)
 			if err != nil {
 				return nil, err

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -599,6 +599,11 @@ func (ctrl *Controller) syncKubeletConfig(key string) error {
 
 	for _, pool := range mcpPools {
 		role := pool.Name
+
+		if err := validateStaticPodPathGivenPool(cfg, pool); err != nil {
+			return ctrl.syncStatusOnly(cfg, err)
+		}
+
 		// Get MachineConfig
 		managedKey, err := getManagedKubeletConfigKey(pool, ctrl.client, cfg)
 		if err != nil {

--- a/pkg/controller/kubelet-config/kubelet_config_controller_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller_test.go
@@ -914,12 +914,6 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "test banned staticpodpath",
-			config: &kubeletconfigv1beta1.KubeletConfiguration{
-				StaticPodPath: "some_value",
-			},
-		},
-		{
 			name: "user cannot supply features gates",
 			config: &kubeletconfigv1beta1.KubeletConfiguration{
 				FeatureGates: map[string]bool{
@@ -971,6 +965,156 @@ func TestKubeletConfigDenylistedOptions(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: failed with %v. should have succeeded", test.name, err)
 		}
+	}
+}
+
+func TestIsControlPlanePool(t *testing.T) {
+	tests := []struct {
+		name     string
+		pool     *mcfgv1.MachineConfigPool
+		expected bool
+	}{
+		{
+			name:     "master pool",
+			pool:     helpers.NewMachineConfigPool(ctrlcommon.MachineConfigPoolMaster, nil, helpers.MasterSelector, "v0"),
+			expected: true,
+		},
+		{
+			name:     "arbiter pool",
+			pool:     helpers.NewMachineConfigPool(ctrlcommon.MachineConfigPoolArbiter, nil, helpers.MasterSelector, "v0"),
+			expected: true,
+		},
+		{
+			name:     "worker pool",
+			pool:     helpers.NewMachineConfigPool(ctrlcommon.MachineConfigPoolWorker, nil, helpers.WorkerSelector, "v0"),
+			expected: false,
+		},
+		{
+			name:     "custom pool",
+			pool:     helpers.NewMachineConfigPool("custom-pool", nil, helpers.WorkerSelector, "v0"),
+			expected: false,
+		},
+		{
+			name: "custom pool derived from master via MatchLabels",
+			pool: helpers.NewMachineConfigPool("infra-master", nil,
+				&metav1.LabelSelector{MatchLabels: map[string]string{ctrlcommon.MasterLabel: ""}}, "v0"),
+			expected: true,
+		},
+		{
+			name: "custom pool derived from master via MatchExpressions Exists",
+			pool: helpers.NewMachineConfigPool("infra-master-expr", nil,
+				&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: ctrlcommon.MasterLabel, Operator: metav1.LabelSelectorOpExists},
+				}}, "v0"),
+			expected: true,
+		},
+		{
+			name: "custom pool derived from master via MatchExpressions In",
+			pool: helpers.NewMachineConfigPool("infra-master-in", nil,
+				&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: ctrlcommon.MasterLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{""}},
+				}}, "v0"),
+			expected: true,
+		},
+		{
+			name: "custom pool excluding master via MatchExpressions DoesNotExist",
+			pool: helpers.NewMachineConfigPool("not-master", nil,
+				&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: ctrlcommon.MasterLabel, Operator: metav1.LabelSelectorOpDoesNotExist},
+				}}, "v0"),
+			expected: false,
+		},
+		{
+			name:     "custom pool with nil node selector",
+			pool:     helpers.NewMachineConfigPool("custom-nil", nil, nil, "v0"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isControlPlanePool(tt.pool)
+			if result != tt.expected {
+				t.Errorf("isControlPlanePool(%q) = %v, want %v", tt.pool.Name, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStaticPodPathPoolValidation(t *testing.T) {
+	kcWithNonEmptyStaticPodPath := newKubeletConfig(
+		"test-staticpodpath-nonempty",
+		&kubeletconfigv1beta1.KubeletConfiguration{
+			StaticPodPath: "/some/path",
+		},
+		metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""),
+	)
+
+	masterPool := helpers.NewMachineConfigPool(ctrlcommon.MachineConfigPoolMaster, nil, helpers.MasterSelector, "v0")
+	arbiterPool := helpers.NewMachineConfigPool(ctrlcommon.MachineConfigPoolArbiter, nil, helpers.MasterSelector, "v0")
+	workerPool := helpers.NewMachineConfigPool(ctrlcommon.MachineConfigPoolWorker, nil, helpers.WorkerSelector, "v0")
+	customPool := helpers.NewMachineConfigPool("custom-pool", nil, helpers.WorkerSelector, "v0")
+	// custom pool derived from master via node selector
+	masterDerivedPool := helpers.NewMachineConfigPool("infra-master", nil,
+		&metav1.LabelSelector{MatchLabels: map[string]string{ctrlcommon.MasterLabel: ""}}, "v0")
+
+	// non-empty staticPodPath should be rejected for all pools
+	err := validateStaticPodPathGivenPool(kcWithNonEmptyStaticPodPath, masterPool)
+	if err == nil {
+		t.Error("expected error for non-empty staticPodPath on master pool, got nil")
+	}
+
+	err = validateStaticPodPathGivenPool(kcWithNonEmptyStaticPodPath, arbiterPool)
+	if err == nil {
+		t.Error("expected error for non-empty staticPodPath on arbiter pool, got nil")
+	}
+
+	err = validateStaticPodPathGivenPool(kcWithNonEmptyStaticPodPath, masterDerivedPool)
+	if err == nil {
+		t.Error("expected error for non-empty staticPodPath on master-derived custom pool, got nil")
+	}
+
+	err = validateStaticPodPathGivenPool(kcWithNonEmptyStaticPodPath, workerPool)
+	if err == nil {
+		t.Error("expected error for non-empty staticPodPath on worker pool, got nil")
+	}
+
+	err = validateStaticPodPathGivenPool(kcWithNonEmptyStaticPodPath, customPool)
+	if err == nil {
+		t.Error("expected error for non-empty staticPodPath on custom pool, got nil")
+	}
+
+	// empty staticPodPath should be allowed for worker and custom pools
+	kcWithEmptyStaticPodPath := newKubeletConfig(
+		"test-staticpodpath-empty",
+		&kubeletconfigv1beta1.KubeletConfiguration{
+			StaticPodPath: "",
+		},
+		metav1.AddLabelToSelector(&metav1.LabelSelector{}, "", ""),
+	)
+
+	err = validateStaticPodPathGivenPool(kcWithEmptyStaticPodPath, workerPool)
+	if err != nil {
+		t.Errorf("expected no error for empty staticPodPath on worker pool, got: %v", err)
+	}
+
+	err = validateStaticPodPathGivenPool(kcWithEmptyStaticPodPath, customPool)
+	if err != nil {
+		t.Errorf("expected no error for empty staticPodPath on custom pool, got: %v", err)
+	}
+
+	// control plane pools should reject staticPodPath even when set to ""
+	kcExplicitEmpty := kcWithEmptyStaticPodPath.DeepCopy()
+	kcExplicitEmpty.Spec.KubeletConfig.Raw = []byte(`{"staticPodPath":""}`)
+
+	err = validateStaticPodPathGivenPool(kcExplicitEmpty, masterPool)
+	if err == nil {
+		t.Error("expected error for explicitly empty staticPodPath on master pool, got nil")
+	}
+
+	err = validateStaticPodPathGivenPool(kcExplicitEmpty, arbiterPool)
+	if err == nil {
+		t.Error("expected error for explicitly empty staticPodPath on arbiter pool, got nil")
 	}
 }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Moved `staticPodPath` validation out of the blanket denylist in `validateUserKubeletConfig` and into a new pool-aware `validateStaticPodPathForPool` function. Setting `staticPodPath` to a non-empty value is rejected for all pools. Setting it to `""` (to disable static pods) is allowed for any pool, enabling workers to satisfy DISA STIG V-242397 compliance.

Fixes: https://issues.redhat.com/browse/OCPBUGS-10431

**- How to verify it**
1. Deploy a cluster with this change
2. Create a KubeletConfig CR targeting worker pools with `staticPodPath: ""` — it should be accepted
3. Create a KubeletConfig CR targeting any pool with `staticPodPath: "/some/path"` — the controller should reject it with an error condition
4. Verify existing worker and control plane kubelet configs remain unchanged without a KubeletConfig CR override

**- Description for the changelog**
Allow setting `staticPodPath` to `""` via KubeletConfig CR to resolve DISA STIG V-242397 compliance finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforce that StaticPodPath cannot be set for control-plane pools; validation now stops processing and returns a clear error when violated.

* **Tests**
  * Added tests for control-plane vs non-control-plane pool classification and StaticPodPath validation; removed StaticPodPath from the previous denylist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->