### PR TITLE
OCPBUGS-84218: Fix units rollback if update failure

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1203,7 +1203,8 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, skipCertificateWrite, false); err != nil {
+			rollbackUnitDiff := ctrlcommon.GetChangedConfigUnitsByType(&newIgnConfig, &oldIgnConfig)
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, slices.Concat(rollbackUnitDiff.Added, rollbackUnitDiff.Updated), skipCertificateWrite, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return
@@ -1423,7 +1424,8 @@ func (dn *Daemon) updateHypershift(oldConfig, newConfig *mcfgv1.MachineConfig, d
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, addedOrChangedUnits, false, false); err != nil {
+			rollbackUnitDiff := ctrlcommon.GetChangedConfigUnitsByType(&newIgnConfig, &oldIgnConfig)
+			if err := dn.updateFiles(newIgnConfig, oldIgnConfig, slices.Concat(rollbackUnitDiff.Added, rollbackUnitDiff.Updated), false, false); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back files writes: %w", errs)
 				return


### PR DESCRIPTION
Fixes: [#OCPBUGS-84218](https://redhat.atlassian.net/browse/OCPBUGS-84218)

**- What I did**

This changes fixes an issue that happened only during rollbacks that had updated existing units. The existing modified unit were never rolledback as the write logic was using the non-rollback arguments effectively writting the target units twice, instead of going back to the previous units.

**- How to verify it**

(credit goes to @sergiordlr)

1. Deploy a cluster with this change on it
2. Apply the following MC
```yaml
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: not-pullable-image-tc54054-ygo9u9tc
spec:
  config:
    ignition:
      version: 3.5.0
    passwd:
      users: []
    storage:
      files:
        - contents:
            source: data:,test-content-for-debugging%0A
          mode: 0644
          overwrite: true
          path: /etc/mco-test-file.conf
    systemd:
      units:
        - contents: |
            [Unit]
            Description=Ensure IKE SA established for existing IPsec connections.
            After=ipsec.service
            Before=kubelet-dependencies.target node-valid-hostname.service

            [Service]
            Type=oneshot
            ExecStart=/usr/local/bin/ipsec-connect-wait.sh
            Environment="MCO_TEST=true"
            StandardOutput=journal+console
            StandardError=journal+console

            [Install]
            WantedBy=ipsec.service
          enabled: true
          name: wait-for-ipsec-connect.service
  extensions: []
  kernelArguments: []
  osImageURL: quay.io/openshifttest/tc54054fakeimage:latest
```
3. The MCP should degrade but the node should try again to pull the wrong image without facing pre-flight errors.

**- Description for the changelog**

Fix the rollback logic of systemd units in case of a mid-update error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved rollback mechanism to more accurately identify and target configuration units that require reverting during system recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->