### PR TITLE
MCO-2224: MCS Firstboot Pivot Failure Reporting 

### DIFF
--- a/cmd/machine-config-server/bootstrap.go
+++ b/cmd/machine-config-server/bootstrap.go
@@ -59,9 +59,12 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 	klog.Infof("Launching bootstrap server with tls min version: %v & cipher suites %v", tlsminversion, tlsciphersuites)
 	tlsConfig := ctrlcommon.GetGoTLSConfig(tlsminversion, tlsciphersuites)
 
+	// Bootstrap mode: no failure reporting (boot images are kept current)
+	failureHandler := server.NewNodeFailureHandler(bs.GetFailureReporter())
+
 	apiHandler := server.NewServerAPIHandler(bs)
-	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key, tlsConfig)
-	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "", tlsConfig)
+	secureServer := server.NewAPIServer(apiHandler, failureHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key, tlsConfig)
+	insecureServer := server.NewAPIServer(apiHandler, failureHandler, rootOpts.isport, true, "", "", tlsConfig)
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -47,7 +48,12 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		klog.Exitf("--apiserver-url cannot be empty")
 	}
 
-	cs, err := server.NewClusterServer(startOpts.kubeconfig, startOpts.apiserverURL)
+	// Create EventBroadcaster for failure reporting
+	// EventBroadcaster must be shut down on exit to avoid leaking goroutines
+	eventBroadcaster := record.NewBroadcaster()
+	defer eventBroadcaster.Shutdown()
+
+	cs, err := server.NewClusterServer(startOpts.kubeconfig, startOpts.apiserverURL, eventBroadcaster)
 	if err != nil {
 		ctrlcommon.WriteTerminationError(err)
 	}
@@ -55,9 +61,11 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	klog.Infof("Launching server with tls min version: %v & cipher suites %v", rootOpts.tlsminversion, rootOpts.tlsciphersuites)
 	tlsConfig := ctrlcommon.GetGoTLSConfig(rootOpts.tlsminversion, rootOpts.tlsciphersuites)
 
+	failureHandler := server.NewNodeFailureHandler(cs.GetFailureReporter())
+
 	apiHandler := server.NewServerAPIHandler(cs)
-	secureServer := server.NewAPIServer(apiHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key, tlsConfig)
-	insecureServer := server.NewAPIServer(apiHandler, rootOpts.isport, true, "", "", tlsConfig)
+	secureServer := server.NewAPIServer(apiHandler, failureHandler, rootOpts.sport, false, rootOpts.cert, rootOpts.key, tlsConfig)
+	insecureServer := server.NewAPIServer(apiHandler, failureHandler, rootOpts.isport, true, "", "", tlsConfig)
 
 	stopCh := make(chan struct{})
 	go secureServer.Serve()

--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -25,3 +25,6 @@ rules:
 - apiGroups: ["route.openshift.io"]
   resources: ["routes"]
   verbs: ["get", "list"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["infrastructures"]
+  verbs: ["get"]

--- a/manifests/machineconfigserver/events-clusterrole.yaml
+++ b/manifests/machineconfigserver/events-clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: machine-config-server-events
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]

--- a/manifests/machineconfigserver/events-rolebinding-default.yaml
+++ b/manifests/machineconfigserver/events-rolebinding-default.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-server-events
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: machine-config-server-events
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-server

--- a/manifests/machineconfigserver/events-rolebinding-target.yaml
+++ b/manifests/machineconfigserver/events-rolebinding-target.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-config-server-events
+  namespace: {{.TargetNamespace}}
+roleRef:
+  kind: ClusterRole
+  name: machine-config-server-events
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{.TargetNamespace}}
+  name: machine-config-server

--- a/pkg/controller/common/firstboot_failure_report.go
+++ b/pkg/controller/common/firstboot_failure_report.go
@@ -1,0 +1,11 @@
+package common
+
+// FirstbootFailureReport represents a failure report from a node during firstboot.
+// Used by the daemon (sender) and the MCS (receiver).
+type FirstbootFailureReport struct {
+	Pool         string `json:"pool"`
+	NodeID       string `json:"nodeID"`
+	Stage        string `json:"stage"`
+	ImageURL     string `json:"imageURL"`
+	ErrorMessage string `json:"errorMessage"`
+}

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -12,7 +12,8 @@ const (
 	CurrentImageAnnotationKey = "machineconfiguration.openshift.io/currentImage"
 	// DesiredImageAnnotationKey is used to specify the desired OS image pullspec for a machine
 	DesiredImageAnnotationKey = "machineconfiguration.openshift.io/desiredImage"
-
+	// MachineConfigServerURLAnnotationKey stores the MCS base URL for status reporting
+	MachineConfigServerURLAnnotationKey = "machineconfiguration.openshift.io/machineConfigServerURL"
 	// CurrentMachineConfigAnnotationKey is used to fetch current MachineConfig for a machine
 	CurrentMachineConfigAnnotationKey = "machineconfiguration.openshift.io/currentConfig"
 	// DesiredMachineConfigAnnotationKey is used to specify the desired MachineConfig for a machine

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -66,6 +66,10 @@ const (
 	InitialNodeAnnotationsFilePath = "/etc/machine-config-daemon/node-annotations.json"
 	// InitialNodeAnnotationsBakPath defines the path of InitialNodeAnnotationsFilePath when the initial bootstrap is done. We leave it around for debugging and reconciling.
 	InitialNodeAnnotationsBakPath = "/etc/machine-config-daemon/node-annotation.json.bak"
+	// MCSRootCABundlePath defines the path where the MCS root CA bundle is written
+	// by the Machine Config Server during ignition provisioning. The MCD uses this
+	// CA to establish TLS trust when sending firstboot failure reports to the MCS.
+	MCSRootCABundlePath = "/etc/machine-config-daemon/mcs-ca-bundle.crt"
 
 	// IgnitionSystemdPresetFile is where Ignition writes initial enabled/disabled systemd unit configs
 	// This should be removed on boot after MCO takes over, so if any of these are deleted we can go back

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1241,6 +1241,7 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig(machineConfigFile string) er
 	if !newEnough || !skopeoSupportsMultiArchSigstore(mc.Spec.OSImageURL) {
 		logSystem("rpm-ostree or skopeo is not new enough for new-format image; forcing an update via container and queuing immediate reboot")
 		if err := dn.InplaceUpdateViaNewContainer(mc.Spec.OSImageURL); err != nil {
+			dn.sendMCSFirstbootFailureReport(&mc, mc.Spec.OSImageURL, err)
 			return err
 		}
 		rebootCmd := rebootCommand("extra reboot for in-place update", dn.os.IsCoreOSVariant())
@@ -1295,8 +1296,12 @@ func (dn *Daemon) RunFirstbootCompleteMachineconfig(machineConfigFile string) er
 	// This "false" is a compatibility for IBM's use case, where they are using the MCD to write the full configuration instead of just
 	// the encapsulated config. This shouldn't affect normal OCP operations, but will allow anyone using this code to write configs to
 	// still get the kubelet cert
+
 	err = dn.update(oldConfig, &mc, false, true)
 	if err != nil {
+		// Best-effort: tell MCS we failed so the cluster can surface an alert
+		// before this node has kubelet or API access.
+		dn.sendMCSFirstbootFailureReport(&mc, mc.Spec.OSImageURL, err)
 		return err
 	}
 

--- a/pkg/daemon/firstboot_failure.go
+++ b/pkg/daemon/firstboot_failure.go
@@ -1,0 +1,171 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"k8s.io/klog/v2"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+)
+
+const (
+	// Sentinel file to prevent duplicate reports on retry loops
+	firstbootFailureSentinelPath = "/run/mcd-firstboot-pivot-failed"
+
+	// Timeout for HTTP request (short to avoid blocking retry path)
+	firstbootReportTimeout = 10 * time.Second
+)
+
+// sendMCSFirstbootFailureReport sends a best-effort failure report to the MCS.
+// Never returns an error - failures are logged only.
+func (dn *Daemon) sendMCSFirstbootFailureReport(mc *mcfgv1.MachineConfig, imageURL string, pivotErr error) {
+	// Check sentinel file - if it exists, we already reported this failure
+	if _, err := os.Stat(firstbootFailureSentinelPath); err == nil {
+		klog.V(2).Infof("Firstboot failure already reported (sentinel exists), skipping duplicate report")
+		return
+	}
+
+	// Extract pool name from MachineConfig
+	poolName := getPoolNameFromMachineConfig(mc)
+
+	// Get node name - try daemon struct first, fallback to NODE_NAME env var, then hostname
+	// During firstboot-complete-machineconfig, dn.name is not set because ClusterConnect hasn't run yet
+	nodeID := dn.name
+	if nodeID == "" {
+		nodeID = os.Getenv("NODE_NAME")
+	}
+	if nodeID == "" {
+		// Final fallback: use hostname (may be temporary name like "localhost")
+		var err error
+		nodeID, err = os.Hostname()
+		if err != nil || nodeID == "" {
+			klog.Warningf("Cannot send MCS failure report: unable to determine node name")
+			return
+		}
+	}
+
+	// Read MCS URL from node annotations file
+	mcsURL, err := getMCSURLFromAnnotations()
+	if err != nil {
+		klog.Warningf("Cannot send MCS failure report: %v", err)
+		return
+	}
+
+	// Build failure report payload
+	report := firstbootFailureReport{
+		Pool:         poolName,
+		NodeID:       nodeID,
+		Stage:        "firstboot-update",
+		ImageURL:     imageURL,
+		ErrorMessage: pivotErr.Error(),
+	}
+
+	// Send report (fire-and-forget)
+	if err := sendFailureReportHTTP(mcsURL, &report); err != nil {
+		klog.Warningf("Failed to send MCS failure report (best-effort): %v", err)
+		return
+	}
+
+	// Create sentinel file to prevent duplicate reports
+	if err := os.WriteFile(firstbootFailureSentinelPath, []byte(fmt.Sprintf("%s\n", time.Now().Format(time.RFC3339))), 0644); err != nil {
+		klog.Warningf("Failed to create firstboot failure sentinel file: %v", err)
+	}
+
+	klog.Infof("Sent firstboot failure report to MCS: pool=%s node=%s stage=firstboot-update", poolName, nodeID)
+}
+
+// getPoolNameFromMachineConfig extracts the pool name from MachineConfig OwnerReferences.
+// Falls back to "master" if OwnerReferences are not set.
+func getPoolNameFromMachineConfig(mc *mcfgv1.MachineConfig) string {
+	// Use OwnerReferences - the most reliable approach
+	ownerMCPs := mc.GetOwnerReferences()
+	if len(ownerMCPs) != 0 {
+		return ownerMCPs[0].Name
+	}
+
+	// Fallback to master pool (OwnerRefs should always be set for rendered configs)
+	klog.Warningf("Could not determine pool from MachineConfig %s (no OwnerReferences), using 'master' as fallback", mc.Name)
+	return ctrlcommon.MachineConfigPoolMaster
+}
+
+// getMCSURLFromAnnotations reads the MCS URL from the node annotations file.
+func getMCSURLFromAnnotations() (string, error) {
+	// Read node annotations JSON file
+	data, err := os.ReadFile(constants.InitialNodeAnnotationsFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read node annotations file: %w", err)
+	}
+
+	// Unmarshal annotations
+	var annotations map[string]string
+	if err := json.Unmarshal(data, &annotations); err != nil {
+		return "", fmt.Errorf("failed to unmarshal node annotations: %w", err)
+	}
+
+	// Extract MCS URL
+	mcsURL := annotations[constants.MachineConfigServerURLAnnotationKey]
+	if mcsURL == "" {
+		return "", fmt.Errorf("MCS URL not found in node annotations")
+	}
+
+	return mcsURL, nil
+}
+
+// firstbootFailureReport matches the server-side struct in pkg/server/failure_reporter.go
+type firstbootFailureReport struct {
+	Pool         string `json:"pool"`
+	NodeID       string `json:"nodeID"`
+	Stage        string `json:"stage"`
+	ImageURL     string `json:"imageURL"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+// sendFailureReportHTTP sends the failure report via HTTPS POST to the MCS.
+func sendFailureReportHTTP(mcsBaseURL string, report *firstbootFailureReport) error {
+	// Build endpoint URL
+	endpoint := fmt.Sprintf("%s/v1/node-failure", strings.TrimSuffix(mcsBaseURL, "/"))
+
+	// Marshal report to JSON
+	payload, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("failed to marshal failure report: %w", err)
+	}
+
+	// Create HTTP client with timeout (uses default cert pool)
+	client := &http.Client{
+		Timeout: firstbootReportTimeout,
+	}
+
+	// Create request with context timeout
+	ctx, cancel := context.WithTimeout(context.Background(), firstbootReportTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status (202 Accepted expected)
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/daemon/firstboot_failure.go
+++ b/pkg/daemon/firstboot_failure.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"k8s.io/klog/v2"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+)
+
+const (
+	// Sentinel file to prevent duplicate reports on retry loops
+	firstbootFailureSentinelPath = "/run/mcd-firstboot-pivot-failed"
+
+	// Timeout for HTTP request (short to avoid blocking retry path)
+	firstbootReportTimeout = 10 * time.Second
+)
+
+// sendMCSFirstbootFailureReport sends a best-effort failure report to the MCS.
+// Never returns an error - failures are logged only.
+func (dn *Daemon) sendMCSFirstbootFailureReport(mc *mcfgv1.MachineConfig, imageURL string, pivotErr error) {
+	// Check sentinel file - if it exists, we already reported this failure
+	if _, err := os.Stat(firstbootFailureSentinelPath); err == nil {
+		klog.V(2).Infof("Firstboot failure already reported (sentinel exists), skipping duplicate report")
+		return
+	}
+
+	// Extract pool name from MachineConfig
+	poolName := getPoolNameFromMachineConfig(mc)
+
+	// Get node name - try daemon struct first, fallback to NODE_NAME env var, then hostname
+	// During firstboot-complete-machineconfig, dn.name is not set because ClusterConnect hasn't run yet
+	nodeID := dn.name
+	if nodeID == "" {
+		nodeID = os.Getenv("NODE_NAME")
+	}
+	if nodeID == "" {
+		// Final fallback: use hostname (may be temporary name like "localhost")
+		var err error
+		nodeID, err = os.Hostname()
+		if err != nil || nodeID == "" {
+			klog.Warningf("Cannot send MCS failure report: unable to determine node name")
+			return
+		}
+	}
+
+	// Read MCS URL from node annotations file
+	mcsURL, err := getMCSURLFromAnnotations()
+	if err != nil {
+		klog.Warningf("Cannot send MCS failure report: %v", err)
+		return
+	}
+
+	// Build failure report payload
+	report := ctrlcommon.FirstbootFailureReport{
+		Pool:         poolName,
+		NodeID:       nodeID,
+		Stage:        "firstboot-update",
+		ImageURL:     imageURL,
+		ErrorMessage: pivotErr.Error(),
+	}
+
+	// Send report (fire-and-forget)
+	if err := sendFailureReportHTTP(mcsURL, &report); err != nil {
+		klog.Warning("Failed to send MCS failure report (best-effort)")
+		return
+	}
+
+	// Create sentinel file to prevent duplicate reports
+	if err := os.WriteFile(firstbootFailureSentinelPath, []byte(fmt.Sprintf("%s\n", time.Now().Format(time.RFC3339))), 0o644); err != nil {
+		klog.Warningf("Failed to create firstboot failure sentinel file: %v", err)
+	}
+
+	klog.Infof("Sent firstboot failure report to MCS: pool=%s stage=firstboot-update", poolName)
+}
+
+// getPoolNameFromMachineConfig extracts the pool name from MachineConfig OwnerReferences.
+// Falls back to "master" if OwnerReferences are not set.
+func getPoolNameFromMachineConfig(mc *mcfgv1.MachineConfig) string {
+	// Use OwnerReferences - the most reliable approach
+	ownerMCPs := mc.GetOwnerReferences()
+	if len(ownerMCPs) != 0 {
+		return ownerMCPs[0].Name
+	}
+
+	// Fallback to master pool (OwnerRefs should always be set for rendered configs)
+	klog.Warningf("Could not determine pool from MachineConfig %s (no OwnerReferences), using 'master' as fallback", mc.Name)
+	return ctrlcommon.MachineConfigPoolMaster
+}
+
+// getMCSURLFromAnnotations reads the MCS URL from the node annotations file.
+func getMCSURLFromAnnotations() (string, error) {
+	// Read node annotations JSON file
+	data, err := os.ReadFile(constants.InitialNodeAnnotationsFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read node annotations file: %w", err)
+	}
+
+	// Unmarshal annotations
+	var annotations map[string]string
+	if err := json.Unmarshal(data, &annotations); err != nil {
+		return "", fmt.Errorf("failed to unmarshal node annotations: %w", err)
+	}
+
+	// Extract MCS URL
+	mcsURL := annotations[constants.MachineConfigServerURLAnnotationKey]
+	if mcsURL == "" {
+		return "", fmt.Errorf("MCS URL not found in node annotations")
+	}
+
+	return mcsURL, nil
+}
+
+// sendFailureReportHTTP sends the failure report via HTTPS POST to the MCS.
+func sendFailureReportHTTP(mcsBaseURL string, report *ctrlcommon.FirstbootFailureReport) error {
+	// Build endpoint URL
+	endpoint := fmt.Sprintf("%s/v1/node-failure", strings.TrimSuffix(mcsBaseURL, "/"))
+
+	// Marshal report to JSON
+	payload, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("failed to marshal failure report: %w", err)
+	}
+
+	// Create HTTP client with timeout (uses default cert pool)
+	client := &http.Client{
+		Timeout: firstbootReportTimeout,
+	}
+
+	// Create request with context timeout
+	ctx, cancel := context.WithTimeout(context.Background(), firstbootReportTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status (202 Accepted expected)
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/daemon/firstboot_failure.go
+++ b/pkg/daemon/firstboot_failure.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -122,21 +124,25 @@ func getMCSURLFromAnnotations() (string, error) {
 
 // sendFailureReportHTTP sends the failure report via HTTPS POST to the MCS.
 func sendFailureReportHTTP(mcsBaseURL string, report *ctrlcommon.FirstbootFailureReport) error {
-	// Build endpoint URL
 	endpoint := fmt.Sprintf("%s/v1/node-failure", strings.TrimSuffix(mcsBaseURL, "/"))
 
-	// Marshal report to JSON
 	payload, err := json.Marshal(report)
 	if err != nil {
 		return fmt.Errorf("failed to marshal failure report: %w", err)
 	}
 
-	// Create HTTP client with timeout (uses default cert pool)
-	client := &http.Client{
-		Timeout: firstbootReportTimeout,
+	tlsConfig, err := buildMCSTLSConfig()
+	if err != nil {
+		klog.Warningf("Failed to build MCS TLS config, falling back to system default: %v", err)
 	}
 
-	// Create request with context timeout
+	client := &http.Client{
+		Timeout: firstbootReportTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), firstbootReportTimeout)
 	defer cancel()
 
@@ -146,17 +152,40 @@ func sendFailureReportHTTP(mcsBaseURL string, report *ctrlcommon.FirstbootFailur
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	// Send request
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Check response status (202 Accepted expected)
 	if resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	return nil
+}
+
+// buildMCSTLSConfig loads the MCS root CA from disk and returns a tls.Config
+// with a custom cert pool. Returns nil if the CA file does not exist, which
+// falls back to the system default cert pool for backward compatibility.
+func buildMCSTLSConfig() (*tls.Config, error) {
+	caPEM, err := os.ReadFile(constants.MCSRootCABundlePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(2).Infof("MCS CA bundle not found at %s, using system default cert pool", constants.MCSRootCABundlePath)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read MCS CA bundle: %w", err)
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("failed to parse any certificates from MCS CA bundle at %s", constants.MCSRootCABundlePath)
+	}
+
+	klog.V(2).Infof("Loaded MCS root CA from %s", constants.MCSRootCABundlePath)
+	return &tls.Config{
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS12,
+	}, nil
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -153,6 +153,9 @@ const (
 	mcsNodeBootstrapperServiceAccountManifestPath = "manifests/machineconfigserver/node-bootstrapper-sa.yaml"
 	mcsNodeBootstrapperTokenManifestPath          = "manifests/machineconfigserver/node-bootstrapper-token.yaml"
 	mcsDaemonsetManifestPath                      = "manifests/machineconfigserver/daemonset.yaml"
+	mcsEventsClusterRoleManifestPath              = "manifests/machineconfigserver/events-clusterrole.yaml"
+	mcsEventsRoleBindingDefaultManifestPath       = "manifests/machineconfigserver/events-rolebinding-default.yaml"
+	mcsEventsRoleBindingTargetManifestPath        = "manifests/machineconfigserver/events-rolebinding-target.yaml"
 
 	// Machine OS puller manifest paths
 	mopRoleBindingManifestPath    = "manifests/machine-os-puller/rolebinding.yaml"
@@ -1674,6 +1677,11 @@ func (optr *Operator) syncMachineConfigServer(config *renderConfig, _ *configv1.
 	paths := manifestPaths{
 		clusterRoles: []string{
 			mcsClusterRoleManifestPath,
+			mcsEventsClusterRoleManifestPath,
+		},
+		roleBindings: []string{
+			mcsEventsRoleBindingDefaultManifestPath,
+			mcsEventsRoleBindingTargetManifestPath,
 		},
 		clusterRoleBindings: []string{
 			mcsClusterRoleBindingManifestPath,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -9,11 +9,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -629,7 +626,7 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 		templatectrl.DockerRegistryKey:        imgs.DockerRegistry,
 	}
 
-	ignitionHost, err := getIgnitionHost(&infra.Status)
+	ignitionHost, err := server.GetIgnitionHost(&infra.Status)
 	if err != nil {
 		return err
 	}
@@ -705,34 +702,6 @@ func (optr *Operator) getTrustedBundle(proxy *configv1.Proxy) ([]byte, error) {
 		}
 	}
 	return trustBundle, nil
-}
-
-func getIgnitionHost(infraStatus *configv1.InfrastructureStatus) (string, error) {
-	internalURL := infraStatus.APIServerInternalURL
-	internalURLParsed, err := url.Parse(internalURL)
-	if err != nil {
-		return "", err
-	}
-	securePortStr := strconv.Itoa(server.SecurePort)
-	ignitionHost := fmt.Sprintf("%s:%s", internalURLParsed.Hostname(), securePortStr)
-	if infraStatus.PlatformStatus != nil {
-		switch infraStatus.PlatformStatus.Type {
-		case configv1.BareMetalPlatformType:
-			ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.BareMetal.APIServerInternalIPs[0], securePortStr)
-		case configv1.OpenStackPlatformType:
-			ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.OpenStack.APIServerInternalIPs[0], securePortStr)
-		case configv1.OvirtPlatformType:
-			ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.Ovirt.APIServerInternalIPs[0], securePortStr)
-		case configv1.VSpherePlatformType:
-			if infraStatus.PlatformStatus.VSphere != nil {
-				if len(infraStatus.PlatformStatus.VSphere.APIServerInternalIPs) > 0 {
-					ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIPs[0], securePortStr)
-				}
-			}
-		}
-	}
-
-	return ignitionHost, nil
 }
 
 func (optr *Operator) syncMachineConfigPools(config *renderConfig, _ *configv1.ClusterOperator) error {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -153,6 +153,8 @@ const (
 	mcsNodeBootstrapperServiceAccountManifestPath = "manifests/machineconfigserver/node-bootstrapper-sa.yaml"
 	mcsNodeBootstrapperTokenManifestPath          = "manifests/machineconfigserver/node-bootstrapper-token.yaml"
 	mcsDaemonsetManifestPath                      = "manifests/machineconfigserver/daemonset.yaml"
+	mcsEventsClusterRoleManifestPath              = "manifests/machineconfigserver/events-clusterrole.yaml"
+	mcsEventsRoleBindingTargetManifestPath        = "manifests/machineconfigserver/events-rolebinding-target.yaml"
 
 	// Machine OS puller manifest paths
 	mopRoleBindingManifestPath    = "manifests/machine-os-puller/rolebinding.yaml"
@@ -1674,6 +1676,10 @@ func (optr *Operator) syncMachineConfigServer(config *renderConfig, _ *configv1.
 	paths := manifestPaths{
 		clusterRoles: []string{
 			mcsClusterRoleManifestPath,
+			mcsEventsClusterRoleManifestPath,
+		},
+		roleBindings: []string{
+			mcsEventsRoleBindingTargetManifestPath,
 		},
 		clusterRoleBindings: []string{
 			mcsClusterRoleBindingManifestPath,

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -45,10 +45,11 @@ type APIServer struct {
 // NewAPIServer initializes a new API server
 // that runs the Machine Config Server as a
 // handler.
-func NewAPIServer(a *APIHandler, p int, is bool, c, k string, t *tls.Config) *APIServer {
+func NewAPIServer(a *APIHandler, failureHandler *NodeFailureHandler, p int, is bool, c, k string, t *tls.Config) *APIServer {
 	mux := http.NewServeMux()
 	mux.Handle("/config/", a)
 	mux.Handle("/healthz", &healthHandler{})
+	mux.Handle("/v1/node-failure", failureHandler)
 	mux.Handle("/", &defaultHandler{})
 
 	return &APIServer{
@@ -181,6 +182,74 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type healthHandler struct{}
+
+// NodeFailureHandler handles POST requests to /v1/node-failure
+type NodeFailureHandler struct {
+	reporter FailureReporter
+}
+
+// NewNodeFailureHandler creates a handler for node failure reports
+func NewNodeFailureHandler(reporter FailureReporter) *NodeFailureHandler {
+	return &NodeFailureHandler{
+		reporter: reporter,
+	}
+}
+
+// ServeHTTP processes firstboot failure reports from nodes
+func (h *NodeFailureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only accept POST
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Read and decode JSON body
+	var report FirstbootFailureReport
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&report); err != nil {
+		klog.Errorf("Failed to decode failure report: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Invalid JSON payload",
+		})
+		return
+	}
+
+	// Validate required fields
+	if report.Pool == "" || report.NodeID == "" || report.Stage == "" {
+		klog.Errorf("Missing required fields in failure report: pool=%s node=%s stage=%s",
+			report.Pool, report.NodeID, report.Stage)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Missing required fields: pool, nodeID, and stage are required",
+		})
+		return
+	}
+
+	klog.Infof("Received failure report: pool=%s node=%s stage=%s",
+		report.Pool, report.NodeID, report.Stage)
+
+	// Report the failure (best-effort, errors are logged but don't fail the request)
+	// In bootstrap mode, reporter may be nil
+	if h.reporter != nil {
+		ctx := r.Context()
+		if err := h.reporter.ReportFailure(ctx, &report); err != nil {
+			// Log error but still return 202 - we don't want the node to retry-loop
+			klog.Errorf("Failed to process failure report (still returning 202): %v", err)
+		}
+	}
+
+	// Always return 202 Accepted (best-effort delivery)
+	// Never return 5xx - the node must not retry-loop on reporter errors
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": "accepted",
+	})
+}
 
 type acceptHeaderValue struct {
 	MIMEType    string

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -45,10 +45,11 @@ type APIServer struct {
 // NewAPIServer initializes a new API server
 // that runs the Machine Config Server as a
 // handler.
-func NewAPIServer(a *APIHandler, p int, is bool, c, k string, t *tls.Config) *APIServer {
+func NewAPIServer(a *APIHandler, failureHandler *NodeFailureHandler, p int, is bool, c, k string, t *tls.Config) *APIServer {
 	mux := http.NewServeMux()
 	mux.Handle("/config/", a)
 	mux.Handle("/healthz", &healthHandler{})
+	mux.Handle("/v1/node-failure", failureHandler)
 	mux.Handle("/", &defaultHandler{})
 
 	return &APIServer{
@@ -181,6 +182,74 @@ func (sh *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type healthHandler struct{}
+
+// NodeFailureHandler handles POST requests to /v1/node-failure
+type NodeFailureHandler struct {
+	reporter FailureReporter
+}
+
+// NewNodeFailureHandler creates a handler for node failure reports
+func NewNodeFailureHandler(reporter FailureReporter) *NodeFailureHandler {
+	return &NodeFailureHandler{
+		reporter: reporter,
+	}
+}
+
+// ServeHTTP processes firstboot failure reports from nodes
+func (h *NodeFailureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only accept POST
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Read and decode JSON body
+	var report ctrlcommon.FirstbootFailureReport
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&report); err != nil {
+		klog.Errorf("Failed to decode failure report: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Invalid JSON payload",
+		})
+		return
+	}
+
+	// Validate required fields
+	if report.Pool == "" || report.NodeID == "" || report.Stage == "" {
+		klog.Errorf("Missing required fields in failure report: pool=%s node=%s stage=%s",
+			report.Pool, report.NodeID, report.Stage)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Missing required fields: pool, nodeID, and stage are required",
+		})
+		return
+	}
+
+	klog.Infof("Received failure report: pool=%s node=%s stage=%s",
+		report.Pool, report.NodeID, report.Stage)
+
+	// Report the failure (best-effort, errors are logged but don't fail the request)
+	// In bootstrap mode, reporter may be nil
+	if h.reporter != nil {
+		ctx := r.Context()
+		if err := h.reporter.ReportFailure(ctx, &report); err != nil {
+			// Log error but still return 202 - we don't want the node to retry-loop
+			klog.Errorf("Failed to process failure report (still returning 202): %v", err)
+		}
+	}
+
+	// Always return 202 Accepted (best-effort delivery)
+	// Never return 5xx - the node must not retry-loop on reporter errors
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": "accepted",
+	})
+}
 
 type acceptHeaderValue struct {
 	MIMEType    string

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -28,6 +28,10 @@ func (ms *mockServer) GetConfig(pr poolRequest) (*runtime.RawExtension, error) {
 	return ms.GetConfigFn(pr)
 }
 
+func (ms *mockServer) GetFailureReporter() FailureReporter {
+	return nil
+}
+
 type checkResponse func(t *testing.T, response *http.Response)
 
 type scenario struct {
@@ -717,7 +721,7 @@ func TestAPIServer(t *testing.T) {
 			ms := &mockServer{
 				GetConfigFn: scenario.serverFunc,
 			}
-			server := NewAPIServer(NewServerAPIHandler(ms), 0, false, "", "", nil)
+			server := NewAPIServer(NewServerAPIHandler(ms), nil, 0, false, "", "", nil)
 			server.handler.ServeHTTP(w, scenario.request)
 
 			resp := w.Result()

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -30,6 +30,13 @@ type bootstrapServer struct {
 	certs []string
 }
 
+// GetFailureReporter returns nil for bootstrap server (no failure reporting during bootstrap).
+// Boot images are kept current with the release payload, so firstboot pivot failures
+// are not a realistic scenario during cluster bootstrap.
+func (bsc *bootstrapServer) GetFailureReporter() FailureReporter {
+	return nil
+}
+
 // NewBootstrapServer initializes a new Bootstrap server that implements
 // the Server interface.
 func NewBootstrapServer(dir, kubeconfig string, ircerts []string) (Server, error) {
@@ -135,7 +142,7 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 	addDataAndMaybeAppendToIgnition(cloudProviderCAPath, cc.Spec.CloudProviderCAData, &ignConf)
 
 	appenders := newAppendersBuilder(nil, bsc.kubeconfigFunc, bsc.certs, bsc.serverBaseDir).
-		WithNodeAnnotations(currConf, "").
+		WithNodeAnnotations(currConf, "", "").
 		build()
 
 	for _, a := range appenders {

--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -13,6 +13,7 @@ import (
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 )
 
 // ensure bootstrapServer implements the
@@ -140,6 +141,7 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 
 	addDataAndMaybeAppendToIgnition(caBundleFilePath, cc.Spec.KubeAPIServerServingCAData, &ignConf)
 	addDataAndMaybeAppendToIgnition(cloudProviderCAPath, cc.Spec.CloudProviderCAData, &ignConf)
+	addDataAndMaybeAppendToIgnition(daemonconsts.MCSRootCABundlePath, cc.Spec.RootCAData, &ignConf)
 
 	appenders := newAppendersBuilder(nil, bsc.kubeconfigFunc, bsc.certs, bsc.serverBaseDir).
 		WithNodeAnnotations(currConf, "", "").

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -21,10 +21,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/klog/v2"
 
@@ -51,11 +54,13 @@ type clusterServer struct {
 	machineOSConfigLister   v1.MachineOSConfigLister
 	machineOSBuildLister    v1.MachineOSBuildLister
 
-	kubeclient  clientset.Interface
-	routeclient routeclientset.Interface
+	kubeclient      clientset.Interface
+	routeclient     routeclientset.Interface
+	failureReporter FailureReporter
 
 	kubeconfigFunc kubeconfigFunc
 	apiserverURL   string
+	mcsURL         string
 }
 
 const minResyncPeriod = 20 * time.Minute
@@ -76,7 +81,8 @@ func resyncPeriod() func() time.Duration {
 // It accepts a kubeConfig, which is not required when it's
 // run from within a cluster(useful in testing).
 // It accepts the apiserverURL which is the location of the KubeAPIServer.
-func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
+// It accepts an eventBroadcaster for recording firstboot failure events.
+func NewClusterServer(kubeConfig, apiserverURL string, eventBroadcaster record.EventBroadcaster) (Server, error) {
 	clientsBuilder, err := clients.NewBuilder(kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes rest client: %w", err)
@@ -85,6 +91,7 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 	machineConfigClient := clientsBuilder.MachineConfigClientOrDie("machine-config-shared-informer")
 	kubeClient := clientsBuilder.KubeClientOrDie("kube-client-shared-informer")
 	routeClient := clientsBuilder.RouteClientOrDie("route-client")
+	configClient := clientsBuilder.ConfigClientOrDie("config-client")
 	sharedInformerFactory := mcfginformers.NewSharedInformerFactory(machineConfigClient, resyncPeriod()())
 	kubeNamespacedSharedInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod()(), informers.WithNamespace("openshift-machine-config-operator"))
 
@@ -112,6 +119,39 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 		return nil, errors.New("failed to wait for cache sync")
 	}
 
+	// Fetch Infrastructure to compute MCS URL
+	// Non-fatal: if this fails, continue with empty mcsURL
+	var mcsURL string
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	infra, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to get cluster infrastructure, continuing without MCS URL: %v", err)
+	} else {
+		ignitionHost, err := GetIgnitionHost(&infra.Status)
+		if err != nil {
+			klog.Warningf("Failed to compute ignition host, continuing without MCS URL: %v", err)
+		} else {
+			mcsURL = fmt.Sprintf("https://%s", ignitionHost)
+		}
+	}
+
+	// Start recording events to the API server
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
+		Interface: kubeClient.CoreV1().Events(ctrlcommon.MCONamespace),
+	})
+
+	// Create EventRecorder for failure reporting
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	mcfgv1.AddToScheme(scheme)
+	eventRecorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{
+		Component: "machine-config-server",
+	})
+
+	// Create failure reporter
+	failureReporter := NewClusterFailureReporter(eventRecorder)
+
 	return &clusterServer{
 		machineConfigPoolLister: mcpLister,
 		machineConfigLister:     mcLister,
@@ -121,8 +161,10 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 		machineOSBuildLister:    mosbLister,
 		kubeclient:              kubeClient,
 		routeclient:             routeClient,
+		failureReporter:         failureReporter,
 		kubeconfigFunc:          func() ([]byte, []byte, error) { return kubeconfigFromSecret(bootstrapTokenDir, apiserverURL, nil) },
 		apiserverURL:            apiserverURL,
+		mcsURL:                  mcsURL,
 	}, nil
 }
 
@@ -187,7 +229,7 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 	desiredImage := cs.resolveDesiredImageForPool(mp)
 
 	appenders := newAppendersBuilder(cr.version, cs.kubeconfigFunc, []string{}, "").
-		WithNodeAnnotations(currConf, desiredImage).
+		WithNodeAnnotations(currConf, desiredImage, cs.mcsURL).
 		WithCustomAppender(appendDesiredOSImage(desiredImage)).
 		build()
 
@@ -368,4 +410,9 @@ func appendDesiredOSImage(desired string) appenderFunc {
 		}
 		return nil
 	}
+}
+
+// GetKubeClient returns the Kubernetes client for this cluster server
+func (cs *clusterServer) GetFailureReporter() FailureReporter {
+	return cs.failureReporter
 }

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -18,6 +18,7 @@ import (
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -225,6 +226,7 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 
 	addDataAndMaybeAppendToIgnition(caBundleFilePath, cc.Spec.KubeAPIServerServingCAData, &ignConf)
 	addDataAndMaybeAppendToIgnition(cloudProviderCAPath, cc.Spec.CloudProviderCAData, &ignConf)
+	addDataAndMaybeAppendToIgnition(daemonconsts.MCSRootCABundlePath, cc.Spec.RootCAData, &ignConf)
 
 	desiredImage := cs.resolveDesiredImageForPool(mp)
 

--- a/pkg/server/failure_reporter.go
+++ b/pkg/server/failure_reporter.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+)
+
+// FirstbootFailureReport represents a failure report from a node during firstboot
+type FirstbootFailureReport struct {
+	Pool         string `json:"pool"`         // MachineConfigPool name (e.g., "worker", "master")
+	NodeID       string `json:"nodeID"`       // Node identifier (hostname or MAC address)
+	Stage        string `json:"stage"`        // Failure stage (e.g., "pivot", "kargs", "updateLayeredOS")
+	ImageURL     string `json:"imageURL"`     // OS image URL that failed to apply
+	ErrorMessage string `json:"errorMessage"` // Detailed error message
+}
+
+// FailureReporter defines the interface for reporting firstboot failures
+type FailureReporter interface {
+	// ReportFailure processes a firstboot failure report
+	// Returns error only for logging; HTTP handler always returns 202
+	ReportFailure(ctx context.Context, report *FirstbootFailureReport) error
+}
+
+// clusterFailureReporter creates Kubernetes Events for firstboot failures using EventRecorder
+type clusterFailureReporter struct {
+	eventRecorder record.EventRecorder
+}
+
+// NewClusterFailureReporter creates a FailureReporter for cluster mode
+func NewClusterFailureReporter(eventRecorder record.EventRecorder) FailureReporter {
+	return &clusterFailureReporter{
+		eventRecorder: eventRecorder,
+	}
+}
+
+func (r *clusterFailureReporter) ReportFailure(ctx context.Context, report *FirstbootFailureReport) error {
+	// Create a reference object (MachineConfigPool) to attach the event to
+	// EventRecorder handles deduplication and count increments automatically
+	poolRef := &mcfgv1.MachineConfigPool{}
+	poolRef.SetNamespace(ctrlcommon.MCONamespace)
+	poolRef.SetName(report.Pool)
+	poolRef.SetGroupVersionKind(mcfgv1.GroupVersion.WithKind("MachineConfigPool"))
+
+	message := formatFailureMessage(report)
+
+	// EventRecorder handles event creation, updates, and deduplication
+	r.eventRecorder.Event(poolRef, corev1.EventTypeWarning, "FirstbootFailed", message)
+
+	return nil
+}
+
+// formatFailureMessage creates a human-readable event message with sanitized content
+func formatFailureMessage(report *FirstbootFailureReport) string {
+	sanitizedError := sanitizeErrorMessage(report.ErrorMessage)
+	sanitizedImage := sanitizeImageURL(report.ImageURL)
+	return fmt.Sprintf("Node %s failed during firstboot at stage '%s': %s (image: %s)",
+		report.NodeID, report.Stage, sanitizedError, sanitizedImage)
+}
+
+// sanitizeErrorMessage redacts potential secrets from error messages
+func sanitizeErrorMessage(errMsg string) string {
+	if errMsg == "" {
+		return "unknown error"
+	}
+	// Truncate very long error messages to avoid event bloat
+	maxLength := 200
+	if len(errMsg) > maxLength {
+		errMsg = errMsg[:maxLength] + "... (truncated)"
+	}
+	// Remove common secret patterns
+	errMsg = redactSecrets(errMsg)
+	return errMsg
+}
+
+// sanitizeImageURL redacts credentials and internal hostnames from image URLs
+func sanitizeImageURL(imageURL string) string {
+	if imageURL == "" {
+		return "none"
+	}
+
+	// Image URLs might not have a scheme (e.g., "quay.io/repo:tag")
+	// Prepend a scheme if missing to help url.Parse
+	urlToParse := imageURL
+	if !strings.Contains(imageURL, "://") {
+		urlToParse = "https://" + imageURL
+	}
+
+	parsed, err := url.Parse(urlToParse)
+	if err != nil || parsed.Host == "" {
+		// If parsing fails or no host found, just return a generic placeholder
+		return "invalid-url"
+	}
+
+	// Clear any embedded credentials
+	parsed.User = nil
+
+	// Redact internal hostnames by showing only the registry type
+	host := parsed.Host
+	if strings.Contains(host, "image-registry.openshift-image-registry") {
+		return "internal-registry"
+	}
+
+	// For external registries, show only the host (registry)
+	// Strip path/query/fragment to avoid exposing repo details
+	parsed.Path = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	parsed.Scheme = ""
+
+	// Return just the host part
+	result := parsed.String()
+	// Clean up the "//" that remains after clearing scheme
+	result = strings.TrimPrefix(result, "//")
+
+	return result
+}
+
+// redactSecrets removes common secret patterns from strings
+func redactSecrets(s string) string {
+	// Redact potential tokens, passwords, keys
+	patterns := []struct {
+		prefix string
+		suffix string
+	}{
+		{"token=", "&"},
+		{"password=", "&"},
+		{"key=", "&"},
+		{"secret=", "&"},
+		{"authorization:", "\n"},
+		{"bearer ", " "},
+	}
+
+	result := s
+	for _, pattern := range patterns {
+		if idx := strings.Index(strings.ToLower(result), pattern.prefix); idx != -1 {
+			start := idx + len(pattern.prefix)
+			end := strings.Index(result[start:], pattern.suffix)
+			if end == -1 {
+				end = len(result) - start
+			}
+			result = result[:start] + "[REDACTED]" + result[start+end:]
+		}
+	}
+
+	return result
+}

--- a/pkg/server/failure_reporter.go
+++ b/pkg/server/failure_reporter.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+)
+
+// FailureReporter defines the interface for reporting firstboot failures
+type FailureReporter interface {
+	// ReportFailure processes a firstboot failure report
+	// Returns error only for logging; HTTP handler always returns 202
+	ReportFailure(ctx context.Context, report *ctrlcommon.FirstbootFailureReport) error
+}
+
+// clusterFailureReporter creates Kubernetes Events for firstboot failures using EventRecorder
+type clusterFailureReporter struct {
+	eventRecorder record.EventRecorder
+}
+
+// NewClusterFailureReporter creates a FailureReporter for cluster mode
+func NewClusterFailureReporter(eventRecorder record.EventRecorder) FailureReporter {
+	return &clusterFailureReporter{
+		eventRecorder: eventRecorder,
+	}
+}
+
+func (r *clusterFailureReporter) ReportFailure(_ context.Context, report *ctrlcommon.FirstbootFailureReport) error {
+	// Create a reference object (MachineConfigPool) to attach the event to
+	// EventRecorder handles deduplication and count increments automatically
+	poolRef := &mcfgv1.MachineConfigPool{}
+	poolRef.SetNamespace(ctrlcommon.MCONamespace)
+	poolRef.SetName(report.Pool)
+	poolRef.SetGroupVersionKind(mcfgv1.GroupVersion.WithKind("MachineConfigPool"))
+
+	message := formatFailureMessage(report)
+
+	// EventRecorder handles event creation, updates, and deduplication
+	r.eventRecorder.Event(poolRef, corev1.EventTypeWarning, "FirstbootFailed", message)
+
+	return nil
+}
+
+// formatFailureMessage creates a human-readable event message with sanitized content
+func formatFailureMessage(report *ctrlcommon.FirstbootFailureReport) string {
+	sanitizedError := sanitizeErrorMessage(report.ErrorMessage)
+	sanitizedImage := sanitizeImageURL(report.ImageURL)
+	return fmt.Sprintf("Node %s failed during firstboot at stage '%s': %s (image: %s)",
+		report.NodeID, report.Stage, sanitizedError, sanitizedImage)
+}
+
+// sanitizeErrorMessage redacts potential secrets from error messages
+func sanitizeErrorMessage(errMsg string) string {
+	if errMsg == "" {
+		return "unknown error"
+	}
+	// Truncate very long error messages to avoid event bloat
+	maxLength := 200
+	if len(errMsg) > maxLength {
+		errMsg = errMsg[:maxLength] + "... (truncated)"
+	}
+	// Remove common secret patterns
+	errMsg = redactSecrets(errMsg)
+	return errMsg
+}
+
+// sanitizeImageURL redacts credentials and internal hostnames from image URLs
+func sanitizeImageURL(imageURL string) string {
+	if imageURL == "" {
+		return "none"
+	}
+
+	// Image URLs might not have a scheme (e.g., "quay.io/repo:tag")
+	// Prepend a scheme if missing to help url.Parse
+	urlToParse := imageURL
+	if !strings.Contains(imageURL, "://") {
+		urlToParse = "https://" + imageURL
+	}
+
+	parsed, err := url.Parse(urlToParse)
+	if err != nil || parsed.Host == "" {
+		// If parsing fails or no host found, just return a generic placeholder
+		return "invalid-url"
+	}
+
+	// Clear any embedded credentials
+	parsed.User = nil
+
+	// Redact internal hostnames by showing only the registry type
+	host := parsed.Host
+	if strings.Contains(host, "image-registry.openshift-image-registry") {
+		return "internal-registry"
+	}
+
+	// Strip port for comparison (e.g., quay.io:443 -> quay.io)
+	hostWithoutPort := host
+	if idx := strings.LastIndex(host, ":"); idx != -1 {
+		hostWithoutPort = host[:idx]
+	}
+
+	// Allowlist of public registries safe to include in events
+	publicRegistries := []string{
+		"quay.io",
+		"registry.redhat.io",
+		"registry.access.redhat.com",
+		"docker.io",
+		"ghcr.io",
+		"gcr.io",
+		"registry.k8s.io",
+	}
+
+	for _, allowed := range publicRegistries {
+		if hostWithoutPort == allowed || strings.HasSuffix(hostWithoutPort, "."+allowed) {
+			return hostWithoutPort
+		}
+	}
+
+	// All other registries are considered private
+	return "private-registry"
+}
+
+// redactSecrets removes common secret patterns from strings
+func redactSecrets(s string) string {
+	// Redact potential tokens, passwords, keys
+	patterns := []struct {
+		prefix string
+		suffix string
+	}{
+		{"token=", "&"},
+		{"password=", "&"},
+		{"key=", "&"},
+		{"secret=", "&"},
+		{"authorization:", "\n"},
+		{"bearer ", " "},
+	}
+
+	result := s
+	for _, pattern := range patterns {
+		offset := 0
+		for {
+			idx := strings.Index(strings.ToLower(result[offset:]), pattern.prefix)
+			if idx == -1 {
+				break
+			}
+			idx += offset // Adjust for offset
+			start := idx + len(pattern.prefix)
+			end := strings.Index(result[start:], pattern.suffix)
+			if end == -1 {
+				end = len(result) - start
+			}
+			result = result[:start] + "[REDACTED]" + result[start+end:]
+			// Move offset past the redacted section to avoid infinite loop
+			offset = start + len("[REDACTED]")
+		}
+	}
+
+	return result
+}

--- a/pkg/server/failure_reporter_test.go
+++ b/pkg/server/failure_reporter_test.go
@@ -1,0 +1,259 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockFailureReporter for testing
+type mockFailureReporter struct {
+	reports []*FirstbootFailureReport
+	err     error
+}
+
+func (m *mockFailureReporter) ReportFailure(ctx context.Context, report *FirstbootFailureReport) error {
+	m.reports = append(m.reports, report)
+	return m.err
+}
+
+func TestNodeFailureHandler_POST(t *testing.T) {
+	reporter := &mockFailureReporter{}
+	handler := NewNodeFailureHandler(reporter)
+
+	report := FirstbootFailureReport{
+		Pool:         "worker",
+		NodeID:       "test-node-1",
+		Stage:        "updateLayeredOS",
+		ImageURL:     "quay.io/test:latest",
+		ErrorMessage: "Image pull failed",
+	}
+
+	body, err := json.Marshal(report)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/node-failure", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	assert.Equal(t, 1, len(reporter.reports))
+	assert.Equal(t, "worker", reporter.reports[0].Pool)
+	assert.Equal(t, "test-node-1", reporter.reports[0].NodeID)
+}
+
+func TestNodeFailureHandler_MethodNotAllowed(t *testing.T) {
+	handler := NewNodeFailureHandler(&mockFailureReporter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/node-failure", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestNodeFailureHandler_InvalidJSON(t *testing.T) {
+	handler := NewNodeFailureHandler(&mockFailureReporter{})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/node-failure", bytes.NewReader([]byte("invalid json")))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNodeFailureHandler_MissingFields(t *testing.T) {
+	handler := NewNodeFailureHandler(&mockFailureReporter{})
+
+	report := FirstbootFailureReport{
+		Pool: "worker",
+		// Missing NodeID and Stage
+	}
+
+	body, _ := json.Marshal(report)
+	req := httptest.NewRequest(http.MethodPost, "/v1/node-failure", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNodeFailureHandler_ReporterError(t *testing.T) {
+	// Even if reporter fails, handler should return 202 (best-effort)
+	reporter := &mockFailureReporter{err: fmt.Errorf("reporter error")}
+	handler := NewNodeFailureHandler(reporter)
+
+	report := FirstbootFailureReport{
+		Pool:   "worker",
+		NodeID: "test",
+		Stage:  "pivot",
+	}
+
+	body, _ := json.Marshal(report)
+	req := httptest.NewRequest(http.MethodPost, "/v1/node-failure", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	// Still returns 202 even though reporter failed
+	assert.Equal(t, http.StatusAccepted, w.Code)
+}
+
+func TestSanitizeErrorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty message",
+			input:    "",
+			expected: "unknown error",
+		},
+		{
+			name:     "normal message",
+			input:    "Image pull failed",
+			expected: "Image pull failed",
+		},
+		{
+			name:     "message with token",
+			input:    "Failed to authenticate with token=abc123&other=value",
+			expected: "Failed to authenticate with token=[REDACTED]&other=value",
+		},
+		{
+			name:     "message with password",
+			input:    "Login failed: password=secret123&user=admin",
+			expected: "Login failed: password=[REDACTED]&user=admin",
+		},
+		{
+			name:     "message with bearer token",
+			input:    "Authorization failed bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9 invalid",
+			expected: "Authorization failed bearer [REDACTED] invalid",
+		},
+		{
+			name:     "very long message",
+			input:    "This is a very long error message that exceeds the maximum length limit and should be truncated to avoid bloating the event storage with unnecessary details that are not helpful for debugging and this text keeps going on and on with more content",
+			expected: "This is a very long error message that exceeds the maximum length limit and should be truncated to avoid bloating the event storage with unnecessary details that are not helpful for debugging and this... (truncated)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeErrorMessage(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeImageURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty URL",
+			input:    "",
+			expected: "none",
+		},
+		{
+			name:     "invalid URL",
+			input:    "not a valid url",
+			expected: "invalid-url",
+		},
+		{
+			name:     "internal registry",
+			input:    "image-registry.openshift-image-registry.svc:5000/openshift/custom:latest",
+			expected: "internal-registry",
+		},
+		{
+			name:     "external registry - quay",
+			input:    "quay.io/openshift/custom:latest",
+			expected: "quay.io",
+		},
+		{
+			name:     "URL with credentials",
+			input:    "https://user:password@registry.example.com/repo/image:tag",
+			expected: "registry.example.com",
+		},
+		{
+			name:     "URL with query parameters",
+			input:    "https://registry.example.com/repo?token=secret&key=value",
+			expected: "registry.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeImageURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatFailureMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		report   *FirstbootFailureReport
+		expected string
+	}{
+		{
+			name: "normal report",
+			report: &FirstbootFailureReport{
+				NodeID:       "node-1",
+				Stage:        "pivot",
+				ErrorMessage: "Failed to pivot",
+				ImageURL:     "quay.io/openshift/image:latest",
+			},
+			expected: "Node node-1 failed during firstboot at stage 'pivot': Failed to pivot (image: quay.io)",
+		},
+		{
+			name: "report with credentials in URL",
+			report: &FirstbootFailureReport{
+				NodeID:       "node-2",
+				Stage:        "updateLayeredOS",
+				ErrorMessage: "Pull failed",
+				ImageURL:     "https://user:pass@registry.com/repo:tag",
+			},
+			expected: "Node node-2 failed during firstboot at stage 'updateLayeredOS': Pull failed (image: registry.com)",
+		},
+		{
+			name: "report with internal registry",
+			report: &FirstbootFailureReport{
+				NodeID:       "node-3",
+				Stage:        "pivot",
+				ErrorMessage: "Network timeout",
+				ImageURL:     "image-registry.openshift-image-registry.svc:5000/test/image:v1",
+			},
+			expected: "Node node-3 failed during firstboot at stage 'pivot': Network timeout (image: internal-registry)",
+		},
+		{
+			name: "report with secret in error message",
+			report: &FirstbootFailureReport{
+				NodeID:       "node-4",
+				Stage:        "kargs",
+				ErrorMessage: "Auth failed with token=abc123&other=data",
+				ImageURL:     "",
+			},
+			expected: "Node node-4 failed during firstboot at stage 'kargs': Auth failed with token=[REDACTED]&other=data (image: none)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatFailureMessage(tt.report)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/server/failure_reporter_test.go
+++ b/pkg/server/failure_reporter_test.go
@@ -9,17 +9,18 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // mockFailureReporter for testing
 type mockFailureReporter struct {
-	reports []*FirstbootFailureReport
+	reports []*ctrlcommon.FirstbootFailureReport
 	err     error
 }
 
-func (m *mockFailureReporter) ReportFailure(ctx context.Context, report *FirstbootFailureReport) error {
+func (m *mockFailureReporter) ReportFailure(ctx context.Context, report *ctrlcommon.FirstbootFailureReport) error {
 	m.reports = append(m.reports, report)
 	return m.err
 }
@@ -28,7 +29,7 @@ func TestNodeFailureHandler_POST(t *testing.T) {
 	reporter := &mockFailureReporter{}
 	handler := NewNodeFailureHandler(reporter)
 
-	report := FirstbootFailureReport{
+	report := ctrlcommon.FirstbootFailureReport{
 		Pool:         "worker",
 		NodeID:       "test-node-1",
 		Stage:        "updateLayeredOS",
@@ -75,7 +76,7 @@ func TestNodeFailureHandler_InvalidJSON(t *testing.T) {
 func TestNodeFailureHandler_MissingFields(t *testing.T) {
 	handler := NewNodeFailureHandler(&mockFailureReporter{})
 
-	report := FirstbootFailureReport{
+	report := ctrlcommon.FirstbootFailureReport{
 		Pool: "worker",
 		// Missing NodeID and Stage
 	}
@@ -94,7 +95,7 @@ func TestNodeFailureHandler_ReporterError(t *testing.T) {
 	reporter := &mockFailureReporter{err: fmt.Errorf("reporter error")}
 	handler := NewNodeFailureHandler(reporter)
 
-	report := FirstbootFailureReport{
+	report := ctrlcommon.FirstbootFailureReport{
 		Pool:   "worker",
 		NodeID: "test",
 		Stage:  "pivot",
@@ -142,6 +143,11 @@ func TestSanitizeErrorMessage(t *testing.T) {
 			expected: "Authorization failed bearer [REDACTED] invalid",
 		},
 		{
+			name:     "message with repeated tokens",
+			input:    "Failed with token=first&x=y&token=second&z=a",
+			expected: "Failed with token=[REDACTED]&x=y&token=[REDACTED]&z=a",
+		},
+		{
 			name:     "very long message",
 			input:    "This is a very long error message that exceeds the maximum length limit and should be truncated to avoid bloating the event storage with unnecessary details that are not helpful for debugging and this text keeps going on and on with more content",
 			expected: "This is a very long error message that exceeds the maximum length limit and should be truncated to avoid bloating the event storage with unnecessary details that are not helpful for debugging and this... (truncated)",
@@ -183,14 +189,24 @@ func TestSanitizeImageURL(t *testing.T) {
 			expected: "quay.io",
 		},
 		{
-			name:     "URL with credentials",
+			name:     "URL with credentials - private registry",
 			input:    "https://user:password@registry.example.com/repo/image:tag",
-			expected: "registry.example.com",
+			expected: "private-registry",
 		},
 		{
-			name:     "URL with query parameters",
+			name:     "URL with query parameters - private registry",
 			input:    "https://registry.example.com/repo?token=secret&key=value",
-			expected: "registry.example.com",
+			expected: "private-registry",
+		},
+		{
+			name:     "public registry - docker.io",
+			input:    "docker.io/library/nginx:latest",
+			expected: "docker.io",
+		},
+		{
+			name:     "public registry - registry.redhat.io",
+			input:    "registry.redhat.io/rhel9/rhel:latest",
+			expected: "registry.redhat.io",
 		},
 	}
 
@@ -205,12 +221,12 @@ func TestSanitizeImageURL(t *testing.T) {
 func TestFormatFailureMessage(t *testing.T) {
 	tests := []struct {
 		name     string
-		report   *FirstbootFailureReport
+		report   *ctrlcommon.FirstbootFailureReport
 		expected string
 	}{
 		{
 			name: "normal report",
-			report: &FirstbootFailureReport{
+			report: &ctrlcommon.FirstbootFailureReport{
 				NodeID:       "node-1",
 				Stage:        "pivot",
 				ErrorMessage: "Failed to pivot",
@@ -220,17 +236,17 @@ func TestFormatFailureMessage(t *testing.T) {
 		},
 		{
 			name: "report with credentials in URL",
-			report: &FirstbootFailureReport{
+			report: &ctrlcommon.FirstbootFailureReport{
 				NodeID:       "node-2",
 				Stage:        "updateLayeredOS",
 				ErrorMessage: "Pull failed",
 				ImageURL:     "https://user:pass@registry.com/repo:tag",
 			},
-			expected: "Node node-2 failed during firstboot at stage 'updateLayeredOS': Pull failed (image: registry.com)",
+			expected: "Node node-2 failed during firstboot at stage 'updateLayeredOS': Pull failed (image: private-registry)",
 		},
 		{
 			name: "report with internal registry",
-			report: &FirstbootFailureReport{
+			report: &ctrlcommon.FirstbootFailureReport{
 				NodeID:       "node-3",
 				Stage:        "pivot",
 				ErrorMessage: "Network timeout",
@@ -240,7 +256,7 @@ func TestFormatFailureMessage(t *testing.T) {
 		},
 		{
 			name: "report with secret in error message",
-			report: &FirstbootFailureReport{
+			report: &ctrlcommon.FirstbootFailureReport{
 				NodeID:       "node-4",
 				Stage:        "kargs",
 				ErrorMessage: "Auth failed with token=abc123&other=data",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/clarketm/json"
@@ -14,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	build "github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -45,6 +48,7 @@ type appenderFunc func(*ign3types.Config, *mcfgv1.MachineConfig) error
 // machine config server implementations.
 type Server interface {
 	GetConfig(poolRequest) (*runtime.RawExtension, error)
+	GetFailureReporter() FailureReporter
 }
 
 // appendersBuilder builds a slice of appenderFunc with guaranteed ordering.
@@ -70,9 +74,9 @@ func newAppendersBuilder(version *semver.Version, kubeconfigFn kubeconfigFunc, c
 }
 
 // WithNodeAnnotations adds the node annotations appender with the specified config and image.
-func (ab *appendersBuilder) WithNodeAnnotations(currMachineConfig, image string) *appendersBuilder {
+func (ab *appendersBuilder) WithNodeAnnotations(currMachineConfig, image, mcsURL string) *appendersBuilder {
 	ab.customAppenders = append(ab.customAppenders, func(cfg *ign3types.Config, mc *mcfgv1.MachineConfig) error {
-		return appendNodeAnnotations(cfg, currMachineConfig, image, mc)
+		return appendNodeAnnotations(cfg, currMachineConfig, image, mcsURL, mc)
 	})
 	return ab
 }
@@ -196,8 +200,8 @@ func appendKubeConfig(conf *ign3types.Config, f kubeconfigFunc) error {
 	return nil
 }
 
-func appendNodeAnnotations(conf *ign3types.Config, currConf, image string, mc *mcfgv1.MachineConfig) error {
-	anno, err := getNodeAnnotation(currConf, image, mc)
+func appendNodeAnnotations(conf *ign3types.Config, currConf, image, mcsURL string, mc *mcfgv1.MachineConfig) error {
+	anno, err := getNodeAnnotation(currConf, image, mcsURL, mc)
 	if err != nil {
 		return err
 	}
@@ -208,12 +212,16 @@ func appendNodeAnnotations(conf *ign3types.Config, currConf, image string, mc *m
 	return nil
 }
 
-func getNodeAnnotation(conf, image string, mc *mcfgv1.MachineConfig) (string, error) {
+func getNodeAnnotation(conf, image, mcsURL string, mc *mcfgv1.MachineConfig) (string, error) {
 	nodeAnnotations := map[string]string{
 		daemonconsts.CurrentMachineConfigAnnotationKey:     conf,
 		daemonconsts.DesiredMachineConfigAnnotationKey:     conf,
 		daemonconsts.FirstPivotMachineConfigAnnotationKey:  conf,
 		daemonconsts.MachineConfigDaemonStateAnnotationKey: daemonconsts.MachineConfigDaemonStateDone,
+	}
+
+	if mcsURL != "" {
+		nodeAnnotations[daemonconsts.MachineConfigServerURLAnnotationKey] = mcsURL
 	}
 
 	// Determine which image to use:
@@ -307,4 +315,42 @@ func addDataAndMaybeAppendToIgnition(path string, data []byte, ignConf *ign3type
 	if !exists && len(data) > 0 {
 		appendFileToIgnition(ignConf, path, (string(data)))
 	}
+}
+
+// GetIgnitionHost computes the MCS hostname:port for serving Ignition configs
+// from the cluster's Infrastructure status. Platform-specific IP addresses
+// take precedence over the parsed APIServerInternalURL hostname.
+func GetIgnitionHost(infraStatus *configv1.InfrastructureStatus) (string, error) {
+	if infraStatus == nil {
+		return "", fmt.Errorf("infraStatus is nil")
+	}
+	internalURL := infraStatus.APIServerInternalURL
+	internalURLParsed, err := url.Parse(internalURL)
+	if err != nil {
+		return "", err
+	}
+	securePortStr := strconv.Itoa(SecurePort)
+	ignitionHost := fmt.Sprintf("%s:%s", internalURLParsed.Hostname(), securePortStr)
+	if infraStatus.PlatformStatus != nil {
+		switch infraStatus.PlatformStatus.Type {
+		case configv1.BareMetalPlatformType:
+			if infraStatus.PlatformStatus.BareMetal != nil && len(infraStatus.PlatformStatus.BareMetal.APIServerInternalIPs) > 0 {
+				ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.BareMetal.APIServerInternalIPs[0], securePortStr)
+			}
+		case configv1.OpenStackPlatformType:
+			if infraStatus.PlatformStatus.OpenStack != nil && len(infraStatus.PlatformStatus.OpenStack.APIServerInternalIPs) > 0 {
+				ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.OpenStack.APIServerInternalIPs[0], securePortStr)
+			}
+		case configv1.OvirtPlatformType:
+			if infraStatus.PlatformStatus.Ovirt != nil && len(infraStatus.PlatformStatus.Ovirt.APIServerInternalIPs) > 0 {
+				ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.Ovirt.APIServerInternalIPs[0], securePortStr)
+			}
+		case configv1.VSpherePlatformType:
+			if infraStatus.PlatformStatus.VSphere != nil && len(infraStatus.PlatformStatus.VSphere.APIServerInternalIPs) > 0 {
+				ignitionHost = net.JoinHostPort(infraStatus.PlatformStatus.VSphere.APIServerInternalIPs[0], securePortStr)
+			}
+		}
+	}
+
+	return ignitionHost, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -185,7 +185,7 @@ func TestBootstrapServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while appending file to ignition: %v", err)
 	}
-	anno, err := getNodeAnnotation(mp.Status.Configuration.Name, "", mc)
+	anno, err := getNodeAnnotation(mp.Status.Configuration.Name, "", "", mc)
 	if err != nil {
 		t.Fatalf("unexpected error while creating annotations err: %v", err)
 	}
@@ -231,6 +231,27 @@ func TestBootstrapServer(t *testing.T) {
 	require.True(t, foundCertFiles)
 	validateIgnitionFiles(t, ignCfg.Storage.Files, resCfg.Storage.Files)
 	validateIgnitionSystemd(t, ignCfg.Systemd.Units, resCfg.Systemd.Units)
+
+	// Verify bootstrap server does not include MCS URL annotation
+	var foundAnnotations bool
+	for _, file := range resCfg.Storage.Files {
+		if file.Path != daemonconsts.InitialNodeAnnotationsFilePath {
+			continue
+		}
+		foundAnnotations = true
+
+		contents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+		require.NoError(t, err)
+
+		var annotations map[string]string
+		err = json.Unmarshal([]byte(contents), &annotations)
+		require.NoError(t, err)
+
+		// Bootstrap server should not have MCS URL annotation
+		_, hasMCSURL := annotations[daemonconsts.MachineConfigServerURLAnnotationKey]
+		assert.False(t, hasMCSURL, "bootstrap server should not include MCS URL annotation")
+	}
+	assert.True(t, foundAnnotations, "node annotations file should be present")
 
 	// verify bootstrap cannot serve ignition to other pool than master
 	res, err = bs.GetConfig(poolRequest{
@@ -360,6 +381,7 @@ func TestClusterServer(t *testing.T) {
 		kubeconfigFunc: func() ([]byte, []byte, error) {
 			return getKubeConfigContent(t)
 		},
+		mcsURL: "https://api-int.test.example.com:22623",
 	}
 
 	mc := new(mcfgv1.MachineConfig)
@@ -380,7 +402,7 @@ func TestClusterServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while appending file to ignition: %v", err)
 	}
-	anno, err := getNodeAnnotation(mp.Status.Configuration.Name, "", mc)
+	anno, err := getNodeAnnotation(mp.Status.Configuration.Name, "", "https://api-int.test.example.com:22623", mc)
 	if err != nil {
 		t.Fatalf("unexpected error while creating annotations err: %v", err)
 	}
@@ -406,6 +428,28 @@ func TestClusterServer(t *testing.T) {
 	}
 	validateIgnitionFiles(t, ignCfg.Storage.Files, resCfg.Storage.Files)
 	validateIgnitionSystemd(t, ignCfg.Systemd.Units, resCfg.Systemd.Units)
+
+	// Verify cluster server includes MCS URL annotation
+	var foundAnnotations bool
+	for _, file := range resCfg.Storage.Files {
+		if file.Path != daemonconsts.InitialNodeAnnotationsFilePath {
+			continue
+		}
+		foundAnnotations = true
+
+		contents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+		require.NoError(t, err)
+
+		var annotations map[string]string
+		err = json.Unmarshal([]byte(contents), &annotations)
+		require.NoError(t, err)
+
+		// Cluster server should include MCS URL annotation
+		mcsURL, hasMCSURL := annotations[daemonconsts.MachineConfigServerURLAnnotationKey]
+		assert.True(t, hasMCSURL, "cluster server should include MCS URL annotation")
+		assert.Equal(t, "https://api-int.test.example.com:22623", mcsURL)
+	}
+	assert.True(t, foundAnnotations, "node annotations file should be present")
 
 	foundEncapsulated := false
 	for _, f := range resCfg.Storage.Files {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -253,6 +253,16 @@ func TestBootstrapServer(t *testing.T) {
 	}
 	assert.True(t, foundAnnotations, "node annotations file should be present")
 
+	// Verify MCS root CA bundle is present in bootstrap ignition config
+	var foundMCSCA bool
+	for _, f := range resCfg.Storage.Files {
+		if f.Path == daemonconsts.MCSRootCABundlePath {
+			foundMCSCA = true
+			break
+		}
+	}
+	assert.True(t, foundMCSCA, "MCS root CA bundle should be present in bootstrap ignition config")
+
 	// verify bootstrap cannot serve ignition to other pool than master
 	res, err = bs.GetConfig(poolRequest{
 		machineConfigPool: testPool,
@@ -468,6 +478,19 @@ func TestClusterServer(t *testing.T) {
 	if !foundEncapsulated {
 		t.Errorf("missing %s", daemonconsts.MachineConfigEncapsulatedPath)
 	}
+
+	// Verify MCS root CA bundle is present in ignition config
+	var foundMCSCA bool
+	for _, f := range resCfg.Storage.Files {
+		if f.Path == daemonconsts.MCSRootCABundlePath {
+			foundMCSCA = true
+			contents, err := ctrlcommon.DecodeIgnitionFileContents(f.Contents.Source, f.Contents.Compression)
+			require.NoError(t, err)
+			assert.Equal(t, []byte("MCS-Root-CA-Testdata"), contents)
+			break
+		}
+	}
+	assert.True(t, foundMCSCA, "MCS root CA bundle should be present in ignition config")
 }
 
 func getKubeConfigContent(t *testing.T) ([]byte, []byte, error) {
@@ -544,6 +567,7 @@ func getTestControllerConfig() *mcfgv1.ControllerConfig {
 		ObjectMeta: metav1.ObjectMeta{Generation: 1, Name: "machine-config-controller"},
 		Spec: mcfgv1.ControllerConfigSpec{
 			KubeAPIServerServingCAData: []byte("Testdata"),
+			RootCAData:                []byte("MCS-Root-CA-Testdata"),
 		},
 	}
 }

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
 	e2eShared "github.com/openshift/machine-config-operator/test/e2e-shared-tests"
@@ -1304,4 +1306,170 @@ func parseMetricValue(metricLine string) (int, error) {
 		return 0, err
 	}
 	return value, nil
+}
+
+// TestFirstbootPivotFailureEvent provisions a new node into a custom pool
+// with a bogus OS image. The node's firstboot pivot fails, the MCD reports
+// the failure to the MCS, and the MCS creates a Warning Event on the pool.
+func TestFirstbootPivotFailureEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cs := framework.NewClientSet("")
+	machineclient := machineclientset.NewForConfigOrDie(cs.GetRestConfig())
+
+	poolName := fmt.Sprintf("fbfail-%s", uuid.NewUUID()[:5])
+	t.Logf("Using custom pool name: %s", poolName)
+
+	// Create the custom MCP
+	deleteMCP := helpers.CreateMCP(t, cs, poolName)
+	t.Cleanup(deleteMCP)
+
+	// Create MC with bogus OSImageURL targeting the custom pool
+	mcName := fmt.Sprintf("99-%s-bad-osimage", poolName)
+	bogusImageURL := "quay.io/does-not-exist/bogus-os-image:latest"
+	mc := helpers.NewMachineConfig(mcName, helpers.MCLabelForRole(poolName), bogusImageURL, nil)
+	helpers.SetMetadataOnObject(t, mc)
+
+	_, err := cs.MachineConfigs().Create(ctx, mc, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MachineConfig %s", mcName)
+	t.Cleanup(func() {
+		if err := cs.MachineConfigs().Delete(context.Background(), mcName, metav1.DeleteOptions{}); err != nil {
+			t.Errorf("Cleanup: failed to delete MachineConfig: %v", err)
+		}
+	})
+	t.Logf("Created MachineConfig %s with bogus OS image", mcName)
+
+	// Wait for rendered config to include our MC
+	renderedConfig, err := helpers.WaitForRenderedConfig(t, cs, poolName, mcName)
+	require.NoError(t, err, "timed out waiting for rendered config in pool %s", poolName)
+	t.Logf("Pool %s rendered config: %s", poolName, renderedConfig)
+
+	// Wait for user-data-managed secret (MCO operator creates it during sync)
+	userDataSecretName := fmt.Sprintf("%s-user-data-managed", poolName)
+	t.Logf("Waiting for secret %s", userDataSecretName)
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := cs.Secrets(ctrlcommon.MachineAPINamespace).Get(ctx, userDataSecretName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "timed out waiting for secret %s", userDataSecretName)
+	t.Logf("Secret %s is available", userDataSecretName)
+
+	// Clone a worker MachineSet for the custom pool
+	machinesets, err := machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "failed to list MachineSets")
+	require.NotEmpty(t, machinesets.Items, "no MachineSets found")
+
+	originalMS := machinesets.Items[0]
+	msName := fmt.Sprintf("%s-e2e-fbfail", poolName)
+
+	clonedMS := originalMS.DeepCopy()
+	clonedMS.Name = msName
+	clonedMS.ResourceVersion = ""
+	clonedMS.UID = ""
+	var zero int32
+	clonedMS.Spec.Replicas = &zero
+	clonedMS.Spec.Selector.MatchLabels["machine.openshift.io/cluster-api-machineset"] = msName
+	clonedMS.Spec.Template.Labels["machine.openshift.io/cluster-api-machineset"] = msName
+
+	_, err = machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Create(ctx, clonedMS, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create cloned MachineSet %s", msName)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cleanupCancel()
+
+		t.Logf("Cleanup: scaling MachineSet %s to 0", msName)
+		ms, err := machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Get(cleanupCtx, msName, metav1.GetOptions{})
+		if err == nil {
+			var zero int32
+			ms.Spec.Replicas = &zero
+			_, err = machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Update(cleanupCtx, ms, metav1.UpdateOptions{})
+			if err != nil {
+				t.Errorf("Cleanup: failed to scale down MachineSet: %v", err)
+			}
+		} else {
+			t.Errorf("Cleanup: failed to get MachineSet: %v", err)
+		}
+
+		t.Logf("Cleanup: waiting for Machines from MachineSet %s to be deleted", msName)
+		if err := wait.PollUntilContextTimeout(cleanupCtx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+			machines, err := machineclient.MachineV1beta1().Machines(ctrlcommon.MachineAPINamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("machine.openshift.io/cluster-api-machineset=%s", msName),
+			})
+			if err != nil {
+				return false, err
+			}
+			return len(machines.Items) == 0, nil
+		}); err != nil {
+			t.Errorf("Cleanup: timed out waiting for Machines to be deleted: %v", err)
+		}
+
+		t.Logf("Cleanup: deleting MachineSet %s", msName)
+		if err := machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Delete(cleanupCtx, msName, metav1.DeleteOptions{}); err != nil {
+			t.Errorf("Cleanup: failed to delete MachineSet: %v", err)
+		}
+	})
+	t.Logf("Created cloned MachineSet %s", msName)
+
+	// Patch userDataSecret to point to the custom pool's secret
+	jsonPatch := fmt.Sprintf(`[{"op":"replace","path":"/spec/template/spec/providerSpec/value/userDataSecret/name","value":"%s"}]`, userDataSecretName)
+	_, err = machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Patch(
+		ctx, msName, types.JSONPatchType, []byte(jsonPatch), metav1.PatchOptions{})
+	require.NoError(t, err, "failed to patch userDataSecret on MachineSet %s", msName)
+	t.Logf("Patched MachineSet %s to use secret %s", msName, userDataSecretName)
+
+	// Record event baseline before scaling up
+	eventFieldSelector := fmt.Sprintf("reason=FirstbootFailed,involvedObject.name=%s", poolName)
+	baselineEvents, err := cs.Events(ctrlcommon.MCONamespace).List(ctx, metav1.ListOptions{
+		FieldSelector: eventFieldSelector,
+	})
+	require.NoError(t, err, "failed to list baseline events")
+	baselineCount := len(baselineEvents.Items)
+
+	// Scale MachineSet to 1 to provision a new node
+	t.Logf("Scaling MachineSet %s to 1 replica", msName)
+	ms, err := machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Get(ctx, msName, metav1.GetOptions{})
+	require.NoError(t, err)
+	var one int32 = 1
+	ms.Spec.Replicas = &one
+	_, err = machineclient.MachineV1beta1().MachineSets(ctrlcommon.MachineAPINamespace).Update(ctx, ms, metav1.UpdateOptions{})
+	require.NoError(t, err, "failed to scale MachineSet %s to 1", msName)
+
+	// Poll for FirstbootFailed event
+	t.Logf("Waiting for FirstbootFailed event on pool %s (timeout 15m)", poolName)
+	var foundEvent *corev1.Event
+	startTime := time.Now()
+
+	err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+		events, err := cs.Events(ctrlcommon.MCONamespace).List(ctx, metav1.ListOptions{
+			FieldSelector: eventFieldSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		if len(events.Items) > baselineCount {
+			e := events.Items[len(events.Items)-1]
+			foundEvent = &e
+			t.Logf("Found FirstbootFailed event after %s: %s", time.Since(startTime).Round(time.Second), e.Message)
+			return true, nil
+		}
+		t.Logf("No FirstbootFailed event yet (elapsed %s)", time.Since(startTime).Round(time.Second))
+		return false, nil
+	})
+	require.NoError(t, err, "timed out waiting for FirstbootFailed event on pool %s", poolName)
+
+	// Assert event details
+	require.NotNil(t, foundEvent)
+	assert.Equal(t, "FirstbootFailed", foundEvent.Reason)
+	assert.Equal(t, corev1.EventTypeWarning, foundEvent.Type)
+	assert.Equal(t, poolName, foundEvent.InvolvedObject.Name)
+	assert.Contains(t, foundEvent.Message, "firstboot")
+	t.Logf("Verified FirstbootFailed event: %s", foundEvent.Message)
 }


### PR DESCRIPTION
- What I did

Added a best-effort failure reporting pipeline for nodes that fail during firstboot OS pivot before kubelet starts. The MCD sends an HTTPS POST to the MCS /v1/node-failure endpoint, which records a FirstbootFailed Warning Event on the node's MachineConfigPool.  TLS trust via persisted MCS root CA, sentinel-file deduplication, and RBAC for event creation. E2E test provisions a node into a custom pool with a bogus OS image and verifies the event appears.

- How to verify it

  - Build a cluster with the custom PR image
  - Export the kubeconfig location with export `KUBCONFIG=`
  - Run the E2E test  `go test ./test/e2e-1of2/ -run TestFirstbootPivotFailureEvent -v -timeout 30m`
  - Test will succeed when it reports an event similar to `Found FirstbootFailed event after 1m45s: Node ip-10-0-1-215  failed during firstboot at stage 'firstboot-update': error running systemd-run --unit machine-config-daemon-update-rpmostree-via-container -p EnvironmentFile=-/etc/mco/proxy.env --collect --wait -- podman pull --authfile /var/lib/kubelet/config.json qua... (truncated) (image: quay.io)` 

- Description for the changelog 

Add firstboot pivot failure reporting from pre-kubelet nodes to MCS, surfaced as Warning Events on MachineConfigPool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* First-boot failures are reported to the Machine Config Server and surfaced as cluster warning events.
* Failure reports include sanitized error and image details to protect sensitive information.
* Machine Config Server event permissions are configured automatically.
* Generated Ignition configurations include the Machine Config Server URL annotation and root certificate.

## Bug Fixes
* Improved Ignition host discovery across supported infrastructure platforms.

## Tests
* Added coverage for failure reporting, certificates, annotations, permissions, and end-to-end event generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->