### PR TITLE
MCO-2222: /automate-test skill for generating e2e tests from specifications

### DIFF
--- a/.claude/commands/automate-test.md
+++ b/.claude/commands/automate-test.md
@@ -1,0 +1,20 @@
+---
+description: Automate MCO test creation from test specifications, learning from previous code reviews
+argument-hint: <spec-source> "<suite-name>" [longduration|disruptive]
+---
+
+Generate new MCO e2e test cases in `test/extended-priv/` from test specifications.
+
+Use the conventions in `.claude/skills/mco-automate-test-workflow.md` for all test generation rules.
+
+**Input modes** (determined by `<spec-source>` format):
+- **Text file**: a file path containing the test specification
+- **Polarion ID** (future, MCO-2220): a numeric ID like `OCP-12345`
+- **Jira ID** (future, MCO-2221): a Jira key like `MCO-1234`
+
+**Workflow:**
+1. Parse arguments. Read the spec file and extract test case ID, title, preconditions, steps, expected results, and tags. Derive target file from suite name (`"mco security"` -> `mco_security.go`).
+2. Learn from previous code reviews — check memory (`review_patterns_mco.md`), fetch new patterns from merged PRs via `gh api` on `openshift/machine-config-operator`.
+3. Read existing tests and utilities in `test/extended-priv/` to understand available helpers and patterns.
+4. Generate the test code following all conventions from the workflow skill.
+5. Build with `make machine-config-tests-ext` and verify the test appears in listing. Fix any build errors.

--- a/.claude/skills/mco-automate-test-workflow.md
+++ b/.claude/skills/mco-automate-test-workflow.md
@@ -1,0 +1,157 @@
+---
+name: MCO Automate Test Workflow
+description: Conventions and workflow for generating new MCO e2e tests from test specifications
+---
+
+# MCO Test Automation Rules
+
+Generate new e2e test code in `test/extended-priv/` from test specifications.
+
+## Input Detection
+
+- **Text file**: path exists on disk -> read and parse it for test case ID, title, preconditions, steps, expected results, tags
+- **Polarion ID**: matches `OCP-\d+` or purely numeric -> future (MCO-2220)
+- **Jira ID**: matches `MCO-\d+` -> future (MCO-2221)
+
+Only text file input is supported now.
+
+## Target File Resolution
+
+Derive from `<suite-name>`: `"mco security"` -> `mco_security.go`
+- If `test/extended-priv/<filename>` exists: add new `g.It()` block to it
+- If it doesn't exist: create new file with full test structure
+
+## Code Review Learning
+
+Learn from previous code reviews to produce review-ready code. This is cumulative — patterns are stored in memory (`review_patterns_mco.md`) and grow with every run.
+
+- Load existing patterns from memory, note the `Last Analyzed PR` as high-water mark
+- Fetch merged PRs that modified `test/extended-priv/` via `gh`, only newer than last analyzed
+- For each PR, fetch inline review comments and PR-level reviews via `gh api`
+- Extract actionable coding standards (naming, resource handling, error handling, code structure, common mistakes)
+- Deduplicate against existing patterns. Newer patterns win on contradiction
+- Save updated patterns to `review_patterns_mco.md` memory
+- Fall back to built-in conventions below if `gh` is unavailable
+
+## Codebase Context
+
+Before generating, read existing code to understand available utilities and patterns:
+
+- The target file (if existing) — its Describe block, JustBeforeEach, variables, existing tests
+- 2-3 similar test files based on topic
+- Resource wrappers: `machineconfig.go`, `machineconfigpool.go`, `node.go`, etc.
+- Helpers: `util.go`, `resource.go`, `remotefile.go`, `gomega_matchers.go`
+- Testdata templates in `test/extended-priv/testdata/files/`
+
+## Conventions
+
+1. **Use GetCompactCompatiblePool** for MCP selection, unless the test requires the master pool
+2. **Call GetCurrentTestPolarionIDNumber()** once per test
+3. **Use Generic MC template** when possible
+4. **Base64 encode** file configuration in MachineConfigs
+5. **Use test number** in file paths, content, and resource names for uniqueness
+6. **Node selection**: `GetSortedNodesOrFail()[0]`
+7. **Step logging**: `exutil.By("<step>")` for each step, `logger.Infof("OK!\n")` after success
+8. **Declare variables** in the `var` block when possible
+9. **Error messages**: log the full resource with `%s`, not just `.GetName()`
+10. **State recovery**: always recover initial state via defer (e.g., `defer resource.DeleteWithWait()`)
+11. **Prefer Resource struct methods** over `oc.AsAdmin().Run`
+12. **RemoteFile** with gomega checkers for verifying files inside nodes
+13. **Concise comments** — one or two lines maximum
+
+## New File Structure
+
+```go
+package extended
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+)
+
+var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/<suite-type>][Serial][Disruptive] MCO <suite-name>", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("mco-<cli-name>", exutil.KubeConfigPath())
+
+	g.JustBeforeEach(func() {
+		PreChecks(oc)
+	})
+
+	g.It("[PolarionID:<id>][OTP] <description> [Disruptive]", func() {
+		// test body
+	})
+})
+```
+
+- `[Serial][Disruptive]` is **always required** on Describe blocks
+- `<cli-name>`: suite name hyphenated (e.g., `mco-security`)
+
+## Existing File Insertion
+
+Insert new `g.It` block inside the existing `g.Describe`, after the last test. Add new imports as needed. Do not modify existing code.
+
+## Test Body Pattern
+
+```go
+g.It("[PolarionID:<id>][OTP] <description> [Disruptive]", g.Label("Platform:aws"), func() {
+	testID := GetCurrentTestPolarionIDNumber()
+	mcp := GetCompactCompatiblePool(oc.AsAdmin())
+	node := mcp.GetSortedNodesOrFail()[0]
+
+	exutil.By("<step 1 from spec>")
+	// implementation
+	logger.Infof("OK!\n")
+
+	exutil.By("<step 2 from spec>")
+	// implementation
+	logger.Infof("OK!\n")
+})
+```
+
+## Generation Rules
+
+- Each spec step becomes an `exutil.By()` block
+- Use existing helpers — prefer utility functions over raw oc commands
+- Defer cleanup immediately after resource creation
+- Resource names include test ID: `fmt.Sprintf("test-%s-mc", testID)`
+- Node verification: `NewRemoteFile(node, path)` with gomega matchers
+- Pool waiting after changes: `mcp.waitForComplete()`
+- Platform labels: `g.Label("Platform:aws", "Platform:gce")` based on spec tags
+- Feature gate labels: `g.Label("OCPFeatureGate:XXX")` if the spec requires it
+- Skip functions for platform/architecture: `skipTestIfSupportedPlatformNotMatched(oc, AWSPlatform, GCPPlatform)`, `architecture.SkipNonAmd64SingleArch(oc)`
+- If the test requires new YAML templates, create them in `test/extended-priv/testdata/files/` and reference with `SetMCOTemplate("<name>.yaml")`
+
+## Platform Constants
+
+| Platform | Constant | g.Label Value |
+|---|---|---|
+| AWS | `AWSPlatform` | `"Platform:aws"` |
+| GCP | `GCPPlatform` | `"Platform:gce"` |
+| Azure | `AzurePlatform` | `"Platform:azure"` |
+| vSphere | `VspherePlatform` | `"Platform:vsphere"` |
+
+## Suite Types
+
+| Type | Describe Annotation |
+|---|---|
+| longduration | `[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive]` |
+| disruptive | `[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive]` |
+
+## Path Mappings
+
+| What | Path |
+|---|---|
+| Test files | `test/extended-priv/mco_<feature>.go` |
+| Testdata/templates | `test/extended-priv/testdata/files/` |
+| Utility functions | `test/extended-priv/util/` |
+| Resource wrappers | `test/extended-priv/*.go` |
+
+## Build & Verify
+
+```bash
+make machine-config-tests-ext
+./_output/linux/amd64/machine-config-tests-ext list | grep <PolarionID>
+```

--- a/.claude/skills/mco-automate-test-workflow.md
+++ b/.claude/skills/mco-automate-test-workflow.md
@@ -58,6 +58,7 @@ Before generating, read existing code to understand available utilities and patt
 11. **Prefer Resource struct methods** over `oc.AsAdmin().Run`
 12. **RemoteFile** with gomega checkers for verifying files inside nodes
 13. **Concise comments** — one or two lines maximum
+14. **Skip on SNO/Compact** when the test requires multiple nodes or a dedicated worker pool: `if IsCompactOrSNOCluster(oc.AsAdmin()) { g.Skip("...") }` or `exutil.SkipOnSingleNodeTopology(oc.AsAdmin())`
 
 ## New File Structure
 
@@ -93,6 +94,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/<suite-typ
 
 Insert new `g.It` block inside the existing `g.Describe`, after the last test. Add new imports as needed. Do not modify existing code.
 
+If the test requires new helper functions, append them **after all existing functions** at the end of the file — never insert between existing functions. Helper functions belong outside the `g.Describe` block, after its closing `})`.
+
 ## Test Body Pattern
 
 ```go
@@ -122,7 +125,17 @@ g.It("[PolarionID:<id>][OTP] <description> [Disruptive]", g.Label("Platform:aws"
 - Platform labels: `g.Label("Platform:aws", "Platform:gce")` based on spec tags
 - Feature gate labels: `g.Label("OCPFeatureGate:XXX")` if the spec requires it
 - Skip functions for platform/architecture: `skipTestIfSupportedPlatformNotMatched(oc, AWSPlatform, GCPPlatform)`, `architecture.SkipNonAmd64SingleArch(oc)`
+- Skip on SNO/Compact: if the test needs more than one node or a dedicated worker pool, add `if IsCompactOrSNOCluster(oc.AsAdmin()) { g.Skip("This test requires multiple nodes and cannot run on SNO/Compact clusters") }` at the start of the test body
 - If the test requires new YAML templates, create them in `test/extended-priv/testdata/files/` and reference with `SetMCOTemplate("<name>.yaml")`
+
+## Post-Generation Verification
+
+After generating the test code, verify completeness:
+
+1. Extract every numbered step, precondition check, and expected result from the specification
+2. Map each to an `exutil.By()` block in the generated code
+3. Confirm 1:1 coverage — every spec step must have a corresponding `exutil.By()` block
+4. Report any missing steps and add the missing `exutil.By()` blocks before finalizing
 
 ## Platform Constants
 


### PR DESCRIPTION


Future integration with Polarion ([MCO-2220](https://redhat.atlassian.net/browse/MCO-2220)) and Jira ([MCO-2221](https://redhat.atlassian.net/browse/MCO-2221)) planned.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

  New Claude skill that generates MCO e2e test cases in test/extended-priv/ from test specifications provided as a text file. Includes code review learning from past PRs and follows all MCO test framework conventions.                                                                                                                                                                                                                                
  The skill includes:                                                                                                                                                                                                             
  - Text file parsing to extract test case ID, steps, expected results, and tags
  - Code review learning from past merged PRs to produce review-ready code                                                                                                                                                        
  - Codebase context awareness — reads existing tests and utilities before generating
  - Built-in conventions for the MCO test framework (resource handling, step logging, state recovery, etc.)                                                                                                                       
  - Build verification via make machine-config-tests-ext 

**- How to verify it**
  1. Run /automate-test ./test-specs.txt "mco security" longduration with a text file containing a test specification                                                                                                             
  2. Verify the generated test code follows MCO conventions (correct imports, Describe/It block format, exutil.By steps, defer cleanup)
  3. Verify the test compiles with make machine-config-tests-ext                                                                                                                                                                  
  4. Verify the test appears in ./_output/linux/amd64/machine-config-tests-ext list  
  
**- Description for the changelog**
Add /automate-test Claude skill for generating e2e tests from text file specifications. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow documentation for automated MCO extended-privilege e2e test generation, including code templates and review standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->