### PR TITLE
OCPBUGS-92811: Inject proxy into MCC deployment

### DIFF
--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -31,6 +31,21 @@ spec:
             cpu: 20m
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
+        {{if .ControllerConfig.Proxy}}
+        env:
+        {{if .ControllerConfig.Proxy.HTTPProxy}}
+        - name: HTTP_PROXY
+          value: {{.ControllerConfig.Proxy.HTTPProxy}}
+        {{end}}
+        {{if .ControllerConfig.Proxy.HTTPSProxy}}
+        - name: HTTPS_PROXY
+          value: {{.ControllerConfig.Proxy.HTTPSProxy}}
+        {{end}}
+        {{if .ControllerConfig.Proxy.NoProxy}}
+        - name: NO_PROXY
+          value: "{{.ControllerConfig.Proxy.NoProxy}}"
+        {{end}}
+        {{end}}
       - name: kube-rbac-proxy
         image: {{.Images.KubeRbacProxy}}
         ports:

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -280,6 +280,30 @@ func TestRenderAsset(t *testing.T) {
 			},
 		},
 		{
+			// Test that MCC deployment is rendered correctly with proxy config
+			Path: "manifests/machineconfigcontroller/deployment.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+					KubeRbacProxy:         "kube-rbac-proxy-image",
+				},
+				ControllerConfig: mcfgv1.ControllerConfigSpec{
+					Proxy: &configv1.ProxyStatus{
+						HTTPSProxy: "https://i.am.a.proxy.server",
+						NoProxy:    "*", // See: https://bugzilla.redhat.com/show_bug.cgi?id=1947066
+					},
+				},
+			},
+			FindExpected: []string{
+				"image: mco-operator-image",
+				"- name: HTTPS_PROXY\n          value: https://i.am.a.proxy.server",
+				"- name: NO_PROXY\n          value: \"*\"", // Ensure the * is quoted: "*": https://bugzilla.redhat.com/show_bug.cgi?id=1947066
+				"--payload-version=4.8.0-rc.0",
+			},
+		},
+		{
 			// Bad path, will cause asset error
 			Path:  "BAD PATH",
 			Error: true,


### PR DESCRIPTION
**- What I did**
The MCC deployment manifest now conditionally renders proxy environment variables from controller config. The annotation suggestion from the bug didn't work, as the operator is continously reconciling the MCC manifest...likely clearing the proxy arguments set on the containers. 

**- How to verify it**
OVA downloads should succeed during vsphere bootimage updates when the cluster is using a proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The machine config controller deployment now supports optional proxy settings, automatically applying HTTP, HTTPS, and no-proxy environment variables when configured.

* **Tests**
  * Added coverage to verify the deployment renders correctly with proxy values enabled, including expected output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->