### PR TITLE
OCPBUGS-84332: Fix ssh and password rollbacks

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1241,7 +1241,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 
 		defer func() {
 			if retErr != nil {
-				if err := dn.updateSSHKeys(newIgnConfig.Passwd.Users, oldIgnConfig.Passwd.Users); err != nil {
+				if err := dn.updateSSHKeys(oldIgnConfig.Passwd.Users, newIgnConfig.Passwd.Users); err != nil {
 					errs := kubeErrs.NewAggregate([]error{err, retErr})
 					retErr = fmt.Errorf("error rolling back SSH keys updates: %w", errs)
 					return
@@ -1257,7 +1257,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 
 	defer func() {
 		if retErr != nil {
-			if err := dn.SetPasswordHash(newIgnConfig.Passwd.Users, oldIgnConfig.Passwd.Users); err != nil {
+			if err := dn.SetPasswordHash(oldIgnConfig.Passwd.Users, newIgnConfig.Passwd.Users); err != nil {
 				errs := kubeErrs.NewAggregate([]error{err, retErr})
 				retErr = fmt.Errorf("error rolling back password hash updates: %w", errs)
 				return


### PR DESCRIPTION
Closes: [#OCPBUGS-84332](https://redhat.atlassian.net/browse/OCPBUGS-84332)

**- What I did**

This change fixes the issue in SSH keys and user passwords that made the rollback useless as it tried to apply the new configuration instead of the previous one.

**- How to verify it**

TBD

**- Description for the changelog**

This change fixes the issue in SSH keys and user passwords that made the rollback useless as it tried to apply the new configuration instead of the previous one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where failed daemon updates did not properly rollback SSH key and password configurations to their previous state. Update failures will now correctly restore the original configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->