### PR TITLE
MCO-2256: Drop RHEL8 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,6 @@ WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN make install DESTDIR=./instroot-rhel9
 
-# Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-5.0 AS rhel8-builder
-ARG TAGS=""
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-# Copy the RHEL 8 machine-config-daemon binary and rename
-COPY . .
-RUN make install DESTDIR=./instroot-rhel8
-
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 ARG TAGS=""
 COPY install /manifests
@@ -45,8 +37,6 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
 # Do this after package installation to avoid invalidating state for faster
 # local builds.
 COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9/usr/bin/* /usr/bin/
-# Copy the RHEL 8 machine-config-daemon binary and rename
-COPY --from=rhel8-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel8/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel8
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -6,14 +6,6 @@ WORKDIR /go/src/github.com/openshift/machine-config-operator
 COPY . .
 RUN make install DESTDIR=./instroot-rhel9
 
-# Add a RHEL 8 builder to compile the RHEL 8 compatible binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-5.0 AS rhel8-builder
-ARG TAGS=""
-WORKDIR /go/src/github.com/openshift/machine-config-operator
-# Copy the RHEL 8 machine-config-daemon binary and rename
-COPY . .
-RUN make install DESTDIR=./instroot-rhel8
-
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 ARG TAGS=""
 COPY install /manifests
@@ -46,8 +38,6 @@ RUN if [ "${TAGS}" = "fcos" ]; then \
 # Do this after package installation to avoid invalidating state for faster
 # local builds.
 COPY --from=rhel9-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel9/usr/bin/* /usr/bin/
-# Copy the RHEL 8 machine-config-daemon binary and rename
-COPY --from=rhel8-builder /go/src/github.com/openshift/machine-config-operator/instroot-rhel8/usr/bin/machine-config-daemon /usr/bin/machine-config-daemon.rhel8
 COPY templates /etc/mcc/templates
 ENTRYPOINT ["/usr/bin/machine-config-operator"]
 LABEL io.openshift.release.operator true

--- a/pkg/daemon/constants/constants.go
+++ b/pkg/daemon/constants/constants.go
@@ -112,11 +112,8 @@ const (
 	// SSH Keys for user "core" will only be written at /home/core/.ssh
 	CoreUserSSHPath = "/home/" + CoreUserName + "/.ssh"
 
-	// SSH keys in RHCOS 8 will be written to /home/core/.ssh/authorized_keys
-	RHCOS8SSHKeyPath = CoreUserSSHPath + "/authorized_keys"
-
 	// SSH keys in RHCOS 9 / FCOS / SCOS will be written to /home/core/.ssh/authorized_keys.d/ignition
-	RHCOS9SSHKeyPath = CoreUserSSHPath + "/authorized_keys.d/ignition"
+	RHCOSDefaultSSHKeyPath = CoreUserSSHPath + "/authorized_keys.d/ignition"
 
 	// CRIOServiceName is used to specify reloads and restarts of the CRI-O service
 	CRIOServiceName = "crio"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -540,12 +540,6 @@ func ReexecuteForTargetRoot(target string) error {
 		case sourceMajor == 10 && targetMajor == 9:
 			sourceBinarySuffix = ".rhel9"
 			klog.Info("container is rhel10, target is rhel9")
-		case sourceMajor == 10 && targetMajor == 8:
-			sourceBinarySuffix = ".rhel8"
-			klog.Info("container is rhel10, target is rhel8")
-		case sourceMajor == 9 && targetMajor == 8:
-			sourceBinarySuffix = ".rhel8"
-			klog.Info("container is rhel9, target is rhel8")
 		default:
 			klog.Infof("using appropriate binary for source=rhel-%d target=rhel-%d", sourceMajor, targetMajor)
 		}
@@ -2002,7 +1996,6 @@ func removeIgnitionArtifacts() error {
 // when scaling up older bootimages and targeting newer RHEL versions.  In this case,
 // we may want to pin NIC interface names that reference static IP addresses.
 // More information:
-//   - RHEL 8→9 transition: https://issues.redhat.com/browse/OCPBUGS-10787
 //   - RHEL 9→10 transition: https://issues.redhat.com/browse/OCPBUGS-63593
 func PersistNetworkInterfaces(osRoot string) error {
 	hostos, err := osrelease.GetHostRunningOSFromRoot(osRoot)
@@ -2022,7 +2015,7 @@ func PersistNetworkInterfaces(osRoot string) error {
 	// likely this NIC pinning should actually be driven automatically by
 	// host updates.  If you change this, you'll need to change the conditions
 	// below too.
-	persisting := hostos.IsEL8() || hostos.IsEL9()
+	persisting := hostos.IsEL9()
 	cleanup := hostos.IsEL10()
 	if !(persisting || cleanup) {
 		return nil
@@ -2038,9 +2031,7 @@ func PersistNetworkInterfaces(osRoot string) error {
 
 	switch {
 	case persisting:
-		if hostos.IsEL8() {
-			klog.Info("Persisting NIC names for RHEL8 host system (RHEL8→9 transition)")
-		} else if hostos.IsEL9() {
+		if hostos.IsEL9() {
 			klog.Info("Persisting NIC names for RHEL9 host system (RHEL9→10 transition)")
 		}
 	case cleanup:
@@ -2103,71 +2094,6 @@ func PersistNetworkInterfaces(osRoot string) error {
 		return fmt.Errorf("failed to run rpm-ostree kargs: %w", err)
 	}
 	return nil
-}
-
-// When we move from RHCOS 8 -> RHCOS 9, the SSH keys do not get written to the
-// new location before the node reboots into RHCOS 9 because:
-//
-// 1. When the upgrade configs are written to the node, it is still running
-// RHCOS 8, so the keys are not being written to the new location since the
-// location is inferred from the currently booted OS.
-// 2. The node reboots into RHCOS 9 to complete the upgrade.
-// 3. The "are we on the latest config" functions detect that we are indeed on
-// the latest config and so it does not attempt to perform an update.
-//
-// To work around that check on bootup if the we should use the new SSH key
-// path and if the old SSH key path exists, we know that we need to migrate tot
-// he new key path by calling dn.updateSSHKeyLocation().
-func (dn *Daemon) isSSHKeyLocationUpdateRequired() (bool, error) {
-	if !dn.useNewSSHKeyPath() {
-		// Return early because we're not using the new SSH key path.
-		return false, nil
-	}
-
-	oldKeyExists, err := fileExists(constants.RHCOS8SSHKeyPath)
-	if err != nil {
-		return false, err
-	}
-
-	newKeyExists, err := fileExists(constants.RHCOS9SSHKeyPath)
-	if err != nil {
-		return false, err
-	}
-
-	// If the old key exists and the new key does not, we need to update.
-	return oldKeyExists && !newKeyExists, nil
-}
-
-// Decode the Ignition config and perform the SSH key update.
-func (dn *Daemon) updateSSHKeyLocation(cfg *mcfgv1.MachineConfig) error {
-	klog.Infof("SSH key location update required. Moving SSH keys from %q to %q.", constants.RHCOS8SSHKeyPath, constants.RHCOS9SSHKeyPath)
-
-	ignConfig, err := ctrlcommon.ParseAndConvertConfig(cfg.Spec.Config.Raw)
-	if err != nil {
-		return fmt.Errorf("ignition failure when updating SSH key location: %w", err)
-	}
-
-	if err := dn.updateSSHKeys(ignConfig.Passwd.Users, ignConfig.Passwd.Users); err != nil {
-		return fmt.Errorf("could not write SSH keys to new location: %w", err)
-	}
-
-	return nil
-}
-
-// Determines if we need to update the SSH key location and performs the
-// necessary update if so.
-func (dn *Daemon) updateSSHKeyLocationIfNeeded(cfg *mcfgv1.MachineConfig) error {
-	sshKeyLocationUpdateRequired, err := dn.isSSHKeyLocationUpdateRequired()
-	if err != nil {
-		return fmt.Errorf("unable to determine if SSH key location update is required: %w", err)
-	}
-
-	if !sshKeyLocationUpdateRequired {
-		klog.Infof("SSH key location (%q) up-to-date!", constants.RHCOS9SSHKeyPath)
-		return nil
-	}
-
-	return dn.updateSSHKeyLocation(cfg)
 }
 
 // checkStateOnFirstRun is a core entrypoint for our state machine.
@@ -2262,13 +2188,6 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		logSystem("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 		return dn.triggerUpdate(state.currentConfig, state.desiredConfig, state.currentImage, state.desiredImage)
 
-	}
-
-	// When upgrading the OS, it is possible that the SSH key location will
-	// change. We should detect whether that is the case and update before we
-	// check for any config drift.
-	if err := dn.updateSSHKeyLocationIfNeeded(state.currentConfig); err != nil {
-		return err
 	}
 
 	if err := dn.validateOnDiskStateOrImage(state.currentConfig, state.currentImage); err != nil {

--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -120,11 +120,6 @@ func (os OperatingSystem) IsEL() bool {
 	return os.id == rhcos || os.id == scos || (os.id == rhel && os.variantID == coreos)
 }
 
-// IsEL8 is true if the OS is RHCOS 8 or SCOS 8
-func (os OperatingSystem) IsEL8() bool {
-	return os.IsEL() && strings.HasPrefix(os.version, "8.") || os.version == "8"
-}
-
 // IsEL9 is true if the OS is RHCOS 9 or SCOS 9
 func (os OperatingSystem) IsEL9() bool {
 	return os.IsEL() && strings.HasPrefix(os.version, "9.") || os.version == "9"
@@ -219,15 +214,6 @@ func getOSVersion(or osrelease.OSRelease) string {
 			// Strip the OpenShift Version prefix from the VERSION field, if it is found.
 			return strings.ReplaceAll(or.VERSION, openshiftVersion, "")
 		}
-	}
-	// 4.1 and 4.2 bootimages doesn't ship RHEL_VERSION and OPENSHIFT_VERSION
-	// into /etc/os-release and hence we need to interpret ourself RHEL Version
-	// from VERSION_ID . See https://issues.redhat.com/browse/OCPBUGS-28974
-	if or.VERSION_ID == "4.1" {
-		return "8.1"
-	}
-	if or.VERSION_ID == "4.2" {
-		return "8.2"
 	}
 
 	// Fallback to the VERSION_ID field

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2523,26 +2523,21 @@ func (dn *Daemon) writeFiles(files []ign3types.File, skipCertificateWrite bool) 
 // Ensures that both the SSH root directory (/home/core/.ssh) as well as any
 // subdirectories are created with the correct (0700) permissions.
 func createSSHKeyDir(authKeyDir string) error {
-	klog.Infof("Creating missing SSH key dir at %q", authKeyDir)
-
 	mkdir := func(dir string) error {
 		return exec.Command("runuser", "-u", constants.CoreUserName, "--", "mkdir", "-m", "0700", "-p", dir).Run()
 	}
 
-	// Create the root SSH key directory (/home/core/.ssh) first (if there does not exist one).
+	// Create the root SSH key directory (/home/core/.ssh) first (if it does not exist).
+	// This must be a separate mkdir call: "mkdir -m 0700 -p" only applies the mode
+	// to the leaf directory, leaving any intermediate directories at the umask default (0755).
 	if _, err := os.Stat(constants.CoreUserSSHPath); os.IsNotExist(err) {
-		if err := mkdir(filepath.Dir(constants.RHCOS8SSHKeyPath)); err != nil {
+		if err := mkdir(constants.CoreUserSSHPath); err != nil {
 			return err
 		}
 	}
 
-	// For RHCOS 8, creating /home/core/.ssh is all that is needed.
-	if authKeyDir == constants.RHCOS8SSHKeyPath {
-		return nil
-	}
-
-	// Create the next level of the SSH key directory (/home/core/.ssh/authorized_keys.d) for RHCOS 9 cases.
-	return mkdir(filepath.Dir(constants.RHCOS9SSHKeyPath))
+	// Create the full target directory (e.g. /home/core/.ssh/authorized_keys.d).
+	return mkdir(authKeyDir)
 }
 
 func (dn *Daemon) atomicallyWriteSSHKey(authKeyPath, keys string) error {
@@ -2671,13 +2666,6 @@ func (dn *Daemon) updateKubeConfigPermission() error {
 	return nil
 }
 
-// Determines if we should use the new SSH key path
-// (/home/core/.ssh/authorized_keys.d/ignition) or the old SSH key path
-// (/home/core/.ssh/authorized_keys)
-func (dn *Daemon) useNewSSHKeyPath() bool {
-	return dn.os.IsEL9() || dn.os.IsEL10() || dn.os.IsFCOS() || dn.os.IsSCOS()
-}
-
 // Update a given PasswdUser's SSHKey
 func (dn *Daemon) updateSSHKeys(newUsers, oldUsers []ign3types.PasswdUser) error {
 	klog.Info("updating SSH keys")
@@ -2705,28 +2693,9 @@ func (dn *Daemon) updateSSHKeys(newUsers, oldUsers []ign3types.PasswdUser) error
 		}
 	}
 
-	authKeyPath := constants.RHCOS8SSHKeyPath
-
 	if !dn.mock {
-		// In RHCOS 8.6 or lower, the keys were written to `/home/core/.ssh/authorized_keys`.
-		// RHCOS 9.0+, FCOS, and SCOS will however expect the keys at `/home/core/.ssh/authorized_keys.d/ignition`.
-		// Check if the authorized_keys file at the legacy path exists. If it does, remove it.
-		// It will be recreated at the new fragment path by the atomicallyWriteSSHKey function
-		// that is called right after.
-		if dn.useNewSSHKeyPath() {
-			authKeyPath = constants.RHCOS9SSHKeyPath
-
-			if err := cleanSSHKeyPaths(); err != nil {
-				return err
-			}
-
-			if err := removeNonIgnitionKeyPathFragments(); err != nil {
-				return err
-			}
-		}
-
 		// Note we write keys only for the core user and so this ignores the user list
-		return dn.atomicallyWriteSSHKey(authKeyPath, concatSSHKeys)
+		return dn.atomicallyWriteSSHKey(constants.RHCOSDefaultSSHKeyPath, concatSSHKeys)
 	}
 
 	return nil
@@ -2777,50 +2746,6 @@ func fileExists(path string) (bool, error) {
 
 	// An unexpected error occurred.
 	return false, fmt.Errorf("cannot stat file: %w", err)
-}
-
-// Removes the old SSH key path (/home/core/.ssh/authorized_keys), if found.
-func cleanSSHKeyPaths() error {
-	oldKeyExists, err := fileExists(constants.RHCOS8SSHKeyPath)
-	if err != nil {
-		return err
-	}
-
-	if !oldKeyExists {
-		return nil
-	}
-
-	if err := os.RemoveAll(constants.RHCOS8SSHKeyPath); err != nil {
-		return fmt.Errorf("failed to remove path '%s': %w", constants.RHCOS8SSHKeyPath, err)
-	}
-
-	return nil
-}
-
-// Ensures authorized_keys.d/ignition is the only fragment that exists within the /home/core/.ssh dir.
-func removeNonIgnitionKeyPathFragments() error {
-	// /home/core/.ssh/authorized_keys.d
-	authKeyFragmentDirPath := filepath.Dir(constants.RHCOS9SSHKeyPath)
-	// ignition
-	authKeyFragmentBasename := filepath.Base(constants.RHCOS9SSHKeyPath)
-
-	keyFragmentsDir, err := ctrlcommon.ReadDir(authKeyFragmentDirPath)
-	if err == nil {
-		for _, fragment := range keyFragmentsDir {
-			if fragment.Name() != authKeyFragmentBasename {
-				keyPath := filepath.Join(authKeyFragmentDirPath, fragment.Name())
-				err := os.RemoveAll(keyPath)
-				if err != nil {
-					return fmt.Errorf("failed to remove path '%s': %w", keyPath, err)
-				}
-			}
-		}
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		// This shouldn't ever happen
-		return fmt.Errorf("unexpectedly failed to get info for path '%s': %w", constants.RHCOS9SSHKeyPath, err)
-	}
-
-	return nil
 }
 
 // InplaceUpdateViaNewContainer runs rpm-ostree ex deploy-via-self

--- a/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
+++ b/templates/common/on-prem/files/NetworkManager-resolv-prepender.yaml
@@ -22,7 +22,7 @@ contents:
     export IP4_DOMAINS IP6_DOMAINS
     export -f resolv_prepender
 
-    # For RHEL8 with NetworkManager >= 1.36 and RHEL9 with NetworkManager >=1.42 we can use simplified logic
+    # For RHEL9 with NetworkManager >=1.42 we can use simplified logic
     # of observing only a single "dns-change" event. Older version of NetworkManager require however that we
     # react on a set of multiple events. Once dns-change event is detected we create a flag file to ignore
     # subsequent up&co. events as undesired.

--- a/test/e2e-1of2/mcd_test.go
+++ b/test/e2e-1of2/mcd_test.go
@@ -320,28 +320,16 @@ func TestNoReboot(t *testing.T) {
 	_, err := cs.MachineConfigs().Create(context.TODO(), oldInfraConfig, metav1.CreateOptions{})
 	require.Nil(t, err)
 	oldInfraRenderedConfig, err := helpers.WaitForRenderedConfig(t, cs, "infra", oldInfraConfig.Name)
+	require.Nil(t, err)
 	infraNode := helpers.GetSingleNodeByRole(t, cs, "infra")
 
 	sshKeyContent := "test adding authorized key without node reboot"
-
-	nodeOS := helpers.GetOSReleaseForNode(t, cs, infraNode).OS
-
-	sshPaths := helpers.GetSSHPaths(nodeOS)
-
-	t.Logf("Expecting SSH keys to be in %s", sshPaths.Expected)
-
-	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
-		// Write an SSH key to the old location on the node because the update process should remove this file.
-		t.Logf("Writing SSH key to %s to ensure that it will be removed later", sshPaths.NotExpected)
-		bashCmd := fmt.Sprintf("printf '%s' > %s", sshKeyContent, filepath.Join("/rootfs", sshPaths.NotExpected))
-		helpers.ExecCmdOnNode(t, cs, infraNode, "/bin/bash", "-c", bashCmd)
-	}
 
 	// Delete the expected SSH keys directory to ensure that the directories are
 	// (re)created correctly by the MCD. This targets the upgrade case where that
 	// directory may not previously exist. Note: This will need to be revisited
 	// once Config Drift Monitor is aware of SSH keys.
-	helpers.ExecCmdOnNode(t, cs, infraNode, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+	helpers.ExecCmdOnNode(t, cs, infraNode, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(constants.RHCOSDefaultSSHKeyPath)))
 
 	output := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", "/rootfs/proc/uptime")
 	oldTime := strings.Split(output, " ")[0]
@@ -388,23 +376,20 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
-	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
+	helpers.AssertFileOnNode(t, cs, infraNode, constants.RHCOSDefaultSSHKeyPath)
 
-	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	foundSSHKey := helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", constants.RHCOSDefaultSSHKeyPath))
 	if !strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSHKey)
 	}
 	t.Logf("Node %s has SSH key", infraNode.Name)
 
-	assertExpectedPerms(t, cs, infraNode, "/home/core/.ssh", []string{constants.CoreUserName, constants.CoreGroupName, "700"})
-
-	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
-		// /home/core/.ssh/authorized_keys.d
-		assertExpectedPerms(t, cs, infraNode, filepath.Dir(constants.RHCOS9SSHKeyPath), []string{constants.CoreUserName, constants.CoreGroupName, "700"})
-	}
-
-	assertExpectedPerms(t, cs, infraNode, sshPaths.Expected, []string{constants.CoreUserName, constants.CoreGroupName, "600"})
+	// /home/core/.ssh
+	assertExpectedPerms(t, cs, infraNode, constants.CoreUserSSHPath, []string{constants.CoreUserName, constants.CoreGroupName, "700"})
+	// /home/core/.ssh/authorized_keys.d
+	assertExpectedPerms(t, cs, infraNode, filepath.Dir(constants.RHCOSDefaultSSHKeyPath), []string{constants.CoreUserName, constants.CoreGroupName, "700"})
+	// /home/core/.ssh/authorized_keys.d/ignition
+	assertExpectedPerms(t, cs, infraNode, constants.RHCOSDefaultSSHKeyPath, []string{constants.CoreUserName, constants.CoreGroupName, "600"})
 
 	currentEtcShadowContents := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "^core:", "/rootfs/etc/shadow")
 
@@ -451,13 +436,12 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], oldInfraRenderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	foundSSHKey = helpers.ExecCmdOnNode(t, cs, infraNode, "cat", filepath.Join("/rootfs", constants.RHCOSDefaultSSHKeyPath))
 	if strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("Node %s did not rollback successfully", infraNode.Name)
 	}
 
-	helpers.AssertFileOnNode(t, cs, infraNode, sshPaths.Expected)
-	helpers.AssertFileNotOnNode(t, cs, infraNode, sshPaths.NotExpected)
+	helpers.AssertFileOnNode(t, cs, infraNode, constants.RHCOSDefaultSSHKeyPath)
 
 	t.Logf("Node %s has successfully rolled back", infraNode.Name)
 
@@ -726,9 +710,7 @@ func TestIgn3Cfg(t *testing.T) {
 	assert.Equal(t, infraNode.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, infraNode.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	sshPaths := helpers.GetSSHPaths(helpers.GetOSReleaseForNode(t, cs, infraNode).OS)
-
-	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", filepath.Join("/rootfs", sshPaths.Expected))
+	foundSSH := helpers.ExecCmdOnNode(t, cs, infraNode, "grep", "1234_test_ign3", filepath.Join("/rootfs", constants.RHCOSDefaultSSHKeyPath))
 	if !strings.Contains(foundSSH, "1234_test_ign3") {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSH)
 	}
@@ -896,33 +878,19 @@ func TestFirstBootHasSSHKeys(t *testing.T) {
 		assert.NotEmpty(t, out, "expected SSH key file %s on %s to contain SSH keys, but it was empty", keyPath, newNode.Name)
 	}
 
-	isFound := false
-	isFoundRhcos8KeyPath := false
-	isFoundRhcos9KeyPath := false
+	isFoundRhcosKeyPath := false
 
-	if sshKeyFileExistsOnNode(constants.RHCOS8SSHKeyPath) {
-		assertSSHKeyContents(constants.RHCOS8SSHKeyPath)
-		isFound = true
-		isFoundRhcos8KeyPath = true
+	if sshKeyFileExistsOnNode(constants.RHCOSDefaultSSHKeyPath) {
+		assertSSHKeyContents(constants.RHCOSDefaultSSHKeyPath)
+		isFoundRhcosKeyPath = true
 	}
 
-	if sshKeyFileExistsOnNode(constants.RHCOS9SSHKeyPath) {
-		assertSSHKeyContents(constants.RHCOS9SSHKeyPath)
-		isFound = true
-		isFoundRhcos9KeyPath = true
-	}
-
-	if isFound {
-		t.Logf("SSH keys found on node in RHCOS8 location %v / RHCOS9 location %v", isFoundRhcos8KeyPath, isFoundRhcos9KeyPath)
+	if isFoundRhcosKeyPath {
+		t.Logf("SSH keys found on node in location %v", isFoundRhcosKeyPath)
 	} else {
-		t.Logf("Neither %s or %s exists on the node", constants.RHCOS8SSHKeyPath, constants.RHCOS9SSHKeyPath)
+		t.Logf("SSH keys path %s does not exists on the node", constants.RHCOSDefaultSSHKeyPath)
 		t.FailNow()
 	}
-}
-
-func sshKeyFileExistsOnNode(t *testing.T, cs *framework.ClientSet, node corev1.Node, path string) bool {
-	_, err := helpers.ExecCmdOnNodeWithError(cs, node, "stat", filepath.Join("/rootfs", path))
-	return err == nil
 }
 
 func createMCToAddFileForRole(name, role, filename, data string) *mcfgv1.MachineConfig {

--- a/test/e2e-single-node/sno_mcd_test.go
+++ b/test/e2e-single-node/sno_mcd_test.go
@@ -263,23 +263,10 @@ func TestNoReboot(t *testing.T) {
 
 	sshKeyContent := "test adding authorized key without node reboot"
 
-	nodeOS := helpers.GetOSReleaseForNode(t, cs, node).OS
-
-	sshPaths := helpers.GetSSHPaths(nodeOS)
-
-	t.Logf("Expecting SSH keys to be in %s", sshPaths.Expected)
-
-	if sshPaths.Expected == constants.RHCOS9SSHKeyPath {
-		// Write an SSH key to the old location on the node because the update process should remove this file.
-		t.Logf("Writing SSH key to %s to ensure that it will be removed later", sshPaths.NotExpected)
-		bashCmd := fmt.Sprintf("printf '%s' > %s", sshKeyContent, filepath.Join("/rootfs", sshPaths.NotExpected))
-		helpers.ExecCmdOnNode(t, cs, node, "/bin/bash", "-c", bashCmd)
-	}
-
 	// Delete the expected SSH keys directory to ensure that the directories are
 	// (re)created correctly by the MCD. This targets the upgrade case where that
 	// directory may not previously exist.
-	helpers.ExecCmdOnNode(t, cs, node, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(sshPaths.Expected)))
+	helpers.ExecCmdOnNode(t, cs, node, "rm", "-rf", filepath.Join("/rootfs", filepath.Dir(constants.RHCOSDefaultSSHKeyPath)))
 
 	// Adding authorized key for user core
 	testIgnConfig := ctrlcommon.NewIgnConfig()
@@ -314,12 +301,11 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], renderedConfig)
 	assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	t.Logf("Expecting SSH keys to be in %s", sshPaths.Expected)
+	t.Logf("Expecting SSH keys to be in %s", constants.RHCOSDefaultSSHKeyPath)
 
-	helpers.AssertFileOnNode(t, cs, node, sshPaths.Expected)
-	helpers.AssertFileNotOnNode(t, cs, node, sshPaths.NotExpected)
+	helpers.AssertFileOnNode(t, cs, node, constants.RHCOSDefaultSSHKeyPath)
 
-	foundSSHKey := helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	foundSSHKey := helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", constants.RHCOSDefaultSSHKeyPath))
 	if !strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("updated ssh keys not found in authorized_keys, got %s", foundSSHKey)
 	}
@@ -359,13 +345,12 @@ func TestNoReboot(t *testing.T) {
 	assert.Equal(t, node.Annotations[constants.CurrentMachineConfigAnnotationKey], oldMasterRenderedConfig)
 	assert.Equal(t, node.Annotations[constants.MachineConfigDaemonStateAnnotationKey], constants.MachineConfigDaemonStateDone)
 
-	foundSSHKey = helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", sshPaths.Expected))
+	foundSSHKey = helpers.ExecCmdOnNode(t, cs, node, "cat", filepath.Join("/rootfs", constants.RHCOSDefaultSSHKeyPath))
 	if strings.Contains(foundSSHKey, sshKeyContent) {
 		t.Fatalf("Node %s did not rollback successfully", node.Name)
 	}
 
-	helpers.AssertFileOnNode(t, cs, node, sshPaths.Expected)
-	helpers.AssertFileNotOnNode(t, cs, node, sshPaths.NotExpected)
+	helpers.AssertFileOnNode(t, cs, node, constants.RHCOSDefaultSSHKeyPath)
 
 	t.Logf("Node %s has successfully rolled back", node.Name)
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -285,7 +285,6 @@ func WaitForPoolComplete(t *testing.T, cs *framework.ClientSet, pool, target str
 	return nil
 }
 
-
 // Waits for both the node image and config to change.
 func WaitForNodeConfigAndImageChange(t *testing.T, cs *framework.ClientSet, node corev1.Node, mcName, image string) error {
 	startTime := time.Now()
@@ -746,28 +745,6 @@ func CreateMCP(t *testing.T, cs *framework.ClientSet, mcpName string) func() {
 		err := cs.MachineConfigPools().Delete(context.TODO(), mcpName, metav1.DeleteOptions{})
 		require.Nil(t, err)
 		t.Logf("Deleted MachineConfigPool %q", mcpName)
-	}
-}
-
-type SSHPaths struct {
-	// The path where SSH keys are expected to be found.
-	Expected string
-	// The path where SSH keys are *not* expected to be found.
-	NotExpected string
-}
-
-// Determines where to expect SSH keys for the core user on a given node based upon the node's OS.
-func GetSSHPaths(os osrelease.OperatingSystem) SSHPaths {
-	if os.IsEL9() || os.IsEL10() || os.IsSCOS() || os.IsFCOS() {
-		return SSHPaths{
-			Expected:    constants.RHCOS9SSHKeyPath,
-			NotExpected: constants.RHCOS8SSHKeyPath,
-		}
-	}
-
-	return SSHPaths{
-		Expected:    constants.RHCOS8SSHKeyPath,
-		NotExpected: constants.RHCOS9SSHKeyPath,
 	}
 }
 
@@ -1672,8 +1649,7 @@ func CollectDebugInfoFromNode(t *testing.T, cs *framework.ClientSet, node *corev
 		"/etc/machine-config-daemon/currentconfig",
 		"/etc/os-release",
 		"/usr/lib/osrelease",
-		constants.RHCOS8SSHKeyPath,
-		constants.RHCOS9SSHKeyPath,
+		constants.RHCOSDefaultSSHKeyPath,
 		"/etc/machine-config-daemon/node-annotation.json.bak",
 		"/etc/ignition-machine-config-encapsulated.json.bak",
 	}


### PR DESCRIPTION
**- What I did**

Dropped support for RHEL8

**- How to verify it**

All CI tests should pass even without RHEL8 custom paths

**- Description for the changelog**

- Removed RHEL8 paths from the codebase
- Adapted e2e tests by dropping RHEL8 checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Core SSH authorized-keys handling to a single default location, simplifying key directory creation and updates.
  * Adjusted first-run SSH key migration behavior and refined NIC name persistence eligibility for current supported OS versions.
* **Chores**
  * Simplified OS version detection by removing RHEL 8–specific logic and legacy version backfills.
  * Streamlined container builds to use only the RHEL 9 builder stage; copied all compiled executables into the final image.
  * Updated a NetworkManager dispatcher comment for a RHEL 9–specific condition.
* **Tests**
  * Updated end-to-end and helper tests to validate only the default SSH key path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->