### PR TITLE
OCPBUGS-82974: Make IRI registry read-only via environment variable

### DIFF
--- a/pkg/controller/internalreleaseimage/internalreleaseimage_helpers_test.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_helpers_test.go
@@ -40,6 +40,8 @@ func verifyInternalReleaseMasterMachineConfig(t *testing.T, mc *mcfgv1.MachineCo
 	verifyIgnitionFile(t, &ignCfg, "/etc/iri-registry/certs/tls.key", "iri-tls-key")
 	verifyIgnitionFile(t, &ignCfg, "/etc/iri-registry/certs/tls.crt", "iri-tls-crt")
 	verifyIgnitionFileContains(t, &ignCfg, "/usr/local/bin/load-registry-image.sh", "docker-registry-image-pullspec")
+	assert.Contains(t, *ignCfg.Systemd.Units[0].Contents, `REGISTRY_STORAGE_MAINTENANCE_READONLY={"enabled":true}`)
+	assert.NotContains(t, *ignCfg.Systemd.Units[0].Contents, "REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED")
 }
 
 func verifyInternalReleaseWorkerMachineConfig(t *testing.T, mc *mcfgv1.MachineConfig) {

--- a/pkg/controller/internalreleaseimage/templates/master/units/iri-registry.service.yaml
+++ b/pkg/controller/internalreleaseimage/templates/master/units/iri-registry.service.yaml
@@ -11,7 +11,7 @@ contents: |
   Environment=PODMAN_SYSTEMD_UNIT=%n
   ExecStartPre=/usr/local/bin/load-registry-image.sh
   ExecStartPre=/bin/rm -f %t/%n.ctr-id
-  ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --log-driver=journald --replace --name=iri-registry -v ${REGISTRY_DIR}:/var/lib/registry:ro,Z -v /etc/iri-registry/certs:/certs:ro -e REGISTRY_HTTP_ADDR=0.0.0.0:22625 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key -u 0 --entrypoint=/usr/bin/distribution {{ .DockerRegistryImage }} serve /etc/registry/config.yaml
+  ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --log-driver=journald --replace --name=iri-registry -v ${REGISTRY_DIR}:/var/lib/registry:ro,Z -v /etc/iri-registry/certs:/certs:ro -e REGISTRY_HTTP_ADDR=0.0.0.0:22625 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key -e 'REGISTRY_STORAGE_MAINTENANCE_READONLY={"enabled":true}' -u 0 --entrypoint=/usr/bin/distribution {{ .DockerRegistryImage }} serve /etc/registry/config.yaml
   ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
   ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Without this change, clients pushing to the IRI registry receive HTTP 500 Internal Server Error. Write requests reach the :ro filesystem mount and fail there, causing the registry to return 500. With REGISTRY_STORAGE_MAINTENANCE_READONLY='enabled: true' set, push and delete requests are rejected at the application layer with 405 Method Not Allowed instead.

REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED=true does not work -- the env var parser produces map[string]interface{} but the registry code expects map[interface{}]interface{} from gopkg.in/yaml.v2, causing a panic. Passing the entire YAML map as the value at path depth 1
(REGISTRY_STORAGE_MAINTENANCE_READONLY='enabled: true') triggers yaml.Unmarshal() and produces the correct type.

Fixes: OCPBUGS-82974

**- How to verify it**

When iri-registry.service is running, push any image to it and you should receive status 405 error:

`
Error: writing blob: initiating layer upload to /v2/test/image/blobs/uploads/ in localhost:22625: StatusCode: 405, "Method not allowed\n"
`

**- Description for the changelog**

Enforce IRI registry read-only mode at the application layer to return 405 instead of 500 on write attempts.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry service now supports enabling a read-only storage maintenance mode when starting the registry.

* **Tests**
  * Added unit test assertions to verify the registry maintenance mode setting is applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->