### PR TITLE
OCPBUGS-86889: use new skopeo location and follow redirects

### DIFF
--- a/hack/install-skopeo.sh
+++ b/hack/install-skopeo.sh
@@ -32,7 +32,7 @@ install_skopeo() {
   fi
 
   # Get the most recent tagged version of skopeo.
-  skopeo_version="$(curl -s https://api.github.com/repos/containers/skopeo/releases/latest | python3 -c 'import sys, json; print(json.load(sys.stdin)["tag_name"])')"
+  skopeo_version="$(curl -sL https://api.github.com/repos/podman-container-tools/skopeo/releases/latest | python3 -c 'import sys, json; print(json.load(sys.stdin)["tag_name"])')"
 
   echo "Installing skopeo $skopeo_version from source"
 


### PR DESCRIPTION
**- What I did**

Skopeo recently changed locations from <https://github.com/containers/skopeo> to <https://github.com/podman-container-tools/skopeo>. The `hack/install-skopeo.sh` script was not following redirects, causing it to break. This script has been updated to use the new location along with modifying the curl call to follow redirects.

**- How to verify it**

This change primarily impacts the OpenShift e2e-gcp-op-ocl-part1 and e2e-gcp-op-ocl-part2 jobs. So running those should verify that the change is successful.

**- Description for the changelog**
Use new Skopeo location for OCL E2E tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the skopeo installation script to retrieve release version information from an updated GitHub source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->