### PR TITLE
NO-JIRA: Add fix for ossImagestream status

### DIFF
--- a/test/extended-priv/machineconfigpool.go
+++ b/test/extended-priv/machineconfigpool.go
@@ -140,7 +140,7 @@ func (mcp *MachineConfigPool) GetOsImageStream() (string, error) {
 
 // GetStatusOsImageStream returns the osImageStream from MCP status
 func (mcp *MachineConfigPool) GetStatusOsImageStream() (string, error) {
-	return mcp.Get(`{.status.osImageStream}`)
+	return mcp.Get(`{.status.osImageStream.name}`)
 }
 
 func (mcp *MachineConfigPool) getConfigNameOfSpec() (string, error) {

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -279,12 +279,11 @@ func validateOsImageStreamInPool(mcp *MachineConfigPool, osis *OSImageStream, st
 
 	logger.Infof("%s is correctly using osImage from stream '%s'", firstNode, streamName)
 
-	// TODO: Uncomment when status.osImageStream is populated by MCO
-	// logger.Infof("Checking MCP status.osImageStream")
-	// o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.Equal(streamName),
-	// 	"%s should report stream '%s' in status.osImageStream",
-	// 	mcp, streamName)
-	// logger.Infof("%s correctly reports osImageStream '%s' in status", mcp, streamName)
+	logger.Infof("Checking MCP status.osImageStream")
+	o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.Equal(streamName),
+		"%s should report stream '%s' in status.osImageStream",
+		mcp, streamName)
+	logger.Infof("%s correctly reports osImageStream '%s' in status", mcp, streamName)
 
 	// If stream name is of form "rhel-X", validate RHEL version starts with X
 	var expectedMajorVersion string


### PR DESCRIPTION
**- What I did**
Modified the function  GetStatusOsImageStream(), and updated as per changes of MCP status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of machine configuration pool status field extraction in the test suite to ensure accurate status information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->