### PR TITLE
OCPBUGS-81761: Cloud ClusterHostedDNS Load Balancer IPs need to returned in a predictable order

### DIFF
--- a/pkg/controller/template/cloudplatform_lb_test.go
+++ b/pkg/controller/template/cloudplatform_lb_test.go
@@ -1,0 +1,115 @@
+package template
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+)
+
+func TestCloudPlatformLoadBalancerIPsOrdering(t *testing.T) {
+	// Test IPs in different orders to verify sorting
+	ip1 := configv1.IP("192.168.1.1")
+	ip2 := configv1.IP("10.0.0.1")
+	ip3 := configv1.IP("172.16.0.1")
+
+	// Expected sorted order: 10.0.0.1, 172.16.0.1, 192.168.1.1
+	expectedSorted := []configv1.IP{ip2, ip3, ip1}
+
+	// Three different input orderings
+	order1 := []configv1.IP{ip1, ip2, ip3}
+	order2 := []configv1.IP{ip3, ip1, ip2}
+	order3 := []configv1.IP{ip2, ip3, ip1}
+
+	tests := []struct {
+		platform configv1.PlatformType
+		ips      []configv1.IP
+	}{
+		{configv1.GCPPlatformType, order1},
+		{configv1.AWSPlatformType, order2},
+		{configv1.AzurePlatformType, order3},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.platform), func(t *testing.T) {
+			cfg := buildRenderConfig(tt.platform, tt.ips)
+
+			var got interface{}
+			var err error
+
+			// cloudPlatformAPIIntLoadBalancerIPs does NOT sort - returns IPs in original order
+			got, err = cloudPlatformAPIIntLoadBalancerIPs(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error getting cloud APIInt LB IPs: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.ips) {
+				t.Errorf("Cloud APIInt LB IPs should be unsorted: got=%v, want=%v", got, tt.ips)
+			}
+
+			// cloudPlatformAPILoadBalancerIPs does NOT sort - returns IPs in original order
+			got, err = cloudPlatformAPILoadBalancerIPs(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error getting cloud API LB IPs: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.ips) {
+				t.Errorf("Cloud API LB IPs should be unsorted: got=%v, want=%v", got, tt.ips)
+			}
+
+			// cloudPlatformIngressLoadBalancerIPs DOES sort - returns IPs in sorted order
+			got, err = cloudPlatformIngressLoadBalancerIPs(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error getting cloud Ingress LB IPs: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, expectedSorted) {
+				t.Errorf("Cloud Ingress LB IPs not sorted correctly: got=%v, want=%v", got, expectedSorted)
+			}
+
+		})
+	}
+}
+
+// Helper function to build RenderConfig for testing
+func buildRenderConfig(platform configv1.PlatformType, ips []configv1.IP) RenderConfig {
+	config := &mcfgv1.ControllerConfigSpec{
+		Infra: &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{
+				Platform: platform,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: platform,
+				},
+			},
+		},
+	}
+
+	lbConfig := &configv1.CloudLoadBalancerConfig{
+		DNSType:       configv1.ClusterHostedDNSType,
+		ClusterHosted: &configv1.CloudLoadBalancerIPs{},
+	}
+	lbConfig.ClusterHosted.APIIntLoadBalancerIPs = append([]configv1.IP(nil), ips...)
+	lbConfig.ClusterHosted.APILoadBalancerIPs = append([]configv1.IP(nil), ips...)
+	lbConfig.ClusterHosted.IngressLoadBalancerIPs = append([]configv1.IP(nil), ips...)
+
+	// Set platform-specific config
+	switch platform {
+	case configv1.GCPPlatformType:
+		config.Infra.Status.PlatformStatus.GCP = &configv1.GCPPlatformStatus{
+			CloudLoadBalancerConfig: lbConfig,
+		}
+	case configv1.AWSPlatformType:
+		config.Infra.Status.PlatformStatus.AWS = &configv1.AWSPlatformStatus{
+			CloudLoadBalancerConfig: lbConfig,
+		}
+	case configv1.AzurePlatformType:
+		config.Infra.Status.PlatformStatus.Azure = &configv1.AzurePlatformStatus{
+			CloudLoadBalancerConfig: lbConfig,
+		}
+	}
+
+	return RenderConfig{
+		ControllerConfigSpec: config,
+	}
+}

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"maps"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -817,6 +818,17 @@ func cloudPlatformLoadBalancerIPs(cfg RenderConfig, lbType LoadBalancerType) (in
 	}
 }
 
+// sortIPs clones and sorts IP addresses to ensure consistent ordering.
+func sortIPs(ips []configv1.IP) []configv1.IP {
+	ipsSorted := slices.Clone(ips)
+	slices.SortFunc(ipsSorted, func(a, b configv1.IP) int {
+		addrA := netip.MustParseAddr(string(a))
+		addrB := netip.MustParseAddr(string(b))
+		return addrA.Compare(addrB)
+	})
+	return ipsSorted
+}
+
 // cloudPlatformAPIIntLoadBalancerIPs provides the API-Int Server IPs for
 // supported cloud platforms when the DNSType is set to `ClusterHosted`.
 func cloudPlatformAPIIntLoadBalancerIPs(cfg RenderConfig) (interface{}, error) {
@@ -831,8 +843,14 @@ func cloudPlatformAPILoadBalancerIPs(cfg RenderConfig) (interface{}, error) {
 
 // cloudPlatformIngressLoadBalancerIPs provides the Ingress IPs for supported
 // cloud platforms when the DNSType is set to `ClusterHosted`.
+// Only the Ingress Load Balancer IPs are sorted at this time because they are
+// the only IP addresses that are updated day-2 by the ingress operator.
 func cloudPlatformIngressLoadBalancerIPs(cfg RenderConfig) (interface{}, error) {
-	return cloudPlatformLoadBalancerIPs(cfg, ingressLB)
+	ips, err := cloudPlatformLoadBalancerIPs(cfg, ingressLB)
+	if err != nil {
+		return nil, err
+	}
+	return sortIPs(ips.([]configv1.IP)), nil
 }
 
 // cloudPlatformLoadBalancerIPState is a helper function that determines if


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/OCPBUGS-81761

With the current behavior, when there are multiple Cloud LB IPs for API, APIInt or Ingress, the IPs are returned in random order. This caused the CoreDNS pod template to be regenerated every time, causing machine config controller churn. 
Added a fix to make sure the LB IPs are sorted before being used to generate the CoreDNS pod from its template. Also added an unit test to verify this behavior. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Load balancer IP lists from cloud platform integrations (GCP, AWS, Azure) are now returned in a consistent, deterministic order, improving stability and predictability for deployments and network configuration.

* **Tests**
  * New unit tests validate that load balancer IP ordering is consistent and correctly sorted across supported cloud platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->