### PR TITLE
OCPBUGS-84814: Skip chrony-wait on first node join

### DIFF
--- a/templates/common/_base/units/chrony-wait.service.yaml
+++ b/templates/common/_base/units/chrony-wait.service.yaml
@@ -1,0 +1,11 @@
+name: chrony-wait.service
+dropins:
+  - name: 10-skip-on-first-join.conf
+    contents: |
+      # Only wait for chrony to sync when we're already a node.
+      # This reduces node bootstrapping by 10-24 seconds depending on the platform
+      # by allowing the Kubelet to start retrieving images that are required to achieve
+      # NodeReady. This also relies on the assumption that chrony sync'd during the first
+      # (previous) boot where rpm-ostree rebase takes 30+ seconds.
+      [Unit]
+      ConditionPathExists=/var/lib/kubelet/pki/kubelet-client-current.pem


### PR DESCRIPTION
## Summary

`chrony-wait.service` blocks boot 2 for 7–24 s waiting for NTP synchronization. On first node join this is unnecessary — `chronyd` has been running throughout boot 1 (~2 minutes) and the clock has either synchronized the RTC updated or it will likely never synchronize, perhaps chrony is misconfigured.

Additionally, the primary concern is Kubelet handling of probes when the clock jumps forward. Given this will only skip the wait when there's no workload present, because the node hasn't joined yet, that is not likely to be a problem.

A single drop-in skips `chrony-wait` when the kubelet client cert is absent, which reliably identifies a first-join boot:

```ini
[Unit]
ConditionPathExists=/var/lib/kubelet/pki/kubelet-client-current.pem
```

`chrony-wait` runs normally on all subsequent reboots once the node has joined.

## Test plan

- [x] Fresh node scale-up: `chrony-wait` skipped, clock synchronized after boot
- [x] Reboot of joined node: `chrony-wait` runs normally
- [x] Initial cluster install: `chrony-wait` skipped on every node's first boot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Potential Future Improvements
It would be nice if we were able to reduce the Kubelet start time on all reboots, benefiting rolling restarts as well. To achieve that we could either
- Increase the tolerance to 1s or 10s in chrony-wait like `ExecStart=/usr/bin/chronyc -h 127.0.0.1,::1 waitsync 0 10 0.0 1` and adjust the Azure specific config to increase polling frequency `refclock PHC /dev/ptp_hyperv poll 0 dpoll -2 offset 0` where `poll 0` means poll every 2^0 seconds and 3-4 measurements are required, reducing to 3-4s.
- Periodically touch /var/lib/chrony/sync-stamp, then skip `chrony-wait.service` whenever that file is within some threshold of the current clock, assuming that if we reboot the clock will be relatively accurate unless the host's clock is exceeds our threshold since last sync.

* **Bug Fixes**
  * chrony-wait now skips waiting when the kubelet client certificate path is absent, preventing unnecessary delays during startup and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->