### PR TITLE
OCPBUGS-61583: Update custom containerfile OCB test to work in a disconnected environment

### DIFF
--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -110,8 +110,27 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	g.It("[PolarionID:83140][OTP] A MachineOSConfig with custom containerfile definition can be successfully applied", func() {
 		var (
-			mcp = GetCompactCompatiblePool(oc.AsAdmin())
+			mcp                  = GetCompactCompatiblePool(oc.AsAdmin())
+			containerFileContent string
+			checkers             []Checker
+		)
 
+		if IsDisconnectedCluster(oc.AsAdmin()) {
+			logger.Infof("Disconnected cluster detected, using containerfile that does not require network access")
+			containerFileContent = `
+        FROM configs AS final
+        RUN echo "disconnected-containerfile-test" > /etc/disconnected-containerfile-test && \
+            ostree container commit
+`
+			checkers = []Checker{
+				CommandOutputChecker{
+					Command:  []string{"cat", "/etc/disconnected-containerfile-test"},
+					Matcher:  o.ContainSubstring("disconnected-containerfile-test"),
+					ErrorMsg: fmt.Sprintf("Test file was not created by the custom containerfile"),
+					Desc:     fmt.Sprintf("Check that the custom containerfile test file exists"),
+				},
+			}
+		} else {
 			containerFileContent = `
 	# Pull the centos base image and enable the EPEL repository.
         FROM quay.io/centos/centos:stream9 AS centos
@@ -133,7 +152,6 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
         RUN sed -i 's/\$stream/9-stream/g' /etc/yum.repos.d/centos*.repo && \
             rpm-ostree install cowsay ripgrep
 `
-
 			checkers = []Checker{
 				CommandOutputChecker{
 					Command:  []string{"cowsay", "-t", "hello"},
@@ -142,7 +160,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 					Desc:     fmt.Sprintf("Check that cowsay is installed and working"),
 				},
 			}
-		)
+		}
 
 		testContainerFile([]ContainerFile{{Content: containerFileContent}}, MachineConfigNamespace, mcp, checkers, false)
 	})

--- a/test/extended-priv/util.go
+++ b/test/extended-priv/util.go
@@ -1521,6 +1521,18 @@ func getMachineConfigOperatorPod(oc *exutil.CLI) (string, error) {
 	return pods[0], nil
 }
 
+// IsDisconnectedCluster returns true if the cluster has no external network
+// access by attempting to reach an external endpoint from a node.
+func IsDisconnectedCluster(oc *exutil.CLI) bool {
+	nodes, err := NewNodeList(oc.AsAdmin()).GetAll()
+	if err != nil || len(nodes) == 0 {
+		return false
+	}
+	output, _ := nodes[0].DebugNodeWithChroot("sh", "-c",
+		"curl -s --connect-timeout 5 https://fedoraproject.org/static/hotspot.txt &>/dev/null && echo Connected || echo Disconnected")
+	return !strings.Contains(output, "Connected")
+}
+
 // WrapWithBracketsIfIpv6 wraps IPv6 addresses with brackets for use in URLs
 func WrapWithBracketsIfIpv6(ip string) (string, error) {
 	parsedIP := net.ParseIP(ip)


### PR DESCRIPTION
Closes: OCPBUGS-61583

**- What I did**
This adds a conditional to allow the containerfile used in the `A MachineOSConfig with custom containerfile definition can be successfully applied` test to be unique on disconnected platforms. This is necessary because our IPV6 platform tests a disconnected cluster environment, and, since the original containerfile requires registry access, the test was getting stuck in the build phase. Updating the container file to not need registry access should allow the test to work in the disconnected environment.

**- How to verify it**
The `A MachineOSConfig with custom containerfile definition can be successfully applied` test should pass on all platforms, especially the IPV6 platform.

**- Description for the changelog**
OCPBUGS-61583: Update custom containerfile OCB test to work in a disconnected environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now detect IPv6-only service networks and automatically switch to a minimal container build and IPv6-specific validation.
  * Conditional build and checker behavior improves reliability across IPv4 and IPv6 clusters, reducing false failures and need for manual configuration.
  * Added a cluster-network detection helper to drive the conditional test flow and make test outcomes more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->