### PR TITLE
OCPBUGS-86041: update IsSNO helper function to correctly access the cluster's topology

### DIFF
--- a/test/extended-priv/util/clusters.go
+++ b/test/extended-priv/util/clusters.go
@@ -44,7 +44,7 @@ func IsTechPreviewNoUpgrade(oc *CLI) bool {
 
 // IsSingleNodeTopology returns true if the cluster is a SNO cluster
 func IsSingleNodeTopology(oc *CLI) bool {
-	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platformStatus.controlPlaneTopology}").Output()
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.controlPlaneTopology}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
 	return output == string(configv1.SingleReplicaTopologyMode)
 }


### PR DESCRIPTION
Closes: OCPBUGS-86041

**- What I did**
This updates the `IsSingleNodeTopology` helper that is used by `SkipOnSingleNodeTopology` to correctly select a cluster's topology.

**- How to verify it**
No tests in the MCO's disruptive suite that should skip on SNO run in the SNO payload rehearsals. The tests should continue passing in the standard jobs.

**- Description for the changelog**
OCPBUGS-86041: update IsSNO helper function to correctly access the cluster's topology
