### PR TITLE
OCPBUGS-85497: only check password hash in /etc/shadow

### DIFF
--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -408,8 +408,11 @@ func TestNoReboot(t *testing.T) {
 
 	currentEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
 
-	if currentEtcShadowContents == initialEtcShadowContents {
-		t.Fatalf("updated password hash not found in etc/shadow, got %s", currentEtcShadowContents)
+	initialPasswordHash := extractPasswordHashFromShadowLine(initialEtcShadowContents)
+	currentPasswordHash := extractPasswordHashFromShadowLine(currentEtcShadowContents)
+
+	if currentPasswordHash == initialPasswordHash {
+		t.Fatalf("updated password hash not found in etc/shadow")
 	}
 
 	t.Logf("Node %s has Password Hash", infraNode.Name)
@@ -489,7 +492,9 @@ func TestNoReboot(t *testing.T) {
 	require.Nil(t, err)
 
 	rollbackEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
-	assert.Equal(t, initialEtcShadowContents, rollbackEtcShadowContents)
+
+	assert.Equal(t, extractPasswordHashFromShadowLine(initialEtcShadowContents), extractPasswordHashFromShadowLine(rollbackEtcShadowContents),
+		"password hash should match after rollback")
 }
 
 func TestPoolDegradedOnFailToRender(t *testing.T) {
@@ -942,6 +947,17 @@ func assertExpectedPerms(t *testing.T, cs *framework.ClientSet, node corev1.Node
 
 	actualPerms := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "stat", "--format=%U %G %a", path), "\n"), " ")
 	assert.Equal(t, expectedPerms, actualPerms, "expected %s to have perms %v, got: %v", path, expectedPerms, actualPerms)
+}
+
+// extractPasswordHashFromShadowLine extracts the password hash field from an /etc/shadow line.
+// The shadow file format is: username:password:lastchg:min:max:warn:inactive:expire:reserved
+// This function returns the password hash (field index 1).
+func extractPasswordHashFromShadowLine(shadowLine string) string {
+	fields := strings.Split(strings.TrimSpace(shadowLine), ":")
+	if len(fields) < 2 {
+		return ""
+	}
+	return fields[1]
 }
 
 // Tests that changes to the internal image registry pull secret has the


### PR DESCRIPTION
**- What I did**

In <https://github.com/openshift/machine-config-operator/pull/5889>, some changes were introduced to how password changes are done. This had the side-effect of breaking the `TestNoReboot` E2E test. The root cause of the test failure is that the E2E test was considering the entire line in `/etc/shadow` when it should only consider whether the password hash changed.

The reason why is because the 3rd column changed during the password change to reflect the day of the password change. Technically speaking, if one were to change their password multiple times in a single day, this value would only change oncee. By comparison, the E2E test should only consider whether the password hash was changed without giving consideration to when it was changed.

This PR remedies this situation.

**- How to verify it**

Run the `/test e2e-gcp-op-part1` on this PR and ensure that TestNoReboot passes.

**- Description for the changelog**
TestNoReboot should only consider the password hash
