### PR TITLE
OCPBUGS-84842: Bootloader update attempt should be conditional

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequestopts.go
+++ b/pkg/controller/build/buildrequest/buildrequestopts.go
@@ -55,7 +55,7 @@ func (b BuildRequestOpts) getKernelPackages() (string, map[string][]string, erro
 	}
 
 	// 64K memory pages kernel is only supported for aarch64
-	if newKtype == ctrlcommon.KernelType64kPages && goruntime.GOARCH != "arm64" {
+	if newKtype == ctrlcommon.KernelType64kPages && goruntime.GOARCH != ctrlcommon.GoArchARM64 {
 		return "", nil, fmt.Errorf("64k-pages is only supported for aarch64 architecture")
 	}
 

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -174,6 +174,10 @@ const (
 	// This matches etcd's default request size limit of 1.5MB (1572864 bytes).
 	// Reference: https://issues.redhat.com/browse/OCPBUGS-62619
 	MaxMachineConfigSize = 1572864
+
+	// Go GOARCH values for architecture matching
+	GoArchAMD64 = "amd64"
+	GoArchARM64 = "arm64"
 )
 
 // Commonly-used MCO ConfigMap names

--- a/pkg/daemon/bootupd.go
+++ b/pkg/daemon/bootupd.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 )
 
 // runGetOut executes a command on the host and returns its stdout output.
@@ -47,7 +50,7 @@ func (dn *Daemon) runBootupdViaContainer(imageURL string) error {
 	}
 	// For now, only attempt bootloader updates on x86_64 and aarch64 as they are the ones
 	// affected by the secure boot issue.
-	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+	if runtime.GOARCH != ctrlcommon.GoArchAMD64 && runtime.GOARCH != ctrlcommon.GoArchARM64 {
 		return nil
 	}
 	logSystem("runBootupdViaContainer: attempting bootloader update")
@@ -327,6 +330,74 @@ func findAnyESP(devices []lsblkDevice) string {
 		}
 	}
 	return ""
+}
+
+// isSecureBootEnabled returns true if mokutil reports Secure Boot is active.
+// If mokutil is unavailable or fails, it returns true to fail open (conservative).
+func isSecureBootEnabled() bool {
+	out, err := runGetOut("mokutil", "--sb-state")
+	if err != nil {
+		logSystem("isSecureBootEnabled: mokutil failed, assuming Secure Boot may be enabled: %v", err)
+		return true
+	}
+	return strings.Contains(string(out), "SecureBoot enabled")
+}
+
+// shimIsSafe returns true if no bootloader update is required: either Secure Boot
+// is not enabled, or the installed shim is at or above 15.8-3.el9_2 (the minimum
+// version with safe signing keys). On non-UEFI arches this always returns true.
+func shimIsSafe() bool {
+	if !isSecureBootEnabled() {
+		logSystem("shimIsSafe: Secure Boot not enabled, bootloader update not required")
+		return true
+	}
+
+	var pkgName string
+	switch runtime.GOARCH {
+	case ctrlcommon.GoArchAMD64:
+		pkgName = "shim-x64"
+	case ctrlcommon.GoArchARM64:
+		pkgName = "shim-aa64"
+	default:
+		return true
+	}
+
+	out, err := runGetOut("rpm", "-q", "--queryformat", "%{VERSION}-%{RELEASE}", pkgName)
+	if err != nil {
+		// Package not installed or rpm failed — fail open so bootupd runs.
+		logSystem("shimIsSafe: could not query %s, proceeding with bootloader update: %v", pkgName, err)
+		return false
+	}
+
+	installed := strings.TrimSpace(string(out))
+	const safeVersion = "15.8-3.el9_2"
+	cmp, err := rpmVercmp(installed, safeVersion)
+	if err != nil {
+		logSystem("shimIsSafe: could not compare versions, proceeding with bootloader update: %v", err)
+		return false
+	}
+	safe := cmp >= 0
+	if safe {
+		logSystem("shimIsSafe: %s %s >= %s, bootloader update not required", pkgName, installed, safeVersion)
+	} else {
+		logSystem("shimIsSafe: %s %s < %s, bootloader update required", pkgName, installed, safeVersion)
+	}
+	return safe
+}
+
+// rpmVercmp compares two RPM version strings using rpm's built-in Lua vercmp.
+// Returns negative if a < b, 0 if equal, positive if a > b.
+func rpmVercmp(a, b string) (int, error) {
+	luaExpr := "%{lua:print(rpm.vercmp('" + a + "', '" + b + "'))}"
+	out, err := runGetOut("rpm", "--eval", luaExpr)
+	if err != nil {
+		return 0, err
+	}
+	result, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("unexpected rpm vercmp output %q: %w", string(out), err)
+	}
+	return result, nil
 }
 
 // findRAIDESPs returns the ESP partition on every disk that is a member of the

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1864,7 +1864,7 @@ func (dn *CoreOSDaemon) switchKernel(oldConfig, newConfig *mcfgv1.MachineConfig)
 	}
 
 	// 64K memory pages kernel is only supported for aarch64
-	if newKtype == ctrlcommon.KernelType64kPages && goruntime.GOARCH != "arm64" {
+	if newKtype == ctrlcommon.KernelType64kPages && goruntime.GOARCH != ctrlcommon.GoArchARM64 {
 		return fmt.Errorf("64k-pages is only supported for aarch64 architecture")
 	}
 
@@ -2758,8 +2758,10 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
 	klog.Infof("Updating OS to layered image %q", newURL)
 
-	if err := dn.runBootupdViaContainer(newURL); err != nil {
-		klog.Warningf("bootloader update failed: %s", err)
+	if !shimIsSafe() {
+		if err := dn.runBootupdViaContainer(newURL); err != nil {
+			klog.Warningf("bootloader update failed: %s", err)
+		}
 	}
 
 	newEnough, err := dn.NodeUpdaterClient.IsNewEnoughForLayering()


### PR DESCRIPTION
**- What I did**
Follow-up fix to https://github.com/openshift/machine-config-operator/pull/5868; this adds a simple shim version check so the bootloader update routine isn't invoked on every node update.

**- How to verify it**
Bootloader updates should continue to work, but they should not be attempted for shims > `15.8-3.el9_2`, i.e. any cluster installed past `4.15.23` or `4.16.0`. All bootimages used after those releases have the minimum version that contains the Secure Boot signing keys. This should be verified on `amd64` and `aarch64` clusters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Secure Boot detection and shim-version validation to gate bootloader updates and avoid unsafe upgrades.

* **Bug Fixes**
  * Improved architecture detection logic for more reliable cross-platform behavior.
  * Bootloader update attempts now skip when the installed shim is deemed safe; failures emit warnings instead of blocking updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->