### PR TITLE
no-jira: Add localhost resolution within the CoreDNS Corefile for cloud platforms

### DIFF
--- a/manifests/cloud-platform-alt-dns/coredns-corefile.tmpl
+++ b/manifests/cloud-platform-alt-dns/coredns-corefile.tmpl
@@ -33,4 +33,9 @@
         match ^api-int.{{ .ControllerConfig.DNS.Spec.BaseDomain }}
         fallthrough
     }
+    hosts /etc/hosts {
+        127.0.0.1 localhost localhost.localdomain
+        ::1 localhost localhost.localdomain
+        fallthrough
+    }
 }

--- a/manifests/cloud-platform-alt-dns/coredns.yaml
+++ b/manifests/cloud-platform-alt-dns/coredns.yaml
@@ -24,6 +24,9 @@ spec:
   - name: manifests
     hostPath:
       path: "/opt/openshift/manifests"
+  - name: hosts-dir
+    hostPath:
+      path: "/etc/hosts"
   initContainers:
   - name: render-config
     image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
@@ -55,6 +58,10 @@ spec:
     - name: manifests
       mountPath: "/opt/openshift/manifests"
       mountPropagation: HostToContainer
+    - name: hosts-dir
+      mountPath: "/etc/hosts"
+      mountPropagation: HostToContainer
+      readOnly: true
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns
@@ -71,6 +78,9 @@ spec:
     volumeMounts:
     - name: conf-dir
       mountPath: "/etc/coredns"
+    - name: hosts-dir
+      mountPath: "/etc/hosts"
+      readOnly: true
     livenessProbe:
       httpGet:
         path: /health

--- a/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns-corefile.yaml
@@ -38,7 +38,9 @@ contents:
             match ^api-int.{{ .DNS.Spec.BaseDomain }}
             fallthrough
         }
-        hosts {
+        hosts /etc/hosts {
+            127.0.0.1 localhost localhost.localdomain
+            ::1 localhost localhost.localdomain
             {{`{{- range .Cluster.NodeAddresses }}
             {{ .Address }} {{ .Name }} {{ .Name }}.{{ $.Cluster.Name }}.{{ $.Cluster.Domain }}
             {{- end }}`}}

--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -28,6 +28,9 @@ contents:
       - name: nm-resolv
         hostPath:
           path: "/var/run/NetworkManager"
+      - name: hosts-dir
+        hostPath:
+          path: "/etc/hosts"
       initContainers:
       - name: render-config-coredns
         image: {{ .Images.baremetalRuntimeCfgImage }}
@@ -59,6 +62,10 @@ contents:
         - name: conf-dir
           mountPath: "/etc/coredns"
           mountPropagation: HostToContainer
+        - name: hosts-dir
+          mountPath: "/etc/hosts"
+          mountPropagation: HostToContainer
+          readOnly: true
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
       containers:
@@ -74,6 +81,9 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
+        - name: hosts-dir
+          mountPath: "/etc/hosts"
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /health
@@ -119,8 +129,12 @@ contents:
           mountPropagation: HostToContainer
         - name: nm-resolv
           mountPath: "/var/run/NetworkManager"
-          mountPropagation: HostToContainer 
-        imagePullPolicy: IfNotPresent        
+          mountPropagation: HostToContainer
+        - name: hosts-dir
+          mountPath: "/etc/hosts"
+          mountPropagation: HostToContainer
+          readOnly: true
+        imagePullPolicy: IfNotPresent
       hostNetwork: true
       tolerations:
       - operator: Exists


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CoreDNS now uses a `hosts` plugin backed by the system `/etc/hosts` to resolve `localhost` and `localhost.localdomain` for both IPv4 (`127.0.0.1`) and IPv6 (`::1`), with `fallthrough` enabled.
  * CoreDNS-related containers (including the config-rendering step and monitoring sidecar) now mount the host `/etc/hosts` as read-only to ensure consistent localhost resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->