### PR TITLE
AGENT-1514: Add ML-KEM verification test for IRI registry

### DIFF
--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -25,9 +25,12 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/test/framework"
 	"github.com/openshift/machine-config-operator/test/helpers"
 )
+
+const iriRootCAPath = "/rootfs" + constants.IRIRootCAPath
 
 func TestIRIResource_Available(t *testing.T) {
 	skipIfNoBaremetal(t)
@@ -212,7 +215,6 @@ func getBaseDomain(t *testing.T, cs *framework.ClientSet) string {
 // Returns the HTTP status code string (e.g. "200", "401").
 func curlIRIRegistry(t *testing.T, cs *framework.ClientSet, node corev1.Node, baseDomain string, extraArgs ...string) string {
 	t.Helper()
-	const iriRootCAPath = "/rootfs/etc/pki/ca-trust/source/anchors/iri-root-ca.crt"
 	url := fmt.Sprintf("https://api-int.%s:%d/v2/", baseDomain, ctrlcommon.IRIRegistryPort)
 	args := []string{"curl", "-s", "--cacert", iriRootCAPath, "-o", "/dev/null", "-w", "%{http_code}"}
 	args = append(args, extraArgs...)
@@ -429,4 +431,29 @@ func TestCertRotation_IRICertIsRegeneratedOnCARotation(t *testing.T) {
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	})
 	require.NoError(t, err, "Rotated IRI TLS cert should be signed by the new MCS CA")
+}
+
+// TestIRIController_VerifyMLKEMSupport verifies that the IRI registry supports
+// ML-KEM (post-quantum) key exchange as required for OpenShift 4.22+.
+func TestIRIController_VerifyMLKEMSupport(t *testing.T) {
+	skipIfNoBaremetal(t)
+
+	cs := framework.NewClientSet("")
+
+	baseDomain := getBaseDomain(t, cs)
+	node := helpers.GetRandomNode(t, cs, "master")
+
+	target := fmt.Sprintf("api-int.%s:%d", baseDomain, ctrlcommon.IRIRegistryPort)
+
+	output := helpers.ExecCmdOnNode(t, cs, node,
+		"bash", "-c",
+		fmt.Sprintf("echo | openssl s_client -connect %s -CAfile %s -groups X25519MLKEM768 -tls1_3 -verify_return_error 2>&1 | grep -E 'Cipher|TLSv1.3|group'",
+			target, iriRootCAPath))
+
+	t.Logf("openssl s_client output:\n%s", output)
+
+	require.Contains(t, output, "TLSv1.3", "IRI registry should support TLS 1.3")
+	require.True(t,
+		strings.Contains(output, "X25519MLKEM768") || strings.Contains(output, "x25519_mlkem768"),
+		"IRI registry should support X25519MLKEM768 (ML-KEM) key exchange. Output: %s", output)
 }


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new e2e test TestIRIController_VerifyMLKEMSupport that verifies the IRI registry supports ML-KEM post-quantum key exchange (X25519MLKEM768) as required for OpenShift 4.22+. The test connects to the registry via api-int using the IRI CA cert and openssl s_client, explicitly requesting the X25519MLKEM768 key exchange group, then asserts that TLS 1.3 was negotiated and the ML-KEM group was used.   

**- How to verify it**

Run on cluster with NoRegistryClusterInstall feature gate:
go test ./test/e2e-iri/... -run TestIRIController_VerifyMLKEMSupport -v -timeout 5m                                                
Expected output:                                                                   
Negotiated TLS1.3 group: X25519MLKEM768                                                                                            
New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256                                                                                     
--- PASS: TestIRIController_VerifyMLKEMSupport 

**- Description for the changelog**

Add e2e test to verify IRI registry supports ML-KEM (X25519MLKEM768) post-quantum key exchange over TLS 1.3.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for ML-KEM post-quantum key exchange support in the IRI registry with dedicated capability validation tests.
  * Improved test infrastructure with dynamic certificate path configuration for better environment adaptability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->