### PR TITLE
OCPBUGS-84516: Add `terminationMessagePolicy` to build pod containers

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -653,12 +653,13 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 			InitContainers: []corev1.Container{
 				{
 					// This container performs the image build / push process.
-					Name:            "image-build",
-					Image:           br.opts.Images.MachineConfigOperator,
-					Env:             env,
-					Command:         append(command, buildahBuildScript),
-					ImagePullPolicy: corev1.PullAlways,
-					SecurityContext: securityContext,
+					Name:                     "image-build",
+					Image:                    br.opts.Images.MachineConfigOperator,
+					Env:                      env,
+					Command:                  append(command, buildahBuildScript),
+					ImagePullPolicy:          corev1.PullAlways,
+					SecurityContext:          securityContext,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					// Only attach the buildah-cache volume mount to the buildah container.
 					VolumeMounts: append(volumeMounts, corev1.VolumeMount{
 						Name:      "buildah-cache",
@@ -673,13 +674,14 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 					// the base OS image (which contains the "oc" binary) to create a
 					// ConfigMap from the digestfile that Buildah creates, which allows
 					// us to avoid parsing log files.
-					Name:            "create-digest-configmap",
-					Command:         append(command, digestCMScript),
-					Image:           br.opts.MachineConfig.Spec.OSImageURL,
-					Env:             env,
-					ImagePullPolicy: corev1.PullAlways,
-					SecurityContext: securityContext,
-					VolumeMounts:    volumeMounts,
+					Name:                     "create-digest-configmap",
+					Command:                  append(command, digestCMScript),
+					Image:                    br.opts.MachineConfig.Spec.OSImageURL,
+					Env:                      env,
+					ImagePullPolicy:          corev1.PullAlways,
+					SecurityContext:          securityContext,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					VolumeMounts:             volumeMounts,
 				},
 			},
 			ServiceAccountName:            "machine-os-builder",


### PR DESCRIPTION
Closes: OCPBUGS-84516

**- What I did**
This adds a `TerminationMessagePolicy` of type `TerminationMessageFallbackToLogsOnError` to the build containers created dynamically.

**- How to verify it**
The `[Monitor:termination-message-policy][sig-arch] all containers in ns/openshift-machine-config-operator must have terminationMessagePolicy=FallbackToLogsOnError` test should pass when the MCO namespace exception is removed, so when tested with https://github.com/openshift/origin/pull/31120.

**- Description for the changelog**
OCPBUGS-84516: Add `terminationMessagePolicy` to build pod containers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build container error reporting and logging by improving termination message handling. Optimized build container initialization with refined volume mount configuration for better system reliability during build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->