### PR TITLE
OCPBUGS-87004: Add -L flag to curl to follow redirects automatically

### DIFF
--- a/hack/install-skopeo.sh
+++ b/hack/install-skopeo.sh
@@ -32,7 +32,7 @@ install_skopeo() {
   fi
 
   # Get the most recent tagged version of skopeo.
-  skopeo_version="$(curl -s https://api.github.com/repos/containers/skopeo/releases/latest | python3 -c 'import sys, json; print(json.load(sys.stdin)["tag_name"])')"
+  skopeo_version="$(curl -sL https://api.github.com/repos/containers/skopeo/releases/latest | python3 -c 'import sys, json; print(json.load(sys.stdin)["tag_name"])')"
 
   echo "Installing skopeo $skopeo_version from source"
 


### PR DESCRIPTION
The GitHub API for `/repos/containers/skopeo/releases/latest` returns a 301 redirect to the canonical repository URL, causing the JSON parsing to fail with:

KeyError: 'tag_name'

The redirect response contains:
    {
      "message": "Moved Permanently",
      "url": "https://api.github.com/repositories/53356367/releases/latest"
    }

Example: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_machine-config-operator/6109/pull-ci-openshift-machine-config-operator-main-e2e-gcp-op-ocl-part1/2061846639768768512
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the skopeo installation process by ensuring proper handling of redirects when fetching the latest version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->