### PR TITLE
OCPBUGS-89325: fix test 74644 so that it pass in rhel10

### DIFF
--- a/test/extended-priv/mco_machineconfignode.go
+++ b/test/extended-priv/mco_machineconfignode.go
@@ -303,7 +303,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		)
 
 		exutil.By("Check that a machineconfignode cannot be patched from another MCD")
-		cmd := []string{"./rootfs/usr/bin/oc", "patch", "machineconfignodes/" + machineConfigNode1.GetName(), "--type=merge", "-p", patchMCN1}
+		cmd := []string{"chroot", "/rootfs", "oc", "patch", "machineconfignodes/" + machineConfigNode1.GetName(), "--type=merge", "-p", patchMCN1}
 		_, err := exutil.RemoteShContainer(oc.AsAdmin(), MachineConfigNamespace, node0.GetMachineConfigDaemon(), MachineConfigDaemon, cmd...)
 		o.Expect(err).To(o.HaveOccurred(), "It should not be allowed to patch a machineconfignode from a different machineconfigdaemon")
 		o.Expect(err).To(o.BeAssignableToTypeOf(&exutil.ExitError{}), "Unexpected error while patching the machineconfignode resource from another MCD. %s", err)


### PR DESCRIPTION

**- What I did**
Use chroot so that the oc binary uses the right libraries in test 74644

**- How to verify it**
Check that the test is passing in rhel10 and rhel9

**- Description for the changelog**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution reliability for machine configuration node patching validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->