### PR TITLE
OCPBUGS-84867: Fix OCL test to handle temporarily empty current-machine-os-build annotation

### DIFF
--- a/test/e2e-ocl-1of2/onclusterlayering_test.go
+++ b/test/e2e-ocl-1of2/onclusterlayering_test.go
@@ -911,7 +911,10 @@ func waitForMOSCToUpdateCurrentMOSB(ctx context.Context, t *testing.T, cs *frame
 		}
 
 		currentMOSB = mosc.GetAnnotations()[constants.CurrentMachineOSBuildAnnotationKey]
-		return currentMOSB != mosbName, nil
+		// Wait for annotation to be non-empty AND different from the old MOSB.
+		// The stale annotation fix may temporarily clear the annotation, so we need
+		// to wait for the new MOSB to be created and annotation set.
+		return currentMOSB != "" && currentMOSB != mosbName, nil
 
 	}))
 	return currentMOSB


### PR DESCRIPTION
The waitForMOSCToUpdateCurrentMOSB helper was failing when the current-machine-os-build annotation was temporarily cleared.

Background:
When the stale annotation fix (OCPBUGS-84150) detects that the annotation points to a build for an old rendered config, it clears the annotation. This creates a brief window where the annotation is empty (between clearing stale and new build creation).

The test helper was checking: currentMOSB != mosbName When annotation is empty (""), this returns true, causing the helper to return "" (empty string) immediately. The test then tries to get a MOSB with name "" which fails with "resource name may not be empty".

Fix:
Wait for annotation to be non-empty AND different from the old MOSB:
  return currentMOSB != "" && currentMOSB != mosbName

This allows the test to wait through the temporary empty state until the new MOSB is created and annotation is set.

Affected test: TestMissingImageIsRebuilt 

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of machine OS configuration polling test to ensure annotations are both populated and updated before proceeding, preventing premature completion during temporary state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->