### PR TITLE
OCPBUGS-86554: Wait for operators after removing master machine

### DIFF
--- a/test/extended-priv/mco_controlplanemachineset.go
+++ b/test/extended-priv/mco_controlplanemachineset.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ManagedBootImagesCPMS] MCO ControlPlaneMachineSet", g.Label("Platform:gce", "Platform:aws", "Platform:azure"), func() {
+var _ = g.Describe("[sig-mco][Serial][Disruptive][OCPFeatureGate:ManagedBootImagesCPMS] MCO ControlPlaneMachineSet", g.Label("Platform:gce", "Platform:aws", "Platform:azure"), func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -71,339 +71,352 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		o.RegisterFailHandler(g.Fail)
 	})
 
-	// AI-assisted: This test case validates that marketplace boot images are correctly handled and NOT updated
-	g.It("[PolarionID:85478][OTP] ControlPlaneMachineSets. Correctly handle marketplace boot-images [apigroup:machineconfiguration.openshift.io]", func() {
-		// After talking with devs this test case doesn't make sense in Azure.
-		// In Azure we shouldn't be allowed to manipulate the values to set invalid values, and we will always update legacy images. Hence, we skip this test case.
-		skipTestIfSupportedPlatformNotMatched(oc, GCPPlatform, AWSPlatform)
+	g.Context("[Suite:openshift/machine-config-operator/disruptive]", func() {
 
-		var (
-			fakeImageName           = "fake-image" // non-updateable marketplace image
-			userDataJSONVersionPath = `ignition.version`
-		)
+		// AI-assisted: This test case validates that marketplace boot images are correctly handled and NOT updated
+		g.It("[PolarionID:85478][OTP] ControlPlaneMachineSets. Correctly handle marketplace boot-images [apigroup:machineconfiguration.openshift.io]", func() {
+			// After talking with devs this test case doesn't make sense in Azure.
+			// In Azure we shouldn't be allowed to manipulate the values to set invalid values, and we will always update legacy images. Hence, we skip this test case.
+			skipTestIfSupportedPlatformNotMatched(oc, GCPPlatform, AWSPlatform)
 
-		o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
+			var (
+				fakeImageName           = "fake-image" // non-updateable marketplace image
+				userDataJSONVersionPath = `ignition.version`
+			)
 
-		exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
-		originalCPMSSpec := cpms.GetSpecOrFail()
-		defer cpms.SetSpec(originalCPMSSpec)
-		logger.Infof("OK!\n")
+			o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
 
-		exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
-		logger.Infof("Getting the user-data secret and backing up its content")
-		userDataSecret, err := cpms.GetUserDataSecret()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
+			exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
+			originalCPMSSpec := cpms.GetSpecOrFail()
+			defer cpms.SetSpec(originalCPMSSpec)
+			logger.Infof("OK!\n")
 
-		// Backup original user-data content to restore later
-		originalUserData, err := userDataSecret.GetDataValue("userData")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
-		defer userDataSecret.SetDataValue("userData", originalUserData)
+			exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
+			logger.Infof("Getting the user-data secret and backing up its content")
+			userDataSecret, err := cpms.GetUserDataSecret()
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
 
-		logger.Infof("Converting user-data to version 2.2.0")
-		convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
+			// Backup original user-data content to restore later
+			originalUserData, err := userDataSecret.GetDataValue("userData")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
+			defer userDataSecret.SetDataValue("userData", originalUserData)
 
-		logger.Infof("Updating the user-data secret with version 2.2.0")
-		o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
-			"Error setting userData in secret %s", userDataSecret)
-		logger.Infof("OK!\n")
+			logger.Infof("Converting user-data to version 2.2.0")
+			convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
 
-		exutil.By("Set a fake/non-updateable boot image in the ControlPlaneMachineSet")
-		o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
-		logger.Infof("OK!\n")
+			logger.Infof("Updating the user-data secret with version 2.2.0")
+			o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
+				"Error setting userData in secret %s", userDataSecret)
+			logger.Infof("OK!\n")
 
-		exutil.By("Opt-in boot images update with All mode")
-		defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
-		o.Expect(
-			machineConfiguration.SetAllManagedBootImagesConfig(ControlPlaneMachineSetResource),
-		).To(o.Succeed(), "Error configuring All managedBootImages in the 'cluster' MachineConfiguration resource")
-		logger.Infof("OK!\n")
+			exutil.By("Set a fake/non-updateable boot image in the ControlPlaneMachineSet")
+			o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
+			logger.Infof("OK!\n")
 
-		exutil.By("Check that the bootimage was NOT updated")
-		// Marketplace/fake images should not be updated even with All mode configured
-		o.Consistently(cpms.GetCoreOsBootImage, "5m", "20s").Should(o.ContainSubstring(fakeImageName),
-			"%s was updated, but it shouldn't be updated for marketplace images", cpms)
-		logger.Infof("OK!\n")
+			exutil.By("Opt-in boot images update with All mode")
+			defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
+			o.Expect(
+				machineConfiguration.SetAllManagedBootImagesConfig(ControlPlaneMachineSetResource),
+			).To(o.Succeed(), "Error configuring All managedBootImages in the 'cluster' MachineConfiguration resource")
+			logger.Infof("OK!\n")
 
-		exutil.By("Check that the user-data secret was NOT updated")
-		// User-data should remain at 2.2.0 when boot image cannot be updated
-		o.Consistently(userDataSecret.GetDataValue, "1m", "15s").WithArguments("userData").Should(
-			HavePathWithValue(userDataJSONVersionPath, o.Equal("2.2.0")),
-			"The user-data secret was updated, but it shouldn't be updated for marketplace images")
-		logger.Infof("OK!\n")
-	})
+			exutil.By("Check that the bootimage was NOT updated")
+			// Marketplace/fake images should not be updated even with All mode configured
+			o.Consistently(cpms.GetCoreOsBootImage, "5m", "20s").Should(o.ContainSubstring(fakeImageName),
+				"%s was updated, but it shouldn't be updated for marketplace images", cpms)
+			logger.Infof("OK!\n")
 
-	// AI-assisted: This test case validates that Partial mode is not allowed for ControlPlaneMachineSets
-	g.It("[PolarionID:85399][OTP] ControlPlaneMachineSets boot-image update. Partial mode not allowed [apigroup:machineconfiguration.openshift.io]", func() {
+			exutil.By("Check that the user-data secret was NOT updated")
+			// User-data should remain at 2.2.0 when boot image cannot be updated
+			o.Consistently(userDataSecret.GetDataValue, "1m", "15s").WithArguments("userData").Should(
+				HavePathWithValue(userDataJSONVersionPath, o.Equal("2.2.0")),
+				"The user-data secret was updated, but it shouldn't be updated for marketplace images")
+			logger.Infof("OK!\n")
+		})
 
-		var (
-			expectedError = "Only All or None selection mode is permitted for ControlPlaneMachineSets"
-		)
+		// AI-assisted: This test case validates that Partial mode is not allowed for ControlPlaneMachineSets
+		g.It("[PolarionID:85399][OTP] ControlPlaneMachineSets boot-image update. Partial mode not allowed [apigroup:machineconfiguration.openshift.io]", func() {
 
-		o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
+			var (
+				expectedError = "Only All or None selection mode is permitted for ControlPlaneMachineSets"
+			)
 
-		exutil.By("Configure MachineConfiguration resource to use Partial mode for ControlPlaneMachineSet resources")
-		defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
+			o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
 
-		err := machineConfiguration.SetPartialManagedBootImagesConfig(ControlPlaneMachineSetResource, "test-label", "test-value")
-		o.Expect(err).To(o.HaveOccurred(), "Expected error when configuring Partial mode for ControlPlaneMachineSets")
-		o.Expect(err).To(o.BeAssignableToTypeOf(&exutil.ExitError{}), "Unexpected error when configuring controlplanemachineset partial mode in MachineConfiguration")
-		o.Expect(err.(*exutil.ExitError).StdErr).To(o.ContainSubstring(expectedError),
-			"Error message does not match expected: %v", err)
-		logger.Infof("OK!\n")
-	})
+			exutil.By("Configure MachineConfiguration resource to use Partial mode for ControlPlaneMachineSet resources")
+			defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
 
-	// AI-assisted: This test case was created to validate ControlPlaneMachineSet boot-image update with All mode
-	g.It("[PolarionID:85467][OTP] ControlPlaneMachineSets. Bootimage upgrade stub ignition to spec 3 [apigroup:machineconfiguration.openshift.io]", func() {
+			err := machineConfiguration.SetPartialManagedBootImagesConfig(ControlPlaneMachineSetResource, "test-label", "test-value")
+			o.Expect(err).To(o.HaveOccurred(), "Expected error when configuring Partial mode for ControlPlaneMachineSets")
+			o.Expect(err).To(o.BeAssignableToTypeOf(&exutil.ExitError{}), "Unexpected error when configuring controlplanemachineset partial mode in MachineConfiguration")
+			o.Expect(err.(*exutil.ExitError).StdErr).To(o.ContainSubstring(expectedError),
+				"Error message does not match expected: %v", err)
+			logger.Infof("OK!\n")
+		})
 
-		var (
-			fakeImageName = getBackdatedBootImage(oc.AsAdmin())
+		// AI-assisted: This test case validates that boot images and user-data are NOT updated when using Mode: None
+		g.It("[PolarionID:85479][OTP] ControlPlaneMachineSets. Not updated when using Mode: None [apigroup:machineconfiguration.openshift.io]", func() {
 
-			userDataJSONVersionPath = `ignition.version`
-		)
+			var (
+				machineConfiguration = GetMachineConfiguration(oc.AsAdmin())
+				fakeImageName        = getBackdatedBootImage(oc.AsAdmin())
 
-		o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
+				userDataJSONVersionPath = `ignition.version`
+			)
 
-		exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
-		originalCPMSSpec := cpms.GetSpecOrFail()
-		defer cpms.SetSpec(originalCPMSSpec)
-		logger.Infof("OK!\n")
+			o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
 
-		exutil.By("Opt-in boot images update with All mode")
-		defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
-		o.Expect(
-			machineConfiguration.SetAllManagedBootImagesConfig(ControlPlaneMachineSetResource),
-		).To(o.Succeed(), "Error configuring All managedBootImages in the 'cluster' MachineConfiguration resource")
-		logger.Infof("OK!\n")
+			exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
+			originalCPMSSpec := cpms.GetSpecOrFail()
+			defer cpms.SetSpec(originalCPMSSpec)
+			logger.Infof("OK!\n")
 
-		exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
-		logger.Infof("Getting the user-data secret and backing up its content")
-		userDataSecret, err := cpms.GetUserDataSecret()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
+			exutil.By("Configure MachineConfiguration resource with mode None for controlplanemachinesets")
+			defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
+			o.Expect(
+				machineConfiguration.SetNoneManagedBootImagesConfig(ControlPlaneMachineSetResource),
+			).To(o.Succeed(), "Error configuring None managedBootImages in the 'cluster' MachineConfiguration resource")
+			logger.Infof("OK!\n")
 
-		// Backup original user-data content to restore later
-		originalUserData, err := userDataSecret.GetDataValue("userData")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
-		defer userDataSecret.SetDataValue("userData", originalUserData)
+			exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
+			logger.Infof("Getting the user-data secret and backing up its content")
+			userDataSecret, err := cpms.GetUserDataSecret()
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
 
-		logger.Infof("Converting user-data to version 2.2.0")
-		convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
+			// Backup original user-data content to restore later
+			originalUserData, err := userDataSecret.GetDataValue("userData")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
+			defer userDataSecret.SetDataValue("userData", originalUserData)
 
-		logger.Infof("Updating the user-data secret with version 2.2.0")
-		o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
-			"Error setting userData in secret %s", userDataSecret)
-		logger.Infof("OK!\n")
+			logger.Infof("Converting user-data to version 2.2.0")
+			convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
 
-		exutil.By("Set a wrong boot image in the ControlPlaneMachineSet")
-		o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
-		logger.Infof("OK!\n")
+			logger.Infof("Updating the user-data secret with version 2.2.0")
+			o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
+				"Error setting userData in secret %s", userDataSecret)
+			logger.Infof("OK!\n")
 
-		exutil.By("Check that the user-data secret is updated to the latest ignition version")
-		o.Eventually(userDataSecret.GetDataValue, "5m", "15s").WithArguments("userData").Should(
-			HavePathWithValue(userDataJSONVersionPath, o.Equal(IgnitionDefaultVersion)),
-			"The user-data secret was not updated to the latest ignition version")
+			exutil.By("Set a wrong boot image in the ControlPlaneMachineSet")
+			o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
+			logger.Infof("OK!\n")
 
-		logger.Infof("OK!\n")
+			exutil.By("Check that the boot image was NOT updated")
+			// With Mode: None, the boot image should remain unchanged (still using the fake image)
+			o.Consistently(cpms.GetCoreOsBootImage, "3m", "30s").Should(o.Equal(fakeImageName),
+				"The boot image was unexpectedly updated when Mode: None was configured")
+			logger.Infof("OK!\n")
 
-		exutil.By("Check that the boot image was updated with the right version")
-		// Check that it was actually updated
-		o.Eventually(cpms.GetCoreOsBootImage, "5m", "20s").ShouldNot(o.Or(o.Equal(fakeImageName), o.BeEmpty()),
-			"%s was NOT updated to use the right boot image", cpms)
-		// Check that the updated image is the right one
-		CheckCurrentOSImageIsUpdated(cpms)
-		logger.Infof("OK!\n")
+			exutil.By("Check that the master-user-data secret was NOT updated and is still using ignition 2.2.0")
+			// With Mode: None, the user-data should remain at version 2.2.0
+			o.Consistently(userDataSecret.GetDataValue, "1m", "20s").WithArguments("userData").Should(
+				HavePathWithValue(userDataJSONVersionPath, o.Equal("2.2.0")),
+				"The user-data secret was unexpectedly updated when Mode: None was configured")
+			logger.Infof("OK!\n")
+		})
 
-		exutil.By("Delete one machine and wait for it to be recreated")
-		if cpms.IsActive() {
-			// Only delete machine if original userData does NOT have storage or systemd sections
-			hasStorage := strings.Contains(originalUserData, "storage")
-			hasSystemd := strings.Contains(originalUserData, "systemd")
+		// AI-assisted: This test case validates that boot images and user-data are NOT updated when CPMS has an owner reference
+		g.It("[PolarionID:85480][OTP] ControlPlaneMachineSets. Not updated when owner reference [apigroup:machineconfiguration.openshift.io]", func() {
 
-			if !hasStorage && !hasSystemd {
-				DeleteOneMachineAndWaitForRecreation(cpms)
+			var (
+				fakeImageName = getBackdatedBootImage(oc.AsAdmin())
+
+				userDataJSONVersionPath = `ignition.version`
+			)
+
+			o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
+
+			exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
+			originalCPMSSpec := cpms.GetSpecOrFail()
+			defer cpms.SetSpec(originalCPMSSpec)
+			logger.Infof("OK!\n")
+
+			exutil.By("Add owner reference to the ControlPlaneMachineSet resource")
+			// Backup original ownerReferences to restore later
+			originalOwnerRefs := cpms.GetOrFail(`{.metadata.ownerReferences}`)
+			defer func() {
+				if originalOwnerRefs == "" {
+					cpms.Patch("json", `[{"op": "remove", "path": "/metadata/ownerReferences"}]`)
+				} else {
+					cpms.Patch("json", `[{"op": "replace", "path": "/metadata/ownerReferences", "value": `+originalOwnerRefs+`}]`)
+				}
+			}()
+
+			o.Expect(
+				cpms.Patch("merge", `{"metadata":{"ownerReferences": [{"apiVersion": "fake","blockOwnerDeletion": true,"controller": true,"kind": "fakekind","name": "master","uid": "fake-uuid"}]}}`),
+			).To(o.Succeed(), "Error patching %s with a fake owner reference", cpms)
+			logger.Infof("OK!\n")
+
+			exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
+			logger.Infof("Getting the user-data secret and backing up its content")
+			userDataSecret, err := cpms.GetUserDataSecret()
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
+
+			// Backup original user-data content to restore later
+			originalUserData, err := userDataSecret.GetDataValue("userData")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
+			defer userDataSecret.SetDataValue("userData", originalUserData)
+
+			logger.Infof("Converting user-data to version 2.2.0")
+			convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
+
+			logger.Infof("Updating the user-data secret with version 2.2.0")
+			o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
+				"Error setting userData in secret %s", userDataSecret)
+			logger.Infof("OK!\n")
+
+			exutil.By("Set a wrong boot image in the ControlPlaneMachineSet")
+			o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
+			logger.Infof("OK!\n")
+
+			exutil.By("Configure MachineConfiguration resource with mode All for controlplanemachinesets")
+			defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
+			o.Expect(
+				machineConfiguration.SetAllManagedBootImagesConfig(ControlPlaneMachineSetResource),
+			).To(o.Succeed(), "Error configuring All managedBootImages in the 'cluster' MachineConfiguration resource")
+			logger.Infof("OK!\n")
+
+			exutil.By("Check that the boot image was NOT updated")
+			// With owner reference, the boot image should remain unchanged even with Mode: All
+			o.Consistently(cpms.GetCoreOsBootImage, "3m", "30s").Should(o.Equal(fakeImageName),
+				"The boot image was unexpectedly updated when owner reference was present")
+			logger.Infof("OK!\n")
+
+			exutil.By("Check that the master-user-data secret was NOT updated and is still using ignition 2.2.0")
+			// With owner reference, the user-data should remain at version 2.2.0 even with Mode: All
+			o.Consistently(userDataSecret.GetDataValue, "1m", "20s").WithArguments("userData").Should(
+				HavePathWithValue(userDataJSONVersionPath, o.Equal("2.2.0")),
+				"The user-data secret was unexpectedly updated when owner reference was present")
+			logger.Infof("OK!\n")
+		})
+
+		// AI-assisted: This test case validates that MachineConfiguration status correctly reflects spec changes
+		g.It("[PolarionID:87023][OTP] MachineConfiguration status correctly reflects spec changes [apigroup:machineconfiguration.openshift.io]", func() {
+
+			var (
+				testConfigs = []struct {
+					description string
+					patchConfig string
+				}{
+					{
+						description: "Test Partial mode for MachineSet resource",
+						patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"machinesets","apiGroup":"machine.openshift.io","selection":{"mode":"Partial","partial":{"machineResourceSelector":{"matchLabels":{"test-label":"test-value"}}}}}]}}}`,
+					},
+					{
+						description: "Test None mode for MachineSet resource",
+						patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"machinesets","apiGroup":"machine.openshift.io","selection":{"mode":"None"}}]}}}`,
+					},
+					{
+						description: "Test All mode for MachineSet resource",
+						patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"machinesets","apiGroup":"machine.openshift.io","selection":{"mode":"All"}}]}}}`,
+					},
+					{
+						description: "Test None mode for ControlPlaneMachineSet resource",
+						patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"controlplanemachinesets","apiGroup":"machine.openshift.io","selection":{"mode":"None"}}]}}}`,
+					},
+					{
+						description: "Test All mode for ControlPlaneMachineSet resource",
+						patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"controlplanemachinesets","apiGroup":"machine.openshift.io","selection":{"mode":"All"}}]}}}`,
+					},
+				}
+			)
+
+			for _, tc := range testConfigs {
+				logger.Infof(tc.description)
+				testMachineConfigurationStatusUpdate(machineConfiguration, tc.patchConfig)
+			}
+		})
+
+	}) // end disruptive context
+
+	g.Context("[Suite:openshift/machine-config-operator/longduration]", func() {
+
+		// AI-assisted: This test case was created to validate ControlPlaneMachineSet boot-image update with All mode
+		g.It("[PolarionID:85467][OTP] ControlPlaneMachineSets. Bootimage upgrade stub ignition to spec 3 [apigroup:machineconfiguration.openshift.io]", func() {
+
+			var (
+				fakeImageName = getBackdatedBootImage(oc.AsAdmin())
+
+				userDataJSONVersionPath = `ignition.version`
+			)
+
+			o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
+
+			exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
+			originalCPMSSpec := cpms.GetSpecOrFail()
+			defer cpms.SetSpec(originalCPMSSpec)
+			logger.Infof("OK!\n")
+
+			exutil.By("Opt-in boot images update with All mode")
+			defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
+			o.Expect(
+				machineConfiguration.SetAllManagedBootImagesConfig(ControlPlaneMachineSetResource),
+			).To(o.Succeed(), "Error configuring All managedBootImages in the 'cluster' MachineConfiguration resource")
+			logger.Infof("OK!\n")
+
+			exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
+			logger.Infof("Getting the user-data secret and backing up its content")
+			userDataSecret, err := cpms.GetUserDataSecret()
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
+
+			// Backup original user-data content to restore later
+			originalUserData, err := userDataSecret.GetDataValue("userData")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
+			defer userDataSecret.SetDataValue("userData", originalUserData)
+
+			logger.Infof("Converting user-data to version 2.2.0")
+			convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
+
+			logger.Infof("Updating the user-data secret with version 2.2.0")
+			o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
+				"Error setting userData in secret %s", userDataSecret)
+			logger.Infof("OK!\n")
+
+			exutil.By("Set a wrong boot image in the ControlPlaneMachineSet")
+			o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
+			logger.Infof("OK!\n")
+
+			exutil.By("Check that the user-data secret is updated to the latest ignition version")
+			o.Eventually(userDataSecret.GetDataValue, "5m", "15s").WithArguments("userData").Should(
+				HavePathWithValue(userDataJSONVersionPath, o.Equal(IgnitionDefaultVersion)),
+				"The user-data secret was not updated to the latest ignition version")
+
+			logger.Infof("OK!\n")
+
+			exutil.By("Check that the boot image was updated with the right version")
+			// Check that it was actually updated
+			o.Eventually(cpms.GetCoreOsBootImage, "5m", "20s").ShouldNot(o.Or(o.Equal(fakeImageName), o.BeEmpty()),
+				"%s was NOT updated to use the right boot image", cpms)
+			// Check that the updated image is the right one
+			CheckCurrentOSImageIsUpdated(cpms)
+			logger.Infof("OK!\n")
+
+			exutil.By("Delete one machine and wait for it to be recreated")
+			if cpms.IsActive() {
+				// Only delete machine if original userData does NOT have storage or systemd sections
+				hasStorage := strings.Contains(originalUserData, "storage")
+				hasSystemd := strings.Contains(originalUserData, "systemd")
+
+				if !hasStorage && !hasSystemd {
+					DeleteOneMachineAndWaitForRecreation(cpms)
+
+					exutil.By("Wait for all cluster operators to stabilize")
+					o.Expect(WaitForStableCluster(oc.AsAdmin(), "3m", "50m")).To(o.Succeed(),
+						"Cluster operators did not stabilize after control plane machine replacement")
+					logger.Infof("OK!\n")
+				} else {
+					logger.Infof("Original user-data secret had storage or systemd sections, skipping machine deletion test")
+				}
 			} else {
-				logger.Infof("Original user-data secret had storage or systemd sections, skipping machine deletion test")
+				logger.Infof("ControlPlaneMachineSet is not active, skipping machine deletion test")
 			}
-		} else {
-			logger.Infof("ControlPlaneMachineSet is not active, skipping machine deletion test")
-		}
-		logger.Infof("OK!\n")
-	})
+			logger.Infof("OK!\n")
+		})
 
-	// AI-assisted: This test case validates that boot images and user-data are NOT updated when using Mode: None
-	g.It("[PolarionID:85479][OTP] ControlPlaneMachineSets. Not updated when using Mode: None [apigroup:machineconfiguration.openshift.io]", func() {
-
-		var (
-			machineConfiguration = GetMachineConfiguration(oc.AsAdmin())
-			fakeImageName        = getBackdatedBootImage(oc.AsAdmin())
-
-			userDataJSONVersionPath = `ignition.version`
-		)
-
-		o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
-
-		exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
-		originalCPMSSpec := cpms.GetSpecOrFail()
-		defer cpms.SetSpec(originalCPMSSpec)
-		logger.Infof("OK!\n")
-
-		exutil.By("Configure MachineConfiguration resource with mode None for controlplanemachinesets")
-		defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
-		o.Expect(
-			machineConfiguration.SetNoneManagedBootImagesConfig(ControlPlaneMachineSetResource),
-		).To(o.Succeed(), "Error configuring None managedBootImages in the 'cluster' MachineConfiguration resource")
-		logger.Infof("OK!\n")
-
-		exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
-		logger.Infof("Getting the user-data secret and backing up its content")
-		userDataSecret, err := cpms.GetUserDataSecret()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
-
-		// Backup original user-data content to restore later
-		originalUserData, err := userDataSecret.GetDataValue("userData")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
-		defer userDataSecret.SetDataValue("userData", originalUserData)
-
-		logger.Infof("Converting user-data to version 2.2.0")
-		convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
-
-		logger.Infof("Updating the user-data secret with version 2.2.0")
-		o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
-			"Error setting userData in secret %s", userDataSecret)
-		logger.Infof("OK!\n")
-
-		exutil.By("Set a wrong boot image in the ControlPlaneMachineSet")
-		o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
-		logger.Infof("OK!\n")
-
-		exutil.By("Check that the boot image was NOT updated")
-		// With Mode: None, the boot image should remain unchanged (still using the fake image)
-		o.Consistently(cpms.GetCoreOsBootImage, "3m", "30s").Should(o.Equal(fakeImageName),
-			"The boot image was unexpectedly updated when Mode: None was configured")
-		logger.Infof("OK!\n")
-
-		exutil.By("Check that the master-user-data secret was NOT updated and is still using ignition 2.2.0")
-		// With Mode: None, the user-data should remain at version 2.2.0
-		o.Consistently(userDataSecret.GetDataValue, "1m", "20s").WithArguments("userData").Should(
-			HavePathWithValue(userDataJSONVersionPath, o.Equal("2.2.0")),
-			"The user-data secret was unexpectedly updated when Mode: None was configured")
-		logger.Infof("OK!\n")
-	})
-
-	// AI-assisted: This test case validates that boot images and user-data are NOT updated when CPMS has an owner reference
-	g.It("[PolarionID:85480][OTP] ControlPlaneMachineSets. Not updated when owner reference [apigroup:machineconfiguration.openshift.io]", func() {
-
-		var (
-			fakeImageName = getBackdatedBootImage(oc.AsAdmin())
-
-			userDataJSONVersionPath = `ignition.version`
-		)
-
-		o.Expect(machines).To(o.HaveLen(3), "Unexpected number of control plane machines")
-
-		exutil.By("Backup the original ControlPlaneMachineSet spec for restoration")
-		originalCPMSSpec := cpms.GetSpecOrFail()
-		defer cpms.SetSpec(originalCPMSSpec)
-		logger.Infof("OK!\n")
-
-		exutil.By("Add owner reference to the ControlPlaneMachineSet resource")
-		// Backup original ownerReferences to restore later
-		originalOwnerRefs := cpms.GetOrFail(`{.metadata.ownerReferences}`)
-		defer func() {
-			if originalOwnerRefs == "" {
-				cpms.Patch("json", `[{"op": "remove", "path": "/metadata/ownerReferences"}]`)
-			} else {
-				cpms.Patch("json", `[{"op": "replace", "path": "/metadata/ownerReferences", "value": `+originalOwnerRefs+`}]`)
-			}
-		}()
-
-		o.Expect(
-			cpms.Patch("merge", `{"metadata":{"ownerReferences": [{"apiVersion": "fake","blockOwnerDeletion": true,"controller": true,"kind": "fakekind","name": "master","uid": "fake-uuid"}]}}`),
-		).To(o.Succeed(), "Error patching %s with a fake owner reference", cpms)
-		logger.Infof("OK!\n")
-
-		exutil.By("Set a 2.2.0 user-data secret in the ControlPlaneMachineSet")
-		logger.Infof("Getting the user-data secret and backing up its content")
-		userDataSecret, err := cpms.GetUserDataSecret()
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting user-data secret from %s", cpms)
-
-		// Backup original user-data content to restore later
-		originalUserData, err := userDataSecret.GetDataValue("userData")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting userData from secret %s", userDataSecret)
-		defer userDataSecret.SetDataValue("userData", originalUserData)
-
-		logger.Infof("Converting user-data to version 2.2.0")
-		convertedUserData, err := convertUserDataToNewVersion(originalUserData, "2.2.0")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error converting userData to version 2.2.0")
-
-		logger.Infof("Updating the user-data secret with version 2.2.0")
-		o.Expect(userDataSecret.SetDataValue("userData", convertedUserData)).To(o.Succeed(),
-			"Error setting userData in secret %s", userDataSecret)
-		logger.Infof("OK!\n")
-
-		exutil.By("Set a wrong boot image in the ControlPlaneMachineSet")
-		o.Expect(cpms.SetCoreOsBootImage(fakeImageName)).To(o.Succeed(), "Error setting a fake boot image in %s", cpms)
-		logger.Infof("OK!\n")
-
-		exutil.By("Configure MachineConfiguration resource with mode All for controlplanemachinesets")
-		defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
-		o.Expect(
-			machineConfiguration.SetAllManagedBootImagesConfig(ControlPlaneMachineSetResource),
-		).To(o.Succeed(), "Error configuring All managedBootImages in the 'cluster' MachineConfiguration resource")
-		logger.Infof("OK!\n")
-
-		exutil.By("Check that the boot image was NOT updated")
-		// With owner reference, the boot image should remain unchanged even with Mode: All
-		o.Consistently(cpms.GetCoreOsBootImage, "3m", "30s").Should(o.Equal(fakeImageName),
-			"The boot image was unexpectedly updated when owner reference was present")
-		logger.Infof("OK!\n")
-
-		exutil.By("Check that the master-user-data secret was NOT updated and is still using ignition 2.2.0")
-		// With owner reference, the user-data should remain at version 2.2.0 even with Mode: All
-		o.Consistently(userDataSecret.GetDataValue, "1m", "20s").WithArguments("userData").Should(
-			HavePathWithValue(userDataJSONVersionPath, o.Equal("2.2.0")),
-			"The user-data secret was unexpectedly updated when owner reference was present")
-		logger.Infof("OK!\n")
-	})
-
-	// AI-assisted: This test case validates that MachineConfiguration status correctly reflects spec changes
-	g.It("[PolarionID:87023][OTP] MachineConfiguration status correctly reflects spec changes [apigroup:machineconfiguration.openshift.io]", func() {
-
-		var (
-			testConfigs = []struct {
-				description string
-				patchConfig string
-			}{
-				{
-					description: "Test Partial mode for MachineSet resource",
-					patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"machinesets","apiGroup":"machine.openshift.io","selection":{"mode":"Partial","partial":{"machineResourceSelector":{"matchLabels":{"test-label":"test-value"}}}}}]}}}`,
-				},
-				{
-					description: "Test None mode for MachineSet resource",
-					patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"machinesets","apiGroup":"machine.openshift.io","selection":{"mode":"None"}}]}}}`,
-				},
-				{
-					description: "Test All mode for MachineSet resource",
-					patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"machinesets","apiGroup":"machine.openshift.io","selection":{"mode":"All"}}]}}}`,
-				},
-				{
-					description: "Test None mode for ControlPlaneMachineSet resource",
-					patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"controlplanemachinesets","apiGroup":"machine.openshift.io","selection":{"mode":"None"}}]}}}`,
-				},
-				{
-					description: "Test All mode for ControlPlaneMachineSet resource",
-					patchConfig: `{"spec":{"managedBootImages":{"machineManagers":[{"resource":"controlplanemachinesets","apiGroup":"machine.openshift.io","selection":{"mode":"All"}}]}}}`,
-				},
-			}
-		)
-
-		for _, tc := range testConfigs {
-			logger.Infof(tc.description)
-			testMachineConfigurationStatusUpdate(machineConfiguration, tc.patchConfig)
-		}
-	})
+	}) // end longduration context
 })
 
 // testMachineConfigurationStatusUpdate validates that MachineConfiguration status updates correctly


### PR DESCRIPTION
…ster machine


**- What I did**

Wait for all cluster operators to be stable after re-creating a master machine in test case `[PolarionID:85467][OTP] ControlPlaneMachineSets. Bootimage upgrade stub ignition to spec 3`

Since now we wait for the operators to be idle, the duration of the test has greatly increased making the prow job timeout. Since we don't need signals for GA, it has been decided to move the test to the long duration suite.

**- How to verify it**

When the test ends, all operators should be stable.

Check the intervals in the execution

In this execution the test ends while the operators are still updating. It should not happen. The test should not end until all operators as stable:


https://sippy.dptools.openshift.org/sippy-ng/job_runs/2058601931412082688/periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-aws-mco-disruptive-techpreview-3of3/intervals?end=2026-05-24T22%3A10%3A34Z&filterText=&intervalFile=e2e-timelines_spyglass_20260524-183519.json&overrideDisplayFlag=0&selectedSources=OperatorAvailable&selectedSources=OperatorProgressing&selectedSources=Alert&selectedSources=Disruption&selectedSources=E2EFailed&selectedSources=E2EPassed&start=2026-05-24T21%3A01%3A30Z




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Restructured test organization into clearer disruptive and long-duration contexts.
  * Improved boot-image upgrade test stability by waiting for cluster operators to stabilize after control-plane recreation, asserting success, and logging confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->