### PR TITLE
OCPEDGE-2473: feat: enabled graceful shutdown for TNF clusters

### DIFF
--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -410,10 +410,10 @@ func TestKubeletGracefulShutdownTNF(t *testing.T) {
 
 					kubeletConf := string(contents)
 					if tc.expectGraceful {
-						if !strings.Contains(kubeletConf, "shutdownGracePeriod: 60s") {
+						if !strings.Contains(kubeletConf, "shutdownGracePeriod: 90s") {
 							t.Errorf("expected shutdownGracePeriod in kubelet.conf for DualReplica")
 						}
-						if !strings.Contains(kubeletConf, "shutdownGracePeriodCriticalPods: 30s") {
+						if !strings.Contains(kubeletConf, "shutdownGracePeriodCriticalPods: 60s") {
 							t.Errorf("expected shutdownGracePeriodCriticalPods in kubelet.conf for DualReplica")
 						}
 					} else {

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -216,6 +216,7 @@ var (
 		"nutanix":           "./test_data/controller_config_nutanix.yaml",
 		"gcp-custom-dns":    "./test_data/controller_config_gcp_custom_dns.yaml",
 		"gcp-default-dns":   "./test_data/controller_config_gcp_default_dns.yaml",
+		"baremetal-tnf":     "./test_data/controller_config_baremetal_tnf.yaml",
 	}
 )
 
@@ -351,6 +352,84 @@ func TestGenerateMachineConfigs(t *testing.T) {
 	}
 }
 
+func TestKubeletGracefulShutdownTNF(t *testing.T) {
+	cases := []struct {
+		name             string
+		controllerConfig string
+		expectGraceful   bool
+	}{
+		{
+			name:             "DualReplica has graceful shutdown",
+			controllerConfig: "./test_data/controller_config_baremetal_tnf.yaml",
+			expectGraceful:   true,
+		},
+		{
+			name:             "HA does not have graceful shutdown",
+			controllerConfig: "./test_data/controller_config_baremetal.yaml",
+			expectGraceful:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controllerConfig, err := controllerConfigFromFile(tc.controllerConfig)
+			if err != nil {
+				t.Fatalf("failed to load controller config: %v", err)
+			}
+
+			cfgs, err := generateTemplateMachineConfigs(
+				&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil},
+				templateDir,
+			)
+			if err != nil {
+				t.Fatalf("failed to generate machine configs: %v", err)
+			}
+
+			found := false
+			for _, cfg := range cfgs {
+				role := cfg.Labels[mcfgv1.MachineConfigRoleLabelKey]
+				if role != masterRole {
+					continue
+				}
+
+				ign, err := ctrlcommon.ParseAndConvertConfig(cfg.Spec.Config.Raw)
+				if err != nil {
+					t.Fatalf("failed to parse ignition config: %v", err)
+				}
+
+				for _, file := range ign.Storage.Files {
+					if file.Path != "/etc/kubernetes/kubelet.conf" {
+						continue
+					}
+
+					found = true
+					contents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+					if err != nil {
+						t.Fatalf("failed to decode kubelet.conf contents: %v", err)
+					}
+
+					kubeletConf := string(contents)
+					if tc.expectGraceful {
+						if !strings.Contains(kubeletConf, "shutdownGracePeriod: 60s") {
+							t.Errorf("expected shutdownGracePeriod in kubelet.conf for DualReplica")
+						}
+						if !strings.Contains(kubeletConf, "shutdownGracePeriodCriticalPods: 30s") {
+							t.Errorf("expected shutdownGracePeriodCriticalPods in kubelet.conf for DualReplica")
+						}
+					} else {
+						if strings.Contains(kubeletConf, "shutdownGracePeriod") {
+							t.Errorf("unexpected shutdownGracePeriod in kubelet.conf for non-DualReplica")
+						}
+					}
+				}
+			}
+			if !found {
+				t.Fatal("kubelet.conf file not found in any master ignition config")
+			}
+		})
+	}
+}
+
 func TestGetPaths(t *testing.T) {
 	APIIntLBIP := configv1.IP("10.10.10.4")
 	APILBIP := configv1.IP("196.78.125.4")
@@ -369,6 +448,10 @@ func TestGetPaths(t *testing.T) {
 		platform: configv1.BareMetalPlatformType,
 		res:      []string{strings.ToLower(string(configv1.BareMetalPlatformType)), "on-prem"},
 		topology: configv1.HighlyAvailableTopologyMode,
+	}, {
+		platform: configv1.BareMetalPlatformType,
+		res:      []string{strings.ToLower(string(configv1.BareMetalPlatformType)), "on-prem", tnf},
+		topology: configv1.DualReplicaTopologyMode,
 	}, {
 		platform: configv1.GCPPlatformType,
 		res:      []string{strings.ToLower(string(configv1.GCPPlatformType))},

--- a/pkg/controller/template/test_data/controller_config_baremetal_tnf.yaml
+++ b/pkg/controller/template/test_data/controller_config_baremetal_tnf.yaml
@@ -1,0 +1,37 @@
+apiVersion: "machineconfigurations.openshift.io/v1"
+kind: "ControllerConfig"
+spec:
+  clusterDNSIP: "10.3.0.10"
+  cloudProviderConfig: ""
+  etcdInitialCount: 2
+  etcdCAData: ZHVtbXkgZXRjZC1jYQo=
+  rootCAData: ZHVtbXkgcm9vdC1jYQo=
+  pullSecret:
+    data: ZHVtbXkgZXRjZC1jYQo=
+  images:
+    etcd: image/etcd:1
+    setupEtcdEnv: image/setupEtcdEnv:1
+    infraImage: image/infraImage:1
+    kubeClientAgentImage: image/kubeClientAgentImage:1
+  infra:
+    apiVersion: config.openshift.io/v1
+    kind: Infrastructure
+    spec:
+      cloudConfig:
+        key: config
+        name: cloud-provider-config
+    status:
+      apiServerInternalURI: https://api-int.my-test-cluster.installer.team.coreos.systems:6443
+      apiServerURL: https://api.my-test-cluster.installer.team.coreos.systems:6443
+      etcdDiscoveryDomain: my-test-cluster.installer.team.coreos.systems
+      infrastructureName: my-test-cluster
+      controlPlaneTopology: DualReplica
+      platformStatus:
+        type: "BareMetal"
+        baremetal:
+          apiServerInternalIP: 10.0.0.1
+          ingressIP: 10.0.0.2
+          nodeDNSIP: 10.0.0.3
+  dns:
+    spec:
+      baseDomain: my-test-cluster.installer.team.coreos.systems

--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -130,4 +130,5 @@ contents:
       tolerations:
       - operator: Exists
       priorityClassName: system-node-critical
+      priority: 2000001000
     status: {}

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -235,4 +235,5 @@ contents:
       tolerations:
       - operator: Exists
       priorityClassName: system-node-critical
+      priority: 2000001000
     status: {}

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -165,4 +165,5 @@ contents:
       tolerations:
       - operator: Exists
       priorityClassName: system-node-critical
+      priority: 2000001000
     status: {}

--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -36,3 +36,7 @@ contents:
       {{- range .TLSCipherSuites }}
         - {{ . }}
       {{- end }}
+    {{- if eq .Infra.Status.ControlPlaneTopology "DualReplica" }}
+    shutdownGracePeriod: 60s
+    shutdownGracePeriodCriticalPods: 30s
+    {{- end }}

--- a/templates/master/01-master-kubelet/_base/files/kubelet.yaml
+++ b/templates/master/01-master-kubelet/_base/files/kubelet.yaml
@@ -37,6 +37,6 @@ contents:
         - {{ . }}
       {{- end }}
     {{- if eq .Infra.Status.ControlPlaneTopology "DualReplica" }}
-    shutdownGracePeriod: 60s
-    shutdownGracePeriodCriticalPods: 30s
+    shutdownGracePeriod: 90s
+    shutdownGracePeriodCriticalPods: 60s
     {{- end }}


### PR DESCRIPTION
**- What I did**

Enabled kubelet graceful node shutdown for Two-Node Fencing (DualReplica) topology. When the control plane topology is DualReplica, the kubelet configuration on master nodes now includes:
    - shutdownGracePeriod: 90s - total time kubelet delays node shutdown to terminate pods
    - shutdownGracePeriodCriticalPods: 60s - time reserved for critical pods (system-cluster-critical / system-node-critical)
    
**- How to verify it**

- Deploy on a DualReplica cluster and verify kubelet config: shutdownGracePeriod: 1m30s and shutdownGracePeriodCriticalPods: 60s
- Verify on a non-DualReplica (HA) cluster that the settings are NOT present

- Run unit tests, validated on a running clusters and running TNF E2E tests

**- Description for the changelog**
Enabled graceful shutdown for control-plane nodes on TNF clusters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubelet graceful-shutdown timings automatically applied for dual-replica control plane on baremetal (90s overall, 60s for critical pods).
  * Explicit pod priority values added for control-plane and on-prem core services to ensure higher scheduling/eviction precedence.

* **Tests**
  * Added validation test and test data to verify baremetal TNF kubelet shutdown settings and updated topology expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->