### PR TITLE
Fixes OCPBUGS-77140: increase LRU cache and prefetch timeout for PinnedImageSet

### DIFF
--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -218,7 +218,8 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	if err != nil {
 		klog.Fatalf("Failed to initialize CRI client: %v", err)
 	}
-	prefetchTimeout := 2 * time.Minute
+	// Allow enough time for large image sets on control-plane nodes (1 worker, 1s throttle per image).
+	prefetchTimeout := 5 * time.Minute
 	pinnedImageSetManager := daemon.NewPinnedImageSetManager(
 		startOpts.nodeName,
 		criClient,

--- a/pkg/daemon/pinned_image_set.go
+++ b/pkg/daemon/pinned_image_set.go
@@ -195,7 +195,8 @@ func NewPinnedImageSetManager(
 		DeleteFunc: p.deletePinnedImageSet,
 	})
 
-	p.cache = newImageCache(256)
+	// PinnedImageSet API allows up to 500 images per set; 1024 accommodates max images + set UID entries.
+	p.cache = newImageCache(1024)
 
 	return p
 }
@@ -377,7 +378,8 @@ func (p *PinnedImageSetManager) prefetchImageSets(ctx context.Context, imageSets
 	for _, imageSet := range imageSets {
 		imageSetCache := imageSet.DeepCopy()
 		imageSetCache.Spec.PinnedImages = nil
-		p.cache.Add(strings.TrimSpace(string(imageSet.UID)), *imageSet)
+		// Cache without PinnedImages to avoid storing large image lists in the LRU.
+		p.cache.Add(strings.TrimSpace(string(imageSet.UID)), *imageSetCache)
 	}
 
 	return nil

--- a/pkg/daemon/pinned_image_set_test.go
+++ b/pkg/daemon/pinned_image_set_test.go
@@ -369,7 +369,7 @@ func TestPrefetchImageSets(t *testing.T) {
 					Factor:   retryFactor,
 					Cap:      10 * time.Millisecond,
 				},
-				cache: newImageCache(256),
+				cache: newImageCache(1024),
 			}
 
 			imageSets := make([]*mcfgv1.PinnedImageSet, len(tt.imageSets))


### PR DESCRIPTION
This fix resolves the issue when specifying a large number of images in a PinnedImageSet, the sync never seems to complete - instead, it seems to get "stuck".

This is caused by the LRU image cache (256 entries) being smaller than the PinnedImageSet API limit (500 images per set). With large image sets, cache evictions cause already-pulled images to be re-scheduled on each sync cycle, creating an infinite loop where prefetching never completes. Additionally, the 2-minute prefetch timeout is insufficient for control-plane nodes, which are limited to 1 prefetch worker with a 1-second throttle between pulls.

**- What I did**

- Increase LRU cache from 256 to 1024 to accommodate max API capacity.
- Increase prefetch timeout from 2 to 5 minutes to allow progress per sync cycle on control-plane nodes.
- Fix unused DeepCopy: cache the stripped copy (*imageSetCache) instead of the full object (*imageSet) to avoid storing large image lists.
- Update test to match new cache size.

**- How to verify it**

- Build a new MCO image, you can use mine: quay.io/alosadag/machine-config-operator:fix-77140
- Deploy the new MCO image to the machine-config-daemon daemonset in your OCP cluster.
- Create a  Pinnedimageset CR. In my tests, I created two, one for the control plane and the other for the worker nodes. Each one contains ~400 images. That number of images was causing the pre-cache to never finish in the current version of MCO. 
- Wait for the task to be completed. You'll see similar logs like the following in the machine-config-daemon Pods:

```
I0514 11:03:03.130949  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:08:05.291363  249021 pinned_image_set.go:239] requeue: prefetching images incomplete after timeout: 5m0s
I0514 11:08:05.312949  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:13:05.871432  249021 pinned_image_set.go:239] requeue: prefetching images incomplete after timeout: 5m0s
I0514 11:13:05.901314  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:14:32.960084  249021 pinned_image_set.go:432] Completed scheduling 24% of images
I0514 11:18:06.069172  249021 pinned_image_set.go:239] requeue: prefetching images incomplete after timeout: 5m0s
I0514 11:18:06.110111  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:22:34.222889  249021 pinned_image_set.go:432] Completed scheduling 49% of images
I0514 11:23:07.588882  249021 pinned_image_set.go:239] requeue: prefetching images incomplete after timeout: 5m0s
I0514 11:23:07.645789  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:23:10.215967  249021 pinned_image_set.go:432] Completed scheduling 49% of images
I0514 11:27:08.165654  249021 certificate_writer.go:294] Certificate was synced from controllerconfig resourceVersion 60170
I0514 11:28:08.534526  249021 pinned_image_set.go:239] requeue: prefetching images incomplete after timeout: 5m0s
I0514 11:28:08.633327  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:31:09.445972  249021 pinned_image_set.go:432] Completed scheduling 74% of images
I0514 11:33:21.689101  249021 pinned_image_set.go:239] requeue: prefetching images incomplete after timeout: 5m0s
I0514 11:33:21.865139  249021 pinned_image_set.go:307] Reconciling pinned image set: precache-operators-controlplane: generation: 1
I0514 11:37:12.625529  249021 pinned_image_set.go:432] Completed scheduling 99% of images
I0514 11:38:19.764606  249021 file_writers.go:234] Writing file "/etc/crio/crio.conf.d/50-pinned-images"
I0514 11:38:19.767930  249021 update.go:2938] Running: systemctl reload crio
```


**- Description for the changelog**
Increase LRU cache and prefetch timeout for PinnedImageSet



Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Alberto Losada <alosadag@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved prefetch window timing and image cache optimization for better handling of large image sets on control-plane nodes
  * Enhanced memory efficiency in image caching while maintaining performance capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->