### PR TITLE
OCPBUGS-91982: Bootstrap MCS logging entire ignition

### DIFF
--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -150,7 +150,6 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 		klog.Errorf("could not marshal ignConf %v", err)
 		return nil, err
 	}
-	klog.Infof("got ignconf %s", rawConf)
 	return &runtime.RawExtension{Raw: rawConf}, nil
 }
 


### PR DESCRIPTION
The bootstrap machine config server was logging the entire ignition config (1MB+) on a single line. This causes several issues:

1. Exposes sensitive data including IRI certificate private keys
2. Makes log files unwieldy and difficult to work with
3. Causes CI artifacts to be redacted, preventing bootstrap failure debugging

This logging was added in PR #3787 and appears to have been left over from development/debugging.

Fixes: OCPBUGS-XXXXX

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when configuration marshalling fails, so issues are now logged more clearly.
  * Removed an unnecessary success log message to reduce noise in server output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->