### PR TITLE
OCPBUGS-86571: templates: pass --dual-stack to nodeip-configuration

### DIFF
--- a/templates/common/_base/units/nodeip-configuration.service.yaml
+++ b/templates/common/_base/units/nodeip-configuration.service.yaml
@@ -31,6 +31,9 @@ contents: |
     {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
     --prefer-ipv6 \
     {{end -}}
+    {{if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") -}}
+    --dual-stack \
+    {{end -}}
     --retry-on-failure \
     --network-type {{.NetworkType}} \
     ${NODEIP_HINT:-${KUBELET_NODEIP_HINT:-}}; \

--- a/templates/common/kubevirt/units/nodeip-configuration.service.yaml
+++ b/templates/common/kubevirt/units/nodeip-configuration.service.yaml
@@ -28,6 +28,9 @@ contents: |
     {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
     --prefer-ipv6 \
     {{end -}}
+    {{if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") -}}
+    --dual-stack \
+    {{end -}}
     --retry-on-failure \
     --network-type {{.NetworkType}} \
     ${NODEIP_HINT:-${KUBELET_NODEIP_HINT:-}}; \

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -36,6 +36,9 @@ contents: |
     {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
     --prefer-ipv6 \
     {{end -}}
+    {{if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") -}}
+    --dual-stack \
+    {{end -}}
     --retry-on-failure \
     ${NODEIP_HINT:-} \
     {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}} \

--- a/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
+++ b/templates/common/vsphere/units/nodeip-configuration-vsphere-upi.service.yaml
@@ -42,6 +42,9 @@ contents: |
     {{if or (eq .IPFamilies "IPv6") (eq .IPFamilies "DualStackIPv6Primary") -}}
     --prefer-ipv6 \
     {{end -}}
+    {{if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") -}}
+    --dual-stack \
+    {{end -}}
     --retry-on-failure \
     ${NODEIP_HINT:-${KUBELET_NODEIP_HINT:-}}; \
     do \


### PR DESCRIPTION
## Summary

Companion PR to [openshift/baremetal-runtimecfg#391](https://github.com/openshift/baremetal-runtimecfg/pull/391).

Passes the new `--dual-stack` flag to `baremetal-runtimecfg node-ip set` when the cluster is configured as dual-stack (`DualStack` or `DualStackIPv6Primary`). This tells `nodeip-configuration` to wait for both IPv4 and IPv6 addresses before writing the kubelet/crio config.

## Background

On RHEL 10, IPv4 ACD (Address Conflict Detection) is enabled by default, delaying IPv4 address assignment by ~200ms-3s. This creates a race condition on dual-stack clusters where `nodeip-configuration.service` sees only IPv6 and writes an IPv6-only config.

The baremetal-runtimecfg fix ([#391](https://github.com/openshift/baremetal-runtimecfg/pull/391)) adds dual-stack awareness to `getSuitableIPs()`:
- Auto-detects dual-stack from VIPs (covers on-prem)
- Accepts `--dual-stack` flag (covers non-VIP platforms like None/External)
- Bounded 10s wait for the second address family
- Graceful fallback if timeout expires

## Changes

Added `--dual-stack` flag to all 4 `nodeip-configuration` service templates:

| Template | Platform |
|----------|----------|
| `_base/units/nodeip-configuration.service.yaml` | None, External |
| `on-prem/units/nodeip-configuration.service.yaml` | BareMetal, OpenStack, oVirt, Nutanix |
| `kubevirt/units/nodeip-configuration.service.yaml` | KubeVirt |
| `vsphere/units/nodeip-configuration-vsphere-upi.service.yaml` | vSphere UPI |

The flag is conditionally passed using the same `.IPFamilies` template variable already used for `--prefer-ipv6`:

```yaml
{{if or (eq .IPFamilies "DualStack") (eq .IPFamilies "DualStackIPv6Primary") -}}
--dual-stack \
{{end -}}
```

**Note:** On-prem deployments also auto-detect dual-stack from VIPs, so the flag is belt-and-suspenders there. Non-on-prem deployments (None/External) have no VIPs, so the flag is essential.

## Dependencies

- Depends on [openshift/baremetal-runtimecfg#391](https://github.com/openshift/baremetal-runtimecfg/pull/391) (adds the `--dual-stack` flag to `node-ip set`)

Fixes: https://issues.redhat.com/browse/OCPBUGS-86571

---
🤖 *This PR was created by [OpenClaw](https://openclaw.ai) on behalf of @mkowalski.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Added dual-stack IP address configuration support across multiple deployment scenarios. The system now properly handles dual-stack IP families during node IP configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->