### PR TITLE
OCPBUGS-87192: Add mco_extensions.go e2e test suite for MCO extension install, enable, and validation

### DIFF
--- a/test/extended-priv/mco_extensions.go
+++ b/test/extended-priv/mco_extensions.go
@@ -1,0 +1,147 @@
+package extended
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/machine-config-operator/test/extended-priv/util"
+	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
+)
+
+var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO extensions", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("mco-extensions", exutil.KubeConfigPath())
+
+	g.JustBeforeEach(func() {
+		PreChecks(oc)
+	})
+
+	g.It("[PolarionID:88729] Verify USBGuard extension can be installed and enabled via MachineConfig on worker nodes [Disruptive]", func() {
+		testID := GetCurrentTestPolarionIDNumber()
+		mcp := GetCompactCompatiblePool(oc.AsAdmin())
+
+		exutil.By("Create a MachineConfig to install the usbguard extension on worker nodes")
+		mcExt := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-ext", testID), mcp.GetName()).
+			SetMCOTemplate("change-worker-extension-usbguard.yaml")
+		defer mcExt.DeleteWithWait()
+		mcExt.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Create a MachineConfig to enable the usbguard systemd unit on worker nodes")
+		mcEnable := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-enable", testID), mcp.GetName())
+		mcEnable.SetParams(fmt.Sprintf(`UNITS=[{"enabled": true, "name": "usbguard.service"}]`))
+		defer mcEnable.Delete()
+		mcEnable.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify usbguard extension is installed on all worker nodes")
+		nodes := mcp.GetSortedNodesOrFail()
+		for _, node := range nodes {
+			o.Expect(node.RpmIsInstalled("usbguard")).To(o.BeTrue(),
+				"usbguard rpm should be installed on node %s", node.GetName())
+		}
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify usbguard.service is enabled on all worker nodes")
+		for _, node := range nodes {
+			o.Expect(node.IsUnitEnabled("usbguard")).To(o.BeTrue(),
+				"usbguard.service should be enabled on node %s", node.GetName())
+		}
+		logger.Infof("OK!\n")
+	})
+
+	/* Map of extensions and packages for each extension
+	{
+		"ipsec":                {"NetworkManager-libreswan", "libreswan"},
+		"usbguard":             {"usbguard"},
+		"kerberos":             {"krb5-workstation", "libkadm5"},
+		"kernel-devel":         {"kernel-devel", "kernel-headers"},
+		"sandboxed-containers": {"kata-containers"},
+		"sysstat":              {"sysstat"},
+	} */
+	g.It("[PolarionID:56131][PolarionID:77354][OTP][LEVEL0] Install all extensions", func() {
+		var (
+			coreOSMcp = GetCoreOsCompatiblePool(oc.AsAdmin())
+			node      = coreOSMcp.GetCoreOsNodesOrFail()[0]
+
+			query         = `mcd_local_unsupported_packages{node="` + node.GetName() + `"}`
+			valueJSONPath = `data.result.0.value.1`
+
+			mcName = fmt.Sprintf("mco-tc-%s-all-extensions", GetCurrentTestPolarionIDNumber())
+
+			applicableExtensions, expectedRpmInstalledPackages = GetAllApplicableExtensionsToMCPOrFail(coreOSMcp)
+
+			skipDrainChecks         = IsSNO(oc.AsAdmin()) // SNO clusters should NOT drain the nodes before rebooting them. The validator is not prepared for that.
+			behaviourValidatorApply = UpdateBehaviourValidator{
+				SkipDrainNodesValidation: skipDrainChecks,
+				Checkers: []Checker{
+					CommandOutputChecker{
+						Command:  append([]string{"rpm", "-q"}, expectedRpmInstalledPackages...),
+						Matcher:  o.MatchRegexp("(?s)" + strings.Join(expectedRpmInstalledPackages, ".*")),
+						ErrorMsg: "Extensions were not properly installed",
+						Desc:     "Checking that all available extensions were properly installed",
+					},
+				},
+			}
+		)
+
+		coreOSMcp.SetWaitingTimeForExtensionsChange()
+		behaviourValidatorApply.Initialize(coreOSMcp, nil)
+
+		exutil.By("Create a MC to install all available extensions")
+		mc := NewMachineConfig(oc.AsAdmin(), mcName, coreOSMcp.GetName())
+		mc.parameters = []string{fmt.Sprintf(`EXTENSIONS=%s`, string(MarshalOrFail(applicableExtensions)))}
+		mc.skipWaitForMcp = true
+
+		defer mc.DeleteWithWait()
+		mc.create()
+		logger.Infof("OK!\n")
+
+		behaviourValidatorApply.Validate()
+
+		exutil.By("Check that no unsupported packages are reported")
+		monitor, err := exutil.NewMonitor(oc.AsAdmin())
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the monitor to query the metricts")
+
+		o.Eventually(monitor.SimpleQuery, "10s", "2s").WithArguments(query).Should(HavePathWithValue(valueJSONPath, o.Equal("0")),
+			"There are reported unsupported packages in %s", node)
+		logger.Infof("OK!\n")
+
+		CheckExtensions(node, applicableExtensions)
+
+		exutil.By("Delete the MC")
+		mc.DeleteWithWait()
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify that extension packages where uninstalled after MC deletion")
+		for _, pkg := range expectedRpmInstalledPackages {
+			o.Expect(node.RpmIsInstalled(pkg)).To(
+				o.BeFalse(),
+				"Package %s should be uninstalled when we remove the extensions MC", pkg)
+		}
+		logger.Infof("OK!\n")
+	})
+
+	g.It("[PolarionID:56123][OTP] Invalid extensions should degrade the machine config pool", func() {
+		var (
+			validExtension   = "usbguard"
+			invalidExtension = "zsh"
+			mcName           = "mco-tc-56123-invalid-extension"
+			mcp              = GetCompactCompatiblePool(oc)
+
+			expectedRDMessage = regexp.QuoteMeta(fmt.Sprintf("invalid extensions found: [%s]", invalidExtension)) // quotemeta to scape regex characters
+			expectedRDReason  = ""
+		)
+
+		exutil.By("Create a MC with invalid extensions")
+		mc := NewMachineConfig(oc.AsAdmin(), mcName, mcp.GetName())
+		mc.parameters = []string{fmt.Sprintf(`EXTENSIONS=["%s", "%s"]`, validExtension, invalidExtension)}
+		mc.skipWaitForMcp = true
+
+		validateMcpRenderDegraded(mc, mcp, expectedRDMessage, expectedRDReason)
+	})
+})

--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -347,7 +347,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		exutil.By("Create a MachineConfig to enable the usbguard systemd unit on worker nodes")
 		mcEnable := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-enable", testID), mcp.GetName())
 		mcEnable.SetParams(fmt.Sprintf(`UNITS=[{"enabled": true, "name": "usbguard.service"}]`))
-		defer mcEnable.DeleteWithWait()
+		defer mcEnable.Delete()
 		mcEnable.create()
 		logger.Infof("OK!\n")
 

--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -332,38 +332,4 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 			"The kernel arguments are not the expected ones")
 		logger.Infof("OK!\n")
 	})
-
-	g.It("[PolarionID:88729] Verify USBGuard extension can be installed and enabled via MachineConfig on worker nodes [Disruptive]", func() {
-		testID := GetCurrentTestPolarionIDNumber()
-		mcp := GetCompactCompatiblePool(oc.AsAdmin())
-
-		exutil.By("Create a MachineConfig to install the usbguard extension on worker nodes")
-		mcExt := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-ext", testID), mcp.GetName()).
-			SetMCOTemplate("change-worker-extension-usbguard.yaml")
-		defer mcExt.DeleteWithWait()
-		mcExt.create()
-		logger.Infof("OK!\n")
-
-		exutil.By("Create a MachineConfig to enable the usbguard systemd unit on worker nodes")
-		mcEnable := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-enable", testID), mcp.GetName())
-		mcEnable.SetParams(fmt.Sprintf(`UNITS=[{"enabled": true, "name": "usbguard.service"}]`))
-		defer mcEnable.Delete()
-		mcEnable.create()
-		logger.Infof("OK!\n")
-
-		exutil.By("Verify usbguard extension is installed on all worker nodes")
-		nodes := mcp.GetSortedNodesOrFail()
-		for _, node := range nodes {
-			o.Expect(node.RpmIsInstalled("usbguard")).To(o.BeTrue(),
-				"usbguard rpm should be installed on node %s", node.GetName())
-		}
-		logger.Infof("OK!\n")
-
-		exutil.By("Verify usbguard.service is enabled on all worker nodes")
-		for _, node := range nodes {
-			o.Expect(node.IsUnitEnabled("usbguard")).To(o.BeTrue(),
-				"usbguard.service should be enabled on node %s", node.GetName())
-		}
-		logger.Infof("OK!\n")
-	})
 })

--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -332,4 +332,39 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 			"The kernel arguments are not the expected ones")
 		logger.Infof("OK!\n")
 	})
+
+	g.It("[PolarionID:88729] Verify USBGuard extension can be installed and enabled via MachineConfig on worker nodes [Disruptive]", func() {
+		testID := GetCurrentTestPolarionIDNumber()
+		mcp := GetCompactCompatiblePool(oc.AsAdmin())
+
+		exutil.By("Create a MachineConfig to install the usbguard extension on worker nodes")
+		mcExt := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-ext", testID), mcp.GetName()).
+			SetMCOTemplate("change-worker-extension-usbguard.yaml")
+		defer mcExt.DeleteWithWait()
+		mcExt.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Create a MachineConfig to enable the usbguard systemd unit on worker nodes")
+		mcEnableName := fmt.Sprintf("test-%s-enable", testID)
+		mcEnable := NewMachineConfig(oc.AsAdmin(), mcEnableName, mcp.GetName())
+		mcEnable.SetParams(fmt.Sprintf(`UNITS=[{"enabled": true, "name": "usbguard.service"}]`))
+		defer mcEnable.DeleteWithWait()
+		mcEnable.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify usbguard extension is installed on all worker nodes")
+		nodes := mcp.GetSortedNodesOrFail()
+		for _, node := range nodes {
+			o.Expect(node.RpmIsInstalled("usbguard")).To(o.BeTrue(),
+				"usbguard rpm should be installed on node %s", node.GetName())
+		}
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify usbguard.service is enabled on all worker nodes")
+		for _, node := range nodes {
+			o.Expect(node.IsUnitEnabled("usbguard")).To(o.BeTrue(),
+				"usbguard.service should be enabled on node %s", node.GetName())
+		}
+		logger.Infof("OK!\n")
+	})
 })

--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -347,11 +347,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		exutil.By("Create a MachineConfig to enable the usbguard systemd unit on worker nodes")
 		mcEnable := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-enable", testID), mcp.GetName())
 		mcEnable.SetParams(fmt.Sprintf(`UNITS=[{"enabled": true, "name": "usbguard.service"}]`))
-		defer func() {
-			exutil.By("Cleanup: delete both MachineConfigs in one shot and wait for a single pool rollout")
-			oc.AsAdmin().WithoutNamespace().Run("delete").Args("mc", mcEnable.GetName(), mcExt.GetName(), "--ignore-not-found=true").Execute()
-			mcp.waitForComplete()
-		}()
+		defer mcEnable.DeleteWithWait()
 		mcEnable.create()
 		logger.Infof("OK!\n")
 

--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -345,10 +345,13 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		exutil.By("Create a MachineConfig to enable the usbguard systemd unit on worker nodes")
-		mcEnableName := fmt.Sprintf("test-%s-enable", testID)
-		mcEnable := NewMachineConfig(oc.AsAdmin(), mcEnableName, mcp.GetName())
+		mcEnable := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-enable", testID), mcp.GetName())
 		mcEnable.SetParams(fmt.Sprintf(`UNITS=[{"enabled": true, "name": "usbguard.service"}]`))
-		defer mcEnable.DeleteWithWait()
+		defer func() {
+			exutil.By("Cleanup: delete both MachineConfigs in one shot and wait for a single pool rollout")
+			oc.AsAdmin().WithoutNamespace().Run("delete").Args("mc", mcEnable.GetName(), mcExt.GetName(), "--ignore-not-found=true").Execute()
+			mcp.waitForComplete()
+		}()
 		mcEnable.create()
 		logger.Infof("OK!\n")
 

--- a/test/extended-priv/mco_machineconfigpool.go
+++ b/test/extended-priv/mco_machineconfigpool.go
@@ -2,9 +2,7 @@ package extended
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
-	"strings"
 
 	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
 
@@ -103,78 +101,6 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 	})
 
-	/* Map of extensions and packages for each extension
-	{
-		"ipsec":                {"NetworkManager-libreswan", "libreswan"},
-		"usbguard":             {"usbguard"},
-		"kerberos":             {"krb5-workstation", "libkadm5"},
-		"kernel-devel":         {"kernel-devel", "kernel-headers"},
-		"sandboxed-containers": {"kata-containers"},
-		"sysstat":              {"sysstat"},
-	} */
-	g.It("[PolarionID:56131][PolarionID:77354][OTP][LEVEL0] Install all extensions", func() {
-		var (
-			coreOSMcp = GetCoreOsCompatiblePool(oc.AsAdmin())
-			node      = coreOSMcp.GetCoreOsNodesOrFail()[0]
-
-			query         = `mcd_local_unsupported_packages{node="` + node.GetName() + `"}`
-			valueJSONPath = `data.result.0.value.1`
-
-			mcName = fmt.Sprintf("mco-tc-%s-all-extensions", GetCurrentTestPolarionIDNumber())
-
-			applicableExtensions, expectedRpmInstalledPackages = GetAllApplicableExtensionsToMCPOrFail(coreOSMcp)
-
-			skipDrainChecks         = IsSNO(oc.AsAdmin()) // SNO clusters should NOT drain the nodes before rebooting them. The validator is not prepared for that.
-			behaviourValidatorApply = UpdateBehaviourValidator{
-				SkipDrainNodesValidation: skipDrainChecks,
-				Checkers: []Checker{
-					CommandOutputChecker{
-						Command:  append([]string{"rpm", "-q"}, expectedRpmInstalledPackages...),
-						Matcher:  o.MatchRegexp("(?s)" + strings.Join(expectedRpmInstalledPackages, ".*")),
-						ErrorMsg: "Extensions were not properly installed",
-						Desc:     "Checking that all available extensions were properly installed",
-					},
-				},
-			}
-		)
-
-		coreOSMcp.SetWaitingTimeForExtensionsChange()
-		behaviourValidatorApply.Initialize(coreOSMcp, nil)
-
-		exutil.By("Create a MC to install all available extensions")
-		mc := NewMachineConfig(oc.AsAdmin(), mcName, coreOSMcp.GetName())
-		mc.parameters = []string{fmt.Sprintf(`EXTENSIONS=%s`, string(MarshalOrFail(applicableExtensions)))}
-		mc.skipWaitForMcp = true
-
-		defer mc.DeleteWithWait()
-		mc.create()
-		logger.Infof("OK!\n")
-
-		behaviourValidatorApply.Validate()
-
-		exutil.By("Check that no unsupported packages are reported")
-		monitor, err := exutil.NewMonitor(oc.AsAdmin())
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the monitor to query the metricts")
-
-		o.Eventually(monitor.SimpleQuery, "10s", "2s").WithArguments(query).Should(HavePathWithValue(valueJSONPath, o.Equal("0")),
-			"There are reported unsupported packages in %s", node)
-		logger.Infof("OK!\n")
-
-		CheckExtensions(node, applicableExtensions)
-
-		exutil.By("Delete the MC")
-		mc.DeleteWithWait()
-		logger.Infof("OK!\n")
-
-		exutil.By("Verify that extension packages where uninstalled after MC deletion")
-		for _, pkg := range expectedRpmInstalledPackages {
-			o.Expect(node.RpmIsInstalled(pkg)).To(
-				o.BeFalse(),
-				"Package %s should be uninstalled when we remove the extensions MC", pkg)
-		}
-		logger.Infof("OK!\n")
-	})
-
 	g.It("[PolarionID:42390][PolarionID:45318][OTP] add machine config without ignition version. Block the Machine-Config-Operator upgrade rollout if any of the pools are Degraded", func() {
 		createMcAndVerifyIgnitionVersion(oc, "empty ign version", "change-worker-ign-version-to-empty", "")
 	})
@@ -267,25 +193,6 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 			"5m", "30s").Should(o.Equal("False"),
 			"machine-config Operator should not report degraded status anymore")
 
-	})
-
-	g.It("[PolarionID:56123][OTP] Invalid extensions should degrade the machine config pool", func() {
-		var (
-			validExtension   = "usbguard"
-			invalidExtension = "zsh"
-			mcName           = "mco-tc-56123-invalid-extension"
-			mcp              = GetCompactCompatiblePool(oc)
-
-			expectedRDMessage = regexp.QuoteMeta(fmt.Sprintf("invalid extensions found: [%s]", invalidExtension)) // quotemeta to scape regex characters
-			expectedRDReason  = ""
-		)
-
-		exutil.By("Create a MC with invalid extensions")
-		mc := NewMachineConfig(oc.AsAdmin(), mcName, mcp.GetName())
-		mc.parameters = []string{fmt.Sprintf(`EXTENSIONS=["%s", "%s"]`, validExtension, invalidExtension)}
-		mc.skipWaitForMcp = true
-
-		validateMcpRenderDegraded(mc, mcp, expectedRDMessage, expectedRDReason)
 	})
 
 	g.It("[PolarionID:70125][OTP] Test patch annotation way of updating a paused pool", func() {


### PR DESCRIPTION
**- What I did**
Created test/extended-priv/mco_extensions.go with three extension-related tests:

  - OCP-88729: Installs the usbguard extension and enables usbguard.service via two MachineConfigs, then verifies RPM installation and service enablement on all worker nodes
  - OCP-56131/OCP-77354: Installs all applicable extensions (usbguard, kerberos, kernel-devel, sandboxed-containers, ipsec, sysstat), validates RPM installation, checks unsupported packages metrics, runs extension-specific verification, and confirms packages are removed after MC deletion
  - OCP-56123: Creates a MachineConfig with an invalid extension ("zsh") alongside a valid one ("usbguard") and verifies the MCP enters a render degraded state

**- How to verify it**

  ./_output/linux/amd64/machine-config-tests-ext run-test "[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO extensions [PolarionID:88729] Verify USBGuard extension can be installed and enabled via MachineConfig on worker nodes [Disruptive]"

  ./_output/linux/amd64/machine-config-tests-ext run-test "[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO extensions [PolarionID:56131][PolarionID:77354][OTP][LEVEL0] Install all extensions"

  ./_output/linux/amd64/machine-config-tests-ext run-test "[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO extensions [PolarionID:56123][OTP] Invalid extensions should degrade the machine config pool"

**- Description for the changelog**

  Add mco_extensions.go test suite with OCP-88729, OCP-56131/OCP-77354, and OCP-56123 to verify extension installation, enablement, and invalid extension handling via MachineConfig.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a long-running extended test that provisions two worker-node configurations to install and enable the usbguard extension on compact-compatible pool nodes.
  * Verifies usbguard RPM is installed and the usbguard systemd unit is enabled across nodes, then removes the test configurations during teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->