### PR TITLE
OCPBUGS-88315: Automation fix- Add fix for TC 59424

### DIFF
--- a/test/extended-priv/mco_password.go
+++ b/test/extended-priv/mco_password.go
@@ -155,8 +155,6 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 			allMasters     = mMcp.GetNodesOrFail()
 		)
 
-		skipTestIfRHELVersion(allCoreOsNodes[0], "<", "9.0")
-
 		exutil.By("Get currently configured authorizedkeys in the cluster")
 		wMc, err := wMcp.GetConfiguredMachineConfig()
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the current configuration for worker pool")


### PR DESCRIPTION
Add fix for TC 59424 failing with below error in SNO ci job
```
{  fail [runtime/panic.go:115]: Test Panicked}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for RHEL-version gated SSH key checks by changing the node source used to decide skipping, ensuring the correct CoreOS node/pool is consulted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->