### PR TITLE
OCPBUGS-86571: templates: disable IPv4 DAD to fix nodeip-configuration race

### DIFF
--- a/templates/common/_base/files/NetworkManager-no-dad.yaml
+++ b/templates/common/_base/files/NetworkManager-no-dad.yaml
@@ -1,0 +1,12 @@
+mode: 0644
+path: "/etc/NetworkManager/conf.d/01-no-dad.conf"
+contents:
+  inline: |
+    # Disable IPv4 DAD (Duplicate Address Detection / Address Conflict Detection).
+    # RHEL 10 enables this by default, which delays IPv4 address assignment by ~3s
+    # while ACD probing runs. This causes a race condition where
+    # nodeip-configuration.service may run before the IPv4 address is assigned,
+    # resulting in IPv6-only kubelet configuration on dual-stack clusters.
+    # See: https://issues.redhat.com/browse/OCPBUGS-86571
+    [connection]
+    ipv4.dad-timeout=0


### PR DESCRIPTION
## Summary

RHEL 10 enables IPv4 DAD (Duplicate Address Detection / ACD) by default in NetworkManager. The ACD probing takes ~3 seconds, during which the IPv4 address is in tentative state and invisible to applications.

This causes a race condition in dual-stack baremetal clusters where `nodeip-configuration.service` starts before IPv4 is assigned, sees only IPv6, and configures kubelet with IPv6-only — despite the interface eventually getting both addresses.

## Root Cause

RHEL 10 changed the default `ipv4.dad-timeout` from `0` (disabled) to a non-zero value, enabling ACD probing for all IPv4 addresses. IPv6 DAD completes faster (~2s), so `nodeip-configuration.service` runs in the window where IPv6 is ready but IPv4 is still probing:

```
T+0s  Interface up, IPv6 tentative, IPv4 ACD probing starts
T+2s  IPv6 DAD complete, IPv4 still probing
      nodeip-configuration.service runs → sees only IPv6 → writes IPv6-only config
T+4s  IPv4 ACD complete (too late)
```

## Fix

Add a global NetworkManager drop-in (`/etc/NetworkManager/conf.d/01-no-dad.conf`) that sets `ipv4.dad-timeout=0`, restoring the RHEL 9 behavior. This follows the same pattern as the existing `01-ipv6.conf` drop-in.

Fixes: https://issues.redhat.com/browse/OCPBUGS-86571

---
🤖 *This PR was created by [OpenClaw](https://openclaw.ai) on behalf of @mkowalski.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition in dual-stack Kubernetes node IP configuration by adjusting IPv4 Duplicate Address Detection handling in NetworkManager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->