### PR TITLE
MCO-1997: MCO-2297: Add test for osImageStream

### DIFF
--- a/test/extended-priv/machineconfigpool.go
+++ b/test/extended-priv/machineconfigpool.go
@@ -1288,19 +1288,18 @@ func CreateCustomMCPWithStreamByLabel(oc *exutil.CLI, name, label, osstream stri
 	return CreateCustomMCPWithStreamByNodes(oc, name, osstream, customMcpNodes)
 }
 
-// CreateCustomMCP create a new custom MCP with the given name and the given number of nodes
+// CreateCustomMCP creates a new custom MCP with the given name and number of nodes
+// No osstream field is set - MCP will inherit from worker pool automatically
 // Nodes will be taken from the worker pool
-// The Custom pool will be created d using the same osstream configured in the worker pool
 func CreateCustomMCP(oc *exutil.CLI, name string, numNodes int) (*MachineConfigPool, error) {
-	osstream, err := GetEffectiveOsImageStream(NewMachineConfigPool(oc.AsAdmin(), MachineConfigPoolWorker))
-	if err != nil {
-		return NewMachineConfigPool(oc, name), err
-	}
-
-	return CreateCustomMCPWithStream(oc, name, osstream, numNodes)
+	// Delegate to CreateCustomMCPWithStream with empty osstream
+	// This reuses the template selection logic in CreateCustomMCPWithStreamByNodes
+	return CreateCustomMCPWithStream(oc, name, "", numNodes)
 }
 
-// CreateCustomMCPWithStream create a new custom MCP with the given name, osstream, and number of nodes
+// CreateCustomMCPWithStream creates a new custom MCP with the given name, osstream, and number of nodes
+// If osstream is empty, creates MCP without osImageStream field (inherits from worker pool)
+// If osstream is provided, creates MCP with the specified osImageStream
 // Nodes will be taken from the worker pool
 func CreateCustomMCPWithStream(oc *exutil.CLI, name, osstream string, numNodes int) (*MachineConfigPool, error) {
 	var (
@@ -1321,37 +1320,34 @@ func CreateCustomMCPWithStream(oc *exutil.CLI, name, osstream string, numNodes i
 }
 
 // CreateCustomMCPWithStreamByNodes creates a new MCP containing the nodes provided in the "nodes" parameter
+// If osstream is empty, creates MCP without osImageStream field (inherits from worker pool)
+// If osstream is provided, creates MCP with the specified osImageStream
 func CreateCustomMCPWithStreamByNodes(oc *exutil.CLI, name, osstream string, nodes []*Node) (*MachineConfigPool, error) {
 	customMcp := NewMachineConfigPool(oc, name)
 
-	err := NewMCOTemplate(oc, "custom-machine-config-pool-osimagestream.yaml").Create(
-		"-p", fmt.Sprintf("NAME=%s", name),
-		"-p", fmt.Sprintf("OSIMAGESTREAM=%s", osstream),
-	)
+	var err error
+	// Choose template based on whether osstream is provided
+	if osstream == "" {
+		// Use basic template without osImageStream
+		err = NewMCOTemplate(oc, "custom-machine-config-pool.yaml").Create(
+			"-p", fmt.Sprintf("NAME=%s", name),
+		)
+	} else {
+		// Use template with osImageStream
+		err = NewMCOTemplate(oc, "custom-machine-config-pool-osimagestream.yaml").Create(
+			"-p", fmt.Sprintf("NAME=%s", name),
+			"-p", fmt.Sprintf("OSIMAGESTREAM=%s", osstream),
+		)
+	}
 
 	if err != nil {
 		logger.Errorf("Could not create a custom MCP for worker nodes with nodes %s", nodes)
 		return customMcp, err
 	}
 
-	for _, n := range nodes {
-		err := n.AddLabel(fmt.Sprintf("node-role.kubernetes.io/%s", name), "")
-		if err != nil {
-			logger.Infof("Error labeling node %s to add it to pool %s", n.GetName(), customMcp.GetName())
-		}
-		logger.Infof("Node %s added to custom pool %s", n.GetName(), customMcp.GetName())
-	}
-
-	expectedNodes := len(nodes)
-	err = customMcp.WaitForMachineCount(expectedNodes, 5*time.Minute)
+	// Reuse AddNodesToMachineConfigPool to add nodes and wait for MCP to be ready
+	err = AddNodesToMachineConfigPool(oc, name, nodes)
 	if err != nil {
-		logger.Errorf("The %s MCP is not reporting the expected machine count", customMcp.GetName())
-		return customMcp, err
-	}
-
-	err = customMcp.WaitImmediateForUpdatedStatus()
-	if err != nil {
-		logger.Errorf("The %s MCP is not updated", customMcp.GetName())
 		return customMcp, err
 	}
 
@@ -1423,7 +1419,6 @@ func GetPoolAndNodesForArchitectureOrFail(oc *exutil.CLI, createMCPName string, 
 		mMcp                  = NewMachineConfigPool(oc, MachineConfigPoolMaster)
 		masterHasTheRightArch = mMcp.AllNodesUseArch(arch)
 		mcpList               = NewMachineConfigPoolList(oc.AsAdmin())
-		osstream              = OrFail[string](GetEffectiveOsImageStream(wMcp))
 	)
 
 	mcpList.PrintDebugCommand()
@@ -1433,10 +1428,11 @@ func GetPoolAndNodesForArchitectureOrFail(oc *exutil.CLI, createMCPName string, 
 	}
 
 	// If there are nodes with the rewquested architecture in the worker pool we build our own custom MCP
+	// Pass empty osstream so the custom MCP inherits osImageStream from the worker pool
 	if len(wMcp.GetNodesByArchitectureOrFail(arch)) > 0 {
 		var err error
 
-		mcp, err := CreateCustomMCPWithStreamByLabel(oc.AsAdmin(), createMCPName, fmt.Sprintf(`%s=%s`, architecture.NodeArchitectureLabel, arch), osstream, numNodes)
+		mcp, err := CreateCustomMCPWithStreamByLabel(oc.AsAdmin(), createMCPName, fmt.Sprintf(`%s=%s`, architecture.NodeArchitectureLabel, arch), "", numNodes)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the custom pool for infrastructure %s", architecture.ARM64)
 		return mcp, mcp.GetNodesOrFail()
 	}
@@ -1645,6 +1641,38 @@ func GetPoolWithArchDifferentFromOrFail(oc *exutil.CLI, arch architecture.Archit
 	}
 
 	e2e.Failf("Something went wrong. There is no suitable pool to execute the test case. There is no pool with nodes using  an architecture different from %s", arch)
+	return nil
+}
+
+// AddNodesToMachineConfigPool adds nodes to an existing MCP by labeling them and waiting for the MCP to be updated
+// This function is similar to CreateCustomMCPWithStreamByNodes but for adding nodes to existing pools
+func AddNodesToMachineConfigPool(oc *exutil.CLI, mcpName string, nodes []*Node) error {
+	mcp := NewMachineConfigPool(oc, mcpName)
+
+	currentNodes, err := mcp.GetNodes()
+	if err != nil {
+		return fmt.Errorf("error getting current nodes from %s: %w", mcpName, err)
+	}
+	expectedCount := len(currentNodes) + len(nodes)
+
+	for _, n := range nodes {
+		err := n.AddLabel(fmt.Sprintf("node-role.kubernetes.io/%s", mcpName), "")
+		if err != nil {
+			return fmt.Errorf("error labeling node %s to add it to pool %s: %w", n.GetName(), mcpName, err)
+		}
+		logger.Infof("Node %s added to pool %s", n.GetName(), mcpName)
+	}
+
+	err = mcp.WaitForMachineCount(expectedCount, 5*time.Minute)
+	if err != nil {
+		return fmt.Errorf("the %s MCP is not reporting the expected machine count: %w", mcpName, err)
+	}
+
+	err = mcp.WaitImmediateForUpdatedStatus()
+	if err != nil {
+		return fmt.Errorf("the %s MCP is not updated: %w", mcpName, err)
+	}
+
 	return nil
 }
 

--- a/test/extended-priv/machineset.go
+++ b/test/extended-priv/machineset.go
@@ -46,6 +46,11 @@ func (ms MachineSet) ScaleTo(scale int) error {
 	return ms.Patch("merge", fmt.Sprintf(`{"spec": {"replicas": %d}}`, scale))
 }
 
+// AddOSStreamLabel adds or updates the machineconfiguration.openshift.io/osstream label on the MachineSet
+func (ms MachineSet) AddOSStreamLabel(streamName string) error {
+	return ms.Patch("merge", fmt.Sprintf(`{"metadata":{"labels":{"machineconfiguration.openshift.io/osstream":"%s"}}}`, streamName))
+}
+
 // GetReplicaOfSpec return replica number of spec
 func (ms MachineSet) GetReplicaOfSpec() string {
 	return ms.GetOrFail(`{.spec.replicas}`)

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -291,6 +291,81 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
 		logger.Infof("OK!\n")
 	})
+
+	// AI-assisted: Test case to validate osImageStream inheritance for custom MachineConfigPools
+	g.It("[PolarionID:88122][OTP] Validate osImageStream inheritance for custom MachineConfigPools [Disruptive] [apigroup:machineconfiguration.openshift.io] [apigroup:machine.openshift.io]", func() {
+
+		SkipIfCompactOrSNO(oc.AsAdmin())
+
+		// Get initial and target streams based on cluster version
+		initialStream, targetStream := GetInitialAndTargetStreams(oc.AsAdmin())
+
+		testCustomMCPInheritsStreamFromWorkerPool(oc.AsAdmin(), osis, mcp, initialStream, targetStream)
+	})
+
+	g.It("[PolarionID:88203][OTP] In image-mode, verify the MOSB is triggered when osImageStream is patched [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+		SkipIfCompactOrSNO(oc.AsAdmin())
+
+		// Get initial and target streams based on cluster version
+		initialStream, targetStream := GetInitialAndTargetStreams(oc.AsAdmin())
+
+		testMOSBTriggeredOnStreamChange(oc.AsAdmin(), osis, initialStream, targetStream)
+	})
+
+	g.It("[PolarionID:88365][OTP] Verify when osstream and osImageurl MC is applied the MCP is degraded [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+		var (
+			testID = GetCurrentTestPolarionIDNumber()
+			mcName = fmt.Sprintf("tc-%s-osimageurl", testID)
+			// Use a fake image URL since it will be rejected in the render phase anyway
+			fakeImageURL = "quay.io/openshift-release-dev/ocp-release:fake-test-image"
+		)
+
+		// Get initial and target streams - use targetStream to ensure a change happens
+		_, targetStream := GetInitialAndTargetStreams(oc.AsAdmin())
+
+		exutil.By("Get pool for testing")
+		customMcp, cleanup, err := GetCompactCompatibleOrCustomPool(oc.AsAdmin(), 1)
+		defer cleanup()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting pool for testing")
+		logger.Infof("OK!\n")
+
+		exutil.By(fmt.Sprintf("Patch the osImageStream to %s on pool", targetStream))
+		o.Expect(customMcp.SetOsImageStream(targetStream)).To(o.Succeed(), "Error setting osImageStream to '%s'", targetStream)
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for MCP update to complete and verify osImageStream is applied")
+		customMcp.waitForComplete()
+		o.Eventually(customMcp.GetOsImageStream, "2m", "10s").Should(o.Equal(targetStream),
+			"MCP should have osImageStream set to '%s'", targetStream)
+		logger.Infof("OK!\n")
+
+		exutil.By("Apply osImageURL MC on custom pool with osImageStream already configured")
+		mc := NewMachineConfig(oc.AsAdmin(), mcName, customMcp.GetName())
+		mc.parameters = []string{"OS_IMAGE=" + fakeImageURL}
+		mc.skipWaitForMcp = true
+		defer mc.DeleteWithWait()
+		mc.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify MCP is degraded with error about osImageURL and osImageStream conflict")
+		o.Eventually(customMcp, "5m", "20s").Should(HaveConditionField("RenderDegraded", "status", TrueString),
+			"MCP should be degraded when both osImageURL and osImageStream are set")
+
+		expectedErrorMsg := "cannot override MachineConfig osImageURL and set MachineConfigPool spec.osImageStream.name simultaneously"
+		o.Eventually(customMcp, "5m", "20s").Should(HaveConditionField("RenderDegraded", "message", o.ContainSubstring(expectedErrorMsg)),
+			"MCP degraded message should mention osImageURL and osImageStream conflict")
+		logger.Infof("MCP correctly degraded with expected error message")
+		logger.Infof("OK!\n")
+
+		exutil.By("Remove conflicting MC and verify MCP recovers from degraded state")
+		mc.DeleteWithWait()
+		o.Eventually(customMcp, "5m", "20s").Should(HaveConditionField("RenderDegraded", "status", FalseString),
+			"MCP should recover from degraded state after removing conflicting MC")
+		logger.Infof("MCP successfully recovered from degraded state")
+		logger.Infof("OK!\n")
+	})
+
+	// AI-assisted: Test case to verify boot image controller logs for CPMS osstream reconciliation
 })
 
 // GetDefaultOSImageStream returns the default OS image stream based on the cluster version.
@@ -325,9 +400,9 @@ func GetEffectiveOsImageStream(mcp *MachineConfigPool) (string, error) {
 	)
 
 	if !osis.Exists() {
-		defaultStream := GetDefaultOSImageStream(oc)
-		logger.Infof("OSImageStream resource does not exist. Likely, no tech preview, by default we use osstream: %s", defaultStream)
-		return defaultStream, nil
+		expectedDefault := GetDefaultOSImageStream(mcp.GetOC().AsAdmin())
+		logger.Infof("OSImageStream resource does not exist. Likely, no tech preview, by default we use osstream: %s", expectedDefault)
+		return expectedDefault, nil
 	}
 
 	streamName, err := mcp.GetOsImageStream()
@@ -551,5 +626,176 @@ func testExtensionsAcrossOSImageStreams(oc *exutil.CLI, osis *OSImageStream, ini
 
 	validateOsImageStreamInPool(mcp, osis, targetStream)
 	logger.Infof("%s is still correctly using %s stream", firstNode, targetStream)
+	logger.Infof("OK!\n")
+}
+
+// testCustomMCPInheritsStreamFromWorkerPool tests osImageStream inheritance for custom MCPs
+// Used by: [PolarionID:88122]
+func testCustomMCPInheritsStreamFromWorkerPool(oc *exutil.CLI, osis *OSImageStream, mcp *MachineConfigPool, initialStream, targetStream string) {
+	var (
+		testID    = GetCurrentTestPolarionIDNumber()
+		mcp1Name  = fmt.Sprintf("tc-%s-mcp1", testID)
+		mcp2Name  = fmt.Sprintf("tc-%s-mcp2", testID)
+		infraName = fmt.Sprintf("tc-%s-infra", testID)
+		cmcp1Name = fmt.Sprintf("tc-%s-cmcp1", testID)
+		cmcp2Name = fmt.Sprintf("tc-%s-cmcp2", testID)
+	)
+
+	defer mcp.waitForComplete()
+	defer mcp.SetSpec(mcp.GetSpecOrFail())
+
+	exutil.By(fmt.Sprintf("Verify %s and %s streams are available", initialStream, targetStream))
+	o.Eventually(osis.GetAvailableStreamNames, "2m", "20s").Should(o.ContainElements(initialStream, targetStream),
+		"Both streams '%s' and '%s' should be available", initialStream, targetStream)
+	logger.Infof("Both %s and %s streams are available", initialStream, targetStream)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Case1: Applied below custom MCP to inherit the default value of worker pool (%s)", initialStream))
+	currentStream, err := GetEffectiveOsImageStream(mcp)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting effective osImageStream from %s", mcp)
+	logger.Infof("Current worker pool stream: '%s'", currentStream)
+
+	if currentStream != initialStream {
+		logger.Infof("Configuring osImageStream to '%s' in %s", initialStream, mcp)
+		o.Expect(mcp.SetOsImageStream(initialStream)).To(o.Succeed(), "Error setting osImageStream to '%s' in %s", initialStream, mcp)
+		mcp.waitForComplete()
+	}
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Create custom MCP that inherits %s from worker pool", initialStream))
+	defer DeleteCustomMCP(oc.AsAdmin(), mcp1Name)
+	mcp1, err := CreateCustomMCP(oc.AsAdmin(), mcp1Name, 1)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s", mcp1Name)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Check the node uses %s", initialStream))
+	validateOsImageStreamInPool(mcp1, osis, initialStream)
+
+	exutil.By(fmt.Sprintf("Create custom MCP with %s explicitly configured", targetStream))
+	defer DeleteCustomMCP(oc.AsAdmin(), mcp2Name)
+	mcp2, err := CreateCustomMCPWithStream(oc.AsAdmin(), mcp2Name, targetStream, 1)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s with %s", mcp2Name, targetStream)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Check the node uses %s", targetStream))
+	validateOsImageStreamInPool(mcp2, osis, targetStream)
+
+	exutil.By("Clean up Case 1 MCPs to free nodes for Case 2")
+	o.Expect(DeleteCustomMCP(oc.AsAdmin(), mcp1Name)).To(o.Succeed(), "Error deleting MCP %s", mcp1Name)
+	o.Expect(DeleteCustomMCP(oc.AsAdmin(), mcp2Name)).To(o.Succeed(), "Error deleting MCP %s", mcp2Name)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Case2: Create custom mcp infra without osstream field, patch worker to %s, and verify infra inherits %s", targetStream, targetStream))
+
+	exutil.By(fmt.Sprintf("Create custom MCP %s without osstream field to test dynamic inheritance", infraName))
+	defer DeleteCustomMCP(oc.AsAdmin(), infraName)
+	infraMcp, err := CreateCustomMCP(oc.AsAdmin(), infraName, 0)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s without osstream", infraName)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Patch worker pool with %s", targetStream))
+	o.Expect(mcp.SetOsImageStream(targetStream)).To(o.Succeed(), "Error setting osImageStream to '%s' in %s", targetStream, mcp)
+	mcp.waitForComplete()
+	logger.Infof("OK!\n")
+
+	exutil.By("Add a node to infra pool")
+	err = AddNodesToMachineConfigPool(oc.AsAdmin(), infraName, []*Node{mcp.GetSortedNodesOrFail()[0]})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error adding node to infra pool")
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Verify node in infra pool inherited %s from worker pool", targetStream))
+	validateOsImageStreamInPool(infraMcp, osis, targetStream)
+
+	exutil.By("Clean up Case 2 MCP to free nodes for Case 3")
+	o.Expect(DeleteCustomMCP(oc.AsAdmin(), infraName)).To(o.Succeed(), "Error deleting MCP %s", infraName)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Case3: Verify worker pool is on %s, then create cmcp1 (inherits %s) and cmcp2 (explicit %s)", targetStream, targetStream, initialStream))
+	o.Expect(GetEffectiveOsImageStream(mcp)).To(o.Equal(targetStream), "Worker pool should be on %s from Case 2", targetStream)
+
+	exutil.By(fmt.Sprintf("Create custom mcp cmcp1 (inherits %s) and cmcp2 (explicit %s)", targetStream, initialStream))
+	defer DeleteCustomMCP(oc.AsAdmin(), cmcp1Name)
+	cmcp1, err := CreateCustomMCP(oc.AsAdmin(), cmcp1Name, 1)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s", cmcp1Name)
+	logger.Infof("OK!\n")
+
+	defer DeleteCustomMCP(oc.AsAdmin(), cmcp2Name)
+	cmcp2, err := CreateCustomMCPWithStream(oc.AsAdmin(), cmcp2Name, initialStream, 1)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s with %s", cmcp2Name, initialStream)
+	logger.Infof("OK!\n")
+
+	exutil.By("Verify nodes use the correct osImageStreams")
+	validateOsImageStreamInPool(cmcp1, osis, targetStream)
+	validateOsImageStreamInPool(cmcp2, osis, initialStream)
+}
+
+// testMOSBTriggeredOnStreamChange tests that MachineOSBuild is triggered when osImageStream changes
+// Used by: [PolarionID:88203]
+func testMOSBTriggeredOnStreamChange(oc *exutil.CLI, osis *OSImageStream, initialStream, targetStream string) {
+	var (
+		testID        = GetCurrentTestPolarionIDNumber()
+		customMcpName = fmt.Sprintf("tc-%s", testID)
+	)
+
+	exutil.By(fmt.Sprintf("Verify %s and %s streams are available", initialStream, targetStream))
+	o.Eventually(osis.GetAvailableStreamNames, "2m", "20s").Should(o.ContainElements(initialStream, targetStream),
+		"Both streams '%s' and '%s' should be available", initialStream, targetStream)
+	logger.Infof("Both %s and %s streams are available", initialStream, targetStream)
+	logger.Infof("OK!\n")
+
+	exutil.By("Create custom pool and apply OCL configuration")
+	customMcp, err := CreateCustomMCP(oc.AsAdmin(), customMcpName, 1)
+	defer DeleteCustomMCP(oc.AsAdmin(), customMcpName)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom pool %s", customMcpName)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Set osImageStream to %s before enabling OCL to ensure known starting state", initialStream))
+	o.Expect(customMcp.SetOsImageStream(initialStream)).To(o.Succeed(), "Error setting osImageStream to %s", initialStream)
+	customMcp.waitForComplete()
+	logger.Infof("OK!\n")
+
+	exutil.By("Enable OCL functionality for the custom MCP")
+	mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, customMcpName, customMcpName, nil)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error creating MachineOSConfig %s", customMcpName)
+	defer mosc.CleanupAndDelete()
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Validate initial MachineOSBuild with %s is triggered and succeeds", initialStream))
+	ValidateSuccessfulMOSC(mosc, nil)
+
+	exutil.By("Get the current MachineOSBuild name before patching osImageStream")
+	initialMOSB, err := mosc.GetCurrentMachineOSBuild()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting current MachineOSBuild")
+	initialMOSBName := initialMOSB.GetName()
+	logger.Infof("Initial MachineOSBuild: %s", initialMOSBName)
+	logger.Infof("OK!\n")
+
+	exutil.By(fmt.Sprintf("Patch the osImageStream from %s to %s", initialStream, targetStream))
+	o.Expect(customMcp.SetOsImageStream(targetStream)).To(o.Succeed(), "Error setting osImageStream to %s", targetStream)
+	logger.Infof("OK!\n")
+	o.Expect(customMcp.GetOsImageStream()).To(o.Equal(targetStream), "%s pool should be on %s", customMcp, targetStream)
+	logger.Infof("%s pool is correctly using %s stream", customMcp, targetStream)
+	logger.Infof("OK!\n")
+
+	exutil.By("Verify a new MachineOSBuild is triggered after osImageStream change")
+	o.Eventually(func() (string, error) {
+		currentMOSB, err := mosc.GetCurrentMachineOSBuild()
+		if err != nil {
+			return "", err
+		}
+		return currentMOSB.GetName(), nil
+	}, "5m", "20s").ShouldNot(o.Equal(initialMOSBName), "A new MachineOSBuild should be triggered after osImageStream change")
+	logger.Infof("New MachineOSBuild triggered after osImageStream change")
+	logger.Infof("OK!\n")
+
+	exutil.By("Validate the new MachineOSBuild succeeds and changes are applied")
+	ValidateSuccessfulMOSC(mosc, nil)
+	// Note: ValidateSuccessfulMOSC already validates the node is using the layered image.
+	// For OCL, nodes boot from layered images (internal registry), not osImageStream base images.
+
+	exutil.By("Verify MCP status reports the new osImageStream")
+	o.Eventually(customMcp.GetStatusOsImageStream, "2m", "20s").Should(o.Equal(targetStream),
+		"MCP should report osImageStream '%s' in status", targetStream)
+	logger.Infof("MCP correctly reports osImageStream '%s' in status", targetStream)
 	logger.Infof("OK!\n")
 }

--- a/test/extended-priv/osimagestream.go
+++ b/test/extended-priv/osimagestream.go
@@ -91,3 +91,25 @@ func (osis *OSImageStream) LogStreamInfo() {
 		logger.Infof("  osExtensionsImage: %s", osExtImage)
 	}
 }
+
+// GetInitialAndTargetStreams determines initial and target osImageStreams based on cluster version.
+// Returns (initialStream, targetStream) where:
+// - initialStream: cluster default stream (rhel-9 in 4.23, rhel-10 in 5.0)
+// - targetStream: alternate stream (rhel-10 in 4.23, rhel-9 in 5.0)
+// This ensures tests always trigger a stream change and work consistently across versions.
+func GetInitialAndTargetStreams(oc *exutil.CLI) (initialStream, targetStream string) {
+	defaultStream := GetDefaultOSImageStream(oc)
+
+	if defaultStream == OSImageStreamRHEL10 {
+		// 5.0 cluster: default is rhel-10, alternate is rhel-9
+		initialStream = OSImageStreamRHEL10
+		targetStream = OSImageStreamRHEL9
+	} else {
+		// 4.23 cluster: default is rhel-9, alternate is rhel-10
+		initialStream = OSImageStreamRHEL9
+		targetStream = OSImageStreamRHEL10
+	}
+
+	logger.Infof("Cluster streams - initial: %s, target: %s", initialStream, targetStream)
+	return initialStream, targetStream
+}

--- a/test/extended-priv/util.go
+++ b/test/extended-priv/util.go
@@ -564,6 +564,13 @@ func SkipIfNotOnPremPlatform(oc *exutil.CLI) {
 	}
 }
 
+// SkipIfCompactOrSNO skips the test if the cluster is SNO/Compact
+func SkipIfCompactOrSNO(oc *exutil.CLI) {
+	if IsCompactOrSNOCluster(oc) {
+		g.Skip("The cluster is SNO/Compact. This test cannot be executed in SNO/Compact clusters")
+	}
+}
+
 // MarshalOrFail marshals the input to JSON and fails the test if there is an error
 func MarshalOrFail(input interface{}) []byte {
 	inputJSON, err := json.Marshal(input)
@@ -1375,13 +1382,6 @@ func skipTestIfOsIsNotCoreOs(oc *exutil.CLI) *Node {
 		g.Skip("CoreOs is required to execute this test case!")
 	}
 	return allCoreOs[0]
-}
-
-// SkipIfCompactOrSNO skips the test case if the cluster is a compact or SNO cluster
-func SkipIfCompactOrSNO(oc *exutil.CLI) {
-	if IsCompactOrSNOCluster(oc) {
-		g.Skip("The test is not supported in Compact or SNO clusters")
-	}
 }
 
 // IsSNO returns true if the cluster is a SNO cluster


### PR DESCRIPTION
   Test Cases Added

  1. [OCP-88122] Validate osImageStream inheritance for custom MachineConfigPools
  - Validates that custom MachineConfigPools correctly inherit osImageStream configuration from their parent worker pool
  - Tests three scenarios:
    - Custom MCP inherits default stream (rhel-9) when no stream is explicitly set on worker pool
    - Custom MCP inherits explicitly set stream (rhel-10) from worker pool
    - Custom MCP with explicitly set stream (rhel-9) inherits updated stream (rhel-10) from worker pool

  2. [OCP-88203] In image-mode, verify the MOSB is triggered when osImageStream is patched
  - Verifies that MachineOSBuild (MOSB) resources are correctly triggered when osImageStream is changed
  - Ensures image-mode clusters properly rebuild images when switching OS streams

  3. [OCP-88365] Verify when osstream and osImageURL MC is applied the MCP is degraded
  - Tests conflict detection when both osImageURL (MachineConfig) and osImageStream (MachineConfigPool) are set simultaneously
  - Validates that MCP enters degraded state with appropriate error message
  - Verifies MCP recovery after removing the conflicting configuration

TODO 
- Add below TC in UT later 

- [ ] [OCP-88708] Verify osstream logs triggered for the boot image controller

  - Verifies that boot image controller generates appropriate logs when an unsupported osImageStream is configured
  - Tests with rhel-10 stream (currently unsupported by boot image controller)

- [ ]  [OCP-88995] Verify osstream logs triggered for the boot image controller for CPMS

  - Similar to OCP-88708 but validates boot image controller behavior with ControlPlaneMachineSet (CPMS)
  - Ensures no unsupported stream warnings when labeling MachineSets with supported streams while CPMS is enabled

  Changes

  - Enhanced MachineConfigPool helper methods to support osImageStream operations
  - Added MachineSet helper for osstream label management
  - Added utility functions for osImageStream testing
  - Fixed test matcher to use substring matching for error message validation

  Related JIRAs

  - MCO-2136, MCO-1972, [MCO-2151](https://redhat.atlassian.net/browse/MCO-2151)

  - 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added disruptive OS image stream scenarios for custom pool inheritance, image-mode osImageStream updates and build verification, degraded conflict detection and recovery, and supported vs unsupported stream behavior (including CPMS and boot-image-controller log checks).

* **Tests / Helpers**
  * Added a shared helper to add nodes to a MachineConfigPool and wait for readiness/Updated.
  * Added MachineSet helper to set the osstream label.
  * Improved default osImageStream expectations to be computed dynamically from cluster version.
  * Updated skipping behavior for SNO/Compact clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->