### PR TITLE
MCO-1540: Set up events for builds

### DIFF
--- a/pkg/controller/build/ocl_events.go
+++ b/pkg/controller/build/ocl_events.go
@@ -1,0 +1,181 @@
+package build
+
+import (
+	"fmt"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+// Event types for OCL processes
+const (
+	// Build lifecycle events
+	EventBuildStarted     = "BuildStarted"
+	EventBuildPreparing   = "BuildPreparing"
+	EventBuildBuilding    = "BuildBuilding"
+	EventBuildCompleted   = "BuildCompleted"
+	EventBuildFailed      = "BuildFailed"
+	EventBuildInterrupted = "BuildInterrupted"
+	EventBuildDeleted     = "BuildDeleted"
+
+	// Job events
+	EventJobCreated   = "JobCreated"
+	EventJobStarted   = "JobStarted"
+	EventJobCompleted = "JobCompleted"
+	EventJobFailed    = "JobFailed"
+	EventJobDeleted   = "JobDeleted"
+
+	// Config events
+	EventConfigReconciled      = "ConfigReconciled"
+	EventConfigReconcileFailed = "ConfigReconcileFailed"
+	EventRebuildRequested      = "RebuildRequested"
+
+	// Config deletion events
+	EventConfigDeleted = "ConfigDeleted"
+
+	// MachineConfigPool events
+	EventPoolConfigChanged = "PoolConfigChanged"
+
+	// Degradation events
+	EventBuildDegraded  = "BuildDegraded"
+	EventBuildRecovered = "BuildRecovered"
+)
+
+// OCLEventRecorder wraps the Kubernetes event recorder with OCL-specific event helpers
+type OCLEventRecorder struct {
+	recorder record.EventRecorder
+}
+
+// NewOCLEventRecorder creates a new OCL event recorder
+func NewOCLEventRecorder(recorder record.EventRecorder) *OCLEventRecorder {
+	return &OCLEventRecorder{
+		recorder: recorder,
+	}
+}
+
+// Build lifecycle event recording
+
+// RecordBuildStarted records when a build starts
+func (r *OCLEventRecorder) RecordBuildStarted(mosb *mcfgv1.MachineOSBuild, mosc *mcfgv1.MachineOSConfig) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventBuildStarted,
+		fmt.Sprintf("Started build for pool %q with config %q",
+			mosc.Spec.MachineConfigPool.Name, mosb.Spec.MachineConfig.Name))
+}
+
+// RecordBuildPreparing records when a build is in the preparing phase
+func (r *OCLEventRecorder) RecordBuildPreparing(mosb *mcfgv1.MachineOSBuild, message string) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventBuildPreparing,
+		fmt.Sprintf("Preparing build: %s", message))
+}
+
+// RecordBuildBuilding records when a build transitions to building state
+func (r *OCLEventRecorder) RecordBuildBuilding(mosb *mcfgv1.MachineOSBuild) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventBuildBuilding,
+		"Build is now in progress")
+}
+
+// RecordBuildCompleted records when a build completes successfully
+func (r *OCLEventRecorder) RecordBuildCompleted(mosb *mcfgv1.MachineOSBuild, imagePullspec string) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventBuildCompleted,
+		fmt.Sprintf("Build completed successfully, image: %s", imagePullspec))
+}
+
+// RecordBuildFailed records when a build fails
+func (r *OCLEventRecorder) RecordBuildFailed(mosb *mcfgv1.MachineOSBuild) {
+	r.recorder.Event(mosb, corev1.EventTypeWarning, EventBuildFailed,
+		fmt.Sprintf("Build failed; see MachineOSBuild %q status conditions for details", mosb.Name))
+}
+
+// RecordBuildInterrupted records when a build is interrupted
+func (r *OCLEventRecorder) RecordBuildInterrupted(mosb *mcfgv1.MachineOSBuild, reason string) {
+	r.recorder.Event(mosb, corev1.EventTypeWarning, EventBuildInterrupted,
+		fmt.Sprintf("Build interrupted: %s", reason))
+}
+
+// RecordBuildDeleted records when a build is deleted
+func (r *OCLEventRecorder) RecordBuildDeleted(mosb *mcfgv1.MachineOSBuild, reason string) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventBuildDeleted,
+		fmt.Sprintf("Build deleted: %s", reason))
+}
+
+// Job event recording
+
+// RecordJobCreated records when a build job is created
+func (r *OCLEventRecorder) RecordJobCreated(mosb *mcfgv1.MachineOSBuild, job *batchv1.Job) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventJobCreated,
+		fmt.Sprintf("Created build job: %s", job.Name))
+}
+
+// RecordJobStarted records when a build job starts
+func (r *OCLEventRecorder) RecordJobStarted(mosb *mcfgv1.MachineOSBuild, job *batchv1.Job) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventJobStarted,
+		fmt.Sprintf("Build job started: %s", job.Name))
+}
+
+// RecordJobCompleted records when a build job completes
+func (r *OCLEventRecorder) RecordJobCompleted(mosb *mcfgv1.MachineOSBuild, job *batchv1.Job) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventJobCompleted,
+		fmt.Sprintf("Build job completed: %s", job.Name))
+}
+
+// RecordJobFailed records when a build job fails
+func (r *OCLEventRecorder) RecordJobFailed(mosb *mcfgv1.MachineOSBuild, job *batchv1.Job) {
+	r.recorder.Event(mosb, corev1.EventTypeWarning, EventJobFailed,
+		fmt.Sprintf("Build job %q failed; see MachineOSBuild %q status conditions for details", job.Name, mosb.Name))
+}
+
+// RecordJobDeleted records when a build job is deleted
+func (r *OCLEventRecorder) RecordJobDeleted(mosb *mcfgv1.MachineOSBuild, jobName string) {
+	r.recorder.Event(mosb, corev1.EventTypeNormal, EventJobDeleted,
+		fmt.Sprintf("Build job deleted: %s", jobName))
+}
+
+// Config event recording
+
+// RecordConfigReconciled records when a MachineOSConfig spec change is detected and acted on.
+func (r *OCLEventRecorder) RecordConfigReconciled(mosc *mcfgv1.MachineOSConfig) {
+	r.recorder.Event(mosc, corev1.EventTypeNormal, EventConfigReconciled,
+		"MachineOSConfig spec change detected and reconciled: new build created or reused")
+}
+
+// RecordConfigReconcileFailed records when a MachineOSConfig spec change could not be reconciled.
+func (r *OCLEventRecorder) RecordConfigReconcileFailed(mosc *mcfgv1.MachineOSConfig, err error) {
+	r.recorder.Event(mosc, corev1.EventTypeWarning, EventConfigReconcileFailed,
+		fmt.Sprintf("Failed to reconcile MachineOSConfig spec change: %v", err))
+}
+
+// RecordRebuildRequested records when a rebuild is requested
+func (r *OCLEventRecorder) RecordRebuildRequested(mosc *mcfgv1.MachineOSConfig, reason string) {
+	r.recorder.Event(mosc, corev1.EventTypeNormal, EventRebuildRequested,
+		fmt.Sprintf("Rebuild requested: %s", reason))
+}
+
+// RecordConfigDeleted records when a MachineOSConfig is deleted
+func (r *OCLEventRecorder) RecordConfigDeleted(mosc *mcfgv1.MachineOSConfig) {
+	r.recorder.Event(mosc, corev1.EventTypeNormal, EventConfigDeleted,
+		fmt.Sprintf("MachineOSConfig %q deleted, removing associated builds", mosc.Name))
+}
+
+// Degradation event recording
+
+// RecordBuildDegraded records when a build enters degraded state
+func (r *OCLEventRecorder) RecordBuildDegraded(mosc *mcfgv1.MachineOSConfig) {
+	r.recorder.Event(mosc, corev1.EventTypeWarning, EventBuildDegraded,
+		fmt.Sprintf("Build for pool %q degraded; see MachineOSBuild status conditions for details", mosc.Spec.MachineConfigPool.Name))
+}
+
+// RecordBuildRecovered records when a build recovers from degraded state
+func (r *OCLEventRecorder) RecordBuildRecovered(mosc *mcfgv1.MachineOSConfig) {
+	r.recorder.Event(mosc, corev1.EventTypeNormal, EventBuildRecovered,
+		fmt.Sprintf("Build for pool %q recovered from degraded state", mosc.Spec.MachineConfigPool.Name))
+}
+
+// MachineConfigPool events
+
+// RecordPoolConfigChanged records when a pool's config changes
+func (r *OCLEventRecorder) RecordPoolConfigChanged(mcp *mcfgv1.MachineConfigPool, oldConfig, newConfig string) {
+	r.recorder.Event(mcp, corev1.EventTypeNormal, EventPoolConfigChanged,
+		fmt.Sprintf("Rendered config changed from %s to %s", oldConfig, newConfig))
+}

--- a/pkg/controller/build/ocl_events_test.go
+++ b/pkg/controller/build/ocl_events_test.go
@@ -1,0 +1,235 @@
+package build
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func newTestOCLRecorder(bufSize int) (*OCLEventRecorder, *record.FakeRecorder) {
+	fake := record.NewFakeRecorder(bufSize)
+	return NewOCLEventRecorder(fake), fake
+}
+
+func assertEvent(t *testing.T, events chan string, wantType, wantReason string) {
+	t.Helper()
+	select {
+	case event := <-events:
+		if !strings.HasPrefix(event, wantType+" ") {
+			t.Errorf("expected event type %q, got: %s", wantType, event)
+		}
+		if !strings.Contains(event, wantReason) {
+			t.Errorf("expected event reason %q, got: %s", wantReason, event)
+		}
+	default:
+		t.Errorf("expected event %q %q but none was recorded", wantType, wantReason)
+	}
+}
+
+func assertNoEvent(t *testing.T, events chan string) {
+	t.Helper()
+	select {
+	case event := <-events:
+		t.Errorf("expected no event but got: %s", event)
+	default:
+	}
+}
+
+func testMOSB(name string) *mcfgv1.MachineOSBuild {
+	return &mcfgv1.MachineOSBuild{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: mcfgv1.MachineOSBuildSpec{
+			MachineConfig: mcfgv1.MachineConfigReference{Name: "rendered-worker-abc"},
+		},
+	}
+}
+
+func testMOSC(name, pool string) *mcfgv1.MachineOSConfig {
+	return &mcfgv1.MachineOSConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: mcfgv1.MachineOSConfigSpec{
+			MachineConfigPool: mcfgv1.MachineConfigPoolReference{Name: pool},
+		},
+	}
+}
+
+func testMCP(name string) *mcfgv1.MachineConfigPool {
+	return &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func testJob(name string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func TestBuildLifecycleEvents(t *testing.T) {
+	t.Parallel()
+
+	mosb := testMOSB("test-build")
+	mosc := testMOSC("test-config", "worker")
+
+	tests := []struct {
+		name       string
+		record     func(*OCLEventRecorder)
+		wantType   string
+		wantReason string
+	}{
+		{"BuildStarted", func(r *OCLEventRecorder) { r.RecordBuildStarted(mosb, mosc) }, "Normal", EventBuildStarted},
+		{"BuildPreparing", func(r *OCLEventRecorder) { r.RecordBuildPreparing(mosb, "creating job") }, "Normal", EventBuildPreparing},
+		{"BuildBuilding", func(r *OCLEventRecorder) { r.RecordBuildBuilding(mosb) }, "Normal", EventBuildBuilding},
+		{"BuildCompleted", func(r *OCLEventRecorder) { r.RecordBuildCompleted(mosb, "quay.io/test@sha256:abc") }, "Normal", EventBuildCompleted},
+		{"BuildFailed", func(r *OCLEventRecorder) { r.RecordBuildFailed(mosb) }, "Warning", EventBuildFailed},
+		{"BuildInterrupted", func(r *OCLEventRecorder) { r.RecordBuildInterrupted(mosb, "job deleted") }, "Warning", EventBuildInterrupted},
+		{"BuildDeleted", func(r *OCLEventRecorder) { r.RecordBuildDeleted(mosb, "removed") }, "Normal", EventBuildDeleted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder, fake := newTestOCLRecorder(1)
+			tt.record(recorder)
+			assertEvent(t, fake.Events, tt.wantType, tt.wantReason)
+			assertNoEvent(t, fake.Events)
+		})
+	}
+}
+
+func TestJobEvents(t *testing.T) {
+	t.Parallel()
+
+	mosb := testMOSB("test-build")
+	job := testJob("test-job")
+
+	tests := []struct {
+		name       string
+		record     func(*OCLEventRecorder)
+		wantType   string
+		wantReason string
+	}{
+		{"JobCreated", func(r *OCLEventRecorder) { r.RecordJobCreated(mosb, job) }, "Normal", EventJobCreated},
+		{"JobStarted", func(r *OCLEventRecorder) { r.RecordJobStarted(mosb, job) }, "Normal", EventJobStarted},
+		{"JobCompleted", func(r *OCLEventRecorder) { r.RecordJobCompleted(mosb, job) }, "Normal", EventJobCompleted},
+		{"JobFailed", func(r *OCLEventRecorder) { r.RecordJobFailed(mosb, job) }, "Warning", EventJobFailed},
+		{"JobDeleted", func(r *OCLEventRecorder) { r.RecordJobDeleted(mosb, job.Name) }, "Normal", EventJobDeleted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder, fake := newTestOCLRecorder(1)
+			tt.record(recorder)
+			assertEvent(t, fake.Events, tt.wantType, tt.wantReason)
+			assertNoEvent(t, fake.Events)
+		})
+	}
+}
+
+func TestConfigEvents(t *testing.T) {
+	t.Parallel()
+
+	mosc := testMOSC("test-config", "worker")
+
+	tests := []struct {
+		name       string
+		record     func(*OCLEventRecorder)
+		wantType   string
+		wantReason string
+	}{
+		{"ConfigReconciled", func(r *OCLEventRecorder) { r.RecordConfigReconciled(mosc) }, "Normal", EventConfigReconciled},
+		{"ConfigReconcileFailed", func(r *OCLEventRecorder) {
+			r.RecordConfigReconcileFailed(mosc, fmt.Errorf("could not create MachineOSBuild"))
+		}, "Warning", EventConfigReconcileFailed},
+		{"RebuildRequested", func(r *OCLEventRecorder) { r.RecordRebuildRequested(mosc, "annotation applied") }, "Normal", EventRebuildRequested},
+		{"ConfigDeleted", func(r *OCLEventRecorder) { r.RecordConfigDeleted(mosc) }, "Normal", EventConfigDeleted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder, fake := newTestOCLRecorder(1)
+			tt.record(recorder)
+			assertEvent(t, fake.Events, tt.wantType, tt.wantReason)
+			assertNoEvent(t, fake.Events)
+		})
+	}
+}
+
+func TestPoolEvents(t *testing.T) {
+	t.Parallel()
+
+	mcp := testMCP("worker")
+
+	tests := []struct {
+		name       string
+		record     func(*OCLEventRecorder)
+		wantType   string
+		wantReason string
+	}{
+		{"PoolConfigChanged", func(r *OCLEventRecorder) {
+			r.RecordPoolConfigChanged(mcp, "rendered-worker-old", "rendered-worker-new")
+		}, "Normal", EventPoolConfigChanged},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder, fake := newTestOCLRecorder(1)
+			tt.record(recorder)
+			assertEvent(t, fake.Events, tt.wantType, tt.wantReason)
+			assertNoEvent(t, fake.Events)
+		})
+	}
+}
+
+func TestDegradationEvents(t *testing.T) {
+	t.Parallel()
+
+	mosc := testMOSC("test-config", "worker")
+
+	tests := []struct {
+		name       string
+		record     func(*OCLEventRecorder)
+		wantType   string
+		wantReason string
+	}{
+		{"BuildDegraded", func(r *OCLEventRecorder) { r.RecordBuildDegraded(mosc) }, "Warning", EventBuildDegraded},
+		{"BuildRecovered", func(r *OCLEventRecorder) { r.RecordBuildRecovered(mosc) }, "Normal", EventBuildRecovered},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder, fake := newTestOCLRecorder(1)
+			tt.record(recorder)
+			assertEvent(t, fake.Events, tt.wantType, tt.wantReason)
+			assertNoEvent(t, fake.Events)
+		})
+	}
+}
+
+// TestBuildStartedMessageContent verifies the message includes the pool and rendered config name.
+func TestBuildStartedMessageContent(t *testing.T) {
+	t.Parallel()
+
+	mosb := testMOSB("test-build")
+	mosc := testMOSC("test-config", "worker")
+
+	recorder, fake := newTestOCLRecorder(1)
+	recorder.RecordBuildStarted(mosb, mosc)
+
+	event := <-fake.Events
+	if !strings.Contains(event, "worker") {
+		t.Errorf("expected event to contain pool name %q, got: %s", "worker", event)
+	}
+	if !strings.Contains(event, "rendered-worker-abc") {
+		t.Errorf("expected event to contain config name %q, got: %s", "rendered-worker-abc", event)
+	}
+}

--- a/pkg/controller/build/osbuildcontroller.go
+++ b/pkg/controller/build/osbuildcontroller.go
@@ -149,7 +149,7 @@ func newOSBuildController(
 		UpdateFunc: ctrl.updateMachineConfigPool,
 	})
 
-	ctrl.buildReconciler = newBuildReconciler(mcfgclient, kubeclient, imageclient, routeclient, ctrl.listers, imagepruner)
+	ctrl.buildReconciler = newBuildReconciler(mcfgclient, kubeclient, imageclient, routeclient, ctrl.listers, imagepruner, ctrl.eventRecorder)
 	ctrl.shutdownDelayHandler = newShutdownDelayHandler(ctrl.listers)
 	ctrl.shutdownChan = make(chan struct{})
 

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -26,6 +26,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
@@ -61,28 +62,30 @@ type reconciler interface {
 // is to respond to incoming events in a specific way. By doing this, the
 // reconciliation process has a clear entrypoint for each incoming event.
 type buildReconciler struct {
-	mcfgclient  mcfgclientset.Interface
-	kubeclient  clientset.Interface
-	imageclient imagev1clientset.Interface
-	routeclient routeclientset.Interface
-	imagepruner imagepruner.ImagePruner
+	mcfgclient    mcfgclientset.Interface
+	kubeclient    clientset.Interface
+	imageclient   imagev1clientset.Interface
+	routeclient   routeclientset.Interface
+	imagepruner   imagepruner.ImagePruner
+	eventRecorder *OCLEventRecorder
 	*listers
 }
 
 // Instantiates a new reconciler instance. This returns an interface to
 // disallow access to its private methods.
-func newBuildReconciler(mcfgclient mcfgclientset.Interface, kubeclient clientset.Interface, imageclient imagev1clientset.Interface, routeclient routeclientset.Interface, l *listers, imagepruner imagepruner.ImagePruner) reconciler {
-	return newBuildReconcilerAsStruct(mcfgclient, kubeclient, imageclient, routeclient, l, imagepruner)
+func newBuildReconciler(mcfgclient mcfgclientset.Interface, kubeclient clientset.Interface, imageclient imagev1clientset.Interface, routeclient routeclientset.Interface, l *listers, imagepruner imagepruner.ImagePruner, eventRecorder record.EventRecorder) reconciler {
+	return newBuildReconcilerAsStruct(mcfgclient, kubeclient, imageclient, routeclient, l, imagepruner, eventRecorder)
 }
 
-func newBuildReconcilerAsStruct(mcfgclient mcfgclientset.Interface, kubeclient clientset.Interface, imageclient imagev1clientset.Interface, routeclient routeclientset.Interface, l *listers, imagepruner imagepruner.ImagePruner) *buildReconciler {
+func newBuildReconcilerAsStruct(mcfgclient mcfgclientset.Interface, kubeclient clientset.Interface, imageclient imagev1clientset.Interface, routeclient routeclientset.Interface, l *listers, imagepruner imagepruner.ImagePruner, eventRecorder record.EventRecorder) *buildReconciler {
 	return &buildReconciler{
-		mcfgclient:  mcfgclient,
-		kubeclient:  kubeclient,
-		imageclient: imageclient,
-		routeclient: routeclient,
-		imagepruner: imagepruner,
-		listers:     l,
+		mcfgclient:    mcfgclient,
+		kubeclient:    kubeclient,
+		imageclient:   imageclient,
+		routeclient:   routeclient,
+		imagepruner:   imagepruner,
+		eventRecorder: NewOCLEventRecorder(eventRecorder),
+		listers:       l,
 	}
 }
 
@@ -119,7 +122,12 @@ func (b *buildReconciler) updateMachineOSConfig(ctx context.Context, old, cur *m
 	// Whenever the MachineOSConfig spec has changed, create a new MachineOSBuild.
 	if !equality.Semantic.DeepEqual(old.Spec, cur.Spec) {
 		klog.Infof("Detected MachineOSConfig change for %s", cur.Name)
-		return b.createNewMachineOSBuildOrReuseExisting(ctx, cur, false)
+		if err := b.createNewMachineOSBuildOrReuseExisting(ctx, cur, false); err != nil {
+			b.eventRecorder.RecordConfigReconcileFailed(cur, err)
+			return err
+		}
+		b.eventRecorder.RecordConfigReconciled(cur)
+		return nil
 	}
 
 	return b.syncMachineOSConfigs(ctx)
@@ -130,6 +138,8 @@ func (b *buildReconciler) updateMachineOSConfig(ctx context.Context, old, cur *m
 // MachineOSBuild and allowing the controller to replace it with a new one.
 func (b *buildReconciler) rebuildMachineOSConfig(ctx context.Context, mosc *mcfgv1.MachineOSConfig) error {
 	klog.Infof("MachineOSConfig %q has rebuild annotation (%q)", mosc.Name, constants.RebuildMachineOSConfigAnnotationKey)
+
+	b.eventRecorder.RecordRebuildRequested(mosc, "rebuild annotation applied")
 
 	if !hasCurrentBuildAnnotation(mosc) {
 		klog.Infof("MachineOSConfig %q does not have current build annotation (%q) set, skipping rebuild", mosc.Name, constants.CurrentMachineOSBuildAnnotationKey)
@@ -209,7 +219,7 @@ func (b *buildReconciler) deleteMachineOSConfig(ctx context.Context, mosc *mcfgv
 			return fmt.Errorf("could not delete MachineOSBuild %s for MachineOSConfig %s: %w", mosb.Name, mosc.Name, err)
 		}
 	}
-
+	b.eventRecorder.RecordConfigDeleted(mosc)
 	return nil
 }
 
@@ -218,6 +228,11 @@ func (b *buildReconciler) deleteMachineOSConfig(ctx context.Context, mosc *mcfgv
 func (b *buildReconciler) AddJob(ctx context.Context, job *batchv1.Job) error {
 	return b.timeObjectOperation(job, addingVerb, func() error {
 		klog.Infof("Adding build job %q", job.Name)
+
+		mosb, err := b.getMachineOSBuildForJob(job)
+		if err == nil && mosb != nil {
+			b.eventRecorder.RecordJobCreated(mosb, job)
+		}
 
 		if err := b.updateMachineOSBuildWithStatus(ctx, job); err != nil {
 			return fmt.Errorf("could not update job status for %q: %w", job.Name, err)
@@ -230,6 +245,22 @@ func (b *buildReconciler) AddJob(ctx context.Context, job *batchv1.Job) error {
 // Executes whenever a build Job is updated
 func (b *buildReconciler) UpdateJob(ctx context.Context, oldJob, curJob *batchv1.Job) error {
 	return b.timeObjectOperation(curJob, updatingVerb, func() error {
+		mosb, err := b.getMachineOSBuildForJob(curJob)
+		if err == nil && mosb != nil {
+			if curJob.Status.Succeeded > 0 && (oldJob.Status.Succeeded == 0) {
+				b.eventRecorder.RecordJobCompleted(mosb, curJob)
+			}
+
+			if curJob.Status.Failed > 0 && (oldJob.Status.Failed == 0) {
+				b.eventRecorder.RecordJobFailed(mosb, curJob)
+			}
+
+			if curJob.Status.Active > 0 && (oldJob.Status.Active == 0) {
+				b.eventRecorder.RecordJobStarted(mosb, curJob)
+				b.eventRecorder.RecordBuildBuilding(mosb)
+			}
+		}
+
 		return b.updateMachineOSBuildWithStatusIfNeeded(ctx, oldJob, curJob)
 	})
 }
@@ -237,10 +268,18 @@ func (b *buildReconciler) UpdateJob(ctx context.Context, oldJob, curJob *batchv1
 // Executes whenever a build Job is deleted
 func (b *buildReconciler) DeleteJob(ctx context.Context, job *batchv1.Job) error {
 	return b.timeObjectOperation(job, deletingVerb, func() error {
-		// Set the DeletionTimestamp so that we can set the build status to interrupted
-		job.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+		mosb, err := b.getMachineOSBuildForJob(job)
+		if err == nil && mosb != nil {
+			b.eventRecorder.RecordJobDeleted(mosb, job.Name)
+			if !ctrlcommon.NewMachineOSBuildState(mosb).IsBuildSuccess() {
+				b.eventRecorder.RecordBuildInterrupted(mosb, "build job was deleted")
+			}
+		}
 
-		err := b.updateMachineOSBuildWithStatus(ctx, job)
+		jobCopy := job.DeepCopy()
+		jobCopy.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		err = b.updateMachineOSBuildWithStatus(ctx, jobCopy)
 		if err != nil {
 			return err
 		}
@@ -296,7 +335,14 @@ func (b *buildReconciler) updateMachineOSBuild(ctx context.Context, old, current
 		}
 
 		// Always update ImageBuildDegraded condition based on current active build status
-		return b.updateImageBuildDegradedCondition(ctx, mcp, mosc)
+		if err := b.updateImageBuildDegradedCondition(ctx, mcp, mosc); err != nil {
+			return err
+		}
+
+		b.eventRecorder.RecordBuildFailed(current)
+		b.eventRecorder.RecordBuildDegraded(mosc)
+
+		return nil
 	}
 
 	// If the build was successful, clean up the build objects and propagate the
@@ -305,9 +351,21 @@ func (b *buildReconciler) updateMachineOSBuild(ctx context.Context, old, current
 	if !oldState.IsBuildSuccess() && curState.IsBuildSuccess() {
 		klog.Infof("MachineOSBuild %s succeeded, cleaning up all ephemeral objects used for the build", current.Name)
 
+		b.eventRecorder.RecordBuildCompleted(current, string(current.Status.DigestedImagePushSpec))
+
 		mcp, err := b.machineConfigPoolLister.Get(mosc.Spec.MachineConfigPool.Name)
 		if err != nil {
 			return fmt.Errorf("could not get MachineConfigPool from MachineOSConfig %q: %w", mosc.Name, err)
+		}
+
+		// Use a live Get to check the actual degraded state — the lister may already
+		// reflect the cleared condition from initializeBuildDegradedCondition running
+		// when the new build started, causing a false negative.
+		liveMCP, err := b.mcfgclient.MachineconfigurationV1().MachineConfigPools().Get(ctx, mcp.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Warningf("Could not live-fetch MachineConfigPool %s to check recovery state: %v", mcp.Name, err)
+		} else if apihelpers.IsMachineConfigPoolConditionTrue(liveMCP.Status.Conditions, mcfgv1.MachineConfigPoolImageBuildDegraded) {
+			b.eventRecorder.RecordBuildRecovered(mosc)
 		}
 
 		// Update BuildDegraded condition based on current active build status
@@ -430,6 +488,7 @@ func (b *buildReconciler) UpdateMachineConfigPool(ctx context.Context, oldMCP, c
 func (b *buildReconciler) updateMachineConfigPool(ctx context.Context, oldMCP, curMCP *mcfgv1.MachineConfigPool) error {
 	if oldMCP.Spec.Configuration.Name != curMCP.Spec.Configuration.Name {
 		klog.Infof("Rendered config for pool %s changed from %s to %s", curMCP.Name, oldMCP.Spec.Configuration.Name, curMCP.Spec.Configuration.Name)
+		b.eventRecorder.RecordPoolConfigChanged(curMCP, oldMCP.Spec.Configuration.Name, curMCP.Spec.Configuration.Name)
 		if err := b.reconcilePoolChange(ctx, curMCP); err != nil {
 			return fmt.Errorf("could not create or reuse existing MachineOSBuild for MachineConfigPool %q change: %w", curMCP.Name, err)
 		}
@@ -454,6 +513,9 @@ func (b *buildReconciler) startBuild(ctx context.Context, mosb *mcfgv1.MachineOS
 	if err := b.deleteOtherBuildsForMachineOSConfig(ctx, mosb, mosc); err != nil {
 		return fmt.Errorf("could not delete other non-terminal MachineOSBuilds for MachineOSConfig %s: %w", mosc.Name, err)
 	}
+
+	b.eventRecorder.RecordBuildStarted(mosb, mosc)
+	b.eventRecorder.RecordBuildPreparing(mosb, fmt.Sprintf("creating build job for pool %q", mosc.Spec.MachineConfigPool.Name))
 
 	// Next, create our new MachineOSBuild.
 	if err := imagebuilder.NewJobImageBuilder(b.kubeclient, b.mcfgclient, mosb, mosc).Start(ctx); err != nil {
@@ -488,6 +550,16 @@ func (b *buildReconciler) getMachineOSConfigForUpdate(mosc *mcfgv1.MachineOSConf
 	}
 
 	return out.DeepCopy(), nil
+}
+
+// Retrieves the MachineOSBuild associated with a Job based on labels
+func (b *buildReconciler) getMachineOSBuildForJob(job *batchv1.Job) (*mcfgv1.MachineOSBuild, error) {
+	if !metav1.HasLabel(job.ObjectMeta, constants.MachineOSBuildNameLabelKey) {
+		return nil, fmt.Errorf("job %q does not have MachineOSBuild label", job.Name)
+	}
+
+	mosbName := job.Labels[constants.MachineOSBuildNameLabelKey]
+	return b.machineOSBuildLister.Get(mosbName)
 }
 
 // Retrieves a deep-copy of the MachineOSBuild from the lister so that the cache is not mutated during the update.
@@ -922,11 +994,13 @@ func (b *buildReconciler) deleteMachineOSBuild(ctx context.Context, mosb *mcfgv1
 	err = b.mcfgclient.MachineconfigurationV1().MachineOSBuilds().Delete(ctx, mosb.Name, metav1.DeleteOptions{})
 	if err == nil {
 		klog.Infof("Deleted MachineOSBuild %s for MachineOSConfig %s", mosb.Name, moscName)
+		b.eventRecorder.RecordBuildDeleted(mosb, "build resources removed")
 		return nil
 	}
 
 	if k8serrors.IsNotFound(err) {
 		klog.Infof("MachineOSBuild %s was not found for MachineOSConfig %s", mosb.Name, moscName)
+		b.eventRecorder.RecordBuildDeleted(mosb, "build resources removed")
 		return nil
 	}
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a new OCLEventRecorder wrapper (ocl_events.go) that fire Kubernetes Event object at each OCL build lifecycle transitions
- Wired recorder into buildReconciler so event attach directly to the relevant resources (MachineOSBuild, MachineOSConfig, or MachineConfigPool), giving a readable timeline by using the oc describe command
- Used EventTypeWarning for failures and degradation transition and EventTypeNormal for everything else

**- How to verify it**
Run the  command below for the unit test 
```
go test ./pkg/controller/build/
```
or 
* Trigger a build by creating or updating a `MachineOSConfig`, then get the build name with `oc get machineosbuild -n openshift-machine-config-operator`
* Run `oc describe machineosbuild <name> -n openshift-machine-config-operator` and scroll to the `Events:` section at the bottom
* You should see a timeline of `Normal`/`Warning` events like `BuildStarted`, `BuildBuilding`, `BuildCompleted` (or `BuildFailed`/`BuildDegraded` on failure) with timestamps and messages


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add Kubernetes event recording for OCL build lifecycle transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes event recording for build, job, machine OS config (reconcile/rebuild/delete), degradation/recovery, and machine pool config changes.
  * Build reconciliation now emits detailed lifecycle events (started/preparing/building/completed/failed/interrupted/deleted), including “build degraded” and “build recovered”, plus “pool config changed” when rendered config changes.
* **Bug Fixes**
  * Improved event accuracy by deriving job/build events from the referenced build state, including correct “job started/completed/failed” and “build interrupted” when the build reference is missing.
  * Ensures “build deleted” is emitted when deletions succeed or when the build was already absent.
* **Tests**
  * Added unit tests covering event types/reasons and key message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->