### PR TITLE
OCPBUGS-87635: Fix MCP.status.osImageStream

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -381,7 +381,7 @@ func (ctrl *Controller) calculateStatus(mcns []*mcfgv1.MachineConfigNode, cconfi
 	// This must be done after all conditions are set, so we use the final calculated state
 	if ctrl.osStreamsFgEnabled {
 		isDegraded := nodeDegraded || renderDegraded || buildDegraded || pinnedImageSetsDegraded
-		status.OSImageStream = ctrl.getOSImageStream(pool, allUpdated, isDegraded)
+		status.OSImageStream = ctrl.getOSImageStream(pool, &status, allUpdated, isDegraded)
 	}
 
 	return status
@@ -520,7 +520,7 @@ func isLayeredPoolBuilding(isLayeredPool bool, mosc *mcfgv1.MachineOSConfig, mos
 }
 
 // getOSImageStream gets the OSImageStream for a pool based on the calculated updated and degraded state
-func (ctrl *Controller) getOSImageStream(pool *mcfgv1.MachineConfigPool, isUpdated, isDegraded bool) mcfgv1.OSImageStreamReference {
+func (ctrl *Controller) getOSImageStream(pool *mcfgv1.MachineConfigPool, status *mcfgv1.MachineConfigPoolStatus, isUpdated, isDegraded bool) mcfgv1.OSImageStreamReference {
 	// Only report OSImageStream status if the pool is Updated and not Degraded
 	if !isUpdated {
 		klog.V(4).Infof("Pool %s is not updated, clearing OSImageStream status", pool.Name)
@@ -532,8 +532,8 @@ func (ctrl *Controller) getOSImageStream(pool *mcfgv1.MachineConfigPool, isUpdat
 		return mcfgv1.OSImageStreamReference{}
 	}
 
-	// Get the rendered MachineConfig from the pool's status
-	renderedConfigName := pool.Status.Configuration.Name
+	// Use the current fresh status instead of the MCP's old one
+	renderedConfigName := status.Configuration.Name
 	if renderedConfigName == "" {
 		klog.V(4).Infof("Pool %s has no rendered configuration", pool.Name)
 		return mcfgv1.OSImageStreamReference{}
@@ -550,6 +550,19 @@ func (ctrl *Controller) getOSImageStream(pool *mcfgv1.MachineConfigPool, isUpdat
 	if err != nil {
 		klog.V(4).Infof("Could not retrieve OSImageStream CR: %v", err)
 		return mcfgv1.OSImageStreamReference{}
+	}
+
+	// If any source MC has osImageURL set, the OS image is user-managed
+	for _, srcRef := range status.Configuration.Source {
+		srcMC, err := ctrl.mcLister.Get(srcRef.Name)
+		if err != nil {
+			klog.Warningf("Could not retrieve source MachineConfig %s for pool %s: %v", srcRef.Name, pool.Name, err)
+			continue
+		}
+		if srcMC.Spec.OSImageURL != "" {
+			klog.V(4).Infof("Source MachineConfig %s has osImageURL set, skipping OSImageStream status for pool %s", srcMC.Name, pool.Name)
+			return mcfgv1.OSImageStreamReference{}
+		}
 	}
 
 	// Get the osImageURL from the rendered config


### PR DESCRIPTION
Closes: [#OCPBUGS-87635](https://redhat.atlassian.net/browse/OCPBUGS-87635)

**- What I did**

The logic that computes the MCP .status.osImageStream was wrongly using the "old" status of the MCP instead of the status thas is currently computed for the MCP, leading to races where the rendered MC used to determine the osImageURL in use can be the old one instead of the current one leading to a wrong stream to be reported. This change also adds an explicit check of the source MCs to ensure that the logic doesn't report a osImageStream if a user provided osImageUrl is in place. This check is a formality.

**- How to verify it**

Run "[PolarionID:88366][Skipped:Disconnected] osImageStream should be empty when osImageURL is set" a few (more than 5) times to ensure it doesn't fail anymore.

**- Description for the changelog**

Fix the osImageStream status field of the MCPs to report based on the latest computed state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection and handling of user-managed OS image configurations to prevent unintended system overrides.
  * OS image stream status reporting is now controlled via feature settings for more granular configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->