### PR TITLE
OCPBUGS-87861: Add background RHCOS (rpm-ostree) pre-caching for cluster upgrades

### DIFF
--- a/docs/OSImagePrecaching.md
+++ b/docs/OSImagePrecaching.md
@@ -1,0 +1,65 @@
+# RHCOS OS image pre-caching
+
+This document describes background pre-caching of RHCOS (rpm-ostree) OS images
+during cluster upgrades.
+
+Related bug: [OCPBUGS-87861](https://issues.redhat.com/browse/OCPBUGS-87861)
+
+## Problem
+
+During a cluster upgrade the Machine Config Daemon (MCD) rebases rpm-ostree to
+the `rhel-coreos` image referenced by the rendered `MachineConfig` `OSImageURL`.
+Today that download typically happens **after** the node is cordoned and drained.
+
+On slow or bandwidth-constrained links each hop can add ~10–20 minutes of
+per-node downtime. Multi-hop upgrades (for example
+4.18.z → 4.19.z → 4.20.z → 4.21.z → 4.22.z) compound this delay.
+
+Container image pre-pull mechanisms such as `PinnedImageSet` populate CRI-O
+storage only. They do **not** populate the host ostree repository and therefore
+do not reduce rpm-ostree rebase time.
+
+## Approach
+
+rpm-ostree supports offline staging:
+
+| Phase | Command | When |
+|-------|---------|------|
+| Pre-cache | `rpm-ostree rebase <ref> --download-only` | Background, node still schedulable |
+| Apply | `rpm-ostree rebase <ref> --cache-only` | During OS update, before network pull fallback |
+
+The MCD:
+
+1. Periodically checks whether the node `desiredImage` annotation differs from
+   the booted OS image and the node is not draining.
+2. Runs `--download-only` for that image while the node remains schedulable.
+3. During `updateLayeredOS`, attempts `--cache-only` before falling back to the
+   existing online registry rebase path.
+
+If pre-cache fails or is incomplete, behavior matches the previous online-only
+flow.
+
+## Observability
+
+Look for log lines from the MCD pod:
+
+```
+OS image precache: downloading layers for ...
+OS image precache completed for ...
+Updated OS to ... from local ostree cache
+Cached OS rebase unavailable for ..., pulling from registry
+```
+
+## Future work
+
+- `PinnedOSImageSet` CR for explicit multi-hop target digests
+- Automatic pre-cache of intermediate CVO hop images
+- `MachineConfigNode` status reporting (mirroring `PinnedImageSet`)
+- Feature gate for TechPreview rollout
+- User-facing OpenShift documentation
+
+## References
+
+- [OSUpgrades.md](OSUpgrades.md)
+- [rpm-ostree administrator handbook](https://coreos.github.io/rpm-ostree/administrator-handbook/)
+- [PinnedImageSet (CRI-O only)](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/machine_configuration/machine-config-pin-preload-images-about)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1396,6 +1396,7 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error, errCh chan er
 
 	go wait.Until(dn.worker, time.Second, stopCh)
 	go wait.Until(dn.controllerConfigWorker, time.Second, stopCh)
+	go dn.runOSImagePrecache(stopCh)
 
 	for {
 		select {

--- a/pkg/daemon/osimage_precache.go
+++ b/pkg/daemon/osimage_precache.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
+)
+
+const osImagePrecacheInterval = 2 * time.Minute
+
+// runOSImagePrecache periodically downloads upcoming OS images while the node
+// remains schedulable. See docs/OSImagePrecaching.md.
+func (dn *Daemon) runOSImagePrecache(stopCh <-chan struct{}) {
+	if dn.NodeUpdaterClient == nil {
+		klog.V(4).Info("OS image precache disabled: node updater client unavailable")
+		return
+	}
+
+	klog.Info("Starting OS image precache loop")
+	workqueue.ParallelizeUntil(stopCh, 1, func(_ int) {
+		ticker := time.NewTicker(osImagePrecacheInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				dn.syncOSImagePrecache()
+			}
+		}
+	})
+}
+
+func (dn *Daemon) syncOSImagePrecache() {
+	node, err := dn.nodeLister.Get(dn.name)
+	if err != nil {
+		klog.Warningf("OS image precache: failed to get node %s: %v", dn.name, err)
+		return
+	}
+
+	desiredImage := node.Annotations[constants.DesiredImageAnnotationKey]
+	currentImage := node.Annotations[constants.CurrentImageAnnotationKey]
+	if desiredImage == "" || desiredImage == currentImage {
+		return
+	}
+
+	bootedImage, _, _, err := dn.NodeUpdaterClient.GetBootedOSImageURL()
+	if err != nil {
+		klog.Warningf("OS image precache: failed to read booted OS image: %v", err)
+		return
+	}
+	if desiredImage == bootedImage {
+		return
+	}
+
+	desiredDrain := node.Annotations[constants.DesiredDrainerAnnotationKey]
+	lastAppliedDrain := node.Annotations[constants.LastAppliedDrainerAnnotationKey]
+	if desiredDrain != "" && desiredDrain != lastAppliedDrain {
+		klog.V(4).Infof("OS image precache: skipping %s while drain is in progress", desiredImage)
+		return
+	}
+
+	klog.Infof("OS image precache: downloading layers for %s", desiredImage)
+	if err := dn.NodeUpdaterClient.DownloadOSImage(desiredImage); err != nil {
+		klog.Warningf("OS image precache failed for %s: %v", desiredImage, err)
+		return
+	}
+	klog.Infof("OS image precache completed for %s", desiredImage)
+}

--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -192,14 +192,41 @@ func (r *RpmOstreeClient) IsNewEnoughForLayering() (bool, error) {
 	return false, nil
 }
 
+func layeredRegistryRebaseRef(imgURL string) string {
+	return "ostree-unverified-registry:" + imgURL
+}
+
+func (r *RpmOstreeClient) ensurePullSecretsForRebase() error {
+	return useMergedPullSecrets(rpmOstreeSystem)
+}
+
+// DownloadOSImage fetches the target ostree layers without staging a deployment.
+// This is used to pre-cache OS images before a node enters cordon/drain during upgrades.
+func (r *RpmOstreeClient) DownloadOSImage(imgURL string) error {
+	if err := r.ensurePullSecretsForRebase(); err != nil {
+		return fmt.Errorf("error while ensuring access to pull secrets: %w", err)
+	}
+	klog.Infof("Downloading OS image layers for %s", imgURL)
+	return runRpmOstree("rebase", "--experimental", layeredRegistryRebaseRef(imgURL), "--download-only")
+}
+
+// RebaseFromCache applies a rebase using previously downloaded ostree layers.
+func (r *RpmOstreeClient) RebaseFromCache(imgURL string) error {
+	if err := r.ensurePullSecretsForRebase(); err != nil {
+		return fmt.Errorf("error while ensuring access to pull secrets: %w", err)
+	}
+	klog.Infof("Executing cached rebase to %s", imgURL)
+	return runRpmOstree("rebase", "--experimental", layeredRegistryRebaseRef(imgURL), "--cache-only")
+}
+
 // RebaseLayered rebases system or errors if already rebased.
 func (r *RpmOstreeClient) RebaseLayered(imgURL string) error {
 	// Try to re-link the merged pull secrets if they exist, since it could have been populated without a daemon reboot
-	if err := useMergedPullSecrets(rpmOstreeSystem); err != nil {
+	if err := r.ensurePullSecretsForRebase(); err != nil {
 		return fmt.Errorf("error while ensuring access to pull secrets: %w", err)
 	}
 	klog.Infof("Executing rebase to %s", imgURL)
-	return runRpmOstree("rebase", "--experimental", "ostree-unverified-registry:"+imgURL)
+	return runRpmOstree("rebase", "--experimental", layeredRegistryRebaseRef(imgURL))
 }
 
 // RebaseLayeredFromContainerStorage rebases the system from an existing local container storage image.

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -25,3 +25,8 @@ func TestParseVersion(t *testing.T) {
 	assert.Contains(t, q.Root.Features, "rust")
 	assert.NotContains(t, q.Root.Features, "container")
 }
+
+func TestLayeredRegistryRebaseRef(t *testing.T) {
+	img := "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123"
+	assert.Equal(t, "ostree-unverified-registry:"+img, layeredRegistryRebaseRef(img))
+}

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2935,7 +2935,10 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 		if err := dn.NodeUpdaterClient.RebaseLayeredFromContainerStorage(podmanImageInfo); err != nil {
 			return fmt.Errorf("failed to update OS from local storage: %s: %w", newURL, err)
 		}
+	} else if err := dn.NodeUpdaterClient.RebaseFromCache(newURL); err == nil {
+		klog.Infof("Updated OS to %s from local ostree cache", newURL)
 	} else {
+		klog.V(4).Infof("Cached OS rebase unavailable for %s, pulling from registry: %v", newURL, err)
 		// Report ImagePulledFromRegistry condition as unknown (pulling)
 		if imageModeStatusReportingEnabled {
 			err := upgrademonitor.GenerateAndApplyMachineConfigNodes(


### PR DESCRIPTION
## Summary

Add MCO support to **pre-download and stage target RHCOS (rpm-ostree) OS images on nodes before they enter the cordon/drain/update sequence**. This addresses multi-hop upgrade scenarios (for example 4.18.z → 4.19.z → 4.20.z → 4.21.z → 4.22.z) on slow or bandwidth-constrained links where per-node OS downloads currently add 10–20 minutes of downtime **per hop**, often exceeding maintenance windows.

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-87861

## Problem

Today, when `OSImageURL` changes during a cluster upgrade:

1. MCO cordons and drains the node.
2. Machine Config Daemon (MCD) invokes `rpm-ostree rebase` against the new `rhel-coreos` container image.
3. The ostree layer download happens **while the node is unavailable**.

Container image pre-pull mechanisms (`PinnedImageSet`, DaemonSet pullers, [KCS 7123745](https://access.redhat.com/solutions/7123745)) populate **CRI-O** storage only. They do **not** populate the host ostree repository.

## Justification

### 1. Multi-hop upgrades multiply OS download time per node

When CVO sequences minor-version hops (for example **4.18.z → 4.19.z → 4.20.z → 4.21.z → 4.22.z**), each hop triggers an ostree download during drain (~10–20 min/node/hop on slow links). Four hops can exceed **60–80 minutes per node** while the cluster is upgrading.

### 2. Architectural and 100% reproducible on constrained bandwidth

The ostree fetch is deferred until after cordon/drain. This is deterministic on slow links ([OCPBUGS-87861](https://redhat.atlassian.net/browse/OCPBUGS-87861)).

### 3. Existing pre-pull mechanisms do not help rpm-ostree

| Mechanism | Helps OS rebase? |
|-----------|------------------|
| `PinnedImageSet` / KCS 7123745 | **No** — CRI-O only |
| TALM `PreCachingConfig` | **No** |
| ZTP factory-precaching-cli | **No** — install only |

### 4. rpm-ostree staging primitives exist but MCO did not use them

`--download-only` and `--cache-only` are documented in the [rpm-ostree handbook](https://coreos.github.io/rpm-ostree/administrator-handbook/) but were not wired into MCD.

### 5. Edge / satellite / telco clusters cannot always widen links

Pre-caching while nodes remain schedulable moves download time out of the maintenance window.

## Solution (this PR)

| Phase | rpm-ostree | Node impact |
|-------|------------|-------------|
| **Pre-cache** (background) | `rebase <ref> --download-only` | Node stays schedulable |
| **Apply** (during update) | `rebase <ref> --cache-only` | Fast local rebase; fallback to online pull |

### Changes in this PR

- `pkg/daemon/rpm-ostree.go`: `DownloadOSImage`, `RebaseFromCache`
- `pkg/daemon/osimage_precache.go`: background loop watching node `desiredImage` annotation
- `pkg/daemon/update.go`: cache-first rebase in `updateLayeredOS`
- `docs/OSImagePrecaching.md`: operator design and observability

### Follow-up (not in this PR)

- `PinnedOSImageSet` CRD and controller
- CVO multi-hop intermediate image pre-cache
- `MachineConfigNode` status reporting
- Feature gate + user documentation

## Test plan

- [ ] Single-hop upgrade with throttled registry: cordon-to-ready time reduced vs baseline
- [ ] Multi-hop 4.18 → 4.19 → 4.20 → 4.21 → 4.22 on slow link: maintenance window within target
- [ ] MCD logs show `OS image precache completed` before drain
- [ ] Incomplete pre-cache: upgrade still succeeds via online pull fallback
- [ ] Unit test: `TestLayeredRegistryRebaseRef`

## Risk / rollout

- Fail-open: incomplete pre-cache falls back to existing online rebase
- Background downloads only when `desiredImage != booted` and node is not draining

/cc @openshift/team-mco


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OS image pre-caching now automatically downloads and stages OS image layers during normal cluster operation to accelerate subsequent cluster upgrades.
* **Documentation**
  * Added documentation describing OS image pre-caching behavior and upgrade workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->