### PR TITLE
crio: inject gomaxprocs by default

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    min_injected_gomaxprocs = 1
 
     [crio.runtime.runtimes.runc]
     runtime_root = "/run/runc"

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    min_injected_gomaxprocs = 1
 
     [crio.runtime.runtimes.runc]
     runtime_root = "/run/runc"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -33,6 +33,7 @@ contents:
         "/etc/hostname",
     ]
     drop_infra_ctr = true
+    min_injected_gomaxprocs = 1
 
     [crio.runtime.runtimes.runc]
     runtime_root = "/run/runc"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Go processes run on nodes with many CPUs suffer a problem where the go runtime creates runtime threads per CPUs it can see, assuming there isn't a CPU limit on the process. However, the kubernetes scheduler is binpacking pods based on CPU request, which means go processes actually have access to less CPU time than the go runtime is expecting. This causes scheduling and GC latency.

min_injected_gomaxprocs is a feature in CRI-O that injects the GOMAXPROCS environment variable into all pods based on their CPU request. if the pod has a limit, GOMAXPROCS isn't set. Otherwise, it is set to 2*requested CPUs. The 2* figure was found from perf testing, allowing the go runtime to burst up to capacity, while mitigating the latency.

Turn this on by default.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container runtime configuration to ensure the Go runtime inside containers receives a minimum processor allocation (min injected GOMAXPROCS = 1) across master, worker, and arbiter nodes. This improves concurrency predictability and process parallelism handling within containerized workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->