### PR TITLE
OCPNODE-4518: Block runc on RHEL 10 via OSImageURL stream class inspection

### DIFF
--- a/cmd/machine-config-controller/bootstrap.go
+++ b/cmd/machine-config-controller/bootstrap.go
@@ -43,7 +43,7 @@ func runbootstrapCmd(_ *cobra.Command, _ []string) {
 		klog.Fatalf("--dest-dir or --manifest-dir not set")
 	}
 
-	if err := bootstrap.New(rootOpts.templates, bootstrapOpts.manifestsDir, bootstrapOpts.pullSecretFile).Run(bootstrapOpts.destinationDir); err != nil {
+	if err := bootstrap.New(rootOpts.templates, bootstrapOpts.manifestsDir, bootstrapOpts.pullSecretFile, nil).Run(bootstrapOpts.destinationDir); err != nil {
 		klog.Fatalf("error running MCC[BOOTSTRAP]: %v", err)
 	}
 }

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -95,6 +95,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			return
 		}
 
+		var inspectorFactory osimagestream.ImagesInspectorFactory
 		var inspectionCache *imageutils.FileInspectionCache
 		if startOpts.streamsCache != "" {
 			inspectionCache = imageutils.NewFileInspectionCache(path.Join(startOpts.streamsCache, "image-inspection.json"), 48*time.Hour)
@@ -105,7 +106,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		// controller starts, since render, node, and template depend on it
 		// for OS image URLs.
 		if osimagestream.IsFeatureEnabled(ctrlctx.FeatureGatesHandler) {
-			var inspectorFactory osimagestream.ImagesInspectorFactory
 			if inspectionCache != nil {
 				inspectorFactory = osimagestream.NewCachedImagesInspectorFactory(
 					&osimagestream.DefaultImagesInspectorFactory{},
@@ -150,7 +150,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctrlctx.Stop, ctrlcommon.RegisterMCCMetrics, startOpts.tlsMinVersion, startOpts.tlsCipherSuites)
 
-		controllers := createControllers(ctrlctx, inspectionCache)
+		controllers := createControllers(ctrlctx, inspectionCache, inspectorFactory)
 		draincontroller := drain.New(
 			drain.DefaultConfig(),
 			ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
@@ -272,7 +272,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	panic("unreachable")
 }
 
-func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *imageutils.FileInspectionCache) []ctrlcommon.Controller {
+func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *imageutils.FileInspectionCache, inspectorFactory osimagestream.ImagesInspectorFactory) []ctrlcommon.Controller {
 	// Only watch IRI informers when the feature gate is enabled. The
 	// InternalReleaseImages CRD is not installed on clusters where the gate is
 	// off, so the informer list call would fail and WaitForCacheSync in the
@@ -292,9 +292,15 @@ func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *image
 		ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
 		ctx.OperatorInformerFactory.Operator().V1().MachineConfigurations(),
 		ctx.InformerFactory.Machineconfiguration().V1().OSImageStreams(),
+		ctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
+		ctx.OperatorInformerFactory.Operator().V1alpha1().ImageContentSourcePolicies(),
+		ctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets(),
+		ctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets(),
+		ctx.ConfigInformerFactory.Config().V1().Images(),
 		ctx.ClientBuilder.KubeClientOrDie("render-controller"),
 		ctx.ClientBuilder.MachineConfigClientOrDie("render-controller"),
 		ctx.FeatureGatesHandler,
+		inspectorFactory,
 	)
 	if inspectionCache != nil {
 		inspectionCache.RegisterEvicter(renderCtrl)

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -371,7 +371,7 @@ func (b *Bootstrap) Run(destDir string) error {
 
 	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
 	inspector := osimagestream.NewStreamClassInspector(b.inspectorFactory, sysCtxFactory)
-	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig, osImageStream, inspector)
+	fpools, gconfigs, err := render.RunBootstrap(context.TODO(), pools, configs, cconfig, osImageStream, inspector)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -51,16 +51,21 @@ type Bootstrap struct {
 	manifestDir string
 	// pull secret file
 	pullSecretFile string
-	// OSImageStreams factory. Used for testing purposes.
 	imageStreamFactory osimagestream.ImageStreamFactory
+	inspectorFactory   osimagestream.ImagesInspectorFactory
 }
 
 // New returns controller for bootstrap
-func New(templatesDir, manifestDir, pullSecretFile string) *Bootstrap {
+func New(templatesDir, manifestDir, pullSecretFile string, inspectorFactory osimagestream.ImagesInspectorFactory) *Bootstrap {
+	if inspectorFactory == nil {
+		inspectorFactory = &osimagestream.DefaultImagesInspectorFactory{}
+	}
 	return &Bootstrap{
-		templatesDir:   templatesDir,
-		manifestDir:    manifestDir,
-		pullSecretFile: pullSecretFile,
+		templatesDir:       templatesDir,
+		manifestDir:        manifestDir,
+		pullSecretFile:     pullSecretFile,
+		imageStreamFactory: osimagestream.NewDefaultStreamSourceFactory(inspectorFactory),
+		inspectorFactory:   inspectorFactory,
 	}
 }
 
@@ -364,7 +369,9 @@ func (b *Bootstrap) Run(destDir string) error {
 		klog.Infof("Successfully created %d pre-built image component MachineConfigs for hybrid OCL.", len(preBuiltImageMCs))
 	}
 
-	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig, osImageStream)
+	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
+	inspector := osimagestream.NewStreamClassInspector(b.inspectorFactory, sysCtxFactory)
+	fpools, gconfigs, err := render.RunBootstrap(pools, configs, cconfig, osImageStream, inspector)
 	if err != nil {
 		return err
 	}
@@ -508,7 +515,7 @@ func (b *Bootstrap) fetchOSImageStream(
 
 	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
 
-	factory := b.getImageStreamFactory()
+	factory := b.imageStreamFactory
 	createOpts := osimagestream.CreateOptions{
 		ExistingOSImageStream: existingOSImageStream,
 		CliImages: &osimagestream.OSImageTuple{
@@ -526,15 +533,6 @@ func (b *Bootstrap) fetchOSImageStream(
 		return nil, fmt.Errorf("error inspecting available OSImageStreams: %w", err)
 	}
 	return osImageStream, nil
-}
-
-// Returns the embedded ImageStreamFactory or constructs a new default one. Used primarily for testing.
-func (b *Bootstrap) getImageStreamFactory() osimagestream.ImageStreamFactory {
-	if b.imageStreamFactory != nil {
-		return b.imageStreamFactory
-	}
-
-	return osimagestream.NewDefaultStreamSourceFactory(&osimagestream.DefaultImagesInspectorFactory{})
 }
 
 func buildSysContextFactory(

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -195,8 +195,6 @@ func setupForBootstrapTest(t *testing.T) (*Bootstrap, *fakeImageStreamFactory, s
 
 	require.NoError(t, exec.Command("cp", "-r", "testdata/bootstrap/.", srcDir).Run())
 
-	bootstrap := New("../../../templates", srcDir, filepath.Join(srcDir, "machineconfigcontroller-pull-secret"))
-
 	fakeFactory := &fakeImageStreamFactory{
 		stream: &mcfgv1.OSImageStream{
 			Status: mcfgv1.OSImageStreamStatus{
@@ -212,9 +210,26 @@ func setupForBootstrapTest(t *testing.T) (*Bootstrap, *fakeImageStreamFactory, s
 		},
 	}
 
+	bootstrap := New("../../../templates", srcDir, filepath.Join(srcDir, "machineconfigcontroller-pull-secret"), &noopImagesInspectorFactory{})
 	bootstrap.imageStreamFactory = fakeFactory
 
 	return bootstrap, fakeFactory, srcDir, destDir
+}
+
+type noopImagesInspectorFactory struct{}
+
+func (n *noopImagesInspectorFactory) ForContext(_ imageutils.SysContextFactory) osimagestream.ImagesInspector {
+	return &noopImagesInspector{}
+}
+
+type noopImagesInspector struct{}
+
+func (n *noopImagesInspector) Inspect(_ context.Context, _ ...string) ([]imageutils.BulkInspectResult, error) {
+	return []imageutils.BulkInspectResult{{}}, nil
+}
+
+func (n *noopImagesInspector) FetchImageFile(_ context.Context, _, _ string) ([]byte, error) {
+	return nil, nil
 }
 
 // TestBootstrapRunHypershift validates OSImageStream behavior under

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -36,6 +36,9 @@ const (
 	// OSImageURLOverriddenKey is used to tag a rendered machineconfig when OSImageURL has been overridden from default using machineconfig
 	OSImageURLOverriddenKey = "machineconfiguration.openshift.io/os-image-url-overridden"
 
+	// OSImageURLOverriddenTrue is the annotation value set on OSImageURLOverriddenKey when the OSImageURL is overridden.
+	OSImageURLOverriddenTrue = "true"
+
 	// RenderedMachineConfigPrefix is the name prefix for rendered MachineConfigs
 	RenderedMachineConfigPrefix = "rendered-"
 

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -65,6 +65,8 @@ var (
 
 // Controller defines the render controller.
 type Controller struct {
+	ctx context.Context
+
 	client        mcfgclientset.Interface
 	eventRecorder record.EventRecorder
 
@@ -194,6 +196,14 @@ func New(
 func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+	ctrl.ctx = ctx
 
 	listerCaches := []cache.InformerSynced{ctrl.mcpListerSynced, ctrl.mcListerSynced, ctrl.ccListerSynced}
 
@@ -758,7 +768,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	// Check for runc on RHEL 10. When the OSImageURL was overridden or no
 	// stream is available, inspect the actual image; otherwise use the stream.
 	if isOSImageURLOverridden {
-		if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, ctrl.imageInspector); err != nil {
+		if err := validateNoRuncOnRHEL10FromOSImageURL(ctrl.ctx, pool, generated, ctrl.imageInspector); err != nil {
 			return err
 		}
 	} else if osImageStreamSet != nil {
@@ -969,7 +979,7 @@ func getOSImageStreamNameForPoolBootstrap(pool *mcfgv1.MachineConfigPool, pools 
 // RunBootstrap runs the render controller in bootstrap mode.
 // For each pool, it matches the machineconfigs based on label selector and
 // returns the generated machineconfigs and pool with CurrentMachineConfig status field set.
-func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig, osImageStream *mcfgv1.OSImageStream, inspector osimagestream.StreamClassInspector) ([]*mcfgv1.MachineConfigPool, []*mcfgv1.MachineConfig, error) {
+func RunBootstrap(ctx context.Context, pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig, osImageStream *mcfgv1.OSImageStream, inspector osimagestream.StreamClassInspector) ([]*mcfgv1.MachineConfigPool, []*mcfgv1.MachineConfig, error) {
 	var (
 		opools   []*mcfgv1.MachineConfigPool
 		oconfigs []*mcfgv1.MachineConfig
@@ -998,7 +1008,7 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 		// stream is available, inspect the actual image; otherwise use the stream.
 		isOverridden := generated.Annotations[ctrlcommon.OSImageURLOverriddenKey] == ctrlcommon.OSImageURLOverriddenTrue
 		if isOverridden {
-			if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, inspector); err != nil {
+			if err := validateNoRuncOnRHEL10FromOSImageURL(ctx, pool, generated, inspector); err != nil {
 				return nil, nil, err
 			}
 		} else if osImageStreamSet != nil {
@@ -1045,7 +1055,7 @@ func validateNoRuncOnRHEL10FromOSImageStream(poolName string, mc *mcfgv1.Machine
 
 // validateNoRuncOnRHEL10FromOSImageURL checks whether the generated MachineConfig uses
 // runc on a RHEL 10 image by inspecting the container image's labels.
-func validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig, inspector osimagestream.StreamClassInspector) error {
+func validateNoRuncOnRHEL10FromOSImageURL(ctx context.Context, pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig, inspector osimagestream.StreamClassInspector) error {
 	osImageURL := generated.Spec.OSImageURL
 	if osImageURL == "" || inspector == nil {
 		return nil
@@ -1060,7 +1070,7 @@ func validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, genera
 		return nil
 	}
 
-	streamClass, err := inspector.InspectStreamClass(osImageURL)
+	streamClass, err := inspector.InspectStreamClass(ctx, osImageURL)
 	if err != nil {
 		return fmt.Errorf("pool %s: failed to inspect OS image for stream class: %w", pool.Name, err)
 	}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -761,7 +761,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	//   stream than the pool's default, so the stream-based check was skipped
 	//   in generateRenderedMachineConfig).
 	if osImageStreamSet == nil || isOSImageURLOverridden {
-		if err := ctrl.validateNoRuncFromOSImageURL(pool, generated); err != nil {
+		if err := ctrl.validateNoRuncOnRHEL10FromOSImageURL(pool, generated); err != nil {
 			return err
 		}
 	}
@@ -881,9 +881,9 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 	// Skip the stream-based runc check when the OSImageURL is overridden —
 	// the override may point to a different stream than the pool's default.
 	// The caller (syncGeneratedMachineConfig) will inspect the actual image
-	// via validateNoRuncFromOSImageURL instead.
+	// via validateNoRuncOnRHEL10FromOSImageURL instead.
 	if merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] != ctrlcommon.OSImageURLOverriddenTrue {
-		if err := validateNoRuncOnRHEL10(pool.Name, merged, osImageStreamSet); err != nil {
+		if err := validateNoRuncOnRHEL10FromOSImageStream(pool.Name, merged, osImageStreamSet); err != nil {
 			return nil, err
 		}
 	}
@@ -1047,10 +1047,10 @@ func runcBlockedError(poolName string, mc *mcfgv1.MachineConfig) error {
 	return nil
 }
 
-// validateNoRuncOnRHEL10 returns an error if the generated MachineConfig uses runc
+// validateNoRuncOnRHEL10FromOSImageStream returns an error if the generated MachineConfig uses runc
 // as the default container runtime and the pool targets a RHEL 10 / CentOS 10 OS
 // image stream.
-func validateNoRuncOnRHEL10(poolName string, mc *mcfgv1.MachineConfig, osImageStreamSet *mcfgv1.OSImageStreamSet) error {
+func validateNoRuncOnRHEL10FromOSImageStream(poolName string, mc *mcfgv1.MachineConfig, osImageStreamSet *mcfgv1.OSImageStreamSet) error {
 	if osImageStreamSet == nil {
 		return nil
 	}
@@ -1060,9 +1060,9 @@ func validateNoRuncOnRHEL10(poolName string, mc *mcfgv1.MachineConfig, osImageSt
 	return runcBlockedError(poolName, mc)
 }
 
-// validateNoRuncFromOSImageURL checks whether the generated MachineConfig uses
+// validateNoRuncOnRHEL10FromOSImageURL checks whether the generated MachineConfig uses
 // runc on a RHEL 10 image by inspecting the container image's labels.
-func (ctrl *Controller) validateNoRuncFromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig) error {
+func (ctrl *Controller) validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig) error {
 	osImageURL := generated.Spec.OSImageURL
 	if osImageURL == "" || ctrl.imageInspector == nil {
 		return nil

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -761,7 +761,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	//   stream than the pool's default, so the stream-based check was skipped
 	//   in generateRenderedMachineConfig).
 	if osImageStreamSet == nil || isOSImageURLOverridden {
-		if err := ctrl.validateNoRuncOnRHEL10FromOSImageURL(pool, generated); err != nil {
+		if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, ctrl.imageInspector); err != nil {
 			return err
 		}
 	}
@@ -1003,20 +1003,16 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 			return nil, nil, err
 		}
 
-		// When OSImageURL was overridden, the stream-based runc check in
-		// generateRenderedMachineConfig is skipped because the override may
-		// target a different stream. Inspect the actual image to catch runc
-		// on RHEL 10.
+		// Check for runc on RHEL 10. When the OSImageURL was overridden or no
+		// stream is available, inspect the actual image; otherwise use the stream.
 		isOverridden := generated.Annotations[ctrlcommon.OSImageURLOverriddenKey] == ctrlcommon.OSImageURLOverriddenTrue
-		if isOverridden && inspector != nil && generated.Spec.OSImageURL != "" {
-			streamClass, inspectErr := inspector.InspectStreamClass(generated.Spec.OSImageURL)
-			if inspectErr != nil {
-				return nil, nil, fmt.Errorf("pool %s: failed to inspect OSImageURL for stream class: %w", pool.Name, inspectErr)
+		if osImageStreamSet == nil || isOverridden {
+			if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, inspector); err != nil {
+				return nil, nil, err
 			}
-			if osimagestream.IsRHEL10Stream(streamClass) {
-				if err := runcBlockedError(pool.Name, generated); err != nil {
-					return nil, nil, err
-				}
+		} else {
+			if err := validateNoRuncOnRHEL10FromOSImageStream(pool.Name, generated, osImageStreamSet); err != nil {
+				return nil, nil, err
 			}
 		}
 
@@ -1062,9 +1058,9 @@ func validateNoRuncOnRHEL10FromOSImageStream(poolName string, mc *mcfgv1.Machine
 
 // validateNoRuncOnRHEL10FromOSImageURL checks whether the generated MachineConfig uses
 // runc on a RHEL 10 image by inspecting the container image's labels.
-func (ctrl *Controller) validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig) error {
+func validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig, inspector osimagestream.StreamClassInspector) error {
 	osImageURL := generated.Spec.OSImageURL
-	if osImageURL == "" || ctrl.imageInspector == nil {
+	if osImageURL == "" || inspector == nil {
 		return nil
 	}
 
@@ -1076,7 +1072,7 @@ func (ctrl *Controller) validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.Machin
 		return nil
 	}
 
-	streamClass, err := ctrl.imageInspector.InspectStreamClass(osImageURL)
+	streamClass, err := inspector.InspectStreamClass(osImageURL)
 	if err != nil {
 		return fmt.Errorf("pool %s: failed to inspect OS image for stream class: %w", pool.Name, err)
 	}

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -755,13 +755,14 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		ctrlcommon.OSImageURLOverride.WithLabelValues(pool.Name).Set(0)
 	}
 
-	// Check for runc on RHEL 10 via OSImageURL inspection when either:
-	// - OSImageStream is not in use (no stream-based check available), or
-	// - The OSImageURL was overridden (the override may target a different
-	//   stream than the pool's default, so the stream-based check was skipped
-	//   in generateRenderedMachineConfig).
+	// Check for runc on RHEL 10. When the OSImageURL was overridden or no
+	// stream is available, inspect the actual image; otherwise use the stream.
 	if osImageStreamSet == nil || isOSImageURLOverridden {
 		if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, ctrl.imageInspector); err != nil {
+			return err
+		}
+	} else {
+		if err := validateNoRuncOnRHEL10FromOSImageStream(pool.Name, generated, osImageStreamSet); err != nil {
 			return err
 		}
 	}
@@ -875,16 +876,6 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		// behaviors based on who set OSImageURL.
 		if pool.Spec.OSImageStream.Name != "" {
 			return nil, fmt.Errorf("cannot override MachineConfig osImageURL and set MachineConfigPool spec.osImageStream.name simultaneously")
-		}
-	}
-
-	// Skip the stream-based runc check when the OSImageURL is overridden —
-	// the override may point to a different stream than the pool's default.
-	// The caller (syncGeneratedMachineConfig) will inspect the actual image
-	// via validateNoRuncOnRHEL10FromOSImageURL instead.
-	if merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] != ctrlcommon.OSImageURLOverriddenTrue {
-		if err := validateNoRuncOnRHEL10FromOSImageStream(pool.Name, merged, osImageStreamSet); err != nil {
-			return nil, err
 		}
 	}
 

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -65,12 +65,10 @@ var (
 
 // Controller defines the render controller.
 type Controller struct {
-	ctx context.Context
-
 	client        mcfgclientset.Interface
 	eventRecorder record.EventRecorder
 
-	syncHandler              func(mcp string) error
+	syncHandler              func(ctx context.Context, mcp string) error
 	enqueueMachineConfigPool func(*mcfgv1.MachineConfigPool)
 
 	mcpLister           mcfglistersv1.MachineConfigPoolLister
@@ -203,7 +201,6 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 		<-stopCh
 		cancel()
 	}()
-	ctrl.ctx = ctx
 
 	listerCaches := []cache.InformerSynced{ctrl.mcpListerSynced, ctrl.mcListerSynced, ctrl.ccListerSynced}
 
@@ -226,7 +223,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-RenderController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(func() { ctrl.worker(ctx) }, time.Second, stopCh)
 	}
 
 	<-stopCh
@@ -500,19 +497,19 @@ func (ctrl *Controller) enqueueCustomPools() {
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
-func (ctrl *Controller) worker() {
-	for ctrl.processNextWorkItem() {
+func (ctrl *Controller) worker(ctx context.Context) {
+	for ctrl.processNextWorkItem(ctx) {
 	}
 }
 
-func (ctrl *Controller) processNextWorkItem() bool {
+func (ctrl *Controller) processNextWorkItem(ctx context.Context) bool {
 	key, quit := ctrl.queue.Get()
 	if quit {
 		return false
 	}
 	defer ctrl.queue.Done(key)
 
-	err := ctrl.syncHandler(key)
+	err := ctrl.syncHandler(ctx, key)
 	ctrl.handleErr(err, key)
 
 	return true
@@ -538,7 +535,7 @@ func (ctrl *Controller) handleErr(err error, key string) {
 
 // syncMachineConfigPool will sync the machineconfig pool with the given key.
 // This function is not meant to be invoked concurrently with the same key.
-func (ctrl *Controller) syncMachineConfigPool(key string) error {
+func (ctrl *Controller) syncMachineConfigPool(ctx context.Context, key string) error {
 	startTime := time.Now()
 	klog.V(4).Infof("Started syncing machineconfigpool %q (%v)", key, startTime)
 	defer func() {
@@ -591,7 +588,7 @@ func (ctrl *Controller) syncMachineConfigPool(key string) error {
 		return ctrl.syncFailingStatus(pool, fmt.Errorf("no MachineConfigs found matching selector %v", selector))
 	}
 
-	if err := ctrl.syncGeneratedMachineConfig(pool, mcs); err != nil {
+	if err := ctrl.syncGeneratedMachineConfig(ctx, pool, mcs); err != nil {
 		klog.Errorf("Error syncing Generated MCFG: %v", err)
 		return ctrl.syncFailingStatus(pool, err)
 	}
@@ -730,7 +727,7 @@ func (ctrl *Controller) getOSImageStreamForPool(pool *mcfgv1.MachineConfigPool) 
 	return imageStreamSet, nil
 }
 
-func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) error {
+func (ctrl *Controller) syncGeneratedMachineConfig(ctx context.Context, pool *mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig) error {
 	if len(configs) == 0 {
 		return nil
 	}
@@ -768,7 +765,7 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 	// Check for runc on RHEL 10. When the OSImageURL was overridden or no
 	// stream is available, inspect the actual image; otherwise use the stream.
 	if isOSImageURLOverridden {
-		if err := validateNoRuncOnRHEL10FromOSImageURL(ctrl.ctx, pool, generated, ctrl.imageInspector); err != nil {
+		if err := validateNoRuncOnRHEL10FromOSImageURL(ctx, pool, generated, ctrl.imageInspector); err != nil {
 			return err
 		}
 	} else if osImageStreamSet != nil {

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -1019,7 +1019,16 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 	return opools, oconfigs, nil
 }
 
-func runcBlockedError(poolName string, mc *mcfgv1.MachineConfig) error {
+// validateNoRuncOnRHEL10FromOSImageStream returns an error if the generated MachineConfig uses runc
+// as the default container runtime and the pool targets a RHEL 10 / CentOS 10 OS
+// image stream.
+func validateNoRuncOnRHEL10FromOSImageStream(poolName string, mc *mcfgv1.MachineConfig, osImageStreamSet *mcfgv1.OSImageStreamSet) error {
+	if osImageStreamSet == nil {
+		return nil
+	}
+	if !osimagestream.IsRHEL10Stream(osImageStreamSet.Name) {
+		return nil
+	}
 	runcMCName, err := ctrlcommon.DetectRuncInMachineConfig(mc)
 	if err != nil {
 		return fmt.Errorf("failed to check runc in generated MachineConfig for pool %s: %w", poolName, err)
@@ -1034,19 +1043,6 @@ func runcBlockedError(poolName string, mc *mcfgv1.MachineConfig) error {
 	return nil
 }
 
-// validateNoRuncOnRHEL10FromOSImageStream returns an error if the generated MachineConfig uses runc
-// as the default container runtime and the pool targets a RHEL 10 / CentOS 10 OS
-// image stream.
-func validateNoRuncOnRHEL10FromOSImageStream(poolName string, mc *mcfgv1.MachineConfig, osImageStreamSet *mcfgv1.OSImageStreamSet) error {
-	if osImageStreamSet == nil {
-		return nil
-	}
-	if !osimagestream.IsRHEL10Stream(osImageStreamSet.Name) {
-		return nil
-	}
-	return runcBlockedError(poolName, mc)
-}
-
 // validateNoRuncOnRHEL10FromOSImageURL checks whether the generated MachineConfig uses
 // runc on a RHEL 10 image by inspecting the container image's labels.
 func validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig, inspector osimagestream.StreamClassInspector) error {
@@ -1055,6 +1051,7 @@ func validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, genera
 		return nil
 	}
 
+	// Check runc first: this is a local config check that doesn't need network access.
 	runcMCName, err := ctrlcommon.DetectRuncInMachineConfig(generated)
 	if err != nil {
 		return fmt.Errorf("pool %s: failed to check runc in generated MachineConfig: %w", pool.Name, err)
@@ -1075,7 +1072,11 @@ func validateNoRuncOnRHEL10FromOSImageURL(pool *mcfgv1.MachineConfigPool, genera
 		return nil
 	}
 
-	return runcBlockedError(pool.Name, generated)
+	return fmt.Errorf(
+		"MachineConfigPool %s targets a RHEL 10 OS image where runc is not available. "+
+			"To unblock, migrate to crun by removing any ContainerRuntimeConfig that sets defaultRuntime to runc, "+
+			"and removing any MachineConfig that sets default_runtime = \"runc\" in CRI-O configuration under /etc/crio/crio.conf.d/",
+		pool.Name)
 }
 
 // getMachineConfigsForPool is called by RunBootstrap and returns configs that match label from configs for a pool.

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -11,17 +11,19 @@ import (
 	"github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	opv1 "github.com/openshift/api/operator/v1"
+	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	"github.com/openshift/client-go/machineconfiguration/clientset/versioned/scheme"
 	mcfginformersv1 "github.com/openshift/client-go/machineconfiguration/informers/externalversions/machineconfiguration/v1"
 	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
 	mcopinformersv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	operatorinformersv1alpha1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1"
 	mcoplistersv1 "github.com/openshift/client-go/operator/listers/operator/v1"
 	mcoResourceApply "github.com/openshift/machine-config-operator/lib/resourceapply"
 	"github.com/openshift/machine-config-operator/pkg/apihelpers"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
-	"github.com/openshift/machine-config-operator/pkg/imageutils"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
 	"github.com/openshift/machine-config-operator/pkg/osimagestream"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +34,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -88,7 +91,15 @@ type Controller struct {
 	mcopLister       mcoplistersv1.MachineConfigurationLister
 	mcopListerSynced cache.InformerSynced
 
+	secretListerSynced cache.InformerSynced
+	icspListerSynced   cache.InformerSynced
+	idmsListerSynced   cache.InformerSynced
+	itmsListerSynced   cache.InformerSynced
+	imgListerSynced    cache.InformerSynced
+
 	fgHandler ctrlcommon.FeatureGatesHandler
+
+	imageInspector osimagestream.StreamClassInspector
 
 	queue workqueue.TypedRateLimitingInterface[string]
 }
@@ -102,9 +113,15 @@ func New(
 	mckInformer mcfginformersv1.KubeletConfigInformer,
 	mcopInformer mcopinformersv1.MachineConfigurationInformer,
 	osImageStreamInformer mcfginformersv1.OSImageStreamInformer,
+	secretInformer coreinformersv1.SecretInformer,
+	icspInformer operatorinformersv1alpha1.ImageContentSourcePolicyInformer,
+	idmsInformer configinformersv1.ImageDigestMirrorSetInformer,
+	itmsInformer configinformersv1.ImageTagMirrorSetInformer,
+	imgInformer configinformersv1.ImageInformer,
 	kubeClient clientset.Interface,
 	mcfgClient mcfgclientset.Interface,
 	featureGatesHandler ctrlcommon.FeatureGatesHandler,
+	inspectorFactory osimagestream.ImagesInspectorFactory,
 ) *Controller {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
@@ -146,6 +163,23 @@ func New(
 	ctrl.mcopLister = mcopInformer.Lister()
 	ctrl.mcopListerSynced = mcopInformer.Informer().HasSynced
 
+	if inspectorFactory != nil {
+		ctrl.imageInspector = osimagestream.NewStreamClassInspector(inspectorFactory,
+			ctrlcommon.NewSysContextFactory(
+				ccInformer.Lister(),
+				secretInformer.Lister(),
+				imgInformer.Lister(),
+				icspInformer.Lister(),
+				idmsInformer.Lister(),
+				itmsInformer.Lister(),
+			))
+		ctrl.secretListerSynced = secretInformer.Informer().HasSynced
+		ctrl.icspListerSynced = icspInformer.Informer().HasSynced
+		ctrl.idmsListerSynced = idmsInformer.Informer().HasSynced
+		ctrl.itmsListerSynced = itmsInformer.Informer().HasSynced
+		ctrl.imgListerSynced = imgInformer.Informer().HasSynced
+	}
+
 	if osImageStreamInformer != nil && osimagestream.IsFeatureEnabled(ctrl.fgHandler) {
 		ctrl.osImageStreamLister = osImageStreamInformer.Lister()
 		ctrl.osImageStreamListerSynced = osImageStreamInformer.Informer().HasSynced
@@ -162,6 +196,13 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer ctrl.queue.ShutDown()
 
 	listerCaches := []cache.InformerSynced{ctrl.mcpListerSynced, ctrl.mcListerSynced, ctrl.ccListerSynced}
+
+	if ctrl.secretListerSynced != nil {
+		listerCaches = append(listerCaches,
+			ctrl.secretListerSynced, ctrl.icspListerSynced, ctrl.idmsListerSynced,
+			ctrl.itmsListerSynced, ctrl.imgListerSynced,
+		)
+	}
 
 	// OSImageStreams and MCPs fetched only if FeatureGateOSStreams active
 	if ctrl.osImageStreamListerSynced != nil {
@@ -714,6 +755,17 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 		ctrlcommon.OSImageURLOverride.WithLabelValues(pool.Name).Set(0)
 	}
 
+	// Check for runc on RHEL 10 via OSImageURL inspection when either:
+	// - OSImageStream is not in use (no stream-based check available), or
+	// - The OSImageURL was overridden (the override may target a different
+	//   stream than the pool's default, so the stream-based check was skipped
+	//   in generateRenderedMachineConfig).
+	if osImageStreamSet == nil || isOSImageURLOverridden {
+		if err := ctrl.validateNoRuncFromOSImageURL(pool, generated); err != nil {
+			return err
+		}
+	}
+
 	source := getMachineConfigRefs(configs)
 
 	_, err = ctrl.mcLister.Get(generated.Name)
@@ -807,7 +859,7 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 	// OSImageURL check during upgrade -- if the user took over managing OS upgrades this way,
 	// the operator shouldn't stop the rest of the upgrade from progressing/completing.
 	if merged.Spec.OSImageURL != ctrlcommon.GetBaseImageContainer(&cconfig.Spec, osImageStreamSet) {
-		merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] = "true"
+		merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] = ctrlcommon.OSImageURLOverriddenTrue
 		// Log a warning if the osImageURL is set using a tag instead of a digest
 		if !strings.Contains(merged.Spec.OSImageURL, "sha256:") {
 			klog.Warningf("OSImageURL %q for MachineConfig %s is set using a tag instead of a digest. It is highly recommended to use a digest", merged.Spec.OSImageURL, merged.Name)
@@ -826,8 +878,14 @@ func generateRenderedMachineConfig(pool *mcfgv1.MachineConfigPool, configs []*mc
 		}
 	}
 
-	if err := validateNoRuncOnRHEL10(pool.Name, merged, osImageStreamSet); err != nil {
-		return nil, err
+	// Skip the stream-based runc check when the OSImageURL is overridden —
+	// the override may point to a different stream than the pool's default.
+	// The caller (syncGeneratedMachineConfig) will inspect the actual image
+	// via validateNoRuncFromOSImageURL instead.
+	if merged.Annotations[ctrlcommon.OSImageURLOverriddenKey] != ctrlcommon.OSImageURLOverriddenTrue {
+		if err := validateNoRuncOnRHEL10(pool.Name, merged, osImageStreamSet); err != nil {
+			return nil, err
+		}
 	}
 
 	return merged, nil
@@ -920,7 +978,7 @@ func getOSImageStreamNameForPoolBootstrap(pool *mcfgv1.MachineConfigPool, pools 
 // RunBootstrap runs the render controller in bootstrap mode.
 // For each pool, it matches the machineconfigs based on label selector and
 // returns the generated machineconfigs and pool with CurrentMachineConfig status field set.
-func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig, osImageStream *mcfgv1.OSImageStream) ([]*mcfgv1.MachineConfigPool, []*mcfgv1.MachineConfig, error) {
+func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineConfig, cconfig *mcfgv1.ControllerConfig, osImageStream *mcfgv1.OSImageStream, inspector osimagestream.StreamClassInspector) ([]*mcfgv1.MachineConfigPool, []*mcfgv1.MachineConfig, error) {
 	var (
 		opools   []*mcfgv1.MachineConfigPool
 		oconfigs []*mcfgv1.MachineConfig
@@ -945,6 +1003,23 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 			return nil, nil, err
 		}
 
+		// When OSImageURL was overridden, the stream-based runc check in
+		// generateRenderedMachineConfig is skipped because the override may
+		// target a different stream. Inspect the actual image to catch runc
+		// on RHEL 10.
+		isOverridden := generated.Annotations[ctrlcommon.OSImageURLOverriddenKey] == ctrlcommon.OSImageURLOverriddenTrue
+		if isOverridden && inspector != nil && generated.Spec.OSImageURL != "" {
+			streamClass, inspectErr := inspector.InspectStreamClass(generated.Spec.OSImageURL)
+			if inspectErr != nil {
+				return nil, nil, fmt.Errorf("pool %s: failed to inspect OSImageURL for stream class: %w", pool.Name, inspectErr)
+			}
+			if osimagestream.IsRHEL10Stream(streamClass) {
+				if err := runcBlockedError(pool.Name, generated); err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+
 		source := getMachineConfigRefs(configs)
 
 		pool.Spec.Configuration.Name = generated.Name
@@ -957,11 +1032,24 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 	return opools, oconfigs, nil
 }
 
+func runcBlockedError(poolName string, mc *mcfgv1.MachineConfig) error {
+	runcMCName, err := ctrlcommon.DetectRuncInMachineConfig(mc)
+	if err != nil {
+		return fmt.Errorf("failed to check runc in generated MachineConfig for pool %s: %w", poolName, err)
+	}
+	if runcMCName != "" {
+		return fmt.Errorf(
+			"MachineConfigPool %s targets a RHEL 10 OS image where runc is not available. "+
+				"To unblock, migrate to crun by removing any ContainerRuntimeConfig that sets defaultRuntime to runc, "+
+				"and removing any MachineConfig that sets default_runtime = \"runc\" in CRI-O configuration under /etc/crio/crio.conf.d/",
+			poolName)
+	}
+	return nil
+}
+
 // validateNoRuncOnRHEL10 returns an error if the generated MachineConfig uses runc
 // as the default container runtime and the pool targets a RHEL 10 / CentOS 10 OS
-// image stream. runc is not available on RHCOS 10; clusters must migrate to crun
-// before switching to a RHEL 10 stream.
-// TODO(OCP 5.3): Remove this guard once RHEL 9 is no longer supported and all nodes run RHEL 10.
+// image stream.
 func validateNoRuncOnRHEL10(poolName string, mc *mcfgv1.MachineConfig, osImageStreamSet *mcfgv1.OSImageStreamSet) error {
 	if osImageStreamSet == nil {
 		return nil
@@ -969,19 +1057,38 @@ func validateNoRuncOnRHEL10(poolName string, mc *mcfgv1.MachineConfig, osImageSt
 	if !osimagestream.IsRHEL10Stream(osImageStreamSet.Name) {
 		return nil
 	}
+	return runcBlockedError(poolName, mc)
+}
 
-	runcMCName, err := ctrlcommon.DetectRuncInMachineConfig(mc)
+// validateNoRuncFromOSImageURL checks whether the generated MachineConfig uses
+// runc on a RHEL 10 image by inspecting the container image's labels.
+func (ctrl *Controller) validateNoRuncFromOSImageURL(pool *mcfgv1.MachineConfigPool, generated *mcfgv1.MachineConfig) error {
+	osImageURL := generated.Spec.OSImageURL
+	if osImageURL == "" || ctrl.imageInspector == nil {
+		return nil
+	}
+
+	runcMCName, err := ctrlcommon.DetectRuncInMachineConfig(generated)
 	if err != nil {
-		return fmt.Errorf("failed to check runc in generated MachineConfig for pool %s: %w", poolName, err)
+		return fmt.Errorf("pool %s: failed to check runc in generated MachineConfig: %w", pool.Name, err)
 	}
-	if runcMCName != "" {
-		return fmt.Errorf(
-			"MachineConfigPool %s targets OS image stream %q where runc is not available. "+
-				"To unblock, migrate to crun by removing any ContainerRuntimeConfig that sets defaultRuntime to runc, "+
-				"and removing any MachineConfig that sets default_runtime = \"runc\" in CRI-O configuration under /etc/crio/crio.conf.d/",
-			poolName, osImageStreamSet.Name)
+	if runcMCName == "" {
+		return nil
 	}
-	return nil
+
+	streamClass, err := ctrl.imageInspector.InspectStreamClass(osImageURL)
+	if err != nil {
+		return fmt.Errorf("pool %s: failed to inspect OS image for stream class: %w", pool.Name, err)
+	}
+	if streamClass == "" {
+		klog.V(4).Infof("Pool %s: OS image has no stream class label; skipping runc check", pool.Name)
+		return nil
+	}
+	if !osimagestream.IsRHEL10Stream(streamClass) {
+		return nil
+	}
+
+	return runcBlockedError(pool.Name, generated)
 }
 
 // getMachineConfigsForPool is called by RunBootstrap and returns configs that match label from configs for a pool.

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -757,11 +757,11 @@ func (ctrl *Controller) syncGeneratedMachineConfig(pool *mcfgv1.MachineConfigPoo
 
 	// Check for runc on RHEL 10. When the OSImageURL was overridden or no
 	// stream is available, inspect the actual image; otherwise use the stream.
-	if osImageStreamSet == nil || isOSImageURLOverridden {
+	if isOSImageURLOverridden {
 		if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, ctrl.imageInspector); err != nil {
 			return err
 		}
-	} else {
+	} else if osImageStreamSet != nil {
 		if err := validateNoRuncOnRHEL10FromOSImageStream(pool.Name, generated, osImageStreamSet); err != nil {
 			return err
 		}
@@ -997,11 +997,11 @@ func RunBootstrap(pools []*mcfgv1.MachineConfigPool, configs []*mcfgv1.MachineCo
 		// Check for runc on RHEL 10. When the OSImageURL was overridden or no
 		// stream is available, inspect the actual image; otherwise use the stream.
 		isOverridden := generated.Annotations[ctrlcommon.OSImageURLOverriddenKey] == ctrlcommon.OSImageURLOverriddenTrue
-		if osImageStreamSet == nil || isOverridden {
+		if isOverridden {
 			if err := validateNoRuncOnRHEL10FromOSImageURL(pool, generated, inspector); err != nil {
 				return nil, nil, err
 			}
-		} else {
+		} else if osImageStreamSet != nil {
 			if err := validateNoRuncOnRHEL10FromOSImageStream(pool.Name, generated, osImageStreamSet); err != nil {
 				return nil, nil, err
 			}

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -1084,7 +1084,7 @@ func TestValidateNoRuncOnRHEL10(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateNoRuncOnRHEL10("worker", tt.mc, tt.osImageStreamSet)
+			err := validateNoRuncOnRHEL10FromOSImageStream("worker", tt.mc, tt.osImageStreamSet)
 			if tt.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "runc")

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -1101,7 +1102,7 @@ type fakeStreamClassInspector struct {
 	err         error
 }
 
-func (f *fakeStreamClassInspector) InspectStreamClass(string) (string, error) {
+func (f *fakeStreamClassInspector) InspectStreamClass(context.Context, string) (string, error) {
 	return f.streamClass, f.err
 }
 
@@ -1201,7 +1202,7 @@ func TestValidateNoRuncOnRHEL10FromOSImageURL(t *testing.T) {
 			if tt.inspector != nil {
 				inspector = tt.inspector
 			}
-			err := validateNoRuncOnRHEL10FromOSImageURL(pool, tt.mc, inspector)
+			err := validateNoRuncOnRHEL10FromOSImageURL(context.Background(), pool, tt.mc, inspector)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -1245,6 +1246,7 @@ func TestRunBootstrapBlocksRuncOnRHEL10(t *testing.T) {
 	}
 
 	_, _, err := RunBootstrap(
+		context.Background(),
 		[]*mcfgv1.MachineConfigPool{pool},
 		[]*mcfgv1.MachineConfig{runcMC},
 		cc,

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -138,7 +138,7 @@ func (f *fixture) runExpectError(mcpname string) {
 func (f *fixture) runController(mcpname string, expectError bool) {
 	c := f.newController()
 
-	err := c.syncHandler(mcpname)
+	err := c.syncHandler(context.Background(), mcpname)
 	if !expectError && err != nil {
 		f.t.Errorf("error syncing machineconfigpool: %v", err)
 	} else if expectError && err == nil {

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -33,6 +33,7 @@ import (
 	informers "github.com/openshift/client-go/machineconfiguration/informers/externalversions"
 	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/osimagestream"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/openshift/machine-config-operator/test/helpers"
@@ -1088,6 +1089,121 @@ func TestValidateNoRuncOnRHEL10(t *testing.T) {
 			if tt.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "runc")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type fakeStreamClassInspector struct {
+	streamClass string
+	err         error
+}
+
+func (f *fakeStreamClassInspector) InspectStreamClass(string) (string, error) {
+	return f.streamClass, f.err
+}
+
+func TestValidateNoRuncOnRHEL10FromOSImageURL(t *testing.T) {
+	pool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+	}
+
+	runcMC := func(osImageURL string) *mcfgv1.MachineConfig {
+		mc := helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+			helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+		})
+		mc.Spec.OSImageURL = osImageURL
+		return mc
+	}
+
+	crunMC := func(osImageURL string) *mcfgv1.MachineConfig {
+		mc := helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+			helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("crun"), 0644),
+		})
+		mc.Spec.OSImageURL = osImageURL
+		return mc
+	}
+
+	tests := []struct {
+		name        string
+		mc          *mcfgv1.MachineConfig
+		inspector   *fakeStreamClassInspector
+		expectError bool
+	}{
+		{
+			name:        "runc on RHEL 10 image should error",
+			mc:          runcMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   &fakeStreamClassInspector{streamClass: "rhel-10"},
+			expectError: true,
+		},
+		{
+			name:        "crun on RHEL 10 image should succeed",
+			mc:          crunMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   &fakeStreamClassInspector{streamClass: "rhel-10"},
+			expectError: false,
+		},
+		{
+			name:        "runc on RHEL 9 image should succeed",
+			mc:          runcMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   &fakeStreamClassInspector{streamClass: "rhel-9"},
+			expectError: false,
+		},
+		{
+			name:        "runc on CentOS 10 image should error",
+			mc:          runcMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   &fakeStreamClassInspector{streamClass: "centos-10"},
+			expectError: true,
+		},
+		{
+			name:        "runc with empty OSImageURL should succeed",
+			mc:          runcMC(""),
+			inspector:   &fakeStreamClassInspector{streamClass: "rhel-10"},
+			expectError: false,
+		},
+		{
+			name:        "runc with nil inspector should succeed",
+			mc:          runcMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   nil,
+			expectError: false,
+		},
+		{
+			name:        "runc with empty stream class label should succeed",
+			mc:          runcMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   &fakeStreamClassInspector{streamClass: ""},
+			expectError: false,
+		},
+		{
+			name:        "runc with inspector error should error",
+			mc:          runcMC("quay.io/openshift/rhcos@sha256:abc"),
+			inspector:   &fakeStreamClassInspector{err: fmt.Errorf("connection refused")},
+			expectError: true,
+		},
+		{
+			name: "runc overridden by crun on RHEL 10 image should succeed",
+			mc: func() *mcfgv1.MachineConfig {
+				mc := helpers.NewMachineConfig("rendered-worker", nil, "", []ign3types.File{
+					helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/00-default", makeCRIODropIn("runc"), 0644),
+					helpers.CreateEncodedIgn3File("/etc/crio/crio.conf.d/01-ctrcfg", makeCRIODropIn("crun"), 0644),
+				})
+				mc.Spec.OSImageURL = "quay.io/openshift/rhcos@sha256:abc"
+				return mc
+			}(),
+			inspector:   &fakeStreamClassInspector{streamClass: "rhel-10"},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var inspector osimagestream.StreamClassInspector
+			if tt.inspector != nil {
+				inspector = tt.inspector
+			}
+			err := validateNoRuncOnRHEL10FromOSImageURL(pool, tt.mc, inspector)
+			if tt.expectError {
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/controller/render/render_controller_test.go
+++ b/pkg/controller/render/render_controller_test.go
@@ -83,7 +83,10 @@ func (f *fixture) newController() *Controller {
 	c := New(i.Machineconfiguration().V1().MachineConfigPools(), i.Machineconfiguration().V1().MachineConfigs(),
 		i.Machineconfiguration().V1().ControllerConfigs(), i.Machineconfiguration().V1().ContainerRuntimeConfigs(),
 		i.Machineconfiguration().V1().KubeletConfigs(), oi.Operator().V1().MachineConfigurations(),
-		i.Machineconfiguration().V1().OSImageStreams(), k8sfake.NewSimpleClientset(), f.client, f.fgHandler)
+		i.Machineconfiguration().V1().OSImageStreams(),
+		nil, nil, nil, nil, nil,
+		k8sfake.NewSimpleClientset(), f.client, f.fgHandler,
+		nil)
 
 	c.mcpListerSynced = alwaysReady
 	c.mcListerSynced = alwaysReady
@@ -1130,6 +1133,7 @@ func TestRunBootstrapBlocksRuncOnRHEL10(t *testing.T) {
 		[]*mcfgv1.MachineConfig{runcMC},
 		cc,
 		osImageStream,
+		nil,
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "runc")

--- a/pkg/osimagestream/stream_class_inspector.go
+++ b/pkg/osimagestream/stream_class_inspector.go
@@ -11,7 +11,7 @@ import (
 // StreamClassInspector inspects a container image URL and returns its OS Image
 // Stream name.
 type StreamClassInspector interface {
-	InspectStreamClass(imageURL string) (string, error)
+	InspectStreamClass(ctx context.Context, imageURL string) (string, error)
 }
 
 type streamClassInspector struct {
@@ -28,8 +28,8 @@ func NewStreamClassInspector(inspectorFactory ImagesInspectorFactory, sysCtxFact
 	}
 }
 
-func (s *streamClassInspector) InspectStreamClass(imageURL string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func (s *streamClassInspector) InspectStreamClass(ctx context.Context, imageURL string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	inspector := s.inspectorFactory.ForContext(s.sysCtxFactory)

--- a/pkg/osimagestream/stream_class_inspector_test.go
+++ b/pkg/osimagestream/stream_class_inspector_test.go
@@ -1,6 +1,7 @@
 package osimagestream
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -115,7 +116,7 @@ func TestInspectStreamClass(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := &mockImagesInspectorFactory{inspector: tt.inspector}
 			sci := NewStreamClassInspector(factory, noopSysCtxFactory)
-			sc, err := sci.InspectStreamClass(testImage)
+			sc, err := sci.InspectStreamClass(context.Background(), testImage)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -380,7 +380,7 @@ metadata:
 			}
 
 			// Run the bootstrap
-			bootstrapper := bootstrap.New(templatesDir, srcDir, filepath.Join(bootstrapTestDataDir, "/machineconfigcontroller-pull-secret"))
+			bootstrapper := bootstrap.New(templatesDir, srcDir, filepath.Join(bootstrapTestDataDir, "/machineconfigcontroller-pull-secret"), nil)
 			err = bootstrapper.Run(destDir)
 			require.NoError(t, err)
 
@@ -613,9 +613,11 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.InformerFactory.Machineconfiguration().V1().KubeletConfigs(),
 			ctx.OperatorInformerFactory.Operator().V1().MachineConfigurations(),
 			ctx.InformerFactory.Machineconfiguration().V1().OSImageStreams(),
+			nil, nil, nil, nil, nil,
 			ctx.ClientBuilder.KubeClientOrDie("render-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("render-controller"),
 			ctx.FeatureGatesHandler,
+			nil,
 		),
 		// The node controller consumes data written by the above
 		node.New(


### PR DESCRIPTION

Assisted-by: Claude Code <https://claude.com/claude-code>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

When OSImageStream is not available, detect RHEL 10 by inspecting the container image's io.openshift.os.streamclass label from the OSImageURL. This complements the OSImageStream-based check (commit 50a508813) by covering the OSImageURL path.

**- How to verify it**

manual test and e2e test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added a block mechanism when OSImageURL is RHEL 10 based and runc is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved RHEL 10 validation when OS image URLs are overridden or unavailable through an image stream.
  * Added support for inspecting image stream classes using image mirror policies and related image data.
  * Added a shared annotation value for marking overridden OS image URLs.

* **Bug Fixes**
  * Ensured validation uses the correct image source and waits for required image and secret data to become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->