### PR TITLE
OCPBUGS-86890: fix: update arbiter crio config

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -17,7 +17,7 @@ contents:
     default_env = [
         "NSS_SDB_USE_CACHE=no",
     ]
-    default_runtime = "runc"
+    default_runtime = "crun"
     log_level = "info"
     cgroup_manager = "systemd"
     default_sysctls = [
@@ -51,6 +51,7 @@ contents:
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
+    default_annotations = {"run.oci.systemd.subgroup" = ""}
 
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
@@ -65,6 +66,7 @@ contents:
     pause_image = "{{.Images.infraImageKey}}"
     pause_image_auth_file = "/var/lib/kubelet/config.json"
     pause_command = "/usr/bin/pod"
+    short_name_mode = "disabled"
 
     [crio.network]
     network_dir = "/etc/kubernetes/cni/net.d/"


### PR DESCRIPTION
update arbtier crio config to keep inline with master and use crun as runc is no longer available in rhel10

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime configuration to optimize performance and compatibility for the Arbiter deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->