### PR TITLE
MCO-2025: OCP-88366 and add OCP-88814 for osImageStream with osImageURL

### DIFF
--- a/test/extended-priv/machineconfigpool.go
+++ b/test/extended-priv/machineconfigpool.go
@@ -140,7 +140,7 @@ func (mcp *MachineConfigPool) GetOsImageStream() (string, error) {
 
 // GetStatusOsImageStream returns the osImageStream from MCP status
 func (mcp *MachineConfigPool) GetStatusOsImageStream() (string, error) {
-	return mcp.Get(`{.status.osImageStream}`)
+	return mcp.Get(`{.status.osImageStream.name}`)
 }
 
 func (mcp *MachineConfigPool) getConfigNameOfSpec() (string, error) {

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -234,6 +234,95 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("%s is still correctly using rhel-10 stream", firstNode)
 		logger.Infof("OK!\n")
 	})
+
+	g.It("[PolarionID:88366][OTP][Skipped:Disconnected] osImageStream should be empty when osImageURL is set [apigroup:machineconfiguration.openshift.io]", func() {
+		var (
+			testID         = GetCurrentTestPolarionIDNumber()
+			osLayerMCName  = fmt.Sprintf("tc-%s-os-layer-custom", testID)
+			degradedMCName = fmt.Sprintf("tc-%s-degraded-test", testID)
+			crd            = NewResource(oc.AsAdmin(), "crd", "osimagestreams.machineconfiguration.openshift.io")
+			node           *Node
+		)
+
+		exutil.By("Check osimagestreams CRD exists")
+		o.Eventually(crd, "10s", "2s").Should(Exist(),
+			"osimagestreams CRD should exist in the cluster")
+		logger.Infof("osimagestreams CRD found")
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify MCP reports rhel-9 osImageStream in status")
+		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.ContainSubstring(OSImageStreamRHEL9),
+			"%s should report rhel-9 in status.osImageStream", mcp)
+		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
+		logger.Infof("OK!\n")
+
+		exutil.By("Build a custom OS image to use as osImageURL")
+		node = mcp.GetSortedNodesOrFail()[0]
+		osImageBuilder := OsImageBuilderInNode{node: node, dockerFileCommands: "RUN ostree container commit"}
+		digestedImage, err := osImageBuilder.CreateAndDigestOsImage()
+		o.Expect(err).NotTo(o.HaveOccurred(),
+			"Error creating the custom osImage")
+		logger.Infof("Built custom OS image: %s", digestedImage)
+		logger.Infof("OK!\n")
+
+		exutil.By("Apply osImageURL MachineConfig to pool")
+		osLayerMC := NewMachineConfig(oc.AsAdmin(), osLayerMCName, mcp.GetName())
+		osLayerMC.parameters = []string{"OS_IMAGE=" + digestedImage}
+		osLayerMC.skipWaitForMcp = true
+
+		defer osLayerMC.DeleteWithWait()
+		osLayerMC.create()
+		logger.Infof("MachineConfig %s created with osImageURL", osLayerMC.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify osImageStream is empty while pool is updating")
+		o.Eventually(mcp.GetUpdatingStatus, "2m", "10s").Should(o.Equal(TrueString),
+			"%s should be updating after applying osImageURL MC", mcp)
+
+		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
+			"status.osImageStream should be empty when update is in progress with osImageURL set")
+		logger.Infof("osImageStream is empty during update (as expected)")
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for pool update to complete")
+		mcp.waitForComplete()
+		logger.Infof("%s update completed", mcp)
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify osImageStream remains empty after osImageURL is applied")
+		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
+			"In %v status.osImageStream should be empty when osImageURL is set", mcp)
+		logger.Infof("osImageStream is empty with osImageURL applied (as expected)")
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify osImageURL is deployed on node")
+		o.Expect(node.GetCurrentBootOSImage()).To(o.Equal(digestedImage),
+			"Node %s should be running the custom osImageURL", node)
+		logger.Infof("Custom osImageURL is deployed on %s", node)
+		logger.Infof("OK!\n")
+
+		exutil.By("Apply invalid MachineConfig to degrade pool")
+		degradedMC := NewMachineConfig(oc.AsAdmin(), degradedMCName, mcp.GetName())
+		degradedMC.parameters = []string{"IGNITION_VERSION=99.99.0"}
+		degradedMC.skipWaitForMcp = true
+
+		defer degradedMC.DeleteWithWait()
+		degradedMC.create()
+		logger.Infof("Invalid MachineConfig %s created", degradedMC.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for pool to become degraded")
+		o.Eventually(mcp, "5m", "20s").Should(BeDegraded(),
+			"%s should become degraded after applying invalid MC", mcp)
+		logger.Infof("%s is degraded (as expected)", mcp)
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify osImageStream is still empty when pool is degraded with osImageURL configured")
+		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
+			"In %v status.osImageStream should be empty when pool is degraded with osImageURL set", mcp)
+		logger.Infof("osImageStream is empty when degraded (as expected)")
+		logger.Infof("OK!\n")
+	})
 })
 
 // GetEffectiveOsImageStream returns the effective osImageStream for an MCP

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -326,7 +326,14 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		invalidMC.parameters = []string{"OS_IMAGE=" + invalidOsImage}
 		invalidMC.skipWaitForMcp = true
 
-		defer invalidMC.DeleteWithWait()
+		defer func() {
+			if invalidMC.Exists() {
+				invalidMC.DeleteOrFail()
+				o.Eventually(mcp, "5m", "20s").ShouldNot(BeDegraded(),
+					"%s should recover after removing invalid MC", mcp)
+				mcp.waitForComplete()
+			}
+		}()
 		invalidMC.create()
 		logger.Infof("MachineConfig %s created with invalid osImageURL", invalidMC.GetName())
 		logger.Infof("OK!\n")
@@ -344,7 +351,10 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 
 		exutil.By("Delete invalid MachineConfig to recover pool")
-		invalidMC.DeleteWithWait()
+		invalidMC.DeleteOrFail()
+		o.Eventually(mcp, "5m", "20s").ShouldNot(BeDegraded(),
+			"%s should recover after removing invalid MC", mcp)
+		mcp.waitForComplete()
 		logger.Infof("Invalid MachineConfig %s deleted, pool recovered", invalidMC.GetName())
 		logger.Infof("OK!\n")
 

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -303,10 +303,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	g.It("[PolarionID:88814][Skipped:Disconnected] Invalid osImageURL degrades MCP and clears osImageStream status [apigroup:machineconfiguration.openshift.io]", func() {
 		var (
-			testID          = GetCurrentTestPolarionIDNumber()
-			invalidMCName   = fmt.Sprintf("tc-%s-invalid-osimage", testID)
-			invalidOsImage  = "quay.io/mcoqe/invalid-image@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-			crd             = NewResource(oc.AsAdmin(), "crd", "osimagestreams.machineconfiguration.openshift.io")
+			testID         = GetCurrentTestPolarionIDNumber()
+			degradedMCName = fmt.Sprintf("tc-%s-degraded-test", testID)
+			crd            = NewResource(oc.AsAdmin(), "crd", "osimagestreams.machineconfiguration.openshift.io")
 		)
 
 		exutil.By("Check osimagestreams CRD exists")
@@ -321,47 +320,37 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
 		logger.Infof("OK!\n")
 
-		exutil.By("Apply MachineConfig with invalid osImageURL to pool")
-		invalidMC := NewMachineConfig(oc.AsAdmin(), invalidMCName, mcp.GetName())
-		invalidMC.parameters = []string{"OS_IMAGE=" + invalidOsImage}
-		invalidMC.skipWaitForMcp = true
+		exutil.By("Apply invalid MachineConfig to degrade pool")
+		degradedMC := NewMachineConfig(oc.AsAdmin(), degradedMCName, mcp.GetName())
+		degradedMC.parameters = []string{"IGNITION_VERSION=99.99.0"}
+		degradedMC.skipWaitForMcp = true
 
-		defer func() {
-			if invalidMC.Exists() {
-				invalidMC.DeleteOrFail()
-				o.Eventually(mcp, "5m", "20s").ShouldNot(BeDegraded(),
-					"%s should recover after removing invalid MC", mcp)
-				mcp.waitForComplete()
-			}
-		}()
-		invalidMC.create()
-		logger.Infof("MachineConfig %s created with invalid osImageURL", invalidMC.GetName())
+		defer degradedMC.DeleteWithWait()
+		degradedMC.create()
+		logger.Infof("Invalid MachineConfig %s created", degradedMC.GetName())
 		logger.Infof("OK!\n")
 
 		exutil.By("Wait for pool to become degraded")
 		o.Eventually(mcp, "5m", "20s").Should(BeDegraded(),
-			"%s should become degraded after applying invalid osImageURL MC", mcp)
+			"%s should become degraded after applying invalid MC", mcp)
 		logger.Infof("%s is degraded (as expected)", mcp)
 		logger.Infof("OK!\n")
 
-		exutil.By("Verify osImageStream is empty when pool is degraded with osImageURL set")
-		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
-			"In %v status.osImageStream should be empty when pool is degraded with osImageURL set", mcp)
-		logger.Infof("osImageStream is empty when degraded with osImageURL (as expected)")
+		exutil.By("Verify osImageStream is still present when pool is degraded without osImageURL")
+		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.ContainSubstring(OSImageStreamRHEL9),
+			"In %v status.osImageStream should still report rhel-9 when degraded without osImageURL", mcp)
+		logger.Infof("osImageStream still reports rhel-9 when degraded (as expected)")
 		logger.Infof("OK!\n")
 
 		exutil.By("Delete invalid MachineConfig to recover pool")
-		invalidMC.DeleteOrFail()
-		o.Eventually(mcp, "5m", "20s").ShouldNot(BeDegraded(),
-			"%s should recover after removing invalid MC", mcp)
-		mcp.waitForComplete()
-		logger.Infof("Invalid MachineConfig %s deleted, pool recovered", invalidMC.GetName())
+		degradedMC.DeleteWithWait()
+		logger.Infof("Invalid MachineConfig %s deleted, pool recovered", degradedMC.GetName())
 		logger.Infof("OK!\n")
 
-		exutil.By("Verify osImageStream recovers to rhel-9 after cleanup")
+		exutil.By("Verify osImageStream is still rhel-9 after recovery")
 		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.ContainSubstring(OSImageStreamRHEL9),
 			"%s should report rhel-9 in status.osImageStream after recovery", mcp)
-		logger.Infof("%s osImageStream recovered: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
+		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
 		logger.Infof("OK!\n")
 	})
 })

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -336,10 +336,10 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("%s is degraded (as expected)", mcp)
 		logger.Infof("OK!\n")
 
-		exutil.By("Verify osImageStream is still present when pool is degraded without osImageURL")
-		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.ContainSubstring(OSImageStreamRHEL9),
-			"In %v status.osImageStream should still report rhel-9 when degraded without osImageURL", mcp)
-		logger.Infof("osImageStream still reports rhel-9 when degraded (as expected)")
+		exutil.By("Verify osImageStream is empty when pool is degraded")
+		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
+			"In %v status.osImageStream should be empty when pool is degraded", mcp)
+		logger.Infof("osImageStream is empty when degraded (as expected)")
 		logger.Infof("OK!\n")
 
 		exutil.By("Delete invalid MachineConfig to recover pool")

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -235,7 +235,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	g.It("[PolarionID:88366][OTP][Skipped:Disconnected] osImageStream should be empty when osImageURL is set [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[PolarionID:88366][Skipped:Disconnected] osImageStream should be empty when osImageURL is set [apigroup:machineconfiguration.openshift.io]", func() {
 		var (
 			testID        = GetCurrentTestPolarionIDNumber()
 			osLayerMCName = fmt.Sprintf("tc-%s-os-layer-custom", testID)
@@ -301,7 +301,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	g.It("[PolarionID:88814][OTP][Skipped:Disconnected] osImageStream should be empty when pool is degraded with invalid osImageURL [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[PolarionID:88814][Skipped:Disconnected] Invalid osImageURL degrades MCP and clears osImageStream status [apigroup:machineconfiguration.openshift.io]", func() {
 		var (
 			testID          = GetCurrentTestPolarionIDNumber()
 			invalidMCName   = fmt.Sprintf("tc-%s-invalid-osimage", testID)

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -237,11 +237,10 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	g.It("[PolarionID:88366][OTP][Skipped:Disconnected] osImageStream should be empty when osImageURL is set [apigroup:machineconfiguration.openshift.io]", func() {
 		var (
-			testID         = GetCurrentTestPolarionIDNumber()
-			osLayerMCName  = fmt.Sprintf("tc-%s-os-layer-custom", testID)
-			degradedMCName = fmt.Sprintf("tc-%s-degraded-test", testID)
-			crd            = NewResource(oc.AsAdmin(), "crd", "osimagestreams.machineconfiguration.openshift.io")
-			node           *Node
+			testID        = GetCurrentTestPolarionIDNumber()
+			osLayerMCName = fmt.Sprintf("tc-%s-os-layer-custom", testID)
+			crd           = NewResource(oc.AsAdmin(), "crd", "osimagestreams.machineconfiguration.openshift.io")
+			node          *Node
 		)
 
 		exutil.By("Check osimagestreams CRD exists")
@@ -300,27 +299,59 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 			"Node %s should be running the custom osImageURL", node)
 		logger.Infof("Custom osImageURL is deployed on %s", node)
 		logger.Infof("OK!\n")
+	})
 
-		exutil.By("Apply invalid MachineConfig to degrade pool")
-		degradedMC := NewMachineConfig(oc.AsAdmin(), degradedMCName, mcp.GetName())
-		degradedMC.parameters = []string{"IGNITION_VERSION=99.99.0"}
-		degradedMC.skipWaitForMcp = true
+	g.It("[PolarionID:88814][OTP][Skipped:Disconnected] osImageStream should be empty when pool is degraded with invalid osImageURL [apigroup:machineconfiguration.openshift.io]", func() {
+		var (
+			testID          = GetCurrentTestPolarionIDNumber()
+			invalidMCName   = fmt.Sprintf("tc-%s-invalid-osimage", testID)
+			invalidOsImage  = "quay.io/mcoqe/invalid-image@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+			crd             = NewResource(oc.AsAdmin(), "crd", "osimagestreams.machineconfiguration.openshift.io")
+		)
 
-		defer degradedMC.DeleteWithWait()
-		degradedMC.create()
-		logger.Infof("Invalid MachineConfig %s created", degradedMC.GetName())
+		exutil.By("Check osimagestreams CRD exists")
+		o.Eventually(crd, "10s", "2s").Should(Exist(),
+			"osimagestreams CRD should exist in the cluster")
+		logger.Infof("osimagestreams CRD found")
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify MCP reports rhel-9 osImageStream in status")
+		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.ContainSubstring(OSImageStreamRHEL9),
+			"%s should report rhel-9 in status.osImageStream", mcp)
+		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
+		logger.Infof("OK!\n")
+
+		exutil.By("Apply MachineConfig with invalid osImageURL to pool")
+		invalidMC := NewMachineConfig(oc.AsAdmin(), invalidMCName, mcp.GetName())
+		invalidMC.parameters = []string{"OS_IMAGE=" + invalidOsImage}
+		invalidMC.skipWaitForMcp = true
+
+		defer invalidMC.DeleteWithWait()
+		invalidMC.create()
+		logger.Infof("MachineConfig %s created with invalid osImageURL", invalidMC.GetName())
 		logger.Infof("OK!\n")
 
 		exutil.By("Wait for pool to become degraded")
 		o.Eventually(mcp, "5m", "20s").Should(BeDegraded(),
-			"%s should become degraded after applying invalid MC", mcp)
+			"%s should become degraded after applying invalid osImageURL MC", mcp)
 		logger.Infof("%s is degraded (as expected)", mcp)
 		logger.Infof("OK!\n")
 
-		exutil.By("Verify osImageStream is still empty when pool is degraded with osImageURL configured")
+		exutil.By("Verify osImageStream is empty when pool is degraded with osImageURL set")
 		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
 			"In %v status.osImageStream should be empty when pool is degraded with osImageURL set", mcp)
-		logger.Infof("osImageStream is empty when degraded (as expected)")
+		logger.Infof("osImageStream is empty when degraded with osImageURL (as expected)")
+		logger.Infof("OK!\n")
+
+		exutil.By("Delete invalid MachineConfig to recover pool")
+		invalidMC.DeleteWithWait()
+		logger.Infof("Invalid MachineConfig %s deleted, pool recovered", invalidMC.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify osImageStream recovers to rhel-9 after cleanup")
+		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.ContainSubstring(OSImageStreamRHEL9),
+			"%s should report rhel-9 in status.osImageStream after recovery", mcp)
+		logger.Infof("%s osImageStream recovered: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
 		logger.Infof("OK!\n")
 	})
 })


### PR DESCRIPTION

Migrated from openshift-tests-private PR #29780. Verifies that status.osImageStream is not reported in the worker MCP when a custom osImageURL is configured, covering update-in-progress, post-update, and degraded-pool scenarios.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Added new test

**- How to verify it**

**- Description for the changelog**
-   Migrate test OCP-88366 from openshift-tests-private (PR #29780) to machine-config-operator. The test verifies that status.osImageStream is not reported in the worker MCP when a custom osImageURL is configured, covering three scenarios: during MCP update, after update completion, and when the pool is degraded with an invalid MachineConfig.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added two (skipped/disconnected) tests for OS image stream behavior: one verifies the osImageStream status is cleared when a custom OS image is applied and the node boots the custom image; the other verifies an invalid OS image entry degrades the pool, clears osImageStream while degraded, then recovers to the expected status after removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->