### PR TITLE
[release-4.20] OCPBUGS-91732: Update custom containerfile OCB test to work in a disconnected environment

### DIFF
--- a/test/extended/mco_ocb.go
+++ b/test/extended/mco_ocb.go
@@ -108,7 +108,28 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 	g.It("PolarionID:83140-A MachineOSConfig with custom containerfile definition can be successfully applied", func() {
 		var (
-			mcp = GetCompactCompatiblePool(oc.AsAdmin())
+			mcp                  = GetCompactCompatiblePool(oc.AsAdmin())
+			containerFileContent string
+			checkers             []Checker
+		)
+
+		if IsDisconnectedCluster(oc.AsAdmin()) {
+			logger.Infof("Disconnected cluster detected, using containerfile that does not require network access")
+			containerFileContent = `
+        FROM configs AS final
+        RUN echo "disconnected-containerfile-test" > /etc/disconnected-containerfile-test && \
+            ostree container commit
+`
+
+			checkers = []Checker{
+				CommandOutputChecker{
+					Command:  []string{"cat", "/etc/disconnected-containerfile-test"},
+					Matcher:  o.ContainSubstring("disconnected-containerfile-test"),
+					ErrorMsg: fmt.Sprintf("Test file was not created by the custom containerfile"),
+					Desc:     fmt.Sprintf("Check that the custom containerfile test file exists"),
+				},
+			}
+		} else {
 
 			containerFileContent = `
 	# Pull the centos base image and enable the EPEL repository.
@@ -140,7 +161,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 					Desc:     fmt.Sprintf("Check that cowsay is installed and working"),
 				},
 			}
-		)
+		}
 
 		testContainerFile([]ContainerFile{{Content: containerFileContent}}, MachineConfigNamespace, mcp, checkers, false)
 	})

--- a/test/extended/util.go
+++ b/test/extended/util.go
@@ -439,3 +439,15 @@ func IsCompactOrSNOCluster(oc *exutil.CLI) bool {
 
 	return wMcp.IsEmpty() && len(mcpList.GetAllOrFail()) == 2
 }
+
+// IsDisconnectedCluster returns true if the cluster has no external network
+// access by attempting to reach an external endpoint from a node.
+func IsDisconnectedCluster(oc *exutil.CLI) bool {
+	nodes, err := NewNodeList(oc.AsAdmin()).GetAll()
+	if err != nil || len(nodes) == 0 {
+		return false
+	}
+	output, _ := nodes[0].DebugNodeWithChroot("sh", "-c",
+		"curl -s --connect-timeout 5 https://fedoraproject.org/static/hotspot.txt &>/dev/null && echo Connected || echo Disconnected")
+	return !strings.Contains(output, "Connected")
+}


### PR DESCRIPTION
Closes: OCPBUGS-91732

**- What I did**
This is a manual cherrypick of https://github.com/openshift/machine-config-operator/pull/6193.

**- How to verify it**
The `A MachineOSConfig with custom containerfile definition can be successfully applied` test should pass on all platforms, especially the IPV6 platform.

**- Description for the changelog**
OCPBUGS-91732: Update custom containerfile OCB test to work in a disconnected environment
