### PR TITLE
OCPBUGS-85519: Add Agent IRI credentials to global pull secret

### DIFF
--- a/pkg/controller/common/iri_secret_merger.go
+++ b/pkg/controller/common/iri_secret_merger.go
@@ -60,7 +60,7 @@ func NewIRISecretMerger(
 			if err != nil {
 				return "", "", fmt.Errorf("could not get ControllerConfig: %w", err)
 			}
-			return extractIRICredentials(secret, cconfig)
+			return ExtractIRICredentials(secret, cconfig)
 		},
 	}
 }
@@ -83,7 +83,7 @@ func NewIRISecretMergerFromObjects(
 			if !iri {
 				return "", "", errIRIDisabled
 			}
-			return extractIRICredentials(secret, cconfig)
+			return ExtractIRICredentials(secret, cconfig)
 		},
 	}
 }
@@ -102,7 +102,7 @@ func (m *IRISecretMerger) Merge(pullSecretRaw []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	merged, changed, err := mergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw, password, baseDomain)
+	merged, changed, err := MergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw, password, baseDomain)
 	if err != nil {
 		return nil, err
 	}
@@ -112,9 +112,9 @@ func (m *IRISecretMerger) Merge(pullSecretRaw []byte) ([]byte, error) {
 	return merged, nil
 }
 
-// extractIRICredentials validates and extracts the password and baseDomain from
+// ExtractIRICredentials validates and extracts the password and baseDomain from
 // the IRI credentials secret and ControllerConfig.
-func extractIRICredentials(secret *corev1.Secret, cconfig *mcfgv1.ControllerConfig) (password, baseDomain string, err error) {
+func ExtractIRICredentials(secret *corev1.Secret, cconfig *mcfgv1.ControllerConfig) (password, baseDomain string, err error) {
 	if secret == nil {
 		return "", "", fmt.Errorf("IRI registry credentials secret must not be nil")
 	}
@@ -135,13 +135,13 @@ func extractIRICredentials(secret *corev1.Secret, cconfig *mcfgv1.ControllerConf
 	return string(pw), bd, nil
 }
 
-// mergeIRIRegistryCredentialsIntoPullSecret merges IRI registry authentication
+// MergeIRIRegistryCredentialsIntoPullSecret merges IRI registry authentication
 // credentials into a dockerconfigjson pull secret. It adds auth entries for
 // api-int.<baseDomain>:<IRIRegistryPort> (all nodes) and
 // localhost:<IRIRegistryPort> (masters, where the registry runs locally).
 // Returns the merged bytes, a boolean indicating whether the pull secret was
 // changed, and any error.
-func mergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw []byte, password, baseDomain string) ([]byte, bool, error) {
+func MergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw []byte, password, baseDomain string) ([]byte, bool, error) {
 	// The IRI registry is reachable via api-int on all nodes, and also via
 	// localhost on master nodes where it runs locally. registries.conf mirror
 	// rules on masters use localhost:22625, so credentials must be present for

--- a/pkg/controller/common/iri_secret_merger.go
+++ b/pkg/controller/common/iri_secret_merger.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -53,7 +54,7 @@ func NewIRISecretMerger(
 			if err != nil {
 				return "", "", fmt.Errorf("could not get ControllerConfig: %w", err)
 			}
-			return extractIRICredentials(secret, cconfig)
+			return ExtractIRICredentials(secret, cconfig)
 		},
 	}
 }
@@ -72,7 +73,7 @@ func NewIRISecretMergerFromObjects(
 			if !iri {
 				return "", "", errIRIDisabled
 			}
-			return extractIRICredentials(secret, cconfig)
+			return ExtractIRICredentials(secret, cconfig)
 		},
 	}
 }
@@ -91,7 +92,7 @@ func (m *IRISecretMerger) Merge(pullSecretRaw []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	merged, changed, err := mergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw, password, baseDomain)
+	merged, changed, err := MergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw, password, baseDomain)
 	if err != nil {
 		return nil, err
 	}
@@ -101,9 +102,9 @@ func (m *IRISecretMerger) Merge(pullSecretRaw []byte) ([]byte, error) {
 	return merged, nil
 }
 
-// extractIRICredentials validates and extracts the password and baseDomain from
+// ExtractIRICredentials validates and extracts the password and baseDomain from
 // the IRI credentials secret and ControllerConfig.
-func extractIRICredentials(secret *corev1.Secret, cconfig *mcfgv1.ControllerConfig) (password, baseDomain string, err error) {
+func ExtractIRICredentials(secret *corev1.Secret, cconfig *mcfgv1.ControllerConfig) (password, baseDomain string, err error) {
 	if secret == nil {
 		return "", "", fmt.Errorf("IRI registry credentials secret must not be nil")
 	}
@@ -124,13 +125,13 @@ func extractIRICredentials(secret *corev1.Secret, cconfig *mcfgv1.ControllerConf
 	return string(pw), bd, nil
 }
 
-// mergeIRIRegistryCredentialsIntoPullSecret merges IRI registry authentication
+// MergeIRIRegistryCredentialsIntoPullSecret merges IRI registry authentication
 // credentials into a dockerconfigjson pull secret. It adds auth entries for
 // api-int.<baseDomain>:<IRIRegistryPort> (all nodes) and
 // localhost:<IRIRegistryPort> (masters, where the registry runs locally).
 // Returns the merged bytes, a boolean indicating whether the pull secret was
 // changed, and any error.
-func mergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw []byte, password, baseDomain string) ([]byte, bool, error) {
+func MergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw []byte, password, baseDomain string) ([]byte, bool, error) {
 	// The IRI registry is reachable via api-int on all nodes, and also via
 	// localhost on master nodes where it runs locally. registries.conf mirror
 	// rules on masters use localhost:22625, so credentials must be present for
@@ -175,5 +176,5 @@ func mergeIRIRegistryCredentialsIntoPullSecret(pullSecretRaw []byte, password, b
 // matches expected.
 func pullSecretHasAuth(auths map[string]interface{}, host, expected string) bool {
 	e, ok := auths[host].(map[string]interface{})
-	return ok && e["auth"] == expected
+	return ok && subtle.ConstantTimeCompare([]byte(e["auth"].(string)), []byte(expected)) == 1
 }

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
@@ -53,6 +53,7 @@ var (
 // Controller defines the InternalReleaseImage controller.
 type Controller struct {
 	client        mcfgclientset.Interface
+	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
 
 	syncHandler func(mcp string) error
@@ -103,6 +104,7 @@ func New(
 
 	ctrl := &Controller{
 		client:        mcfgClient,
+		kubeClient:    kubeClient,
 		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-internalreleaseimagecontroller"})),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
@@ -51,6 +51,7 @@ var updateBackoff = wait.Backoff{
 // Controller defines the InternalReleaseImage controller.
 type Controller struct {
 	client        mcfgclientset.Interface
+	kubeClient    clientset.Interface
 	eventRecorder record.EventRecorder
 
 	syncHandler func(mcp string) error
@@ -101,6 +102,7 @@ func New(
 
 	ctrl := &Controller{
 		client:        mcfgClient,
+		kubeClient:    kubeClient,
 		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-internalreleaseimagecontroller"})),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -35,6 +35,7 @@ import (
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corev1clientset "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -70,12 +71,12 @@ type Controller struct {
 	apiserverLister       configlistersv1.APIServerLister
 	apiserverListerSynced cache.InformerSynced
 
+	iriSecretsLister         corelistersv1.SecretLister
+	iriLister                mcfglistersv1.InternalReleaseImageLister
 	ccListerSynced           cache.InformerSynced
 	secretsInformerSynced    cache.InformerSynced
 	iriSecretsInformerSynced cache.InformerSynced
 	iriInformerSynced        cache.InformerSynced
-
-	iriMerger *ctrlcommon.IRISecretMerger
 
 	queue workqueue.TypedRateLimitingInterface[string]
 
@@ -92,7 +93,7 @@ func New(
 	apiserverInformer configinformersv1.APIServerInformer,
 	kubeClient clientset.Interface,
 	mcfgClient mcfgclientset.Interface,
-	fgHandler ctrlcommon.FeatureGatesHandler,
+	_ ctrlcommon.FeatureGatesHandler,
 ) *Controller {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
@@ -119,15 +120,15 @@ func New(
 
 	if iriSecretsInformer != nil {
 		ctrl.iriSecretsInformerSynced = iriSecretsInformer.Informer().HasSynced
+		ctrl.iriSecretsLister = iriSecretsInformer.Lister()
 	} else {
 		ctrl.iriSecretsInformerSynced = func() bool { return true }
 	}
 	if iriInformer != nil {
 		ctrl.iriInformerSynced = iriInformer.Informer().HasSynced
-		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(iriSecretsInformer.Lister(), ctrl.ccLister, iriInformer.Lister(), fgHandler)
+		ctrl.iriLister = iriInformer.Lister()
 	} else {
 		ctrl.iriInformerSynced = func() bool { return true }
-		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(nil, ctrl.ccLister, nil, fgHandler)
 	}
 
 	ccInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -164,9 +165,28 @@ func New(
 }
 
 func (ctrl *Controller) filterSecret(secret *corev1.Secret) {
-	if secret.Name == "pull-secret" || secret.Name == ctrlcommon.InternalReleaseImageAuthSecretName {
+	// Check if this is the IRI auth secret
+	if secret.Namespace == ctrlcommon.MCONamespace && secret.Name == ctrlcommon.InternalReleaseImageAuthSecretName {
 		ctrl.enqueueController()
-		klog.Infof("Re-syncing ControllerConfig due to secret %s change", secret.Name)
+		klog.Infof("Re-syncing ControllerConfig due to secret %s/%s change", secret.Namespace, secret.Name)
+		return
+	}
+
+	// Check if this is the configured global pull secret
+	cfg, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
+	if err != nil {
+		// If we can't get the ControllerConfig, we can't determine if this secret
+		// is the pull secret, so skip the check. The controller will eventually
+		// sync when the ControllerConfig is available.
+		klog.V(4).Infof("Could not get ControllerConfig to check secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		return
+	}
+
+	if cfg.Spec.PullSecret != nil &&
+		secret.Namespace == cfg.Spec.PullSecret.Namespace &&
+		secret.Name == cfg.Spec.PullSecret.Name {
+		ctrl.enqueueController()
+		klog.Infof("Re-syncing ControllerConfig due to secret %s/%s change", secret.Namespace, secret.Name)
 	}
 }
 
@@ -585,14 +605,9 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 		clusterPullSecretRaw = clusterPullSecret.Data[corev1.DockerConfigJsonKey]
 	}
 
-	// If IRI is in use, merge its registry credentials into the pull secret so
-	// that kubelet and CRI-O on all nodes can authenticate to the IRI registry.
-	// Credentials are merged at render time rather than writing back to the
-	// user-controlled global pull secret, avoiding ownership conflicts and the
-	// timing window where 00-master/00-worker could be rendered without IRI creds.
-	clusterPullSecretRaw, err = ctrl.iriMerger.Merge(clusterPullSecretRaw)
-	if err != nil {
-		return ctrl.syncFailingStatus(cfg, fmt.Errorf("could not merge IRI registry credentials into pull secret: %w", err))
+	// Sync IRI credentials into the global pull secret if IRI is enabled
+	if err := ctrl.syncGlobalPullSecret(cfg); err != nil {
+		return ctrl.syncFailingStatus(cfg, fmt.Errorf("could not sync global pull secret with IRI credentials: %w", err))
 	}
 
 	// Grab the tlsSecurityProfile from the apiserver object
@@ -627,6 +642,127 @@ func (ctrl *Controller) syncControllerConfig(key string) error {
 	}
 
 	return ctrl.syncCompletedStatus(cfg)
+}
+
+// syncGlobalPullSecret merges IRI registry credentials into the global pull secret
+// referenced by ControllerConfig.Spec.PullSecret when IRI is enabled. This ensures
+// that all components that use the global pull secret (including kubelet/CRI-O) can
+// authenticate to the IRI registry.
+//
+// This method only updates an existing global pull secret. It does not create one
+// if it doesn't exist, as the global pull secret should be created by the installer
+// or cluster-bootstrap process.
+//
+// Feature gate check: This method checks if IRI is enabled before attempting to
+// merge credentials. If IRI is not enabled (feature gate off or no IRI object exists),
+// it returns without error.
+func (ctrl *Controller) syncGlobalPullSecret(cfg *mcfgv1.ControllerConfig) error {
+	// If there's no pull secret configured, nothing to do
+	if cfg.Spec.PullSecret == nil {
+		klog.V(4).Info("No global pull secret configured in ControllerConfig, skipping IRI credential sync")
+		return nil
+	}
+
+	// If IRI listers are not available, IRI feature is not enabled
+	if ctrl.iriSecretsLister == nil || ctrl.iriLister == nil {
+		klog.V(4).Info("IRI feature not enabled, skipping IRI credential sync")
+		return nil
+	}
+
+	// Check if IRI object exists
+	iri, err := ctrl.iriLister.Get(ctrlcommon.InternalReleaseImageInstanceName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// IRI not configured, skip
+			klog.V(4).Info("InternalReleaseImage not configured, skipping IRI credential sync")
+			return nil
+		}
+		return fmt.Errorf("could not get InternalReleaseImage: %w", err)
+	}
+
+	// If IRI is being deleted, skip credential sync
+	if !iri.DeletionTimestamp.IsZero() {
+		klog.V(4).Info("InternalReleaseImage is being deleted, skipping IRI credential sync")
+		return nil
+	}
+
+	// Get the IRI auth secret
+	iriAuthSecret, err := ctrl.iriSecretsLister.Secrets(ctrlcommon.MCONamespace).Get(ctrlcommon.InternalReleaseImageAuthSecretName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// IRI auth secret doesn't exist yet, skip for now
+			klog.V(4).Info("IRI auth secret not found, skipping IRI credential sync")
+			return nil
+		}
+		return fmt.Errorf("could not get IRI auth secret: %w", err)
+	}
+
+	// Extract IRI credentials (password and baseDomain)
+	password, baseDomain, err := ctrlcommon.ExtractIRICredentials(iriAuthSecret, cfg)
+	if err != nil {
+		return fmt.Errorf("could not extract IRI credentials: %w", err)
+	}
+
+	// Try to get the global pull secret
+	globalPullSecret, err := ctrl.kubeClient.CoreV1().Secrets(cfg.Spec.PullSecret.Namespace).Get(
+		context.TODO(),
+		cfg.Spec.PullSecret.Name,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Global pull secret doesn't exist yet. This can happen during cluster bootstrap
+			// before the installer has created the pull secret. We'll retry on the next sync.
+			klog.V(4).Infof("Global pull secret %s/%s does not exist yet, will retry on next sync",
+				cfg.Spec.PullSecret.Namespace, cfg.Spec.PullSecret.Name)
+			return nil
+		}
+		return fmt.Errorf("could not get global pull secret %s/%s: %w",
+			cfg.Spec.PullSecret.Namespace, cfg.Spec.PullSecret.Name, err)
+	}
+
+	// Validate secret type
+	if globalPullSecret.Type != corev1.SecretTypeDockerConfigJson {
+		return fmt.Errorf("expected global pull secret type %s found %s",
+			corev1.SecretTypeDockerConfigJson, globalPullSecret.Type)
+	}
+
+	// Get the current pull secret data
+	pullSecretData := globalPullSecret.Data[corev1.DockerConfigJsonKey]
+	if pullSecretData == nil {
+		return fmt.Errorf("global pull secret missing %s key", corev1.DockerConfigJsonKey)
+	}
+
+	// Merge IRI credentials into the pull secret
+	mergedData, changed, err := ctrlcommon.MergeIRIRegistryCredentialsIntoPullSecret(pullSecretData, password, baseDomain)
+	if err != nil {
+		return fmt.Errorf("could not merge IRI credentials into global pull secret: %w", err)
+	}
+
+	// If the data didn't change, no need to update
+	if !changed {
+		klog.V(4).Infof("Global pull secret %s/%s already contains IRI credentials, no update needed",
+			cfg.Spec.PullSecret.Namespace, cfg.Spec.PullSecret.Name)
+		return nil
+	}
+
+	// Update the secret with merged credentials
+	globalPullSecret.Data[corev1.DockerConfigJsonKey] = mergedData
+
+	_, err = ctrl.kubeClient.CoreV1().Secrets(cfg.Spec.PullSecret.Namespace).Update(
+		context.TODO(),
+		globalPullSecret,
+		metav1.UpdateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("could not update global pull secret %s/%s: %w",
+			cfg.Spec.PullSecret.Namespace, cfg.Spec.PullSecret.Name, err)
+	}
+
+	klog.Infof("Successfully merged IRI credentials into global pull secret %s/%s",
+		cfg.Spec.PullSecret.Namespace, cfg.Spec.PullSecret.Name)
+
+	return nil
 }
 
 // clearImageURLs clears OSImageURL and BaseOSExtensionsContainerImage from template-generated

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -158,9 +158,28 @@ func New(
 }
 
 func (ctrl *Controller) filterSecret(secret *corev1.Secret) {
-	if secret.Name == "pull-secret" || secret.Name == ctrlcommon.InternalReleaseImageAuthSecretName {
+	// Check if this is the IRI auth secret
+	if secret.Namespace == ctrlcommon.MCONamespace && secret.Name == ctrlcommon.InternalReleaseImageAuthSecretName {
 		ctrl.enqueueController()
-		klog.Infof("Re-syncing ControllerConfig due to secret %s change", secret.Name)
+		klog.Infof("Re-syncing ControllerConfig due to secret %s/%s change", secret.Namespace, secret.Name)
+		return
+	}
+
+	// Check if this is the configured global pull secret
+	cfg, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
+	if err != nil {
+		// If we can't get the ControllerConfig, we can't determine if this secret
+		// is the pull secret, so skip the check. The controller will eventually
+		// sync when the ControllerConfig is available.
+		klog.V(4).Infof("Could not get ControllerConfig to check secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		return
+	}
+
+	if cfg.Spec.PullSecret != nil &&
+		secret.Namespace == cfg.Spec.PullSecret.Namespace &&
+		secret.Name == cfg.Spec.PullSecret.Name {
+		ctrl.enqueueController()
+		klog.Infof("Re-syncing ControllerConfig due to secret %s/%s change", secret.Namespace, secret.Name)
 	}
 }
 
@@ -170,7 +189,7 @@ func (ctrl *Controller) addSecret(obj interface{}) {
 		ctrl.deleteSecret(secret)
 		return
 	}
-	klog.V(4).Infof("Add Secret %v", secret)
+	klog.V(4).Infof("Add Secret %s/%s", secret.Namespace, secret.Name)
 	ctrl.filterSecret(secret)
 }
 
@@ -178,7 +197,7 @@ func (ctrl *Controller) updateSecret(old, newObj interface{}) {
 	oldSecret := old.(*corev1.Secret)
 	newSecret := newObj.(*corev1.Secret)
 
-	klog.V(4).Infof("Update Secret %v", newSecret)
+	klog.V(4).Infof("Update Secret %s/%s", newSecret.Namespace, newSecret.Name)
 
 	// Only trigger resync if the secret data actually changed
 	// This prevents log spam from informer resyncs and watch reconnections
@@ -189,7 +208,7 @@ func (ctrl *Controller) updateSecret(old, newObj interface{}) {
 
 func (ctrl *Controller) deleteSecret(obj interface{}) {
 	secret, ok := obj.(*corev1.Secret)
-	klog.V(4).Infof("Delete Secret %v", secret)
+	klog.V(4).Infof("Delete Secret %s/%s", secret.Namespace, secret.Name)
 
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 
@@ -540,11 +539,10 @@ func TestKubeletAutoNodeSizingEnabled(t *testing.T) {
 	}
 }
 
-// TestMergesIRIRegistryCredentialsIntoPullSecret verifies that the template controller merges
-// IRI registry credentials into the pull secret when rendering 00-master, so that
-// nodes can authenticate to the IRI registry without writing to the user-controlled
-// global pull secret.
-func TestMergesIRIRegistryCredentialsIntoPullSecret(t *testing.T) {
+// TestRendersIRIRegistryCredentialsFromGlobalPullSecret verifies that the template
+// controller renders the global pull secret to /var/lib/kubelet/config.json, including
+// IRI registry credentials that were added to the global pull secret by the IRI controller.
+func TestRendersIRIRegistryCredentialsFromGlobalPullSecret(t *testing.T) {
 	f := newFixture(t)
 
 	cc := newControllerConfig(ctrlcommon.ControllerConfigName)
@@ -552,27 +550,18 @@ func TestMergesIRIRegistryCredentialsIntoPullSecret(t *testing.T) {
 		Spec: configv1.DNSSpec{BaseDomain: "example.com"},
 	}
 
-	pullSecretJSON := []byte(`{"auths":{"quay.io":{"auth":"dGVzdDp0ZXN0"}}}`)
+	// The global pull secret now already contains IRI credentials (added by IRI controller).
+	expectedAuth := base64.StdEncoding.EncodeToString([]byte("openshift:testpassword"))
+	pullSecretJSON := []byte(`{"auths":{` +
+		`"quay.io":{"auth":"dGVzdDp0ZXN0"},` +
+		`"api-int.example.com:22625":{"auth":"` + expectedAuth + `"},` +
+		`"localhost:22625":{"auth":"` + expectedAuth + `"}` +
+		`}}`)
 	ps := newPullSecret("coreos-pull-secret", pullSecretJSON)
-
-	iriRegistryCredentialsSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ctrlcommon.InternalReleaseImageAuthSecretName,
-			Namespace: ctrlcommon.MCONamespace,
-		},
-		Data: map[string][]byte{
-			"password": []byte("testpassword"),
-		},
-	}
 
 	f.ccLister = append(f.ccLister, cc)
 	f.objects = append(f.objects, cc)
-	f.kubeobjects = append(f.kubeobjects, ps, iriRegistryCredentialsSecret)
-	f.iriObjects = append(f.iriObjects, &mcfgv1.InternalReleaseImage{
-		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.InternalReleaseImageInstanceName},
-	})
-	f.fgHandler = ctrlcommon.NewFeatureGatesHardcodedHandler(
-		[]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall}, nil)
+	f.kubeobjects = append(f.kubeobjects, ps)
 
 	ctrl := f.newController()
 	if err := ctrl.syncHandler(ctrlcommon.ControllerConfigName); err != nil {
@@ -614,21 +603,22 @@ func TestMergesIRIRegistryCredentialsIntoPullSecret(t *testing.T) {
 		t.Fatal("pull secret missing 'auths' field")
 	}
 
-	// Verify IRI entries are present for both api-int and localhost with correct credentials.
-	expectedAuth := base64.StdEncoding.EncodeToString([]byte("openshift:testpassword"))
-	for _, host := range []string{"api-int.example.com:22625", "localhost:22625"} {
-		entry, found := auths[host].(map[string]interface{})
-		if !found {
-			t.Errorf("IRI auth entry missing for %s in rendered pull secret", host)
-			continue
-		}
-		if entry["auth"] != expectedAuth {
-			t.Errorf("IRI auth value for %s = %q, want %q", host, entry["auth"], expectedAuth)
-		}
+	// Verify that all entries from the global pull secret are preserved,
+	// including IRI credentials that were added by the IRI controller.
+	expectedHosts := map[string]string{
+		"quay.io":                    "dGVzdDp0ZXN0",
+		"api-int.example.com:22625":  expectedAuth,
+		"localhost:22625":            expectedAuth,
 	}
 
-	// Verify the original quay.io entry is preserved.
-	if _, found := auths["quay.io"]; !found {
-		t.Error("original quay.io auth entry was dropped from pull secret")
+	for host, expectedAuthValue := range expectedHosts {
+		entry, found := auths[host].(map[string]interface{})
+		if !found {
+			t.Errorf("auth entry missing for %s in rendered pull secret", host)
+			continue
+		}
+		if entry["auth"] != expectedAuthValue {
+			t.Errorf("auth value for %s = %q, want %q", host, entry["auth"], expectedAuthValue)
+		}
 	}
 }

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -530,8 +530,8 @@ func TestKubeletAutoNodeSizingEnabled(t *testing.T) {
 	}
 }
 
-// TestMergesIRIRegistryCredentialsIntoPullSecret verifies that the template controller merges
-// IRI registry credentials into the pull secret when rendering 00-master, so that
+// TestMergesIRIRegistryCredentialsIntoPullSecret verifies that the template
+// controller merges IRI registry credentials into the rendered pull secret so
 // nodes can authenticate to the IRI registry without writing to the user-controlled
 // global pull secret.
 func TestMergesIRIRegistryCredentialsIntoPullSecret(t *testing.T) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -290,6 +290,7 @@ func New(
 		apiserverInformer.Informer(),
 		moscInformer.Informer(),
 		networkPolicyInformer.Informer(),
+		iriInformer.Informer(),
 	}
 	for _, i := range informers {
 		i.AddEventHandler(optr.eventHandler())

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -2324,6 +2324,19 @@ func (optr *Operator) getImageRegistryPullSecrets() ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal the merged pull secrets: %w", err)
 		}
 
+		// Ensure nodes can authenticate to the internal release image (IRI)
+		// registry when pulling images during OS updates. The credentials
+		// added here become part of ControllerConfig.Spec.InternalRegistryPullSecret,
+		// which is the auth source the OS-update path (rpm-ostree/bootc) uses;
+		// that path is separate from the kubelet's pull secret, so IRI credentials
+		// must be supplied here in addition to the render-time merge. When IRI is
+		// not enabled on the cluster this merge makes no changes.
+		iriMerger := ctrlcommon.NewIRISecretMerger(optr.mcoSecretLister, optr.ccLister, optr.iriLister)
+		mergedPullSecrets, err = iriMerger.Merge(mergedPullSecrets)
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge IRI registry credentials into image registry pull secrets: %w", err)
+		}
+
 		return mergedPullSecrets, nil
 	}
 

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -14,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
@@ -304,6 +307,136 @@ func TestMachineOSBuilderSecretReconciliation(t *testing.T) {
 			secrets, err := kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).List(context.TODO(), metav1.ListOptions{})
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, secrets.Items, tc.expectedMCOSecrets)
+		})
+	}
+}
+
+// newNamespacedIndexer returns an indexer configured with the namespace index,
+// as required by the namespaced core listers (Secrets, ServiceAccounts).
+func newNamespacedIndexer(objs ...interface{}) cache.Indexer {
+	idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, o := range objs {
+		idx.Add(o)
+	}
+	return idx
+}
+
+// TestGetImageRegistryPullSecretsIRIMerge verifies that getImageRegistryPullSecrets
+// merges InternalReleaseImage (IRI) registry credentials into the assembled
+// image-registry pull secret when IRI is in use, and leaves the secret untouched
+// when IRI is absent. This blob feeds ControllerConfig.Spec.InternalRegistryPullSecret,
+// which the daemon writes to /etc/mco/internal-registry-pull-secret.json for the
+// OS-update image-pull path.
+func TestGetImageRegistryPullSecretsIRIMerge(t *testing.T) {
+	const (
+		baseDomain  = "example.com"
+		iriPassword = "s3cr3t"
+	)
+	expectedIRIAuth := base64.StdEncoding.EncodeToString([]byte(ctrlcommon.IRIRegistryUsername + ":" + iriPassword))
+	iriAPIIntHost := "api-int." + baseDomain + ":22625"
+	iriLocalHost := "localhost:22625"
+
+	// Common fixtures independent of whether IRI is enabled.
+	imageRegistryCO := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: "image-registry"}}
+	clusterDNS := &configv1.DNS{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       configv1.DNSSpec{BaseDomain: baseDomain},
+	}
+	// machine-os-puller SA with no image pull secrets; the cluster pull secret
+	// alone keeps the assembled "auths" map non-empty so the merge path runs.
+	machineOSPullerSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-os-puller", Namespace: ctrlcommon.MCONamespace},
+	}
+	populatedPullSecretContent := `{"auths":{"registry.example.com":{"auth":"` +
+		base64.StdEncoding.EncodeToString([]byte("user:pass")) + `"}}}`
+
+	// IRI-specific fixtures.
+	iriInstance := &mcfgv1.InternalReleaseImage{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.InternalReleaseImageInstanceName},
+	}
+	iriAuthSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.InternalReleaseImageAuthSecretName, Namespace: ctrlcommon.MCONamespace},
+		Data:       map[string][]byte{"password": []byte(iriPassword)},
+	}
+	controllerConfig := &mcfgv1.ControllerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.ControllerConfigName},
+		Spec: mcfgv1.ControllerConfigSpec{
+			DNS: &configv1.DNS{Spec: configv1.DNSSpec{BaseDomain: baseDomain}},
+		},
+	}
+
+	cases := []struct {
+		name string
+		// pullSecretContent is the raw ".dockerconfigjson" of the cluster pull secret.
+		pullSecretContent string
+		iriEnabled        bool
+		// expectNil asserts getImageRegistryPullSecrets returns a nil secret,
+		// used for the empty-"auths" ("don't roll config") path.
+		expectNil bool
+	}{
+		{name: "IRI absent - pull secret unchanged", pullSecretContent: populatedPullSecretContent, iriEnabled: false},
+		{name: "IRI present - credentials merged", pullSecretContent: populatedPullSecretContent, iriEnabled: true},
+		// With no image-pull secrets on the SA and an empty cluster pull secret,
+		// the assembled "auths" map is empty. Even with IRI enabled the function
+		// must return nil rather than emitting a secret carrying only IRI creds.
+		{name: "empty auths with IRI enabled - returns nil", pullSecretContent: "{}", iriEnabled: true, expectNil: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mcoSecretObjs := []interface{}{}
+			iriObjs := []interface{}{}
+			if tc.iriEnabled {
+				mcoSecretObjs = append(mcoSecretObjs, iriAuthSecret)
+				iriObjs = append(iriObjs, iriInstance)
+			}
+
+			clusterPullSecret := helpers.NewDockerCfgJSONSecret(ctrlcommon.GlobalPullSecretName, ctrlcommon.OpenshiftConfigNamespace, tc.pullSecretContent)
+
+			optr := &Operator{
+				namespace:             ctrlcommon.MCONamespace,
+				clusterOperatorLister: configlistersv1.NewClusterOperatorLister(newNamespacedIndexer(imageRegistryCO)),
+				dnsLister:             configlistersv1.NewDNSLister(newNamespacedIndexer(clusterDNS)),
+				mcoSALister:           corev1listers.NewServiceAccountLister(newNamespacedIndexer(machineOSPullerSA)),
+				mcoSecretLister:       corev1listers.NewSecretLister(newNamespacedIndexer(mcoSecretObjs...)),
+				ocSecretLister:        corev1listers.NewSecretLister(newNamespacedIndexer(clusterPullSecret)),
+				ccLister:              mcplister.NewControllerConfigLister(newNamespacedIndexer(controllerConfig)),
+				iriLister:             mcplister.NewInternalReleaseImageLister(newNamespacedIndexer(iriObjs...)),
+			}
+
+			raw, err := optr.getImageRegistryPullSecrets()
+			assert.NoError(t, err)
+
+			if tc.expectNil {
+				// Empty "auths": nothing to roll, so no secret is emitted (and
+				// IRI creds are not emitted on their own).
+				assert.Nil(t, raw)
+				return
+			}
+			assert.NotEmpty(t, raw)
+
+			var parsed struct {
+				Auths map[string]struct {
+					Auth string `json:"auth"`
+				} `json:"auths"`
+			}
+			assert.NoError(t, json.Unmarshal(raw, &parsed))
+
+			// The original registry entry is always present.
+			assert.Contains(t, parsed.Auths, "registry.example.com")
+
+			if tc.iriEnabled {
+				assert.Contains(t, parsed.Auths, iriAPIIntHost, "expected api-int IRI auth entry to be merged")
+				assert.Contains(t, parsed.Auths, iriLocalHost, "expected localhost IRI auth entry to be merged")
+				assert.Equal(t, expectedIRIAuth, parsed.Auths[iriAPIIntHost].Auth)
+				assert.Equal(t, expectedIRIAuth, parsed.Auths[iriLocalHost].Auth)
+			} else {
+				assert.NotContains(t, parsed.Auths, iriAPIIntHost, "IRI auth entry must not be present when IRI is absent")
+				assert.NotContains(t, parsed.Auths, iriLocalHost, "IRI auth entry must not be present when IRI is absent")
+			}
 		})
 	}
 }


### PR DESCRIPTION
The IRI credentials were being added to /var/lib/kubelet/config.json which gave only kubelet the necessary credentials to pull images from the IRI registry.
Fix now adds the IRI credentials to the global pull secret so that other components like the MCO could also pull images from this internal registry.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
  - IRI credentials are now merged into the global pull secret by the template controller during its sync loop                                                         
  - The logic only updates an existing global pull secret; it does not create one if it doesn't exist                                                                  
  - The template controller checks if IRI is enabled before attempting to sync credentials           
  - If IRI is not configured or the auth secret doesn't exist, the sync is skipped without error       

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controller now syncs IRI registry credentials into the configured cluster-wide global pull secret and uses finer-grained event triggers to requeue only relevant changes.
* **Bug Fixes**
  * Avoids unnecessary updates by modifying the global pull secret only when its content actually changes.
* **Behavior Change**
  * Template rendering no longer injects IRI credentials at render time; it relies on the global pull secret.
* **Tests**
  * Tests updated to validate rendering when IRI credentials originate from the global pull secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->