### PR TITLE
kubelet-config: register MCP informer to trigger reconciliation on pool changes

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -371,11 +371,15 @@ func (ctrl *Controller) requeueKubeletConfigsForPool() {
 	features, err := ctrl.featLister.Get(ctrlcommon.ClusterFeatureInstanceName)
 	if err == nil {
 		ctrl.enqueueFeature(features)
+	} else if !macherrors.IsNotFound(err) {
+		utilruntime.HandleError(fmt.Errorf("could not get FeatureGate for MCP re-sync: %w", err))
 	}
 
 	nodeConfig, err := ctrl.nodeConfigLister.Get(ctrlcommon.ClusterNodeInstanceName)
 	if err == nil {
 		ctrl.enqueueNodeConfig(nodeConfig)
+	} else if !macherrors.IsNotFound(err) {
+		utilruntime.HandleError(fmt.Errorf("could not get NodeConfig for MCP re-sync: %w", err))
 	}
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -138,6 +138,12 @@ func New(
 		fgHandler: fgHandler,
 	}
 
+	mcpInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    ctrl.addMachineConfigPool,
+		UpdateFunc: ctrl.updateMachineConfigPool,
+		DeleteFunc: ctrl.deleteMachineConfigPool,
+	})
+
 	mkuInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ctrl.addKubeletConfig,
 		UpdateFunc: ctrl.updateKubeletConfig,
@@ -314,6 +320,62 @@ func (ctrl *Controller) deleteKubeletConfig(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't delete object %#v: %w", cfg, err))
 	} else {
 		klog.V(4).Infof("Deleted KubeletConfig %s and restored default config", cfg.Name)
+	}
+}
+
+func (ctrl *Controller) addMachineConfigPool(obj interface{}) {
+	pool := obj.(*mcfgv1.MachineConfigPool)
+	klog.V(4).Infof("MachineConfigPool %s added, re-syncing kubelet config controller", pool.Name)
+	ctrl.requeueKubeletConfigsForPool()
+}
+
+func (ctrl *Controller) updateMachineConfigPool(old, cur interface{}) {
+	oldPool := old.(*mcfgv1.MachineConfigPool)
+	curPool := cur.(*mcfgv1.MachineConfigPool)
+	if !reflect.DeepEqual(oldPool.Labels, curPool.Labels) {
+		klog.V(4).Infof("MachineConfigPool %s labels changed, re-syncing kubelet config controller", curPool.Name)
+		ctrl.requeueKubeletConfigsForPool()
+	}
+}
+
+func (ctrl *Controller) deleteMachineConfigPool(obj interface{}) {
+	pool, ok := obj.(*mcfgv1.MachineConfigPool)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		pool, ok = tombstone.Obj.(*mcfgv1.MachineConfigPool)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a MachineConfigPool %#v", obj))
+			return
+		}
+	}
+	klog.V(4).Infof("MachineConfigPool %s deleted", pool.Name)
+}
+
+// requeueKubeletConfigsForPool triggers reconciliation of all kubelet-related
+// controllers so that generated MachineConfigs are created for any new or
+// updated MachineConfigPool.
+func (ctrl *Controller) requeueKubeletConfigsForPool() {
+	kcs, err := ctrl.mckLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("could not list KubeletConfigs for MCP re-sync: %w", err))
+	} else {
+		for _, kc := range kcs {
+			ctrl.enqueueKubeletConfig(kc)
+		}
+	}
+
+	features, err := ctrl.featLister.Get(ctrlcommon.ClusterFeatureInstanceName)
+	if err == nil {
+		ctrl.enqueueFeature(features)
+	}
+
+	nodeConfig, err := ctrl.nodeConfigLister.Get(ctrlcommon.ClusterNodeInstanceName)
+	if err == nil {
+		ctrl.enqueueNodeConfig(nodeConfig)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The kubelet config controller did not register event handlers on the MachineConfigPool informer, so adding a new MCP never triggered reconciliation of kubelet-related MachineConfigs.
- Adds MCP Add/Update/Delete event handlers that re-enqueue all KubeletConfigs, FeatureGates, and NodeConfigs, ensuring per-pool generated MachineConfigs (`97-<pool>-generated-kubelet`, `98-<pool>-generated-kubelet`) are created without requiring a controller restart.

## Root Cause

The `New()` constructor in the kubelet config controller registered informer event handlers for KubeletConfig, FeatureGate, NodeConfig, and APIServer — but **not** for MachineConfigPool. When a new MCP was created:

1. `syncFeatureHandler` (which generates `97-<pool>-generated-kubelet`) was never triggered for the new pool
2. `syncKubeletConfig` (which generates `98-<pool>-generated-kubelet`) was never triggered for matching KubeletConfigs
3. `syncNodeConfigHandler` was never triggered for the new pool

The only workaround was restarting the machine-config-controller pod, which caused initial ADD events to fire for FeatureGates/KubeletConfigs, triggering the missing reconciliation.

## Fix

Register `AddFunc`, `UpdateFunc`, and `DeleteFunc` handlers on the MCP informer:

- **Add**: When a new MCP is created, re-enqueue all KubeletConfigs, the cluster FeatureGate, and the cluster NodeConfig for reconciliation
- **Update**: When MCP labels change (which affects pool selector matching), trigger the same re-sync
- **Delete**: Log the deletion (generated MC cleanup is handled by other controllers)

This follows the same pattern used by other MCO controllers (render, pinned-image-set, node) that already watch for MCP changes.

## How to Reproduce (before fix)

1. Have an existing cluster with KubeletConfig CRs
2. Create a new MachineConfigPool:
   ```yaml
   apiVersion: machineconfiguration.openshift.io/v1
   kind: MachineConfigPool
   metadata:
     name: demo
     labels:
       machineconfiguration.openshift.io/role: demo
   spec:
     machineConfigSelector:
       matchExpressions:
         - key: machineconfiguration.openshift.io/role
           operator: In
           values: [worker, demo]
     nodeSelector:
       matchLabels:
         node-role.kubernetes.io/demo: ""
   ```
3. Watch MachineConfigs: `oc get machineconfig -w`
4. **Expected**: `97-demo-generated-kubelet`, `98-demo-generated-kubelet`, and `rendered-demo-*` are created
5. **Actual**: Only `rendered-demo-*` is created; 97/98 configs only appear after restarting the controller

Fixes: https://github.com/openshift/machine-config-operator/issues/5521


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kubelet configuration controller now monitors and responds to configuration pool events, automatically triggering controller reconciliation to keep cluster configurations synchronized when configuration pools are added, updated, or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->