### PR TITLE
Revert "OCPBUGS-69936: ovs: increase CPU priority for Open vSwitch Forwarding Unit"

### DIFF
--- a/templates/common/_base/units/ovs-vswitchd.service.yaml
+++ b/templates/common/_base/units/ovs-vswitchd.service.yaml
@@ -9,9 +9,3 @@ dropins:
       ExecStartPre=-/bin/sh -c '/usr/bin/chown -R :$${OVS_USER_ID##*:} /run/openvswitch'
       ExecStartPost=-/usr/bin/ovs-appctl vlog/set syslog:info
       ExecReload=-/usr/bin/ovs-appctl vlog/set syslog:info
-  - name: 20-ovs-vswitchd-cpu-priority.conf
-    contents: |
-      [Service]
-      CPUSchedulingPolicy=fifo
-      CPUSchedulingPriority=10
-      Nice=-10


### PR DESCRIPTION
This reverts #5797 which added CPU scheduling priority (`CPUSchedulingPolicy=fifo`, `CPUSchedulingPriority=10`, `Nice=-10`) to `ovs-vswitchd.service`.

/hold