### PR TITLE
OCPBUGS-100389: machine-config-daemon-firstboot: disable ostree fsync during bootstrap

### DIFF
--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -15,9 +15,17 @@ contents: |
   RemainAfterExit=yes
   # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
+  # Bind mount a tmpfs-backed copy of the ostree repo config so that disabling fsync is ephemeral;
+  # if the host crashes or reboots the bind mount disappears and the on-disk config is unchanged.
+  # We append a second [core] section (GKeyFile merges duplicate groups) rather than using
+  # `ostree config set` because ostree uses an atomic rename which fails with EBUSY on a bind-mounted
+  # file; the bind mount must be established before `ostree config set` is called, and once it is,
+  # the rename target is a mount point and can't be replaced.
+  ExecStartPre=-/usr/bin/sh -c "cp /sysroot/ostree/repo/config /run/ostree-bootstrap-config && printf '\n[core]\nfsync = false\n' >> /run/ostree-bootstrap-config && mount --bind /run/ostree-bootstrap-config /sysroot/ostree/repo/config"
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
   ExecStart=/usr/bin/podman run --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig
+  ExecStopPost=-/usr/bin/umount /sysroot/ostree/repo/config
   {{if .Proxy -}}
   EnvironmentFile=/etc/mco/proxy.env
   {{end -}}


### PR DESCRIPTION
Saves a few seconds on ostree rebase during firstboot, measured at ~3-5s on AWS m6a.xlarge (n=18). Assumes we tolerate the outcome that corruption due to power failure means we have to re-ignite a node from scratch. Suggested by @dustymabe and original analysis at https://github.com/dustymabe/20250529-ostree-fsync-analysis

**- What I did**

Bind mount a tmpfs-backed copy of the ostree repo config over `/sysroot/ostree/repo/config` before the rebase. Setting `core.fsync=false` is then ephemeral: if the host crashes or reboots before `ExecStopPost` runs, the kernel tears down the bind mount and the original on-disk config is automatically restored.

We append a second `[core]` section to the tmpfs copy (GKeyFile merges duplicate groups, last value wins) rather than using `ostree config set`. The reason: ostree writes config changes via an atomic rename, which fails with `EBUSY` when the target file is itself a bind-mount point. Discovered during testing — journald shows `renameat(./tmp.zXuFKh, config): Device or resource busy` if `ostree config set` is attempted after the bind mount is in place.

**- How to verify it**

Prior to this change, the node journal will contain many `Starting/Completed syncfs() for system repo` entries from `rpm-ostree` during the rebase. After this change, those per-object syncfs calls are absent during the rebase window (the bind mount is confirmed active by `sysroot-ostree-repo-config.mount: Deactivated successfully` at service stop).

**- Description for the changelog**

Disabled ostree fsync during bootstrapping via ephemeral bind mount to save ~3-5s on rebase