### PR TITLE
OCPNODE-4604: upgrade CRIOCredentialProviderConfig to v1

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -13,14 +13,12 @@ import (
 	signature "github.com/containers/image/v5/signature"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	apicfgv1 "github.com/openshift/api/config/v1"
-	apicfgv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	features "github.com/openshift/api/features"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	cligoinformersv1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	cligolistersv1 "github.com/openshift/client-go/config/listers/config/v1"
-	cligolistersv1alpha1 "github.com/openshift/client-go/config/listers/config/v1alpha1"
 	runtimeutils "github.com/openshift/runtime-utils/pkg/registries"
 
 	operatorinformersv1alpha1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1"
@@ -111,7 +109,7 @@ type Controller struct {
 	itmsLister       cligolistersv1.ImageTagMirrorSetLister
 	itmsListerSynced cache.InformerSynced
 
-	criocpLister         cligolistersv1alpha1.CRIOCredentialProviderConfigLister
+	criocpLister         cligolistersv1.CRIOCredentialProviderConfigLister
 	criocpListerSynced   cache.InformerSynced
 	addedCRIOCPObservers bool
 
@@ -345,13 +343,13 @@ func (ctrl *Controller) itmsConfDeleted(_ interface{}) {
 }
 
 func (ctrl *Controller) addCRIOCPObservers() {
-	ctrl.configInformerFactory.Config().V1alpha1().CRIOCredentialProviderConfigs().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	ctrl.configInformerFactory.Config().V1().CRIOCredentialProviderConfigs().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ctrl.criocpConfAdded,
 		UpdateFunc: ctrl.criocpConfUpdated,
 		DeleteFunc: ctrl.criocpConfDeleted,
 	})
-	ctrl.criocpLister = ctrl.configInformerFactory.Config().V1alpha1().CRIOCredentialProviderConfigs().Lister()
-	ctrl.criocpListerSynced = ctrl.configInformerFactory.Config().V1alpha1().CRIOCredentialProviderConfigs().Informer().HasSynced
+	ctrl.criocpLister = ctrl.configInformerFactory.Config().V1().CRIOCredentialProviderConfigs().Lister()
+	ctrl.criocpListerSynced = ctrl.configInformerFactory.Config().V1().CRIOCredentialProviderConfigs().Informer().HasSynced
 	ctrl.addedCRIOCPObservers = true
 }
 
@@ -1086,7 +1084,7 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfig(key string) error {
 	}
 
 	var (
-		crioCredentialProviderConfig *apicfgv1alpha1.CRIOCredentialProviderConfig
+		crioCredentialProviderConfig *apicfgv1.CRIOCredentialProviderConfig
 		err                          error
 	)
 
@@ -1119,7 +1117,7 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfig(key string) error {
 
 		managedKeyCredentialProvider, err := getManagedKeyCRIOCredentialProvider(pool)
 		if err != nil {
-			ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1alpha1.ConditionTypeMachineConfigRendered, apicfgv1alpha1.ReasonMachineConfigRenderingFailed, "could not get CRIOCredentialProviderConfig managed key: %v", err)
+			ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingFailed, "could not get CRIOCredentialProviderConfig managed key: %v", err)
 			return err
 		}
 
@@ -1127,24 +1125,24 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfig(key string) error {
 
 			credentialProviderConfigIgn, overlappedEntries, err := crioCredentialProviderConfigIgnition(ctrl.templatesDir, controllerConfig, pool.Name, crioCredentialProviderConfig)
 			if err != nil {
-				ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1alpha1.ConditionTypeMachineConfigRendered, apicfgv1alpha1.ReasonMachineConfigRenderingFailed, "could not generate CRIOCredentialProvider Ignition config: %v", err)
+				ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingFailed, "could not generate CRIOCredentialProvider Ignition config: %v", err)
 				return err
 			}
 			if len(overlappedEntries) > 0 {
-				ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1alpha1.ConditionTypeValidated, apicfgv1alpha1.ReasonConfigurationPartiallyApplied, "CRIOCredentialProviderConfig has one or multiple entries that overlap with the original credential provider config. Skip rendering entries: %v.", overlappedEntries)
+				ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1.ConditionTypeValidated, apicfgv1.ReasonConfigurationPartiallyApplied, "CRIOCredentialProviderConfig has one or multiple entries that overlap with the original credential provider config. Skip rendering entries: %v.", overlappedEntries)
 			} else {
-				ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1alpha1.ConditionTypeValidated, "")
+				ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1.ConditionTypeValidated, "")
 			}
 
 			applied, err = ctrl.syncIgnitionConfig(managedKeyCredentialProvider, credentialProviderConfigIgn, pool, ownerReferenceCredentialProviderConfig(crioCredentialProviderConfig))
 			if err != nil {
-				ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1alpha1.ConditionTypeMachineConfigRendered, apicfgv1alpha1.ReasonMachineConfigRenderingFailed, "could not sync CRIOCredentialProvider Ignition config: %v", err)
+				ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingFailed, "could not sync CRIOCredentialProvider Ignition config: %v", err)
 				return err
 			}
 
 			return nil
 		}); err != nil {
-			ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1alpha1.ConditionTypeMachineConfigRendered, apicfgv1alpha1.ReasonMachineConfigRenderingFailed, "could not Create/Update MachineConfig: %v", err)
+			ctrl.syncCRIOCredentialProviderConfigStatusOnly(err, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingFailed, "could not Create/Update MachineConfig: %v", err)
 			return err
 		}
 
@@ -1152,7 +1150,7 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfig(key string) error {
 			klog.Infof("Applied CRIOCredentialProviderConfig cluster on MachineConfigPool %v", pool.Name)
 			ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync CRIO Credential Provider Config", pool.Name)
 		}
-		ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1alpha1.ConditionTypeMachineConfigRendered, apicfgv1alpha1.ReasonMachineConfigRenderingSucceeded)
+		ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingSucceeded)
 	}
 
 	return nil
@@ -1174,7 +1172,7 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfigStatusOnly(err error, co
 		}
 
 		meta.SetStatusCondition(&newCfg.Status.Conditions, newStatusCondition)
-		_, updateErr := ctrl.configClient.ConfigV1alpha1().CRIOCredentialProviderConfigs().UpdateStatus(context.TODO(), newCfg, metav1.UpdateOptions{})
+		_, updateErr := ctrl.configClient.ConfigV1().CRIOCredentialProviderConfigs().UpdateStatus(context.TODO(), newCfg, metav1.UpdateOptions{})
 		return updateErr
 	})
 	// If an error occurred in updating the status just log it
@@ -1528,7 +1526,7 @@ func (ctrl *Controller) getPoolsForContainerRuntimeConfig(config *mcfgv1.Contain
 	return pools, nil
 }
 
-func crioCredentialProviderConfigIgnition(templateDir string, controllerConfig *mcfgv1.ControllerConfig, role string, crioCredentialProviderConfig *apicfgv1alpha1.CRIOCredentialProviderConfig) (*ign3types.Config, []string, error) {
+func crioCredentialProviderConfigIgnition(templateDir string, controllerConfig *mcfgv1.ControllerConfig, role string, crioCredentialProviderConfig *apicfgv1.CRIOCredentialProviderConfig) (*ign3types.Config, []string, error) {
 
 	var (
 		credProviderConfigYaml           []byte

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -30,7 +30,6 @@ import (
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	apicfgv1 "github.com/openshift/api/config/v1"
-	apicfgv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
@@ -76,7 +75,7 @@ type fixture struct {
 	itmsLister               []*apicfgv1.ImageTagMirrorSet
 	clusterImagePolicyLister []*apicfgv1.ClusterImagePolicy
 	imagePolicyLister        []*apicfgv1.ImagePolicy
-	criocpLister             []*apicfgv1alpha1.CRIOCredentialProviderConfig
+	criocpLister             []*apicfgv1.CRIOCredentialProviderConfig
 
 	actions               []core.Action
 	skipActionsValidation bool
@@ -334,7 +333,7 @@ func (f *fixture) newController() *Controller {
 		ci.Config().V1().ImagePolicies().Informer().GetIndexer().Add(c)
 	}
 	for _, c := range f.criocpLister {
-		ci.Config().V1alpha1().CRIOCredentialProviderConfigs().Informer().GetIndexer().Add(c)
+		ci.Config().V1().CRIOCredentialProviderConfigs().Informer().GetIndexer().Add(c)
 	}
 
 	return c
@@ -648,7 +647,7 @@ type criocpConfigVerifyOptions struct {
 	expectMCNilContent bool
 }
 
-func (f *fixture) verifyCRIOCredentialProviderConfigContents(t *testing.T, mcName string, criocp *apicfgv1alpha1.CRIOCredentialProviderConfig, verifyOpts criocpConfigVerifyOptions) {
+func (f *fixture) verifyCRIOCredentialProviderConfigContents(t *testing.T, mcName string, criocp *apicfgv1.CRIOCredentialProviderConfig, verifyOpts criocpConfigVerifyOptions) {
 	updatedMC, err := f.client.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mcName, metav1.GetOptions{})
 	require.NoError(t, err)
 
@@ -2337,7 +2336,7 @@ func TestCrioCredentialProviderConfigUpdate(t *testing.T) {
 
 			f = newFixture(t)
 			criocpUpdate := criocp.DeepCopy()
-			criocpUpdate.Spec.MatchImages = []apicfgv1alpha1.MatchImage{"example.com", "example1.com"}
+			criocpUpdate.Spec.MatchImages = []apicfgv1.MatchImage{"example.com", "example1.com"}
 
 			f.criocpLister = append(f.criocpLister, criocpUpdate)
 			f.ccLister = append(f.ccLister, cc)
@@ -2366,21 +2365,21 @@ func TestCrioCredentialProviderConfigUpdate(t *testing.T) {
 	}
 }
 
-func newCrioCredentialProviderConfig(name string, matchImages []string) *apicfgv1alpha1.CRIOCredentialProviderConfig {
-	var images []apicfgv1alpha1.MatchImage
+func newCrioCredentialProviderConfig(name string, matchImages []string) *apicfgv1.CRIOCredentialProviderConfig {
+	var images []apicfgv1.MatchImage
 	for _, img := range matchImages {
-		images = append(images, apicfgv1alpha1.MatchImage(img))
+		images = append(images, apicfgv1.MatchImage(img))
 	}
 
-	return &apicfgv1alpha1.CRIOCredentialProviderConfig{
+	return &apicfgv1.CRIOCredentialProviderConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: apicfgv1alpha1.SchemeGroupVersion.String(),
+			APIVersion: apicfgv1.SchemeGroupVersion.String(),
 			Kind:       "CrioCredentialProviderConfig",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: &apicfgv1alpha1.CRIOCredentialProviderConfigSpec{
+		Spec: &apicfgv1.CRIOCredentialProviderConfigSpec{
 			MatchImages: images,
 		},
 	}

--- a/pkg/controller/container-runtime-config/helpers.go
+++ b/pkg/controller/container-runtime-config/helpers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/opencontainers/go-digest"
 	apicfgv1 "github.com/openshift/api/config/v1"
-	apicfgv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/runtime-utils/pkg/registries"
 	runtimeutils "github.com/openshift/runtime-utils/pkg/registries"
@@ -983,9 +982,9 @@ func ownerReferenceImageConfig(imageConfig *apicfgv1.Image) metav1.OwnerReferenc
 	}
 }
 
-func ownerReferenceCredentialProviderConfig(credentialProviderConfig *apicfgv1alpha1.CRIOCredentialProviderConfig) metav1.OwnerReference {
+func ownerReferenceCredentialProviderConfig(credentialProviderConfig *apicfgv1.CRIOCredentialProviderConfig) metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion: apicfgv1alpha1.SchemeGroupVersion.String(),
+		APIVersion: apicfgv1.SchemeGroupVersion.String(),
 		Kind:       "CRIOCredentialProviderConfig",
 		Name:       credentialProviderConfig.Name,
 		UID:        credentialProviderConfig.UID,
@@ -1392,7 +1391,7 @@ type credentialProviderConfigWithVersion struct {
 	Providers  []*credentialProviderWithTag `json:"providers"`
 }
 
-func updateCredentialProviderConfig(credProviderConfigObject *credentialProviderConfigWithVersion, newImages []apicfgv1alpha1.MatchImage) ([]byte, []string, error) {
+func updateCredentialProviderConfig(credProviderConfigObject *credentialProviderConfigWithVersion, newImages []apicfgv1.MatchImage) ([]byte, []string, error) {
 
 	// newImages is not expected to be empty here as the caller should skip calling this function if there are no images
 	var (
@@ -1511,13 +1510,13 @@ func wrapErrorWithCRIOCredentialProviderConfigCondition(err error, conditionType
 	}
 
 	if conditionType == "" {
-		conditionType = apicfgv1alpha1.ConditionTypeMachineConfigRendered
+		conditionType = apicfgv1.ConditionTypeMachineConfigRendered
 	}
 
 	if err == nil {
 		if reason == "" {
-			if conditionType == apicfgv1alpha1.ConditionTypeMachineConfigRendered {
-				reason = apicfgv1alpha1.ReasonMachineConfigRenderingSucceeded
+			if conditionType == apicfgv1.ConditionTypeMachineConfigRendered {
+				reason = apicfgv1.ReasonMachineConfigRenderingSucceeded
 			} else {
 				reason = "Succeeded"
 			}
@@ -1527,7 +1526,7 @@ func wrapErrorWithCRIOCredentialProviderConfigCondition(err error, conditionType
 		}
 
 		status := metav1.ConditionTrue
-		if conditionType == apicfgv1alpha1.ConditionTypeValidated && reason == apicfgv1alpha1.ReasonConfigurationPartiallyApplied {
+		if conditionType == apicfgv1.ConditionTypeValidated && reason == apicfgv1.ReasonConfigurationPartiallyApplied {
 			status = metav1.ConditionFalse
 		}
 
@@ -1540,7 +1539,7 @@ func wrapErrorWithCRIOCredentialProviderConfigCondition(err error, conditionType
 	}
 
 	if reason == "" {
-		reason = apicfgv1alpha1.ReasonMachineConfigRenderingFailed
+		reason = apicfgv1.ReasonMachineConfigRenderingFailed
 	}
 	if message == "" {
 		message = fmt.Sprintf("Error: %v", err)

--- a/pkg/controller/container-runtime-config/helpers_test.go
+++ b/pkg/controller/container-runtime-config/helpers_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/v5/types"
 	storageconfig "github.com/containers/storage/pkg/config"
 	apicfgv1 "github.com/openshift/api/config/v1"
-	apicfgv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -2687,28 +2686,28 @@ func TestWrapErrorWithCRIOCredentialProviderConfigCondition(t *testing.T) {
 			conditionType:  "",
 			reason:         "",
 			args:           nil,
-			expectedType:   apicfgv1alpha1.ConditionTypeMachineConfigRendered,
+			expectedType:   apicfgv1.ConditionTypeMachineConfigRendered,
 			expectedStatus: metav1.ConditionTrue,
-			expectedReason: apicfgv1alpha1.ReasonMachineConfigRenderingSucceeded,
+			expectedReason: apicfgv1.ReasonMachineConfigRenderingSucceeded,
 			expectedMsg:    "Success",
 		},
 		{
 			name:           "validated partial applied returns false status",
 			err:            nil,
-			conditionType:  apicfgv1alpha1.ConditionTypeValidated,
-			reason:         apicfgv1alpha1.ReasonConfigurationPartiallyApplied,
+			conditionType:  apicfgv1.ConditionTypeValidated,
+			reason:         apicfgv1.ReasonConfigurationPartiallyApplied,
 			args:           []interface{}{"partially applied"},
-			expectedType:   apicfgv1alpha1.ConditionTypeValidated,
+			expectedType:   apicfgv1.ConditionTypeValidated,
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: apicfgv1alpha1.ReasonConfigurationPartiallyApplied,
+			expectedReason: apicfgv1.ReasonConfigurationPartiallyApplied,
 			expectedMsg:    "partially applied",
 		},
 		{
 			name:           "validated success returns true status",
 			err:            nil,
-			conditionType:  apicfgv1alpha1.ConditionTypeValidated,
+			conditionType:  apicfgv1.ConditionTypeValidated,
 			reason:         "",
-			expectedType:   apicfgv1alpha1.ConditionTypeValidated,
+			expectedType:   apicfgv1.ConditionTypeValidated,
 			expectedStatus: metav1.ConditionTrue,
 			expectedReason: "Succeeded",
 			expectedMsg:    "Success",
@@ -2716,23 +2715,23 @@ func TestWrapErrorWithCRIOCredentialProviderConfigCondition(t *testing.T) {
 		{
 			name:           "error defaults reason to machine config rendering failed",
 			err:            errors.New("boom"),
-			conditionType:  apicfgv1alpha1.ConditionTypeValidated,
+			conditionType:  apicfgv1.ConditionTypeValidated,
 			reason:         "",
 			args:           nil,
-			expectedType:   apicfgv1alpha1.ConditionTypeValidated,
+			expectedType:   apicfgv1.ConditionTypeValidated,
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: apicfgv1alpha1.ReasonMachineConfigRenderingFailed,
+			expectedReason: apicfgv1.ReasonMachineConfigRenderingFailed,
 			expectedMsg:    "Error: boom",
 		},
 		{
 			name:           "error with explicit reason and message format",
 			err:            errors.New("bad input"),
-			conditionType:  apicfgv1alpha1.ConditionTypeMachineConfigRendered,
-			reason:         apicfgv1alpha1.ReasonValidationFailed,
+			conditionType:  apicfgv1.ConditionTypeMachineConfigRendered,
+			reason:         apicfgv1.ReasonValidationFailed,
 			args:           []interface{}{"custom %s", "message"},
-			expectedType:   apicfgv1alpha1.ConditionTypeMachineConfigRendered,
+			expectedType:   apicfgv1.ConditionTypeMachineConfigRendered,
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: apicfgv1alpha1.ReasonValidationFailed,
+			expectedReason: apicfgv1.ReasonValidationFailed,
 			expectedMsg:    "custom message",
 		},
 	}
@@ -2935,9 +2934,9 @@ providers:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			var testImages []apicfgv1alpha1.MatchImage
+			var testImages []apicfgv1.MatchImage
 			for _, img := range tt.matchImages {
-				testImages = append(testImages, apicfgv1alpha1.MatchImage(img))
+				testImages = append(testImages, apicfgv1.MatchImage(img))
 			}
 
 			credProviderConfigObject, err := credProviderConfigObject(tt.templateConfig)

--- a/test/framework/envtest.go
+++ b/test/framework/envtest.go
@@ -116,7 +116,6 @@ func NewTestEnv(t *testing.T) *envtest.Environment {
 				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "operator", "v1", "zz_generated.crd-manifests"),
 				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "operator", "v1alpha1", "zz_generated.crd-manifests"),
 				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests"),
-				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "config", "v1alpha1", "zz_generated.crd-manifests", "0000_10_config-operator_01_criocredentialproviderconfigs.crd.yaml"),
 				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machineconfiguration", "v1alpha1", "zz_generated.crd-manifests"),
 				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machineconfiguration", "v1", "zz_generated.crd-manifests"),
 			},


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

merge with:
- [ ] https://github.com/openshift/machine-config-operator/pull/6220
- [ ] https://github.com/openshift/origin/pull/31324
- [ ] https://github.com/openshift/api/pull/2900

**- What I did**

**- How to verify it**
- [Job logs and status](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-machine-config-operator-6220-openshift-api-2725-openshift-client-go-385-openshift-machine-config-operator-6220-openshift-origin-31324-openshift-api-2900-unit/2069579457819054080)
- [Job logs and status](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-machine-config-operator-6220-openshift-api-2725-openshift-client-go-385-openshift-machine-config-operator-6220-openshift-origin-31324-openshift-api-2900-unit/2069477525779648512):
```
/testwith openshift/machine-config-operator/main/unit https://github.com/openshift/api/pull/2725 https://github.com/openshift/client-go/pull/385 https://github.com/openshift/machine-config-operator/pull/6220 https://github.com/openshift/origin/pull/31324 https://github.com/openshift/api/pull/2900
```
- [Job logs and status](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-machine-config-operator-6220-openshift-api-2725-openshift-client-go-385-openshift-machine-config-operator-6220-openshift-origin-31324-openshift-api-2900-e2e-gcp-op-techpreview/2069476967350013952):
```
/testwith openshift/machine-config-operator/main/e2e-gcp-op-techpreview https://github.com/openshift/api/pull/2725 https://github.com/openshift/client-go/pull/385 https://github.com/openshift/machine-config-operator/pull/6220 https://github.com/openshift/origin/pull/31324 https://github.com/openshift/api/pull/2900
```
- [Job logs and status](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-machine-config-operator-6220-openshift-api-2725-openshift-client-go-385-openshift-machine-config-operator-6220-openshift-origin-31324-openshift-api-2900-bootstrap-unit/2069491516862107648)
- [Job logs and status](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-machine-config-operator-6220-openshift-api-2725-openshift-client-go-385-openshift-machine-config-operator-6220-openshift-origin-31324-openshift-api-2900-bootstrap-unit/2069495409121693696)
```
/testwith openshift/machine-config-operator/main/bootstrap-unit https://github.com/openshift/api/pull/2725 https://github.com/openshift/client-go/pull/385 https://github.com/openshift/machine-config-operator/pull/6220 https://github.com/openshift/origin/pull/31324 https://github.com/openshift/api/pull/2900
```
- [Job logs and status](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-machine-config-operator-6220-openshift-api-2725-openshift-client-go-385-openshift-machine-config-operator-6220-openshift-origin-31324-openshift-api-2900-e2e-aws-ovn/2069578070146158592)
```
/testwith openshift/machine-config-operator/main/e2e-aws-ovn https://github.com/openshift/api/pull/2725 https://github.com/openshift/client-go/pull/385 https://github.com/openshift/machine-config-operator/pull/6220 https://github.com/openshift/origin/pull/31324 https://github.com/openshift/api/pull/2900
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **Chores**
  * Updated dependencies (OpenShift/Kubernetes tooling and related libraries) to newer versions.
* **Refactor**
  * Migrated CRIO credential provider configuration handling from the alpha API to the stable v1 API.
* **Tests**
  * Updated controller and helper tests to use the v1 CRIO credential provider types/spec fields.
  * Updated the envtest setup to no longer install the v1alpha1 CRD manifest, aligning the test environment with v1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->