### PR TITLE
OCPBUGS-91746: temporarily remove sandboxed-containers from extensions test

### DIFF
--- a/test/e2e-2of2/extension_test.go
+++ b/test/e2e-2of2/extension_test.go
@@ -55,7 +55,7 @@ func TestExtensions(t *testing.T) {
 			Config: runtime.RawExtension{
 				Raw: helpers.MarshalOrDie(ctrlcommon.NewIgnConfig()),
 			},
-			Extensions: []string{"two-node-ha", "ipsec", "usbguard", "kerberos", "kernel-devel", "sandboxed-containers", "sysstat"},
+			Extensions: []string{"two-node-ha", "ipsec", "usbguard", "kerberos", "kernel-devel", "sysstat"},
 		},
 	}
 
@@ -84,8 +84,8 @@ func TestExtensions(t *testing.T) {
 		// "kerberos" extension is not available on OKD
 		expectedPackages = []string{"libreswan", "usbguard", "kernel-devel"}
 	} else {
-		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat")
-		expectedPackages = []string{"pacemaker", "pcs", "fence-agents-all", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5", "sysstat"}
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-q", "pacemaker", "pcs", "fence-agents-all", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat")
+		expectedPackages = []string{"pacemaker", "pcs", "fence-agents-all", "libreswan", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5", "sysstat"}
 
 	}
 	for _, v := range expectedPackages {
@@ -119,7 +119,7 @@ func TestExtensions(t *testing.T) {
 		// "sandboxed-containers" extension is not available on OKD
 		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel")
 	} else {
-		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers", "kata-containers", "krb5-workstation", "libkadm5")
+		installedPackages = helpers.ExecCmdOnNode(t, cs, infraNode, "chroot", "/rootfs", "rpm", "-qa", "usbguard", "kernel-devel", "kernel-headers", "krb5-workstation", "libkadm5")
 	}
 	for _, v := range expectedPackages {
 		if strings.Contains(installedPackages, v) {


### PR DESCRIPTION
**- What I did**

RHEL10 does not (yet) have sandboxed-containers built for it. Consequently, this causes our E2E tests to fail. This commit should be reverted once <https://redhat.atlassian.net/browse/KATA-4726> and/or <https://redhat.atlassian.net/browse/OCPBUGS-90618> is resolved.

**- How to verify it**

Run the e2e-gcp-op-2of2, specifically the TestExtensions test against an OCP cluster running RHEL10. The test should pass.

**- Description for the changelog**
Fix E2E extensions test until sandboxed-containers is ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test suite to adjust extension and package expectations for non-OKD clusters.

---

**Note:** This release contains no user-visible changes; updates are internal to the test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->