### PR TITLE
[release-4.20] OCPBUGS-90969: Process rebuild annotation on machine-os-builder restart

### DIFF
--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -159,6 +159,13 @@ func (b *buildReconciler) rebuildMachineOSConfig(ctx context.Context, mosc *mcfg
 // Runs whenever a new MachineOSConfig is added. Determines if a new
 // MachineOSBuild should be created and then creates it, if needed.
 func (b *buildReconciler) addMachineOSConfig(ctx context.Context, mosc *mcfgv1.MachineOSConfig) error {
+	// If the rebuild annotation is present (e.g., pod restarted while a rebuild
+	// was pending), process it now instead of falling through to the normal sync
+	// path which would see the existing MOSB and return early.
+	if hasRebuildAnnotation(mosc) {
+		return b.rebuildMachineOSConfig(ctx, mosc)
+	}
+
 	return b.syncMachineOSConfig(ctx, mosc)
 }
 

--- a/test/extended/mco_ocb.go
+++ b/test/extended/mco_ocb.go
@@ -506,7 +506,7 @@ func RebuildImageAndCheck(mosc *MachineOSConfig) {
 	logger.Infof("OK!\n")
 
 	exutil.By("Check that the existing MOSB is reused and it builds a new image")
-	o.Eventually(mosb.GetJob, "2m", "20s").Should(Exist(), "Rebuild job was not created")
+	o.Eventually(mosb.GetJob, "5m", "20s").Should(Exist(), "Rebuild job was not created")
 	o.Eventually(mosb, "20m", "20s").Should(HaveConditionField("Building", "status", FalseString), "Rebuild was not finished")
 	o.Eventually(mosb, "10m", "20s").Should(HaveConditionField("Succeeded", "status", TrueString), "Rebuild didn't succeed")
 	o.Eventually(mosb, "2m", "20s").Should(HaveConditionField("Interrupted", "status", FalseString), "Reuild was interrupted")


### PR DESCRIPTION
Closes: OCPBUGS-90969

**- What I did**
This is a manual cherrypick of https://github.com/openshift/machine-config-operator/pull/6197.

**- How to verify it**
See the verification details in https://github.com/openshift/machine-config-operator/pull/6160.

**- Description for the changelog**
OCPBUGS-90969: Process rebuild annotation on machine-os-builder restart