### PR TITLE
[release-4.21] OCPBUGS-86232: Apply password only if changes exist

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1173,22 +1173,22 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 				}
 			}
 		}()
-	}
 
-	// Set password hash
-	if err := dn.SetPasswordHash(newIgnConfig.Passwd.Users, oldIgnConfig.Passwd.Users); err != nil {
-		return err
-	}
-
-	defer func() {
-		if retErr != nil {
-			if err := dn.SetPasswordHash(oldIgnConfig.Passwd.Users, newIgnConfig.Passwd.Users); err != nil {
-				errs := kubeErrs.NewAggregate([]error{err, retErr})
-				retErr = fmt.Errorf("error rolling back password hash updates: %w", errs)
-				return
-			}
+		// Set password hash
+		if err := dn.SetPasswordHash(newIgnConfig.Passwd.Users, oldIgnConfig.Passwd.Users); err != nil {
+			return err
 		}
-	}()
+
+		defer func() {
+			if retErr != nil {
+				if err := dn.SetPasswordHash(oldIgnConfig.Passwd.Users, newIgnConfig.Passwd.Users); err != nil {
+					errs := kubeErrs.NewAggregate([]error{err, retErr})
+					retErr = fmt.Errorf("error rolling back password hash updates: %w", errs)
+					return
+				}
+			}
+		}()
+	}
 
 	if dn.os.IsCoreOSVariant() {
 		coreOSDaemon := CoreOSDaemon{dn}
@@ -2318,7 +2318,21 @@ func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
 	return nil
 }
 
-// Set a given PasswdUser's Password Hash
+func getUserPasswordHash(user string) (string, error) {
+	shadowOut, err := exec.Command("getent", "shadow", user).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to check password hash for %s: %w", user, err)
+	}
+	shadowSlice := strings.SplitN(strings.TrimSpace(string(shadowOut)), ":", 3)
+	if len(shadowSlice) >= 2 {
+		return shadowSlice[1], nil
+	}
+	return "", nil
+
+}
+
+// SetPasswordHash updates the password for each user in newUsers, skipping
+// users whose password already matches the desired configuration.
 func (dn *Daemon) SetPasswordHash(newUsers, oldUsers []ign3types.PasswdUser) error {
 	// confirm that user exits
 	klog.Info("Checking if absent users need to be disconfigured")
@@ -2341,6 +2355,15 @@ func (dn *Daemon) SetPasswordHash(newUsers, oldUsers []ign3types.PasswdUser) err
 		pwhash := "*"
 		if u.PasswordHash != nil && *u.PasswordHash != "" {
 			pwhash = *u.PasswordHash
+		}
+
+		// Check if hash update is needed. Skip if not.
+		currentHash, err := getUserPasswordHash(u.Name)
+		if err != nil {
+			return err
+		}
+		if currentHash == pwhash {
+			continue
 		}
 
 		if out, err := exec.Command("usermod", "-p", pwhash, u.Name).CombinedOutput(); err != nil {

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -408,8 +408,11 @@ func TestNoReboot(t *testing.T) {
 
 	currentEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
 
-	if currentEtcShadowContents == initialEtcShadowContents {
-		t.Fatalf("updated password hash not found in etc/shadow, got %s", currentEtcShadowContents)
+	initialPasswordHash := extractPasswordHashFromShadowLine(initialEtcShadowContents)
+	currentPasswordHash := extractPasswordHashFromShadowLine(currentEtcShadowContents)
+
+	if currentPasswordHash == initialPasswordHash {
+		t.Fatalf("updated password hash not found in etc/shadow")
 	}
 
 	t.Logf("Node %s has Password Hash", infraNode.Name)
@@ -489,7 +492,9 @@ func TestNoReboot(t *testing.T) {
 	require.Nil(t, err)
 
 	rollbackEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
-	assert.Equal(t, initialEtcShadowContents, rollbackEtcShadowContents)
+
+	assert.Equal(t, extractPasswordHashFromShadowLine(initialEtcShadowContents), extractPasswordHashFromShadowLine(rollbackEtcShadowContents),
+		"password hash should match after rollback")
 }
 
 func TestPoolDegradedOnFailToRender(t *testing.T) {
@@ -942,6 +947,17 @@ func assertExpectedPerms(t *testing.T, cs *framework.ClientSet, node corev1.Node
 
 	actualPerms := strings.Split(strings.TrimSuffix(helpers.ExecCmdOnNode(t, cs, node, "chroot", "/rootfs", "stat", "--format=%U %G %a", path), "\n"), " ")
 	assert.Equal(t, expectedPerms, actualPerms, "expected %s to have perms %v, got: %v", path, expectedPerms, actualPerms)
+}
+
+// extractPasswordHashFromShadowLine extracts the password hash field from an /etc/shadow line.
+// The shadow file format is: username:password:lastchg:min:max:warn:inactive:expire:reserved
+// This function returns the password hash (field index 1).
+func extractPasswordHashFromShadowLine(shadowLine string) string {
+	fields := strings.Split(strings.TrimSpace(shadowLine), ":")
+	if len(fields) < 2 {
+		return ""
+	}
+	return fields[1]
 }
 
 // Tests that changes to the internal image registry pull secret has the


### PR DESCRIPTION
Closes: [#OCPBUGS-86232](https://redhat.atlassian.net/browse/OCPBUGS-86232)

Combined manual backport of https://github.com/openshift/machine-config-operator/pull/6053 and https://github.com/openshift/machine-config-operator/pull/6030

What I did
This bugfix ensures that the MCD only runs usermod if the password hash has actually changed and not in every update. This aligns the behavior we currently have for SSH passwords.

How to verify it
TBD

Description for the changelog
This bugfix ensures that the MCD only runs usermod if the password hash has actually changed and not in every update.