### PR TITLE
OCPBUGS-85427: Remove trailing newline (\n) characters in klog message strings

### DIFF
--- a/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
+++ b/cmd/machine-config-daemon/firstboot_complete_machineconfig.go
@@ -67,7 +67,7 @@ func executeFirstbootCompleteMachineConfig(cmd *cobra.Command, args []string) {
 	for {
 		err := runFirstBootCompleteMachineConfig(cmd, args)
 		if err != nil {
-			klog.Warningf("error: %v\n", err)
+			klog.Warningf("error: %v", err)
 			klog.Info("Sleeping 1 minute for retry")
 			time.Sleep(time.Minute)
 		} else {

--- a/pkg/controller/certrotation/certrotation_controller.go
+++ b/pkg/controller/certrotation/certrotation_controller.go
@@ -472,7 +472,7 @@ func (c *CertRotationController) reconcileSecret(secret corev1.Secret) error {
 	}
 
 	if bytes.Equal(userData, updatedIgnition) {
-		klog.V(4).Infof("Secret %s already updated to use the latest CA, nothing to do\n", secret.Name)
+		klog.V(4).Infof("Secret %s already updated to use the latest CA, nothing to do", secret.Name)
 		return nil
 	}
 
@@ -483,7 +483,7 @@ func (c *CertRotationController) reconcileSecret(secret corev1.Secret) error {
 		return fmt.Errorf("could not update secret %s: %w", secret.Name, err)
 	}
 
-	klog.Infof("Successfully modified %s secret \n", secret.Name)
+	klog.Infof("Successfully modified %s secret", secret.Name)
 	return nil
 }
 

--- a/pkg/controller/certrotation/helpers.go
+++ b/pkg/controller/certrotation/helpers.go
@@ -35,7 +35,7 @@ func isUserDataSecret(secret corev1.Secret) bool {
 	_, isIgn, err := unstructured.NestedMap(userDataIgn.(map[string]interface{}), ctrlcommon.IgnFieldIgnition)
 	if !isIgn || err != nil {
 		// Didn't find ignition in user-data, warn but continue
-		klog.Infof("Unable to find ignition in user-data, skipping secret %s\n", secret.Name)
+		klog.Infof("Unable to find ignition in user-data, skipping secret %s", secret.Name)
 		return false
 	}
 	return true

--- a/pkg/daemon/coreos.go
+++ b/pkg/daemon/coreos.go
@@ -67,7 +67,7 @@ func logInitionProvisioning() error {
 	if err := json.Unmarshal(contents, &ignProvisioning); err != nil {
 		return err
 	}
-	klog.Infof("Ignition provisioning: time=%v\n", ignProvisioning.ProvisioningDate)
+	klog.Infof("Ignition provisioning: time=%v", ignProvisioning.ProvisioningDate)
 	return nil
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1827,7 +1827,7 @@ func (dn *Daemon) LogSystemData() {
 	if err != nil {
 		klog.Errorf("Listing boots: %v", err)
 	}
-	klog.Info("journalctl --list-boots:\n" + string(boots))
+	klog.Info("journalctl --list-boots:" + string(boots))
 
 	// Since nothing in the cluster today watches systemd units, let's
 	// at least capture them in our logs to start.  See also
@@ -1841,7 +1841,7 @@ func (dn *Daemon) LogSystemData() {
 	case err != nil:
 		klog.Errorf("Listing failed systemd services: %v", err)
 	case len(failedServices) > 0:
-		klog.Info("systemctl --failed:\n" + string(failedServices))
+		klog.Info("systemctl --failed:" + string(failedServices))
 	default:
 		klog.Info("systemd service state: OK")
 	}

--- a/pkg/daemon/pivot/utils/run.go
+++ b/pkg/daemon/pivot/utils/run.go
@@ -16,7 +16,7 @@ import (
 
 // runImpl is the actual shell execution implementation used by other functions.
 func runImpl(command string, args ...string) ([]byte, error) {
-	klog.Infof("Running: %s %s\n", command, strings.Join(args, " "))
+	klog.Infof("Running: %s %s", command, strings.Join(args, " "))
 	cmd := exec.Command(command, args...)
 	// multiplex writes to std streams so we keep seeing logs in MCD/systemd
 	// but we'll still be able to give out something here

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2694,7 +2694,7 @@ func (dn *Daemon) updateSSHKeys(newUsers, oldUsers []ign3types.PasswdUser) error
 func deconfigureAbsentUsers(newUsers, oldUsers []ign3types.PasswdUser) {
 	for _, oldUser := range oldUsers {
 		if !isUserPresent(oldUser, newUsers) {
-			klog.Infof("Absent user detected, deconfiguring the password for user %s\n", oldUser.Name)
+			klog.Infof("Absent user detected, deconfiguring the password for user %s", oldUser.Name)
 			deconfigureUser(oldUser)
 		}
 	}


### PR DESCRIPTION
- What I did
I removed the trailing newlines from the Klog messages. 

- How to Verify
Build a cluster and view the log messages for and extra newlines

- Description for the change log
Removed the "\n" from the end of klog messages. Fixes OCPBUGS-85427: Remove trailing newline (\n) characters in klog message strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized log message formatting across multiple system components by removing trailing newlines and extra whitespace from informational and warning logs.
  * Improves consistency and readability of logs without changing behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->