### PR TITLE
OCPBUGS-85498: BareMetal skew e2e fails patching provisioning CR after CBO webhook fix

### DIFF
--- a/test/extended-priv/mco_bootimages_skew.go
+++ b/test/extended-priv/mco_bootimages_skew.go
@@ -261,13 +261,14 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		machineConfiguration.WaitForBootImageSkewEnforcementStatusMode(SkewEnforcementNoneMode)
 		logger.Infof("bootImageSkewEnforcementStatus.mode is None as expected")
 
-		// Legacy qcow2 path (simulated): patch the provisioning CR with a URL to trigger Manual mode
+		// Legacy qcow2 path (simulated): patch the provisioning CR with a URL to trigger Manual mode.
+		// The URL must satisfy vprovisioning.kb.io validation: .qcow2.gz/.qcow2.xz extension and
+		// a sha256 query parameter (64 hex chars).
 		exutil.By("Simulate legacy qcow2 path by patching provisioning CR with a URL")
 		defer func() {
-			exutil.By("Restoring provisioning CR: clearing provisioningOSDownloadURL")
+			exutil.By("Restoring provisioning CR")
 			patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args(
-				"provisioning", provisioningCRName,
-				"--type=merge",
+				"provisioning", provisioningCRName, "--type=merge",
 				"-p", `{"spec":{"provisioningOSDownloadURL":""}}`,
 			).Execute()
 			o.Expect(patchErr).NotTo(o.HaveOccurred(), "Failed to restore provisioning CR")
@@ -275,9 +276,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		}()
 
 		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
-			"provisioning", provisioningCRName,
-			"--type=merge",
-			"-p", `{"spec":{"provisioningOSDownloadURL":"https://example.com/rhcos.qcow2"}}`,
+			"provisioning", provisioningCRName, "--type=merge",
+			"-p", `{"spec":{"provisioningOSDownloadURL":"https://example.com/rhcos.qcow2.gz?sha256=0000000000000000000000000000000000000000000000000000000000000000"}}`,
 		).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to patch provisioning CR with legacy URL")
 


### PR DESCRIPTION
**- What I did**
The `Verify BareMetal defaults to None mode and flips to Manual on legacy provisioning path` test began failing after cluster-baremetal-operator [PR #587](https://github.com/openshift/cluster-baremetal-operator/pull/587) (merged May 4, 2026) fixed the `vprovisioning.kb.io` validating webhook server. Prior to that fix, a missing `WithValidator(r)` call meant no webhook handlers were ever registered; combined with `failurePolicy: Ignore`, all patch requests to the provisioning CR silently passed. The test was added in https://github.com/openshift/machine-config-operator/pull/5768/changes/9971d2f42e6d162204328238cea9e6099581b180 under those conditions.

After the webhook fix, patching provisioningOSDownloadURL alone is rejected on machine-os-images clusters (4.10+). We need to update the patch request so it passes the webhook’s validation, which requires ~certain values to be read back and set~ the URL to be formatted slightly differently.

**- How to verify it**
The baremetal e2es should now begin to pass, no additional QE is necessary. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for BareMetal provisioning scenarios with legacy configurations
  * Adjusted legacy provisioning simulation to validate qcow2.gz download URLs with sha256 checksums
  * Strengthened verification that enforcement mode transitions between None and Manual and that cleanup restores state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->