### PR TITLE
AGENT-1517: move helpers in iri e2e main test

### DIFF
--- a/test/e2e-iri/iri_test.go
+++ b/test/e2e-iri/iri_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -22,7 +21,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -299,31 +297,6 @@ func TestIRIController_VerifyIRIRegistryOnAllTheMasterNodes_NoCert(t *testing.T)
 			Timeout: 30 * time.Second,
 		}
 		pingIRIRegistry(t, client, nodeAddr)
-	}
-}
-
-func skipIfNoBaremetal(t *testing.T) {
-	infra, err := framework.NewClientSet("").Infrastructures().Get(context.Background(), "cluster", v1.GetOptions{})
-	require.NoError(t, err)
-	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
-		t.Skip("Skipping non-baremetal platforms")
-	}
-}
-
-// Currently some tests are not supported in the OpenShift CI
-// environment (due the proxy settings)
-func skipIfOpenShiftCI(t *testing.T) {
-	items := []string{
-		// Specific to OpenShift CI.
-		"OPENSHIFT_CI",
-		// Common to all CI systems.
-		"CI",
-	}
-
-	for _, item := range items {
-		if _, ok := os.LookupEnv(item); ok {
-			t.Skip("Skipping OpenShift CI environment")
-		}
 	}
 }
 

--- a/test/e2e-iri/main_test.go
+++ b/test/e2e-iri/main_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/openshift/api/features"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-config-operator/test/framework"
 )
 
@@ -41,4 +43,29 @@ func skipIRITests() (bool, error) {
 	}
 
 	return false, nil
+}
+
+func skipIfNoBaremetal(t *testing.T) {
+	infra, err := framework.NewClientSet("").Infrastructures().Get(context.Background(), "cluster", v1.GetOptions{})
+	require.NoError(t, err)
+	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
+		t.Skip("Skipping non-baremetal platforms")
+	}
+}
+
+// Currently some tests are not supported in the OpenShift CI
+// environment (due the proxy settings)
+func skipIfOpenShiftCI(t *testing.T) {
+	items := []string{
+		// Specific to OpenShift CI.
+		"OPENSHIFT_CI",
+		// Common to all CI systems.
+		"CI",
+	}
+
+	for _, item := range items {
+		if _, ok := os.LookupEnv(item); ok {
+			t.Skip("Skipping OpenShift CI environment")
+		}
+	}
 }


### PR DESCRIPTION
**- What I did**
Moved test helpers in a common place to allow running both IRI standard and deletion tests.

Required by https://github.com/openshift/release/pull/79305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added e2e test gating to skip IRI tests on non-bare-metal clusters and when running in CI environments.

* **Refactor**
  * Reorganized and consolidated test helpers across files for clearer test structure and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->