### PR TITLE
MCO-2343: Temporary make MCO default to rhel-9

### DIFF
--- a/pkg/osimagestream/osimagestream.go
+++ b/pkg/osimagestream/osimagestream.go
@@ -137,11 +137,12 @@ func getDefaultStreamSet(streams []mcfgv1.OSImageStreamSet, createOptions *Creat
 		if len(streams) == 1 {
 			return streams[0].Name, nil
 		}
-		builtinDefault, err := GetBuiltinDefaultStreamName(createOptions.InstallVersion)
-		if err != nil {
-			return "", fmt.Errorf("could not determine the builtin default stream: %w", err)
-		}
-		requestedDefaultStream = builtinDefault
+		// TODO MCO-2343: Restore as soon as the full GA of the feature finishes
+		// builtinDefault, err := GetBuiltinDefaultStreamName(createOptions.InstallVersion)
+		// if err != nil {
+		//   return "", fmt.Errorf("could not determine the builtin default stream: %w", err)
+		// }
+		requestedDefaultStream = StreamNameRHEL9
 	}
 
 	if slices.Contains(streamNames, requestedDefaultStream) {


### PR DESCRIPTION
**- What I did**

For the feature promotion process we need to make sure we always fallback to 9.

**- How to verify it**

CI is enough.

**- Description for the changelog**

For the feature promotion process we need to make sure we always fallback to 9.