### PR TITLE
NO-ISSUE: Update TC-88366 to check osImageStream status after update completes

### DIFF
--- a/test/e2e-iri/iri_delete_test.go
+++ b/test/e2e-iri/iri_delete_test.go
@@ -33,13 +33,23 @@ func TestIRIController_IRIDelete(t *testing.T) {
 	_, err = cs.MachineConfigs().Get(ctx, "02-master-internalreleaseimage", v1.GetOptions{})
 	require.NoError(t, err, "Master MC should exist before deletion")
 
-	// Remove the VAP binding that prevents IRI deletion.
+	// Remove the VAP binding and delete the IRI in a retry loop.
+	// The operator sync may re-create the binding between the two operations.
 	vapBindingName := "internalreleaseimage-deletion-guard-binding"
-	err = cs.GetKubeclient().AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, vapBindingName, v1.DeleteOptions{})
-	require.NoError(t, err, "Should be able to delete VAP binding")
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+		delErr := cs.GetKubeclient().AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, vapBindingName, v1.DeleteOptions{})
+		if delErr != nil && !k8serrors.IsNotFound(delErr) {
+			t.Logf("Failed to delete VAP binding (will retry): %v", delErr)
+			return false, nil
+		}
 
-	// Delete the IRI resource.
-	err = cs.InternalReleaseImages().Delete(ctx, "cluster", v1.DeleteOptions{})
+		delErr = cs.InternalReleaseImages().Delete(ctx, "cluster", v1.DeleteOptions{})
+		if delErr == nil {
+			return true, nil
+		}
+		t.Logf("Failed to delete IRI (will retry): %v", delErr)
+		return false, nil
+	})
 	require.NoError(t, err, "Should be able to delete IRI after VAP binding removal")
 
 	// Wait for the IRI to be fully garbage-collected (finalizer removed).

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -289,7 +289,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 
 		exutil.By("Verify osImageStream remains empty after osImageURL is applied")
-		o.Expect(mcp.GetStatusOsImageStream()).To(o.BeEmpty(),
+		o.Eventually(mcp.GetStatusOsImageStream, "2m", "20s").Should(o.BeEmpty(),
 			"In %v status.osImageStream should be empty when osImageURL is set", mcp)
 		logger.Infof("osImageStream is empty with osImageURL applied (as expected)")
 		logger.Infof("OK!\n")


### PR DESCRIPTION
 Changed line 292 from Expect (immediate assertion) to Eventually (2m timeout, 20s poll interval) to wait through the transient state before asserting empty, for below error
 ```
{  fail [github.com/openshift/machine-config-operator/test/extended-priv/mco_osimagestream.go:292]: In <Kind: mcp, Name: worker, Namespace: > status.osImageStream should be empty when osImageURL is set
Expected
    <string>: rhel-9
to be empty}
 ```
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation for eventual consistency scenarios during image stream pool updates to ensure reliable behavior verification over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->