### PR TITLE
WIP: Gracefully stop kube-apiserver before MCO reboot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -261,11 +261,14 @@ var (
 )
 
 // rebootCommand creates a new transient systemd unit to reboot the system.
-// With the upstream implementation of kubelet graceful shutdown feature,
-// we don't explicitly stop the kubelet so that kubelet can gracefully shutdown
-// pods when `GracefulNodeShutdown` feature gate is enabled.
-// kubelet uses systemd inhibitor locks to delay node shutdown to terminate pods.
-// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+// Before rebooting, it gracefully stops kube-apiserver containers to prevent
+// non-graceful termination. Without GracefulNodeShutdown configured, kubelet
+// exits immediately on SIGTERM without terminating pods. This causes
+// kube-apiserver to be SIGKILLed by systemd before completing its graceful
+// shutdown (up to 194s on AWS), since systemd's DefaultTimeoutStopSec is
+// only 90s. The graceful stop runs inside the transient systemd unit so
+// that kubelet is still alive when systemd-run is invoked, preserving MCD
+// error recovery if the unit fails to start.
 func rebootCommand(rationale string, workaroundOCPBUGS51150 bool) *exec.Cmd {
 	systemdRunArgs := []string{"--unit", "machine-config-daemon-reboot",
 		"--description", fmt.Sprintf("machine-config-daemon: %s", rationale)}
@@ -273,7 +276,40 @@ func rebootCommand(rationale string, workaroundOCPBUGS51150 bool) *exec.Cmd {
 	if workaroundOCPBUGS51150 {
 		systemdRunArgs = append(systemdRunArgs, "-p", "Requires=ostree-finalize-staged.service", "-p", "After=ostree-finalize-staged.service")
 	}
-	systemdRunArgs = append(systemdRunArgs, "/bin/sh", "-c", "systemctl reboot")
+	// Cap how long the transient unit can run. The script can take up to ~230s
+	// (30s kubelet stop + 200s crictl stop) so 300s provides headroom while
+	// preventing an indefinite hang if CRI-O is stuck.
+	systemdRunArgs = append(systemdRunArgs, "-p", "TimeoutStartSec=300")
+	// Gracefully stop kube-apiserver before rebooting. Only runs on control
+	// plane nodes (workers have no kube-apiserver containers, so the crictl
+	// query returns empty and the script skips straight to reboot).
+	// The 200s crictl timeout covers the worst-case kube-apiserver
+	// terminationGracePeriodSeconds of 194s (AWS).
+	rebootScript := `
+CONTAINERS=$(crictl ps -q --label io.kubernetes.container.name=kube-apiserver 2>/dev/null)
+if [ -n "$CONTAINERS" ]; then
+  logger 'machine-config-daemon: stopping kubelet to prevent static pod restarts'
+  if ! timeout 30 systemctl stop kubelet; then
+    logger 'machine-config-daemon: WARNING: failed to stop kubelet within 30s'
+  fi
+  # Re-list after kubelet stop to catch any container restarted during the gap.
+  CONTAINERS=$(crictl ps -q --label io.kubernetes.container.name=kube-apiserver 2>/dev/null)
+  STOP_FAILED=0
+  for cid in $CONTAINERS; do
+    logger "machine-config-daemon: gracefully stopping kube-apiserver container $cid"
+    if ! crictl stop --timeout 200 "$cid"; then
+      STOP_FAILED=1
+      logger "machine-config-daemon: WARNING: failed to stop kube-apiserver container $cid"
+    fi
+  done
+  if [ "$STOP_FAILED" -eq 0 ]; then
+    logger 'machine-config-daemon: kube-apiserver containers stopped'
+  else
+    logger 'machine-config-daemon: WARNING: kube-apiserver stop had failures; proceeding with reboot'
+  fi
+fi
+systemctl reboot`
+	systemdRunArgs = append(systemdRunArgs, "/bin/sh", "-c", rebootScript)
 	return exec.Command("systemd-run", systemdRunArgs...)
 }
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -540,6 +541,53 @@ func TestPrepUpdateFromClusterOnDiskDrift(t *testing.T) {
 			dn.currentImagePath = currentImagePath
 			ufc, err := dn.prepUpdateFromCluster()
 			test.verify(t, ufc, err)
+		})
+	}
+}
+
+func TestRebootCommand(t *testing.T) {
+	tests := []struct {
+		name                  string
+		rationale             string
+		workaroundOCPBUGS51150 bool
+	}{
+		{
+			name:                  "without workaround",
+			rationale:             "test reboot",
+			workaroundOCPBUGS51150: false,
+		},
+		{
+			name:                  "with workaround",
+			rationale:             "test reboot",
+			workaroundOCPBUGS51150: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := rebootCommand(tt.rationale, tt.workaroundOCPBUGS51150)
+			args := cmd.Args
+
+			assert.Equal(t, "systemd-run", args[0])
+			assert.Contains(t, args, "--unit")
+			assert.Contains(t, args, "machine-config-daemon-reboot")
+
+			if tt.workaroundOCPBUGS51150 {
+				assert.Contains(t, args, "Requires=ostree-finalize-staged.service")
+				assert.Contains(t, args, "After=ostree-finalize-staged.service")
+			}
+
+			assert.Contains(t, args, "TimeoutStartSec=300")
+
+			// The last three args should be the shell invocation.
+			assert.Equal(t, "/bin/sh", args[len(args)-3])
+			assert.Equal(t, "-c", args[len(args)-2])
+
+			script := args[len(args)-1]
+			assert.True(t, strings.Contains(script, "crictl ps -q --label io.kubernetes.container.name=kube-apiserver"))
+			assert.True(t, strings.Contains(script, "systemctl stop kubelet"))
+			assert.True(t, strings.Contains(script, "crictl stop --timeout 200"))
+			assert.True(t, strings.Contains(script, "systemctl reboot"))
 		})
 	}
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -3018,7 +3018,7 @@ func (dn *Daemon) reboot(rationale string) error {
 		return fmt.Errorf("reboot command failed, something is seriously wrong")
 	}
 	// if we're here, reboot went through successfully, so we set rebootQueued
-	// and we wait for GracefulNodeShutdown
+	// and we wait for the system to shut down
 	dn.rebootQueued = true
 	logSystem("reboot successful")
 


### PR DESCRIPTION
**- What I did**

Alternative to #5708 that avoids enabling GracefulNodeShutdown (GNS).

Without GNS, kubelet exits immediately on SIGTERM without terminating pods during MCO-triggered reboots. kube-apiserver needs up to 194s for graceful shutdown but systemd's `DefaultTimeoutStopSec` is 90s, so it gets SIGKILLed.

The transient systemd reboot unit now gracefully stops kube-apiserver before rebooting:

1. Query for kube-apiserver containers via `crictl ps` (no-op on workers)
2. If found, stop kubelet (`timeout 30 systemctl stop kubelet`) to prevent static pod restarts
3. Gracefully stop kube-apiserver containers (`crictl stop --timeout 200`)
4. Proceed with `systemctl reboot`

Failures in steps 2 and 3 are logged via `logger` and do not block the reboot. The transient unit has `TimeoutStartSec=300` to prevent indefinite hangs if CRI-O is stuck.

This works because kube-apiserver runs under `watch-termination` (PID 1 in the container). `crictl stop` sends SIGTERM to `watch-termination`, which forwards it to kube-apiserver. After graceful shutdown completes, `watch-termination` removes its lock file (`/var/log/kube-apiserver/.terminating`) via defer and exits. On next startup, the absence of this file indicates graceful termination. No dependency on kubelet for detection.

**- How to verify it**

- Deploy to a cluster with MCO-triggered reboots (e.g. via KubeletConfig change)
- Run `[sig-api-machinery][Feature:APIServer][Late] kubelet terminates kube-apiserver gracefully extended`
- Verify `/var/log/kube-apiserver/.terminating` is absent after reboot

**- Description for the changelog**

Gracefully stop kube-apiserver containers before MCO-triggered reboots to prevent non-graceful termination.