### PR TITLE
OCPBUGS-86474: Tests using realtime kernel should not be limited to a…

### DIFF
--- a/test/extended-priv/mco_kernel.go
+++ b/test/extended-priv/mco_kernel.go
@@ -20,9 +20,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		PreChecks(oc)
 	})
 
-	g.It("[PolarionID:42365][OTP] add real time kernel argument [Disruptive]", g.Label("Platform:aws", "Platform:gce"), func() {
+	g.It("[PolarionID:42365][OTP] add real time kernel argument [Disruptive]", func() {
 		architecture.SkipNonAmd64SingleArch(oc)
-		skipTestIfSupportedPlatformNotMatched(oc, AWSPlatform, GCPPlatform)
 		mcp := GetCompactCompatiblePool(oc.AsAdmin())
 
 		node := mcp.GetSortedNodesOrFail()[0]
@@ -81,13 +80,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		createMcAndVerifyMCValue(oc, "Duplicated kernel argument", "change-worker-duplicated-kernel-argument", workerNode, textToVerify, "cat", "/rootfs/proc/cmdline")
 	})
 
-	g.It("[PolarionID:53668][OTP] when FIPS and realtime kernel are both enabled node should NOT be degraded [Disruptive]", g.Label("Platform:aws", "Platform:gce"), func() {
+	g.It("[PolarionID:53668][OTP] when FIPS and realtime kernel are both enabled node should NOT be degraded [Disruptive]", func() {
 		// skip if arm64. realtime kernel is not supported.
 		architecture.SkipNonAmd64SingleArch(oc)
 		// skip the test if fips is not enabled
 		skipTestIfFIPSIsNotEnabled(oc)
-		// skip the test if platform is not aws or gcp. realtime kargs currently supported on these platforms
-		skipTestIfSupportedPlatformNotMatched(oc, AWSPlatform, GCPPlatform)
 
 		exutil.By("create machine config to enable fips ")
 		fipsMcName := "50-fips-bz-poc"

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -116,9 +116,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	})
 
 	// AI-assisted: Test case to validate real-time kernel configuration across OS image streams
-	g.It("[PolarionID:87095][OTP] Realtime kernel from rhel9 stream to rhel10 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", g.Label("Platform:aws", "Platform:gce"), func() {
+	g.It("[PolarionID:87095][OTP] Realtime kernel from rhel9 stream to rhel10 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
 		architecture.SkipIfNoNodeWithArchitectures(oc.AsAdmin(), architecture.AMD64)
-		skipTestIfSupportedPlatformNotMatched(oc.AsAdmin(), AWSPlatform, GCPPlatform)
 
 		testID := GetCurrentTestPolarionIDNumber()
 		createdCustomPoolName := fmt.Sprintf("tc-%s-%s", testID, architecture.AMD64)


### PR DESCRIPTION
…ws and gcp platforms

**- What I did**

Remove the platform constraints in the realtime kernel test cases.

**- How to verify it**

Real time kernel tests should be executed in azure, vsphere and baremetal jobs too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test configuration for kernel and image stream validation tests by removing platform-specific constraints, allowing broader infrastructure compatibility while maintaining architecture-level checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->