### PR TITLE
OCPBUGS-84490: Bump image build timeout for status reporting test

### DIFF
--- a/test/extended/machineconfignode.go
+++ b/test/extended/machineconfignode.go
@@ -203,7 +203,7 @@ func ValidateTransitionThroughConditions(machineConfigClient *machineconfigclien
 	updatingWaitTime := 1 * time.Minute
 	updatingWaitInterval := 1 * time.Second
 	if isImageMode {
-		updatingWaitTime = 15 * time.Minute
+		updatingWaitTime = 25 * time.Minute
 		updatingWaitInterval = 5 * time.Second
 	}
 


### PR DESCRIPTION
Closes: OCPBUGS-84490

**- What I did**
This bumps the timeout for image builds in the status reporting tests so tests do not fail prematurely.

**- How to verify it**
MCO disruptive test suites should pass.

**- Description for the changelog**
OCPBUGS-84490: Bump image build timeout for status reporting test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted timeout duration for image-mode update validation tests to ensure adequate time for transition observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->