### PR TITLE
OCPBUGS-57473: create digest configmap without oc binary

### DIFF
--- a/cmd/machine-os-builder/digestconfigmap.go
+++ b/cmd/machine-os-builder/digestconfigmap.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/openshift/machine-config-operator/internal/clients"
+	"github.com/openshift/machine-config-operator/pkg/controller/build"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/version"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+var (
+	createDigestConfigMapCmd = &cobra.Command{
+		Use:   "create-digest-configmap",
+		Short: "Create the digest ConfigMap",
+		Long:  "",
+		RunE:  runCreateDigestConfigMapCmd,
+	}
+
+	createOpts struct {
+		configMapName string
+		digestFile    string
+		labels        string
+		namespace     string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(createDigestConfigMapCmd)
+	createDigestConfigMapCmd.PersistentFlags().StringVar(&createOpts.configMapName, "configmap-name", "", "The name of the digest ConfigMap to create.")
+	createDigestConfigMapCmd.PersistentFlags().StringVar(&createOpts.digestFile, "digestfile", "", "Path to the digest file.")
+	createDigestConfigMapCmd.PersistentFlags().StringVar(&createOpts.namespace, "namespace", ctrlcommon.MCONamespace, "The namespace to create the digest ConfigMap in.")
+	createDigestConfigMapCmd.PersistentFlags().StringVar(&createOpts.labels, "labels", "", "Labels to apply to the digest ConfigMap.")
+}
+
+func runCreateDigestConfigMapCmd(_ *cobra.Command, _ []string) error {
+	flag.Set("v", "4")
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	klog.V(2).Infof("Options parsed: %+v", createOpts)
+
+	// To help debugging, immediately log version
+	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cb, err := clients.NewBuilder("")
+	if err != nil {
+		return err
+	}
+
+	opts := build.DigestConfigMapOpts{
+		ConfigMapName: createOpts.configMapName,
+		Namespace:     createOpts.namespace,
+		DigestFile:    createOpts.digestFile,
+		Labels:        createOpts.labels,
+	}
+
+	if err := build.ApplyDigestConfigMapFromFile(ctx, cb.KubeClientOrDie(""), opts); err != nil {
+		return fmt.Errorf("apply configmap: %w", err)
+	}
+
+	klog.Infof("Applied digest configmap %q in namespace %q", createOpts.configMapName, createOpts.namespace)
+	return nil
+}

--- a/pkg/controller/build/buildrequest/assets/create-digest-cm.sh
+++ b/pkg/controller/build/buildrequest/assets/create-digest-cm.sh
@@ -6,16 +6,12 @@
 
 set -xeuo
 
-# Inject the contents of the digestfile into a ConfigMap.
+# Injects the contents of the digestfile into a ConfigMap using the
+# machine-os-builder binary. This is done to avoid needing an oc or kubectl
+# binary.
 
-# Create and label the digestfile ConfigMap
-if ! oc create configmap \
-    "$DIGEST_CONFIGMAP_NAME" \
-    --namespace openshift-machine-config-operator \
-    --from-file=digest=/tmp/done/digestfile \
-    --dry-run=client -o yaml | \
-    oc label --local -f - $DIGEST_CONFIGMAP_LABELS -o yaml | \
-    oc apply -f -; then
-    echo "Failed to create and label ConfigMap $DIGEST_CONFIGMAP_NAME"
-    exit 1
-fi
+machine-os-builder \
+    create-digest-configmap \
+    --configmap-name "${DIGEST_CONFIGMAP_NAME}" \
+    --digestfile /tmp/done/digestfile \
+    --labels "${DIGEST_CONFIGMAP_LABELS}"

--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -414,10 +414,9 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 		},
 		{
 			Name: "DIGEST_CONFIGMAP_LABELS",
-			// Gets the labels for all objects created by imageBuildRequest, converts
-			// them into a string representation, and replaces the separating commas
-			// with spaces.
-			Value: strings.ReplaceAll(labels.Set(br.getLabelsForObjectMeta()).String(), ",", " "),
+			// Gets the labels for all objects created by imageBuildRequest and
+			// converts them into a string representation.
+			Value: labels.Set(br.getLabelsForObjectMeta()).String(),
 		},
 		{
 			Name:  "HOME",
@@ -669,14 +668,15 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 			},
 			Containers: []corev1.Container{
 				{
-					// This container waits for the init container doing the build to finish
-					// building so we can get the final image SHA. We do this by using
-					// the base OS image (which contains the "oc" binary) to create a
-					// ConfigMap from the digestfile that Buildah creates, which allows
-					// us to avoid parsing log files.
+					// This container waits for the init container doing the build to
+					// finish building so we can get the final image SHA. We do this by
+					// using an option built into the machine-os-builder binary to create
+					// a ConfigMap from the digestfile created by Buildah. This approach
+					// allows us to avoid parsing log files and also avoids the need for
+					// an oc / kubectl binary to be present.
 					Name:                     "create-digest-configmap",
 					Command:                  append(command, digestCMScript),
-					Image:                    br.opts.MachineConfig.Spec.OSImageURL,
+					Image:                    br.opts.Images.MachineConfigOperator,
 					Env:                      env,
 					ImagePullPolicy:          corev1.PullAlways,
 					SecurityContext:          securityContext,

--- a/pkg/controller/build/buildrequest/buildrequest_test.go
+++ b/pkg/controller/build/buildrequest/buildrequest_test.go
@@ -231,8 +231,7 @@ func assertBuildJobIsCorrect(t *testing.T, buildJob *batchv1.Job, opts BuildRequ
 	)
 
 	assert.Equal(t, buildJob.Spec.Template.Spec.InitContainers[0].Image, mcoImagePullspec)
-
-	assert.Equal(t, fixtures.BaseOSContainerImage, buildJob.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, buildJob.Spec.Template.Spec.Containers[0].Image, mcoImagePullspec)
 
 	assertPodHasVolume(t, buildJob.Spec.Template.Spec, corev1.Volume{
 		Name: "final-image-push-creds",

--- a/pkg/controller/build/digestconfigmap.go
+++ b/pkg/controller/build/digestconfigmap.go
@@ -1,0 +1,94 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/build/imagebuilder"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// DigestConfigMapOpts holds the options needed to create a digestfile ConfigMap from a file.
+type DigestConfigMapOpts struct {
+	ConfigMapName string
+	Namespace     string
+	DigestFile    string
+	Labels        string
+}
+
+// applyDigestConfigMap creates or updates a ConfigMap.
+// This function is idempotent: it creates the ConfigMap if it doesn't exist, or updates
+// the Data and Labels if it already exists.
+func applyDigestConfigMap(ctx context.Context, kubeclient clientset.Interface, cm *corev1.ConfigMap) error {
+	_, err := kubeclient.CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+
+	// It is highly unlikely that the ConfigMap already exists. But in the event
+	// that it does, we should fetch it and update its data and labels to keep
+	// parity with what oc apply does.
+	if apierrors.IsAlreadyExists(err) {
+		existing, getErr := kubeclient.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+
+		// Update Data and Labels
+		existing.Data = cm.Data
+		existing.Labels = cm.Labels
+
+		_, updateErr := kubeclient.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+		return updateErr
+	}
+
+	return err
+}
+
+// ApplyDigestConfigMapFromFile reads a digest from a file, parses labels, and creates or updates
+// a ConfigMap with the digest. This function combines file I/O and ConfigMap operations for
+// convenience in the machine-os-builder CLI.
+func ApplyDigestConfigMapFromFile(ctx context.Context, kubeclient clientset.Interface, opts DigestConfigMapOpts) error {
+	// Read the digest file
+	digestBytes, err := os.ReadFile(opts.DigestFile)
+	if err != nil {
+		return fmt.Errorf("read digestfile: %w", err)
+	}
+
+	trimmedDigest := strings.TrimSpace(string(digestBytes))
+	if trimmedDigest == "" {
+		return fmt.Errorf("digestfile %q is empty", opts.DigestFile)
+	}
+
+	// Parse labels from string into map
+	configmapLabels, err := labels.ConvertSelectorToLabelsMap(opts.Labels)
+	if err != nil {
+		return fmt.Errorf("parse labels: %w", err)
+	}
+
+	// Default to the MCO namespace if no namespace value is supplied.
+	if opts.Namespace == "" {
+		opts.Namespace = ctrlcommon.MCONamespace
+	}
+
+	// Create the ConfigMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.ConfigMapName,
+			Namespace: opts.Namespace,
+			Labels:    configmapLabels,
+		},
+		Data: map[string]string{
+			imagebuilder.DigestConfigMapKey: trimmedDigest,
+		},
+	}
+
+	return applyDigestConfigMap(ctx, kubeclient, cm)
+}

--- a/pkg/controller/build/digestconfigmap_test.go
+++ b/pkg/controller/build/digestconfigmap_test.go
@@ -1,0 +1,369 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/build/imagebuilder"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// Assisted-By: Claude Sonnet 4.5
+func TestApplyDigestConfigMap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	configMapName := "test-digest-configmap"
+	digest := "sha256:1234567890abcdef"
+
+	t.Run("creates new ConfigMap successfully", func(t *testing.T) {
+		t.Parallel()
+
+		client := fake.NewSimpleClientset()
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels: map[string]string{
+					"test-label": "test-value",
+				},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: digest,
+			},
+		}
+
+		err := applyDigestConfigMap(ctx, client, cm)
+		require.NoError(t, err)
+
+		// Verify ConfigMap was created
+		created, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configMapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, configMapName, created.Name)
+		assert.Equal(t, ctrlcommon.MCONamespace, created.Namespace)
+		assert.Equal(t, digest, created.Data[imagebuilder.DigestConfigMapKey])
+		assert.Equal(t, "test-value", created.Labels["test-label"])
+	})
+
+	t.Run("updates existing ConfigMap successfully", func(t *testing.T) {
+		t.Parallel()
+
+		// Create initial ConfigMap with old data
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels: map[string]string{
+					"old-label": "old-value",
+				},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: "sha256:olddigest",
+			},
+		}
+
+		client := fake.NewSimpleClientset(existingCM)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels: map[string]string{
+					"new-label": "new-value",
+				},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: digest,
+			},
+		}
+
+		err := applyDigestConfigMap(ctx, client, cm)
+		require.NoError(t, err)
+
+		// Verify ConfigMap was updated
+		updated, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configMapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, digest, updated.Data[imagebuilder.DigestConfigMapKey])
+		assert.Equal(t, "new-value", updated.Labels["new-label"])
+		assert.NotContains(t, updated.Labels, "old-label")
+	})
+
+	t.Run("handles Get error after AlreadyExists", func(t *testing.T) {
+		t.Parallel()
+
+		client := fake.NewSimpleClientset()
+		// Add a reactor to return an error when Get is called after Create fails
+		client.PrependReactor("get", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, apierrors.NewInternalError(assert.AnError)
+		})
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels:    map[string]string{},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: digest,
+			},
+		}
+
+		// First create to trigger AlreadyExists on second call
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: "sha256:olddigest",
+			},
+		}
+		_, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Create(ctx, existingCM, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// Now try to apply, which should fail on Get
+		err = applyDigestConfigMap(ctx, client, cm)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsInternalError(err))
+	})
+
+	t.Run("handles Update error", func(t *testing.T) {
+		t.Parallel()
+
+		// Create initial ConfigMap
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: "sha256:olddigest",
+			},
+		}
+
+		client := fake.NewSimpleClientset(existingCM)
+		// Add a reactor to return an error when Update is called
+		client.PrependReactor("update", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, apierrors.NewInternalError(assert.AnError)
+		})
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels:    map[string]string{},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: digest,
+			},
+		}
+
+		err := applyDigestConfigMap(ctx, client, cm)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsInternalError(err))
+	})
+
+	t.Run("idempotent: multiple applies succeed", func(t *testing.T) {
+		t.Parallel()
+
+		client := fake.NewSimpleClientset()
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels: map[string]string{
+					"test-label": "test-value",
+				},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: digest,
+			},
+		}
+
+		// First apply
+		err := applyDigestConfigMap(ctx, client, cm)
+		require.NoError(t, err)
+
+		// Second apply should succeed (update)
+		err = applyDigestConfigMap(ctx, client, cm)
+		require.NoError(t, err)
+
+		// Third apply should succeed (update)
+		err = applyDigestConfigMap(ctx, client, cm)
+		require.NoError(t, err)
+
+		// Verify ConfigMap still has correct data
+		result, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configMapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, digest, result.Data[imagebuilder.DigestConfigMapKey])
+		assert.Equal(t, "test-value", result.Labels["test-label"])
+	})
+}
+
+// Assisted-By: Claude Sonnet 4.5
+func TestApplyDigestConfigMapFromFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	configMapName := "test-digest-configmap"
+	digest := "sha256:1234567890abcdef"
+
+	t.Run("creates ConfigMap from valid digest file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a temporary digest file
+		tmpDir := t.TempDir()
+		digestFile := filepath.Join(tmpDir, "digest")
+		err := os.WriteFile(digestFile, []byte(digest+"\n"), 0644)
+		require.NoError(t, err)
+
+		client := fake.NewSimpleClientset()
+		opts := DigestConfigMapOpts{
+			ConfigMapName: configMapName,
+			Namespace:     ctrlcommon.MCONamespace,
+			DigestFile:    digestFile,
+			Labels:        "test-label=test-value",
+		}
+		err = ApplyDigestConfigMapFromFile(ctx, client, opts)
+		require.NoError(t, err)
+
+		// Verify ConfigMap was created
+		cm, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configMapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, digest, cm.Data[imagebuilder.DigestConfigMapKey])
+		assert.Equal(t, "test-value", cm.Labels["test-label"])
+	})
+
+	t.Run("handles empty digest file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create an empty digest file
+		tmpDir := t.TempDir()
+		digestFile := filepath.Join(tmpDir, "digest")
+		err := os.WriteFile(digestFile, []byte("   \n  "), 0644)
+		require.NoError(t, err)
+
+		client := fake.NewSimpleClientset()
+		opts := DigestConfigMapOpts{
+			ConfigMapName: configMapName,
+			Namespace:     ctrlcommon.MCONamespace,
+			DigestFile:    digestFile,
+			Labels:        "",
+		}
+		err = ApplyDigestConfigMapFromFile(ctx, client, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is empty")
+	})
+
+	t.Run("handles missing digest file", func(t *testing.T) {
+		t.Parallel()
+
+		client := fake.NewSimpleClientset()
+		opts := DigestConfigMapOpts{
+			ConfigMapName: configMapName,
+			Namespace:     ctrlcommon.MCONamespace,
+			DigestFile:    "/nonexistent/digest",
+			Labels:        "",
+		}
+		err := ApplyDigestConfigMapFromFile(ctx, client, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read digestfile")
+	})
+
+	t.Run("handles invalid labels", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a temporary digest file
+		tmpDir := t.TempDir()
+		digestFile := filepath.Join(tmpDir, "digest")
+		err := os.WriteFile(digestFile, []byte(digest), 0644)
+		require.NoError(t, err)
+
+		client := fake.NewSimpleClientset()
+		opts := DigestConfigMapOpts{
+			ConfigMapName: configMapName,
+			Namespace:     ctrlcommon.MCONamespace,
+			DigestFile:    digestFile,
+			Labels:        "invalid-label-format",
+		}
+		err = ApplyDigestConfigMapFromFile(ctx, client, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse labels")
+	})
+
+	t.Run("trims whitespace from digest", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a digest file with whitespace
+		tmpDir := t.TempDir()
+		digestFile := filepath.Join(tmpDir, "digest")
+		err := os.WriteFile(digestFile, []byte("  \n"+digest+"\n  \n"), 0644)
+		require.NoError(t, err)
+
+		client := fake.NewSimpleClientset()
+		opts := DigestConfigMapOpts{
+			ConfigMapName: configMapName,
+			Namespace:     ctrlcommon.MCONamespace,
+			DigestFile:    digestFile,
+			Labels:        "",
+		}
+		err = ApplyDigestConfigMapFromFile(ctx, client, opts)
+		require.NoError(t, err)
+
+		// Verify ConfigMap was created with trimmed digest
+		cm, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configMapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, digest, cm.Data[imagebuilder.DigestConfigMapKey])
+	})
+
+	t.Run("updates existing ConfigMap from file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create initial ConfigMap
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: ctrlcommon.MCONamespace,
+				Labels: map[string]string{
+					"old-label": "old-value",
+				},
+			},
+			Data: map[string]string{
+				imagebuilder.DigestConfigMapKey: "sha256:olddigest",
+			},
+		}
+
+		client := fake.NewSimpleClientset(existingCM)
+
+		// Create a temporary digest file
+		tmpDir := t.TempDir()
+		digestFile := filepath.Join(tmpDir, "digest")
+		err := os.WriteFile(digestFile, []byte(digest), 0644)
+		require.NoError(t, err)
+
+		opts := DigestConfigMapOpts{
+			ConfigMapName: configMapName,
+			Namespace:     ctrlcommon.MCONamespace,
+			DigestFile:    digestFile,
+			Labels:        "new-label=new-value",
+		}
+		err = ApplyDigestConfigMapFromFile(ctx, client, opts)
+		require.NoError(t, err)
+
+		// Verify ConfigMap was updated
+		cm, err := client.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(ctx, configMapName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, digest, cm.Data[imagebuilder.DigestConfigMapKey])
+		assert.Equal(t, "new-value", cm.Labels["new-label"])
+		assert.NotContains(t, cm.Labels, "old-label")
+	})
+}

--- a/pkg/controller/build/imagebuilder/base.go
+++ b/pkg/controller/build/imagebuilder/base.go
@@ -17,6 +17,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
+const (
+	DigestConfigMapKey string = "digest"
+)
+
 // Holds the common objects and methods needed to implement an ImageBuilder.
 type baseImageBuilder struct {
 	kubeclient   clientset.Interface
@@ -147,9 +151,9 @@ func (b *baseImageBuilder) getFinalImagePullspec(ctx context.Context) (string, e
 		return "", fmt.Errorf("could not get final image digest configmap %q: %w", name, err)
 	}
 
-	sha, err := utils.ParseImagePullspec(string(b.mosc.Spec.RenderedImagePushSpec), digestConfigMap.Data["digest"])
+	sha, err := utils.ParseImagePullspec(string(b.mosc.Spec.RenderedImagePushSpec), digestConfigMap.Data[DigestConfigMapKey])
 	if err != nil {
-		return "", fmt.Errorf("could not create digested image pullspec from the pullspec %q and the digest %q: %w", b.mosc.Status.CurrentImagePullSpec, digestConfigMap.Data["digest"], err)
+		return "", fmt.Errorf("could not create digested image pullspec from the pullspec %q and the digest %q: %w", b.mosc.Status.CurrentImagePullSpec, digestConfigMap.Data[DigestConfigMapKey], err)
 	}
 
 	return sha, nil


### PR DESCRIPTION
**- What I did**

This is a different implementation for the problem discussed in https://github.com/openshift/machine-config-operator/pull/5313 . Instead of including the `oc` binary in the MCO image or extracting it from the build process, this does the following:

- Creates a new `create-digest-configmap` subcommand onto the `machine-os-builder` command.
- Modifies the create-digest-configmap.sh script to call this new subcommand instead of requiring `oc`.

This should result in a smaller overall MCO image as well as eliminating the need to use the `oc` binary.

**- How to verify it**

The image build process should continue to work as-is, meaning that the current E2E test suites should be able to verify it.

**- Description for the changelog**
Create digest configmap without oc binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI subcommand to create or update digest ConfigMaps with configurable name, file, labels, and namespace.
  * ConfigMap key for stored digest made consistent across the system.

* **Refactor**
  * Build workflow now invokes the new CLI for ConfigMap creation instead of relying on OS tooling; build job image selection updated accordingly.

* **Tests**
  * Added tests covering ConfigMap creation, updates, error paths, file-based digest handling, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->