### PR TITLE
[release-4.18] OCPBUGS-94116: move cleanUpDuplicatedMC to avoid double reboot on first updated 
  Master node

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_nodes.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes.go
@@ -74,9 +74,6 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		err := fmt.Errorf("could not fetch Node: %w", err)
 		return err
 	}
-	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
-		return err
-	}
 
 	if nodeConfig.Spec.CgroupMode == osev1.CgroupModeV1 {
 		klog.Warningf(cgroupsV1DeprecationMsg)
@@ -168,6 +165,9 @@ func (ctrl *Controller) syncNodeConfigHandler(key string) error {
 		}
 		klog.Infof("Applied Node configuration %v on MachineConfigPool %v", key, pool.Name)
 		ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-kubelet-config", "Sync NodeConfig", pool.Name)
+	}
+	if err := ctrl.cleanUpDuplicatedMC(managedNodeConfigKeyPrefix); err != nil {
+		return err
 	}
 	// fetch the kubeletconfigs
 	kcs, err := ctrl.mckLister.List(labels.Everything())

--- a/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_nodes_test.go
@@ -74,6 +74,7 @@ func TestNodeConfigDefault(t *testing.T) {
 			f.expectGetMachineConfigAction(mcsDeprecated)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectCreateMachineConfigAction(mcs)
+			f.expectGetMachineConfigAction(mcs)
 			f.runNode(getKeyFromConfigNode(nodeConfig, t))
 		})
 	}


### PR DESCRIPTION
Cherry-pick of #6201 onto release-4.18 with manual conflict resolution.