### PR TITLE
AGENT-1531: Remove localhost.localdomain workaround for MCN IRI image field

### DIFF
--- a/pkg/controller/internalreleaseimage/aggregation.go
+++ b/pkg/controller/internalreleaseimage/aggregation.go
@@ -283,9 +283,9 @@ func buildAPIIntUnavailableReleases(specReleases []mcfgv1alpha1.InternalReleaseI
 	return releases
 }
 
-// transformToAPIIntURL converts a localhost URL (e.g. localhost:22625/path or
-// localhost.localdomain:22625/path) to api-int.<domain>:22625/path by replacing
-// the hostname before the port with the api-int hostname.
+// transformToAPIIntURL converts a localhost URL (e.g. localhost:22625/path)
+// to api-int.<domain>:22625/path by replacing the hostname before the port
+// with the api-int hostname.
 func transformToAPIIntURL(localhostURL, clusterDomain string) string {
 	// Find the host:port boundary by looking for ":" before the first "/"
 	slashIdx := strings.Index(localhostURL, "/")

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller_test.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller_test.go
@@ -476,12 +476,6 @@ func TestTransformToAPIIntURL(t *testing.T) {
 			expected:      "api-int.ostest.test.metalkube.org:22625/openshift/release-images@sha256:abc123",
 		},
 		{
-			name:          "localhost.localdomain",
-			localhostURL:  "localhost.localdomain:22625/openshift/release-images@sha256:abc123",
-			clusterDomain: "ostest.test.metalkube.org",
-			expected:      "api-int.ostest.test.metalkube.org:22625/openshift/release-images@sha256:abc123",
-		},
-		{
 			name:          "no port returns input unchanged",
 			localhostURL:  "localhost",
 			clusterDomain: "example.com",

--- a/pkg/daemon/internalreleaseimage/internalreleaseimage_manager.go
+++ b/pkg/daemon/internalreleaseimage/internalreleaseimage_manager.go
@@ -239,20 +239,6 @@ func (i *Manager) updateMCNStatus(mcnOld, mcn *mcfgv1.MachineConfigNode) error {
 	return nil
 }
 
-// TODO: Remove this method once the MCN IRI CEL validation rule for the image field will be fixed,
-// since currently it does not accept the plain 'localhost' value
-func (i *Manager) sanitizeImagePullspec(image string) string {
-	const (
-		short = "localhost"
-		long  = "localhost.localdomain"
-	)
-
-	if strings.Contains(image, long) {
-		return strings.ReplaceAll(image, long, short)
-	}
-	return strings.ReplaceAll(image, short, long)
-}
-
 func (i *Manager) refreshMachineConfigNodeStatus(mcn *mcfgv1.MachineConfigNode, iriReg *iriRegistry) error {
 	// Get the current OCP releases bundles stored in the local IRI registry.
 	registryBundles, err := iriReg.GetOCPBundlesTags()
@@ -289,7 +275,7 @@ func (i *Manager) refreshMachineConfigNodeStatus(mcn *mcfgv1.MachineConfigNode, 
 
 		iriRelease := mcfgv1.MachineConfigNodeStatusInternalReleaseImageRef{
 			Name:  bundle,
-			Image: i.sanitizeImagePullspec(pullSpec),
+			Image: pullSpec,
 		}
 		mcnUpdated.Status.InternalReleaseImage.Releases = append(mcnUpdated.Status.InternalReleaseImage.Releases, iriRelease)
 	}
@@ -302,7 +288,7 @@ func (i *Manager) refreshMachineConfigNodeStatus(mcn *mcfgv1.MachineConfigNode, 
 	for n := range mcnUpdated.Status.InternalReleaseImage.Releases {
 		r := &mcnUpdated.Status.InternalReleaseImage.Releases[n]
 
-		err := iriReg.CheckImageAvailability(i.sanitizeImagePullspec(r.Image))
+		err := iriReg.CheckImageAvailability(r.Image)
 		if err == nil {
 			meta.SetStatusCondition(&r.Conditions, metav1.Condition{
 				Type:    string(mcfgv1alpha1.InternalReleaseImageConditionTypeDegraded),

--- a/pkg/daemon/internalreleaseimage/internalreleaseimage_manager_test.go
+++ b/pkg/daemon/internalreleaseimage/internalreleaseimage_manager_test.go
@@ -64,7 +64,7 @@ func TestInternalReleaseImageManager(t *testing.T) {
 				assert.Len(t, mcn.Status.InternalReleaseImage.Releases, 1)
 				r := mcn.Status.InternalReleaseImage.Releases[0]
 				assert.Equal(t, "ocp-release-bundle-4.22.0-0.ci-2026-04-01-050515", r.Name)
-				assert.Equal(t, "localhost.localdomain:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389", r.Image)
+				assert.Equal(t, "localhost:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389", r.Image)
 				verifyCondition(t, r.Conditions, string(mcfgv1alpha1.InternalReleaseImageConditionTypeAvailable), metav1.ConditionTrue)
 				verifyCondition(t, r.Conditions, string(mcfgv1alpha1.InternalReleaseImageConditionTypeDegraded), metav1.ConditionFalse)
 			},
@@ -101,7 +101,7 @@ func TestInternalReleaseImageManager(t *testing.T) {
 				assert.Len(t, mcn.Status.InternalReleaseImage.Releases, 1)
 				r := mcn.Status.InternalReleaseImage.Releases[0]
 				assert.Equal(t, "ocp-release-bundle-4.22.0-0.ci-2026-04-01-050515", r.Name)
-				assert.Equal(t, "localhost.localdomain:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389", r.Image)
+				assert.Equal(t, "localhost:22625/openshift/release-images@sha256:68bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0389", r.Image)
 				verifyCondition(t, r.Conditions, string(mcfgv1alpha1.InternalReleaseImageConditionTypeAvailable), metav1.ConditionFalse)
 				verifyCondition(t, r.Conditions, string(mcfgv1alpha1.InternalReleaseImageConditionTypeDegraded), metav1.ConditionTrue)
 			},


### PR DESCRIPTION
**- What I did**
The MCN CEL validation rule now accepts plain 'localhost' as a valid host (openshift/api#2800), so the sanitizeImagePullspec() workaround that converted localhost to localhost.localdomain is no longer needed.

**- How to verify it**
The iso-no-registry job must pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal release image reference resolution to use `localhost` instead of `localhost.localdomain`, ensuring proper image registry connectivity for internal releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->