### PR TITLE
[release-4.22] OCPBUGS-85341: Apply password only if changes exist

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1249,22 +1249,22 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 				}
 			}
 		}()
-	}
 
-	// Set password hash
-	if err := dn.SetPasswordHash(newIgnConfig.Passwd.Users, oldIgnConfig.Passwd.Users); err != nil {
-		return err
-	}
-
-	defer func() {
-		if retErr != nil {
-			if err := dn.SetPasswordHash(oldIgnConfig.Passwd.Users, newIgnConfig.Passwd.Users); err != nil {
-				errs := kubeErrs.NewAggregate([]error{err, retErr})
-				retErr = fmt.Errorf("error rolling back password hash updates: %w", errs)
-				return
-			}
+		// Set password hash
+		if err := dn.SetPasswordHash(newIgnConfig.Passwd.Users, oldIgnConfig.Passwd.Users); err != nil {
+			return err
 		}
-	}()
+
+		defer func() {
+			if retErr != nil {
+				if err := dn.SetPasswordHash(oldIgnConfig.Passwd.Users, newIgnConfig.Passwd.Users); err != nil {
+					errs := kubeErrs.NewAggregate([]error{err, retErr})
+					retErr = fmt.Errorf("error rolling back password hash updates: %w", errs)
+					return
+				}
+			}
+		}()
+	}
 
 	if dn.os.IsCoreOSVariant() {
 		coreOSDaemon := CoreOSDaemon{dn}
@@ -2441,7 +2441,21 @@ func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
 	return nil
 }
 
-// Set a given PasswdUser's Password Hash
+func getUserPasswordHash(user string) (string, error) {
+	shadowOut, err := exec.Command("getent", "shadow", user).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to check password hash for %s: %w", user, err)
+	}
+	shadowSlice := strings.SplitN(strings.TrimSpace(string(shadowOut)), ":", 3)
+	if len(shadowSlice) >= 2 {
+		return shadowSlice[1], nil
+	}
+	return "", nil
+
+}
+
+// SetPasswordHash updates the password for each user in newUsers, skipping
+// users whose password already matches the desired configuration.
 func (dn *Daemon) SetPasswordHash(newUsers, oldUsers []ign3types.PasswdUser) error {
 	// confirm that user exits
 	klog.Info("Checking if absent users need to be disconfigured")
@@ -2464,6 +2478,15 @@ func (dn *Daemon) SetPasswordHash(newUsers, oldUsers []ign3types.PasswdUser) err
 		pwhash := "*"
 		if u.PasswordHash != nil && *u.PasswordHash != "" {
 			pwhash = *u.PasswordHash
+		}
+
+		// Check if hash update is needed. Skip if not.
+		currentHash, err := getUserPasswordHash(u.Name)
+		if err != nil {
+			return err
+		}
+		if currentHash == pwhash {
+			continue
 		}
 
 		if out, err := exec.Command("usermod", "-p", pwhash, u.Name).CombinedOutput(); err != nil {


### PR DESCRIPTION
Closes: [#OCPBUGS-85341](https://redhat.atlassian.net/browse/OCPBUGS-85341)

Backport of https://github.com/openshift/machine-config-operator/pull/5889

- What I did

This bugfix ensures that the MCD only runs usermod if the password hash has actually changed and not in every update. This aligns the behavior we currently have for SSH passwords.

- How to verify it

TBD

- Description for the changelog

This bugfix ensures that the MCD only runs usermod if the password hash has actually changed and not in every update.