### PR TITLE
OCPBUGS-73909: In vsphere, nodes with old images (4.3 and 4.5) cannot join the cluster intermittently. Found ordering cycle .

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -6,7 +6,7 @@ contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service firstboot-osupdate.target
+  After=NetworkManager-wait-online.service
   Before=kubelet-dependencies.target ovs-configuration.service
 
   [Service]

--- a/templates/common/kubevirt/units/nodeip-configuration.service.yaml
+++ b/templates/common/kubevirt/units/nodeip-configuration.service.yaml
@@ -4,7 +4,7 @@ contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service firstboot-osupdate.target
+  After=NetworkManager-wait-online.service
   Before=kubelet-dependencies.target ovs-configuration.service
 
   [Service]
@@ -36,6 +36,8 @@ contents: |
     done"
   ExecStart=/bin/systemctl daemon-reload
   ExecStartPre=/bin/mkdir -p /run/nodeip-configuration
+  StandardOutput=journal+console
+  StandardError=journal+console
 
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -7,7 +7,7 @@ contents: |
   # address picking logic is flawed and may end up selecting an address from a
   # different subnet or a deprecated address
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service firstboot-osupdate.target
+  After=NetworkManager-wait-online.service
   Before=kubelet-dependencies.target ovs-configuration.service
 
   [Service]

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -17,7 +17,7 @@ contents: |
   [Unit]
   Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
   Wants=NetworkManager-wait-online.service
-  After=NetworkManager-wait-online.service firstboot-osupdate.target
+  After=NetworkManager-wait-online.service
   Before=kubelet-dependencies.target ovs-configuration.service
 
   [Service]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
 Removed `firstboot-osupdate.target` from `After=` dependencies in all nodeip-configuration service units to break a systemd ordering cycle that prevents nodes with old boot images (4.3/4.5) from joining 4.22 clusters.
**- How to verify it**
  1. Create a machineset using 4.3 or 4.5 boot image with ignition 2.2.0 in user-data-secret                                             
  2. Wait for new node to boot                              
  3. Verify node joins cluster successfully without intermittent failures                                                                
  4. Check `journalctl` - confirm no "Found ordering cycle" errors involving nmstate-configuration, nodeip-configuration, or             
  firstboot-osupdate.target       
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog: Fix systemd ordering cycle preventing old boot images from joining cluster on vSphere and other platforms
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated service startup ordering so node IP configuration waits for container runtime readiness rather than first-boot completion across all deployment types.
  * For the kubevirt deployment, service output is now routed to both journal and console so logs are visible in system journal and on the node console.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->