### PR TITLE
OCPBUGS-84832: daemon: don't pull/extract extensions for all OS updates

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -3041,6 +3041,18 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		mcDiff.osUpdate = false
 	}
 
+	// If either of our old or new configs have extensions OR kerneltype (which just
+	// uses extensions under the hood) set then we need to fetch/extract and add the
+	// extensions repo so our operation won't fail because of a missing repo. It doesn't
+	// matter if there are no changes between the old and new configs (i.e. mcDiff.extensions
+	// and mcDiff.kerneltype can't be used), because when we do an os update if the yum
+	// repo isn't there rpm-ostree will fail if there are layered packages.
+	// See https://redhat.atlassian.net/browse/OCPBUGS-2269
+	haveExtensions := len(oldConfig.Spec.Extensions) != 0 || len(newConfig.Spec.Extensions) != 0
+	haveKernelType :=
+		helpers.CanonicalizeKernelType(oldConfig.Spec.KernelType) != ctrlcommon.KernelTypeDefault ||
+			helpers.CanonicalizeKernelType(newConfig.Spec.KernelType) != ctrlcommon.KernelTypeDefault
+
 	var osExtensionsContentDir string
 	var err error
 
@@ -3054,7 +3066,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 		}
 	}
 
-	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType) && !mcDiff.oclEnabled {
+	if newConfig.Spec.BaseOSExtensionsContainerImage != "" && (haveExtensions || haveKernelType) && !mcDiff.oclEnabled {
 		// TODO(jkyros): the original intent was that we use the extensions container as a service, but that currently results
 		// in a lot of complexity due to boostrap and firstboot where the service isn't easily available, so for now we are going
 		// to extract them to disk like we did previously.


### PR DESCRIPTION
We only need the extensions locally when we're going to use them, or when they had previously been used. RPM-OSTree can fail if a layered package was added and the yum repo for it isn't available [1].

The previous fix [2] for the problem, though, was a little overzealous in basically making it such that any os update would require extensions be pulled/extracted for it. We can be smarter here by just checking the old and new configs to see if that is needed.

The mcDiff.extensions and mcDiff.kerneltype aren't enough here because even if there is no diff between the old and new config there could be extensions currently in use (i.e. extensions or kerneltype set in both old and new, so no diff, but still need the extensions repo to exist, otherwise RPM-OSTree will complain).

[1] https://redhat.atlassian.net/browse/OCPBUGS-2269
[2] https://github.com/openshift/machine-config-operator/pull/3373

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS update reliability when layered packages are in use by ensuring all necessary components are properly prepared during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->