### PR TITLE
[release:4.21] OCPBUGS-89234: In OCB to check when a image is removed the old build is triggered again and the MC should start updating directly and no new MOSB should be triggred

### DIFF
--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -147,7 +147,21 @@ func (j *jobImageBuilder) start(ctx context.Context) (*batchv1.Job, error) {
 	}
 
 	if k8serrors.IsAlreadyExists(err) {
-		return j.getBuildJobStrict(ctx)
+		existingJob, getErr := j.getBuildJobStrict(ctx)
+		if getErr != nil {
+			return nil, getErr
+		}
+
+		klog.Infof("Build job %q already exists for MachineOSBuild %q, reusing", existingJob.Name, mosbName)
+
+		if j.mosb != nil {
+			metav1.SetMetaDataAnnotation(&j.mosb.ObjectMeta, constants.JobUIDAnnotationKey, string(existingJob.UID))
+			if _, updateErr := j.mcfgclient.MachineconfigurationV1().MachineOSBuilds().Update(ctx, j.mosb, metav1.UpdateOptions{}); updateErr != nil && !k8serrors.IsNotFound(updateErr) {
+				return nil, fmt.Errorf("could not update MachineOSBuild %s with job UID annotation: %w", mosbName, updateErr)
+			}
+		}
+
+		return existingJob, nil
 	}
 
 	return nil, fmt.Errorf("could not create build job: %w", err)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1371,6 +1371,12 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 		return err
 	}
 
+	// No action needed if the rendered config has not changed.
+	if oldRendered == newRendered && firstOptIn != "" {
+		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
+		return nil
+	}
+
 	// This is our trigger point
 	if (oldRendered != newRendered && needsImageRebuild) || firstOptIn == "" {
 		klog.Infof("pool %q: rendered config changed and requires an image rebuild. Verifying if a valid build already exists...", mcp.Name)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1362,16 +1362,13 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 	// old pool
 	old := mcp.DeepCopy()
 	old.Spec.Configuration.Name = mcp.Status.Configuration.Name
-	if firstOptIn == "" {
-		return fmt.Errorf("no current build annotation on MachineOSConfig %q", mosc.Name)
-	}
 
 	needsImageRebuild, err := b.reconcileImageRebuild(old, mcp)
 	if err != nil {
 		return err
 	}
 
-	// No action needed if the rendered config has not changed.
+	// No action needed if the rendered config has not changed and we have an annotation
 	if oldRendered == newRendered && firstOptIn != "" {
 		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
 		return nil


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Changes the missingAnnotation to  firstOptIn != "" 
