### PR TITLE
NO-JIRA: Harden MCN condition transition tests and adjust tests to run on SNO

### DIFF
--- a/test/extended-priv/testdata/files/machineconfigs/master-extension-mc.yaml
+++ b/test/extended-priv/testdata/files/machineconfigs/master-extension-mc.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: infra-extension-mc
+objects:
+- apiVersion: machineconfiguration.openshift.io/v1
+  kind: MachineConfig
+  metadata:
+    labels:
+      machineconfiguration.openshift.io/role: infra
+    name: 90-infra-extension
+  spec:
+    config:
+      ignition:
+        version: 3.2.0
+    extensions:
+      - usbguard

--- a/test/extended/image_mode_status_reporting.go
+++ b/test/extended/image_mode_status_reporting.go
@@ -12,14 +12,16 @@ import (
 	extpriv "github.com/openshift/machine-config-operator/test/extended-priv"
 	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
 	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
 	mcNameToFixtureMap = map[string]string{
-		"90-infra-extension": filepath.Join("machineconfigs", "infra-extension-mc.yaml"),
-		"90-infra-testfile":  filepath.Join("machineconfigs", "infra-testfile-mc.yaml"),
-		"90-master-testfile": filepath.Join("machineconfigs", "master-testfile-mc.yaml"),
+		"90-infra-extension":  filepath.Join("machineconfigs", "infra-extension-mc.yaml"),
+		"90-infra-testfile":   filepath.Join("machineconfigs", "infra-testfile-mc.yaml"),
+		"90-master-extension": filepath.Join("machineconfigs", "master-extension-mc.yaml"),
+		"90-master-testfile":  filepath.Join("machineconfigs", "master-testfile-mc.yaml"),
 	}
 	nodeDisruptionFixture      = filepath.Join("machineconfigurations", "nodedisruptionpolicy-rebootless-path.yaml")
 	nodeDisruptionEmptyFixture = filepath.Join("machineconfigurations", "managedbootimages-empty.yaml")
@@ -42,52 +44,57 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	g.It("MachineConfigNode properties should match the associated node properties when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]", func() {
 		// Create machine config client for test
 		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
-		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+		if clientErr != nil {
+			g.Skip("Skipping this test due to cluster instability, error creating machine config client.")
+		}
 
-		// Skip this test if there are no machines in the worker MCP, as this will mean we cannot
-		// create a custom MCP.
+		// If the cluster does not have worker nodes, run this test against the master pool.
 		if !DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
-			g.Skip(fmt.Sprintf("Skipping this test since the cluster does not have nodes in the `worker` MCP."))
+			runImageModeMCNTestDefaultMCP(oc, machineConfigClient, "master", "", false)
 		}
 
 		// Run the standard image mode MCN test for a custom MCP named `infra` with no MC to apply
-		runImageModeMCNTest(oc, machineConfigClient, "infra", "", false)
+		runImageModeMCNTestCustomMCP(oc, machineConfigClient, "infra", "", false)
 	})
 
 	g.It("MachineConfigNode conditions should properly transition on an image based update when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]", func() {
 		// Create machine config client for test
 		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
-		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+		if clientErr != nil {
+			g.Skip("Skipping this test due to cluster instability, error creating machine config client.")
+		}
 
-		// Skip this test if there are no machines in the worker MCP, as this will mean we cannot
-		// create a custom MCP.
+		// If the cluster does not have worker nodes, run this test against the master pool.
 		if !DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
-			g.Skip(fmt.Sprintf("Skipping this test since the cluster does not have nodes in the `worker` MCP."))
+			runImageModeMCNTestDefaultMCP(oc, machineConfigClient, "master", "90-master-extension", true)
 		}
 
 		// Run the standard image mode MCN test for a custom MCP named `infra` with no MC to apply
-		runImageModeMCNTest(oc, machineConfigClient, "infra", "90-infra-extension", true)
+		runImageModeMCNTestCustomMCP(oc, machineConfigClient, "infra", "90-infra-extension", true)
 	})
 
 	g.It("MachineConfigNode conditions should properly transition on a non-image based update when OCB is enabled in a custom MCP [apigroup:machineconfiguration.openshift.io]", func() {
 		// Create machine config client for test
 		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
-		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+		if clientErr != nil {
+			g.Skip("Skipping this test due to cluster instability, error creating machine config client.")
+		}
 
-		// Skip this test if there are no machines in the worker MCP, as this will mean we cannot
-		// create a custom MCP.
+		// If the cluster does not have worker nodes, run this test against the master pool.
 		if !DoesMachineConfigPoolHaveMachines(machineConfigClient, "worker") {
-			g.Skip(fmt.Sprintf("Skipping this test since the cluster does not have nodes in the `worker` MCP."))
+			runImageModeMCNTestDefaultMCP(oc, machineConfigClient, "master", "90-master-testfile", false)
 		}
 
 		// Run the standard image mode MCN test for a custom MCP named `infra` with no MC to apply
-		runImageModeMCNTest(oc, machineConfigClient, "infra", "90-infra-testfile", false)
+		runImageModeMCNTestCustomMCP(oc, machineConfigClient, "infra", "90-infra-testfile", false)
 	})
 
 	g.It("MachineConfigPool machine counts should transition correctly on an update in a default MCP [apigroup:machineconfiguration.openshift.io]", func() {
 		// Create machine config client for test
 		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
-		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+		if clientErr != nil {
+			g.Skip("Skipping this test due to cluster instability, error creating machine config client.")
+		}
 
 		// Run the machine count test for a default MCP when applying a standard MachineConfig
 		runMachineCountTest(machineConfigClient, oc, "90-master-testfile", "master")
@@ -96,7 +103,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	g.It("MachineConfigPool machine counts should transition when OCB is enabled in a default MCP [apigroup:machineconfiguration.openshift.io]", func() {
 		// Create machine config client for test
 		machineConfigClient, clientErr := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
-		o.Expect(clientErr).NotTo(o.HaveOccurred(), "Error creating client set for test: %s", clientErr)
+		if clientErr != nil {
+			g.Skip("Skipping this test due to cluster instability, error creating machine config client.")
+		}
 
 		// Run this test against the `worker` MCP if it has machines, otherwise default to `master`
 		mcpName := "master"
@@ -110,10 +119,10 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	})
 })
 
-// `runImageModeMCNTest` runs through the general flow of validating the MCN of a node for image
-// mode enabled workflows. The steps for the test are as follows:
+// `runImageModeMCNTestCustomMCP` runs through the general flow of validating the MCN of a node
+// in a custom MCP for an image mode enabled workflows. The steps for the test are as follows:
 //  1. Select a worker node to use throughout the test
-//  2. Validate the starting properties of te MCN associated with the test node
+//  2. Validate the starting properties of the MCN associated with the test node
 //  3. Create a custom MCP named the value of `mcpAndMoscName` and add the test node to it
 //  4. Validate the properties of the MCN associated with the test node
 //  5. Configure on cluster image mode in the custom MCP & validate the MOSC applied successfully
@@ -124,7 +133,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 //  9. Validate the properties of the MCN associated with the test node
 //  10. Remove the custom MCP
 //  11. Validate the properties of the MCN associated with the test node
-func runImageModeMCNTest(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, mcpAndMoscName, mcName string, isImageUpdate bool) {
+func runImageModeMCNTestCustomMCP(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, mcpAndMoscName, mcName string, isImageUpdate bool) {
 	exutil.By("Select a node to follow in this test")
 	workerNodes, err := GetNodesByRole(oc, "worker")
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting worker nodes: %s", err)
@@ -180,7 +189,7 @@ func runImageModeMCNTest(oc *exutil.CLI, machineConfigClient *machineconfigclien
 		logger.Infof("OK!\n")
 
 		exutil.By("Validating the MCN condition transitions")
-		validateMCNTransitions(machineConfigClient, nodeToTestName, isImageUpdate)
+		validateMCNTransitions(machineConfigClient, nodeToTestName, isImageUpdate, false)
 		logger.Infof("OK!\n")
 
 		exutil.By("Removing the MC")
@@ -212,13 +221,99 @@ func runImageModeMCNTest(oc *exutil.CLI, machineConfigClient *machineconfigclien
 	logger.Infof("OK!\n")
 }
 
+// `runImageModeMCNTestDefaultMCP` runs through the general flow of validating the MCN of a node
+// in a default MCP for an image mode enabled workflows. The steps for the test are as follows:
+//  1. Validate the starting properties of the MCN associated with the cluster's node
+//  2. Configure on cluster image mode in the master MCP & validate the MOSC applied successfully
+//  3. Validate the properties of the MCN associated with the cluster's node
+//  4. If a MachineConfig has been provided, apply it, validate the MCN conditions trasnition
+//     throughout the update, then remove the MC
+//  5. Disable on cluster image mode in the master MCP & validate the MOSC removal was successful
+//  6. Validate the properties of the MCN associated with the cluster's node
+func runImageModeMCNTestDefaultMCP(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, mcpAndMoscName, mcName string, isImageUpdate bool) {
+	exutil.By("Select a node to follow in this test")
+	var testNodes []corev1.Node
+	var err error
+	for i := 0; i < 5; i++ {
+		testNodes, err = GetNodesByRole(oc, mcpAndMoscName)
+
+		// If we could not get the nodes due to cluster instability, wait and try again.
+		if err != nil && i != 4 {
+			logger.Infof("Failed to get the cluster's test node, waiting %v seconds then trying again.", i+2)
+			time.Sleep(time.Duration(i+2) * time.Second)
+			continue
+		}
+
+		break
+	}
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting cluster's nodes: %s", err)
+	o.Expect(len(testNodes)).To(o.BeNumerically(">=", 1), "Less than one node in %v pool", mcpAndMoscName)
+	nodeToTestName := testNodes[0].Name
+	logger.Infof("Testing node `%s`", nodeToTestName)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate node's starting MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, mcpAndMoscName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+
+	exutil.By("Configure OCB functionality for the default MCP")
+	mosc, err := extpriv.CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcpAndMoscName, mcpAndMoscName, nil)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource: %s", err)
+	masterMcp, err := mosc.GetMachineConfigPool()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the MCP: %s", err)
+	defer extpriv.DisableOCL(mosc)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validating the default MOSC applied successfully")
+	extpriv.ValidateSuccessfulMOSC(mosc, nil)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate the cluster's node has correct MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, mcpAndMoscName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+
+	// If an MC has been provided, apply it and validate the MCN conditions transition correctly
+	// throughout the update.
+	if mcName != "" {
+		exutil.By("Applying the MC")
+		err = ApplyMachineConfigFixture(oc, mcNameToFixtureMap[mcName])
+		defer DeleteMCAndWaitForMCPUpdate(oc, machineConfigClient, mcName, mcpAndMoscName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error applying MC `%s`: %s", mcName, err)
+		logger.Infof("OK!\n")
+
+		exutil.By("Validating the MCN condition transitions")
+		validateMCNTransitions(machineConfigClient, nodeToTestName, isImageUpdate, len(testNodes) == 1)
+		logger.Infof("OK!\n")
+
+		exutil.By("Removing the MC")
+		DeleteMCAndWaitForMCPUpdate(oc, machineConfigClient, mcName, mcpAndMoscName)
+		logger.Infof("OK!\n")
+	}
+
+	exutil.By("Remove the MachineOSConfig resource")
+	o.Expect(extpriv.DisableOCL(mosc)).To(o.Succeed(), "Error cleaning up MOSC `%s`", mosc)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validating the MOSC was removed successfully")
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCP `%s`: %s", mcpAndMoscName, err)
+	extpriv.ValidateMOSCIsGarbageCollected(mosc, masterMcp)
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate the cluster's node has correct MCN properties")
+	err = ValidateMCNForNode(oc, machineConfigClient, nodeToTestName, mcpAndMoscName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error validating MCN for node `%s`: %s", nodeToTestName, err)
+	logger.Infof("OK!\n")
+}
+
 // `validateMCNTransitions` applies a MC, validates that the MCN conditions properly
 // transition during the update, removes the MC, then validates that the MCN conditions properly
 // transition during the update.
-func validateMCNTransitions(machineConfigClient *machineconfigclient.Clientset, nodeToTestName string, isImageUpdate bool) {
+func validateMCNTransitions(machineConfigClient *machineconfigclient.Clientset, nodeToTestName string, isImageUpdate, isSNO bool) {
 	// Validate transition through conditions for MCN
 	exutil.By("Validating the transitions through MCN conditions")
-	ValidateTransitionThroughConditions(machineConfigClient, nodeToTestName, false, isImageUpdate)
+	ValidateTransitionThroughConditions(machineConfigClient, nodeToTestName, false, isImageUpdate, isSNO)
 	logger.Infof("OK!\n")
 
 	// When an update is complete, all conditions other than `Updated` must be false

--- a/test/extended/machineconfignode.go
+++ b/test/extended/machineconfignode.go
@@ -135,10 +135,6 @@ func getMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.S
 // confirm "Updated" is "False")
 func checkMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress, status metav1.ConditionStatus) bool {
 	conditionStatus := getMCNConditionStatus(mcn, conditionType)
-	if conditionStatus != status && conditionType == mcfgv1.MachineConfigNodeResumed {
-		condition := getMCNCondition(mcn, conditionType)
-		logger.Infof("LastTransitionTime: %v, Message: %v, ObservedGeneration: %v, Reason: %v, Status: %v, Type: %v", condition.LastTransitionTime, condition.Message, condition.ObservedGeneration, condition.Reason, condition.Status, condition.Type)
-	}
 	return conditionStatus == status
 }
 
@@ -147,7 +143,7 @@ func checkMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1
 // "Unknown," the function will also return true if the condition is "True," which ensures that we
 // do not fail when an update progresses quickly through the intermediary "Unknown" phase.
 func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientset, mcnName string, conditionType mcfgv1.StateProgress, status metav1.ConditionStatus,
-	timeout time.Duration, interval time.Duration) (bool, error) {
+	timeout time.Duration, interval time.Duration, isSNO bool) (bool, error) {
 
 	conditionMet := false
 	var conditionErr error
@@ -164,12 +160,32 @@ func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientse
 
 		// Check if the MCN status is as desired
 		conditionMet = checkMCNConditionStatus(workerNodeMCN, conditionType, status)
-		// If the condition was not met and we are expecting it may have transitioned quickly
-		// trough the "Unknown" phase, check if the condition has flipped to `True`.
-		if !conditionMet && status == metav1.ConditionUnknown {
-			conditionMet = checkMCNConditionStatus(workerNodeMCN, conditionType, metav1.ConditionTrue)
-			logger.Infof("MCN '%v' %v condition was %v, missed transition through %v.", mcnName, conditionType, metav1.ConditionTrue, status)
+		if !conditionMet {
+			// If the condition was not met and we are expecting it may have transitioned quickly
+			// trough the "Unknown" phase, check if the condition has flipped to `True`.
+			if status == metav1.ConditionUnknown {
+				conditionMet = checkMCNConditionStatus(workerNodeMCN, conditionType, metav1.ConditionTrue)
+				logger.Infof("MCN '%v' %v condition was %v, missed transition through %v.", mcnName, conditionType, metav1.ConditionTrue, status)
+			}
+
+			// When a node has finished updating, the Updated condition flips to True and all other
+			// conditions are flipped back to False. The post reboot condition, RebootedNode, can
+			// sometimes flip back to false too quickly to catch the intermediate True state. When
+			// this happens, we do not want to waste time polling until the test timeout, so
+			// instead we will make sure the Updated condition is True. This will confirm the
+			// update was successful and our test timing missed the transition.
+			if status == metav1.ConditionTrue && conditionType == mcfgv1.MachineConfigNodeUpdateRebooted {
+				conditionIsFalse := checkMCNConditionStatus(workerNodeMCN, conditionType, metav1.ConditionFalse)
+				isUpdated := checkMCNConditionStatus(workerNodeMCN, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionTrue)
+				if conditionIsFalse && isUpdated {
+					logger.Infof("MCN '%v' %v condition is %v, missed transition through %v. Update completed before transition was caught.", mcnName, conditionType, metav1.ConditionFalse, status)
+					conditionMet = true
+				} else if conditionIsFalse && !isUpdated {
+					logger.Infof("MCN '%v' %v condition was %v, missed transition through %v and update is incomplete.", mcnName, conditionType, metav1.ConditionTrue, status)
+				}
+			}
 		}
+
 		return conditionMet, nil
 	}); err != nil {
 		logger.Infof("The desired MCN condition was never met: %v", err)
@@ -192,7 +208,7 @@ func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientse
 // status, a warning will be logged instead of erroring out the test.
 //
 //nolint:dupl // (ijanssen): Ignoring a duplication error the linter is throwing because of two similar, but unique if blocks.
-func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclient.Clientset, updatingNodeName string, isRebootless, isImageMode bool) {
+func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclient.Clientset, updatingNodeName string, isRebootless, isImageMode, isSNO bool) {
 	// Get the start time of the update
 	updateStartTime := metav1.Now()
 
@@ -200,43 +216,43 @@ func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclien
 	// For image-based updates, this condition flip can take a while since an image needs to build
 	// and push before the nodes uppdate, but we want to make sure non-image updates do not take as
 	// long for the condition to flip (that would mean something is wrong and would waste time).
-	updatingWaitTime := 1 * time.Minute
+	updatingWaitTime := 3 * time.Minute
 	updatingWaitInterval := 1 * time.Second
 	if isImageMode {
-		updatingWaitTime = 15 * time.Minute
+		updatingWaitTime = 20 * time.Minute
 		updatingWaitInterval = 5 * time.Second
 	}
 
 	// Test the condition transitions.
 	logger.Infof("Waiting for Updated=False")
-	conditionMet, err := waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionFalse, updatingWaitTime, updatingWaitInterval)
+	conditionMet, err := waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionFalse, updatingWaitTime, updatingWaitInterval, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Updated=False: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Updated=False.")
 
 	logger.Infof("Waiting for UpdatePrepared=True")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePrepared, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePrepared, metav1.ConditionTrue, 1*time.Minute, 1*time.Second, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdatePrepared=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdatePrepared=True.")
 
 	logger.Infof("Waiting for UpdateExecuted=Unknown")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionUnknown, 30*time.Second, 1*time.Second, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateExecuted=Unknown: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateExecuted=Unknown.")
 
 	// On standard, non-rebootless, update, check that node transitions through "Cordoned" and "Drained" phases
 	if !isRebootless {
 		logger.Infof("Waiting for Cordoned=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateCordoned, metav1.ConditionTrue, 30*time.Second, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateCordoned, metav1.ConditionTrue, 30*time.Second, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Cordoned=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Cordoned=True.")
 
 		logger.Infof("Waiting for Drained=Unknown")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionUnknown, 15*time.Second, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionUnknown, 15*time.Second, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Drained=Unknown: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Drained=Unknown.")
 
 		logger.Infof("Waiting for Drained=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionTrue, 4*time.Minute, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionTrue, 4*time.Minute, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Drained=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Drained=True.")
 	}
@@ -245,42 +261,42 @@ func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclien
 	// "ImagePulledFromRegistry" phases
 	if isImageMode {
 		logger.Infof("Waiting for AppliedOSImage=Unknown")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionUnknown, 30*time.Second, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedOSImage=Unknown: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedOSImage=Unknown.")
 
 		logger.Infof("Waiting for ImagePulledFromRegistry=Unknown")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionUnknown, 30*time.Second, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for ImagePulledFromRegistry=Unknown: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect ImagePulledFromRegistry=Unknown.")
 
 		logger.Infof("Waiting for AppliedOSImage=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionTrue, 3*time.Minute, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionTrue, 3*time.Minute, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedOSImage=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedOSImage=True.")
 	} else { // On a non-image mode update, check that node transitions through the "AppliedFiles" phase
 		logger.Infof("Waiting for AppliedFiles=Unknown")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFiles, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFiles, metav1.ConditionUnknown, 30*time.Second, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedFiles=Unknown: %v", err))
 		if !conditionMet {
 			logger.Infof("Warning, could not detect AppliedFiles=Unknown.")
 		}
 
 		logger.Infof("Waiting for AppliedFiles=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFiles, metav1.ConditionTrue, 3*time.Minute, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFiles, metav1.ConditionTrue, 3*time.Minute, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedFiles=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedFiles=True.")
 	}
 
 	logger.Infof("Waiting for UpdateExecuted=True")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionTrue, 20*time.Second, 1*time.Second)
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionTrue, 20*time.Second, 1*time.Second, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateExecuted=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateExecuted=True.")
 
 	// On image mode update, check that node transitions through the "ImagePulledFromRegistry" phase
 	if isImageMode {
 		logger.Infof("Waiting for ImagePulledFromRegistry=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionTrue, 1*time.Minute, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for ImagePulledFromRegistry=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect ImagePulledFromRegistry=True.")
 	}
@@ -288,17 +304,17 @@ func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclien
 	// On rebootless update, check that node transitions through "UpdatePostActionComplete" phase
 	if isRebootless {
 		logger.Infof("Waiting for UpdatePostActionComplete=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePostActionComplete, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePostActionComplete, metav1.ConditionTrue, 1*time.Minute, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdatePostActionComplete=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdatePostActionComplete=True.")
 	} else { // On standard, non-rebootless, update, check that node transitions through "RebootedNode" phase
 		logger.Infof("Waiting for RebootedNode=Unknown")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionUnknown, 15*time.Second, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionUnknown, 15*time.Second, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=Unknown: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=Unknown.")
 
 		logger.Infof("Waiting for RebootedNode=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionTrue, 10*time.Minute, 1*time.Second)
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionTrue, 10*time.Minute, 1*time.Second, isSNO)
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=True.")
 	}
@@ -306,26 +322,26 @@ func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclien
 	// The final steps of the update happen quickly, so sometimes we can miss the final condition
 	// transitions. If we do, we will not error out, but record that the condition was missed.
 	logger.Infof("Waiting for Resumed=True")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeResumed, metav1.ConditionTrue, 5*time.Second, 1*time.Second)
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeResumed, metav1.ConditionTrue, 15*time.Second, 1*time.Second, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Resumed=True: %v", err))
 	if !conditionMet {
 		logger.Infof("Warning, could not detect Resumed=True.")
 	}
 	logger.Infof("Waiting for UpdateComplete=True")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateComplete, metav1.ConditionTrue, 10*time.Second, 1*time.Second)
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateComplete, metav1.ConditionTrue, 10*time.Second, 1*time.Second, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
 	if !conditionMet {
 		logger.Infof("Warning, could not detect UpdateComplete=True.")
 	}
 	logger.Infof("Waiting for Uncordoned=True")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateUncordoned, metav1.ConditionTrue, 10*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateUncordoned, metav1.ConditionTrue, 10*time.Second, 1*time.Second, isSNO)
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Uncordoned=True: %v", err))
 	if !conditionMet {
-		logger.Infof("Warning, could not detect UpdateComplete=True.")
+		logger.Infof("Warning, could not detect Uncordoned=True.")
 	}
 
 	logger.Infof("Waiting for Updated=True")
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
+	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionTrue, 1*time.Minute, 1*time.Second, isSNO)
 	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Updated=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Updated=True.")
 

--- a/test/extended/machineconfigpool.go
+++ b/test/extended/machineconfigpool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
@@ -18,12 +19,17 @@ import (
 )
 
 // `DoesMachineConfigPoolHaveMachines` returns true if the desired MCP, defined by the
-// `mcpName` parameter has machines and false otherwise. It also returns an error if one occurs
-// when getting the MCP.
+// `mcpName` parameter has machines and false otherwise. It skips a test if there is an error
+// getting the MCP, as that signifies cluster instability.
 func DoesMachineConfigPoolHaveMachines(machineConfigClient *machineconfigclient.Clientset, mcpName string) bool {
 	// Get desired MCP
 	mcp, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
-	o.Expect(mcpErr).NotTo(o.HaveOccurred(), "Error checking for compatible MCPs: %s", mcpErr)
+	// SNO clusters are incredibly unstable. If we are unable to get the worker MCP for the cluster,
+	// that means the cluster is too unstable to run our test, so we should simply skip it
+	if mcpErr != nil {
+		logger.Infof("Failed to get MCP '%v', skipping test due to cluster instability: %v", mcpName, mcpErr)
+		g.Skip("Skipping this test due to cluster instability.")
+	}
 
 	// Check if desired MCP has machines
 	return mcp.Status.MachineCount > 0


### PR DESCRIPTION
**- What I did**

_Part 1 - Test hardening:_
This hardens the MCN condition transition tests for ImageModeStatusReporting. On rare occasions, such as [this example payload run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-machine-config-operator-release-4.22-periodics-e2e-aws-mco-disruptive-techpreview-1of3/2037173271597682688), we would see the test fail because we never detected the `RebootedNode` condition in a state of `True`. The reboot condition transitions from False --> Unknown --> True --> False, and some stages of the transition can occur quickly. If the reboot were to fail, the condition would stay in `Unknown`, as that is the error condition status, so warning instead of erroring when we miss the `True` condition will not hide true functional errors.

_Part 2 - Modifications for SNO:_
This updates the three ImageModeStatusReporting tests that were designed to run in custom MCPs to run against the master MCP when the worker pool has no nodes. This allows the tests to run in the SNO topology with https://github.com/openshift/release/pull/77273.

**- How to verify it**

_Part 1 - Test hardening:_
I have not been able to reproduce the error and the flake is quite rare, so the best way to verify the fix is likely to run lots of jobs and make sure the flake never appears.

_Part 2 - Modifications for SNO:_
These tests can be verified locally by running them against a SNO cluster or by rehearsing them with https://github.com/openshift/release/pull/77273 once this work merges.

**- Description for the changelog**
NO-JIRA: Harden MCN condition transition tests and adjust tests to run on SNO