### PR TITLE
MCO-2393: Use /proc/sys/crypto/fips_enabled for FIPS check in tests

### DIFF
--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -827,12 +827,12 @@ func (n *Node) GetDateWithDelta(delta string) (time.Time, error) {
 
 // IsFIPSEnabled check whether fips is enabled on node
 func (n *Node) IsFIPSEnabled() (bool, error) {
-	output, err := n.DebugNodeWithChroot("cat", "/proc/sys/crypto/fips_enabled")
+	stdout, _, err := n.DebugNodeWithChrootStd("cat", "/proc/sys/crypto/fips_enabled")
 	if err != nil {
 		logger.Errorf("Error checking fips mode %s", err)
 	}
 
-	return strings.TrimSpace(output) == "1", err
+	return strings.TrimSpace(stdout) == "1", err
 }
 
 // IsKernelArgEnabled check whether kernel arg is enabled on node

--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -827,12 +827,12 @@ func (n *Node) GetDateWithDelta(delta string) (time.Time, error) {
 
 // IsFIPSEnabled check whether fips is enabled on node
 func (n *Node) IsFIPSEnabled() (bool, error) {
-	output, err := n.DebugNodeWithChroot("fips-mode-setup", "--check")
+	output, err := n.DebugNodeWithChroot("cat", "/proc/sys/crypto/fips_enabled")
 	if err != nil {
 		logger.Errorf("Error checking fips mode %s", err)
 	}
 
-	return strings.Contains(output, "FIPS mode is enabled"), err
+	return strings.TrimSpace(output) == "1", err
 }
 
 // IsKernelArgEnabled check whether kernel arg is enabled on node


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Updated IsFIPSEnabled() in test/extended-priv/node.go to read /proc/sys/crypto/fips_enabled instead of running fips-mode-setup --check. The fips-mode-setup binary (from crypto-policies-scripts) is not available on RHEL 10, which causes the MCO kernel test PolarionID:53668 to fail with chroot: failed to run command 'fips-mode-setup': No such file or directory. The /proc/sys/crypto/fips_enabled interface is available on all RHEL versions and is already used by the MCO daemon itself in pkg/daemon/update.go.

**- How to verify it**
- Run the MCO kernel test PolarionID:53668 ([sig-mco] MCO kernel when FIPS and realtime kernel are both enabled node should NOT be degraded) on an OCP 5.0 FIPS-enabled cluster.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Use /proc/sys/crypto/fips_enabled for FIPS check in tests to fix RHEL 10 compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FIPS mode detection by reading the system’s FIPS status directly and interpreting the result more reliably, instead of relying on the previous command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->