### PR TITLE
AGENT-1491: reclaim disk space from the node when IRI resource is deleted

### DIFF
--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -154,6 +154,7 @@ const (
 	IRILoadImageScriptPath = "/usr/local/bin/load-registry-image.sh"
 	IRIRootCAPath          = "/etc/pki/ca-trust/source/anchors/iri-root-ca.crt"
 	IRIRegistryServiceName = "iri-registry.service"
+	IRIRegistryDataPath    = "/var/lib/iri-registry"
 
 	// rpm-ostree command arguments
 	RPMOSTreeUpdateArg    = "update"

--- a/pkg/daemon/internalreleaseimage/.claude/skills/iri-mcd/SKILL.md
+++ b/pkg/daemon/internalreleaseimage/.claude/skills/iri-mcd/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: iri-mcd
+description: Describes the acceptance criteria and BDD tests to be used for new/existing features of the InternalReleaseImage MachineConfigDaemon manager. The manager implements the NoRegistryClusterInstall main feature for the part related to manage/monitor a single control plane node
+user-invocable: false
+---
+
+# InternalReleaseImage daemon manager BDD workflow
+
+When working on InternalReleaseImage daemon manager changes:
+
+1. Identify the specific behavior being changed.
+2. Read only the relevant acceptance file under `acceptance/`.
+3. If the change touches multiple behaviors, read all matching files.
+4. Do not invent behavior that is not covered by the acceptance criteria.
+5. When behavior changes, update the relevant acceptance file before implementing code.
+
+# General implementation notes
+
+When defining the implementation:
+
+- Ensure that any new portion of code is covered at least by one or more unit tests.
+- Keep production changes minimal.
+- Avoid duplications, prefer a coding style that improves the readability and maintenance.
+- Do not perform broad refactors unless needed to make the behavior testable.
+- If a behavior is not covered by acceptance criteria, stop and ask before implementing it.
+- When reporting completion, map each changed test back to the acceptance scenario it covers.
+- Minimize comments, and keep them short.
+
+# Specific IRI MCD manager implementation notes
+
+- Keep the `syncInternalReleaseImage` method short and readable. Prefer to refactor included tasks into private type methods.
+- Do not instantiate the IRI registry within `syncInternalReleaseImage` method more than once per loop: keep it simple stupid.
+
+# Test implementation notes
+
+- When testing different cases for the same scenario, use the cases := []struct{} to capture the relevant key fields for the test. Add always a speaking
+  name field to represent the current case.
+- Reuse the existing test methods if possible.
+- Keep the test focused on the behaviors, avoid testing unnecessary technical details.
+- Do not add too many comments to the tests
+
+# Functional testing notes
+
+The NoRegistryClusterInstall feature is also tested functionally in `/test/e2e-iri` folder.
+
+## Supporting files
+
+- `acceptance/storage-reclaim.md`: IRI deletion workflow, how to reclaim the disk node space previously used.
+- `acceptance/feature-disabled.md`: the expected behavior when the feature is not enabled.

--- a/pkg/daemon/internalreleaseimage/.claude/skills/iri-mcd/acceptance/feature-disabled.md
+++ b/pkg/daemon/internalreleaseimage/.claude/skills/iri-mcd/acceptance/feature-disabled.md
@@ -1,0 +1,17 @@
+# IRI feature disabled
+
+## Goal
+
+Avoid to consume cpu/mem resources when the NoRegistryClusterInstall is disabled. There could be two different scenarios to consider:
+
+- The feature was never activated
+- The user explicitly disabled the feature by deleting the IRI resource
+
+In both the cases, we'd like to consume as few as possible resources when the feature is not enabled
+
+
+## Scenario: skip everything if feature is disabled
+
+Given the `/var/lib/iri-registry` does not exist
+When the manager reconciles
+Then skip all the actions and return immediately (requeue with a longer time)

--- a/pkg/daemon/internalreleaseimage/.claude/skills/iri-mcd/acceptance/storage-reclaim.md
+++ b/pkg/daemon/internalreleaseimage/.claude/skills/iri-mcd/acceptance/storage-reclaim.md
@@ -1,0 +1,31 @@
+# IRI storage reclaim acceptance criteria
+
+## Goal
+
+When the singleton InternalReleaseImage resource (name "cluster") is deleted, MCD should reclaim storage used by the local IRI registry backend without racing against registry shutdown.
+Since the deletion of the IRI singleton resource will be used to opt-out from the NoRegistryClusterInstall feature, there's no specific need to 
+report the progress. It's important that the manager will ensure that the storage is cleaned up when the IRI is not present and the registry is down.
+The local IRI registry service will be stopped automatically when the IRI MachineConfigs will be deleted by the IRI controller
+
+## Scenario: ensure disk cleanup on IRI deletion
+
+Given the IRI resource is deleted
+And the local IRI registry is not active on port 22625
+And `/var/lib/iri-registry` is not empty
+
+When the manager reconciles
+
+Then it should remove `/var/lib/iri-registry` content
+
+
+## Scenario: storage is not cleaned up during IRI deletion
+
+Given the IRI resource is being deleted
+And the local IRI registry is still active
+
+When the manager reconciles
+
+Then it should not remove `/var/lib/iri-registry`
+And it should wait for the local IRI registry to be stopped
+And avoid to perform any other task
+

--- a/pkg/daemon/internalreleaseimage/internalreleaseimage_helpers_test.go
+++ b/pkg/daemon/internalreleaseimage/internalreleaseimage_helpers_test.go
@@ -31,6 +31,12 @@ func iri() *iriBuilder {
 	}
 }
 
+func (ib *iriBuilder) withDeletionTimestamp() *iriBuilder {
+	now := metav1.Now()
+	ib.obj.DeletionTimestamp = &now
+	return ib
+}
+
 func (ib *iriBuilder) build() runtime.Object {
 	return ib.obj
 }

--- a/pkg/daemon/internalreleaseimage/internalreleaseimage_manager.go
+++ b/pkg/daemon/internalreleaseimage/internalreleaseimage_manager.go
@@ -3,7 +3,10 @@ package internalreleaseimage
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -27,6 +30,7 @@ import (
 	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
 	mcfglistersv1alpha1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1alpha1"
 	"github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 )
 
 const (
@@ -44,6 +48,8 @@ type Manager struct {
 	registryClient *http.Client
 	// authToken overrides the token read from the kubelet auth file; used in tests.
 	authToken string
+	// registryDataPath overrides the default registry data path; used in tests.
+	registryDataPath string
 
 	syncHandler                 func(iri string) error
 	enqueueInternalReleaseImage func(*mcfgv1alpha1.InternalReleaseImage)
@@ -399,8 +405,160 @@ func (i *Manager) cleanupMachineConfigNodeStatus(mcn *mcfgv1.MachineConfigNode) 
 	return i.updateMCNStatus(mcn, mcnUpdated)
 }
 
+// reclaimRegistryStorage removes the IRI registry data directory contents when safe.
+// Returns an error if the directory cannot be removed, or nil if removal succeeded
+// or if the directory doesn't exist.
+func (i *Manager) reclaimRegistryStorage() error {
+	registryDataPath := i.registryDataPath
+	if registryDataPath == "" {
+		registryDataPath = constants.IRIRegistryDataPath
+	}
+
+	// Check if directory exists
+	info, err := os.Stat(registryDataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(2).Infof("Registry data directory %s does not exist, nothing to reclaim", registryDataPath)
+			return nil
+		}
+		return fmt.Errorf("failed to stat registry data path %s: %w", registryDataPath, err)
+	}
+
+	// Verify it's a directory
+	if !info.IsDir() {
+		return fmt.Errorf("registry data path %s exists but is not a directory", registryDataPath)
+	}
+
+	base, err := filepath.Abs(registryDataPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve registry data path %q: %w", registryDataPath, err)
+	}
+	base = filepath.Clean(base)
+
+	if base == string(os.PathSeparator) {
+		return fmt.Errorf("invalid registry data path")
+	}
+
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return fmt.Errorf("failed to read registry data path %q: %w", base, err)
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(base, entry.Name())
+
+		rel, err := filepath.Rel(base, path)
+		if err != nil {
+			return fmt.Errorf("failed to validate registry data path %q: %w", path, err)
+		}
+
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("refusing to remove path outside registry data path: %q", path)
+		}
+
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("failed to remove registry data path %q: %w", path, err)
+		}
+
+		klog.V(2).Infof("Removed registry data path: %s", path)
+	}
+
+	klog.Infof("Successfully reclaimed storage: removed %d entries from %s", len(entries), registryDataPath)
+	return nil
+}
+
+// getIRIRegistry creates and returns an IRI registry client.
+// Returns the registry and an error indicating whether the registry is reachable.
+func (i *Manager) getIRIRegistry() (*iriRegistry, error) {
+	authToken := i.authToken
+	if authToken == "" {
+		var err error
+		authToken, err = readIRIAuthToken(net.JoinHostPort(iriRegistryHost, fmt.Sprintf("%d", iriRegistryPort)))
+		if err != nil {
+			return nil, fmt.Errorf("could not read IRI auth token: %w", err)
+		}
+	}
+
+	iriReg := newIRIRegistry(i.nodeName, i.registryClient, authToken)
+	err := iriReg.CheckLocalRegistry()
+	return iriReg, err
+}
+
+// wasFeatureActivated checks if the NoRegistryClusterInstall feature was ever activated on this node.
+// Returns true if the registry data directory exists (feature was activated),
+// false if the directory doesn't exist (feature never used),
+// or an error if the check failed (permission denied, I/O error, etc.).
+func (i *Manager) wasFeatureActivated() (bool, error) {
+	registryDataPath := i.registryDataPath
+	if registryDataPath == "" {
+		registryDataPath = constants.IRIRegistryDataPath
+	}
+	_, err := os.Stat(registryDataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // Directory doesn't exist - feature never activated
+		}
+		return false, fmt.Errorf("failed to check registry data path %s: %w", registryDataPath, err)
+	}
+	return true, nil
+}
+
+// isRegistryPortListening checks if the registry port is accepting connections.
+// Returns true if port is listening (registry service is running), false otherwise.
+// This is a cheap TCP dial check (~microseconds for localhost) that provides a stronger
+// signal than HTTP errors, which can occur for reasons other than service being down.
+func (i *Manager) isRegistryPortListening() bool {
+	address := net.JoinHostPort(iriRegistryHost, fmt.Sprintf("%d", iriRegistryPort))
+	conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// handleIRIDeletion handles the IRI deletion scenario (both in-progress and completed).
+// This method is only called when the registry directory exists (feature was activated).
+// If registry port is still listening, it waits for shutdown.
+// If registry port is down, it cleans up MCN status and reclaims storage.
+func (i *Manager) handleIRIDeletion(mcn *mcfgv1.MachineConfigNode) error {
+	// Check if registry port is listening
+	if i.isRegistryPortListening() {
+		// Registry port is still listening - wait for shutdown and avoid any other task
+		klog.V(2).Infof("Registry port is still listening, waiting for shutdown before cleanup")
+		i.queue.AddAfter(common.InternalReleaseImageInstanceName, syncRetryInterval)
+		return nil
+	}
+
+	// Registry port is not listening - safe to clean up and reclaim storage
+	klog.V(2).Infof("Registry port is not listening - proceeding with cleanup")
+
+	// Clean up MCN status
+	if err := i.cleanupMachineConfigNodeStatus(mcn); err != nil {
+		return fmt.Errorf("failed to cleanup MCN: %w", err)
+	}
+
+	// Reclaim storage
+	if err := i.reclaimRegistryStorage(); err != nil {
+		return fmt.Errorf("failed to reclaim registry storage: %w", err)
+	}
+
+	return nil
+}
+
 func (i *Manager) syncInternalReleaseImage(key string) error {
 	klog.V(4).Infof("Syncing InternalReleaseImage %q", key)
+
+	// Check if feature was ever activated - if not, skip all work
+	wasActivated, err := i.wasFeatureActivated()
+	if err != nil {
+		return err
+	}
+	if !wasActivated {
+		klog.V(4).Infof("InternalReleaseImage feature never activated")
+		i.queue.AddAfter(common.InternalReleaseImageInstanceName, 5*time.Minute)
+		return nil
+	}
 
 	// Get the MachineConfigNode for the current node.
 	mcn, err := i.mcnLister.Get(i.nodeName)
@@ -412,31 +570,22 @@ func (i *Manager) syncInternalReleaseImage(key string) error {
 		return err
 	}
 
-	// Fetch the InternalReleaseImage.
-	_, err = i.iriLister.Get(common.InternalReleaseImageInstanceName)
-	if apierrors.IsNotFound(err) {
-		// Manage the feature only when the IRI resource was defined.
-		// If not present, refresh the related MCN resource if required.
-		err = i.cleanupMachineConfigNodeStatus(mcn)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
+	// Check if IRI resource exists
+	iri, err := i.iriLister.Get(common.InternalReleaseImageInstanceName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return i.handleIRIDeletion(mcn)
+		}
 		return err
 	}
 
-	authToken := i.authToken
-	var registryErr error
-	if authToken == "" {
-		authToken, registryErr = readIRIAuthToken(fmt.Sprintf("%s:%d", iriRegistryHost, iriRegistryPort))
+	// Check if IRI is being deleted
+	if !iri.DeletionTimestamp.IsZero() {
+		return i.handleIRIDeletion(mcn)
 	}
-	var iriReg *iriRegistry
-	if registryErr == nil {
-		iriReg = newIRIRegistry(i.nodeName, i.registryClient, authToken)
-		registryErr = iriReg.CheckLocalRegistry()
-	}
+
+	// Update MCN status based on registry availability
+	iriReg, registryErr := i.getIRIRegistry()
 	if registryErr != nil {
 		err = i.setMachineConfigNodeAsDegraded(mcn, registryErr)
 	} else {

--- a/pkg/daemon/internalreleaseimage/internalreleaseimage_manager_test.go
+++ b/pkg/daemon/internalreleaseimage/internalreleaseimage_manager_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -26,30 +28,20 @@ func TestInternalReleaseImageManager(t *testing.T) {
 		nodeName      string
 		mcn           *mcnBuilder
 		setupRegistry func(r *FakeIRIRegistry)
-		verify        func(t *testing.T, actualMCN *mcfgv1.MachineConfigNode)
+		verify        func(t *testing.T, actualMCN *mcfgv1.MachineConfigNode, registryDataPath string)
 
-		registryDisabled bool
+		registryDisabled     bool
+		skipRegistryDirSetup bool
 	}{
 		{
-			name:     "cleanup MachineConfigNode status when IRI is deleted",
-			mcn:      machineConfigNode("master-0").withIRIBundle("ocp-release-bundle-4.22.0-0.ci-2026-04-01-050515", "localhost:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389"),
-			nodeName: "master-0",
-			iri:      nil,
+			name:                 "feature not enabled",
+			mcn:                  machineConfigNode("master-0"),
+			nodeName:             "master-0",
+			iri:                  nil,
+			registryDisabled:     true,
+			skipRegistryDirSetup: true,
 
-			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode) {
-				for _, c := range mcn.Status.Conditions {
-					assert.NotEqual(t, string(mcfgv1.MachineConfigNodeInternalReleaseImageDegraded), c.Type)
-				}
-				assert.Empty(t, mcn.Status.InternalReleaseImage)
-			},
-		},
-		{
-			name:     "feature not enabled",
-			mcn:      machineConfigNode("master-0"),
-			nodeName: "master-0",
-			iri:      nil,
-
-			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode) {
+			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode, registryDataPath string) {
 				assert.Empty(t, mcn.Status.InternalReleaseImage)
 			},
 		},
@@ -66,7 +58,7 @@ func TestInternalReleaseImageManager(t *testing.T) {
 					AddResponse("/v2/openshift/release-images/manifests/sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389", http.StatusOK, "{}")
 			},
 
-			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode) {
+			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode, registryDataPath string) {
 				verifyCondition(t, mcn.Status.Conditions, string(mcfgv1.MachineConfigNodeInternalReleaseImageDegraded), metav1.ConditionFalse)
 
 				assert.Len(t, mcn.Status.InternalReleaseImage.Releases, 1)
@@ -78,14 +70,13 @@ func TestInternalReleaseImageManager(t *testing.T) {
 			},
 		},
 		{
-			name:     "registry down",
-			iri:      iri(),
-			nodeName: "master-0",
-			mcn:      machineConfigNode("master-0"),
-
+			name:             "registry down",
+			iri:              iri(),
+			nodeName:         "master-0",
+			mcn:              machineConfigNode("master-0"),
 			registryDisabled: true,
 
-			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode) {
+			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode, registryDataPath string) {
 				verifyCondition(t, mcn.Status.Conditions, string(mcfgv1.MachineConfigNodeInternalReleaseImageDegraded), metav1.ConditionTrue)
 
 				assert.Len(t, mcn.Status.InternalReleaseImage.Releases, 0)
@@ -104,7 +95,7 @@ func TestInternalReleaseImageManager(t *testing.T) {
 					AddResponse("/v2/openshift/release-images/manifests/sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389", http.StatusNotFound, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":{"Tag":"68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0388"}}]}`)
 			},
 
-			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode) {
+			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode, registryDataPath string) {
 				verifyCondition(t, mcn.Status.Conditions, string(mcfgv1.MachineConfigNodeInternalReleaseImageDegraded), metav1.ConditionTrue)
 
 				assert.Len(t, mcn.Status.InternalReleaseImage.Releases, 1)
@@ -115,11 +106,67 @@ func TestInternalReleaseImageManager(t *testing.T) {
 				verifyCondition(t, r.Conditions, string(mcfgv1alpha1.InternalReleaseImageConditionTypeDegraded), metav1.ConditionTrue)
 			},
 		},
+		{
+			name:     "IRI deletion in progress - registry still active",
+			mcn:      machineConfigNode("master-0").withIRIBundle("ocp-release-bundle-4.22.0-0.ci-2026-04-01-050515", "localhost:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389"),
+			nodeName: "master-0",
+			iri:      iri().withDeletionTimestamp(),
+			setupRegistry: func(r *FakeIRIRegistry) {
+				r.AddResponse("/v2", http.StatusOK, "{}")
+			},
+
+			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode, registryDataPath string) {
+				// MCN status should NOT be cleaned (registry still active)
+				assert.NotEmpty(t, mcn.Status.InternalReleaseImage.Releases, "MCN IRI status should not be cleaned while registry is active")
+
+				// Storage should NOT be reclaimed (registry still active)
+				testFile := filepath.Join(registryDataPath, "test-data.txt")
+				_, err := os.Stat(testFile)
+				assert.NoError(t, err, "Storage should not be reclaimed while registry is active")
+			},
+		},
+		{
+			name:             "IRI deleted - registry down",
+			mcn:              machineConfigNode("master-0").withIRIBundle("ocp-release-bundle-4.22.0-0.ci-2026-04-01-050515", "localhost:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389"),
+			nodeName:         "master-0",
+			iri:              nil,
+			registryDisabled: true,
+
+			verify: func(t *testing.T, mcn *mcfgv1.MachineConfigNode, registryDataPath string) {
+				// MCN status should be cleaned
+				for _, c := range mcn.Status.Conditions {
+					assert.NotEqual(t, string(mcfgv1.MachineConfigNodeInternalReleaseImageDegraded), c.Type)
+				}
+				assert.Empty(t, mcn.Status.InternalReleaseImage)
+
+				// Storage should be reclaimed (registry is down)
+				entries, err := os.ReadDir(registryDataPath)
+				assert.NoError(t, err)
+				assert.Empty(t, entries, "Storage should be reclaimed when registry is down")
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+
+			// Use a temp directory for registry data in tests
+			tempDir := t.TempDir()
+
+			// Set the actual registry data path
+			var registryDataPath string
+			if tc.skipRegistryDirSetup {
+				// For "feature not enabled" case: point to non-existent directory
+				registryDataPath = filepath.Join(tempDir, "nonexistent-registry")
+			} else {
+				// For normal cases: use tempDir and ensure it exists
+				registryDataPath = tempDir
+				require.NoError(t, os.MkdirAll(registryDataPath, 0755))
+
+				testFile := filepath.Join(registryDataPath, "test-data.txt")
+				require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0644))
+			}
 
 			fakeMCClient := fake.NewClientset(tc.mcn.obj)
 			mcInformerFactory := mcfginformers.NewSharedInformerFactory(fakeMCClient, func() time.Duration { return 0 }())
@@ -153,13 +200,14 @@ func TestInternalReleaseImageManager(t *testing.T) {
 			}
 			// Provide a dummy auth token so the manager doesn't try to read
 			// /var/lib/kubelet/config.json (which doesn't exist in unit tests).
-			iriManager.authToken = "dGVzdDp0ZXN0" // base64("test:test")
+			iriManager.authToken = "dGVzdDp0ZXN0"          // base64("test:test")
+			iriManager.registryDataPath = registryDataPath // Use test directory (may not exist)
 			require.NoError(t, iriManager.syncHandler(common.InternalReleaseImageInstanceName))
 
 			if tc.mcn != nil {
 				mcnUpdated, err := fakeMCClient.MachineconfigurationV1().MachineConfigNodes().Get(context.Background(), tc.mcn.obj.Name, metav1.GetOptions{})
 				require.NoError(t, err)
-				tc.verify(t, mcnUpdated)
+				tc.verify(t, mcnUpdated, registryDataPath)
 			}
 		})
 	}

--- a/pkg/daemon/internalreleaseimage/iriregistry.go
+++ b/pkg/daemon/internalreleaseimage/iriregistry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -50,7 +51,7 @@ func newIRIRegistry(nodeName string, client *http.Client, authToken string) *iri
 	return &iriRegistry{
 		nodeName:         nodeName,
 		client:           client,
-		registryHostPort: fmt.Sprintf("%s:%d", iriRegistryHost, iriRegistryPort),
+		registryHostPort: net.JoinHostPort(iriRegistryHost, fmt.Sprintf("%d", iriRegistryPort)),
 		authToken:        authToken,
 	}
 }


### PR DESCRIPTION
**- What I did**
This patch adds a new behavior to IRI MCD manager to reclaim the disk space on the control plane in case of IRI removal (this happens when the user decides to opt-out from the feature).
Also, this patch adds the necessary Claude skill files to provide more context for the code generation of the specific new behavior.

**- How to verify it**
Deploy an OCP cluster using the OVE ISO, then delete the IRI resource (this requires a previous upgrade)

**- Description for the changelog**
Reclaim disk space on node when the InternalReleaseImage resource is deleted.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful cleanup of local registry storage when the InternalReleaseImage is deleted; improved handling while deletion is in progress.

* **Bug Fixes**
  * Fixed registry host/port address formatting for broader network compatibility.

* **Tests**
  * Added scenarios covering deletion with active vs. inactive registry and a deletion-timestamp test helper.

* **Documentation**
  * Added acceptance criteria and workflow docs for feature-disabled and storage-reclaim behaviors.

* **Chores**
  * Added a configurable default for the local registry data path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->