### PR TITLE
OCPBUGS-84652: Add InternalReleaseImage CA to OSImageStream

### DIFF
--- a/pkg/operator/osimagestream_ocp.go
+++ b/pkg/operator/osimagestream_ocp.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/api/machineconfiguration/v1alpha1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
@@ -281,6 +282,27 @@ func (optr *Operator) buildMinimalControllerConfigForOSImageStream() (*mcfgv1.Co
 		return nil, fmt.Errorf("could not get trusted CA bundle: %w", err)
 	}
 	cc.Spec.AdditionalTrustBundle = trustBundle
+
+	// If NoRegistryClusterInstall feature is enabled, include the InternalReleaseImage registry CA
+	// certificate in RootCAData so that OSImageStream inspection can trust the mirrored registry.
+	if osimagestream.IsFeatureEnabled(optr.fgHandler) && optr.fgHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
+		iriTLSSecret, err := optr.mcoSecretLister.Secrets(ctrlcommon.MCONamespace).Get(ctrlcommon.InternalReleaseImageTLSSecretName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("InternalReleaseImage TLS secret not found, OSImageStream inspection may fail for mirrored registries")
+			} else {
+				return nil, fmt.Errorf("could not get InternalReleaseImage TLS secret: %w", err)
+			}
+		} else {
+			// Extract the TLS certificate from the secret
+			if tlsCert, ok := iriTLSSecret.Data[corev1.TLSCertKey]; ok && len(tlsCert) > 0 {
+				cc.Spec.RootCAData = tlsCert
+				klog.V(4).Info("Added InternalReleaseImage TLS certificate to RootCAData for OSImageStream inspection")
+			} else {
+				klog.Warningf("InternalReleaseImage TLS secret exists but %s field is missing or empty", corev1.TLSCertKey)
+			}
+		}
+	}
 
 	return cc, nil
 }


### PR DESCRIPTION
When the OSImageStream feature is enabled with the Agent-Based Installer and ISONoRegistry, MCO fails to build the OSImageStream with the error "unable to retrieve any OSImageStream from the configured sources". This occurs because MCO cannot trust the self-signed TLS certificates used by the InternalReleaseImage mirrored registries.

This fix sets the RootCA used for OSImageStream to the InternalReleaseImage CA.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate handling for image stream operations: when the feature is enabled the operator will attempt to load a cluster TLS certificate, log a warning if it is missing, and only fail when unexpected retrieval errors occur. Valid certificates are now applied to controller configuration; missing or empty certificate entries are ignored with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->