### PR TITLE
WIP

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1016,7 +1016,10 @@ func (dn *Daemon) updateOnClusterLayering(oldConfig, newConfig *mcfgv1.MachineCo
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(oldIgnConfig, newIgnConfig, addedOrChangedUnits, skipCertificateWrite, forceFilePresent); err != nil {
+			// Recalculate unit diffs for rollback direction (new -> old)
+			rollbackUnitDiff := ctrlcommon.GetChangedConfigUnitsByType(&newIgnConfig, &oldIgnConfig)
+			rollbackAddedOrChangedUnits := slices.Concat(rollbackUnitDiff.Added, rollbackUnitDiff.Updated)
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, rollbackAddedOrChangedUnits, skipCertificateWrite, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1385,7 +1388,10 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, skipCertificateWrite, false); err != nil {
+			// Recalculate unit diffs for rollback direction (new -> old)
+			rollbackUnitDiff := ctrlcommon.GetChangedConfigUnitsByType(&newIgnConfig, &oldIgnConfig)
+			rollbackAddedOrChangedUnits := slices.Concat(rollbackUnitDiff.Added, rollbackUnitDiff.Updated)
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, rollbackAddedOrChangedUnits, skipCertificateWrite, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1525,7 +1531,10 @@ func (dn *Daemon) updateHypershift(oldConfig, newConfig *mcfgv1.MachineConfig, d
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, false, false); err != nil {
+			// Recalculate unit diffs for rollback direction (new -> old)
+			rollbackUnitDiff := ctrlcommon.GetChangedConfigUnitsByType(&newIgnConfig, &oldIgnConfig)
+			rollbackAddedOrChangedUnits := slices.Concat(rollbackUnitDiff.Added, rollbackUnitDiff.Updated)
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, rollbackAddedOrChangedUnits, false, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return


### PR DESCRIPTION
PR #5688 introduced a bug in the rollback logic for systemd unit updates. When an update fails and needs to roll back, the code was using the forward-direction unit diffs (old->new) instead of recalculating the reverse-direction diffs (new->old). This caused incomplete rollbacks that could leave systemd units in an inconsistent state.

This issue manifested during upgrades where kube-apiserver pods failed to terminate gracefully, likely because kubelet or related systemd units weren't properly restored during rollback.

The fix ensures that:
1. In updateOnClusterLayering: configs are properly swapped (was using oldIgnConfig->newIgnConfig, now uses newIgnConfig->oldIgnConfig)
2. In all three update functions: unit diffs are recalculated for the rollback direction (new->old) to ensure only the correct units are written during rollback

Related: OCPBUGS-77221, OCPBUGS-58023
Test failure: periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-upgrade-fips

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
