### PR TITLE
OCPBUGS-83401: add RootCA cert to the sysContextBuilder certs

### DIFF
--- a/pkg/imageutils/sys_context.go
+++ b/pkg/imageutils/sys_context.go
@@ -95,7 +95,8 @@ func (b *SysContextBuilder) hasCerts() bool {
 	return b.controllerConfig != nil &&
 		(len(b.controllerConfig.Spec.ImageRegistryBundleData) > 0 ||
 			len(b.controllerConfig.Spec.ImageRegistryBundleUserData) > 0 ||
-			len(b.controllerConfig.Spec.AdditionalTrustBundle) > 0)
+			len(b.controllerConfig.Spec.AdditionalTrustBundle) > 0 ||
+			len(b.controllerConfig.Spec.RootCAData) > 0)
 }
 
 // buildAuth configures authentication by writing the Docker secret as authfile.json
@@ -210,7 +211,7 @@ func (b *SysContextBuilder) buildCerts(sysContext *SysContext) error {
 	// a common CA bundle is given by AdditionalTrustBundle we need to create a temporal bundle
 	// that concatenates all the bundles into a single file and pass that to the lib.
 	// We loose the ability to isolate CAs per registry till the fix in the library lands
-	if len(b.controllerConfig.Spec.AdditionalTrustBundle) > 0 {
+	if len(b.controllerConfig.Spec.AdditionalTrustBundle) > 0 || len(b.controllerConfig.Spec.RootCAData) > 0 {
 		var certBundle bytes.Buffer
 
 		for _, irb := range b.controllerConfig.Spec.ImageRegistryBundleData {
@@ -225,6 +226,12 @@ func (b *SysContextBuilder) buildCerts(sysContext *SysContext) error {
 		// Append AdditionalTrustBundle
 		if len(b.controllerConfig.Spec.AdditionalTrustBundle) > 0 {
 			certBundle.Write(b.controllerConfig.Spec.AdditionalTrustBundle)
+			certBundle.WriteString("\n")
+		}
+
+		// Append RootCA data. This is required to access the InternalReleaseImage registry
+		if len(b.controllerConfig.Spec.RootCAData) > 0 {
+			certBundle.Write(b.controllerConfig.Spec.RootCAData)
 			certBundle.WriteString("\n")
 		}
 

--- a/pkg/imageutils/sys_context_test.go
+++ b/pkg/imageutils/sys_context_test.go
@@ -183,6 +183,20 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOSW8w==
 			expectProxy:   true,
 		},
 		{
+			name: "WithControllerConfig only - just rootCA",
+			controllerConfig: &mcfgv1.ControllerConfig{
+				Spec: mcfgv1.ControllerConfigSpec{
+					RootCAData: []byte(`-----BEGIN CERTIFICATE-----
+MIICljCCAX4CCQCKz8Vz4VR5+jANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJV
+UzAeFw0yMDAxMDEwMDAwMDBaFw0zMDAxMDEwMDAwMDBaMA0xCzAJBgNVBAYTAlVT
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOSW8w==
+-----END CERTIFICATE-----`),
+				},
+			},
+			expectTempDir: true,
+			expectCerts:   true,
+		},
+		{
 			name: "Both WithSecret and WithControllerConfig",
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**- What I did**
Added the rootCA cert to the certs built by sysContextBuilder. This is required to support the `OSStreams` feature during the bootstrap when the `NoRegistryClusterInstall` feature is enabled (and thus the OCP release payload is stored internally in the IRI registries, all of them signed by using the rootCA cert)

**- How to verify it**
Run the iso-no-registry CI job

**- Description for the changelog**
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CA bundle construction now includes controller-provided root CA data when present, ensuring merged CA files contain those certificates and improving image registry certificate validation.
* **Tests**
  * Added a test verifying that controller-supplied root CA data triggers creation of certificate outputs and temporary context as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->