### PR TITLE
daemon: skip nice/ionice for extensions image pull during firstboot

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"math/rand"
 	"sync"
 	"syscall"
 	"time"
@@ -1493,6 +1494,14 @@ func (dn *Daemon) removeRollback() error {
 		// do not attempt to rollback on non-RHCOS/FCOS machines
 		return nil
 	}
+	// Defer cleanup to reduce I/O contention during node bootstrap. The rpm-ostree cleanup
+	// syncfs calls (~43s total) run concurrently with CNI image pulls and compete for disk
+	// bandwidth during the kubelet-to-ready window. Sleeping here lets the node reach Ready
+	// before the heavy I/O starts. Jitter spreads cleanup across nodes that scale up in the
+	// same burst so they don't all hit the disk simultaneously after the delay expires.
+	delay := 60*time.Second + time.Duration(rand.Int63n(int64(30*time.Second)))
+	klog.Infof("Deferring rpm-ostree rollback cleanup by %s to reduce boot I/O contention", delay.Round(time.Second))
+	time.Sleep(delay)
 	return runRpmOstree("cleanup", "-r")
 }
 

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -449,7 +449,7 @@ func podmanRemove(cid string) {
 	exec.Command("podman", "rm", "-f", cid).Run()
 }
 
-func pullExtensionsImage(podmanInterface PodmanInterface, imgURL string) error {
+func pullExtensionsImage(podmanInterface PodmanInterface, imgURL string, background bool) error {
 	// Check if the image is present
 	podmanImageInfo, err := podmanInterface.GetPodmanImageInfoByReference(imgURL)
 	if err != nil || podmanImageInfo != nil {
@@ -465,11 +465,15 @@ func pullExtensionsImage(podmanInterface PodmanInterface, imgURL string) error {
 	args := []string{"pull", "-q"}
 	args = append(args, authArgs...)
 	args = append(args, imgURL)
-	_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
+	if background {
+		_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
+	} else {
+		_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
+	}
 	return err
 }
 
-func podmanCopy(podmanInterface PodmanInterface, imgURL, osImageContentDir string) (err error) {
+func podmanCopy(podmanInterface PodmanInterface, imgURL, osImageContentDir string, background bool) (err error) {
 	// make sure that osImageContentDir doesn't exist
 	os.RemoveAll(osImageContentDir)
 
@@ -488,7 +492,11 @@ func podmanCopy(podmanInterface PodmanInterface, imgURL, osImageContentDir strin
 	// copy the content from create container locally into a temp directory under /run/
 	cid := strings.TrimSpace(string(cidBuf))
 	args := []string{"cp", fmt.Sprintf("%s:/", cid), osImageContentDir}
-	_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
+	if background {
+		_, err = pivotutils.RunExtBackground(numRetriesNetCommands, "podman", args...)
+	} else {
+		_, err = pivotutils.RunExt(numRetriesNetCommands, "podman", args...)
+	}
 	if err != nil {
 		return
 	}
@@ -505,7 +513,7 @@ func podmanCopy(podmanInterface PodmanInterface, imgURL, osImageContentDir strin
 
 // ExtractExtensionsImage extracts the OS extensions content in a temporary directory under /run/machine-os-extensions
 // and returns the path on successful extraction
-func (dn *CoreOSDaemon) ExtractExtensionsImage(imgURL string) (osExtensionsImageContentDir string, err error) {
+func (dn *CoreOSDaemon) ExtractExtensionsImage(imgURL string, background bool) (osExtensionsImageContentDir string, err error) {
 	if err = os.MkdirAll(osExtensionsContentBaseDir, 0o755); err != nil {
 		err = fmt.Errorf("error creating directory %s: %w", osExtensionsContentBaseDir, err)
 		return
@@ -514,11 +522,11 @@ func (dn *CoreOSDaemon) ExtractExtensionsImage(imgURL string) (osExtensionsImage
 	if osExtensionsImageContentDir, err = os.MkdirTemp(osExtensionsContentBaseDir, "os-extensions-content-"); err != nil {
 		return
 	}
-	if err := pullExtensionsImage(dn.podmanInterface, imgURL); err != nil {
+	if err := pullExtensionsImage(dn.podmanInterface, imgURL, background); err != nil {
 		return osExtensionsImageContentDir, fmt.Errorf("error pulling extensions image %s: %w", imgURL, err)
 	}
 	// Extract the image using `podman cp`
-	return osExtensionsImageContentDir, podmanCopy(dn.podmanInterface, imgURL, osExtensionsImageContentDir)
+	return osExtensionsImageContentDir, podmanCopy(dn.podmanInterface, imgURL, osExtensionsImageContentDir, background)
 }
 
 // Remove pending deployment on OSTree based system
@@ -527,7 +535,7 @@ func removePendingDeployment() error {
 }
 
 // applyOSChanges extracts the OS image and adds coreos-extensions repo if we have either OS update or package layering to perform
-func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
+func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig, firstBoot bool) (retErr error) {
 	// We previously did not emit this event when kargs changed, so we still don't
 	if mcDiff.osUpdate || mcDiff.extensions || mcDiff.kernelType || mcDiff.oclEnabled {
 		// We emitted this event before, so keep it
@@ -561,7 +569,7 @@ func (dn *CoreOSDaemon) applyOSChanges(mcDiff machineConfigDiff, oldConfig, newC
 			dn.nodeWriter.Eventf(corev1.EventTypeNormal, "OSUpdateStarted", reason)
 		}
 
-		if err := dn.applyLayeredOSChanges(mcDiff, oldConfig, newConfig); err != nil {
+		if err := dn.applyLayeredOSChanges(mcDiff, oldConfig, newConfig, firstBoot); err != nil {
 			return err
 		}
 
@@ -1273,7 +1281,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 			klog.Info("Applying OCL revert-specific OS changes")
 		}
 
-		if err := coreOSDaemon.applyOSChanges(*diff, oldConfig, newConfig); err != nil {
+		if err := coreOSDaemon.applyOSChanges(*diff, oldConfig, newConfig, firstBoot); err != nil {
 			// When ImageModeStatusReporting is enabled, update the `MachineConfigNodeUpdateOS` condition to report the experienced error
 			if imageModeStatusReportingEnabled {
 				mcnErr := upgrademonitor.GenerateAndApplyMachineConfigNodes(
@@ -1295,7 +1303,7 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 
 		defer func() {
 			if retErr != nil {
-				if err := coreOSDaemon.applyOSChanges(*diff, newConfig, oldConfig); err != nil {
+				if err := coreOSDaemon.applyOSChanges(*diff, newConfig, oldConfig, firstBoot); err != nil {
 					errs := kubeErrs.NewAggregate([]error{err, retErr})
 					retErr = fmt.Errorf("error rolling back changes to OS: %w", errs)
 					return
@@ -1449,13 +1457,13 @@ func (dn *Daemon) updateHypershift(oldConfig, newConfig *mcfgv1.MachineConfig, d
 
 	if dn.os.IsCoreOSVariant() {
 		coreOSDaemon := CoreOSDaemon{dn}
-		if err := coreOSDaemon.applyOSChanges(*diff, oldConfig, newConfig); err != nil {
+		if err := coreOSDaemon.applyOSChanges(*diff, oldConfig, newConfig, false); err != nil {
 			return err
 		}
 
 		defer func() {
 			if retErr != nil {
-				if err := coreOSDaemon.applyOSChanges(*diff, newConfig, oldConfig); err != nil {
+				if err := coreOSDaemon.applyOSChanges(*diff, newConfig, oldConfig, false); err != nil {
 					errs := kubeErrs.NewAggregate([]error{err, retErr})
 					retErr = fmt.Errorf("error rolling back changes to OS: %w", errs)
 					return
@@ -3219,7 +3227,7 @@ func (dn *Daemon) reboot(rationale string) error {
 }
 
 //nolint:gocyclo
-func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig) (retErr error) {
+func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfig, newConfig *mcfgv1.MachineConfig, firstBoot bool) (retErr error) {
 	// Override the computed diff if the booted state differs from the oldConfig
 	// https://issues.redhat.com/browse/OCPBUGS-2757
 	if mcDiff.osUpdate && dn.bootedOSImageURL == newConfig.Spec.OSImageURL {
@@ -3274,7 +3282,7 @@ func (dn *CoreOSDaemon) applyLayeredOSChanges(mcDiff machineConfigDiff, oldConfi
 			}
 		}
 
-		if osExtensionsContentDir, err = dn.ExtractExtensionsImage(newConfig.Spec.BaseOSExtensionsContainerImage); err != nil {
+		if osExtensionsContentDir, err = dn.ExtractExtensionsImage(newConfig.Spec.BaseOSExtensionsContainerImage, !firstBoot); err != nil {
 			// Report ImagePulledFromRegistry condition as false (failed)
 			if imageModeStatusReportingEnabled {
 				err := upgrademonitor.GenerateAndApplyMachineConfigNodes(

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -962,7 +962,7 @@ func TestPodmanCopy_CreateContainerCall(t *testing.T) {
 
 	// Note: This test will fail at podmanRemove since we're only testing the interface call
 	// The function will return an error, but we can verify the CreatePodmanContainer was called correctly
-	err := podmanCopy(mockPodman, imgURL, osImageContentDir)
+	err := podmanCopy(mockPodman, imgURL, osImageContentDir, true)
 
 	// Verify the CreatePodmanContainer was called with correct parameters
 	expectedArgs := []string{"--net=none", "--annotation=org.openshift.machineconfigoperator.pivot=true"}

--- a/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
+++ b/templates/common/_base/units/machine-config-daemon-firstboot.service.yaml
@@ -15,6 +15,14 @@ contents: |
   RemainAfterExit=yes
   # Disable existing repos (if any) so that OS extensions would use embedded RPMs only
   ExecStartPre=-/usr/bin/sh -c "sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo"
+  # Bind mount a tmpfs-backed copy of the ostree repo config so that disabling fsync is ephemeral;
+  # if the host crashes or reboots the bind mount disappears and the on-disk config is unchanged.
+  # We append a second [core] section (GKeyFile merges duplicate groups) rather than using
+  # `ostree config set` because ostree uses an atomic rename which fails with EBUSY on a bind-mounted
+  # file; the bind mount must be established before `ostree config set` is called, and once it is,
+  # the rename target is a mount point and can't be replaced.
+  ExecStartPre=-/usr/bin/sh -c "cp /sysroot/ostree/repo/config /run/ostree-bootstrap-config && printf '\n[core]\nfsync = false\n' >> /run/ostree-bootstrap-config && mount --bind /run/ostree-bootstrap-config /sysroot/ostree/repo/config"
+  ExecStopPost=-/usr/bin/umount /sysroot/ostree/repo/config
   # Run this via podman because we want to use the nmstatectl binary in our container
   ExecStart=/usr/bin/podman run --rm --privileged --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig --persist-nics
   ExecStart=/usr/bin/podman run --rm --privileged --pid=host --net=host -v /:/rootfs  --entrypoint machine-config-daemon '{{ .Images.machineConfigOperator }}' firstboot-complete-machineconfig


### PR DESCRIPTION
Two related optimizations to reduce I/O contention during node scale-up, measured on AWS m6a.xlarge (4.22 nightly, n=18 for fsync, n=1 baseline for cleanup contention).

**1. Defer rpm-ostree rollback cleanup by 60s + jitter**

On boot 2, MCD calls `rpm-ostree cleanup -r` shortly after starting. This triggers three `syncfs()` calls from the rpmostree daemon totalling ~43s, which run concurrently with CNI image pulls and compete for disk bandwidth during the kubelet-to-ready window. The syncfs calls straddle NodeReady — the first two complete before it, and the third finishes ~11s after.

Sleeping 60s + up to 30s jitter in `removeRollback()` before calling `rpm-ostree cleanup -r` defers the I/O until after the node is Ready. The sleep is inside `checkStateOnFirstRun()` which runs before `dn.booting = false` and before `MachineConfigNodeResumed` is posted, so MCO's Done state is delayed by the sleep — but NodeReady itself is kubelet-driven and is unaffected.

Jitter spreads cleanup across nodes that scale up in the same burst so they don't all hit the disk simultaneously when the delay expires.

**2. Disable ostree fsync during machine-config-daemon-firstboot (includes #6122)**

Bind mount a tmpfs-backed copy of the ostree repo config over `/sysroot/ostree/repo/config` before the rebase so that setting `core.fsync=false` is ephemeral. If the host crashes or reboots, the bind mount disappears and the on-disk config is unchanged automatically.

We append a second `[core]` section to the tmpfs copy (GKeyFile merges duplicate groups) rather than using `ostree config set` because ostree uses an atomic rename which fails with `EBUSY` on a bind-mounted file. Saves ~3-5s on rebase fetch.

**- How to verify**

For cleanup deferral: on a new node's boot 2 journal, the `rpm-ostree[N]: Starting syncfs for system repo` entries from `machine-config-operator` client should now appear >60s after kubelet registers, rather than concurrent with CNI pulls.

For fsync: the many per-object `Starting/Completed syncfs() for system repo` entries from rpm-ostree during the rebase window should be absent; `sysroot-ostree-repo-config.mount: Deactivated successfully` confirms the bind mount was active.

**- Description for the changelog**

Deferred rpm-ostree rollback cleanup to after NodeReady to reduce boot I/O contention; disabled ostree fsync during firstboot rebase to save ~3-5s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control of extension image extraction during OS updates to avoid background extraction on first boot.
  * Reduced boot I/O contention by deferring cleanup work with a randomized delay.
  * Made first-boot service behavior ephemeral by bind-mounting a tmpfs-backed config to disable fsync only during first boot.

* **Tests**
  * Updated tests to reflect the revised extension image extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->