### PR TITLE
OCPBUGS-79502: Enable AutoSizingReserved for Hypershift workers

### DIFF
--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -507,7 +507,7 @@ func TestKubeletAutoNodeSizingEnabled(t *testing.T) {
 	}
 }
 
-func TestKubeletAutoNodeSizingDisabledForHypershift(t *testing.T) {
+func TestKubeletAutoNodeSizingEnabledForHypershift(t *testing.T) {
 	cc := newControllerConfig("test-cluster")
 	// Set ControlPlaneTopology to External to simulate Hypershift
 	cc.Spec.Infra.Status.ControlPlaneTopology = configv1.ExternalTopologyMode
@@ -539,9 +539,16 @@ func TestKubeletAutoNodeSizingDisabledForHypershift(t *testing.T) {
 
 				contentsStr := string(contents)
 
-				// Verify NODE_SIZING_ENABLED=false is present for Hypershift
-				if !strings.Contains(contentsStr, "NODE_SIZING_ENABLED=false") {
-					t.Errorf("Expected NODE_SIZING_ENABLED=false for Hypershift in %s, got: %s", mc.Name, contentsStr)
+				// Master nodes are always disabled and worker nodes should now be enabled even for Hypershift
+				isMasterNode := strings.Contains(mc.Name, "master")
+				if isMasterNode {
+					if !strings.Contains(contentsStr, "NODE_SIZING_ENABLED=false") {
+						t.Errorf("Expected NODE_SIZING_ENABLED=false for Hypershift master in %s, got: %s", mc.Name, contentsStr)
+					}
+				} else {
+					if !strings.Contains(contentsStr, "NODE_SIZING_ENABLED=true") {
+						t.Errorf("Expected NODE_SIZING_ENABLED=true for Hypershift worker in %s, got: %s", mc.Name, contentsStr)
+					}
 				}
 
 				// Verify other expected values are still present

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -542,64 +542,6 @@ func TestKubeletAutoNodeSizingEnabled(t *testing.T) {
 	}
 }
 
-func TestKubeletAutoNodeSizingDisabledForHypershift(t *testing.T) {
-	cc := newControllerConfig("test-cluster")
-	// Set ControlPlaneTopology to External to simulate Hypershift
-	cc.Spec.Infra.Status.ControlPlaneTopology = configv1.ExternalTopologyMode
-	ps := []byte(`{"dummy": "dummy"}`)
-
-	mcs, err := getMachineConfigsForControllerConfig(templateDir, cc, ps, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Find machine configs that should contain the auto-node-sizing file
-	autoSizingFileFound := false
-	for _, mc := range mcs {
-		ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
-		if err != nil {
-			t.Fatalf("Failed to parse ignition config for %s: %v", mc.Name, err)
-		}
-
-		// Look for the auto-node-sizing file
-		for _, file := range ignCfg.Storage.Files {
-			if file.Path == ctrlcommon.NodeSizingEnabledEnvPath {
-				autoSizingFileFound = true
-
-				// Decode the file contents
-				contents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
-				if err != nil {
-					t.Fatalf("Failed to decode auto-node-sizing file contents: %v", err)
-				}
-
-				contentsStr := string(contents)
-
-				// Verify NODE_SIZING_ENABLED=false is present for Hypershift
-				if !strings.Contains(contentsStr, "NODE_SIZING_ENABLED=false") {
-					t.Errorf("Expected NODE_SIZING_ENABLED=false for Hypershift in %s, got: %s", mc.Name, contentsStr)
-				}
-
-				// Verify other expected values are still present
-				if !strings.Contains(contentsStr, "SYSTEM_RESERVED_MEMORY=1Gi") {
-					t.Errorf("Expected SYSTEM_RESERVED_MEMORY=1Gi in %s, got: %s", mc.Name, contentsStr)
-				}
-
-				if !strings.Contains(contentsStr, "SYSTEM_RESERVED_CPU=500m") {
-					t.Errorf("Expected SYSTEM_RESERVED_CPU=500m in %s, got: %s", mc.Name, contentsStr)
-				}
-
-				if !strings.Contains(contentsStr, "SYSTEM_RESERVED_ES=1Gi") {
-					t.Errorf("Expected SYSTEM_RESERVED_ES=1Gi in %s, got: %s", mc.Name, contentsStr)
-				}
-			}
-		}
-	}
-
-	if !autoSizingFileFound {
-		t.Errorf("Expected to find %s file in at least one machine config", ctrlcommon.NodeSizingEnabledEnvPath)
-	}
-}
-
 // TestMergesIRIRegistryCredentialsIntoPullSecret verifies that the template controller merges
 // IRI registry credentials into the pull secret when rendering 00-master, so that
 // nodes can authenticate to the IRI registry without writing to the user-controlled

--- a/templates/common/_base/files/kubelet-auto-node-sizing-enabled.yaml
+++ b/templates/common/_base/files/kubelet-auto-node-sizing-enabled.yaml
@@ -2,7 +2,7 @@ mode: 0644
 path: "/etc/node-sizing-enabled.env"
 contents:
   inline: |
-    NODE_SIZING_ENABLED={{if eq .Infra.Status.ControlPlaneTopology "External"}}false{{else}}true{{end}}
+    NODE_SIZING_ENABLED=true
     SYSTEM_RESERVED_MEMORY=1Gi
     SYSTEM_RESERVED_CPU=500m
     SYSTEM_RESERVED_ES=1Gi


### PR DESCRIPTION
AutoSizingReserved was disabled for Hypershift (ControlPlaneTopology=External) in PR #5390 because the old dynamic reservation formula reserved too much memory on small nodes, causing platform pods to fail scheduling.

MCO PR #5716 fixed the formula by reducing reservation on 8 GiB nodes from 2 GiB back to 1 GiB, making it safe to re enable AutoSizingReserved for Hypershift worker nodes.

Ref: OCPBUGS-79502

**- What I did**
Removed the Hypershift (ControlPlaneTopology=External) exception that disabled AutoSizingReserved on worker nodes. Removed TestKubeletAutoNodeSizingDisabledForHypershift since there is no longer any Hypershift-specific logic to test.

**- How to verify it**
- Unit tests: `go test ./pkg/controller/template/... -run TestKubeletAutoNodeSizing -v`
- Payload-test with Hypershift e2e to confirm platform pods schedule successfully on small instance types with AutoSizingReserved enabled.

**- Description for the changelog**
Re-enable AutoSizingReserved for Hypershift worker nodes now that dynamic memory reservation has been reduced (MCO #5716)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kubelet auto node sizing now writes NODE_SIZING_ENABLED=true unconditionally (no longer toggled by control-plane topology), so node sizing is enabled consistently across deployments. Existing system-reserved settings (memory, CPU, ES) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->