### PR TITLE
MCO-2273: MCO-2215: MCO-2183: Migrate remaining TCs from mco.go to MCO, units, kublet suite

### DIFF
--- a/test/extended-priv/mco.go
+++ b/test/extended-priv/mco.go
@@ -1,8 +1,10 @@
 package extended
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -121,6 +123,164 @@ func verifyRenderedMcs(oc *exutil.CLI, renderSuffix string, allRes []ResourceInt
 	}
 
 	return allMcs
+}
+
+var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("mco", exutil.KubeConfigPath())
+
+	g.JustBeforeEach(func() {
+		PreChecks(oc)
+	})
+
+	g.It("[PolarionID:42347][OTP] health check for machine-config-operator [Serial]", func() {
+		exutil.By("make sure that pools are fully updated before executing the checks")
+		// If any previous test created a MC, it can happen that pools are updating and will report Upgradeable=False, failing the test
+		// The checks in this test case only make sense in a cluster that is not updating any pool
+		mMcp := NewMachineConfigPool(oc.AsAdmin(), MachineConfigPoolMaster)
+		mMcp.waitForComplete()
+		wMcp := NewMachineConfigPool(oc.AsAdmin(), MachineConfigPoolWorker)
+		wMcp.waitForComplete()
+
+		exutil.By("checking mco status")
+		co := NewResource(oc.AsAdmin(), "co", "machine-config")
+		coStatus := co.GetOrFail(`{range .status.conditions[*]}{.type}{.status}{"\n"}{end}`)
+		logger.Infof(coStatus)
+		o.Expect(coStatus).Should(
+			o.And(
+				o.ContainSubstring("ProgressingFalse"),
+				o.ContainSubstring("UpgradeableTrue"),
+				o.ContainSubstring("DegradedFalse"),
+				o.ContainSubstring("AvailableTrue"),
+			), "CO machine-config does not have the right condition status.\n%s", co.PrettyString())
+
+		logger.Infof("machine config operator is healthy")
+
+		exutil.By("checking mco pod status")
+		o.Expect(waitForAllMCOPodsReady(oc, 5*time.Minute)).To(o.Succeed(),
+			"Some MCO pods are not Ready")
+		logger.Infof("mco pods are healthy")
+
+		exutil.By("checking mcp status")
+		mcp := NewResource(oc.AsAdmin(), "mcp", "")
+		mcpStatus := mcp.GetOrFail(`{.items[*].status.conditions[?(@.type=="Degraded")].status}`)
+		logger.Infof(mcpStatus)
+		o.Expect(mcpStatus).ShouldNot(o.ContainSubstring("True"))
+		logger.Infof("mcps are not degraded")
+
+	})
+
+	g.It("[PolarionID:43124][OTP] add machine config with invalid ignition version [Serial]", func() {
+		createMcAndVerifyIgnitionVersion(oc, "invalid ign version", "change-worker-ign-version-to-invalid", "3.9.0")
+	})
+
+	g.It("[PolarionID:43726][OTP] azure Controller-Config Infrastructure does not match cluster Infrastructure resource [Serial]", func() {
+		exutil.By("Get machine-config-controller platform status.")
+		mccPlatformStatus := NewResource(oc.AsAdmin(), "controllerconfig", "machine-config-controller").GetOrFail("{.spec.infra.status.platformStatus}")
+		logger.Infof("test mccPlatformStatus:\n %s", mccPlatformStatus)
+
+		if exutil.CheckPlatform(oc) == AzurePlatform {
+			exutil.By("check cloudName field.")
+
+			var jsonMccPlatformStatus map[string]interface{}
+			errparseinfra := json.Unmarshal([]byte(mccPlatformStatus), &jsonMccPlatformStatus)
+			o.Expect(errparseinfra).NotTo(o.HaveOccurred())
+			o.Expect(jsonMccPlatformStatus).Should(o.HaveKey("azure"))
+
+			azure := jsonMccPlatformStatus["azure"].(map[string]interface{})
+			o.Expect(azure).Should(o.HaveKey("cloudName"))
+		}
+
+		exutil.By("Get infrastructure platform status.")
+		infraPlatformStatus := NewResource(oc.AsAdmin(), "infrastructures", "cluster").GetOrFail("{.status.platformStatus}")
+		logger.Infof("infraPlatformStatus:\n %s", infraPlatformStatus)
+
+		exutil.By("Check same status in infra and machine-config-controller.")
+		o.Expect(mccPlatformStatus).To(o.Equal(infraPlatformStatus))
+	})
+
+	g.It("[PolarionID:63868][OTP] ControllerConfig sync after Infrastructure objects are updated [Disruptive]", func() {
+		var (
+			label      = "break.the.mco"
+			labelValue = "yes-tc-63868"
+			infra      = NewResource(oc.AsAdmin(), "Infrastructure", "cluster")
+			mcCO       = NewResource(oc.AsAdmin(), "ClusterOperator", "machine-config")
+		)
+
+		exutil.By("Label a Infrastructure resource")
+		defer func() {
+			// In case of error, the machine-config ClusterOperator will become degraded,
+			// so we need to recover the machine-config CO from degraded state.
+			// It is done by removing the machine-config-operator pod.
+			_ = infra.RemoveLabel(label)
+			oc.AsAdmin().WithoutNamespace().Run("delete").Args("pod", "-n", MachineConfigNamespace,
+				"-l", "k8s-app=machine-config-operator", "--ignore-not-found=true").Execute()
+			o.Eventually(mcCO, "5m", "30s").ShouldNot(BeDegraded(), "Could not recover the machine-config CO from degraded status")
+
+		}()
+		o.Expect(
+			infra.AddLabel(label, labelValue),
+		).To(
+			o.Succeed(),
+			"%s/%s could not be labeled", infra.GetKind(), infra.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Check that machine-config ClusterOperator is not degraded")
+		o.Consistently(mcCO,
+			"5m", "30s").ShouldNot(BeDegraded(),
+			"machine-config ClusterOperator is degraded.\n%s", mcCO.PrettyString())
+		logger.Infof("OK!\n")
+
+	})
+
+	g.It("[PolarionID:68695][OTP] Machine-Config-Operator should not be degraded when image-registry is not installed [Serial]", func() {
+
+		// for cluster setup, we need to use upi-on-aws + baselineCapabilitySet: None, because ipi needs known capability `machine-api`
+		exutil.By("check whether capability ImageRegistry is enabled, if yes, skip the test")
+		if IsCapabilityEnabled(oc, "ImageRegistry") {
+			g.Skip("image registry is installed, skip this test")
+		}
+
+		exutil.By("check operator status, it should not be degraded")
+		mco := NewResource(oc.AsAdmin(), "co", "machine-config")
+		o.Expect(mco).ShouldNot(BeDegraded(),
+			"co/machine-config Degraded condition status is not the expected one: %s", mco.GetConditionByType("Degraded"))
+	})
+
+	g.It("[PolarionID:75258][OTP] No ordering cycle issues should exist [Disruptive]", func() {
+		exutil.By("Check that there are no ordering cycle problems in the nodes")
+		for _, node := range OrFail[[]*Node](NewNodeList(oc.AsAdmin()).GetAllLinux()) {
+			if node.HasTaintEffectOrFail("NoExecute") {
+				logger.Infof("Skipping node %s since it is tainted with NoExecute and no debug pod can be run in it", node.GetName())
+				continue
+			}
+			logger.Infof("Checking node %s", node.GetName())
+			// For debugging purposes. We ignore the error here
+			logMsg, _ := node.DebugNodeWithChroot("sh", "-c", `journalctl -o with-unit | grep "Found ordering cycle" -A 10 || true`)
+			logger.Infof("Orderging cycle messages: %s", logMsg)
+
+			o.Expect(node.DebugNodeWithChroot(`journalctl`, `-o`, `with-unit`)).NotTo(o.ContainSubstring("Found ordering cycle"),
+				"Ordering cycle problems found in node %s", node.GetName())
+		}
+		logger.Infof("OK!\n")
+	})
+})
+
+func createMcAndVerifyIgnitionVersion(oc *exutil.CLI, stepText, mcName, ignitionVersion string) {
+	var (
+		mcTemplate        = "change-worker-ign-version.yaml"
+		mcp               = GetCompactCompatiblePool(oc.AsAdmin())
+		expectedRDMessage = `parsing Ignition config failed: (unknown|invalid) version\. Supported spec versions: 2\.2,3\.0,3\.1,3\.2,3\.3,3\.4,3\.5$`
+		expectedRDReason  = "^$" // empty string
+	)
+	exutil.By(fmt.Sprintf("Create machine config with %s", stepText))
+
+	mc := NewMachineConfig(oc.AsAdmin(), mcName, mcp.GetName()).SetMCOTemplate(mcTemplate)
+	mc.parameters = []string{"IGNITION_VERSION=" + ignitionVersion}
+	mc.skipWaitForMcp = true
+
+	validateMcpRenderDegraded(mc, mcp, expectedRDMessage, expectedRDReason)
 }
 
 func createMcAndVerifyMCValue(oc *exutil.CLI, stepText, mcName string, node *Node, textToVerify TextToVerify, cmd ...string) {

--- a/test/extended-priv/mco_kubelet_and_containerruntime.go
+++ b/test/extended-priv/mco_kubelet_and_containerruntime.go
@@ -361,4 +361,71 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		o.Eventually(NewRemoteFile(node, "/etc/kubernetes/kubelet.conf").Read, "2m", "30s").Should(HaveContent(o.ContainSubstring(`maxPods: 200`)), "Kubelet config was not correctly applied")
 		logger.Infof("OK!\n")
 	})
+
+	g.It("[PolarionID:74540][OTP] kubelet does not start after reboot due to dependency issue [Disruptive]", func() {
+		var (
+			unitEnabled    = true
+			unitName       = "hello.service"
+			filePath       = "/etc/systemd/system/default.target.wants/hello.service"
+			fileContent    = "[Unit]\nDescription=A hello world unit\nAfter=network-online.target\nRequires=network-online.target\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/echo Hello, World\n[Install]\nWantedBy="
+			unitConfig     = getSingleUnitConfig(unitName, unitEnabled, fileContent+"default.target")
+			mcName         = "tc-74540"
+			mcp            = GetCompactCompatiblePool(oc.AsAdmin())
+			node           = mcp.GetSortedNodesOrFail()[0]
+			activeString   = "Active: active"
+			inactiveString = "Active: inactive"
+		)
+
+		exutil.By("Create a MC to deploy a unit.")
+		mc := NewMachineConfig(oc.AsAdmin(), mcName, MachineConfigPoolWorker)
+		mc.parameters = []string{fmt.Sprintf("UNITS=[%s]", unitConfig)}
+		defer mc.DeleteWithWait()
+		mc.create()
+		logger.Infof("OK \n")
+
+		exutil.By("Wait until worker MCP has finished the configuration. No machine should be degraded.")
+		mcp.waitForComplete()
+		logger.Infof("OK \n")
+
+		exutil.By("Verfiy file content is properly applied")
+		rf := NewRemoteFile(node, filePath)
+		o.Expect(rf.Read()).To(HaveContent(fileContent + "default.target"))
+		logger.Infof("OK \n")
+
+		exutil.By("Validate that the hello unit service is active")
+		o.Expect(
+			node.DebugNodeWithChroot("systemctl", "status", unitName),
+		).To(o.And(o.ContainSubstring(activeString), o.Not(o.ContainSubstring(inactiveString))),
+			"%s unit is not active", unitName)
+		logger.Infof("OK \n")
+
+		exutil.By("Update the unit of MC")
+
+		o.Expect(
+			mc.Patch("json", fmt.Sprintf(`[{ "op": "replace", "path": "/spec/config/systemd/units/0/contents", "value": %s}]`, jsonEncode(fileContent+"multi-user.target"))),
+		).To(o.Succeed(), "Error patching %s with the new WantedBy value", fileContent+"multi-user.target")
+
+		logger.Infof("OK \n")
+
+		exutil.By("Wait until worker MCP has finished the configuration. No machine should be degraded.")
+		mcp.waitForComplete()
+		logger.Infof("OK \n")
+
+		exutil.By("To verify that previous file does not exist")
+		o.Expect(rf).NotTo(Exist())
+		logger.Infof("OK \n")
+
+		exutil.By("To verify that new file does exist")
+		filePath = "/etc/systemd/system/multi-user.target.wants/hello.service"
+		rf = NewRemoteFile(node, filePath)
+		o.Expect(rf.Read()).To(HaveContent(fileContent + "multi-user.target"))
+		logger.Infof("OK \n")
+
+		exutil.By("Validate that the hello unit service is active after update")
+		o.Expect(
+			node.DebugNodeWithChroot("systemctl", "status", unitName),
+		).To(o.And(o.ContainSubstring(activeString), o.Not(o.ContainSubstring(inactiveString))),
+			"%s unit is not active", unitName)
+		logger.Infof("OK \n")
+	})
 })

--- a/test/extended-priv/mco_units.go
+++ b/test/extended-priv/mco_units.go
@@ -3,6 +3,7 @@ package extended
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -358,5 +359,54 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		behaviourValidatorRemove.Validate()
+	})
+
+	g.It("[PolarionID:72025][OTP] nmstate keeps service yamls [Disruptive]", func() {
+		var (
+			node                             = GetCompactCompatiblePool(oc.AsAdmin()).GetNodesOrFail()[0]
+			nmstateConfigFileFullPath        = "/etc/nmstate/mco-tc-72025-basic-nmsconfig.yml"
+			nmstateConfigFileAppliedFullPath = strings.ReplaceAll(nmstateConfigFileFullPath, ".yml", ".applied")
+
+			nmstateConfigRemote        = NewRemoteFile(node, nmstateConfigFileFullPath)
+			nmstateConfigAppliedRemote = NewRemoteFile(node, nmstateConfigFileAppliedFullPath)
+
+			nmstateBasicConfig = `
+desiredState:
+  interfaces:
+  - name: dummytc72025
+    type: dummy
+    state: absent
+`
+		)
+
+		exutil.By(fmt.Sprintf("Create a config file for nmstate in node %s", node.GetName()))
+
+		logger.Infof("Config content:\n%s", nmstateBasicConfig)
+		defer func() {
+			nmstateConfigRemote.Rm("-f")
+			nmstateConfigAppliedRemote.Rm("-f")
+			logger.Infof("Restarting nmstate service")
+			_, err := node.DebugNodeWithChroot("systemctl", "restart", "nmstate")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error restarting the nsmtate service in node %s", node.GetName())
+		}()
+		logger.Infof("Creating the config file")
+		o.Expect(nmstateConfigRemote.Create([]byte(nmstateBasicConfig), 0o600)).To(o.Succeed(),
+			"Error creating the basic config file %s in node %s", nmstateConfigFileFullPath, node.GetName())
+
+		nmstateConfigRemote.PrintDebugInfo()
+		logger.Infof("OK!\n")
+
+		exutil.By(fmt.Sprintf("Restart nmstate service in node %s", node.GetName()))
+		_, err := node.DebugNodeWithChroot("systemctl", "restart", "nmstate")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error restarting the nsmtate service in node %s", node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Check that the configuration file was not removed and it was correctly cloned")
+		o.Expect(nmstateConfigRemote.Exists()).To(o.BeTrue(),
+			"The configuration file %s does not exist after restarting the nmstate service, but it should exist", nmstateConfigRemote.GetFullPath())
+
+		o.Expect(nmstateConfigAppliedRemote.Exists()).To(o.BeTrue(),
+			"The applied configuration file %s does not exist after restarting the nmstate service, but it should exist", nmstateConfigAppliedRemote.GetFullPath())
+		logger.Infof("OK!\n")
 	})
 })

--- a/test/extended-priv/testdata/files/change-worker-ign-version.yaml
+++ b/test/extended-priv/testdata/files/change-worker-ign-version.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: change-worker-ign-version-to-empty
+objects:
+  - kind: MachineConfig
+    apiVersion: machineconfiguration.openshift.io/v1
+    metadata:
+      labels:
+        machineconfiguration.openshift.io/role: "${POOL}"
+      name: "${NAME}"
+    spec:
+      config:
+        ignition:
+          version: ${IGNITION_VERSION}
+      kernelArguments:
+        - enforcing=0
+parameters:
+  - name: NAME
+  - name: POOL
+  - name: IGNITION_VERSION


### PR DESCRIPTION
- Add 6 general MCO TCs (42347, 43124, 43726, 63868, 68695, 75258) to mco.go
- Add TC 72025 (nmstate keeps service yamls) to mco_units.go
- Add TC 74540 (kubelet dependency issue after reboot) to mco_kubelet_and_containerruntime.go
- Add change-worker-ign-version.yaml template for TC 43124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for machine configuration operations, including Ignition version validation and Azure platform consistency checks.
  * Added disruptive tests for systemd unit management (ensuring unit updates and continued service activity) and nmstate config persistence across service restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->