### PR TITLE
NO-ISSUE: Lower IRI deletion log verbosity

### DIFF
--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
@@ -475,7 +475,7 @@ func (ctrl *Controller) syncInternalReleaseImage(key string) (syncErr error) {
 	// Fetch the InternalReleaseImage
 	iri, err := ctrl.iriLister.Get(name)
 	if errors.IsNotFound(err) {
-		klog.V(2).Infof("InternalReleaseImage %v has been deleted", key)
+		klog.V(4).Infof("InternalReleaseImage %v has been deleted", key)
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
This is spamming controller logs on every sync and makes things harder to debug. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging verbosity for better debugging efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->