### PR TITLE
OCPBUGS-78524: Allow enablement of systemd units with existing files

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2292,8 +2292,8 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 		// to not go through.
 
 		if u.Enabled != nil {
-			// Only when a unit has contents should we attempt to enable or disable it.
-			// See: https://issues.redhat.com/browse/OCPBUGS-56648
+			// Only when a unit has contents or a unit file exists should we attempt to enable or disable it.
+			// See: https://redhat.atlassian.net/browse/OCPBUGS-56648 &  https://redhat.atlassian.net/browse/OCPBUGS-78524
 			_, unitExists := systemdUnits[u.Name]
 			if unitHasContent(u) || unitExists {
 				if *u.Enabled {
@@ -2329,7 +2329,10 @@ func (dn *Daemon) writeUnits(units []ign3types.Unit) error {
 	return nil
 }
 
-func (dn *Daemon) listSystemdUnits() (result map[string]systemddbus.UnitStatus, err error) {
+// `listSystemdUnits` returns all systemd unit files on disk, keyed by unit name, including loaded
+// and unloaded units. This is necessary for detecting units provided by extensions or RPM packages
+// that have not been started.
+func (dn *Daemon) listSystemdUnits() (result map[string]systemddbus.UnitFile, err error) {
 	conn, err := systemddbus.NewSystemdConnectionContext(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to system bus to list units: %w", err)
@@ -2338,14 +2341,16 @@ func (dn *Daemon) listSystemdUnits() (result map[string]systemddbus.UnitStatus, 
 		conn.Close()
 	}()
 
-	units, err := conn.ListUnitsContext(context.Background())
+	unitFiles, err := conn.ListUnitFilesContext(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("failed to list systemd units: %w", err)
+		return nil, fmt.Errorf("failed to list systemd unit files: %w", err)
 	}
 
-	result = make(map[string]systemddbus.UnitStatus)
-	for _, unit := range units {
-		result[unit.Name] = unit
+	result = make(map[string]systemddbus.UnitFile)
+	for _, unitFile := range unitFiles {
+		// Extract just the filename from the full path
+		unitName := filepath.Base(unitFile.Path)
+		result[unitName] = unitFile
 	}
 	return result, nil
 


### PR DESCRIPTION
Closes: OCPBUGS-78524

**- What I did**

This replaces `ListUnitsContext`, which returns all currently loaded (active and/or enabled) units, with `ListUnitFilesContext`, which returns all available units on disk, to allow the enablement of systemd units where files exist.

**- How to verify it**

1. Apply the two following MCs.
_To install the usbguard extension:_
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 80-worker-extensions
spec:
  config:
    ignition:
      version: 3.1.0
  extensions:
  - usbguard
EOF
```

_To enable the unit:_
```
$  oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  name: 75-worker-enable
  labels:
    machineconfiguration.openshift.io/role: worker
spec:
  config:
    ignition:
      version: 3.1.0
    systemd:
      units:
      - name: usbguard.service
        enabled: true
EOF
```

2. Check that `usbguard.service` is enabled.

```
$ oc get nodes -l node-role.kubernetes.io/worker= -o name | xargs -I{} oc debug {} -- chroot /host systemctl is-enabled usbguard.service
Starting pod/ci-ln-citcmc2-72292-svh9j-worker-a-487pj-debug-dncj2 ...
enabled
...
Starting pod/ci-ln-citcmc2-72292-svh9j-worker-b-6znrc-debug-mzrrd ...
enabled
...
Starting pod/ci-ln-citcmc2-72292-svh9j-worker-f-44hjm-debug-jnm7k ...
enabled
```

**- Description for the changelog**
OCPBUGS-78524: Allow enablement of systemd units with existing files