### PR TITLE
MCO-2201: Improve /migrate-tests skill: default labels and ordering verification

### DIFF
--- a/.claude/commands/migrate-tests.md
+++ b/.claude/commands/migrate-tests.md
@@ -8,8 +8,9 @@ Migrate MCO test files from `openshift-tests-private/test/extended/mco/` to `mac
 Use the transformation rules in `.claude/skills/mco-migration-workflow.md` for all domain-specific mappings (imports, test names, qualifiers, paths).
 
 **Workflow:**
-1. Ask for source repo, destination repo, compat_otp path (optional), filename, and target suite (longduration or disruptive, default: longduration). Check memory (`migrate_tests_config.md`) for saved paths.
+1. Ask for source repo, destination repo, compat_otp path (optional), and filename. Check memory (`migrate_tests_config.md`) for saved paths.
 2. Analyze the source file — identify tests, helpers, templates, and compat_otp dependencies. Check what already exists in destination.
 3. Migrate — apply all transformations, copy templates, migrate helpers. Don't simplify or refactor code. Preserve function order from source.
 4. Build with `make machine-config-tests-ext` and verify migrated tests appear in listing. Fix build errors iteratively.
-5. Save paths to memory for next run.
+5. **Verify ordering** — compare the sequence of functions, test cases (g.It), and helpers in the destination file against the source file. Report any ordering mismatches and fix them.
+6. Save paths to memory for next run.

--- a/.claude/skills/mco-migration-workflow.md
+++ b/.claude/skills/mco-migration-workflow.md
@@ -40,18 +40,13 @@ Source:
 g.Describe("[sig-mco] MCO <SuiteName>", func() {
 ```
 
-Destination (longduration — default):
+Destination:
 ```go
 g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO <SuiteName>", func() {
 ```
 
-Destination (disruptive):
-```go
-g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO <SuiteName>", func() {
-```
-
-- Ask the user which suite to use: `longduration` (default) or `disruptive`
-- `[Serial][Disruptive]` is **always required** — in the new framework `[Disruptive]` no longer implies `[Serial]`
+- Both `[Serial]` and `[Disruptive]` are **always applied by default** — do not ask which suite to use
+- In the new framework `[Disruptive]` no longer implies `[Serial]`, so both must be present
 
 ## Test Name Transformation (g.It blocks)
 
@@ -113,8 +108,9 @@ make machine-config-tests-ext
 
 ## Workflow
 
-1. **Collect inputs** — source repo path, destination repo path, compat_otp path (optional), filename to migrate, and target suite (`longduration` default, or `disruptive`). Check memory (`migrate_tests_config.md`) for saved paths.
+1. **Collect inputs** — source repo path, destination repo path, compat_otp path (optional), and filename to migrate. Both `[Serial]` and `[Disruptive]` labels are always applied by default (do not ask). Check memory (`migrate_tests_config.md`) for saved paths.
 2. **Analyze** — read source file, identify tests/helpers/templates/compat_otp deps, check what already exists in destination.
 3. **Migrate** — apply all transformations above, copy templates, migrate helper functions and compat_otp utilities as needed.
-4. **Verify** — build and confirm migrated tests appear in listing. Fix any build errors iteratively.
-5. **Save paths** to memory for next run.
+4. **Verify build** — build and confirm migrated tests appear in listing. Fix any build errors iteratively.
+5. **Verify ordering** — compare the sequence of all functions (test case functions, helper functions, and `g.It` blocks) in the destination file against their order in the source file. List any mismatches and fix them before proceeding.
+6. **Save paths** to memory for next run.


### PR DESCRIPTION
**- What I did**
  Improved the /migrate-tests skill with two changes:                                                                                                                                                                             
  - Removed the suite label question (longduration vs disruptive). Both [Serial] and [Disruptive] labels are always applied by default since they can't be separately labeled in the MCO test suite.
  - Added a post-migration ordering verification step (step 5) that compares the sequence of functions, test cases (g.It), and helpers in the destination file against the source file, and fixes any mismatches. 
 
**- How to verify it**
  1. Run /migrate-tests and confirm it no longer asks about longduration/disruptive suite                                                                                                                                         
  2. Verify the Describe block uses the default format with both [Serial][Disruptive] labels                                                                                                                                      
  3. Verify the ordering verification step runs after a successful build 

**- Description for the changelog**
- Improve /migrate-tests skill: apply default labels without asking and add post-migration function ordering verification    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated migration workflow documentation to simplify configuration by removing target suite selection requirement
* Enhanced verification procedures with explicit ordering validation between source and destination components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->