### PR TITLE
OCPBUGS-59958: move cleanUpDuplicatedMC to avoid double reboot on first updated Master node

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -72,10 +72,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
-	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
-		return err
-	}
-
 	// Fetch the controllerconfig
 	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
 	if err != nil {
@@ -161,6 +157,9 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		}
 		klog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
 		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync NodeConfig", pool.Name)
+	}
+	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
+		return err
 	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -73,6 +73,7 @@ func TestNodeConfigDefault(t *testing.T) {
 			f.expectGetMachineConfigAction(mcsDeprecated)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectCreateMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcs)
 			f.runNode(getKeyFromConfigNode(nodeConfig, t))
 		})
 	}


### PR DESCRIPTION
Closes [OCPBUGS-59958](https://redhat.atlassian.net/browse/OCPBUGS-59958)

### What I did

Moved `cleanUpDuplicatedMC` to after the loop that creates/updates MachineConfigs.

### How to verify it

1. Deploy a stock cluster (without this fix)
2. Apply a `KubeletConfig` with `autoSizingReserved: true` targeting the master pool and wait for the pool to reach `UPDATED: True`
3. Corrupt the `GeneratedByControllerVersionAnnotationKey` annotation on `97-master-generated-kubelet` with an arbitrary value to simulate the pre-upgrade state, then restart the
`machine-config-controller` pod
4. **Without the fix:** `DELETED` followed by `ADDED` events appear on `97-master-generated-kubelet`, and a new `rendered-master-*` is created
5. Apply the MCC image containing this fix and repeat steps 3–4
6. **With the fix:** only `MODIFIED` events appear on `97-master-generated-kubelet`, with no new `rendered-master-*`

**Note:** corrupting the annotation manually is necessary to simulate the version mismatch that occurs naturally during an MCO upgrade, when the new MCC binary carries a different `GeneratedByControllerVersionAnnotationKey` value than the one stored in the existing MC annotation.

  ### Description for the changelog

Running the loop first guarantees that all existing MCs have their `GeneratedByControllerVersionAnnotationKey` annotation updated before `cleanUpDuplicatedMC` runs, preventing it from wrongly removing them.

`cleanUpDuplicatedMC` will only act on MCs not associated with any existing MachineConfigPool.

`cleanUpDuplicatedMC`'s git history shows that its [original position](https://github.com/openshift/machine-config-operator/commit/459993144) was after the create/update MCs loop and was [moved](https://github.com/openshift/machine-config-operator/commit/3e98b0937) to avoid a corner case related to an early exit when no cgroup v2 was present. Then, after [defaulting cgroups](https://github.com/openshift/machine-config-operator/commit/ce5f22e54), that corner case was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kubelet configuration reconciliation by adjusting when duplicate machine configuration cleanup occurs, resulting in more predictable kubelet configuration updates across cluster pools.
* **Tests**
  * Updated node configuration tests to reflect the updated machine configuration fetch behavior during reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->