### PR TITLE
AGENT-1517: disable iri-registry service on IRI delete

### DIFF
--- a/pkg/controller/internalreleaseimage/internalreleaseimage_bootstrap.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_bootstrap.go
@@ -13,7 +13,7 @@ func RunInternalReleaseImageBootstrap(iri *mcfgv1alpha1.InternalReleaseImage, ir
 
 	for _, role := range SupportedRoles {
 		r := NewRendererByRole(role, iri, iriSecret, iriRegistryCredentialsSecret, cconfig)
-		mc, err := r.CreateEmptyMachineConfig()
+		mc, err := r.createEmptyMachineConfig()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,12 +40,11 @@ import (
 
 const (
 	maxRetries = 15
+
+	iriFinalizerName = "internalreleaseimage.machineconfiguration.openshift.io"
 )
 
 var (
-	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = mcfgv1alpha1.SchemeGroupVersion.WithKind("InternalReleaseImage")
-
 	updateBackoff = wait.Backoff{
 		Steps:    5,
 		Duration: 100 * time.Millisecond,
@@ -270,8 +270,7 @@ func (ctrl *Controller) deleteMachineConfig(obj interface{}) {
 func (ctrl *Controller) processMachineConfigEvent(obj interface{}, logMsg string) {
 	mc := obj.(*mcfgv1.MachineConfig)
 
-	// Skip any event not related to the InternalReleaseImage machine configs
-	if len(mc.OwnerReferences) == 0 || mc.OwnerReferences[0].Kind != controllerKind.Kind {
+	if !strings.HasSuffix(mc.Name, machineConfigNameSuffix) {
 		return
 	}
 
@@ -338,10 +337,12 @@ func (ctrl *Controller) syncInternalReleaseImage(key string) (syncErr error) {
 	// Deep-copy otherwise we are mutating our cache.
 	iri = iri.DeepCopy()
 
-	// Check for Deleted InternalReleaseImage and optionally delete finalizers.
+	// Check for Deleted InternalReleaseImage. Re-render MCs with a disabled
+	// service so the MCD stops the registry via the normal NDP restart cycle,
+	// then remove finalizers to garbage-collect the IRI.
 	if !iri.DeletionTimestamp.IsZero() {
 		if len(iri.GetFinalizers()) > 0 {
-			return ctrl.cascadeDelete(iri)
+			return ctrl.disableAndRemoveFinalizer(iri)
 		}
 		return nil
 	}
@@ -383,7 +384,7 @@ func (ctrl *Controller) syncInternalReleaseImage(key string) (syncErr error) {
 			return fmt.Errorf("could not get MachineConfig: %w", err)
 		}
 		if isNotFound {
-			mc, err = r.CreateEmptyMachineConfig()
+			mc, err = r.createEmptyMachineConfig()
 			if err != nil {
 				return fmt.Errorf("could not create MachineConfig: %w", err)
 			}
@@ -397,9 +398,10 @@ func (ctrl *Controller) syncInternalReleaseImage(key string) (syncErr error) {
 		if err != nil {
 			return fmt.Errorf("could not create/update MachineConfig: %w", err)
 		}
-		if err := ctrl.addFinalizerToInternalReleaseImage(iri, mc); err != nil {
-			return fmt.Errorf("could not add finalizer: %w", err)
-		}
+	}
+
+	if err := ctrl.addFinalizerToInternalReleaseImage(iri); err != nil {
+		return fmt.Errorf("could not add finalizer: %w", err)
 	}
 
 	// Initialize status if empty
@@ -522,24 +524,40 @@ func (ctrl *Controller) createOrUpdateMachineConfig(isNotFound bool, mc *mcfgv1.
 	})
 }
 
-func (ctrl *Controller) addFinalizerToInternalReleaseImage(iri *mcfgv1alpha1.InternalReleaseImage, mc *mcfgv1.MachineConfig) error {
-	if ctrlcommon.InSlice(mc.Name, iri.Finalizers) {
+func (ctrl *Controller) addFinalizerToInternalReleaseImage(iri *mcfgv1alpha1.InternalReleaseImage) error {
+	if ctrlcommon.InSlice(iriFinalizerName, iri.Finalizers) {
 		return nil
 	}
 
-	iri.Finalizers = append(iri.Finalizers, mc.Name)
+	iri.Finalizers = append(iri.Finalizers, iriFinalizerName)
 	_, err := ctrl.client.MachineconfigurationV1alpha1().InternalReleaseImages().Update(context.TODO(), iri, metav1.UpdateOptions{})
 	return err
 }
 
-func (ctrl *Controller) cascadeDelete(iri *mcfgv1alpha1.InternalReleaseImage) error {
-	mcName := iri.GetFinalizers()[0]
-	err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(context.TODO(), mcName, metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
+// disableAndRemoveFinalizer re-renders the master IRI MachineConfig with a
+// disabled service (no-op ExecStart=/bin/true), then removes the finalizer so
+// the IRI can be garbage-collected. Only the master role is updated because the
+// iri-registry service runs exclusively on control-plane nodes. The MCD picks
+// up the updated MC through its normal sync cycle: NDP fires DaemonReload+Restart,
+// which stops the old podman container and starts the no-op service.
+func (ctrl *Controller) disableAndRemoveFinalizer(iri *mcfgv1alpha1.InternalReleaseImage) error {
+	r := NewSimpleRenderer("master")
+
+	mc, err := ctrl.mcLister.Get(r.GetMachineConfigName())
+	if err != nil {
+		return fmt.Errorf("could not get MachineConfig %s: %w", r.GetMachineConfigName(), err)
 	}
 
-	iri.Finalizers = append([]string{}, iri.Finalizers[1:]...)
+	mc = mc.DeepCopy()
+	if err := r.RenderDisabledRegistryService(mc); err != nil {
+		return fmt.Errorf("could not render disabled registry service for %s: %w", r.GetMachineConfigName(), err)
+	}
+
+	if err := ctrl.createOrUpdateMachineConfig(false, mc); err != nil {
+		return fmt.Errorf("could not update MachineConfig %s: %w", r.GetMachineConfigName(), err)
+	}
+
+	iri.Finalizers = []string{}
 	_, err = ctrl.client.MachineconfigurationV1alpha1().InternalReleaseImages().Update(context.TODO(), iri, metav1.UpdateOptions{})
 	return err
 }

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller_test.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller_test.go
@@ -45,15 +45,14 @@ func TestInternalReleaseImageCreate(t *testing.T) {
 			name:           "add finalizer if not present",
 			initialObjects: objs(iri(), clusterVersion(), cconfig().withDNS("example.com"), iriCertSecret(), iriRegistryCredentialsSecret(), pullSecret()),
 			verify: func(t *testing.T, actualIRI *mcfgv1alpha1.InternalReleaseImage, actualMasterMC *mcfgv1.MachineConfig, actualWorkerMC *mcfgv1.MachineConfig) {
-				assert.Len(t, actualIRI.Finalizers, 2)
-				assert.Contains(t, actualIRI.Finalizers, masterName())
-				assert.Contains(t, actualIRI.Finalizers, workerName())
+				assert.Len(t, actualIRI.Finalizers, 1)
+				assert.Contains(t, actualIRI.Finalizers, iriFinalizerName)
 			},
 		},
 		{
 			name: "update status if not set",
 			initialObjects: objs(
-				iri().finalizer(masterName(), workerName()),
+				iri().finalizer(iriFinalizerName),
 				clusterVersion(), cconfig().withDNS("example.com"), iriCertSecret(), iriRegistryCredentialsSecret(), pullSecret()),
 			verify: func(t *testing.T, actualIRI *mcfgv1alpha1.InternalReleaseImage, actualMasterMC *mcfgv1.MachineConfig, actualWorkerMC *mcfgv1.MachineConfig) {
 				assert.Len(t, actualIRI.Status.Releases, 1)
@@ -75,7 +74,7 @@ func TestInternalReleaseImageCreate(t *testing.T) {
 		{
 			name: "avoid machine-config drifting",
 			initialObjects: objs(
-				iri().finalizer(masterName(), workerName()),
+				iri().finalizer(iriFinalizerName),
 				clusterVersion(), cconfig().withDNS("example.com"), iriCertSecret(), iriRegistryCredentialsSecret(), pullSecret(),
 				machineconfigmaster().ignition("some garbage"),
 				machineconfigworker().ignition("other garbage")),
@@ -87,7 +86,7 @@ func TestInternalReleaseImageCreate(t *testing.T) {
 		{
 			name: "refresh machine-config on controllerConfig update",
 			initialObjects: objs(
-				iri().finalizer(masterName(), workerName()),
+				iri().finalizer(iriFinalizerName),
 				clusterVersion(), cconfig().dockerRegistryImage("a-new-docker-registry-image-pullspec").withDNS("example.com"), iriCertSecret(), iriRegistryCredentialsSecret(), pullSecret(),
 				machineconfigmaster(), machineconfigworker()),
 			verify: func(t *testing.T, actualIRI *mcfgv1alpha1.InternalReleaseImage, actualMasterMC *mcfgv1.MachineConfig, actualWorkerMC *mcfgv1.MachineConfig) {
@@ -96,35 +95,21 @@ func TestInternalReleaseImageCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "machine-config cascade delete on iri removal - removes the first machineconfig",
+			name: "disables service and removes finalizer on iri deletion",
 			initialObjects: objs(
-				iri().finalizer(masterName(), workerName()).setDeletionTimestamp(),
+				iri().finalizer(iriFinalizerName).setDeletionTimestamp(),
 				clusterVersion(), cconfig(), iriCertSecret(),
 				machineconfigmaster(), machineconfigworker()),
 			verify: func(t *testing.T, actualIRI *mcfgv1alpha1.InternalReleaseImage, actualMasterMC *mcfgv1.MachineConfig, actualWorkerMC *mcfgv1.MachineConfig) {
-				assert.NotNil(t, iri)
-				assert.Equal(t, []string{workerName()}, actualIRI.Finalizers)
-				assert.Nil(t, actualMasterMC)
-				assert.NotNil(t, actualWorkerMC)
-			},
-		},
-		{
-			name: "machine-config cascade delete on iri removal - then removes the remaining machineconfig",
-			initialObjects: objs(
-				iri().finalizer(workerName()).setDeletionTimestamp(),
-				clusterVersion(), cconfig(), iriCertSecret(),
-				machineconfigworker()),
-			verify: func(t *testing.T, actualIRI *mcfgv1alpha1.InternalReleaseImage, actualMasterMC *mcfgv1.MachineConfig, actualWorkerMC *mcfgv1.MachineConfig) {
-				assert.NotNil(t, iri)
+				assert.NotNil(t, actualIRI)
 				assert.Empty(t, actualIRI.Finalizers)
-				assert.Nil(t, actualMasterMC)
-				assert.Nil(t, actualWorkerMC)
+				verifyDisabledMasterMachineConfig(t, actualMasterMC)
 			},
 		},
 		{
 			name: "status condition Degraded=False on successful sync",
 			initialObjects: objs(
-				iri().finalizer(masterName(), workerName()),
+				iri().finalizer(iriFinalizerName),
 				clusterVersion(), cconfig().withDNS("example.com"), iriCertSecret(), iriRegistryCredentialsSecret(), pullSecret(),
 				machineconfigmaster(), machineconfigworker()),
 			verify: func(t *testing.T, actualIRI *mcfgv1alpha1.InternalReleaseImage, actualMasterMC *mcfgv1.MachineConfig, actualWorkerMC *mcfgv1.MachineConfig) {

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_helpers_test.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_helpers_test.go
@@ -21,7 +21,6 @@ import (
 func verifyInternalReleaseMasterMachineConfig(t *testing.T, mc *mcfgv1.MachineConfig) {
 	assert.Equal(t, masterName(), mc.Name)
 	assert.Equal(t, ctrlcommon.MachineConfigPoolMaster, mc.Labels[mcfgv1.MachineConfigRoleLabelKey])
-	assert.Equal(t, controllerKind.Kind, mc.OwnerReferences[0].Kind)
 
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	assert.NoError(t, err, mc.Name)
@@ -41,10 +40,24 @@ func verifyInternalReleaseMasterMachineConfig(t *testing.T, mc *mcfgv1.MachineCo
 	assert.NotContains(t, *ignCfg.Systemd.Units[0].Contents, "REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED")
 }
 
+func verifyDisabledMasterMachineConfig(t *testing.T, mc *mcfgv1.MachineConfig) {
+	assert.NotNil(t, mc)
+	assert.Equal(t, masterName(), mc.Name)
+
+	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
+	assert.NoError(t, err)
+
+	assert.Len(t, ignCfg.Systemd.Units, 1)
+	assert.Equal(t, "iri-registry.service", ignCfg.Systemd.Units[0].Name)
+	assert.Contains(t, *ignCfg.Systemd.Units[0].Contents, "ExecStart=/bin/true")
+	assert.Contains(t, *ignCfg.Systemd.Units[0].Contents, "Type=oneshot")
+	assert.NotContains(t, *ignCfg.Systemd.Units[0].Contents, "podman")
+	assert.Len(t, ignCfg.Storage.Files, 0)
+}
+
 func verifyInternalReleaseWorkerMachineConfig(t *testing.T, mc *mcfgv1.MachineConfig) {
 	assert.Equal(t, workerName(), mc.Name)
 	assert.Equal(t, ctrlcommon.MachineConfigPoolWorker, mc.Labels[mcfgv1.MachineConfigRoleLabelKey])
-	assert.Equal(t, controllerKind.Kind, mc.OwnerReferences[0].Kind)
 
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	assert.NoError(t, err)
@@ -65,7 +78,6 @@ func verifyIgnitionFileContains(t *testing.T, ignCfg *ign3types.Config, path str
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), expectedContent, path)
 }
-
 
 // objs is an helper func to improve the test readability.
 func objs(builders ...objBuilder) func() []runtime.Object {
@@ -186,11 +198,6 @@ func machineconfig(role string) *machineConfigBuilder {
 				Name: fmt.Sprintf(machineConfigNameFmt, role),
 				Labels: map[string]string{
 					mcfgv1.MachineConfigRoleLabelKey: role,
-				},
-				OwnerReferences: []v1.OwnerReference{
-					{
-						Kind: "InternalReleaseImage",
-					},
 				},
 			},
 			Spec: mcfgv1.MachineConfigSpec{

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_renderer.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_renderer.go
@@ -10,9 +10,7 @@ import (
 	"text/template"
 
 	"github.com/clarketm/json"
-	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
@@ -29,31 +27,40 @@ var (
 	// Templates folders are organized by those roles.
 	SupportedRoles = []string{"master", "worker"}
 
+	// Suffix of the name for the InternalReleaseImage machine configs.
+	machineConfigNameSuffix = "-internalreleaseimage"
 	// Format of the name for the InternalReleaseImage machine configs.
-	machineConfigNameFmt = "02-%s-internalreleaseimage"
+	machineConfigNameFmt = "02-%s" + machineConfigNameSuffix
 )
 
 // Renderer takes care of generating the required ignition (by role) for
 // the InternalReleaseImage machine config resources. It can also create
 // a MachineConfig instance when required.
 type Renderer struct {
-	role          string
-	iri           *mcfgv1alpha1.InternalReleaseImage
-	iriSecret     *corev1.Secret
+	role                         string
+	iri                          *mcfgv1alpha1.InternalReleaseImage
+	iriSecret                    *corev1.Secret
 	iriRegistryCredentialsSecret *corev1.Secret
-	cconfig       *mcfgv1.ControllerConfig
+	cconfig                      *mcfgv1.ControllerConfig
 }
 
 // NewRendererByRole creates a new Renderer instance for generating
 // the machine config for the given role.
 func NewRendererByRole(role string, iri *mcfgv1alpha1.InternalReleaseImage, iriSecret, iriRegistryCredentialsSecret *corev1.Secret, cconfig *mcfgv1.ControllerConfig) *Renderer {
 	return &Renderer{
-		role:          role,
-		iri:           iri,
-		iriSecret:     iriSecret,
+		role:                         role,
+		iri:                          iri,
+		iriSecret:                    iriSecret,
 		iriRegistryCredentialsSecret: iriRegistryCredentialsSecret,
-		cconfig:       cconfig,
+		cconfig:                      cconfig,
 	}
+}
+
+// NewSimpleRenderer creates a minimal Renderer that only knows its role.
+// Use this when secrets and ControllerConfig are not needed (e.g., rendering
+// a disabled service configuration).
+func NewSimpleRenderer(role string) *Renderer {
+	return &Renderer{role: role}
 }
 
 // GetMachineConfigName returns the name of the MachineConfig instance.
@@ -61,15 +68,13 @@ func (r *Renderer) GetMachineConfigName() string {
 	return fmt.Sprintf(machineConfigNameFmt, r.role)
 }
 
-// CreateEmptyMachineConfig creates an empty MachineConfig (without any ignition configured) owned by InternalReleaseImage.
-func (r *Renderer) CreateEmptyMachineConfig() (*mcfgv1.MachineConfig, error) {
+// createEmptyMachineConfig creates an empty MachineConfig (without any ignition configured).
+func (r *Renderer) createEmptyMachineConfig() (*mcfgv1.MachineConfig, error) {
 	mc, err := ctrlcommon.MachineConfigFromIgnConfig(r.role, r.GetMachineConfigName(), ctrlcommon.NewIgnConfig())
 	if err != nil {
 		return nil, err
 	}
 
-	cref := metav1.NewControllerRef(r.iri, controllerKind)
-	mc.SetOwnerReferences([]metav1.OwnerReference{*cref})
 	mc.SetAnnotations(map[string]string{
 		ctrlcommon.GeneratedByControllerVersionAnnotationKey: version.Hash,
 	})
@@ -84,23 +89,22 @@ func (r *Renderer) RenderAndSetIgnition(mc *mcfgv1.MachineConfig) error {
 		return err
 	}
 
-	ignCfg, err := r.generateIgnitionFromTemplates(rc)
+	units, err := r.renderTemplateFolder(rc, filepath.Join(r.role, "units"))
+	if err != nil {
+		return err
+	}
+	files, err := r.renderTemplateFolder(rc, filepath.Join(r.role, "files"))
 	if err != nil {
 		return err
 	}
 
-	rawIgn, err := json.Marshal(ignCfg)
-	if err != nil {
-		return err
-	}
-
-	mc.Spec.Config.Raw = rawIgn
-	return nil
+	return r.transpileAndSetIgnition(mc, files, units)
 }
 
 // renderContext is a type used to hold the configuration required
 // for current the template rendering.
 type renderContext struct {
+	RegistryEnabled     bool
 	DockerRegistryImage string
 	IriTLSKey           string
 	IriTLSCert          string
@@ -123,6 +127,7 @@ func (r *Renderer) newRenderContext() (*renderContext, error) {
 	iriHtpasswd := string(r.iriRegistryCredentialsSecret.Data["htpasswd"])
 
 	return &renderContext{
+		RegistryEnabled:     true,
 		DockerRegistryImage: r.cconfig.Spec.Images[templatectrl.DockerRegistryKey],
 		IriTLSKey:           iriTLSKey,
 		IriTLSCert:          iriTLSCert,
@@ -140,24 +145,38 @@ func (r *Renderer) extractTLSCertFieldFromSecret(secret *corev1.Secret, fieldNam
 	return string(raw), nil
 }
 
-// generateIgnitionFromTemplates creates the required ignition for the given roles
-// using the InternalReleaseImage templates.
-func (r *Renderer) generateIgnitionFromTemplates(rc *renderContext) (*ign3types.Config, error) {
-	// Render template subfolders, if defined.
-	units, err := r.renderTemplateFolder(rc, filepath.Join(r.role, "units"))
-	if err != nil {
-		return nil, err
-	}
-	files, err := r.renderTemplateFolder(rc, filepath.Join(r.role, "files"))
-	if err != nil {
-		return nil, err
+// RenderDisabledRegistryService renders the iri-registry systemd unit with
+// RegistryEnabled=false (producing a no-op ExecStart=/bin/true service) and
+// sets the resulting ignition on the specified MachineConfig.
+// This method does not require secrets or ControllerConfig.
+func (r *Renderer) RenderDisabledRegistryService(mc *mcfgv1.MachineConfig) error {
+	rc := &renderContext{
+		RegistryEnabled: false,
 	}
 
+	units, err := r.renderTemplateFolder(rc, filepath.Join("master", "units"))
+	if err != nil {
+		return err
+	}
+
+	return r.transpileAndSetIgnition(mc, nil, units)
+}
+
+// transpileAndSetIgnition transpiles the rendered files and units to an Ignition
+// config and sets it on the specified MachineConfig.
+func (r *Renderer) transpileAndSetIgnition(mc *mcfgv1.MachineConfig, files, units []string) error {
 	ignCfg, err := ctrlcommon.TranspileCoreOSConfigToIgn(files, units)
 	if err != nil {
-		return nil, fmt.Errorf("error transpiling CoreOS config to Ignition config: %w", err)
+		return fmt.Errorf("error transpiling CoreOS config to Ignition: %w", err)
 	}
-	return ignCfg, nil
+
+	rawIgn, err := json.Marshal(ignCfg)
+	if err != nil {
+		return err
+	}
+
+	mc.Spec.Config.Raw = rawIgn
+	return nil
 }
 
 // renderTemplateFolder renders all the templates found in the specified folder.

--- a/pkg/controller/internalreleaseimage/templates/master/units/iri-registry.service.yaml
+++ b/pkg/controller/internalreleaseimage/templates/master/units/iri-registry.service.yaml
@@ -1,6 +1,7 @@
 name: iri-registry.service
 enabled: true
 contents: |
+{{ if .RegistryEnabled }}
   [Unit]
   Description=InternalReleaseImage Registry
   Wants=network.target
@@ -27,6 +28,14 @@ contents: |
   RestartSec=10
   TimeoutStartSec=9000
   TimeoutStopSec=300
-  
+
   [Install]
   WantedBy=multi-user.target
+{{ else }}
+  [Unit]
+  Description=InternalReleaseImage Registry (disabled)
+
+  [Service]
+  Type=oneshot
+  ExecStart=/bin/true
+{{ end }}

--- a/test/e2e-iri/README.md
+++ b/test/e2e-iri/README.md
@@ -3,3 +3,7 @@
 This test package should be used for testing the behaviors of the InternalReleaseImage controller.
 Currently it is deployed as part of the Agent Installer for OpenShift-Virt (OVE) - and specifically for the NoRegistryClusterInstall feature.
 To run the tests, deploy first a baremetal cluster using the OVE ISO.
+
+# Available suites
+- `iri_test.go`: This suite contains all the standard tests.
+- `iri_deletion_test.go`: This suite verifies the scenario where the IRI resource is deleted.

--- a/test/e2e-iri/iri_delete_test.go
+++ b/test/e2e-iri/iri_delete_test.go
@@ -1,0 +1,79 @@
+//go:build iri_delete
+
+package e2e_iri_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+)
+
+func TestIRIController_IRIDelete(t *testing.T) {
+	skipIfNoBaremetal(t)
+
+	cs := framework.NewClientSet("")
+	ctx := context.Background()
+
+	// Verify IRI and its master MachineConfig exist before deletion.
+	_, err := cs.InternalReleaseImages().Get(ctx, "cluster", v1.GetOptions{})
+	require.NoError(t, err, "IRI should exist before deletion")
+
+	_, err = cs.MachineConfigs().Get(ctx, "02-master-internalreleaseimage", v1.GetOptions{})
+	require.NoError(t, err, "Master MC should exist before deletion")
+
+	// Remove the VAP binding that prevents IRI deletion.
+	vapBindingName := "internalreleaseimage-deletion-guard-binding"
+	err = cs.GetKubeclient().AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, vapBindingName, v1.DeleteOptions{})
+	require.NoError(t, err, "Should be able to delete VAP binding")
+
+	// Delete the IRI resource.
+	err = cs.InternalReleaseImages().Delete(ctx, "cluster", v1.DeleteOptions{})
+	require.NoError(t, err, "Should be able to delete IRI after VAP binding removal")
+
+	// Wait for the IRI to be fully garbage-collected (finalizer removed).
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := cs.InternalReleaseImages().Get(ctx, "cluster", v1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	require.NoError(t, err, "IRI should be garbage-collected after deletion")
+
+	// Verify master MC still exists with disabled content.
+	masterMC, err := cs.MachineConfigs().Get(ctx, "02-master-internalreleaseimage", v1.GetOptions{})
+	require.NoError(t, err, "Master MC should still exist after IRI deletion")
+
+	masterIgn, err := ctrlcommon.ParseAndConvertConfig(masterMC.Spec.Config.Raw)
+	require.NoError(t, err)
+	require.Len(t, masterIgn.Systemd.Units, 1, "Master MC should have exactly one unit")
+	require.Equal(t, constants.IRIRegistryServiceName, masterIgn.Systemd.Units[0].Name)
+	require.Contains(t, *masterIgn.Systemd.Units[0].Contents, "ExecStart=/bin/true")
+	require.Contains(t, *masterIgn.Systemd.Units[0].Contents, "Type=oneshot")
+	require.NotContains(t, *masterIgn.Systemd.Units[0].Contents, "podman")
+	require.Empty(t, masterIgn.Storage.Files, "Master MC should have no files when disabled")
+
+	// Verify the registry port is no longer listening on a master node.
+	node := helpers.GetRandomNode(t, cs, "master")
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		output, cmdErr := helpers.ExecCmdOnNodeWithError(cs, node, "bash", "-c",
+			fmt.Sprintf("ss -tlnp | grep ':%d ' || echo PORT_CLOSED", ctrlcommon.IRIRegistryPort))
+		if cmdErr != nil {
+			return false, nil
+		}
+		return strings.Contains(output, "PORT_CLOSED"), nil
+	})
+	require.NoError(t, err, "Registry port should no longer be listening after IRI deletion")
+}

--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -344,7 +344,7 @@ func TestIRIController_ShouldRestoreMachineConfigsWhenModified(t *testing.T) {
 			require.NoError(t, err)
 			iriMachineConfigs := []*mcfgv1.MachineConfig{}
 			for _, mc := range machineConfigs.Items {
-				if len(mc.OwnerReferences) != 0 && mc.OwnerReferences[0].Kind == "InternalReleaseImage" && mc.OwnerReferences[0].Name == "cluster" {
+				if strings.HasSuffix(mc.Name, "-internalreleaseimage") {
 					iriMachineConfigs = append(iriMachineConfigs, mc.DeepCopy())
 				}
 			}


### PR DESCRIPTION
**- What I did**
This patch refactors the current IRI deletion logic by just disabling the iri-registry service - instead of removing all the related IRI MachineConfigs.
This is required to support all the IRI NodeDisruptionPolicies (in particular to rotate the TLS credentials and registry creds).

**- How to verify it**
- Deploy an OVE cluster and delete the IRI resource
- A new e2e test has been added to cover this special case

Required by #5988 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renderer can produce a disabled registry service unit so master configs render without the registry when appropriate.

* **Bug Fixes**
  * Deletion now uses a single fixed finalizer, clears finalizers on delete, and disables the registry service on master MachineConfig to allow garbage collection.
  * MachineConfig detection improved to more reliably target IRI-related configs by name suffix.

* **Tests**
  * Added e2e deletion test and updated unit/integration tests to match new finalizer and disabled-registry behavior.

* **Documentation**
  * e2e test README updated with run instructions and available suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->