### PR TITLE
OCPBUGS-87905: Process rebuild annotation on machine-os-builder restart

### DIFF
--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -159,6 +159,13 @@ func (b *buildReconciler) rebuildMachineOSConfig(ctx context.Context, mosc *mcfg
 // Runs whenever a new MachineOSConfig is added. Determines if a new
 // MachineOSBuild should be created and then creates it, if needed.
 func (b *buildReconciler) addMachineOSConfig(ctx context.Context, mosc *mcfgv1.MachineOSConfig) error {
+	// If the rebuild annotation is present (e.g., pod restarted while a rebuild
+	// was pending), process it now instead of falling through to the normal sync
+	// path which would see the existing MOSB and return early.
+	if hasRebuildAnnotation(mosc) {
+		return b.rebuildMachineOSConfig(ctx, mosc)
+	}
+
 	// Check for pre-built image seeding annotation - only seed if not already seeded
 	if preBuiltImage, hasImage := getPreBuiltImage(mosc); hasImage {
 		if shouldSeedWithPreBuiltImage(mosc) {

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -508,7 +508,7 @@ func RebuildImageAndCheck(mosc *MachineOSConfig) {
 	logger.Infof("OK!\n")
 
 	exutil.By("Check that the existing MOSB is reused and it builds a new image")
-	o.Eventually(mosb.GetJob, "2m", "20s").Should(Exist(), "Rebuild job was not created")
+	o.Eventually(mosb.GetJob, "5m", "20s").Should(Exist(), "Rebuild job was not created")
 	o.Eventually(mosb, "20m", "20s").Should(HaveConditionField("Building", "status", FalseString), "Rebuild was not finished")
 	o.Eventually(mosb, "10m", "20s").Should(HaveConditionField("Succeeded", "status", TrueString), "Rebuild didn't succeed")
 	o.Eventually(mosb, "2m", "20s").Should(HaveConditionField("Interrupted", "status", FalseString), "Reuild was interrupted")


### PR DESCRIPTION
Closes: OCPBUGS-87905

**- What I did**
This adds a check in the main function to determine if a MachineOSBuild should be created to see if the MachineOSConfig has the rebuild annotation. In cases where we reach this function and the MOSC already has a rebuild annotation, it signals that something like a pod restart interrupted the MOSC build and so the MOSC should be rebuilt. This is especially important for SNO cases due to how pod restarts happen in the platform.

**- How to verify it**
The issue this remediates was highlighted in the SNO test suites and it seems this issue is somewhat unique to SNO due to the way pods are restarted. Thus, the `[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive] MCO ocb [PolarionID:77781][OTP] A successfully built MachineOSConfig can be re-build` should continue passing in all platforms and start passing in the SNO suite.

**- Description for the changelog**
OCPBUGS-87905: Process rebuild annotation on machine-os-builder restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rebuild annotation is now processed with immediate priority, ensuring rebuilds are triggered before normal seeding/sync paths.

* **Tests**
  * Rebuild verification timeout increased (2m → 5m) to reduce flakiness when confirming reuse and new image build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->