### PR TITLE
OCPBUGS-94000: Remove sensitive ControllerConfig logging

### DIFF
--- a/pkg/server/bootstrap_server.go
+++ b/pkg/server/bootstrap_server.go
@@ -123,7 +123,6 @@ func (bsc *bootstrapServer) GetConfig(cr poolRequest) (*runtime.RawExtension, er
 		klog.Errorf("could not read file: %s", fileName)
 		return nil, fmt.Errorf("server: could not read file %s, err: %w", fileName, err)
 	}
-	klog.Infof("got controllerConfig: %s", string(data))
 
 	cc := new(mcfgv1.ControllerConfig)
 	err = yaml.Unmarshal(data, cc)


### PR DESCRIPTION
The bootstrap MCS was logging the entire ControllerConfig YAML which contains sensitive data (internalRegistryPullSecret). This causes LeakTK to redact CI artifacts, preventing bootstrap failure debugging.

The file read is already logged on line 116, which is sufficient.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary log entry during startup, helping keep configuration details out of logs and reducing noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->