### PR TITLE
AGENT-1517: avoid running IRI deletion tests for standard e2e IRI tests

### DIFF
--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -1,3 +1,5 @@
+//go:build !iri_delete
+
 package e2e_iri_test
 
 import (


### PR DESCRIPTION
**- What I did**
Small fix, followup of https://github.com/openshift/machine-config-operator/pull/6041, required by https://github.com/openshift/release/pull/79305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes in this release. This update includes internal build configuration adjustments to support different build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->