### PR TITLE
MCO-1972: Add test OCP-88202: off-cluster and on-cluster layering implementation

### DIFF
--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -217,6 +217,78 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
+	g.It("[PolarionID:88202][OTP][Skipped:Disconnected] Both off-cluster and on-cluster layering can coexist on the same pool [Disruptive]", func() {
+		var (
+			testID         = GetCurrentTestPolarionIDNumber()
+			mcpName        = fmt.Sprintf("tc-%s-custom", testID)
+			osLayerMCName  = fmt.Sprintf("tc-%s-os-layer", testID)
+			osImageURL     = "quay.io/mcoqe/layering@sha256:3760b74a58b882494c5e99d7191647822a2dfea43983cb5882887325b99327a7"
+			offClusterFile = "/etc/test-offlayering.test"
+			onClusterFile  = "/etc/test-onlayering.test"
+			containerFiles = []ContainerFile{{Content: fmt.Sprintf("RUN echo \"on-cluster layering %s\" > %s", testID, onClusterFile)}}
+		)
+
+		exutil.By("Create a custom MachineConfigPool")
+		customMcp, err := CreateCustomMCP(oc.AsAdmin(), mcpName, 1)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s", mcpName)
+		defer customMcp.delete()
+		logger.Infof("Custom MCP %s created", customMcp)
+		logger.Infof("OK!\n")
+
+		node := customMcp.GetSortedNodesOrFail()[0]
+
+		exutil.By("Apply osImageURL MachineConfig to pool (off-cluster layering)")
+		osLayerMC := NewMachineConfig(oc.AsAdmin(), osLayerMCName, customMcp.GetName())
+		osLayerMC.parameters = []string{"OS_IMAGE=" + osImageURL}
+		defer osLayerMC.DeleteWithWait()
+		osLayerMC.create()
+		logger.Infof("MachineConfig %s created with osImageURL %s", osLayerMC.GetName(), osImageURL)
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify off-cluster layering is applied on the node")
+		o.Expect(node.GetCurrentBootOSImage()).To(o.ContainSubstring("quay.io/mcoqe/layering"),
+			"Node %s should be running the off-cluster osImageURL", node)
+		offClusterRF := NewRemoteFile(node, offClusterFile)
+		o.Expect(offClusterRF.Exists()).To(o.BeTrue(),
+			"%s should exist on %s after off-cluster layering", offClusterFile, node)
+		logger.Infof("Off-cluster layering verified: %s exists on %s", offClusterFile, node)
+		logger.Infof("OK!\n")
+
+		exutil.By("Enable on-cluster layering (OCL) with a containerFile")
+		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, customMcp.GetName(), customMcp.GetName(), containerFiles)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating MachineOSConfig for %s", customMcp.GetName())
+		defer DisableOCL(mosc)
+		logger.Infof("OK!\n")
+
+		exutil.By("Validate OCL build succeeds")
+		ValidateSuccessfulMOSC(mosc, nil)
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify both off-cluster and on-cluster layering files are present")
+		o.Expect(offClusterRF.Exists()).To(o.BeTrue(),
+			"%s should still exist alongside on-cluster layering", offClusterFile)
+		onClusterRF := NewRemoteFile(node, onClusterFile)
+		o.Expect(onClusterRF.Exists()).To(o.BeTrue(),
+			"%s should exist after on-cluster layering is applied", onClusterFile)
+		logger.Infof("Both %s and %s are present on %s", offClusterFile, onClusterFile, node)
+		logger.Infof("OK!\n")
+
+		exutil.By("Delete the off-cluster MC and verify a new MachineOSBuild is triggered")
+		osLayerMC.DeleteWithWait()
+		logger.Infof("Off-cluster MachineConfig %s deleted", osLayerMCName)
+		logger.Infof("OK!\n")
+
+		exutil.By("Verify only on-cluster layering content remains after MC deletion")
+		offClusterRF = NewRemoteFile(node, offClusterFile)
+		o.Expect(offClusterRF.Exists()).To(o.BeFalse(),
+			"%s should be removed after off-cluster MC is deleted", offClusterFile)
+		onClusterRF = NewRemoteFile(node, onClusterFile)
+		o.Expect(onClusterRF.Exists()).To(o.BeTrue(),
+			"%s should still exist after off-cluster MC is deleted", onClusterFile)
+		logger.Infof("Only on-cluster layering file remains on %s (as expected)", node)
+		logger.Infof("OK!\n")
+	})
+
 })
 
 func testContainerFile(containerFiles []ContainerFile, imageNamespace string, mcp *MachineConfigPool, checkers []Checker, defaultPullSecret bool) {

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -289,19 +289,19 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 
 		exutil.By("Wait for a new MachineOSBuild to be triggered after MC deletion")
+		var newMOSB *MachineOSBuild
 		o.Eventually(func() string {
-			newMOSB, err := mosc.GetCurrentMachineOSBuild()
+			mosb, err := mosc.GetCurrentMachineOSBuild()
 			if err != nil {
 				return currentMOSBName
 			}
-			return newMOSB.GetName()
+			newMOSB = mosb
+			return mosb.GetName()
 		}, "5m", "20s").ShouldNot(o.Equal(currentMOSBName),
 			"A new MOSB should be created after deleting the off-cluster MC")
 		logger.Infof("OK!\n")
 
 		exutil.By("Wait for the new build to succeed and deploy")
-		newMOSB, err := mosc.GetCurrentMachineOSBuild()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the new MOSB")
 		o.Eventually(newMOSB, "20m", "20s").Should(HaveConditionField("Succeeded", "status", TrueString),
 			"New MachineOSBuild didn't succeed after MC deletion")
 		logger.Infof("New MOSB %s built successfully", newMOSB.GetName())

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -220,43 +220,46 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	g.It("[PolarionID:88202][Skipped:Disconnected] Both off-cluster and on-cluster layering can coexist on the same pool [Disruptive]", func() {
 		var (
 			testID         = GetCurrentTestPolarionIDNumber()
-			mcpName        = fmt.Sprintf("tc-%s-custom", testID)
 			osLayerMCName  = fmt.Sprintf("tc-%s-os-layer", testID)
-			osImageURL     = "quay.io/mcoqe/layering@sha256:3760b74a58b882494c5e99d7191647822a2dfea43983cb5882887325b99327a7"
 			offClusterFile = "/etc/test-offlayering.test"
 			onClusterFile  = "/etc/test-onlayering.test"
 			containerFiles = []ContainerFile{{Content: fmt.Sprintf("RUN echo \"on-cluster layering %s\" > %s", testID, onClusterFile)}}
 		)
 
-		exutil.By("Create a custom MachineConfigPool")
-		customMcp, err := CreateCustomMCP(oc.AsAdmin(), mcpName, 1)
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating custom MCP %s", mcpName)
-		defer customMcp.delete()
-		logger.Infof("Custom MCP %s created", customMcp)
+		mcp := GetCompactCompatiblePool(oc.AsAdmin())
+		node := mcp.GetSortedNodesOrFail()[0]
+		offClusterRF := NewRemoteFile(node, offClusterFile)
+		onClusterRF := NewRemoteFile(node, onClusterFile)
+
+		exutil.By("Build a custom OS image for off-cluster layering")
+		osImageBuilder := OsImageBuilderInNode{
+			node:               node,
+			dockerFileCommands: fmt.Sprintf("RUN echo \"off-cluster layering %s\" > %s\nRUN ostree container commit", testID, offClusterFile),
+		}
+		digestedImage, err := osImageBuilder.CreateAndDigestOsImage()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the custom osImage for off-cluster layering")
+		logger.Infof("Built custom OS image: %s", digestedImage)
 		logger.Infof("OK!\n")
 
-		node := customMcp.GetSortedNodesOrFail()[0]
-
 		exutil.By("Apply osImageURL MachineConfig to pool (off-cluster layering)")
-		osLayerMC := NewMachineConfig(oc.AsAdmin(), osLayerMCName, customMcp.GetName())
-		osLayerMC.parameters = []string{"OS_IMAGE=" + osImageURL}
+		osLayerMC := NewMachineConfig(oc.AsAdmin(), osLayerMCName, mcp.GetName())
+		osLayerMC.parameters = []string{"OS_IMAGE=" + digestedImage}
 		defer osLayerMC.DeleteWithWait()
 		osLayerMC.create()
-		logger.Infof("MachineConfig %s created with osImageURL %s", osLayerMC.GetName(), osImageURL)
+		logger.Infof("MachineConfig %s created with osImageURL %s", osLayerMC.GetName(), digestedImage)
 		logger.Infof("OK!\n")
 
 		exutil.By("Verify off-cluster layering is applied on the node")
-		o.Expect(node.GetCurrentBootOSImage()).To(o.ContainSubstring("quay.io/mcoqe/layering"),
-			"Node %s should be running the off-cluster osImageURL", node)
-		offClusterRF := NewRemoteFile(node, offClusterFile)
+		o.Expect(node.GetCurrentBootOSImage()).To(o.Equal(digestedImage),
+			"Node %s should be running the off-cluster osImageURL %s", node, digestedImage)
 		o.Expect(offClusterRF.Exists()).To(o.BeTrue(),
 			"%s should exist on %s after off-cluster layering", offClusterFile, node)
 		logger.Infof("Off-cluster layering verified: %s exists on %s", offClusterFile, node)
 		logger.Infof("OK!\n")
 
 		exutil.By("Enable on-cluster layering (OCL) with a containerFile")
-		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, customMcp.GetName(), customMcp.GetName(), containerFiles)
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating MachineOSConfig for %s", customMcp.GetName())
+		mosc, err := CreateMachineOSConfigUsingExternalOrInternalRegistry(oc.AsAdmin(), MachineConfigNamespace, mcp.GetName(), mcp.GetName(), containerFiles)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating MachineOSConfig for %s", mcp.GetName())
 		defer DisableOCL(mosc)
 		logger.Infof("OK!\n")
 
@@ -267,22 +270,47 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		exutil.By("Verify both off-cluster and on-cluster layering files are present")
 		o.Expect(offClusterRF.Exists()).To(o.BeTrue(),
 			"%s should still exist alongside on-cluster layering", offClusterFile)
-		onClusterRF := NewRemoteFile(node, onClusterFile)
 		o.Expect(onClusterRF.Exists()).To(o.BeTrue(),
 			"%s should exist after on-cluster layering is applied", onClusterFile)
 		logger.Infof("Both %s and %s are present on %s", offClusterFile, onClusterFile, node)
 		logger.Infof("OK!\n")
 
-		exutil.By("Delete the off-cluster MC and verify a new MachineOSBuild is triggered")
-		osLayerMC.DeleteWithWait()
+		exutil.By("Record current MOSB before deleting off-cluster MC")
+		currentMOSB, err := mosc.GetCurrentMachineOSBuild()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting current MOSB")
+		currentMOSBName := currentMOSB.GetName()
+		logger.Infof("Current MOSB before MC deletion: %s", currentMOSBName)
+		logger.Infof("OK!\n")
+
+		exutil.By("Delete the off-cluster MC")
+		o.Expect(osLayerMC.Delete()).To(o.Succeed(),
+			"Error deleting off-cluster MachineConfig %s", osLayerMCName)
 		logger.Infof("Off-cluster MachineConfig %s deleted", osLayerMCName)
 		logger.Infof("OK!\n")
 
+		exutil.By("Wait for a new MachineOSBuild to be triggered after MC deletion")
+		o.Eventually(func() string {
+			newMOSB, err := mosc.GetCurrentMachineOSBuild()
+			if err != nil {
+				return currentMOSBName
+			}
+			return newMOSB.GetName()
+		}, "5m", "20s").ShouldNot(o.Equal(currentMOSBName),
+			"A new MOSB should be created after deleting the off-cluster MC")
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for the new build to succeed and deploy")
+		newMOSB, err := mosc.GetCurrentMachineOSBuild()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the new MOSB")
+		o.Eventually(newMOSB, "20m", "20s").Should(HaveConditionField("Succeeded", "status", TrueString),
+			"New MachineOSBuild didn't succeed after MC deletion")
+		logger.Infof("New MOSB %s built successfully", newMOSB.GetName())
+		mcp.waitForComplete()
+		logger.Infof("OK!\n")
+
 		exutil.By("Verify only on-cluster layering content remains after MC deletion")
-		offClusterRF = NewRemoteFile(node, offClusterFile)
 		o.Expect(offClusterRF.Exists()).To(o.BeFalse(),
 			"%s should be removed after off-cluster MC is deleted", offClusterFile)
-		onClusterRF = NewRemoteFile(node, onClusterFile)
 		o.Expect(onClusterRF.Exists()).To(o.BeTrue(),
 			"%s should still exist after off-cluster MC is deleted", onClusterFile)
 		logger.Infof("Only on-cluster layering file remains on %s (as expected)", node)

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -217,7 +217,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	g.It("[PolarionID:88202][OTP][Skipped:Disconnected] Both off-cluster and on-cluster layering can coexist on the same pool [Disruptive]", func() {
+	g.It("[PolarionID:88202][Skipped:Disconnected] Both off-cluster and on-cluster layering can coexist on the same pool [Disruptive]", func() {
 		var (
 			testID         = GetCurrentTestPolarionIDNumber()
 			mcpName        = fmt.Sprintf("tc-%s-custom", testID)


### PR DESCRIPTION
Verify that both off-cluster layering (via osImageURL in MachineConfig) and on-cluster layering (via MachineOSConfig with containerFile) can coexist on the same MachineConfigPool, and that deleting the off-cluster MC leaves only the on-cluster layering content.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Added automated e2e test for Polarion OCP-88202 ([MCO-1972](https://redhat.atlassian.net/browse/MCO-1972)) in test/extended-priv/mco_ocb.go. The test verifies that both off-cluster layering (via osImageURL in MachineConfig) and on-cluster layering (via MachineOSConfig with containerFile) can coexist on the same MachineConfigPool. It also validates that deleting the off-cluster MachineConfig triggers a new MachineOSBuild and only on-cluster layering content remains.

**- How to verify it**
- make machine-config-tests-ext
- ./_output/linux/amd64/machine-config-tests-ext list | grep 88202
- export KUBECONFIG=/path/to/kubeconfig
- ./_output/linux/amd64/machine-config-tests-ext run-test "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:88202][OTP][Skipped:Disconnected] Both off-cluster and on-cluster layering can coexist on the same pool [Disruptive]"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Add e2e test OCP-88202: verify off-cluster and on-cluster layering coexistence on the same MachineConfigPool


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a disruptive, skipped test that validates coexistence of off-cluster and on-cluster OS layering on the same machine pool/node. Verifies applying an off-cluster OS image, layering an on-cluster build, simultaneous presence of expected markers, removal of the off-cluster config triggers a rebuild and cleanup of off-cluster artifacts while preserving the on-cluster result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->