### PR TITLE
OCPBUGS-74970: Fix kubelet certificate wait loop in criometricsproxy.yaml

### DIFF
--- a/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/arbiter/01-arbiter-kubelet/_base/files/criometricsproxy.yaml
@@ -29,13 +29,14 @@ contents:
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: var-lib-kubelet
-          mountPath: "/var"
+          mountPath: "/var/lib/kubelet"
           mountPropagation: HostToContainer
+          readOnly: true
         command: ['/bin/bash', '-ec']
         args:
         - |
           echo -n "Waiting for kubelet key and certificate to be available"
-          while [ -n "$(test -e /var/lib/kubelet/pki/kubelet-server-current.pem)" ] ; do
+          while [ ! -e /var/lib/kubelet/pki/kubelet-server-current.pem ] ; do
             echo -n "."
             sleep 1
             (( tries += 1 ))

--- a/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/master/01-master-kubelet/_base/files/criometricsproxy.yaml
@@ -29,13 +29,14 @@ contents:
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: var-lib-kubelet
-          mountPath: "/var"
+          mountPath: "/var/lib/kubelet"
           mountPropagation: HostToContainer
+          readOnly: true
         command: ['/bin/bash', '-ec']
         args:
         - |
           echo -n "Waiting for kubelet key and certificate to be available"
-          while [ -n "$(test -e /var/lib/kubelet/pki/kubelet-server-current.pem)" ] ; do
+          while [ ! -e /var/lib/kubelet/pki/kubelet-server-current.pem ] ; do
             echo -n "."
             sleep 1
             (( tries += 1 ))

--- a/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
+++ b/templates/worker/01-worker-kubelet/_base/files/criometricsproxy.yaml
@@ -29,13 +29,14 @@ contents:
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: var-lib-kubelet
-          mountPath: "/var"
+          mountPath: "/var/lib/kubelet"
           mountPropagation: HostToContainer
+          readOnly: true
         command: ['/bin/bash', '-ec']
         args:
         - |
           echo -n "Waiting for kubelet key and certificate to be available"
-          while [ -n "$(test -e /var/lib/kubelet/pki/kubelet-server-current.pem)" ] ; do
+          while [ ! -e /var/lib/kubelet/pki/kubelet-server-current.pem ] ; do
             echo -n "."
             sleep 1
             (( tries += 1 ))


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

- Related [bug](https://redhat.atlassian.net/browse/OCPBUGS-74970): Fix kubelet certificate wait loop and mount path in criometricsproxy.yaml

- The previous condition `[ -n "$(test -e ...)" ]` always evaluated to false because `test -e` produces no stdout output — it communicates via exit code only. So `-n` always evaluated to false, causing the loop to exit immediately instead of waiting for the kubelet certificate to appear. 
- The init container mounts the host's /`var/lib/kubelet` at `/var`. So inside the init container, the host's `/var/lib/kubelet/pki/kubelet-server-current.pem` appears at `/var/pki/kubelet-server-current.pem` — but the script checks `/var/lib/kubelet/pki/kubelet-server-current.pem`, which doesn't exist at that path inside the init container.

**- What I did**
- Replaced with the correct condition `[ ! -e /var/lib/kubelet/pki/kubelet-server-current.pem ]`, which properly loops until the kubelet certificate file exists
- Updated init container mount path to `/var/lib/kubelet` from `/var` to match main container so the script's path `/var/lib/kubelet/pki/kubelet-server-current.pem` resolves correctly.
 

**- How to verify it**
- Check `kube-rbac-proxy-crio-ip` pod logs in namespace `openshift-machine-config-operator` to verify the CRI-O metrics proxy init container correctly waits for the kubelet certificate before proceeding

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixes the kubelet certificate wait loop condition in `criometricsproxy.yaml` across all node roles (arbiter, master, worker)
- The old condition `[ -n "$(test -e /var/lib/kubelet/pki/kubelet-server-current.pem)" ]` was incorrect. Replaced with the correct condition `[ ! -e /var/lib/kubelet/pki/kubelet-server-current.pem ]`, which properly loops until the kubelet certificate file exists



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures arbiter, master, and worker nodes now reliably wait for the kubelet server certificate/key to appear before starting dependent pods, improving startup stability and preventing race conditions during node initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->