### PR TITLE
OCPBUGS-65645: Verify extension packages are installed

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2349,6 +2349,15 @@ func (dn *Daemon) updateConfigAndState(state *stateAndConfigs) (bool, bool, erro
 		// Great, we've successfully rebooted for the desired config,
 		// let's mark it done!
 
+		// Verify extension packages are actually installed before marking as done
+		// See: https://redhat.atlassian.net/browse/OCPBUGS-65645
+		if dn.os.IsCoreOSVariant() {
+			coreOSDaemon := CoreOSDaemon{dn}
+			if err := coreOSDaemon.verifyExtensionPackages(state.currentConfig); err != nil {
+				return missingODC, inDesiredConfig, fmt.Errorf("extension package verification failed: %w", err)
+			}
+		}
+
 		// Get MCP associated with node
 		pool, err := helpers.GetPrimaryPoolNameForMCN(dn.mcpLister, dn.node)
 		if err != nil {

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1841,7 +1841,119 @@ func (dn *CoreOSDaemon) applyExtensions(oldConfig, newConfig *mcfgv1.MachineConf
 	// Add "update" to the start of argument list
 	args = append([]string{constants.RPMOSTreeUpdateArg}, args...)
 	logSystem("Applying extensions : %+q", args)
-	return runRpmOstree(args...)
+	if err := runRpmOstree(args...); err != nil {
+		return err
+	}
+
+	// Verify extension packages are staged before rebooting
+	// See: https://redhat.atlassian.net/browse/OCPBUGS-65645
+	return dn.verifyExtensionsStaged(newConfig)
+}
+
+// verifyExtensionsStaged verifies that all extension packages specified in a MachineConfig
+// are staged in the rpm-ostree deployment before the node enters a reboot.
+// See: https://redhat.atlassian.net/browse/OCPBUGS-65645
+func (dn *CoreOSDaemon) verifyExtensionsStaged(config *mcfgv1.MachineConfig) error {
+	// Only verify on RHCOS/SCOS nodes
+	if !dn.os.IsEL() {
+		return nil
+	}
+
+	// Get the list of extensions from the config
+	extensions := config.Spec.Extensions
+	if len(extensions) == 0 {
+		// No extensions to verify
+		return nil
+	}
+
+	// Map extensions to actual package names using the existing helper
+	expectedPackages, err := ctrlcommon.GetPackagesForSupportedExtensions(extensions)
+	if err != nil {
+		return fmt.Errorf("failed to get packages for extensions: %w", err)
+	}
+
+	klog.Infof("Verifying %d extension packages are staged for config %s", len(expectedPackages), config.GetName())
+
+	// Get the staged deployment
+	_, staged, err := dn.NodeUpdaterClient.GetBootedAndStagedDeployment()
+	if err != nil {
+		return fmt.Errorf("failed to get staged deployment: %w", err)
+	}
+
+	if staged == nil {
+		return fmt.Errorf("no staged deployment found after applying extensions")
+	}
+
+	// Create a set of requested packages in the staged deployment for quick lookup
+	stagedPackages := sets.New(staged.RequestedPackages...)
+
+	// Verify each expected package is in the staged deployment
+	var missingPackages []string
+	for _, pkg := range expectedPackages {
+		if !stagedPackages.Has(pkg) {
+			missingPackages = append(missingPackages, pkg)
+			klog.Warningf("Extension package %s not found in staged deployment", pkg)
+		}
+	}
+
+	if len(missingPackages) > 0 {
+		return fmt.Errorf("the following extension packages are missing from the staged deployment: %v", missingPackages)
+	}
+
+	klog.Infof("Successfully verified all %d extension packages are staged", len(expectedPackages))
+	return nil
+}
+
+// verifyExtensionPackages verifies that all extension packages specified in a
+// MachineConfig are actually installed in the RPM database after a node reboot.
+// See: https://redhat.atlassian.net/browse/OCPBUGS-65645
+func (dn *CoreOSDaemon) verifyExtensionPackages(config *mcfgv1.MachineConfig) error {
+	// Only verify on RHCOS/SCOS nodes
+	if !dn.os.IsEL() {
+		return nil
+	}
+
+	// Get the list of extensions from the config
+	extensions := config.Spec.Extensions
+	if len(extensions) == 0 {
+		// No extensions to verify
+		return nil
+	}
+
+	// Map extensions to actual package names using the existing helper
+	expectedPackages, err := ctrlcommon.GetPackagesForSupportedExtensions(extensions)
+	if err != nil {
+		return fmt.Errorf("failed to get packages for extensions: %w", err)
+	}
+
+	klog.Infof("Verifying %d extension packages are installed for config %s", len(expectedPackages), config.GetName())
+
+	// Verify each package is in the RPM database
+	var missingPackages []string
+	var exitErr *exec.ExitError
+	for _, pkg := range expectedPackages {
+		// Query RPM database directly for installed packages
+		out, err := exec.Command("rpm", "-q", pkg).CombinedOutput()
+		if err == nil {
+			continue
+		}
+		// Check if this is exit code 1 (package not installed) vs other errors
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			missingPackages = append(missingPackages, pkg)
+			klog.Warningf("Extension package %s not found in RPM database", pkg)
+			continue
+		}
+
+		// Other errors (execution failure, permission issues, etc.) should fail immediately
+		return fmt.Errorf("failed to query RPM database for package %q: %v: %s", pkg, err, strings.TrimSpace(string(out)))
+	}
+
+	if len(missingPackages) > 0 {
+		return fmt.Errorf("the following extension packages are missing from the RPM database: %v", missingPackages)
+	}
+
+	klog.Infof("Successfully verified all %d extension packages are installed", len(expectedPackages))
+	return nil
 }
 
 // switchKernel updates kernel on host with the kernelType specified in MachineConfig.


### PR DESCRIPTION
Closes: OCPBUGS-65645

**- What I did**
_Note that this PR was created with assistance from Claude._

This adds pre-reboot verification to validate that extension packages are successfully staged for install and post-reboot verification to ensure extension packages are actually installed in the RPM database before marking a node as updated. This addresses cases where rpm-ostree reports a success, but packages aren't actually installed. This can lead to tricky debugging situations as was faced in [OCPBUGS-63576](https://redhat.atlassian.net/browse/OCPBUGS-63576) when extension installs seem to succeed, but do not. This implementation follows the pattern used in the existing extension's e2e test for verifying the installed packages. https://github.com/openshift/machine-config-operator/blob/48d0c9d4ac4880c5ef4a4dd80ea3f232c3ac7c0c/test/e2e-2of2/extension_test.go#L87

**- How to verify it**
1. Launch a cluster with this fix included.
2. Apply an MC to install an extension.
3. Force the install to fail due to a package missing. I mocked this by using https://github.com/openshift/machine-config-operator/pull/6016.
4. Wait for the MCP to degrade.
```
$ oc describe mcp infra
Name:         infra
...
Status:
  Conditions:
...
    Last Transition Time:  2026-05-12T18:07:49Z
    Message:               
    Reason:                
    Status:                False
    Type:                  Updated
    Last Transition Time:  2026-05-12T18:07:49Z
    Message:               All nodes are updating to MachineConfig rendered-infra-ed47406e1f118becaf627d34a14ca10d
    Reason:                
    Status:                True
    Type:                  Updating
    Last Transition Time:  2026-05-12T18:11:17Z
    Message:               Node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv is reporting: "Node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv upgrade failure. extension package verification failed: the following extension packages are missing from the RPM database: [sysstat].", Node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv is reporting: "extension package verification failed: the following extension packages are missing from the RPM database: [sysstat]."
    Reason:                1 nodes are reporting degraded status on sync
    Status:                True
    Type:                  NodeDegraded
    Last Transition Time:  2026-05-12T18:11:17Z
    Message:               Node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv is reporting: "Node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv upgrade failure. extension package verification failed: the following extension packages are missing from the RPM database: [sysstat].", Node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv is reporting: "extension package verification failed: the following extension packages are missing from the RPM database: [sysstat]."
    Reason:                
    Status:                True
    Type:                  Degraded
  Degraded Machine Count:  1
  Machine Count:           1
...
```
5. See the degrade errors in the MCD logs.
```
$ oc logs -n openshift-machine-config-operator -c machine-config-daemon machine-config-daemon-g7lzz
...
I0512 18:16:18.069431    2671 update.go:1872] Verifying 1 extension packages are installed for config rendered-infra-ed47406e1f118becaf627d34a14ca10d
W0512 18:16:18.084937    2671 update.go:1889] Extension package sysstat not found in RPM database
E0512 18:16:18.085001    2671 writer.go:231] Marking Degraded due to: "extension package verification failed: the following extension packages are missing from the RPM database: [sysstat]."
I0512 18:16:18.094924    2671 daemon.go:643] Error syncing node ci-ln-6srgi0b-72292-8vmxx-worker-b-5nnnv (retries 24): extension package verification failed: the following extension packages are missing from the RPM database: [sysstat].
```

Note that for a pre-reboot error where not all packages are staged , the degrade will look like the following:
```
    Last Transition Time:  2026-05-15T12:55:05Z
    Message:               Node ci-ln-g1yrbqt-72292-nnmnr-worker-a-qd8xs is reporting: "Node ci-ln-g1yrbqt-72292-nnmnr-worker-a-qd8xs upgrade failure. the following extension packages are missing from the staged deployment: [sysstat]", Node ci-ln-g1yrbqt-72292-nnmnr-worker-a-qd8xs is reporting: "the following extension packages are missing from the staged deployment: [sysstat]"
    Reason:                1 nodes are reporting degraded status on sync
    Status:                True
    Type:                  NodeDegraded
```

**- Description for the changelog**
OCPBUGS-65645: Verify extension packages are installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a CoreOS-only post-reboot check that verifies configured extension packages are present before finalizing an update.
  * If required extension packages are missing, the update is halted and a clear error is reported.
  * Improved diagnostics around extension package verification to make success/failure outcomes more transparent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->