### PR TITLE
OCPNODE-4487: replace --system-reserved flags with config drop-in

### DIFF
--- a/pkg/controller/template/kubelet_config_dir_test.go
+++ b/pkg/controller/template/kubelet_config_dir_test.go
@@ -11,49 +11,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestKubeletConfigDirParameter verifies that the --config-dir parameter is correctly configured
-// in kubelet.service systemd unit files for worker nodes only.
-// This test ensures that:
-// - Worker nodes have --config-dir=/etc/openshift/kubelet.conf.d in their kubelet.service
-// - Master and arbiter nodes do NOT have the --config-dir parameter
-//
-// The --config-dir parameter allows the kubelet to load additional configuration from a directory,
-// which is useful for dynamic kubelet configuration updates on worker nodes.
+// TestKubeletConfigDirParameter verifies that the --config-dir parameter is present
+// in kubelet.service systemd unit files for all node roles (worker, master, arbiter).
 func TestKubeletConfigDirParameter(t *testing.T) {
 	testCases := []struct {
-		name               string
-		platform           configv1.PlatformType
-		controllerConfig   string
-		expectedWorkerFlag bool
-		expectedMasterFlag bool
+		name             string
+		platform         configv1.PlatformType
+		controllerConfig string
 	}{
 		{
-			name:               "AWS",
-			platform:           configv1.AWSPlatformType,
-			controllerConfig:   "./test_data/controller_config_aws.yaml",
-			expectedWorkerFlag: true,
-			expectedMasterFlag: false,
+			name:             "AWS",
+			platform:         configv1.AWSPlatformType,
+			controllerConfig: "./test_data/controller_config_aws.yaml",
 		},
 		{
-			name:               "BareMetal",
-			platform:           configv1.BareMetalPlatformType,
-			controllerConfig:   "./test_data/controller_config_baremetal.yaml",
-			expectedWorkerFlag: true,
-			expectedMasterFlag: false,
+			name:             "BareMetal",
+			platform:         configv1.BareMetalPlatformType,
+			controllerConfig: "./test_data/controller_config_baremetal.yaml",
 		},
 		{
-			name:               "GCP",
-			platform:           configv1.GCPPlatformType,
-			controllerConfig:   "./test_data/controller_config_gcp.yaml",
-			expectedWorkerFlag: true,
-			expectedMasterFlag: false,
+			name:             "GCP",
+			platform:         configv1.GCPPlatformType,
+			controllerConfig: "./test_data/controller_config_gcp.yaml",
 		},
 		{
-			name:               "None",
-			platform:           configv1.NonePlatformType,
-			controllerConfig:   "./test_data/controller_config_none.yaml",
-			expectedWorkerFlag: true,
-			expectedMasterFlag: false,
+			name:             "None",
+			platform:         configv1.NonePlatformType,
+			controllerConfig: "./test_data/controller_config_none.yaml",
 		},
 	}
 
@@ -65,8 +49,6 @@ func TestKubeletConfigDirParameter(t *testing.T) {
 			cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, templateDir)
 			require.NoError(t, err, "Failed to generate machine configs for %s", tc.name)
 
-			kubeletConfigs := make(map[string]*string)
-
 			for _, cfg := range cfgs {
 				role, ok := cfg.Labels[mcfgv1.MachineConfigRoleLabelKey]
 				require.True(t, ok, "Machine config missing role label")
@@ -76,46 +58,10 @@ func TestKubeletConfigDirParameter(t *testing.T) {
 
 				for _, unit := range ign.Systemd.Units {
 					if unit.Name == "kubelet.service" && unit.Contents != nil {
-						kubeletConfigs[role] = unit.Contents
+						assert.Contains(t, *unit.Contents, "--config-dir=/etc/openshift/kubelet.conf.d",
+							"%s node should have --config-dir for platform %s", role, tc.name)
 						break
 					}
-				}
-			}
-
-			for role, kubeletUnit := range kubeletConfigs {
-
-				hasConfigDirFlag := strings.Contains(*kubeletUnit, "--config-dir=/etc/openshift/kubelet.conf.d")
-
-				switch role {
-				case workerRole:
-					if tc.expectedWorkerFlag {
-						assert.True(t, hasConfigDirFlag,
-							"Worker node should have --config-dir parameter for platform %s", tc.name)
-					} else {
-						assert.False(t, hasConfigDirFlag,
-							"Worker node should not have --config-dir parameter for platform %s", tc.name)
-					}
-				case masterRole:
-					if tc.expectedMasterFlag {
-						assert.True(t, hasConfigDirFlag,
-							"Master node should have --config-dir parameter for platform %s", tc.name)
-					} else {
-						assert.False(t, hasConfigDirFlag,
-							"Master node should not have --config-dir parameter for platform %s", tc.name)
-					}
-				case arbiterRole:
-					if tc.expectedMasterFlag {
-						assert.True(t, hasConfigDirFlag,
-							"Arbiter node should have --config-dir parameter for platform %s", tc.name)
-					} else {
-						assert.False(t, hasConfigDirFlag,
-							"Arbiter node should not have --config-dir parameter for platform %s", tc.name)
-					}
-				}
-
-				if hasConfigDirFlag {
-					assert.Contains(t, *kubeletUnit, "--config-dir=/etc/openshift/kubelet.conf.d",
-						"--config-dir should point to /etc/openshift/kubelet.conf.d for %s/%s", tc.name, role)
 				}
 			}
 		})

--- a/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/mkdir --parents /etc/openshift/kubelet.conf.d
   ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") }}
   Environment="KUBELET_NODE_IP=::"
@@ -21,11 +22,11 @@ contents: |
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
-  EnvironmentFile=/etc/node-sizing.env
 
   ExecStart=/usr/local/bin/kubenswrapper \
       /usr/bin/kubelet \
         --config=/etc/kubernetes/kubelet.conf \
+        --config-dir=/etc/openshift/kubelet.conf.d \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
@@ -43,7 +44,6 @@ contents: |
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
         --register-with-taints=node-role.kubernetes.io/arbiter=:NoSchedule \
-        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/arbiter/01-arbiter-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/mkdir --parents /etc/openshift/kubelet.conf.d
   ExecStartPre=-/usr/sbin/restorecon /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
@@ -19,11 +20,11 @@ contents: |
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
-  EnvironmentFile=/etc/node-sizing.env
 
   ExecStart=/usr/local/bin/kubenswrapper \
       /usr/bin/kubelet \
         --config=/etc/kubernetes/kubelet.conf \
+        --config-dir=/etc/openshift/kubelet.conf.d \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
@@ -41,7 +42,6 @@ contents: |
         $KUBELET_CRIO_IMAGE_CREDENTIAL_PROVIDER_FLAGS \
         --hostname-override=${KUBELET_NODE_NAME} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule,node-role.kubernetes.io/arbiter=:NoSchedule \
-        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/common/_base/files/kubelet-auto-sizing.yaml
+++ b/templates/common/_base/files/kubelet-auto-sizing.yaml
@@ -4,7 +4,6 @@ contents:
   inline: |
     #!/bin/bash
     set -e
-    NODE_SIZES_ENV=${NODE_SIZES_ENV:-/etc/node-sizing.env}
     VERSION_1=1
     VERSION_2=2
     NODE_AUTO_SIZING_VERSION=${NODE_AUTO_SIZING_VERSION:-$VERSION_2}
@@ -31,7 +30,7 @@ contents:
             recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.02 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
         fi
         recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory | awk '{printf("%d\n",$1 + 0.5)}') # Round off so we avoid float conversions
-        echo "SYSTEM_RESERVED_MEMORY=${recommended_systemreserved_memory}Gi">> ${NODE_SIZES_ENV}
+        SYSTEM_RESERVED_MEMORY="${recommended_systemreserved_memory}Gi"
     }
     function dynamic_cpu_sizing {
         total_cpu=$(getconf _NPROCESSORS_ONLN)
@@ -79,7 +78,7 @@ contents:
         # Enforce minimum threshold of 0.5 CPU
         recommended_systemreserved_cpu=$(awk -v val="$recommended_systemreserved_cpu" 'BEGIN {if (val < 0.5) print 0.5; else print val}')
 
-        echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}">> ${NODE_SIZES_ENV}
+        SYSTEM_RESERVED_CPU="${recommended_systemreserved_cpu}"
     }
     function dynamic_ephemeral_sizing {
         echo "Not implemented yet"
@@ -92,35 +91,45 @@ contents:
         if [ -z "${SYSTEM_RESERVED_MEMORY}" ]; then
             SYSTEM_RESERVED_MEMORY="1Gi"
         fi
-        echo "SYSTEM_RESERVED_MEMORY=${SYSTEM_RESERVED_MEMORY}" >> ${NODE_SIZES_ENV}
     }
     function set_cpu {
         SYSTEM_RESERVED_CPU=$1
         if [ -z "${SYSTEM_RESERVED_CPU}" ]; then
             SYSTEM_RESERVED_CPU="500m"
         fi
-        echo "SYSTEM_RESERVED_CPU=${SYSTEM_RESERVED_CPU}" >> ${NODE_SIZES_ENV}
     }
     function set_es {
         SYSTEM_RESERVED_ES=$1
         if [ -z "${SYSTEM_RESERVED_ES}" ]; then
             SYSTEM_RESERVED_ES="1Gi"
         fi
-        echo "SYSTEM_RESERVED_ES=${SYSTEM_RESERVED_ES}" >> ${NODE_SIZES_ENV}
+    }
+    function write_kubelet_config_dropin {
+        DROPIN_DIR=${DROPIN_DIR:-/etc/openshift/kubelet.conf.d}
+        DROPIN_PATH="${DROPIN_DIR}/20-auto-sizing.conf"
+        mkdir -p ${DROPIN_DIR}
+        cat > ${DROPIN_PATH} <<DROPIN_EOF
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    systemReserved:
+      cpu: "${SYSTEM_RESERVED_CPU}"
+      memory: "${SYSTEM_RESERVED_MEMORY}"
+      ephemeral-storage: "${SYSTEM_RESERVED_ES}"
+    DROPIN_EOF
     }
     function dynamic_node_sizing {
-        rm -f ${NODE_SIZES_ENV}
         dynamic_memory_sizing
         dynamic_cpu_sizing $1
         set_es $2
+        write_kubelet_config_dropin
         #dynamic_ephemeral_sizing
         #dynamic_pid_sizing
     }
     function static_node_sizing {
-        rm -f ${NODE_SIZES_ENV}
         set_memory $1
         set_cpu $2
         set_es $3
+        write_kubelet_config_dropin
     }
     function create_version_file {
         echo "{\"version\": $1}" > $2

--- a/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/mkdir --parents /etc/openshift/kubelet.conf.d
   ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") }}
   Environment="KUBELET_NODE_IP=::"
@@ -21,11 +22,11 @@ contents: |
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
-  EnvironmentFile=/etc/node-sizing.env
 
   ExecStart=/usr/local/bin/kubenswrapper \
       /usr/bin/kubelet \
         --config=/etc/kubernetes/kubelet.conf \
+        --config-dir=/etc/openshift/kubelet.conf.d \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
@@ -43,7 +44,6 @@ contents: |
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/master/01-master-kubelet/on-prem/units/kubelet.service.yaml
@@ -10,6 +10,7 @@ contents: |
   [Service]
   Type=notify
   ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
+  ExecStartPre=/bin/mkdir --parents /etc/openshift/kubelet.conf.d
   ExecStartPre=-/usr/sbin/restorecon -ri /var/lib/kubelet/pod-resources /usr/local/bin/kubenswrapper /usr/bin/kubensenter
 {{- if eq .IPFamilies "IPv6"}}
   Environment="KUBELET_NODE_IP=::"
@@ -19,11 +20,11 @@ contents: |
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
-  EnvironmentFile=/etc/node-sizing.env
 
   ExecStart=/usr/local/bin/kubenswrapper \
       /usr/bin/kubelet \
         --config=/etc/kubernetes/kubelet.conf \
+        --config-dir=/etc/openshift/kubelet.conf.d \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
         --kubeconfig=/var/lib/kubelet/kubeconfig \
         --container-runtime-endpoint=/var/run/crio/crio.sock \
@@ -41,7 +42,6 @@ contents: |
         $KUBELET_CRIO_IMAGE_CREDENTIAL_PROVIDER_FLAGS \
         --hostname-override=${KUBELET_NODE_NAME} \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/_base/units/kubelet.service.yaml
@@ -22,7 +22,6 @@ contents: |
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
-  EnvironmentFile=/etc/node-sizing.env
 
   ExecStart=/usr/local/bin/kubenswrapper \
       /usr/bin/kubelet \
@@ -44,7 +43,6 @@ contents: |
         {{credentialProviderConfigFlag . }} \
         --hostname-override=${KUBELET_NODE_NAME} \
         --provider-id=${KUBELET_PROVIDERID} \
-        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
+++ b/templates/worker/01-worker-kubelet/on-prem/units/kubelet.service.yaml
@@ -20,7 +20,6 @@ contents: |
   EnvironmentFile=/etc/os-release
   EnvironmentFile=-/etc/kubernetes/kubelet-workaround
   EnvironmentFile=-/etc/kubernetes/kubelet-env
-  EnvironmentFile=/etc/node-sizing.env
 
   ExecStart=/usr/local/bin/kubenswrapper \
       /usr/bin/kubelet \
@@ -42,7 +41,6 @@ contents: |
         $KUBELET_CRIO_IMAGE_CREDENTIAL_PROVIDER_FLAGS \
         --cloud-provider={{cloudProvider .}} \
         --hostname-override=${KUBELET_NODE_NAME} \
-        --system-reserved=cpu=${SYSTEM_RESERVED_CPU},memory=${SYSTEM_RESERVED_MEMORY},ephemeral-storage=${SYSTEM_RESERVED_ES} \
         --v=${KUBELET_LOG_LEVEL}
 
   Restart=always

--- a/test/e2e-2of2/kubeletcfg_test.go
+++ b/test/e2e-2of2/kubeletcfg_test.go
@@ -357,3 +357,21 @@ func getValueFromKubeletConfig(t *testing.T, cs *framework.ClientSet, node corev
 	require.NotEmpty(t, matches[1], "regex %s attempted on kubelet config of node %s came back empty", node.Name, regexKey)
 	return matches[1], true
 }
+
+// TestKubeletAutoSizingDropIn verifies that the auto-sizing script creates a
+// KubeletConfiguration drop-in with systemReserved values on each node.
+func TestKubeletAutoSizingDropIn(t *testing.T) {
+	cs := framework.NewClientSet("")
+	dropInPath := "/etc/openshift/kubelet.conf.d/20-auto-sizing.conf"
+
+	for _, role := range []string{"worker", "master"} {
+		t.Run(role, func(t *testing.T) {
+			node := helpers.GetRandomNode(t, cs, role)
+			dropIn := helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", dropInPath))
+			require.Contains(t, dropIn, "kind: KubeletConfiguration",
+				"%s drop-in should be a KubeletConfiguration", role)
+			require.Contains(t, dropIn, "systemReserved:",
+				"%s drop-in should contain systemReserved", role)
+		})
+	}
+}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Remove `EnvironmentFile=/etc/node-sizing.env` and the `--system-reserved` command-line flag from `kubelet.service`. The auto-sizing script (`dynamic-system-reserved-calc.sh`) now writes a `KubeletConfiguration` drop-in file to `/etc/openshift/kubelet.conf.d/20-auto-sizing.conf`, which kubelet reads via `--config-dir` flag. Add `--config-dir` to master and arbiter `kubelet.service` for consistency with workers.

**- How to verify it**

- `go test ./pkg/controller/kubelet-config/... -v` passes
- `go test ./pkg/controller/template/... -v` passes (verifies --config-dir is present on all node roles)
- e2e test `TestKubeletAutoSizingDropIn` verifies the auto-sizing drop-in exists with systemReserved values

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Kubelet now receives systemReserved values via a KubeletConfiguration drop-in instead of --system-reserved command-line flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Kubelet now loads system-reserved settings from an OpenShift kubelet config drop-in directory (created at startup) instead of embedding them on the command line or using an external node-sizing env file; unit templates stop sourcing the old env file and adjust environment sources.

* **Tests**
  * New e2e test verifies the kubelet auto-sizing drop-in exists on nodes and contains systemReserved settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->