### PR TITLE
OCPBUGS-82500: ClusterHostedDNS on AWS/Azure/GCP: Modify Corefile template to better handle empty record types

### DIFF
--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -18,7 +18,6 @@ contents:
         }
         template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match .*[.]apps.{{ .DNS.Spec.BaseDomain }}
-            {{ if gt (len (cloudPlatformIngressLoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformIngressLoadBalancerIPs .) 1 }}"{{ end }}
             fallthrough
         }
         template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
@@ -28,7 +27,6 @@ contents:
         }
         template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match ^api.{{ .DNS.Spec.BaseDomain }}
-            {{ if gt (len (cloudPlatformAPILoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformAPILoadBalancerIPs .) 1 }}"{{ end }}
             fallthrough
         }
         template IN {{`{{ .Cluster.CloudLBRecordType }}`}} {{ .DNS.Spec.BaseDomain }} {
@@ -38,7 +36,6 @@ contents:
         }
         template IN {{`{{ .Cluster.CloudLBEmptyType }}`}} {{ .DNS.Spec.BaseDomain }} {
             match ^api-int.{{ .DNS.Spec.BaseDomain }}
-            {{ if gt (len (cloudPlatformAPIIntLoadBalancerIPs .)) 1 }}answer "{{`{{"{{ .Name }}"}}`}} 60 in {{`{{"{{ .Type }}"}}`}} {{ index (cloudPlatformAPIIntLoadBalancerIPs .) 1 }}"{{ end }}
             fallthrough
         }
         hosts {


### PR DESCRIPTION
In IPv4 only clusters, any AAAA requests would be handled by the empty record line in the Corefile. Update the Corefile template to return no errors in that case. Currently, it is incorrectly responding with the 2nd IP address which can be the IPv4 address of a 2nd Load Balancer in some cloud platforms.

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-82500