### PR TITLE
OCPNODE-4443: Add runc upgradeable guard to block upgrades on RHEL 10 streams

### DIFF
--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/BurntSushi/toml"
 	"github.com/clarketm/json"
 	fcctbase "github.com/coreos/fcct/base/v0_1"
 	"github.com/coreos/go-semver/semver"
@@ -1505,4 +1506,66 @@ func GetEffectiveOSImageStreamName(pool *mcfgv1.MachineConfigPool, mcpLister mcf
 
 	// Return worker pool's stream (which may be empty, indicating default)
 	return workerPool.Spec.OSImageStream.Name, nil
+}
+
+const CRIODropInDir = "/etc/crio/crio.conf.d/"
+
+type crioRuntimeConfig struct {
+	Crio struct {
+		Runtime struct {
+			DefaultRuntime string `toml:"default_runtime,omitempty"`
+		} `toml:"runtime"`
+	} `toml:"crio"`
+}
+
+// DetectRuncInMachineConfig inspects a MachineConfig's Ignition config for CRI-O
+// drop-in files under /etc/crio/crio.conf.d/ and returns the MC name if the
+// effective default container runtime is runc. Drop-ins are processed in
+// lexicographic order (matching CRI-O's layering behavior) so the last file's
+// default_runtime wins.
+func DetectRuncInMachineConfig(mc *mcfgv1.MachineConfig) (string, error) {
+	if mc.Spec.Config.Raw == nil || len(mc.Spec.Config.Raw) == 0 {
+		return "", nil
+	}
+
+	ignCfg, err := ParseAndConvertConfig(mc.Spec.Config.Raw)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Ignition config for MC %q: %w", mc.Name, err)
+	}
+
+	type crioDropIn struct {
+		path string
+		file ign3types.File
+	}
+	var crioFiles []crioDropIn
+	for _, f := range ignCfg.Storage.Files {
+		if strings.HasPrefix(f.Path, CRIODropInDir) {
+			crioFiles = append(crioFiles, crioDropIn{path: f.Path, file: f})
+		}
+	}
+	sort.Slice(crioFiles, func(i, j int) bool { return crioFiles[i].path < crioFiles[j].path })
+
+	effectiveRuntime := ""
+	for _, dropin := range crioFiles {
+		fileData, err := DecodeIgnitionFileContents(dropin.file.Contents.Source, dropin.file.Contents.Compression)
+		if err != nil {
+			return "", fmt.Errorf("failed to decode CRI-O drop-in %q in MC %q: %w", dropin.path, mc.Name, err)
+		}
+		if len(fileData) == 0 {
+			continue
+		}
+
+		var cfg crioRuntimeConfig
+		if _, err := toml.NewDecoder(bytes.NewReader(fileData)).Decode(&cfg); err != nil {
+			return "", fmt.Errorf("failed to parse TOML from CRI-O drop-in %q in MC %q: %w", dropin.path, mc.Name, err)
+		}
+		if cfg.Crio.Runtime.DefaultRuntime != "" {
+			effectiveRuntime = cfg.Crio.Runtime.DefaultRuntime
+		}
+	}
+
+	if effectiveRuntime == mcfgv1.ContainerRuntimeDefaultRuntimeRunc {
+		return mc.Name, nil
+	}
+	return "", nil
 }

--- a/pkg/controller/common/helpers_test.go
+++ b/pkg/controller/common/helpers_test.go
@@ -1921,3 +1921,84 @@ func TestGetEffectiveOSImageStreamName(t *testing.T) {
 		})
 	}
 }
+
+func makeCRIODropIn(runtime string) string {
+	return "[crio.runtime]\ndefault_runtime = \"" + runtime + "\"\n"
+}
+
+func TestDetectRuncInMachineConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		mc         *mcfgv1.MachineConfig
+		expectedMC string
+	}{
+		{
+			name:       "no CRI-O drop-ins",
+			mc:         helpers.NewMachineConfig("test", nil, "", nil),
+			expectedMC: "",
+		},
+		{
+			name: "runc in single drop-in",
+			mc: helpers.NewMachineConfig("test-runc", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+			}),
+			expectedMC: "test-runc",
+		},
+		{
+			name: "crun in single drop-in",
+			mc: helpers.NewMachineConfig("test", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("crun"), 0644),
+			}),
+			expectedMC: "",
+		},
+		{
+			name: "runc overridden by crun in later drop-in",
+			mc: helpers.NewMachineConfig("test", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/01-ctrcfg", makeCRIODropIn("crun"), 0644),
+			}),
+			expectedMC: "",
+		},
+		{
+			name: "crun overridden by runc in later drop-in",
+			mc: helpers.NewMachineConfig("test-runc-override", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("crun"), 0644),
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/01-ctrcfg", makeCRIODropIn("runc"), 0644),
+			}),
+			expectedMC: "test-runc-override",
+		},
+		{
+			name: "non-CRI-O files are ignored",
+			mc: helpers.NewMachineConfig("test", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/other/config", makeCRIODropIn("runc"), 0644),
+			}),
+			expectedMC: "",
+		},
+		{
+			name: "empty config raw",
+			mc: &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			expectedMC: "",
+		},
+		{
+			name: "runc in gzip-compressed drop-in",
+			mc: func() *mcfgv1.MachineConfig {
+				gzFile, err := helpers.CreateGzippedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644)
+				if err != nil {
+					t.Fatalf("failed to create gzipped file: %v", err)
+				}
+				return helpers.NewMachineConfig("test-runc-gzip", nil, "", []ign3types.File{gzFile})
+			}(),
+			expectedMC: "test-runc-gzip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcName, err := DetectRuncInMachineConfig(tt.mc)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedMC, mcName)
+		})
+	}
+}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -697,6 +697,10 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		return fmt.Errorf("could not generate rendered MachineConfig: %w", err)
 	}
 
+	if err := validateNoRuncOnRHEL10(pool.Name, generated, osImageStreamSet); err != nil {
+		return err
+	}
+
 	// Validate that the generated MachineConfig does not exceed etcd size limits
 	if err := ctrlcommon.ValidateMachineConfigSize(generated); err != nil {
 		return fmt.Errorf("size validation failed: %w", err)
@@ -953,6 +957,33 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 		oconfigs = append(oconfigs, generated)
 	}
 	return opools, oconfigs, nil
+}
+
+// validateNoRuncOnRHEL10 returns an error if the generated MachineConfig uses runc
+// as the default container runtime and the pool targets a RHEL 10 / CentOS 10 OS
+// image stream. runc is not available on RHCOS 10; clusters must migrate to crun
+// before switching to a RHEL 10 stream.
+// TODO(OCP 5.3): Remove this guard once RHEL 9 is no longer supported and all nodes run RHEL 10.
+func validateNoRuncOnRHEL10(poolName string, mc *mcfgv1.MachineConfig, osImageStreamSet *mcfgv1.OSImageStreamSet) error {
+	if osImageStreamSet == nil {
+		return nil
+	}
+	if !osimagestream.IsRHEL10Stream(osImageStreamSet.Name) {
+		return nil
+	}
+
+	runcMCName, err := ctrlcommon.DetectRuncInMachineConfig(mc)
+	if err != nil {
+		return fmt.Errorf("failed to check runc in generated MachineConfig for pool %s: %w", poolName, err)
+	}
+	if runcMCName != "" {
+		return fmt.Errorf(
+			"MachineConfigPool %s targets OS image stream %q where runc is not available. "+
+				"To unblock, migrate to crun by removing any ContainerRuntimeConfig that sets defaultRuntime to runc, "+
+				"and removing any MachineConfig that sets default_runtime = \"runc\" in CRI-O configuration under /etc/crio/crio.conf.d/",
+			poolName, osImageStreamSet.Name)
+	}
+	return nil
 }
 
 // getMachineConfigsForPool is called by RunBootstrap and returns configs that match label from configs for a pool.

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -697,10 +697,6 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		return fmt.Errorf("could not generate rendered MachineConfig: %w", err)
 	}
 
-	if err := validateNoRuncOnRHEL10(pool.Name, generated, osImageStreamSet); err != nil {
-		return err
-	}
-
 	// Validate that the generated MachineConfig does not exceed etcd size limits
 	if err := ctrlcommon.ValidateMachineConfigSize(generated); err != nil {
 		return fmt.Errorf("size validation failed: %w", err)
@@ -830,6 +826,10 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		if pool.Spec.OSImageStream.Name != "" {
 			return nil, fmt.Errorf("cannot override MachineConfig osImageURL and set MachineConfigPool spec.osImageStream.name simultaneously")
 		}
+	}
+
+	if err := validateNoRuncOnRHEL10(pool.Name, merged, osImageStreamSet); err != nil {
+		return nil, err
 	}
 
 	return merged, nil

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -1010,3 +1010,84 @@ func TestGetOSImageStreamVersionGuard(t *testing.T) {
 		})
 	}
 }
+
+func makeCRIODropIn(runtime string) string {
+	return "[crio.runtime]\ndefault_runtime = \"" + runtime + "\"\n"
+}
+
+func TestValidateNoRuncOnRHEL10(t *testing.T) {
+	tests := []struct {
+		name             string
+		mc               *mcfgv1.MachineConfig
+		osImageStreamSet *mcfgv1.OSImageStreamSet
+		expectError      bool
+	}{
+		{
+			name: "runc on RHEL 10 should error",
+			mc: helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+			}),
+			osImageStreamSet: &mcfgv1.OSImageStreamSet{Name: "rhel-10"},
+			expectError:      true,
+		},
+		{
+			name: "crun on RHEL 10 should succeed",
+			mc: helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("crun"), 0644),
+			}),
+			osImageStreamSet: &mcfgv1.OSImageStreamSet{Name: "rhel-10"},
+			expectError:      false,
+		},
+		{
+			name: "runc on RHEL 9 should succeed",
+			mc: helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+			}),
+			osImageStreamSet: &mcfgv1.OSImageStreamSet{Name: "rhel-9"},
+			expectError:      false,
+		},
+		{
+			name: "runc with nil OSImageStreamSet should succeed",
+			mc: helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+			}),
+			osImageStreamSet: nil,
+			expectError:      false,
+		},
+		{
+			name: "runc on CentOS 10 should error",
+			mc: helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+			}),
+			osImageStreamSet: &mcfgv1.OSImageStreamSet{Name: "centos-10"},
+			expectError:      true,
+		},
+		{
+			name:             "no CRI-O drop-ins on RHEL 10 should succeed",
+			mc:               helpers.NewMachineConfig("rendered-worker", nil, "", nil),
+			osImageStreamSet: &mcfgv1.OSImageStreamSet{Name: "rhel-10"},
+			expectError:      false,
+		},
+		{
+			name: "runc overridden by crun on RHEL 10 should succeed",
+			mc: helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+				helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/01-ctrcfg", makeCRIODropIn("crun"), 0644),
+			}),
+			osImageStreamSet: &mcfgv1.OSImageStreamSet{Name: "rhel-10"},
+			expectError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNoRuncOnRHEL10("worker", tt.mc, tt.osImageStreamSet)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "runc")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -1091,3 +1091,47 @@ func TestValidateNoRuncOnRHEL10(t *testing.T) {
 		})
 	}
 }
+
+func TestRunBootstrapBlocksRuncOnRHEL10(t *testing.T) {
+	pool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"machineconfiguration.openshift.io/role": "worker"},
+			},
+		},
+	}
+
+	runcMC := helpers.NewMachineConfig("99-worker-runc",
+		map[string]string{"machineconfiguration.openshift.io/role": "worker"},
+		"",
+		[]ign3types.File{
+			helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/99-runc",
+				makeCRIODropIn("runc"), 0644),
+		})
+
+	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
+
+	osImageStream := &mcfgv1.OSImageStream{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ClusterInstanceNameOSImageStream},
+		Status: mcfgv1.OSImageStreamStatus{
+			DefaultStream: "rhel-10",
+			AvailableStreams: []mcfgv1.OSImageStreamSet{
+				{
+					Name:    "rhel-10",
+					OSImage: mcfgv1.ImageDigestFormat("quay.io/openshift/rhcos@sha256:fake"),
+				},
+			},
+		},
+	}
+
+	_, _, err := RunBootstrap(
+		[]*mcfgv1.MachineConfigPool{pool},
+		[]*mcfgv1.MachineConfig{runcMC},
+		cc,
+		osImageStream,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "runc")
+	assert.Contains(t, err.Error(), "not available")
+}

--- a/pkg/osimagestream/streams.go
+++ b/pkg/osimagestream/streams.go
@@ -16,6 +16,11 @@ const (
 	StreamNameCentOS10 = "centos-10"
 )
 
+// IsRHEL10Stream returns true if the given stream name targets RHEL 10 or CentOS 10.
+func IsRHEL10Stream(stream string) bool {
+	return stream == StreamNameRHEL10 || stream == StreamNameCentOS10
+}
+
 // GetBuiltinDefaultStreamName returns the default stream name for the current build.
 // For OKD/SCOS builds it always returns "centos-10" as OKD only ships a single stream.
 // For OCP builds it returns the default stream based on the OCP version:


### PR DESCRIPTION


Assisted-by: Claude Code <https://claude.com/claude-code>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Block cluster upgrades if any MachineConfigPool targeting a RHEL 10 or CentOS 10 OS image stream has runc configured as the default container runtime. Each pool's effective stream is resolved via the OSImageStream API, so upgraded clusters that remain on RHCOS 9 are not affected.

**- How to verify it**

e2e, runc cluster upgrade to rhcos 10.

**- Description for the changelog**

Block cluster upgrades if any MachineConfigPool targeting a RHEL 10 or CentOS 10 OS image stream has runc configured as the default container runtime.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of runc container runtime configuration in machine settings
  * Added validation to prevent runc usage on RHEL 10/CentOS 10 with guidance to migrate to crun

* **Tests**
  * Added comprehensive tests for runtime detection and RHEL 10 validation across various configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->