### PR TITLE
OCPBUGS-88726: Fix streams in imagemode tests

### DIFF
--- a/test/extended-priv/const.go
+++ b/test/extended-priv/const.go
@@ -209,9 +209,6 @@ var (
 	// OSImageStreamRHEL10 represents the RHEL 10 OS image stream
 	OSImageStreamRHEL10 = "rhel-10"
 
-	// DefaultOSImageStream is the default OS image stream name
-	DefaultOSImageStream = OSImageStreamRHEL9
-
 	// SupportedOSImageStreams is the list of supported OS image streams
 	SupportedOSImageStreams = []string{
 		OSImageStreamRHEL9,

--- a/test/extended-priv/mco_metrics.go
+++ b/test/extended-priv/mco_metrics.go
@@ -25,6 +25,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 	})
 
 	g.It("[PolarionID:77356][OTP] Test mcd_local_unsupported_packages metric [Disruptive]", func() {
+		majorVersion := GetOSImageStreamMajorVersion(exutil.OrFail[string](GetEffectiveOsImageStream(mcp)))
+
 		var (
 			node                        = mcp.GetSortedNodesOrFail()[0]
 			query                       = `mcd_local_unsupported_packages{node="` + node.GetName() + `"}`
@@ -32,11 +34,13 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 			valueJSONPath               = `data.result.0.value.1`
 			expectedUnsupportedPackages = "5"
 			deferredReesetNeeded        = true
+			centosStreamRepo            = majorVersion + "-stream"
+			epelRpmName                 = fmt.Sprintf("epel-release-latest-%s.noarch.rpm", majorVersion)
 		)
 
 		exutil.By("Configure coreos stream repo in a node")
 		defer RemoveConfiguredStreamCentosRepo(node)
-		o.Expect(ConfigureStreamCentosRepo(node, "9-stream")).To(o.Succeed(),
+		o.Expect(ConfigureStreamCentosRepo(node, centosStreamRepo)).To(o.Succeed(),
 			"Error configuring the centos repo in %s", node)
 		logger.Infof("OK!\n")
 
@@ -73,10 +77,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 
 		exutil.By("Install package locally")
 		logger.Infof("Dowload package")
-		_, err = node.DebugNodeWithChroot("sh", "-c", useProxyInCommand("curl -kL https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -o /tmp/epel-release-latest-9.noarch.rpm"))
+		epelURL := fmt.Sprintf("https://dl.fedoraproject.org/pub/epel/%s", epelRpmName)
+		_, err = node.DebugNodeWithChroot("sh", "-c", useProxyInCommand(fmt.Sprintf("curl -kL %s -o /tmp/%s", epelURL, epelRpmName)))
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error downloading the epel rpm package")
 		logger.Infof("Install")
-		_, err = node.InstallRpm("/tmp/epel-release-latest-9.noarch.rpm")
+		_, err = node.InstallRpm(fmt.Sprintf("/tmp/%s", epelRpmName))
 		o.Expect(err).NotTo(o.HaveOccurred(),
 			"Error installing %s package in %s", "epel-release", node)
 		logger.Infof("OK!\n")

--- a/test/extended-priv/mco_ocb.go
+++ b/test/extended-priv/mco_ocb.go
@@ -131,27 +131,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 				},
 			}
 		} else {
-			containerFileContent = `
-	# Pull the centos base image and enable the EPEL repository.
-        FROM quay.io/centos/centos:stream9 AS centos
-        RUN dnf install -y epel-release
-
-        # Pull an image containing the yq utility.
-        FROM quay.io/multi-arch/yq:4.25.3 AS yq
-
-        # Build the final OS image for this MachineConfigPool.
-        FROM configs AS final
-
-        # Copy the EPEL configs into the final image.
-        COPY --from=yq /usr/bin/yq /usr/bin/yq
-        COPY --from=centos /etc/yum.repos.d /etc/yum.repos.d
-        COPY --from=centos /etc/pki/rpm-gpg/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
-
-        # Install cowsay and ripgrep from the EPEL repository into the final image,
-        # along with a custom cow file.
-        RUN sed -i 's/\$stream/9-stream/g' /etc/yum.repos.d/centos*.repo && \
-            rpm-ostree install cowsay ripgrep
-`
+			containerFileContent = getConnectedCustomContainerFileContent(mcp)
 			checkers = []Checker{
 				CommandOutputChecker{
 					Command:  []string{"cowsay", "-t", "hello"},
@@ -509,6 +489,40 @@ func checkMisconfiguredMOSC(oc *exutil.CLI, moscAndMcpName, baseImagePullSecret,
 	o.Eventually(machineConfigCO, "5m", "20s").ShouldNot(BeDegraded(),
 		"%s should stop being degraded when the offending MOSC is deleted", machineConfigCO)
 
+}
+
+// getConnectedCustomContainerFileContent returns a containerfile content that installs cowsay and ripgrep
+// using the CentOS stream repos matching the MCP's effective OS image stream (e.g. rhel-9 -> stream9, rhel-10 -> stream10).
+// This containerfile requires network access and should not be used in disconnected environments.
+func getConnectedCustomContainerFileContent(mcp *MachineConfigPool) string {
+	stream, err := GetEffectiveOsImageStream(mcp)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting effective osImageStream from %s", mcp)
+	logger.Infof("Generating custom containerfile for stream '%s'", stream)
+
+	majorVersion := GetOSImageStreamMajorVersion(stream)
+
+	return fmt.Sprintf(`
+        # Pull the centos base image and enable the EPEL repository.
+        FROM quay.io/centos/centos:stream%s AS centos
+        RUN dnf install -y epel-release
+
+        # Pull an image containing the yq utility.
+        FROM quay.io/multi-arch/yq:4.25.3 AS yq
+
+        # Build the final OS image for this MachineConfigPool.
+        FROM configs AS final
+
+        # Copy the EPEL configs into the final image.
+        COPY --from=yq /usr/bin/yq /usr/bin/yq
+        COPY --from=centos /etc/yum.repos.d /etc/yum.repos.d
+        COPY --from=centos /etc/pki/rpm-gpg/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
+
+        # Install cowsay and ripgrep from the EPEL repository into the final image.
+        # The ncurses override handles package incompatibilities across streams.
+        RUN sed -i 's/\$stream/%s-stream/g' /etc/yum.repos.d/centos*.repo && \
+            rpm-ostree override replace --experimental --from repo=baseos ncurses ncurses-libs ncurses-base || true && \
+            rpm-ostree install cowsay ripgrep
+`, majorVersion, majorVersion)
 }
 
 // RebuildImageAndCheck rebuild the latest image of the MachineOSConfig resource and checks that it is properly built and applied

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -2,6 +2,7 @@ package extended
 
 import (
 	"fmt"
+	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -302,6 +303,11 @@ func GetDefaultOSImageStream(oc *exutil.CLI) string {
 		return OSImageStreamRHEL9
 	}
 	return OSImageStreamRHEL10
+}
+
+// GetOSImageStreamMajorVersion extracts the major version from a stream name (e.g. "rhel-9" -> "9", "rhel-10" -> "10").
+func GetOSImageStreamMajorVersion(stream string) string {
+	return strings.TrimPrefix(stream, "rhel-")
 }
 
 // SkipIfDefaultOSImageStream skips the test if the cluster's default OS image stream matches the given stream.

--- a/test/extended-priv/mco_osimagestream.go
+++ b/test/extended-priv/mco_osimagestream.go
@@ -37,14 +37,15 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 			emptyStreamName      = ""
 			expectedInvalidError = "The specified osImageStream name must reference a valid stream from the cluster OSImageStream resource"
 			expectedEmptyError   = "spec.osImageStream.name in body should be at least 1 chars long"
+			defaultStream        = GetDefaultOSImageStream(oc.AsAdmin())
 		)
 
 		defer mcp.SetSpec(mcp.GetSpecOrFail())
 
 		exutil.By("Validate OSImageStream resource contains expected streams")
-		o.Eventually(osis.GetDefaultStream, "2m", "20s").Should(o.Equal(DefaultOSImageStream),
-			"Expected default stream to be '%s'", DefaultOSImageStream)
-		logger.Infof("Default stream is correctly set to '%s'", DefaultOSImageStream)
+		o.Eventually(osis.GetDefaultStream, "2m", "20s").Should(o.Equal(defaultStream),
+			"Expected default stream to be '%s'", defaultStream)
+		logger.Infof("Default stream is correctly set to '%s'", defaultStream)
 
 		o.Eventually(osis.GetAvailableStreamNames, "2m", "20s").Should(o.ConsistOf(SupportedOSImageStreams),
 			"Available streams should match supported streams %v", SupportedOSImageStreams)
@@ -115,8 +116,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("OK!\n")
 	})
 
-	// AI-assisted: Test case to validate real-time kernel configuration across OS image streams
+	// AI-assisted: Test case to validate real-time kernel configuration across OS image streams (rhel9 -> rhel10)
 	g.It("[PolarionID:87095][OTP] Realtime kernel from rhel9 stream to rhel10 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+		SkipIfDefaultOSImageStream(oc.AsAdmin(), OSImageStreamRHEL10)
 		architecture.SkipIfNoNodeWithArchitectures(oc.AsAdmin(), architecture.AMD64)
 
 		testID := GetCurrentTestPolarionIDNumber()
@@ -127,8 +129,22 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		testKernelTypeAcrossOSImageStreams(oc, osis, mcp, testID, KernelTypeRealtime, "set-realtime-kernel.yaml", OSImageStreamRHEL9, OSImageStreamRHEL10)
 	})
 
-	// AI-assisted: Test case to validate 64k-pages kernel configuration across OS image streams
+	// AI-assisted: Test case to validate real-time kernel configuration across OS image streams (rhel10 -> rhel9)
+	g.It("[PolarionID:89322][OTP] Realtime kernel from rhel10 stream to rhel9 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+		SkipIfDefaultOSImageStream(oc.AsAdmin(), OSImageStreamRHEL9)
+		architecture.SkipIfNoNodeWithArchitectures(oc.AsAdmin(), architecture.AMD64)
+
+		testID := GetCurrentTestPolarionIDNumber()
+		createdCustomPoolName := fmt.Sprintf("tc-%s-%s", testID, architecture.AMD64)
+		defer DeleteCustomMCP(oc.AsAdmin(), createdCustomPoolName)
+
+		mcp, _ := GetPoolAndNodesForArchitectureOrFail(oc.AsAdmin(), createdCustomPoolName, architecture.AMD64, 1)
+		testKernelTypeAcrossOSImageStreams(oc, osis, mcp, testID, KernelTypeRealtime, "set-realtime-kernel.yaml", OSImageStreamRHEL10, OSImageStreamRHEL9)
+	})
+
+	// AI-assisted: Test case to validate 64k-pages kernel configuration across OS image streams (rhel9 -> rhel10)
 	g.It("[PolarionID:87096][OTP] 64k pages kernel from rhel9 stream to rhel10 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", g.Label("NoPlatform:gce"), func() {
+		SkipIfDefaultOSImageStream(oc.AsAdmin(), OSImageStreamRHEL10)
 		architecture.SkipIfNoNodeWithArchitectures(oc.AsAdmin(), architecture.ARM64)
 		skipTestIfNotSupportedPlatform(oc.AsAdmin(), GCPPlatform)
 
@@ -140,9 +156,30 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		testKernelTypeAcrossOSImageStreams(oc, osis, mcp, testID, KernelType64kPages, "set-64k-pages-kernel.yaml", OSImageStreamRHEL9, OSImageStreamRHEL10)
 	})
 
-	// AI-assisted: Test case to validate extensions configuration survives osImageStream changes
-	g.It("[PolarionID:87097][OTP] Extensions from rhel9 stream to rhel10 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+	// AI-assisted: Test case to validate 64k-pages kernel configuration across OS image streams (rhel10 -> rhel9)
+	g.It("[PolarionID:89323][OTP] 64k pages kernel from rhel10 stream to rhel9 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", g.Label("NoPlatform:gce"), func() {
+		SkipIfDefaultOSImageStream(oc.AsAdmin(), OSImageStreamRHEL9)
+		architecture.SkipIfNoNodeWithArchitectures(oc.AsAdmin(), architecture.ARM64)
+		skipTestIfNotSupportedPlatform(oc.AsAdmin(), GCPPlatform)
+
+		testID := GetCurrentTestPolarionIDNumber()
+		createdCustomPoolName := fmt.Sprintf("tc-%s-%s", testID, architecture.ARM64)
+		defer DeleteCustomMCP(oc.AsAdmin(), createdCustomPoolName)
+
+		mcp, _ := GetPoolAndNodesForArchitectureOrFail(oc.AsAdmin(), createdCustomPoolName, architecture.ARM64, 1)
+		testKernelTypeAcrossOSImageStreams(oc, osis, mcp, testID, KernelType64kPages, "set-64k-pages-kernel.yaml", OSImageStreamRHEL10, OSImageStreamRHEL9)
+	})
+
+	// AI-assisted: Test case to validate extensions configuration survives osImageStream changes (rhel9 -> rhel10)
+	g.It("[PolarionID:87259][OTP] Extensions from rhel9 stream to rhel10 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+		SkipIfDefaultOSImageStream(oc.AsAdmin(), OSImageStreamRHEL10)
 		testExtensionsAcrossOSImageStreams(oc, osis, OSImageStreamRHEL9, OSImageStreamRHEL10)
+	})
+
+	// AI-assisted: Test case to validate extensions configuration survives osImageStream changes (rhel10 -> rhel9)
+	g.It("[PolarionID:89324][OTP] Extensions from rhel10 stream to rhel9 stream [Disruptive] [apigroup:machineconfiguration.openshift.io]", func() {
+		SkipIfDefaultOSImageStream(oc.AsAdmin(), OSImageStreamRHEL9)
+		testExtensionsAcrossOSImageStreams(oc, osis, OSImageStreamRHEL10, OSImageStreamRHEL9)
 	})
 
 	g.It("[PolarionID:88366][Skipped:Disconnected] osImageStream should be empty when osImageURL is set [apigroup:machineconfiguration.openshift.io]", func() {
@@ -255,13 +292,36 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	})
 })
 
+// GetDefaultOSImageStream returns the default OS image stream based on the cluster version.
+// OCP 4.x clusters default to "rhel-9", OCP 5+ default to "rhel-10".
+func GetDefaultOSImageStream(oc *exutil.CLI) string {
+	clusterVersion, _, err := exutil.GetClusterVersion(oc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting cluster version")
+
+	if clusterVersion[:1] == "4" {
+		return OSImageStreamRHEL9
+	}
+	return OSImageStreamRHEL10
+}
+
+// SkipIfDefaultOSImageStream skips the test if the cluster's default OS image stream matches the given stream.
+func SkipIfDefaultOSImageStream(oc *exutil.CLI, stream string) {
+	if GetDefaultOSImageStream(oc) == stream {
+		g.Skip(fmt.Sprintf("Skipping test: default OS image stream is '%s'", stream))
+	}
+}
+
 // GetEffectiveOsImageStream returns the effective osImageStream for an MCP
 func GetEffectiveOsImageStream(mcp *MachineConfigPool) (string, error) {
+	var (
+		oc   = mcp.GetOC().AsAdmin()
+		osis = NewOSImageStream(oc)
+	)
 
-	osis := NewOSImageStream(mcp.GetOC().AsAdmin())
 	if !osis.Exists() {
-		logger.Infof("OSImageStream resource does not exist. Likely, no tech preview, by default we use osstream: %s", DefaultOSImageStream)
-		return DefaultOSImageStream, nil
+		defaultStream := GetDefaultOSImageStream(oc)
+		logger.Infof("OSImageStream resource does not exist. Likely, no tech preview, by default we use osstream: %s", defaultStream)
+		return defaultStream, nil
 	}
 
 	streamName, err := mcp.GetOsImageStream()


### PR DESCRIPTION

**- What I did**
I made tests  take into account the osImageStream to select the centos stream when they use it create a containerfile

**- How to verify it**

Modified tests should pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OS image stream test coverage to dynamically support both RHEL 9 and RHEL 10 configurations.
  * Expanded test variants for improved stream compatibility testing and upgrade scenarios.
  * Improved test intelligence to adapt based on cluster's default OS image stream.

* **Chores**
  * Removed deprecated default OS image stream constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->