### PR TITLE
OCPBUGS-83859: Fix encapsulated IGN version

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/clarketm/json"
 	"github.com/coreos/go-semver/semver"
-	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	"github.com/vincent-petithory/dataurl"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -136,30 +135,23 @@ func appendCerts(cfg *ign3types.Config, certs []string, serverDir string) error 
 // machine-config-daemon-firstboot.service to process the bits that the main Ignition (that runs in the initramfs)
 // didn't handle such as kernel arguments.
 func appendEncapsulated(conf *ign3types.Config, mc *mcfgv1.MachineConfig, version *semver.Version) error {
-	var rawTmpIgnCfg []byte
-	var err error
 	// In order to handle old RHCOS versions with the MCD baked in (i.e. before the MCS has
 	// https://github.com/openshift/machine-config-operator/pull/1766 )
 	// we need to ensure that the Ignition version we're putting in here is compatible.
 	// It's kind of silly because there isn't *actually* an Ignition config here,
 	// we're just adding a version to make it be a valid MachineConfig which currently
 	// requires an empty Ignition version.
-	if version == nil || version.Slice()[0] == 3 {
-		tmpIgnCfg := ctrlcommon.NewIgnConfig()
-		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
+	var rawCfg any = ctrlcommon.NewIgnConfig()
+	if version != nil {
+		var err error
+		rawCfg, err = ctrlcommon.IgnitionConverterSingleton().Convert(rawCfg, ign3types.MaxVersion, *version)
 		if err != nil {
-			return fmt.Errorf("error marshalling Ignition config: %w", err)
+			return err
 		}
-	} else {
-		tmpIgnCfg := ign2types.Config{
-			Ignition: ign2types.Ignition{
-				Version: ign2types.MaxVersion.String(),
-			},
-		}
-		rawTmpIgnCfg, err = json.Marshal(tmpIgnCfg)
-		if err != nil {
-			return fmt.Errorf("error marshalling Ignition config: %w", err)
-		}
+	}
+	rawTmpIgnCfg, err := json.Marshal(rawCfg)
+	if err != nil {
+		return fmt.Errorf("error marshalling Ignition config: %w", err)
 	}
 
 	tmpcfg := mc.DeepCopy()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,7 +13,11 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	ign2 "github.com/coreos/ignition/config/v2_2"
-	ign3 "github.com/coreos/ignition/v2/config/v3_5"
+	ign3_1 "github.com/coreos/ignition/v2/config/v3_1"
+	ign3_2 "github.com/coreos/ignition/v2/config/v3_2"
+	ign3_3 "github.com/coreos/ignition/v2/config/v3_3"
+	ign3_4 "github.com/coreos/ignition/v2/config/v3_4"
+	ign3_5 "github.com/coreos/ignition/v2/config/v3_5"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	yaml "github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +44,31 @@ const (
 var (
 	testKubeConfig = fmt.Sprintf("%s/kubeconfig", testDir)
 )
+
+func parseIgnitionByVersion(raw []byte, version *semver.Version) (string, error) {
+	switch {
+	case version.Major == 2:
+		cfg, _, err := ign2.Parse(raw)
+		return cfg.Ignition.Version, err
+	case version.Equal(*semver.New("3.1.0")):
+		cfg, _, err := ign3_1.Parse(raw)
+		return cfg.Ignition.Version, err
+	case version.Equal(*semver.New("3.2.0")):
+		cfg, _, err := ign3_2.Parse(raw)
+		return cfg.Ignition.Version, err
+	case version.Equal(*semver.New("3.3.0")):
+		cfg, _, err := ign3_3.Parse(raw)
+		return cfg.Ignition.Version, err
+	case version.Equal(*semver.New("3.4.0")):
+		cfg, _, err := ign3_4.Parse(raw)
+		return cfg.Ignition.Version, err
+	case version.Equal(*semver.New("3.5.0")):
+		cfg, _, err := ign3_5.Parse(raw)
+		return cfg.Ignition.Version, err
+	default:
+		return "", fmt.Errorf("unsupported test version %s", version)
+	}
+}
 
 func TestStringEncode(t *testing.T) {
 	inp := "Hello, world!"
@@ -84,7 +113,6 @@ func TestEncapsulated(t *testing.T) {
 		semver.New("3.2.0"), semver.New("3.1.0"), semver.New("2.2.0")}
 	t.Logf("vers: %v\n", vers)
 	for _, v := range vers {
-		major := v.Slice()[0]
 		mcIgnCfg, err = ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 		assert.Nil(t, err)
 		err = appendEncapsulated(&mcIgnCfg, mc, v)
@@ -107,15 +135,9 @@ func TestEncapsulated(t *testing.T) {
 		var mc mcfgv1.MachineConfig
 		err = json.Unmarshal(encapData, &mc)
 		assert.Nil(t, err)
-		// TODO(jkyros): the encap only supplies what the current internal version is, and 3.1 was able to parse a 3.2 config
-		// because it's weird so we should probably revisit whether it's okay if the encap is now supplying 3.5
-		if major == 3 {
-			_, _, err := ign3.Parse(mc.Spec.Config.Raw)
-			assert.Nil(t, err)
-		} else {
-			_, _, err := ign2.Parse(mc.Spec.Config.Raw)
-			assert.Nil(t, err)
-		}
+		parsedVersion, err := parseIgnitionByVersion(mc.Spec.Config.Raw, v)
+		assert.Nil(t, err)
+		assert.Equal(t, v.String(), parsedVersion)
 	}
 }
 


### PR DESCRIPTION
Fixes: [#OCPBUGS-83859](https://redhat.atlassian.net/browse/OCPBUGS-83859)

**- What I did**

This bugfix ensures that the encapsualted IGN the MCS serves properly obveys the requested version instead of defaulting to the latest one available in the MCS, that may lead to an older MCD to fail the first-boot if the encapsulated version is higher than what it supports.

**- How to verify it**

<TBD>

**- Description for the changelog**
Fix encapsulated MachineConfig Ignition version to match the client's requested version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of embedded configuration version conversion with streamlined payload generation logic.
  * Removed outdated dependency on legacy configuration type imports.
  * Enhanced error propagation for configuration conversion failures.

* **Tests**
  * Strengthened version-specific test assertions for configuration parsing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->