### PR TITLE
OCPBUGS-90502: Run nmstatectl format in nmstate-configuration

### DIFF
--- a/templates/common/_base/files/nmstate-configuration.yaml
+++ b/templates/common/_base/files/nmstate-configuration.yaml
@@ -43,3 +43,6 @@ contents:
 
     cp "$src_path/$config_file" /etc/nmstate
     cp "$src_path/$config_file" "$src_path/applied"
+
+    # Write a formatted copy of nmpolicy configurations for easier adoption on day 2
+    nmstatectl format "$src_path/$config_file" > "$src_path/formatted"

--- a/templates/common/_base/files/nmstate-configuration.yaml
+++ b/templates/common/_base/files/nmstate-configuration.yaml
@@ -44,5 +44,5 @@ contents:
     cp "$src_path/$config_file" /etc/nmstate
     cp "$src_path/$config_file" "$src_path/applied"
 
-    # Write a formatted copy of nmpolicy configurations for easier adoption on day 2
+    # Process nmpolicy configs into static configs for easier adoption on day 2
     nmstatectl format "$src_path/$config_file" > "$src_path/formatted"


### PR DESCRIPTION
Previously it was very difficult to adopt a day 1 config using nmpolicy constructs into the day 2 operator to allow changes after deployment. This is because nmpolicies rely on having a specific start state for the system, and once the config has been applied that state no longer exists. The operator handles this by saving the start state internally, but since the operator isn't present on day one we need a different approach there.

Running the nmstatectl format command allows us to save off a fully formatted version of the nmpolicy config that can be applied on day 2 with no more changes than any other day 1 NMState config. This makes modifications on day 2 substantially easier.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Network configuration files are now automatically formatted after initial setup for improved consistency and easier post-installation operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->