### PR TITLE
MCO-2344: Revert MCO-2343

### DIFF
--- a/pkg/osimagestream/osimagestream.go
+++ b/pkg/osimagestream/osimagestream.go
@@ -137,12 +137,11 @@ func getDefaultStreamSet(streams []mcfgv1.OSImageStreamSet, createOptions *Creat
 		if len(streams) == 1 {
 			return streams[0].Name, nil
 		}
-		// TODO MCO-2343: Restore as soon as the full GA of the feature finishes
-		// builtinDefault, err := GetBuiltinDefaultStreamName(createOptions.InstallVersion)
-		// if err != nil {
-		//   return "", fmt.Errorf("could not determine the builtin default stream: %w", err)
-		// }
-		requestedDefaultStream = StreamNameRHEL9
+		builtinDefault, err := GetBuiltinDefaultStreamName(createOptions.InstallVersion)
+		if err != nil {
+			return "", fmt.Errorf("could not determine the builtin default stream: %w", err)
+		}
+		requestedDefaultStream = builtinDefault
 	}
 
 	if slices.Contains(streamNames, requestedDefaultStream) {


### PR DESCRIPTION
Depends on: https://github.com/openshift/installer/pull/10533

**- What I did**

This change restores the original OS Image Stream fallback behavior that picked the stream based on the install version and removes the temporal hard-coded rhel-9 one.

**- How to verify it**

E2E are enough.

**- Description for the changelog**

This change restores the original OS Image Stream fallback behavior that picked the stream based on the install version and removes the temporal hard-coded rhel-9 one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS image stream default selection with enhanced error handling for resolution failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->