### PR TITLE
BUGFIX: server: preserve rendered MC ignition version in encapsulated…

### DIFF
--- a/docs/OSUpgrades.md
+++ b/docs/OSUpgrades.md
@@ -124,6 +124,15 @@ Then when the node boots into e.g. `rendered-worker-0x1234`, the `machine-config
 (also written by Ignition) reads that file and handles the bits (kernel arguments, extensions, )
 that weren't handled by the "main Ignition" process.
 
+Note: the `spec.config` portion of the encapsulated MachineConfig is intentionally stripped down
+to a bare Ignition stub (no files, no systemd units) because those were already delivered by the
+outer Ignition document.  The Ignition version in that stub is taken from the rendered MachineConfig's
+own `spec.config.ignition.version`.  This is important during rolling upgrades: while the
+MachineConfigPool is in progress (`status.updatedMachineCount == 0`), the MCS serves the previous
+rendered config which may target an older RHCOS version with a lower maximum Ignition version.
+Writing a higher Ignition version into the encapsulated stub would cause `machine-config-daemon-firstboot.service`
+to fail to parse it on those older nodes.
+
 These OS level changes are done along with the OS update process described above.
 
 This ensures that for example if one specifies `nosmt` as a kernel argument,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -145,7 +145,25 @@ func appendEncapsulated(conf *ign3types.Config, mc *mcfgv1.MachineConfig, versio
 	// we're just adding a version to make it be a valid MachineConfig which currently
 	// requires an empty Ignition version.
 	if version == nil || version.Slice()[0] == 3 {
+		// Use the version from the rendered MachineConfig's spec.config so that the
+		// encapsulated file remains compatible with the MCD container image version
+		// referenced in that MC's rendered systemd units. Using NewIgnConfig() (MaxVersion)
+		// here would break firstboot during a rolling upgrade when the MCS is serving the
+		// previous MC with an older MCD image that has an older Ignition library.
 		tmpIgnCfg := ctrlcommon.NewIgnConfig()
+		if mc.Spec.Config.Raw != nil {
+			// Use a minimal struct to avoid coupling to the full v3.5 schema.
+			var minIgn struct {
+				Ignition struct {
+					Version string `json:"version"`
+				} `json:"ignition"`
+			}
+			if err = json.Unmarshal(mc.Spec.Config.Raw, &minIgn); err == nil && minIgn.Ignition.Version != "" {
+				if v, parseErr := semver.NewVersion(minIgn.Ignition.Version); parseErr == nil && v.Slice()[0] == 3 {
+					tmpIgnCfg.Ignition.Version = minIgn.Ignition.Version
+				}
+			}
+		}
 		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
 		if err != nil {
 			return fmt.Errorf("error marshalling Ignition config: %w", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -119,6 +119,144 @@ func TestEncapsulated(t *testing.T) {
 	}
 }
 
+// TestEncapsulatedVersionMatchesMC verifies that when the MachineConfig stores a v3 Ignition
+// config (e.g. a rendered MC from a 4.18 cluster with ignition 3.4.0), appendEncapsulated
+// preserves that version in the encapsulated stub instead of always using MaxVersion.
+// This prevents firstboot failures on older RHCOS nodes during a rolling upgrade where the
+// MCS is still serving the previous MC (UpdatedMachineCount == 0).
+func TestEncapsulatedVersionMatchesMC(t *testing.T) {
+	tests := []struct {
+		name            string
+		mcIgnVersion    string
+		requestVersion  string
+		expectedVersion string
+	}{
+		{
+			name:            "3.4.0 MC with 3.4.0 request preserves 3.4.0",
+			mcIgnVersion:    "3.4.0",
+			requestVersion:  "3.4.0",
+			expectedVersion: "3.4.0",
+		},
+		{
+			name:            "3.5.0 MC with 3.5.0 request preserves 3.5.0",
+			mcIgnVersion:    "3.5.0",
+			requestVersion:  "3.5.0",
+			expectedVersion: "3.5.0",
+		},
+		{
+			name:            "3.4.0 MC with 3.5.0 request preserves 3.4.0",
+			mcIgnVersion:    "3.4.0",
+			requestVersion:  "3.5.0",
+			expectedVersion: "3.4.0",
+		},
+	}
+
+	maxVersion := ctrlcommon.NewIgnConfig().Ignition.Version
+
+	// Negative / fallback cases: all expect MaxVersion in the encapsulated stub.
+	fallbackCases := []struct {
+		name string
+		mc   *mcfgv1.MachineConfig
+	}{
+		{
+			name: "nil spec.config.raw falls back to MaxVersion",
+			mc: &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mc"},
+				Spec:       mcfgv1.MachineConfigSpec{},
+			},
+		},
+		{
+			name: "malformed JSON falls back to MaxVersion",
+			mc: &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mc"},
+				Spec: mcfgv1.MachineConfigSpec{
+					Config: runtime.RawExtension{Raw: []byte(`{not valid json`)},
+				},
+			},
+		},
+		{
+			name: "missing ignition version falls back to MaxVersion",
+			mc: &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mc"},
+				Spec: mcfgv1.MachineConfigSpec{
+					Config: runtime.RawExtension{Raw: []byte(`{"ignition":{}}`)},
+				},
+			},
+		},
+		{
+			name: "v2 ignition version falls back to MaxVersion",
+			mc: &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mc"},
+				Spec: mcfgv1.MachineConfigSpec{
+					Config: runtime.RawExtension{Raw: []byte(`{"ignition":{"version":"2.2.0"}}`)},
+				},
+			},
+		},
+	}
+
+	t.Run("fallback cases", func(t *testing.T) {
+		for _, fc := range fallbackCases {
+			t.Run(fc.name, func(t *testing.T) {
+				ignCfg := ctrlcommon.NewIgnConfig()
+				err := appendEncapsulated(&ignCfg, fc.mc, semver.New("3.5.0"))
+				require.Nil(t, err)
+				require.Equal(t, 1, len(ignCfg.Storage.Files))
+				encapSource := *ignCfg.Storage.Files[0].Contents.Source
+				encapDataStr, err := url.PathUnescape(encapSource[len("data:,"):])
+				require.Nil(t, err)
+				var encapMC mcfgv1.MachineConfig
+				err = json.Unmarshal([]byte(encapDataStr), &encapMC)
+				require.Nil(t, err)
+				var encapIgn ign3types.Config
+				err = json.Unmarshal(encapMC.Spec.Config.Raw, &encapIgn)
+				require.Nil(t, err)
+				assert.Equal(t, maxVersion, encapIgn.Ignition.Version,
+					"expected fallback to MaxVersion (%s)", maxVersion)
+			})
+		}
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build a minimal MC with the specified ignition version in spec.config.raw
+			rawIgn, err := json.Marshal(map[string]interface{}{
+				"ignition": map[string]interface{}{
+					"version": tt.mcIgnVersion,
+				},
+			})
+			require.Nil(t, err)
+
+			mc := &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mc"},
+				Spec: mcfgv1.MachineConfigSpec{
+					Config: runtime.RawExtension{Raw: rawIgn},
+				},
+			}
+
+			ignCfg := ctrlcommon.NewIgnConfig()
+			requestVer := semver.New(tt.requestVersion)
+			err = appendEncapsulated(&ignCfg, mc, requestVer)
+			require.Nil(t, err)
+
+			require.Equal(t, 1, len(ignCfg.Storage.Files))
+			encapSource := *ignCfg.Storage.Files[0].Contents.Source
+			encapDataStr, err := url.PathUnescape(encapSource[len("data:,"):])
+			require.Nil(t, err)
+
+			var encapMC mcfgv1.MachineConfig
+			err = json.Unmarshal([]byte(encapDataStr), &encapMC)
+			require.Nil(t, err)
+
+			var encapIgn ign3types.Config
+			err = json.Unmarshal(encapMC.Spec.Config.Raw, &encapIgn)
+			require.Nil(t, err)
+
+			assert.Equal(t, tt.expectedVersion, encapIgn.Ignition.Version,
+				"encapsulated ignition version should match MC's stored version")
+		})
+	}
+}
+
 // TestBootstrapServer tests the behavior of the machine config server
 // when it's running in bootstrap mode.
 // The test does the following:


### PR DESCRIPTION
… stub

**What I did**

`appendEncapsulated` in `pkg/server/server.go` was unconditionally using `ctrlcommon.NewIgnConfig()` (MaxVersion = 3.5.0 in OCP 4.20) when building the Ignition stub written to `/etc/ignition-machine-config-encapsulated.json`. During a rolling upgrade, the MCS serves the previous rendered MC (`status.configuration.name`) until at least one node updates. If that MC targets an older RHCOS (e.g. 4.18, max Ignition 3.4.0), writing 3.5.0 into the encapsulated stub causes `machine-config-daemon-firstboot.service` to fail parsing it on any newly provisioned node, preventing it from joining the cluster.

The fix reads the Ignition version from the MC's own `spec.config.raw` and uses it for the stub, so the encapsulated file always matches the RHCOS version the MC targets.


**How to verify it**

```
go test ./pkg/server/... -run TestEncapsulatedVersionMatchesMC
```

**Changelog**

`server: fix firstboot failure on older RHCOS nodes during rolling upgrade by preserving MC Ignition version in encapsulated stub`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure encapsulated Ignition stubs preserve the MachineConfig's Ignition v3.x version to avoid parsing failures on older nodes during rolling OS upgrades.

* **Documentation**
  * Clarified how Ignition versions are determined and preserved for encapsulated MachineConfig stubs during rolling upgrades.

* **Tests**
  * Added tests validating Ignition version selection and fallback behavior for encapsulated stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->