### PR TITLE
OCPBUGS-88333: Fix bootupd workaround in old nodes

### DIFF
--- a/pkg/daemon/bootupd.go
+++ b/pkg/daemon/bootupd.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -45,14 +44,6 @@ type lsblkOutput struct {
 // -v /dev:/dev: bootupd mounts the ESP from host block devices dynamically; without this
 // the container only sees a synthetic devtmpfs with no host-specific nodes.
 func (dn *Daemon) runBootupdViaContainer(imageURL string) error {
-	if !dn.os.IsCoreOSVariant() {
-		return nil
-	}
-	// For now, only attempt bootloader updates on x86_64 and aarch64 as they are the ones
-	// affected by the secure boot issue.
-	if runtime.GOARCH != ctrlcommon.GoArchAMD64 && runtime.GOARCH != ctrlcommon.GoArchARM64 {
-		return nil
-	}
 	logSystem("runBootupdViaContainer: attempting bootloader update")
 
 	systemdPodmanArgs := []string{"--unit", "machine-config-daemon-bootupd", "-p", "EnvironmentFile=-/etc/mco/proxy.env", "--collect", "--wait", "--", "podman"}
@@ -343,61 +334,44 @@ func isSecureBootEnabled() bool {
 	return strings.Contains(string(out), "SecureBoot enabled")
 }
 
-// shimIsSafe returns true if no bootloader update is required: either Secure Boot
-// is not enabled, or the installed shim is at or above 15.8-3.el9_2 (the minimum
-// version with safe signing keys). On non-UEFI arches this always returns true.
-func shimIsSafe() bool {
+// runBootloaderUpdate orchestrates the pre-pivot bootloader update. It first
+// tries a fast node-level bootupctl update on RHEL 9.6+, falling back to the
+// container-based approach (pull + bootupctl from container + manual EFI copy).
+func (dn *Daemon) runBootloaderUpdate(imageURL string) error {
+	if !dn.os.IsCoreOSVariant() {
+		return nil
+	}
+	// For now, only attempt bootloader updates on x86_64 and aarch64 as they are the ones
+	// affected by the secure boot issue.
+	if runtime.GOARCH != ctrlcommon.GoArchAMD64 && runtime.GOARCH != ctrlcommon.GoArchARM64 {
+		return nil
+	}
+
 	if !isSecureBootEnabled() {
-		logSystem("shimIsSafe: Secure Boot not enabled, bootloader update not required")
-		return true
+		logSystem("runBootloaderUpdate: Secure Boot not enabled, bootloader update not required")
+		return nil
 	}
 
-	var pkgName string
-	switch runtime.GOARCH {
-	case ctrlcommon.GoArchAMD64:
-		pkgName = "shim-x64"
-	case ctrlcommon.GoArchARM64:
-		pkgName = "shim-aa64"
-	default:
-		return true
+	// On RHEL 9.6+ (OCP 4.19+), try updating the bootloader directly from the
+	// node. This covers nodes where /usr has been updated but the ESP still
+	// contains old bootloader binaries (e.g. nodes born from 4.15 or older).
+	// Trigger the systemd unit instead of calling the binary directly so that
+	// the update output is captured by the journal and visible via journalctl.
+	major, minor := dn.os.BaseVersionMajor(), dn.os.BaseVersionMinor()
+	if major > 9 || (major == 9 && minor >= 6) {
+		logSystem("runBootloaderUpdate: RHEL 9.6+ detected, attempting node-level bootloader update via bootloader-update.service")
+		var err error
+		// bootloader-update.service sets RemainAfterExit=yes, so --wait would block indefinitely.
+		// Plain "start" is sufficient: systemd waits for the oneshot ExecStart to complete and
+		// returns its exit code.
+		if err = runCmdSync("systemctl", "start", "bootloader-update.service"); err == nil {
+			logSystem("runBootloaderUpdate: node-level bootloader-update.service succeeded")
+			return nil
+		}
+		logSystem("runBootloaderUpdate: bootloader-update.service failed with error: %v, falling back to container-based update", err)
 	}
 
-	out, err := runGetOut("rpm", "-q", "--queryformat", "%{VERSION}-%{RELEASE}", pkgName)
-	if err != nil {
-		// Package not installed or rpm failed — fail open so bootupd runs.
-		logSystem("shimIsSafe: could not query %s, proceeding with bootloader update: %v", pkgName, err)
-		return false
-	}
-
-	installed := strings.TrimSpace(string(out))
-	const safeVersion = "15.8-3.el9_2"
-	cmp, err := rpmVercmp(installed, safeVersion)
-	if err != nil {
-		logSystem("shimIsSafe: could not compare versions, proceeding with bootloader update: %v", err)
-		return false
-	}
-	safe := cmp >= 0
-	if safe {
-		logSystem("shimIsSafe: %s %s >= %s, bootloader update not required", pkgName, installed, safeVersion)
-	} else {
-		logSystem("shimIsSafe: %s %s < %s, bootloader update required", pkgName, installed, safeVersion)
-	}
-	return safe
-}
-
-// rpmVercmp compares two RPM version strings using rpm's built-in Lua vercmp.
-// Returns negative if a < b, 0 if equal, positive if a > b.
-func rpmVercmp(a, b string) (int, error) {
-	luaExpr := "%{lua:print(rpm.vercmp('" + a + "', '" + b + "'))}"
-	out, err := runGetOut("rpm", "--eval", luaExpr)
-	if err != nil {
-		return 0, err
-	}
-	result, err := strconv.Atoi(strings.TrimSpace(string(out)))
-	if err != nil {
-		return 0, fmt.Errorf("unexpected rpm vercmp output %q: %w", string(out), err)
-	}
-	return result, nil
+	return dn.runBootupdViaContainer(imageURL)
 }
 
 // findRAIDESPs returns the ESP partition on every disk that is a member of the

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -537,17 +537,17 @@ func ReexecuteForTargetRoot(target string) error {
 
 		// When container is newer than target, use target-compatible binary
 		switch {
-		case sourceMajor == "10" && targetMajor == "9":
+		case sourceMajor == 10 && targetMajor == 9:
 			sourceBinarySuffix = ".rhel9"
 			klog.Info("container is rhel10, target is rhel9")
-		case sourceMajor == "10" && targetMajor == "8":
+		case sourceMajor == 10 && targetMajor == 8:
 			sourceBinarySuffix = ".rhel8"
 			klog.Info("container is rhel10, target is rhel8")
-		case sourceMajor == "9" && targetMajor == "8":
+		case sourceMajor == 9 && targetMajor == 8:
 			sourceBinarySuffix = ".rhel8"
 			klog.Info("container is rhel9, target is rhel8")
 		default:
-			klog.Infof("using appropriate binary for source=rhel-%s target=rhel-%s", sourceMajor, targetMajor)
+			klog.Infof("using appropriate binary for source=rhel-%d target=rhel-%d", sourceMajor, targetMajor)
 		}
 	} else {
 		klog.Info("assuming we can use container binary chroot() to host")

--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -3,6 +3,7 @@ package osrelease
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ashcrow/osrelease"
@@ -85,8 +86,28 @@ func (os OperatingSystem) BaseVersion() string {
 
 // BaseVersionMajor returns the first number in a `.` separated BaseVersion.
 // For example with VERSION_ID=9.2, this will return 9.
-func (os OperatingSystem) BaseVersionMajor() string {
-	return strings.Split(os.BaseVersion(), ".")[0]
+// Returns -1 if the version cannot be parsed.
+func (os OperatingSystem) BaseVersionMajor() int {
+	major, err := strconv.Atoi(strings.Split(os.BaseVersion(), ".")[0])
+	if err != nil {
+		return -1
+	}
+	return major
+}
+
+// BaseVersionMinor returns the second number in a `.` separated BaseVersion.
+// For example with VERSION_ID=9.6, this will return 6.
+// Returns -1 if there is no minor component or it cannot be parsed.
+func (os OperatingSystem) BaseVersionMinor() int {
+	parts := strings.SplitN(os.BaseVersion(), ".", 2)
+	if len(parts) < 2 {
+		return -1
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return -1
+	}
+	return minor
 }
 
 // IsEL is true if the OS is an Enterprise Linux variant of CoreOS

--- a/pkg/daemon/osrelease/osrelease_test.go
+++ b/pkg/daemon/osrelease/osrelease_test.go
@@ -167,6 +167,8 @@ OPENSHIFT_VERSION="4.20"`
 		IsCoreOSVariant        bool
 		IsLikeTraditionalRHEL7 bool
 		ToPrometheusLabel      string
+		BaseVersionMajor       int
+		BaseVersionMinor       int
 	}{
 		{
 			Name:                   "RHCOS 8.6",
@@ -179,6 +181,8 @@ OPENSHIFT_VERSION="4.20"`
 			IsCoreOSVariant:        true,
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "RHCOS",
+			BaseVersionMajor:       8,
+			BaseVersionMinor:       6,
 		},
 		{
 			Name:                   "RHCOS 9.0",
@@ -190,6 +194,8 @@ OPENSHIFT_VERSION="4.20"`
 			IsCoreOSVariant:        true,
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "RHCOS",
+			BaseVersionMajor:       9,
+			BaseVersionMinor:       0,
 		},
 		{
 			Name:                   "RHCOS 10.1",
@@ -202,6 +208,8 @@ OPENSHIFT_VERSION="4.20"`
 			IsCoreOSVariant:        true,
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "RHEL",
+			BaseVersionMajor:       10,
+			BaseVersionMinor:       1,
 		},
 		{
 			Name:                   "Fedora 37 Server",
@@ -214,6 +222,8 @@ OPENSHIFT_VERSION="4.20"`
 			IsCoreOSVariant:        false,
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "FEDORA",
+			BaseVersionMajor:       37,
+			BaseVersionMinor:       -1,
 		},
 		{
 			Name:                   "SCOS",
@@ -226,6 +236,8 @@ OPENSHIFT_VERSION="4.20"`
 			IsCoreOSVariant:        true,
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "SCOS",
+			BaseVersionMajor:       9,
+			BaseVersionMinor:       -1,
 		},
 		{
 			Name:                   "FCOS",
@@ -238,6 +250,8 @@ OPENSHIFT_VERSION="4.20"`
 			IsCoreOSVariant:        true,
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "FEDORA",
+			BaseVersionMajor:       37,
+			BaseVersionMinor:       -1,
 		},
 	}
 
@@ -256,6 +270,8 @@ OPENSHIFT_VERSION="4.20"`
 			assert.Equal(t, testCase.IsSCOS, os.IsSCOS(), "expected IsSCOS() to be %v", testCase.IsSCOS)
 			assert.Equal(t, testCase.IsLikeTraditionalRHEL7, os.IsLikeTraditionalRHEL7(), "expected IsLikeTraditionalRHEL7() to be %v", testCase.IsLikeTraditionalRHEL7)
 			assert.Equal(t, testCase.ToPrometheusLabel, os.ToPrometheusLabel(), "expected ToPrometheusLabel() to be %s, got %s", testCase.ToPrometheusLabel, os.ToPrometheusLabel())
+			assert.Equal(t, testCase.BaseVersionMajor, os.BaseVersionMajor(), "expected BaseVersionMajor() to be %d", testCase.BaseVersionMajor)
+			assert.Equal(t, testCase.BaseVersionMinor, os.BaseVersionMinor(), "expected BaseVersionMinor() to be %d", testCase.BaseVersionMinor)
 		})
 	}
 }

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2896,10 +2896,8 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	newURL := config.Spec.OSImageURL
 	klog.Infof("Updating OS to layered image %q", newURL)
 
-	if !shimIsSafe() {
-		if err := dn.runBootupdViaContainer(newURL); err != nil {
-			klog.Warningf("bootloader update failed: %s", err)
-		}
+	if err := dn.runBootloaderUpdate(newURL); err != nil {
+		klog.Warningf("bootloader update failed: %s", err)
 	}
 
 	newEnough, err := dn.NodeUpdaterClient.IsNewEnoughForLayering()


### PR DESCRIPTION
Closes: [#OCPBUGS-88333](https://redhat.atlassian.net/browse/OCPBUGS-88333)

**- What I did**

The shim version check (shimIsSafe) looked at the RPM database in /usr, which reflects the system image. For nodes born from older releases, the shim in /usr is up to date but the ESP still contains old bootloader binaries, causing the workaround to be incorrectly skipped.

Replace the shim version check with a node-level bootupctl update on RHEL 9.6+ before falling back to the container-based approach.

**- How to verify it**

1. Setup a Secure Boot enabled 4.15 cluster and update it to 4.20 or setup a 4.20 cluster and manually rollback the shim & GRUB binaries in the ESP to the ones from 4.15 or earlier.
2. Trigger the update to 4.22

**- Description for the changelog**

Fix bootloader update being skipped on nodes with stale bootloader binaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bootloader updates now use smarter decision logic based on CoreOS variant, supported CPU architecture, and Secure Boot status.
  * For RHEL 9.6+, the updater attempts a node-level update first, then falls back to the container-based approach (and ultimately to a direct EFI copy if needed).

* **Bug Fixes**
  * Improved OS major-version handling when selecting the appropriate update binary.
  * Enhanced OS version parsing by providing numeric major/minor components.

* **Tests**
  * Expanded OS release parsing tests to validate major/minor extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->