### PR TITLE
OCPBUGS-83492: Auto-append :ref suffix to additionalLayerStores in storage.conf

### DIFF
--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -444,7 +444,12 @@ func updateStorageConfig(data []byte, internal *mcfgv1.ContainerRuntimeConfigura
 	if additionalStorageEnabled && len(internal.AdditionalLayerStores) > 0 {
 		paths := make([]string, 0, len(internal.AdditionalLayerStores))
 		for _, store := range internal.AdditionalLayerStores {
-			paths = append(paths, string(store.Path))
+			path := string(store.Path)
+			// containers/storage requires :ref for reference-based layer resolution
+			if !strings.HasSuffix(path, ":ref") {
+				path += ":ref"
+			}
+			paths = append(paths, path)
 		}
 		tomlConf.Storage.Options.AdditionalLayerStores = paths
 	}

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -1380,7 +1380,7 @@ func TestUpdateStorageConfigAdditionalStores(t *testing.T) {
 				}{
 					Options: struct{ storageconfig.OptionsConfig }{
 						storageconfig.OptionsConfig{
-							AdditionalLayerStores: []string{"/var/lib/stargz-store", "/mnt/nfs-layers"},
+							AdditionalLayerStores: []string{"/var/lib/stargz-store:ref", "/mnt/nfs-layers:ref"},
 						},
 					},
 				},
@@ -1433,8 +1433,30 @@ func TestUpdateStorageConfigAdditionalStores(t *testing.T) {
 					Options: struct{ storageconfig.OptionsConfig }{
 						storageconfig.OptionsConfig{
 							Size:                  "10G",
-							AdditionalLayerStores: []string{"/var/lib/stargz-store"},
+							AdditionalLayerStores: []string{"/var/lib/stargz-store:ref"},
 							AdditionalImageStores: []string{"/mnt/nfs-images"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "path with :ref suffix is not doubled",
+			cfg: &mcfgv1.ContainerRuntimeConfiguration{
+				AdditionalLayerStores: []mcfgv1.AdditionalLayerStore{
+					{Path: "/var/lib/stargz-store/store:ref"},
+				},
+			},
+			want: tomlConfigStorage{
+				Storage: struct {
+					Driver    string                                "toml:\"driver\""
+					RunRoot   string                                "toml:\"runroot\""
+					GraphRoot string                                "toml:\"graphroot\""
+					Options   struct{ storageconfig.OptionsConfig } "toml:\"options\""
+				}{
+					Options: struct{ storageconfig.OptionsConfig }{
+						storageconfig.OptionsConfig{
+							AdditionalLayerStores: []string{"/var/lib/stargz-store/store:ref"},
 						},
 					},
 				},


### PR DESCRIPTION
## Description

Automatically append `:ref` suffix to `additionalLayerStores` paths when generating `storage.conf`.                                                                                                              
                                                                                                                                                                                                                    This allows users to provide clean paths in `ContainerRuntimeConfig` while MCO automatically transforms them to include the `:ref` suffix in the generated `/etc/containers/storage.conf` on nodes.

## Why

The `:ref` suffix is required by containers/storage for reference-based layer resolution. Previously, we attempted to add validation in the API layer (openshift/api#2806) to require users to include the
   `:ref` suffix. However, this exposes an implementation detail in the user-facing API and makes it harder to use.

The correct approach is to handle this transformation transparently in the MCO controller.

## Changes

   **pkg/controller/container-runtime-config/helpers.go:**
   - Modified `updateStorageConfig()` to append `:ref` suffix to all `additionalLayerStores` paths
   - Applies to ALL layer stores (not specific to any storage type)

   **pkg/controller/container-runtime-config/helpers_test.go:**
   - Updated test expectations to include `:ref` suffix for all layer stores
   - Renamed test to "path with :ref suffix is not doubled" for clarity

## Example

**User creates ContainerRuntimeConfig:**
```yaml
spec:
  containerRuntimeConfig:
    additionalLayerStores:
    - path: /var/lib/stargz-store/store
    - path: /mnt/nfs-layers
```

**MCO generates storage.conf:**
```toml
[storage.options]
additional_layer_stores = ["/var/lib/stargz-store/store:ref", "/mnt/nfs-layers:ref"]
```

## Testing

All existing tests pass. Added new test case for `:ref` suffix idempotency.

```bash
$ go test ./pkg/controller/container-runtime-config/...
ok  	github.com/openshift/machine-config-operator/pkg/controller/container-runtime-config	87.196s
```
Verified manually:
Step 1: Create ContainerRuntimeConfig
Created a ContainerRuntimeConfig with a clean path (no :ref suffix):
```
$ cat layerstore.yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
  name: test-layer-stores
spec:
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
  containerRuntimeConfig:
    additionalLayerStores:
      - path: /var/lib/stargz-store/store

$ oc create -f layerstore.yaml
containerruntimeconfig.machineconfiguration.openshift.io/test-layer-stores created

$ oc get containerruntimeconfigs.machineconfiguration.openshift.io
NAME                AGE
test-layer-stores   6s
```
Step 2: Post-MCP Rollout Validation
After the MCP rollout completed, verified that :ref was automatically appended in storage.conf:
```
$ oc debug node/$WORKER-NODE -- chroot /host cat /etc/containers/storage.conf | grep layer
additionallayerstores = ["/var/lib/stargz-store/store:ref"]

```
Result: MCO automatically appended the :ref suffix to the configured path.
Step 3: Functional Verification
```
First Pod:
Created a pod using an eStargz-formatted image
Snapshot was created at: /var/lib/stargz-store/store

Second Pod:
Created another pod using the same eStargz image
Cached snapshot was reused from the first pod
No re-download observed (verified via stargz-store logs)
```
Result: Lazy image pulling with snapshot reuse is working as expected.

## Related PRs

- Reverts openshift/api#2806 (API validation approach)
- Implements proper MCO controller-based solution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Additional layer store entries now automatically include the `:ref` suffix when missing; entries already containing `:ref` are preserved unchanged to ensure consistent storage path formatting.

* **Tests**
  * Added/updated tests to verify `:ref` is appended only when absent and not duplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->