### PR TITLE
OCPBUGS-91746: Remove sandboxed-containers (kata-containers) from extended-priv tests

### DIFF
--- a/test/extended-priv/const.go
+++ b/test/extended-priv/const.go
@@ -203,7 +203,7 @@ var (
 		usbguardExtension:            {"usbguard"},
 		kerberosExtension:            {"krb5-workstation", "libkadm5"},
 		kernelDevelExtension:         {"kernel-devel", "kernel-headers"},
-		sandboxedContainersExtension: {"kata-containers"},
+		// sandboxedContainersExtension: {"kata-containers"}, // Temporarily disabled until kata-containers builds are available again (MCO-2389)
 		sysstatExtension:             {"sysstat"},
 	}
 


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- kata-containers RPM has been removed from both RHEL 9 and RHEL 10 OS builds, causing extension tests to fail. This temporarily removes the sandboxed-containers extension from the extended-priv test suite until kata-containers builds are available again (tracked by [MCO-2389](https://redhat.atlassian.net/browse/MCO-2389)).

**- How to verify it**
- [PolarionID:56131] Install all extensions test should pass without trying to install kata-containers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- temporarily commented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled sandboxed containers extension support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->