### PR TITLE
deploy-from-self if skopeo < 1.22.2

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1236,8 +1236,10 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig(machineConfigFile string) er
 	// If the host isn't new enough to understand the new container model natively, run as a privileged container.
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
 	// This currently will incur a double reboot; see https://github.com/coreos/rpm-ostree/issues/4018
-	if !newEnough {
-		logSystem("rpm-ostree is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
+	// If Skopeo used by rpm-ostree is an older version supporting multi-arch Sigstore verificaiton, run as a privileged container which has updated skopeo.
+	// See https://redhat.atlassian.net/browse/OCPBUGS-83826 and https://redhat.atlassian.net/browse/OCPBUGS-81187
+	if !newEnough || !skopeoSupportsMultiArchSigstore() {
+		logSystem("rpm-ostree or skopeo is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
 		if err := dn.InplaceUpdateViaNewContainer(mc.Spec.OSImageURL); err != nil {
 			return err
 		}

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -296,27 +296,48 @@ func (r *RpmOstreeClient) patchPoliciesForContainerStorage(podmanImageInfo *Podm
 		return err
 	}
 
-	policy, err := signature.NewPolicyFromBytes(policyOriginalContent)
-	if err != nil {
-		return err
-	}
+	var policy *signature.Policy
 
-	_, containerStoragePoliciesPresent := policy.Transports[imagePolicyTransportContainerStorage]
-	if (reflect.DeepEqual(policy.Default[0], signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()}) && !containerStoragePoliciesPresent) {
-		// Temporary patching the policies.json file can be skipped, with warranties, and without re-implementing the
-		// logic that evaluates the policies or importing it under the following circumstances (must match all):
-		//  1. The default policy should be "insecureAcceptAnything"
-		//  2. Transport-specific policies for containers-storage shouldn't be in place.
-		return nil
-	}
+	// Skopeo (< 1.22.2) fails on multi-arch manifest-lists Sigstore verification , overrides
+	// policy to avoid "A signature was required, but no signature exists" errors during
+	// rpm-ostree rebase operations on older boot images.
+	// See https://issues.redhat.com/browse/OCPBUGS-81187 for details.
+	if !skopeoSupportsMultiArchSigstore() {
+		klog.Infof("skopeo does not support multi-arch Sigstore, using fully permissive policy for rpm-ostree")
+		policy = &signature.Policy{
+			Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+			Transports: map[string]signature.PolicyTransportScopes{
+				"docker": {
+					"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+				},
+				imagePolicyTransportContainerStorage: {
+					"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
+				},
+			},
+		}
+	} else {
+		policy, err = signature.NewPolicyFromBytes(policyOriginalContent)
+		if err != nil {
+			return err
+		}
 
-	// At this point there's no warranty the policy will allow rpm-ostree to fetch the image
-	// from local storage -> Add a specific rule to allow the image
-	if !containerStoragePoliciesPresent {
-		policy.Transports[imagePolicyTransportContainerStorage] = make(map[string]signature.PolicyRequirements)
-	}
-	policy.Transports[imagePolicyTransportContainerStorage][url] = signature.PolicyRequirements{
-		signature.NewPRInsecureAcceptAnything(),
+		_, containerStoragePoliciesPresent := policy.Transports[imagePolicyTransportContainerStorage]
+		if (reflect.DeepEqual(policy.Default[0], signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()}) && !containerStoragePoliciesPresent) {
+			// Temporary patching the policies.json file can be skipped, with warranties, and without re-implementing the
+			// logic that evaluates the policies or importing it under the following circumstances (must match all):
+			//  1. The default policy should be "insecureAcceptAnything"
+			//  2. Transport-specific policies for containers-storage shouldn't be in place.
+			return nil
+		}
+
+		// At this point there's no warranty the policy will allow rpm-ostree to fetch the image
+		// from local storage -> Add a specific rule to allow the image
+		if !containerStoragePoliciesPresent {
+			policy.Transports[imagePolicyTransportContainerStorage] = make(map[string]signature.PolicyRequirements)
+		}
+		policy.Transports[imagePolicyTransportContainerStorage][url] = signature.PolicyRequirements{
+			signature.NewPRInsecureAcceptAnything(),
+		}
 	}
 
 	// Prepare the json patched content

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -296,48 +296,27 @@ func (r *RpmOstreeClient) patchPoliciesForContainerStorage(podmanImageInfo *Podm
 		return err
 	}
 
-	var policy *signature.Policy
+	policy, err := signature.NewPolicyFromBytes(policyOriginalContent)
+	if err != nil {
+		return err
+	}
 
-	// Skopeo (< 1.22.2) fails on multi-arch manifest-lists Sigstore verification , overrides
-	// policy to avoid "A signature was required, but no signature exists" errors during
-	// rpm-ostree rebase operations on older boot images.
-	// See https://issues.redhat.com/browse/OCPBUGS-81187 for details.
-	if !skopeoSupportsMultiArchSigstore() {
-		klog.Infof("skopeo does not support multi-arch Sigstore, using fully permissive policy for rpm-ostree")
-		policy = &signature.Policy{
-			Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
-			Transports: map[string]signature.PolicyTransportScopes{
-				"docker": {
-					"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
-				},
-				imagePolicyTransportContainerStorage: {
-					"": signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()},
-				},
-			},
-		}
-	} else {
-		policy, err = signature.NewPolicyFromBytes(policyOriginalContent)
-		if err != nil {
-			return err
-		}
+	_, containerStoragePoliciesPresent := policy.Transports[imagePolicyTransportContainerStorage]
+	if (reflect.DeepEqual(policy.Default[0], signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()}) && !containerStoragePoliciesPresent) {
+		// Temporary patching the policies.json file can be skipped, with warranties, and without re-implementing the
+		// logic that evaluates the policies or importing it under the following circumstances (must match all):
+		//  1. The default policy should be "insecureAcceptAnything"
+		//  2. Transport-specific policies for containers-storage shouldn't be in place.
+		return nil
+	}
 
-		_, containerStoragePoliciesPresent := policy.Transports[imagePolicyTransportContainerStorage]
-		if (reflect.DeepEqual(policy.Default[0], signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()}) && !containerStoragePoliciesPresent) {
-			// Temporary patching the policies.json file can be skipped, with warranties, and without re-implementing the
-			// logic that evaluates the policies or importing it under the following circumstances (must match all):
-			//  1. The default policy should be "insecureAcceptAnything"
-			//  2. Transport-specific policies for containers-storage shouldn't be in place.
-			return nil
-		}
-
-		// At this point there's no warranty the policy will allow rpm-ostree to fetch the image
-		// from local storage -> Add a specific rule to allow the image
-		if !containerStoragePoliciesPresent {
-			policy.Transports[imagePolicyTransportContainerStorage] = make(map[string]signature.PolicyRequirements)
-		}
-		policy.Transports[imagePolicyTransportContainerStorage][url] = signature.PolicyRequirements{
-			signature.NewPRInsecureAcceptAnything(),
-		}
+	// At this point there's no warranty the policy will allow rpm-ostree to fetch the image
+	// from local storage -> Add a specific rule to allow the image
+	if !containerStoragePoliciesPresent {
+		policy.Transports[imagePolicyTransportContainerStorage] = make(map[string]signature.PolicyRequirements)
+	}
+	policy.Transports[imagePolicyTransportContainerStorage][url] = signature.PolicyRequirements{
+		signature.NewPRInsecureAcceptAnything(),
 	}
 
 	// Prepare the json patched content

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2758,8 +2758,10 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	// If the host isn't new enough to understand the new container model natively, run as a privileged container.
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
 	// This currently will incur a double reboot; see https://github.com/coreos/rpm-ostree/issues/4018
-	if !newEnough {
-		logSystem("rpm-ostree is not new enough for layering; forcing an update via container")
+	// If Skopeo used by rpm-ostree is an older version supporting multi-arch Sigstore verificaiton, run as a privileged container which has updated skopeo.
+	// See https://redhat.atlassian.net/browse/OCPBUGS-83826 and https://redhat.atlassian.net/browse/OCPBUGS-81187
+	if !newEnough || !skopeoSupportsMultiArchSigstore() {
+		logSystem("rpm-ostree or skopeo is not new enough for layering; forcing an update via container")
 		return dn.InplaceUpdateViaNewContainer(newURL)
 	}
 
@@ -2936,6 +2938,46 @@ func podmanSupportsSigstore() bool {
 		podmanSigstoreSupportedValue = imgPodmanVersion.Compare(*semver.New(sigstorePodman)) >= 0
 	})
 	return podmanSigstoreSupportedValue
+}
+
+var (
+	skopeoMultiArchSigstoreSupported      sync.Once
+	skopeoMultiArchSigstoreSupportedValue bool
+)
+
+func skopeoSupportsMultiArchSigstore() bool {
+	skopeoMultiArchSigstoreSupported.Do(func() {
+		// https://issues.redhat.com/browse/OCPBUGS-81187
+		// Multi-arch Sigstore fixed in skopeo 1.22.2
+		cmd := exec.Command("skopeo", "--version")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			klog.Errorf("failed to run skopeo --version: %v", err)
+			skopeoMultiArchSigstoreSupportedValue = false
+			return
+		}
+		// Output format: "skopeo version 1.21.0-dev commit: d8be59c1ecc5c1860b7bab4f60721d55da2cda9a"
+		fields := strings.Fields(strings.TrimSpace(string(out)))
+		if len(fields) < 3 {
+			klog.Errorf("unexpected skopeo version output format: %s", string(out))
+			skopeoMultiArchSigstoreSupportedValue = false
+			return
+		}
+
+		versionStr := fields[2]
+		if dashIdx := strings.Index(versionStr, "-"); dashIdx != -1 {
+			versionStr = versionStr[:dashIdx]
+		}
+		skopeoVersion, err := semver.NewVersion(versionStr)
+		if err != nil {
+			klog.Errorf("failed to parse skopeo version %s: %v", versionStr, err)
+			skopeoMultiArchSigstoreSupportedValue = false
+			return
+		}
+		minSkopeoVersionForMultiArchSigstore := "1.22.2"
+		skopeoMultiArchSigstoreSupportedValue = skopeoVersion.Compare(*semver.New(minSkopeoVersionForMultiArchSigstore)) >= 0
+	})
+	return skopeoMultiArchSigstoreSupportedValue
 }
 
 // Log a message to the systemd journal as well as our stdout

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2909,15 +2909,6 @@ func runCmdSync(cmdName string, args ...string) error {
 	return nil
 }
 
-const (
-	// minPodmanVersionForSigstore is the minimum podman version that supports Sigstore verification
-	// https://issues.redhat.com/browse/OCPBUGS-38809
-	minPodmanVersionForSigstore = "4.4.1"
-	// minSkopeoVersionForMultiArchSigstore is the minimum skopeo version that supports multi-arch Sigstore verification
-	// https://issues.redhat.com/browse/OCPBUGS-81187
-	minSkopeoVersionForMultiArchSigstore = "1.22.2"
-)
-
 var (
 	podmanSigstoreSupported      sync.Once
 	podmanSigstoreSupportedValue bool
@@ -2925,6 +2916,8 @@ var (
 
 func podmanSupportsSigstore() bool {
 	podmanSigstoreSupported.Do(func() {
+		// https://issues.redhat.com/browse/OCPBUGS-38809 failed for base image 4.11 or older, OCP 4.12 is with podman 4.4.1
+		// returns false if podman version is less than 4.4.1
 		cmd := exec.Command("podman", "version", "-f", "{{.APIVersion}}")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -2932,58 +2925,17 @@ func podmanSupportsSigstore() bool {
 			podmanSigstoreSupportedValue = false
 			return
 		}
+		sigstorePodman := "4.4.1"
+		// Example version format: 5.3.0-rc1
 		imgPodmanVersion, err := semver.NewVersion(strings.TrimSpace(string(out)))
 		if err != nil {
 			klog.Errorf("failed to parse podman version: %v", err)
 			podmanSigstoreSupportedValue = false
 			return
 		}
-		podmanSigstoreSupportedValue = imgPodmanVersion.Compare(*semver.New(minPodmanVersionForSigstore)) >= 0
+		podmanSigstoreSupportedValue = imgPodmanVersion.Compare(*semver.New(sigstorePodman)) >= 0
 	})
 	return podmanSigstoreSupportedValue
-}
-
-var (
-	skopeoMultiArchSigstoreSupported      sync.Once
-	skopeoMultiArchSigstoreSupportedValue bool
-)
-
-func skopeoSupportsMultiArchSigstore() bool {
-	skopeoMultiArchSigstoreSupported.Do(func() {
-		// Multi-arch Sigstore verification requires skopeo >= 1.22.2.
-		// Older boot images will fail with "A signature was required, but no signature exists"
-		// when rpm-ostree attempts to pull multi-arch images with Sigstore enforcement.
-		cmd := exec.Command("skopeo", "--version")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			klog.Errorf("failed to run skopeo --version: %v", err)
-			skopeoMultiArchSigstoreSupportedValue = false
-			return
-		}
-		// Example output: "skopeo version 1.21.0-dev commit: d8be59c1ecc5c1860b7bab4f60721d55da2cda9a"
-		outStr := strings.TrimSpace(string(out))
-		fields := strings.Fields(outStr)
-		if len(fields) < 3 {
-			klog.Errorf("failed to parse skopeo version output: %s", outStr)
-			skopeoMultiArchSigstoreSupportedValue = false
-			return
-		}
-
-		versionStr := fields[2]
-		if dashIdx := strings.Index(versionStr, "-"); dashIdx != -1 {
-			versionStr = versionStr[:dashIdx]
-		}
-
-		skopeoVersion, err := semver.NewVersion(versionStr)
-		if err != nil {
-			klog.Errorf("failed to parse skopeo version %s: %v", versionStr, err)
-			skopeoMultiArchSigstoreSupportedValue = false
-			return
-		}
-		skopeoMultiArchSigstoreSupportedValue = skopeoVersion.Compare(*semver.New(minSkopeoVersionForMultiArchSigstore)) >= 0
-		klog.Infof("skopeo version %s, multi-arch Sigstore support: %v", versionStr, skopeoMultiArchSigstoreSupportedValue)
-	})
-	return skopeoMultiArchSigstoreSupportedValue
 }
 
 // Log a message to the systemd journal as well as our stdout

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2909,6 +2909,15 @@ func runCmdSync(cmdName string, args ...string) error {
 	return nil
 }
 
+const (
+	// minPodmanVersionForSigstore is the minimum podman version that supports Sigstore verification
+	// https://issues.redhat.com/browse/OCPBUGS-38809
+	minPodmanVersionForSigstore = "4.4.1"
+	// minSkopeoVersionForMultiArchSigstore is the minimum skopeo version that supports multi-arch Sigstore verification
+	// https://issues.redhat.com/browse/OCPBUGS-81187
+	minSkopeoVersionForMultiArchSigstore = "1.22.2"
+)
+
 var (
 	podmanSigstoreSupported      sync.Once
 	podmanSigstoreSupportedValue bool
@@ -2916,8 +2925,6 @@ var (
 
 func podmanSupportsSigstore() bool {
 	podmanSigstoreSupported.Do(func() {
-		// https://issues.redhat.com/browse/OCPBUGS-38809 failed for base image 4.11 or older, OCP 4.12 is with podman 4.4.1
-		// returns false if podman version is less than 4.4.1
 		cmd := exec.Command("podman", "version", "-f", "{{.APIVersion}}")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -2925,17 +2932,58 @@ func podmanSupportsSigstore() bool {
 			podmanSigstoreSupportedValue = false
 			return
 		}
-		sigstorePodman := "4.4.1"
-		// Example version format: 5.3.0-rc1
 		imgPodmanVersion, err := semver.NewVersion(strings.TrimSpace(string(out)))
 		if err != nil {
 			klog.Errorf("failed to parse podman version: %v", err)
 			podmanSigstoreSupportedValue = false
 			return
 		}
-		podmanSigstoreSupportedValue = imgPodmanVersion.Compare(*semver.New(sigstorePodman)) >= 0
+		podmanSigstoreSupportedValue = imgPodmanVersion.Compare(*semver.New(minPodmanVersionForSigstore)) >= 0
 	})
 	return podmanSigstoreSupportedValue
+}
+
+var (
+	skopeoMultiArchSigstoreSupported      sync.Once
+	skopeoMultiArchSigstoreSupportedValue bool
+)
+
+func skopeoSupportsMultiArchSigstore() bool {
+	skopeoMultiArchSigstoreSupported.Do(func() {
+		// Multi-arch Sigstore verification requires skopeo >= 1.22.2.
+		// Older boot images will fail with "A signature was required, but no signature exists"
+		// when rpm-ostree attempts to pull multi-arch images with Sigstore enforcement.
+		cmd := exec.Command("skopeo", "--version")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			klog.Errorf("failed to run skopeo --version: %v", err)
+			skopeoMultiArchSigstoreSupportedValue = false
+			return
+		}
+		// Example output: "skopeo version 1.21.0-dev commit: d8be59c1ecc5c1860b7bab4f60721d55da2cda9a"
+		outStr := strings.TrimSpace(string(out))
+		fields := strings.Fields(outStr)
+		if len(fields) < 3 {
+			klog.Errorf("failed to parse skopeo version output: %s", outStr)
+			skopeoMultiArchSigstoreSupportedValue = false
+			return
+		}
+
+		versionStr := fields[2]
+		if dashIdx := strings.Index(versionStr, "-"); dashIdx != -1 {
+			versionStr = versionStr[:dashIdx]
+		}
+
+		skopeoVersion, err := semver.NewVersion(versionStr)
+		if err != nil {
+			klog.Errorf("failed to parse skopeo version %s: %v", versionStr, err)
+			skopeoMultiArchSigstoreSupportedValue = false
+			return
+		}
+		skopeoMultiArchSigstoreSupportedValue = skopeoVersion.Compare(*semver.New(minSkopeoVersionForMultiArchSigstore)) >= 0
+		klog.Infof("skopeo version %s, multi-arch Sigstore support: %v", versionStr, skopeoMultiArchSigstoreSupportedValue)
+	})
+	return skopeoMultiArchSigstoreSupportedValue
 }
 
 // Log a message to the systemd journal as well as our stdout


### PR DESCRIPTION
uses deploy-from-self when skopeo is actually older than 1.22.2 that has issue
with multi-arch sigstore verification

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system update logic to properly handle cases where certain tool versions don't meet requirements. Updates will now use an alternative method when necessary tool dependencies aren't sufficiently up-to-date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->