### PR TITLE
OCPBUGS-85117: Fix 2 flakes happening in the ocl test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ test-e2e-ocl-1of2: install-go-junit-report install-skopeo
 	set -o pipefail; PATH="$(PATH):/tmp/skopeo/bin" go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-ocl-1of2/ ./test/e2e-ocl-shared/ | ./hack/test-with-junit.sh $(@)
 
 test-e2e-ocl-2of2: install-go-junit-report install-skopeo
-	set -o pipefail; PATH="$(PATH):/tmp/skopeo/bin" go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-ocl-2of2/ ./test/e2e-ocl-shared/ | ./hack/test-with-junit.sh $(@)
+	set -o pipefail; PATH="$(PATH):/tmp/skopeo/bin" go test -tags=$(GOTAGS) -failfast -timeout 150m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-ocl-2of2/ ./test/e2e-ocl-shared/ | ./hack/test-with-junit.sh $(@)
 
 test-e2e-iri: install-go-junit-report
 	set -o pipefail; go test -tags=$(GOTAGS) -failfast -timeout 120m -v$${WHAT:+ -run="$$WHAT"} ./test/e2e-iri/ | ./hack/test-with-junit.sh $(@)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -191,6 +191,13 @@ func (b *buildReconciler) deleteMachineOSConfig(ctx context.Context, mosc *mcfgv
 	}
 
 	for _, mosb := range mosbList {
+		// Only delete MOSBs owned by this specific MOSC instance. A new MOSC
+		// with the same name (but different UID) may already exist and have
+		// created new MOSBs that match the same label selector.
+		if !metav1.IsControlledBy(mosb, mosc) {
+			klog.Infof("Skipping MachineOSBuild %s: not owned by deleted MachineOSConfig %s (UID %s)", mosb.Name, mosc.Name, mosc.UID)
+			continue
+		}
 		if err := b.deleteMachineOSBuild(ctx, mosb); err != nil {
 			return fmt.Errorf("could not delete MachineOSBuild %s for MachineOSConfig %s: %w", mosb.Name, mosc.Name, err)
 		}

--- a/test/helpers/assertions.go
+++ b/test/helpers/assertions.go
@@ -674,6 +674,9 @@ func (a *Assertions) machineOSBuildHasConditionTrue(mosb *mcfgv1.MachineOSBuild,
 
 	stateFunc := func(apiMosb *mcfgv1.MachineOSBuild, err error) (bool, error) {
 		if err != nil {
+			if a.poll && k8serrors.IsNotFound(err) {
+				return false, nil
+			}
 			return false, err
 		}
 


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/OCPBUGS-85117
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed two flakes happening in the sharded ocl test suites.

**- How to verify it**
OCL test suites should pass

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent unintended deletion of resources when removing configurations, ensuring only directly associated resources are affected.

* **Tests**
  * Improved test reliability by enhancing error handling during polling operations to gracefully handle transient conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->