### PR TITLE
OCP-88366: Fix use internal registry when building custom OS image

### DIFF
--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -236,6 +236,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	})
 
 	g.It("[PolarionID:88366][Skipped:Disconnected] osImageStream should be empty when osImageURL is set [apigroup:machineconfiguration.openshift.io]", func() {
+		SkipTestIfCannotUseInternalRegistry(oc.AsAdmin())
+
 		var (
 			testID        = GetCurrentTestPolarionIDNumber()
 			osLayerMCName = fmt.Sprintf("tc-%s-os-layer-custom", testID)
@@ -254,9 +256,6 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 			"%s should report rhel-9 in status.osImageStream", mcp)
 		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
 		logger.Infof("OK!\n")
-
-		exutil.By("Skip if the internal registry cannot be used")
-		SkipTestIfCannotUseInternalRegistry(oc.AsAdmin())
 
 		exutil.By("Build a custom OS image to use as osImageURL")
 		node = mcp.GetSortedNodesOrFail()[0]

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -255,9 +255,12 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("%s osImageStream: %s", mcp, mcp.GetSafe(`{.status.osImageStream}`, ""))
 		logger.Infof("OK!\n")
 
+		exutil.By("Skip if the internal registry cannot be used")
+		SkipTestIfCannotUseInternalRegistry(oc.AsAdmin())
+
 		exutil.By("Build a custom OS image to use as osImageURL")
 		node = mcp.GetSortedNodesOrFail()[0]
-		osImageBuilder := OsImageBuilderInNode{node: node, dockerFileCommands: "RUN ostree container commit"}
+		osImageBuilder := OsImageBuilderInNode{node: node, dockerFileCommands: "RUN ostree container commit", UseInternalRegistry: true}
 		digestedImage, err := osImageBuilder.CreateAndDigestOsImage()
 		o.Expect(err).NotTo(o.HaveOccurred(),
 			"Error creating the custom osImage")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
-   Added SkipTestIfCannotUseInternalRegistry(oc.AsAdmin()) to OCP-88366 before the image build step, and set UseInternalRegistry: true on OsImageBuilderInNode so the custom OS image is pushed to the cluster's internal registry  (image-registry.openshift-image-registry.svc:5000) instead of an external one.

**- How to verify it**
 - Run OCP-88366 on a cluster without a usable internal registry (ImageRegistry capability disabled or emptyDir storage), the test should skip gracefully. On a cluster with a properly configured internal registry, the test should build and push the custom OS image to the internal registry and pass end-to-end.
 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix OCP-88366 test to use the cluster's internal registry when building a custom OS image, and skip gracefully when the internal registry is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved OS image stream testing to ensure proper handling of internal registry configurations and appropriate fallback behavior when internal registry is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->