### PR TITLE
MCO-2257: make rhel-10 the default for new installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,10 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     # comment out rhel-coreos-10 for scos
     sed -i '/- name: rhel-coreos-10/,+3 s/^/#/' /manifests/* && \
     # rewrite image names for scos
-    sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi && \
+    sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; \
+    else \
+    # rewrite image names for rhel-coreos-10
+    sed -i 's/rhel-coreos/rhel-coreos-10/g' /manifests/0000_80_machine-config_05_osimageurl.yaml; fi && \
     dnf -y install 'nmstate >= 2.2.10' && \
     if ! rpm -q util-linux; then dnf install -y util-linux; fi && \
     # We also need to install fuse-overlayfs and cpp for Buildah to work correctly.

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -30,7 +30,10 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
     # comment out rhel-coreos-10 for scos
     sed -i '/- name: rhel-coreos-10/,+3 s/^/#/' /manifests/* && \
     # rewrite image names for scos
-    sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; fi && \
+    sed -i 's/rhel-coreos/stream-coreos/g' /manifests/*; \
+    else \
+    # rewrite image names for rhel-coreos-10
+    sed -i 's/rhel-coreos/rhel-coreos-10/g' /manifests/0000_80_machine-config_05_osimageurl.yaml; fi && \
     dnf -y install 'nmstate >= 2.2.10' && \
     if ! rpm -q util-linux; then dnf install -y util-linux; fi && \
     # We also need to install fuse-overlayfs and cpp for Buildah to work correctly.

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -109,7 +109,7 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
 
-	baseOSContainerImageTag := "rhel-coreos"
+	baseOSContainerImageTag := "rhel-coreos-10"
 	if version.IsFCOS() {
 		baseOSContainerImageTag = "fedora-coreos"
 	} else if version.IsSCOS() {

--- a/install/image-references
+++ b/install/image-references
@@ -31,11 +31,11 @@ spec:
   - name: rhel-coreos-10
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel10-coreos
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-10
   - name: rhel-coreos-10-extensions
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel10-coreos-extensions
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:rhel-coreos-10-extensions
   - name: keepalived-ipfailover
     from:
       kind: DockerImage

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -1174,12 +1174,15 @@ func TestInstallRPMAndCheckMCDMetrics(t *testing.T) {
 
 	// Download the RPM package on the node
 	t.Logf("Downloading the RPM package on node %s", node.Name)
+	pkg := "epel-release-latest-10.noarch.rpm"
+	pkgSrc := "https://dl.fedoraproject.org/pub/epel/" + pkg
+	pkgDest := filepath.Join("/tmp", pkg)
 	downloadCmd := []string{
-		"chroot", "/rootfs", "curl", "-KL", "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm", "-o", "/tmp/epel-release-latest-9.noarch.rpm",
+		"chroot", "/rootfs", "curl", "-L", pkgSrc, "-o", pkgDest,
 	}
 
-	_, err := helpers.ExecCmdOnNodeWithError(cs, node, downloadCmd...)
-	require.NoError(t, err, "Failed to download RPM package on node %s: %v", node.Name, err)
+	output, err := helpers.ExecCmdOnNodeWithError(cs, node, downloadCmd...)
+	require.NoError(t, err, "Failed to download RPM package on node %s: %v: error: %v", node.Name, output, err)
 	t.Logf("RPM package downloaded successfully")
 
 	// Reboot the node to apply changes
@@ -1191,7 +1194,7 @@ func TestInstallRPMAndCheckMCDMetrics(t *testing.T) {
 	t.Logf("Executing rpm-ostree install command on node %s", node.Name)
 	// Install the RPM package
 	installCmd := []string{
-		"chroot", "/rootfs", "rpm-ostree", "install", "/tmp/epel-release-latest-9.noarch.rpm",
+		"chroot", "/rootfs", "rpm-ostree", "install", pkgDest,
 	}
 
 	out, err := helpers.ExecCmdOnNodeWithError(cs, node, installCmd...)

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -112,7 +112,7 @@ func TestRunShared(t *testing.T) {
 func TestKernelArguments(t *testing.T) {
 	cs := framework.NewClientSet("")
 
-	delete := helpers.CreateMCP(t, cs, "infra")
+	deleteMCP := helpers.CreateMCP(t, cs, "infra")
 	workerOldMc := helpers.GetMcName(t, cs, "worker")
 
 	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
@@ -124,7 +124,7 @@ func TestKernelArguments(t *testing.T) {
 		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
 			t.Fatal(err)
 		}
-		delete()
+		deleteMCP()
 		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
 	})
 	// create old mc to have something to verify we successfully rolled back
@@ -204,7 +204,7 @@ func TestKernelType(t *testing.T) {
 		t.Skip("skipping test on OKD")
 	}
 
-	delete := helpers.CreateMCP(t, cs, "infra")
+	deleteMCP := helpers.CreateMCP(t, cs, "infra")
 	workerOldMc := helpers.GetMcName(t, cs, "worker")
 
 	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
@@ -216,9 +216,8 @@ func TestKernelType(t *testing.T) {
 		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
 			t.Fatal(err)
 		}
-		delete()
+		deleteMCP()
 		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
-
 	})
 
 	_, err = cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
@@ -296,12 +295,11 @@ func TestKernelType(t *testing.T) {
 	}
 	err = helpers.WaitForPoolComplete(t, cs, "infra", oldInfraRenderedConfig)
 	require.Nil(t, err)
-
 }
 
 func TestNoReboot(t *testing.T) {
 	cs := framework.NewClientSet("")
-	delete := helpers.CreateMCP(t, cs, "infra")
+	deleteMCP := helpers.CreateMCP(t, cs, "infra")
 	workerOldMc := helpers.GetMcName(t, cs, "worker")
 
 	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
@@ -313,13 +311,14 @@ func TestNoReboot(t *testing.T) {
 		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
 			t.Fatal(err)
 		}
-		delete()
+		deleteMCP()
 		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
-
 	})
 	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
 	require.Nil(t, err)
 	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+	require.NoError(t, err)
+
 	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
 
 	sshKeyContent := "test adding authorized key without node reboot"
@@ -545,7 +544,7 @@ func TestPoolDegradedOnFailToRender(t *testing.T) {
 func TestDontDeleteRPMFiles(t *testing.T) {
 	cs := framework.NewClientSet("")
 
-	delete := helpers.CreateMCP(t, cs, "infra")
+	deleteMCP := helpers.CreateMCP(t, cs, "infra")
 	workerOldMc := helpers.GetMcName(t, cs, "worker")
 
 	unlabelFunc := helpers.LabelRandomNodeFromPool(t, cs, "worker", "node-role.kubernetes.io/infra")
@@ -557,9 +556,8 @@ func TestDontDeleteRPMFiles(t *testing.T) {
 		if err := helpers.WaitForPoolComplete(t, cs, "worker", workerOldMc); err != nil {
 			t.Fatal(err)
 		}
-		delete()
+		deleteMCP()
 		require.Nil(t, cs.MachineConfigs().Delete(context.TODO(), oldInfraConfig.Name, metav1.DeleteOptions{}))
-
 	})
 
 	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -407,8 +407,11 @@ func TestNoReboot(t *testing.T) {
 
 	currentEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
 
-	if currentEtcShadowContents == initialEtcShadowContents {
-		t.Fatalf("updated password hash not found in etc/shadow, got %s", currentEtcShadowContents)
+	initialPasswordHash := extractPasswordHashFromShadowLine(initialEtcShadowContents)
+	currentPasswordHash := extractPasswordHashFromShadowLine(currentEtcShadowContents)
+
+	if currentPasswordHash == initialPasswordHash {
+		t.Fatalf("updated password hash not found in etc/shadow")
 	}
 
 	t.Logf("Node %s has Password Hash", infraNode.Name)
@@ -488,7 +491,9 @@ func TestNoReboot(t *testing.T) {
 	require.Nil(t, err)
 
 	rollbackEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
-	assert.Equal(t, initialEtcShadowContents, rollbackEtcShadowContents)
+
+	assert.Equal(t, extractPasswordHashFromShadowLine(initialEtcShadowContents), extractPasswordHashFromShadowLine(rollbackEtcShadowContents),
+		"password hash should match after rollback")
 }
 
 func TestPoolDegradedOnFailToRender(t *testing.T) {
@@ -940,6 +945,17 @@ func assertExpectedPerms(t *testing.T, cs *framework.ClientSet, node corev1.Node
 
 	actualPerms := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "stat", "--format=%U %G %a", path), "\n"), " ")
 	assert.Equal(t, expectedPerms, actualPerms, "expected %s to have perms %v, got: %v", path, expectedPerms, actualPerms)
+}
+
+// extractPasswordHashFromShadowLine extracts the password hash field from an /etc/shadow line.
+// The shadow file format is: username:password:lastchg:min:max:warn:inactive:expire:reserved
+// This function returns the password hash (field index 1).
+func extractPasswordHashFromShadowLine(shadowLine string) string {
+	fields := strings.Split(strings.TrimSpace(shadowLine), ":")
+	if len(fields) < 2 {
+		return ""
+	}
+	return fields[1]
 }
 
 // Tests that changes to the internal image registry pull secret has the

--- a/test/e2e-ocl-shared/Containerfile.cowsay
+++ b/test/e2e-ocl-shared/Containerfile.cowsay
@@ -1,9 +1,11 @@
-FROM quay.io/centos/centos:stream9 AS centos
-RUN dnf install -y epel-release
+FROM quay.io/centos/centos:stream10 AS centos
+RUN dnf install -y epel-release && \
+  sed -i 's/\$stream/10-stream/g' /etc/yum.repos.d/centos*.repo && \
+  sed -i 's/EPEL\-\$releasever_major/EPEL-10/g' /etc/yum.repos.d/epel*.repo && \
+  sed -i -E 's/\$\{releasever_minor\:\+\-z\}//g' /etc/yum.repos.d/epel*.repo
 
 FROM configs AS final
 COPY --from=centos /etc/yum.repos.d /etc/yum.repos.d
 COPY --from=centos /etc/pki/rpm-gpg/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
-RUN sed -i 's/\$stream/9-stream/g' /etc/yum.repos.d/centos*.repo && \
-    rpm-ostree install cowsay && \
-		ostree container commit
+RUN dnf install -y cowsay && \
+  ostree container commit

--- a/test/e2e-ocl-shared/helpers.go
+++ b/test/e2e-ocl-shared/helpers.go
@@ -861,7 +861,7 @@ func SkipIfEntitlementNotPresent(t *testing.T, cs *framework.ClientSet) {
 	require.NoError(t, err)
 }
 
-// Uses the centos stream 9 container and extracts the contents of both the
+// Uses the centos stream 10 container and extracts the contents of both the
 // /etc/yum.repos.d and /etc/pki/rpm-gpg directories and injects those into a
 // ConfigMap and Secret, respectively. This is so that the build process will
 // consume those objects as part of the build process, injecting them into the
@@ -872,7 +872,7 @@ func InjectYumRepos(t *testing.T, cs *framework.ClientSet, skipCleanupAlways, sk
 	yumReposPath := filepath.Join(tempDir, "yum-repos-d")
 	require.NoError(t, os.MkdirAll(yumReposPath, 0o755))
 
-	centosPullspec := "quay.io/centos/centos:stream9"
+	centosPullspec := "quay.io/centos/centos:stream10"
 	yumReposContents := ConvertFilesFromContainerImageToBytesMap(t, centosPullspec, "/etc/yum.repos.d/")
 	rpmGpgContents := ConvertFilesFromContainerImageToBytesMap(t, centosPullspec, "/etc/pki/rpm-gpg/")
 

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -114,8 +114,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 			containerFileContent = `
 	# Pull the centos base image and enable the EPEL repository.
-        FROM quay.io/centos/centos:stream9 AS centos
-        RUN dnf install -y epel-release
+        FROM quay.io/centos/centos:stream10 AS centos
+        RUN dnf install -y epel-release && \
+	          sed -i 's/\$stream/10-stream/g' /etc/yum.repos.d/centos*.repo && \
+	          sed -i 's/EPEL\-\$releasever_major/EPEL-10/g' /etc/yum.repos.d/epel*.repo && \
+	          sed -i -E 's/\$\{releasever_minor\:\+\-z\}//g' /etc/yum.repos.d/epel*.repo
 
         # Pull an image containing the yq utility.
         FROM quay.io/multi-arch/yq:4.25.3 AS yq
@@ -130,8 +133,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
         # Install cowsay and ripgrep from the EPEL repository into the final image,
         # along with a custom cow file.
-        RUN sed -i 's/\$stream/9-stream/g' /etc/yum.repos.d/centos*.repo && \
-            rpm-ostree install cowsay ripgrep
+        RUN dnf install -y cowsay ripgrep
 `
 
 			checkers = []Checker{

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -781,7 +781,7 @@ type SSHPaths struct {
 
 // Determines where to expect SSH keys for the core user on a given node based upon the node's OS.
 func GetSSHPaths(os osrelease.OperatingSystem) SSHPaths {
-	if os.IsEL9() || os.IsSCOS() || os.IsFCOS() {
+	if os.IsEL9() || os.IsEL10() || os.IsSCOS() || os.IsFCOS() {
 		return SSHPaths{
 			Expected:    constants.RHCOS9SSHKeyPath,
 			NotExpected: constants.RHCOS8SSHKeyPath,


### PR DESCRIPTION
**- What I did**

This updates the MCO's Dockerfiles to set the RHEL 10 image as the default OS image for new installs.

**- How to verify it**

Bring up a new cluster with this PR and it should be running RHEL 10.

**- Description for the changelog**
Use RHEL 10 by default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image selection and rewrite logic so the proper OS image tags are chosen across deployment variants; default bootstrap image tag updated to RHEL CoreOS 10.

* **Tests**
  * Updated test container bases and repository rewrites to Stream 10; switched some test builds to use dnf installs.
  * Improved test helpers, cleanup patterns, and password-hash comparison/assertions.

* **Chores**
  * Standardized RHEL CoreOS image reference names for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->