### PR TITLE
NO-JIRA: daemon: expand os image presence check

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2801,19 +2801,12 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 		return dn.InplaceUpdateViaNewContainer(newURL)
 	}
 
-	isPisConfigured, err := dn.isPinnedImageSetConfigured()
+	// Check to see if the new container image is already present.
+	// This could happen if PIS is configured or if the bootloader
+	// update happened (which pulls the container down).
+	podmanImageInfo, err := dn.podmanInterface.GetPodmanImageInfoByReference(newURL)
 	if err != nil {
-		// Ignore the error and default to remote pull
-		klog.Errorf("Failed to determine if pinned image set is configured: %v", err)
-	}
-
-	// If PIS is configured check if the image is locally present. If so, rebase using
-	// the local image
-	var podmanImageInfo *PodmanImageInfo
-	if isPisConfigured {
-		if podmanImageInfo, err = dn.podmanInterface.GetPodmanImageInfoByReference(newURL); err != nil {
-			return err
-		}
+		return err
 	}
 
 	// For image mode status reporting we need the node's MCP association to populate its MCN
@@ -2902,28 +2895,6 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	}
 
 	return nil
-}
-
-func (dn *Daemon) isPinnedImageSetConfigured() (bool, error) {
-	if dn.node == nil || dn.mcpLister == nil {
-		// If we are here it means we are in the MCD first boot run. No connection to the cluster
-		// and the node not being populated means we cannot check the PIS config.
-		return false, nil
-	}
-
-	// PIS is enabled. Check if it's configured in any of its pools
-	pools, _, err := helpers.GetPoolsForNode(dn.mcpLister, dn.node)
-	if err != nil {
-		return false, fmt.Errorf("failed to get pools for node %q: %w", dn.node.Name, err)
-	}
-
-	for _, pool := range pools {
-		if pool.Spec.PinnedImageSets != nil && len(pool.Spec.PinnedImageSets) > 0 {
-			return true, nil
-		}
-	}
-	// No pools with PIS configured
-	return false, nil
 }
 
 // TODO: Delete this function to always consume the CommandRunner interface instance


### PR DESCRIPTION
**- What I did**

In #5868 [1] we started running bootupd from the OS update container, which means the container image gets pulled down and is already present. Let's expand the GetPodmanImageInfoByReference check here to run it unconditionally, not just if isPisConfigured.

This should prevent us pulling the OS image into container storage and then having rpm-ostree separately pull it (directly into ostree storage). If podmanImageInfo isn't nil then we'll rebase directly from `containers-storage:` transport.

[1] https://github.com/openshift/machine-config-operator/pull/5868

**- How to verify it**

Look at the logs and verify the rebase is coming from `containers-storage:`. 

**- Description for the changelog**

Tell rpm-ostree rebase to use the image from containers-storage if the image is already present, which will be true if we previously updated the bootloader.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OS updates now always check for and reuse locally cached images when available, reducing redundant downloads and speeding updates.
  * Local image lookup errors are reported earlier in the update process, improving visibility of update issues.
  * Update status now accurately reflects registry/pull state and retry/backoff behavior when remote pulls occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->