### PR TITLE
OCPBUGS-84691: prom rules: add alert for nodes using runc

### DIFF
--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -15,6 +15,22 @@ spec:
       rules:
         - expr: sum(os_image_url_override)
           record: os_image_url_override:sum
+    - name: runc-deprecated
+      rules:
+        - alert: RuncDeprecated
+          expr: |
+            count(container_runtime_crio_default_runtime{runtime="runc"}) > 0
+          for: 10m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: info
+          annotations:
+            summary: "This cluster is using the deprecated runc container runtime"
+            description: >-
+              The runc OCI runtime has been deprecated and support will be removed in a future release. Migrate to crun before upgrading to a future OpenShift release.
+              See https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/machine_configuration/machine-configs-custom#config-container-runtime_machine-configs-custom
+              for migration steps.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/RuncDeprecated.md
     - name: mcc-drain-error
       rules:
         - alert: MCCDrainError

--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -101,5 +101,6 @@ contents:
       "image_pulls_failure_total",
       "image_layer_reuse_total",
       "containers_oom_count_total",
-      "processes_defunct"
+      "processes_defunct",
+      "default_runtime"
     ]

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -103,5 +103,6 @@ contents:
       "image_pulls_failure_total",
       "image_layer_reuse_total",
       "containers_oom_count_total",
-      "processes_defunct"
+      "processes_defunct",
+      "default_runtime"
     ]

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -103,5 +103,6 @@ contents:
       "image_pulls_failure_total",
       "image_layer_reuse_total",
       "containers_oom_count_total",
-      "processes_defunct"
+      "processes_defunct",
+      "default_runtime"
     ]


### PR DESCRIPTION
relies on a cri-o metric that's emitted when the cluster is using runc
generated with claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational alert (RuncDeprecated) that notifies when the deprecated runc runtime is detected for 10 minutes; includes summary, migration guidance, and a runbook link.
  * Extended CRI-O metrics collection to include a new "default_runtime" metric collector on control-plane and worker nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->