### PR TITLE
OCPBUGS-83826: deploy-from-self when skopeo  < 1.22.2

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1236,8 +1236,10 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig(machineConfigFile string) er
 	// If the host isn't new enough to understand the new container model natively, run as a privileged container.
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
 	// This currently will incur a double reboot; see https://github.com/coreos/rpm-ostree/issues/4018
-	if !newEnough {
-		logSystem("rpm-ostree is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
+	// If skopeo is < 1.22.2 on a multi-arch image, run as a privileged container which has updated skopeo.
+	// See https://redhat.atlassian.net/browse/OCPBUGS-83826 and https://redhat.atlassian.net/browse/OCPBUGS-81187
+	if !newEnough || !skopeoSupportsMultiArchSigstore(mc.Spec.OSImageURL) {
+		logSystem("rpm-ostree or skopeo is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
 		if err := dn.InplaceUpdateViaNewContainer(mc.Spec.OSImageURL); err != nil {
 			return err
 		}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2762,7 +2762,6 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	}
 	// If the host isn't new enough to understand the new container model natively, run as a privileged container.
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
-	// This currently will incur a double reboot; see https://github.com/coreos/rpm-ostree/issues/4018
 	if !newEnough {
 		logSystem("rpm-ostree is not new enough for layering; forcing an update via container")
 		return dn.InplaceUpdateViaNewContainer(newURL)
@@ -2941,6 +2940,78 @@ func podmanSupportsSigstore() bool {
 		podmanSigstoreSupportedValue = imgPodmanVersion.Compare(*semver.New(sigstorePodman)) >= 0
 	})
 	return podmanSigstoreSupportedValue
+}
+
+var (
+	skopeoVersionChecked   sync.Once
+	skopeoVersionNewEnough bool
+)
+
+// skopeoVersionSupportsMultiArchSigstore checks (once) whether the host skopeo is >= 1.22.2.
+// Returns false on any version check or parse failure (OCPBUGS-81187).
+func skopeoVersionSupportsMultiArchSigstore() bool {
+	skopeoVersionChecked.Do(func() {
+		cmd := exec.Command("skopeo", "--version")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			klog.Errorf("failed to run skopeo --version: %v", err)
+			return
+		}
+		klog.Infof("skopeo version output: %s", strings.TrimSpace(string(out)))
+		// Output format: "skopeo version X.Y.Z commit: abcdefg"
+		fields := strings.Fields(strings.TrimSpace(string(out)))
+		if len(fields) < 3 {
+			klog.Errorf("unexpected skopeo version output format: %s", string(out))
+			return
+		}
+		skopeoVersion, err := semver.NewVersion(fields[2])
+		if err != nil {
+			klog.Errorf("failed to parse skopeo version %s: %v", fields[2], err)
+			return
+		}
+		minVersion := "1.22.2"
+		skopeoVersionNewEnough = skopeoVersion.Compare(*semver.New(minVersion)) >= 0
+	})
+	return skopeoVersionNewEnough
+}
+
+// skopeoSupportsMultiArchSigstore returns false when skopeo < 1.22.2 and the image is a multi-arch
+func skopeoSupportsMultiArchSigstore(imageURL string) bool {
+	if skopeoVersionSupportsMultiArchSigstore() {
+		return true
+	}
+
+	multiArch, err := isMultiArchImage(imageURL)
+	if err != nil {
+		klog.Warningf("Failed to determine if image %s is multi-arch: %v", imageURL, err)
+		return false
+	}
+	return !multiArch
+}
+
+func isMultiArchImage(imageURL string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	args := []string{"inspect", "--raw"}
+	if _, err := os.Stat(kubeletAuthFile); err == nil {
+		args = append(args, "--authfile", kubeletAuthFile)
+	}
+	args = append(args, "docker://"+imageURL)
+	cmd := exec.CommandContext(ctx, "skopeo", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("skopeo inspect failed for %s: %w", imageURL, err)
+	}
+	var manifest struct {
+		MediaType string `json:"mediaType"`
+	}
+	if err := json.Unmarshal(out, &manifest); err != nil {
+		return false, fmt.Errorf("failed to parse manifest for %s: %w", imageURL, err)
+	}
+	multiArch := manifest.MediaType == "application/vnd.docker.distribution.manifest.list.v2+json" ||
+		manifest.MediaType == "application/vnd.oci.image.index.v1+json"
+	klog.Infof("Image %s mediaType: %s, multi-arch: %v", imageURL, manifest.MediaType, multiArch)
+	return multiArch, nil
 }
 
 // Log a message to the systemd journal as well as our stdout


### PR DESCRIPTION
use deploy-from-self when skopeo is older than 1.22.2 and the boot image is multi-arch, which causes skopeo sigstore to fail.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

Can manually verify on a non multi-arch release the skopeo version check runs and triggers the in-place update with the order version of skopeo
4.22.0-0.nightly-2026-04-23-021021, openshift/machine-config-operator#5867 cluster:
```
/registry-build10-ci-openshift-org-ci-ln-2dmblvb-stable-sha256-ed400db8213c7f0e23d62efa30436f976cb6b4434ba8cbd42b1696bdccd1f6ad/host_service_logs/masters/machine-config-daemon-firstboot_service.log

423 14:40:49.877077    1912 update.go:2965] skopeo version output: skopeo version 1.22.0 commit: 1a41cccfa63d5bd923b57e85986041d7283e720c

423 14:40:49.877116    1912 update.go:2994] "rpm-ostree or skopeo is not new enough for new-format image; forcing an update via container and queuing immediate reboot"
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update now probes host tooling and image metadata to detect multi-arch Sigstore support; when host tooling or the target image lacks support, the updater falls back to container-based updates and forces an immediate reboot. Logging was clarified to reference either host tooling or image capabilities for improved observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->