### PR TITLE
OCPBUGS-68350: In OCB to check when a image is removed the old build is triggered again and the MC should start updating directly and no new MOSB should be triggred

### DIFF
--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1390,6 +1390,12 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 	// In both cases, we need to create/continue a build
 	missingAnnotation := firstOptIn == ""
 
+	// No action needed if the rendered config has not changed.
+	if oldRendered == newRendered {
+		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
+		return nil
+	}
+
 	// This is our trigger point
 	// Create/continue a build if:
 	// 1. Config changed AND needs image rebuild, OR

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1391,7 +1391,7 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 	missingAnnotation := firstOptIn == ""
 
 	// No action needed if the rendered config has not changed.
-	if oldRendered == newRendered {
+	if oldRendered == newRendered && !missingAnnotation {
 		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
 		return nil
 	}


### PR DESCRIPTION
**-Problem**
When a MachineOSBuild (MOSB) image is deleted from the registry and automatically rebuilt, reapplying the same MachineConfig (MC) incorrectly triggers a new MOSB instead of directly updating the 
  MachineConfigPool (MCP) with the rebuilt image. The expected behavior is that the MCP should update immediately using the existing rebuilt MOSB without creating an unnecessary new build.

**- What I did**
Add an early check in reconcilePoolChange to skip builds when the rendered MachineConfig hasn't changed. Allowing the MachineConfigPool to update directly with the existing rebuilt image

**- How to verify it**
Steps:
  1. Apply MOSC and wait for MOSB-1 to complete
  2. Apply MC and wait for MOSB-2 and MCP to complete
  3. Delete the MOSB-1 image tag from the registry
  4. Delete the MC
  5. Wait for MOSB-1 to automatically re-trigger and complete
  6. Re-apply the same MC
  
Expected: 
  - MCP should update directly (no MOSB-3 created)
  - Check logs for: "pool <name>: Configuration unchanged (<hash>), no action needed"
  - Only 2 MOSBs should exist (MOSB-1 and MOSB-2)

**- Description for the changelog**
Fixed an issue where reapplying an unchanged MachineConfig would incorrectly trigger a new MachineOSBuild after an image rebuild. The MachineConfigPool now updates directly when the rendered configuration hasn't changed, preventing unnecessary builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids redundant reconciliation steps when a machine configuration is unchanged and a current build marker is present, preventing unnecessary build-triggering logic and improving overall efficiency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->