### PR TITLE
OCPBUGS-84652: Include RootCA in the temporal CC

### DIFF
--- a/pkg/operator/osimagestream_ocp.go
+++ b/pkg/operator/osimagestream_ocp.go
@@ -259,10 +259,16 @@ func (optr *Operator) buildMinimalControllerConfigForOSImageStream() (*mcfgv1.Co
 		return nil, fmt.Errorf("could not get image registry bundles: %w", err)
 	}
 
+	mcsCABundle, err := optr.getMCSCABundle()
+	if err != nil {
+		return nil, fmt.Errorf("could not get MCSC CA bundle: %w", err)
+	}
+
 	cc := &mcfgv1.ControllerConfig{
 		Spec: mcfgv1.ControllerConfigSpec{
 			ImageRegistryBundleData:     imgRegistryData,
 			ImageRegistryBundleUserData: imgRegistryUsrData,
+			RootCAData:                  mcsCABundle,
 		},
 	}
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -504,15 +504,9 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 	}
 
 	// Sync up machine-config-server-ca bundle
-	// Attempt the managed bundle in the MCO namespace first. If not found, use the unmanaged rootCA bundle instead
-	machineConfigServerCABundle, err := optr.getCAsFromConfigMap(ctrlcommon.MCONamespace, ctrlcommon.MachineConfigServerCAName, "ca-bundle.crt")
+	machineConfigServerCABundle, err := optr.getMCSCABundle()
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			machineConfigServerCABundle, err = optr.getCAsFromConfigMap("kube-system", ctrlcommon.RootCAConfigMapName, "ca.crt")
-		}
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("could not get MCSC CA bundle: %w", err)
 	}
 
 	bootstrapComplete := false
@@ -659,6 +653,18 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra, pointerConfigData, apiServer, fmt.Sprintf("%d", optr.logLevel))
 
 	return nil
+}
+
+func (optr *Operator) getMCSCABundle() ([]byte, error) {
+	// Attempt the managed bundle in the MCO namespace first. If not found, use the unmanaged rootCA bundle instead
+	machineConfigServerCABundle, err := optr.getCAsFromConfigMap(ctrlcommon.MCONamespace, ctrlcommon.MachineConfigServerCAName, "ca-bundle.crt")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return optr.getCAsFromConfigMap("kube-system", ctrlcommon.RootCAConfigMapName, "ca.crt")
+		}
+		return nil, err
+	}
+	return machineConfigServerCABundle, nil
 }
 
 func (optr *Operator) getTrustedBundle(proxy *configv1.Proxy) ([]byte, error) {


### PR DESCRIPTION
Closes: [#OCPBUGS-84652](https://redhat.atlassian.net/browse/OCPBUGS-84652)

**- What I did**

This change includes the MCS CA bundle as part of the OS Image Stream temporal CC to allow the logic to pull images from the temporal IRI registry that uses a certificate signed with the MCS CA cert.

**- How to verify it**

TBD

**- Description for the changelog**

Include the MCS CA bundle in the OS Image Stream temporal CC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OS image stream inspection now properly includes the Machine Config Server Root CA certificate bundle.
  * Certificate bundle retrieval now fails early with clearer, wrapped error context when the CA bundle cannot be obtained.
  * Lookup behavior for the CA bundle is more robust, trying the managed source first and falling back to the cluster root CA only when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->