### PR TITLE
OCPBUGS-76338: MCDs are broken when the loadbalancer-serving-signer certificate expires

### DIFF
--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -117,6 +117,10 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	onDiskKC := clientcmdv1.Config{}
 
 	if currentNodeControllerConfigResource != controllerConfig.ObjectMeta.ResourceVersion || controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue {
+		klog.Infof("CERT-ROTATION: Starting certificate sync. ControllerConfig RV: %s, ServiceCARotate annotation: %s",
+			controllerConfig.ObjectMeta.ResourceVersion, controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation])
+		klog.Infof("CERT-ROTATION: Current node annotation: %s", dn.node.Annotations[constants.ControllerConfigSyncServerCA])
+
 		pathToData := make(map[string][]byte)
 		kubeAPIServerServingCABytes := controllerConfig.Spec.KubeAPIServerServingCAData
 		cloudCA := controllerConfig.Spec.CloudProviderCAData
@@ -133,14 +137,17 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		}
 
 		if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && dn.node.Annotations[constants.ControllerConfigSyncServerCA] != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] {
+			klog.Infof("CERT-ROTATION: ServiceCA rotation detected - annotation mismatch")
 			cm, cmErr = dn.kubeClient.CoreV1().ConfigMaps("openshift-machine-config-operator").Get(context.TODO(), "kubeconfig-data", v1.GetOptions{})
 			if cmErr != nil {
-				klog.Errorf("Error retrieving kubeconfig-data. %v", cmErr)
+				klog.Errorf("CERT-ROTATION: Error retrieving kubeconfig-data. %v", cmErr)
 			} else {
+				klog.Infof("CERT-ROTATION: Successfully retrieved kubeconfig-data ConfigMap")
 				data, err = cmToData(cm, "ca-bundle.crt")
 				if err != nil {
-					klog.Errorf("kubeconfig-data ConfigMap not populated yet. %v", err)
+					klog.Errorf("CERT-ROTATION: kubeconfig-data ConfigMap not populated yet. %v", err)
 				} else if data != nil {
+					klog.Infof("CERT-ROTATION: Extracted ca-bundle.crt from ConfigMap (%d bytes)", len(data))
 					kcBytes, err := os.ReadFile(kubeConfigPath)
 					if err != nil {
 						return err
@@ -151,11 +158,13 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							return fmt.Errorf("could not unmarshal kubeconfig into struct. Data: %s, Error: %v", string(kcBytes), err)
 						}
 						kubeConfigDiff = !bytes.Equal(bytes.TrimSpace(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData), bytes.TrimSpace(data))
+						klog.Infof("CERT-ROTATION: kubeConfigDiff=%v (on-disk CA matches ConfigMap: %v)", kubeConfigDiff, !kubeConfigDiff)
 
 						// We should always write the latest certs from the configmap onto disk, but we should check what was changed/modified
 						// if any certs were added or updated, determine if we need to defer the kubelet restarting
 						certsConfigmap := strings.SplitAfter(strings.TrimSpace(string(data)), "-----END CERTIFICATE-----")
 						certsDisk := strings.SplitAfter(strings.TrimSpace(string(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData)), "-----END CERTIFICATE-----")
+						klog.Infof("CERT-ROTATION: Comparing certificates - ConfigMap has %d certs, on-disk has %d certs", len(certsConfigmap), len(certsDisk))
 						var addedOrUpdatedCAs []string
 
 						for _, cert := range certsConfigmap {
@@ -185,8 +194,9 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							fullCA = append(fullCA, cert)
 						}
 
+						klog.Infof("CERT-ROTATION: Found %d new/updated certificates", len(addedOrUpdatedCAs))
 						dn.deferKubeletRestart = true
-						for _, cert := range addedOrUpdatedCAs {
+						for i, cert := range addedOrUpdatedCAs {
 							b, _ := pem.Decode([]byte(cert))
 							if b == nil {
 								klog.Infof("Unable to decode cert into a pem block. Cert is either empty or invalid.")
@@ -197,18 +207,23 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 								logSystem("Malformed Cert, not syncing: %s", cert)
 								continue
 							}
-							logSystem("Cert not found in kubeconfig. This means we need to write to disk. Subject is: %s", c.Subject.CommonName)
+							klog.Infof("CERT-ROTATION: New cert #%d - Subject: %s, Issuer: %s, NotBefore: %s, NotAfter: %s",
+								i+1, c.Subject.CommonName, c.Issuer.CommonName, c.NotBefore, c.NotAfter)
 							// these rotate randomly during upgrades. need to ignore. DO NOT restart kubelet until we error.
 							// TODO(jerzhang): handle this better
-							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") && !strings.Contains(c.Subject.CommonName, "kube-apiserver-lb-signer") {
-								logSystem("Need to restart kubelet")
+							// Note: loadbalancer-serving-signer (kube-apiserver-lb-signer) is NOT in this list
+							// because it needs immediate kubelet restart when it rotates (OCPBUGS-73800)
+							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") {
+								klog.Infof("CERT-ROTATION: Certificate '%s' requires immediate kubelet restart - setting deferKubeletRestart=false", c.Subject.CommonName)
 								dn.deferKubeletRestart = false
 							} else {
-								logSystem("Skipping kubelet restart")
+								klog.Infof("CERT-ROTATION: Certificate '%s' is a localhost signer - deferring kubelet restart", c.Subject.CommonName)
 							}
 						}
+						klog.Infof("CERT-ROTATION: Final decision - deferKubeletRestart=%v, allCertsThere=%v", dn.deferKubeletRestart, allCertsThere)
 
 						if kubeConfigDiff && !allCertsThere {
+							klog.Infof("CERT-ROTATION: Updating /etc/kubernetes/kubeconfig (kubeConfigDiff=%v, allCertsThere=%v)", kubeConfigDiff, allCertsThere)
 							var newData []byte
 							if onDiskKC.Clusters == nil {
 								return errors.New("clusters cannot be nil")
@@ -221,7 +236,9 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							}
 
 							pathToData[kubeConfigPath] = newData
-							klog.Infof("Writing new Data to /etc/kubernetes/kubeconfig")
+							klog.Infof("CERT-ROTATION: Queued /etc/kubernetes/kubeconfig for update with %d certificates", len(fullCA))
+						} else {
+							klog.Infof("CERT-ROTATION: Skipping kubeconfig update (kubeConfigDiff=%v, allCertsThere=%v)", kubeConfigDiff, allCertsThere)
 						}
 					} else {
 						klog.Info("Could not read kubeconfig file, or data does not need to be changed")
@@ -292,15 +309,21 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	}
 
 	klog.Infof("Certificate was synced from controllerconfig resourceVersion %s", controllerConfig.ObjectMeta.ResourceVersion)
+	klog.Infof("CERT-ROTATION: Checking if kubelet restart needed - ServiceCARotate=%s, oldAnno=%s, cmErr=%v, kubeConfigDiff=%v, allCertsThere=%v, deferKubeletRestart=%v",
+		controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation], oldAnno, cmErr, kubeConfigDiff, allCertsThere, dn.deferKubeletRestart)
+
 	if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && oldAnno != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] && cmErr == nil && kubeConfigDiff && !allCertsThere && !dn.deferKubeletRestart {
+		klog.Infof("CERT-ROTATION: ✅ All conditions met for immediate kubelet restart!")
 		if len(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData) > 0 {
-			logSystem("restarting kubelet due to server-ca rotation")
+			klog.Infof("CERT-ROTATION: Stopping kubelet for certificate update...")
 			if err := runCmdSync("systemctl", "stop", "kubelet"); err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Kubelet stopped successfully")
+			klog.Infof("CERT-ROTATION: Reading kubelet's kubeconfig at /var/lib/kubelet/kubeconfig...")
 			f, err := os.ReadFile("/var/lib/kubelet/kubeconfig")
 			if err != nil && os.IsNotExist(err) {
-				klog.Warningf("Failed to get kubeconfig file: %v", err)
+				klog.Warningf("CERT-ROTATION: Failed to get kubeconfig file: %v", err)
 				return err
 			} else if err != nil {
 				return fmt.Errorf("unexpected error reading kubeconfig file, %v", err)
@@ -310,6 +333,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			if err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Updating kubelet's kubeconfig with new CA bundle...")
 			// set CA data to the one we just parsed above, the rest of the data should be preserved.
 			kubeletKC.Clusters[0].Cluster.CertificateAuthorityData = onDiskKC.Clusters[0].Cluster.CertificateAuthorityData
 			newData, err := yaml.Marshal(kubeletKC)
@@ -322,17 +346,30 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			if err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Kubelet kubeconfig updated successfully")
 
+			klog.Infof("CERT-ROTATION: Running systemctl daemon-reload...")
 			if err := runCmdSync("systemctl", "daemon-reload"); err != nil {
 				return err
 			}
 
+			klog.Infof("CERT-ROTATION: Starting kubelet...")
 			if err := runCmdSync("systemctl", "start", "kubelet"); err != nil {
 				return err
 			}
-		}
+			klog.Infof("CERT-ROTATION: Kubelet started successfully")
 
-		klog.V(4).Infof("Finished syncing ControllerConfig %q (%v)", key, time.Since(startTime))
+			// Exit MCD so kubelet can restart the DaemonSet pod with fresh certificates.
+			// This is critical for fixing OCPBUGS-73800: MCD's in-memory Kubernetes client
+			// was initialized with the old CA bundle and can't reload it without pod restart.
+			// After kubelet restarts, it will recreate this pod with the updated certs.
+			klog.Infof("CERT-ROTATION: 🔄 Exiting MCD to allow pod restart with fresh certificates (OCPBUGS-73800 fix)")
+			return fmt.Errorf("MCD exiting to reload certificates after loadbalancer-serving-signer rotation")
+		} else {
+			klog.Infof("CERT-ROTATION: ⚠️ Skipping kubelet restart - no CA data in onDiskKC")
+		}
+	} else {
+		klog.Infof("CERT-ROTATION: Kubelet restart not needed or deferred")
 	}
 
 	klog.V(4).Infof("Finished syncing ControllerConfig %q (%v)", key, time.Since(startTime))

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -116,6 +116,10 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	allCertsThere := true
 	onDiskKC := clientcmdv1.Config{}
 
+	// this determins if we should run the certificate sync logic, we want to run this logic if either:
+	// 1. we haven't processed any ControllerConfig yet (currentNodeControllerConfigResource == "")
+	// 2. the ControllerConfig resourceVersion has updated since the last time we processed (currentNodeControllerConfigResource != controllerConfig.ObjectMeta.ResourceVersion)
+	// 3. the ServiceCARotate annotation is set to true, which indicates a rotation event, and our node annotation doesn't reflect that yet, which means we haven't processed a config since the rotation event started.
 	if currentNodeControllerConfigResource != controllerConfig.ObjectMeta.ResourceVersion || controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue {
 		klog.Infof("CERT-ROTATION: Starting certificate sync. ControllerConfig RV: %s, ServiceCARotate annotation: %s",
 			controllerConfig.ObjectMeta.ResourceVersion, controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation])
@@ -296,14 +300,22 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		}
 	}
 
+	// Update the annotation to reflect the latest ControllerConfig we've processed
+	// true == saw a rotation event
+	// false == no rotation event
+	// "" == haven't processed any ControllerConfig yet.
 	oldAnno := dn.node.Annotations[constants.ControllerConfigSyncServerCA]
+	// We always want to update the resource version annotation, but we only want to update the ServiceCARotate annotation if it has changed, since that's what triggers the kubelet restart logic
 	annos := map[string]string{
 		constants.ControllerConfigResourceVersionKey: controllerConfig.ObjectMeta.ResourceVersion,
 	}
+	// if the old annotation on the node is different than controller configs ServiceCARotate annotation, update it.
 	if dn.node.Annotations[constants.ControllerConfigSyncServerCA] != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] {
+		// copy the value from the controllerconfig annotation to the node annotation, since that's what we use to determine if we've seen a rotation event before or not
 		annos[constants.ControllerConfigSyncServerCA] = controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation]
-
 	}
+
+	// setting annotations on node
 	if _, err := dn.nodeWriter.SetAnnotations(annos); err != nil {
 		return fmt.Errorf("failed to set annotations on node: %w", err)
 	}

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -291,7 +291,13 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 
 	klog.Infof("Certificate was synced from controllerconfig resourceVersion %s", controllerConfig.ObjectMeta.ResourceVersion)
 
-	if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && oldAnno != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] && cmErr == nil && kubeConfigDiff && !allCertsThere && !dn.deferKubeletRestart {
+	// Only perform immediate kubelet restart if:
+	// 1. ServiceCARotate annotation is true (rotation is happening)
+	// 2. oldAnno exists and differs (not first boot, actual rotation event)
+	// 3. No errors retrieving ConfigMap
+	// 4. kubeconfig has changed and new certs were added
+	// 5. We're not deferring the restart (non-localhost cert)
+	if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && oldAnno != "" && oldAnno != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] && cmErr == nil && kubeConfigDiff && !allCertsThere && !dn.deferKubeletRestart {
 		if len(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData) > 0 {
 			klog.Info("Certificate rotation detected - performing immediate kubelet restart")
 			if err := runCmdSync("systemctl", "stop", "kubelet"); err != nil {

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -117,9 +117,6 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	onDiskKC := clientcmdv1.Config{}
 
 	if currentNodeControllerConfigResource != controllerConfig.ObjectMeta.ResourceVersion || controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue {
-		klog.Infof("CERT-ROTATION: Starting certificate sync. ControllerConfig RV: %s, ServiceCARotate annotation: %s",
-			controllerConfig.ObjectMeta.ResourceVersion, controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation])
-		klog.Infof("CERT-ROTATION: Current node annotation: %s", dn.node.Annotations[constants.ControllerConfigSyncServerCA])
 
 		pathToData := make(map[string][]byte)
 		kubeAPIServerServingCABytes := controllerConfig.Spec.KubeAPIServerServingCAData
@@ -137,17 +134,14 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		}
 
 		if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && dn.node.Annotations[constants.ControllerConfigSyncServerCA] != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] {
-			klog.Infof("CERT-ROTATION: ServiceCA rotation detected - annotation mismatch")
 			cm, cmErr = dn.kubeClient.CoreV1().ConfigMaps("openshift-machine-config-operator").Get(context.TODO(), "kubeconfig-data", v1.GetOptions{})
 			if cmErr != nil {
-				klog.Errorf("CERT-ROTATION: Error retrieving kubeconfig-data. %v", cmErr)
+				klog.Errorf("Error retrieving kubeconfig-data ConfigMap: %v", cmErr)
 			} else {
-				klog.Infof("CERT-ROTATION: Successfully retrieved kubeconfig-data ConfigMap")
 				data, err = cmToData(cm, "ca-bundle.crt")
 				if err != nil {
-					klog.Errorf("CERT-ROTATION: kubeconfig-data ConfigMap not populated yet. %v", err)
+					klog.Errorf("kubeconfig-data ConfigMap not populated yet: %v", err)
 				} else if data != nil {
-					klog.Infof("CERT-ROTATION: Extracted ca-bundle.crt from ConfigMap (%d bytes)", len(data))
 					kcBytes, err := os.ReadFile(kubeConfigPath)
 					if err != nil {
 						return err
@@ -158,13 +152,11 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							return fmt.Errorf("could not unmarshal kubeconfig into struct. Data: %s, Error: %v", string(kcBytes), err)
 						}
 						kubeConfigDiff = !bytes.Equal(bytes.TrimSpace(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData), bytes.TrimSpace(data))
-						klog.Infof("CERT-ROTATION: kubeConfigDiff=%v (on-disk CA matches ConfigMap: %v)", kubeConfigDiff, !kubeConfigDiff)
 
 						// We should always write the latest certs from the configmap onto disk, but we should check what was changed/modified
 						// if any certs were added or updated, determine if we need to defer the kubelet restarting
 						certsConfigmap := strings.SplitAfter(strings.TrimSpace(string(data)), "-----END CERTIFICATE-----")
 						certsDisk := strings.SplitAfter(strings.TrimSpace(string(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData)), "-----END CERTIFICATE-----")
-						klog.Infof("CERT-ROTATION: Comparing certificates - ConfigMap has %d certs, on-disk has %d certs", len(certsConfigmap), len(certsDisk))
 						var addedOrUpdatedCAs []string
 
 						for _, cert := range certsConfigmap {
@@ -194,9 +186,8 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							fullCA = append(fullCA, cert)
 						}
 
-						klog.Infof("CERT-ROTATION: Found %d new/updated certificates", len(addedOrUpdatedCAs))
 						dn.deferKubeletRestart = true
-						for i, cert := range addedOrUpdatedCAs {
+						for _, cert := range addedOrUpdatedCAs {
 							b, _ := pem.Decode([]byte(cert))
 							if b == nil {
 								klog.Infof("Unable to decode cert into a pem block. Cert is either empty or invalid.")
@@ -207,23 +198,16 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 								logSystem("Malformed Cert, not syncing: %s", cert)
 								continue
 							}
-							klog.Infof("CERT-ROTATION: New cert #%d - Subject: %s, Issuer: %s, NotBefore: %s, NotAfter: %s",
-								i+1, c.Subject.CommonName, c.Issuer.CommonName, c.NotBefore, c.NotAfter)
 							// these rotate randomly during upgrades. need to ignore. DO NOT restart kubelet until we error.
 							// TODO(jerzhang): handle this better
 							// Note: loadbalancer-serving-signer (kube-apiserver-lb-signer) is NOT in this list
 							// because it needs immediate kubelet restart when it rotates (OCPBUGS-73800)
 							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") {
-								klog.Infof("CERT-ROTATION: Certificate '%s' requires immediate kubelet restart - setting deferKubeletRestart=false", c.Subject.CommonName)
 								dn.deferKubeletRestart = false
-							} else {
-								klog.Infof("CERT-ROTATION: Certificate '%s' is a localhost signer - deferring kubelet restart", c.Subject.CommonName)
 							}
 						}
-						klog.Infof("CERT-ROTATION: Final decision - deferKubeletRestart=%v, allCertsThere=%v", dn.deferKubeletRestart, allCertsThere)
 
 						if kubeConfigDiff && !allCertsThere {
-							klog.Infof("CERT-ROTATION: Updating /etc/kubernetes/kubeconfig (kubeConfigDiff=%v, allCertsThere=%v)", kubeConfigDiff, allCertsThere)
 							var newData []byte
 							if onDiskKC.Clusters == nil {
 								return errors.New("clusters cannot be nil")
@@ -236,9 +220,6 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							}
 
 							pathToData[kubeConfigPath] = newData
-							klog.Infof("CERT-ROTATION: Queued /etc/kubernetes/kubeconfig for update with %d certificates", len(fullCA))
-						} else {
-							klog.Infof("CERT-ROTATION: Skipping kubeconfig update (kubeConfigDiff=%v, allCertsThere=%v)", kubeConfigDiff, allCertsThere)
 						}
 					} else {
 						klog.Info("Could not read kubeconfig file, or data does not need to be changed")
@@ -309,21 +290,16 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	}
 
 	klog.Infof("Certificate was synced from controllerconfig resourceVersion %s", controllerConfig.ObjectMeta.ResourceVersion)
-	klog.Infof("CERT-ROTATION: Checking if kubelet restart needed - ServiceCARotate=%s, oldAnno=%s, cmErr=%v, kubeConfigDiff=%v, allCertsThere=%v, deferKubeletRestart=%v",
-		controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation], oldAnno, cmErr, kubeConfigDiff, allCertsThere, dn.deferKubeletRestart)
 
 	if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && oldAnno != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] && cmErr == nil && kubeConfigDiff && !allCertsThere && !dn.deferKubeletRestart {
-		klog.Infof("CERT-ROTATION: ✅ All conditions met for immediate kubelet restart!")
 		if len(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData) > 0 {
-			klog.Infof("CERT-ROTATION: Stopping kubelet for certificate update...")
+			klog.Info("Certificate rotation detected - performing immediate kubelet restart")
 			if err := runCmdSync("systemctl", "stop", "kubelet"); err != nil {
 				return err
 			}
-			klog.Infof("CERT-ROTATION: Kubelet stopped successfully")
-			klog.Infof("CERT-ROTATION: Reading kubelet's kubeconfig at /var/lib/kubelet/kubeconfig...")
 			f, err := os.ReadFile("/var/lib/kubelet/kubeconfig")
 			if err != nil && os.IsNotExist(err) {
-				klog.Warningf("CERT-ROTATION: Failed to get kubeconfig file: %v", err)
+				klog.Warningf("Failed to get kubeconfig file: %v", err)
 				return err
 			} else if err != nil {
 				return fmt.Errorf("unexpected error reading kubeconfig file, %v", err)
@@ -333,7 +309,6 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			if err != nil {
 				return err
 			}
-			klog.Infof("CERT-ROTATION: Updating kubelet's kubeconfig with new CA bundle...")
 			// set CA data to the one we just parsed above, the rest of the data should be preserved.
 			kubeletKC.Clusters[0].Cluster.CertificateAuthorityData = onDiskKC.Clusters[0].Cluster.CertificateAuthorityData
 			newData, err := yaml.Marshal(kubeletKC)
@@ -346,31 +321,23 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			if err != nil {
 				return err
 			}
-			klog.Infof("CERT-ROTATION: Kubelet kubeconfig updated successfully")
 
-			klog.Infof("CERT-ROTATION: Running systemctl daemon-reload...")
 			if err := runCmdSync("systemctl", "daemon-reload"); err != nil {
 				return err
 			}
 
-			klog.Infof("CERT-ROTATION: Starting kubelet...")
 			if err := runCmdSync("systemctl", "start", "kubelet"); err != nil {
 				return err
 			}
-			klog.Infof("CERT-ROTATION: Kubelet started successfully")
 
 			// Exit MCD so kubelet can restart the DaemonSet pod with fresh certificates.
 			// This is critical for fixing OCPBUGS-73800: MCD's in-memory Kubernetes client
 			// was initialized with the old CA bundle and can't reload it without pod restart.
 			// After kubelet restarts, it will recreate this pod with the updated certs.
-			klog.Infof("CERT-ROTATION: 🔄 Exiting MCD to allow pod restart with fresh certificates (OCPBUGS-73800 fix)")
+			klog.Info("Exiting MCD to allow pod restart with fresh certificates")
 			klog.Flush()
 			os.Exit(0)
-		} else {
-			klog.Infof("CERT-ROTATION: ⚠️ Skipping kubelet restart - no CA data in onDiskKC")
 		}
-	} else {
-		klog.Infof("CERT-ROTATION: Kubelet restart not needed or deferred")
 	}
 
 	klog.V(4).Infof("Finished syncing ControllerConfig %q (%v)", key, time.Since(startTime))

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -117,6 +117,10 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	onDiskKC := clientcmdv1.Config{}
 
 	if currentNodeControllerConfigResource != controllerConfig.ObjectMeta.ResourceVersion || controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue {
+		klog.Infof("CERT-ROTATION: Starting certificate sync. ControllerConfig RV: %s, ServiceCARotate annotation: %s",
+			controllerConfig.ObjectMeta.ResourceVersion, controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation])
+		klog.Infof("CERT-ROTATION: Current node annotation: %s", dn.node.Annotations[constants.ControllerConfigSyncServerCA])
+
 		pathToData := make(map[string][]byte)
 		kubeAPIServerServingCABytes := controllerConfig.Spec.KubeAPIServerServingCAData
 		cloudCA := controllerConfig.Spec.CloudProviderCAData
@@ -133,14 +137,17 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		}
 
 		if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && dn.node.Annotations[constants.ControllerConfigSyncServerCA] != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] {
+			klog.Infof("CERT-ROTATION: ServiceCA rotation detected - annotation mismatch")
 			cm, cmErr = dn.kubeClient.CoreV1().ConfigMaps("openshift-machine-config-operator").Get(context.TODO(), "kubeconfig-data", v1.GetOptions{})
 			if cmErr != nil {
-				klog.Errorf("Error retrieving kubeconfig-data. %v", cmErr)
+				klog.Errorf("CERT-ROTATION: Error retrieving kubeconfig-data. %v", cmErr)
 			} else {
+				klog.Infof("CERT-ROTATION: Successfully retrieved kubeconfig-data ConfigMap")
 				data, err = cmToData(cm, "ca-bundle.crt")
 				if err != nil {
-					klog.Errorf("kubeconfig-data ConfigMap not populated yet. %v", err)
+					klog.Errorf("CERT-ROTATION: kubeconfig-data ConfigMap not populated yet. %v", err)
 				} else if data != nil {
+					klog.Infof("CERT-ROTATION: Extracted ca-bundle.crt from ConfigMap (%d bytes)", len(data))
 					kcBytes, err := os.ReadFile(kubeConfigPath)
 					if err != nil {
 						return err
@@ -151,11 +158,13 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							return fmt.Errorf("could not unmarshal kubeconfig into struct. Data: %s, Error: %v", string(kcBytes), err)
 						}
 						kubeConfigDiff = !bytes.Equal(bytes.TrimSpace(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData), bytes.TrimSpace(data))
+						klog.Infof("CERT-ROTATION: kubeConfigDiff=%v (on-disk CA matches ConfigMap: %v)", kubeConfigDiff, !kubeConfigDiff)
 
 						// We should always write the latest certs from the configmap onto disk, but we should check what was changed/modified
 						// if any certs were added or updated, determine if we need to defer the kubelet restarting
 						certsConfigmap := strings.SplitAfter(strings.TrimSpace(string(data)), "-----END CERTIFICATE-----")
 						certsDisk := strings.SplitAfter(strings.TrimSpace(string(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData)), "-----END CERTIFICATE-----")
+						klog.Infof("CERT-ROTATION: Comparing certificates - ConfigMap has %d certs, on-disk has %d certs", len(certsConfigmap), len(certsDisk))
 						var addedOrUpdatedCAs []string
 
 						for _, cert := range certsConfigmap {
@@ -185,8 +194,9 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							fullCA = append(fullCA, cert)
 						}
 
+						klog.Infof("CERT-ROTATION: Found %d new/updated certificates", len(addedOrUpdatedCAs))
 						dn.deferKubeletRestart = true
-						for _, cert := range addedOrUpdatedCAs {
+						for i, cert := range addedOrUpdatedCAs {
 							b, _ := pem.Decode([]byte(cert))
 							if b == nil {
 								klog.Infof("Unable to decode cert into a pem block. Cert is either empty or invalid.")
@@ -197,16 +207,23 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 								logSystem("Malformed Cert, not syncing: %s", cert)
 								continue
 							}
+							klog.Infof("CERT-ROTATION: New cert #%d - Subject: %s, Issuer: %s, NotBefore: %s, NotAfter: %s",
+								i+1, c.Subject.CommonName, c.Issuer.CommonName, c.NotBefore, c.NotAfter)
 							// these rotate randomly during upgrades. need to ignore. DO NOT restart kubelet until we error.
 							// TODO(jerzhang): handle this better
 							// Note: loadbalancer-serving-signer (kube-apiserver-lb-signer) is NOT in this list
 							// because it needs immediate kubelet restart when it rotates
 							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") {
+								klog.Infof("CERT-ROTATION: Certificate '%s' requires immediate kubelet restart - setting deferKubeletRestart=false", c.Subject.CommonName)
 								dn.deferKubeletRestart = false
+							} else {
+								klog.Infof("CERT-ROTATION: Certificate '%s' is a localhost signer - deferring kubelet restart", c.Subject.CommonName)
 							}
 						}
+						klog.Infof("CERT-ROTATION: Final decision - deferKubeletRestart=%v, allCertsThere=%v", dn.deferKubeletRestart, allCertsThere)
 
 						if kubeConfigDiff && !allCertsThere {
+							klog.Infof("CERT-ROTATION: Updating /etc/kubernetes/kubeconfig (kubeConfigDiff=%v, allCertsThere=%v)", kubeConfigDiff, allCertsThere)
 							var newData []byte
 							if onDiskKC.Clusters == nil {
 								return errors.New("clusters cannot be nil")
@@ -219,6 +236,9 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							}
 
 							pathToData[kubeConfigPath] = newData
+							klog.Infof("CERT-ROTATION: Queued /etc/kubernetes/kubeconfig for update with %d certificates", len(fullCA))
+						} else {
+							klog.Infof("CERT-ROTATION: Skipping kubeconfig update (kubeConfigDiff=%v, allCertsThere=%v)", kubeConfigDiff, allCertsThere)
 						}
 					} else {
 						klog.Info("Could not read kubeconfig file, or data does not need to be changed")
@@ -291,8 +311,16 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	klog.Infof("Certificate was synced from controllerconfig resourceVersion %s", controllerConfig.ObjectMeta.ResourceVersion)
 
 	// Log all decision variables for troubleshooting certificate rotation behavior
-	klog.Infof("Certificate rotation decision: ServiceCARotate=%s, oldAnno=%q, cmErr=%v, kubeConfigDiff=%v, allCertsThere=%v, deferKubeletRestart=%v",
+	klog.Infof("CERT-ROTATION: Checking if kubelet restart needed - ServiceCARotate=%s, oldAnno=%q, cmErr=%v, kubeConfigDiff=%v, allCertsThere=%v, deferKubeletRestart=%v",
 		controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation], oldAnno, cmErr, kubeConfigDiff, allCertsThere, dn.deferKubeletRestart)
+	klog.Infof("CERT-ROTATION: Condition breakdown - ServiceCARotate=='true': %v, oldAnno!='': %v, oldAnno!=ServiceCARotate: %v, cmErr==nil: %v, kubeConfigDiff: %v, !allCertsThere: %v, !deferKubeletRestart: %v",
+		controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue,
+		oldAnno != "",
+		oldAnno != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation],
+		cmErr == nil,
+		kubeConfigDiff,
+		!allCertsThere,
+		!dn.deferKubeletRestart)
 
 	// Only perform immediate kubelet restart if:
 	// 1. ServiceCARotate annotation is true (rotation is happening)
@@ -301,14 +329,17 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	// 4. kubeconfig has changed and new certs were added
 	// 5. We're not deferring the restart (non-localhost cert)
 	if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && oldAnno != "" && oldAnno != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] && cmErr == nil && kubeConfigDiff && !allCertsThere && !dn.deferKubeletRestart {
+		klog.Infof("CERT-ROTATION: ✅ All conditions met for immediate kubelet restart!")
 		if len(onDiskKC.Clusters[0].Cluster.CertificateAuthorityData) > 0 {
-			klog.Info("Certificate rotation detected - performing immediate kubelet restart")
+			klog.Infof("CERT-ROTATION: Stopping kubelet for certificate update...")
 			if err := runCmdSync("systemctl", "stop", "kubelet"); err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Kubelet stopped successfully")
+			klog.Infof("CERT-ROTATION: Reading kubelet's kubeconfig at /var/lib/kubelet/kubeconfig...")
 			f, err := os.ReadFile("/var/lib/kubelet/kubeconfig")
 			if err != nil && os.IsNotExist(err) {
-				klog.Warningf("Failed to get kubeconfig file: %v", err)
+				klog.Warningf("CERT-ROTATION: Failed to get kubeconfig file: %v", err)
 				return err
 			} else if err != nil {
 				return fmt.Errorf("unexpected error reading kubeconfig file, %v", err)
@@ -318,6 +349,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			if err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Updating kubelet's kubeconfig with new CA bundle...")
 			// set CA data to the one we just parsed above, the rest of the data should be preserved.
 			kubeletKC.Clusters[0].Cluster.CertificateAuthorityData = onDiskKC.Clusters[0].Cluster.CertificateAuthorityData
 			newData, err := yaml.Marshal(kubeletKC)
@@ -330,22 +362,30 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			if err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Kubelet kubeconfig updated successfully")
 
+			klog.Infof("CERT-ROTATION: Running systemctl daemon-reload...")
 			if err := runCmdSync("systemctl", "daemon-reload"); err != nil {
 				return err
 			}
 
+			klog.Infof("CERT-ROTATION: Starting kubelet...")
 			if err := runCmdSync("systemctl", "start", "kubelet"); err != nil {
 				return err
 			}
+			klog.Infof("CERT-ROTATION: Kubelet started successfully")
 
 			// Exit MCD so kubelet can restart the DaemonSet pod with fresh certificates.
 			// MCD's in-memory Kubernetes client was initialized with the old CA bundle and can't reload
 			// it without pod restart. After kubelet restarts, it will recreate this pod with the updated certs.
-			klog.Info("Exiting MCD to allow pod restart with fresh certificates")
+			klog.Infof("CERT-ROTATION: 🔄 Exiting MCD to allow pod restart with fresh certificates (OCPBUGS-73800 fix)")
 			klog.Flush()
 			os.Exit(0)
+		} else {
+			klog.Infof("CERT-ROTATION: ⚠️ Skipping kubelet restart - no CA data in onDiskKC")
 		}
+	} else {
+		klog.Infof("CERT-ROTATION: Kubelet restart not needed or deferred")
 	}
 
 	klog.V(4).Infof("Finished syncing ControllerConfig %q (%v)", key, time.Since(startTime))

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -364,7 +364,8 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			// was initialized with the old CA bundle and can't reload it without pod restart.
 			// After kubelet restarts, it will recreate this pod with the updated certs.
 			klog.Infof("CERT-ROTATION: 🔄 Exiting MCD to allow pod restart with fresh certificates (OCPBUGS-73800 fix)")
-			return fmt.Errorf("MCD exiting to reload certificates after loadbalancer-serving-signer rotation")
+			klog.Flush()
+			os.Exit(0)
 		} else {
 			klog.Infof("CERT-ROTATION: ⚠️ Skipping kubelet restart - no CA data in onDiskKC")
 		}

--- a/pkg/daemon/certificate_writer.go
+++ b/pkg/daemon/certificate_writer.go
@@ -117,7 +117,6 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 	onDiskKC := clientcmdv1.Config{}
 
 	if currentNodeControllerConfigResource != controllerConfig.ObjectMeta.ResourceVersion || controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue {
-
 		pathToData := make(map[string][]byte)
 		kubeAPIServerServingCABytes := controllerConfig.Spec.KubeAPIServerServingCAData
 		cloudCA := controllerConfig.Spec.CloudProviderCAData
@@ -136,11 +135,11 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 		if controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] == ctrlcommon.ServiceCARotateTrue && dn.node.Annotations[constants.ControllerConfigSyncServerCA] != controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation] {
 			cm, cmErr = dn.kubeClient.CoreV1().ConfigMaps("openshift-machine-config-operator").Get(context.TODO(), "kubeconfig-data", v1.GetOptions{})
 			if cmErr != nil {
-				klog.Errorf("Error retrieving kubeconfig-data ConfigMap: %v", cmErr)
+				klog.Errorf("Error retrieving kubeconfig-data. %v", cmErr)
 			} else {
 				data, err = cmToData(cm, "ca-bundle.crt")
 				if err != nil {
-					klog.Errorf("kubeconfig-data ConfigMap not populated yet: %v", err)
+					klog.Errorf("kubeconfig-data ConfigMap not populated yet. %v", err)
 				} else if data != nil {
 					kcBytes, err := os.ReadFile(kubeConfigPath)
 					if err != nil {
@@ -201,7 +200,7 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 							// these rotate randomly during upgrades. need to ignore. DO NOT restart kubelet until we error.
 							// TODO(jerzhang): handle this better
 							// Note: loadbalancer-serving-signer (kube-apiserver-lb-signer) is NOT in this list
-							// because it needs immediate kubelet restart when it rotates (OCPBUGS-73800)
+							// because it needs immediate kubelet restart when it rotates
 							if !strings.Contains(c.Subject.CommonName, "kube-apiserver-localhost-signer") && !strings.Contains(c.Subject.CommonName, "openshift-kube-apiserver-operator_localhost-recovery-serving-signer") {
 								dn.deferKubeletRestart = false
 							}
@@ -291,6 +290,10 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 
 	klog.Infof("Certificate was synced from controllerconfig resourceVersion %s", controllerConfig.ObjectMeta.ResourceVersion)
 
+	// Log all decision variables for troubleshooting certificate rotation behavior
+	klog.Infof("Certificate rotation decision: ServiceCARotate=%s, oldAnno=%q, cmErr=%v, kubeConfigDiff=%v, allCertsThere=%v, deferKubeletRestart=%v",
+		controllerConfig.Annotations[ctrlcommon.ServiceCARotateAnnotation], oldAnno, cmErr, kubeConfigDiff, allCertsThere, dn.deferKubeletRestart)
+
 	// Only perform immediate kubelet restart if:
 	// 1. ServiceCARotate annotation is true (rotation is happening)
 	// 2. oldAnno exists and differs (not first boot, actual rotation event)
@@ -337,9 +340,8 @@ func (dn *Daemon) syncControllerConfigHandler(key string) error {
 			}
 
 			// Exit MCD so kubelet can restart the DaemonSet pod with fresh certificates.
-			// This is critical for fixing OCPBUGS-73800: MCD's in-memory Kubernetes client
-			// was initialized with the old CA bundle and can't reload it without pod restart.
-			// After kubelet restarts, it will recreate this pod with the updated certs.
+			// MCD's in-memory Kubernetes client was initialized with the old CA bundle and can't reload
+			// it without pod restart. After kubelet restarts, it will recreate this pod with the updated certs.
 			klog.Info("Exiting MCD to allow pod restart with fresh certificates")
 			klog.Flush()
 			os.Exit(0)

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1070,14 +1070,17 @@ func (optr *Operator) syncControllerConfig(config *renderConfig) error {
 	// https://bugzilla.redhat.com/show_bug.cgi?id=1879099
 
 	editCCAnno := false
+	klog.Infof("CERT-ROTATION-OPERATOR: Starting CA rotation check in syncControllerConfig")
 	kubeConfigData, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-apiserver-server-ca")
 	if err != nil {
-		klog.Errorf("Could not get in-cluster server-ca data %v", err)
+		klog.Errorf("CERT-ROTATION-OPERATOR: Could not get in-cluster server-ca data %v", err)
 	} else {
+		klog.Infof("CERT-ROTATION-OPERATOR: Successfully retrieved kube-apiserver-server-ca ConfigMap")
 		data, err := cmToData(kubeConfigData, "ca-bundle.crt")
 		if err != nil {
-			klog.Errorf("kube-apiserver-server-ca ConfigMap not populated yet. %v", err)
+			klog.Errorf("CERT-ROTATION-OPERATOR: kube-apiserver-server-ca ConfigMap not populated yet. %v", err)
 		} else if data != nil {
+			klog.Infof("CERT-ROTATION-OPERATOR: Retrieved CA bundle data from kube-apiserver-server-ca (%d bytes)", len(data))
 			cmNew := corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "kubeconfig-data",
@@ -1085,15 +1088,18 @@ func (optr *Operator) syncControllerConfig(config *renderConfig) error {
 			}
 			mcoCM, getErr := optr.kubeClient.CoreV1().ConfigMaps(ctrlcommon.MCONamespace).Get(context.TODO(), "kubeconfig-data", metav1.GetOptions{})
 			if getErr != nil {
-				klog.Errorf("Issue getting the kubeconfig-data configmap: %v", getErr)
+				klog.Errorf("CERT-ROTATION-OPERATOR: Issue getting the kubeconfig-data configmap: %v", getErr)
 				if !apierrors.IsNotFound(getErr) && !apierrors.IsTimeout(getErr) && !apierrors.IsServerTimeout(getErr) {
 					return getErr
 				}
+			} else {
+				klog.Infof("CERT-ROTATION-OPERATOR: Successfully retrieved kubeconfig-data ConfigMap from MCO namespace")
 			}
 			dataOld, err := cmToData(mcoCM, "ca-bundle.crt")
 			if err != nil && getErr == nil {
-				klog.Errorf("Could not get ca-bundle.crt from kubeconfig-data cm %v", err)
+				klog.Errorf("CERT-ROTATION-OPERATOR: Could not get ca-bundle.crt from kubeconfig-data cm %v", err)
 			} else if !bytes.Equal(data, dataOld) && getErr == nil {
+				klog.Infof("CERT-ROTATION-OPERATOR: *** CA DATA MISMATCH DETECTED *** MCO ConfigMap != kube-apiserver-server-ca ConfigMap (old: %d bytes, new: %d bytes)", len(dataOld), len(data))
 				// -1 == mcoCM < kubeCM
 				// 1 == mcoCM > kubeCM
 				klog.Infof("the MCO configmap for the server-ca and the openshift-config-managed one do not match. Diff: (0 means equal -1 means data has been removed 1 means data has been added) %d.", bytes.Compare(dataOld, data))
@@ -1147,8 +1153,10 @@ func (optr *Operator) syncControllerConfig(config *renderConfig) error {
 				if err != nil {
 					return fmt.Errorf("Could not patch kubeconfig-data with data %s: %w", string(patchBytes), err)
 				}
+				klog.Infof("CERT-ROTATION-OPERATOR: Successfully patched kubeconfig-data ConfigMap - setting editCCAnno=true")
 				editCCAnno = true
 			} else if getErr != nil {
+				klog.Infof("CERT-ROTATION-OPERATOR: kubeconfig-data ConfigMap not found - creating it with new CA data")
 				binData := make(map[string][]byte)
 				binData["ca-bundle.crt"] = data
 				cmNew.BinaryData = binData
@@ -1156,15 +1164,21 @@ func (optr *Operator) syncControllerConfig(config *renderConfig) error {
 				if err != nil {
 					return fmt.Errorf("Could not make kubeconfig-data CM, %v", err)
 				}
+				klog.Infof("CERT-ROTATION-OPERATOR: Successfully created kubeconfig-data ConfigMap - setting editCCAnno=true")
 				editCCAnno = true
+			} else {
+				klog.Infof("CERT-ROTATION-OPERATOR: CA data is identical - no rotation needed (data: %d bytes, dataOld: %d bytes)", len(data), len(dataOld))
 			}
 
 		}
 	}
+	klog.Infof("CERT-ROTATION-OPERATOR: Finished CA rotation check - editCCAnno=%v", editCCAnno)
 	cc.Annotations[daemonconsts.GeneratedByVersionAnnotationKey] = version.Raw
 	if editCCAnno {
+		klog.Infof("CERT-ROTATION-OPERATOR: *** SETTING ServiceCARotate=true ***")
 		cc.Annotations[ctrlcommon.ServiceCARotateAnnotation] = ctrlcommon.ServiceCARotateTrue
 	} else {
+		klog.Infof("CERT-ROTATION-OPERATOR: Setting ServiceCARotate=false (no CA changes detected)")
 		cc.Annotations[ctrlcommon.ServiceCARotateAnnotation] = ctrlcommon.ServiceCARotateFalse
 	}
 	// add ocp release version as annotation to controller config, for use when


### PR DESCRIPTION
Restart MCD pod after updating kubeconfig during certificate rotation so the NodeWriter can reload the new CA bundle.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added `os.Exit(0)` after MCD updates kubeconfig and restarts kubelet during certificate rotation. This ensures the NodeWriter reinitializes with the new CA bundle instead of keeping the expired certificate in memory.
**- How to verify it**
 1. Pick a master MCD pod to monitor
  `export TEST_MCD_POD=$(oc get pods -n openshift-machine-config-operator -l k8s-app=machine-config-daemon -o jsonpath='{.items[0].metadata.name}')`

2. Backup ConfigMap
  `oc get cm kubeconfig-data -n openshift-machine-config-operator -o yaml > /tmp/kubeconfig-backup.yaml`

  Simulate Certificate Rotation

3. Create fake cert and append to CA bundle
  `openssl req -x509 -newkey rsa:2048 -nodes -keyout /tmp/key.pem -out /tmp/cert.pem -days 1 -subj "/CN=test-lb-cert-$(date +%s)"`
  `oc get cm kubeconfig-data -n openshift-machine-config-operator -o jsonpath='{.binaryData.ca-bundle\.crt}' | base64 -d > /tmp/ca.crt`
  `cat /tmp/ca.crt /tmp/cert.pem | base64 | tr -d '\n' > /tmp/ca-new.txt`

4. Patch ConfigMap with new cert
  `kubectl patch cm kubeconfig-data -n openshift-machine-config-operator --type json -p '[{"op":"replace","path":"/binaryData/ca-bundle.crt","value":"'$(cat /tmp/ca-new.txt)'"}]'`

5. Trigger rotation
  `oc annotate controllerconfig machine-config-controller machineconfiguration.openshift.io/service-ca-rotate=true --overwrite`

6. Monitor (in separate terminal)

  `oc logs -n openshift-machine-config-operator $TEST_MCD_POD -f | grep "CERT-ROTATION"`

  Verify
  
7. MCD container should have restarted (new logs from startup)
  `oc logs -n openshift-machine-config-operator $TEST_MCD_POD --tail=50`

8. No x509 errors (should return nothing)
  `oc logs -n openshift-machine-config-operator $TEST_MCD_POD | grep -i "x509\|unknown authority"`

9. All nodes remain Ready
  `oc get nodes`


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
Fix MCD degradation when loadbalancer-serving-signer certificate rotates by restarting the pod to reload certificates
-->
