### PR TITLE
[DO NOT MERGE] - run TestInjectYumRepos for debugging purposes

### DIFF
--- a/test/e2e-ocl-1of2/onclusterlayering_test.go
+++ b/test/e2e-ocl-1of2/onclusterlayering_test.go
@@ -266,7 +266,6 @@ func TestMissingImageIsRebuilt(t *testing.T) {
 // Satellite user.
 func TestYumReposBuilds(t *testing.T) {
 	// Skipping this test as it is having a package conflict issue unrelated to MCO
-	t.Skip()
 	runOnClusterLayeringTest(t, onClusterLayeringTestOpts{
 		poolName: layeredMCPName,
 		customDockerfiles: map[string]string{


### PR DESCRIPTION
Run `TestInjectYumRepos` for debugging purposes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled previously skipped test for on-cluster layering with yum repository integration, improving test coverage for build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->