### PR TITLE
OCPBUGS-75894: use `--delete-if-present` for karg removal

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1733,8 +1733,11 @@ func generateKargs(oldKernelArguments, newKernelArguments []string) []string {
 	// kernel arguments which have been applied by MCO previously and append all of the
 	// kernel arguments present in the new rendered MachineConfig.
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1866546#c10.
+	// Use --delete-if-present instead of --delete to tolerate drift between
+	// the old MachineConfig spec and the actual state.
+	// See https://issues.redhat.com/browse/OCPBUGS-75894.
 	for _, arg := range oldKargs {
-		cmdArgs = append(cmdArgs, "--delete="+arg)
+		cmdArgs = append(cmdArgs, "--delete-if-present="+arg)
 	}
 	for _, arg := range newKargs {
 		cmdArgs = append(cmdArgs, "--append="+arg)

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -301,29 +301,29 @@ func TestKernelAguments(t *testing.T) {
 		{
 			oldKargs: []string{"hello=world"},
 			newKargs: nil,
-			out:      []string{"--delete=hello=world"},
+			out:      []string{"--delete-if-present=hello=world"},
 		},
 		{
 			oldKargs: []string{"foo", "bar=1", "hello=world"},
 			newKargs: []string{"hello=world"},
-			out:      []string{"--delete=foo", "--delete=bar=1", "--delete=hello=world", "--append=hello=world"},
+			out:      []string{"--delete-if-present=foo", "--delete-if-present=bar=1", "--delete-if-present=hello=world", "--append=hello=world"},
 		},
 		{
 			oldKargs: []string{"foo", "bar=1 hello=world", "baz"},
 			newKargs: []string{"foo", "bar=1", "hello=world"},
-			out: []string{"--delete=foo", "--delete=bar=1", "--delete=hello=world", "--delete=baz",
+			out: []string{"--delete-if-present=foo", "--delete-if-present=bar=1", "--delete-if-present=hello=world", "--delete-if-present=baz",
 				"--append=foo", "--append=bar=1", "--append=hello=world"},
 		},
 		{
 			oldKargs: []string{" baz=test bar=\"hello world\""},
 			newKargs: []string{" baz=test bar=\"hello world\"", "foo"},
-			out: []string{"--delete=baz=test", "--delete=bar=\"hello world\"",
+			out: []string{"--delete-if-present=baz=test", "--delete-if-present=bar=\"hello world\"",
 				"--append=baz=test", "--append=bar=\"hello world\"", "--append=foo"},
 		},
 		{
 			oldKargs: []string{"hugepagesz=1G hugepages=4", "hugepagesz=2M hugepages=4"},
 			newKargs: []string{"hugepagesz=1G hugepages=4", "hugepagesz=2M hugepages=6"},
-			out: []string{"--delete=hugepagesz=1G", "--delete=hugepages=4", "--delete=hugepagesz=2M", "--delete=hugepages=4",
+			out: []string{"--delete-if-present=hugepagesz=1G", "--delete-if-present=hugepages=4", "--delete-if-present=hugepagesz=2M", "--delete-if-present=hugepages=4",
 				"--append=hugepagesz=1G", "--append=hugepages=4", "--append=hugepagesz=2M", "--append=hugepages=6"},
 		},
 	}


### PR DESCRIPTION
Closes: OCPBUGS-75894

_Note: The changes in this PR and description were created with the assistance of Claude._

**- What I did**

The `generateKargs()` function used `--delete=` to remove old kernel arguments during reconciliation. When there is drift or a mismatch in the expected and actual kargs, which should typically be caught by our configuration drift monitor, but can occur in cases such as the one highlighted in OCPBUGS-75894, rpm-ostree fails the entire kargs transaction with "No key found", leaving the node degraded. This changes `--delete=` to `--delete-if-present=`, which allows us to skip missing kargs without erroring out.

**- How to verify it**

1. Apply a MC to add custom kargs to nodes and wait for the change to be applied.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1                
kind: MachineConfig                                                                                                                 
metadata:                                                       
  labels:                                                                                                                           
    machineconfiguration.openshift.io/role: infra              
  name: 99-karg-test                                                                                                                
spec:
  kernelArguments:                                                                                                                  
    - rcutree.nohz_full_patience_delay=1000                     
    - nmi_watchdog=0
EOF
```

2. Confirm the karg is present on the node.
```
$ oc debug node/<node> -- chroot /host rpm-ostree kargs | grep rcutree
# Expected output includes `rcutree.nohz_full_patience_delay=1000`
```

3. Create drift by removing the karg and rebooting the node.
```
$ oc debug node/<node> -- chroot /host rpm-ostree kargs --delete=rcutree.nohz_full_patience_delay=1000
$ oc debug node/<node> -- chroot /host systemctl reboot
```

4. Wait for the node to become `Ready`. The MCD will detect the missing karg and mark the node degraded. This is expected.
5. Apply another MC to create a kargs diff.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1                                                                                    
kind: MachineConfig                                                                                                                 
metadata:                                                       
  labels:                                                                                                                           
    machineconfiguration.openshift.io/role: infra              
  name: 99-karg-test2                                        
spec:
  kernelArguments:                                                                                                                  
    - rcutree.nohz_full_patience_delay=2000                     
    - nmi_watchdog=0
EOF
```

6. Point the node at the new rendered MC and touch the force file.
```                                                             
$ oc annotate node <node> machineconfiguration.openshift.io/desiredConfig=<new-mc> --overwrite
$ oc debug node/<node>  -- chroot /host touch /run/machine-config-daemon-force
```

7. Check the MCD logs. Before the fix the logs will include `error: No key 'rcutree.nohz_full_patience_delay' found` and the node degrades. After the fix, the update should succeed and the node should not degrade.

**- Description for the changelog**
OCPBUGS-75894: use `--delete-if-present` for karg removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kernel argument removal during system updates is now drift-tolerant when the bootloader state has changed or is missing, reducing update failures in edge cases.
  * Addition of new kernel arguments is unaffected and continues to work as before.
  * Behavior validated by updated tests to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->