### PR TITLE
OCPBUGS-86035: Adapt test '54922 - daemon: add check before updating kerne…

### DIFF
--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -136,7 +136,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 
 			expectedLogArg1Regex = regexp.QuoteMeta("Running rpm-ostree [kargs") + ".*" + regexp.QuoteMeta(fmt.Sprintf("--append=%s", kernelArg1)) +
 				".*" + regexp.QuoteMeta("]")
-			expectedLogArg2Regex = regexp.QuoteMeta("Running rpm-ostree [kargs") + ".*" + regexp.QuoteMeta(fmt.Sprintf("--delete=%s", kernelArg1)) +
+			expectedLogArg2Regex = regexp.QuoteMeta("Running rpm-ostree [kargs") + ".*" + regexp.QuoteMeta(fmt.Sprintf("--delete-if-present=%s", kernelArg1)) +
 				".*" + regexp.QuoteMeta(fmt.Sprintf("--append=%s", kernelArg1)) +
 				".*" + regexp.QuoteMeta(fmt.Sprintf("--append=%s", kernelArg2)) +
 				".*" + regexp.QuoteMeta("]")


### PR DESCRIPTION
…lArgs'. Use --delete-if-present


**- What I did**

Adapt test case OCP-54922 to use --delete-if-present instead of --delete

The test case needs to be modified since we merged: https://github.com/openshift/machine-config-operator/pull/5914


**- How to verify it**

Test  OCP-54922  should pass

**- Description for the changelog**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for kernel argument removal behavior to match current implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->