### PR TITLE
OCPBUGS-92062: reduce memory usage in MCC and MCD

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -186,14 +186,15 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		go pinnedImageSet.Run(ctx, 2)
 
 		// Start the shared factory informers that you need to use in your controller
-		ctrlctx.InformerFactory.Start(ctx.Done())
-		ctrlctx.KubeInformerFactory.Start(ctx.Done())
-		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctx.Done())
-		ctrlctx.OperatorInformerFactory.Start(ctx.Done())
-		ctrlctx.ConfigInformerFactory.Start(ctx.Done())
-		ctrlctx.KubeNamespacedInformerFactory.Start(ctx.Done())
-		ctrlctx.KubeMAOSharedInformer.Start(ctx.Done())
-		ctrlctx.OCLInformerFactory.Start(ctx.Done())
+		ctrlctx.InformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.KubeMAOSharedInformer.Start(ctrlctx.Stop)
+		ctrlctx.OCLInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.MCOPodInformerFactory.Start(ctrlctx.Stop)
 
 		close(ctrlctx.InformersStarted)
 
@@ -357,7 +358,7 @@ func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *image
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctx.KubeInformerFactory.Core().V1().Nodes(),
-			ctx.KubeInformerFactory.Core().V1().Pods(),
+			ctx.MCOPodInformerFactory.Core().V1().Pods(),
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSConfigs(),
 			ctx.OCLInformerFactory.Machineconfiguration().V1().MachineOSBuilds(),
 			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -236,12 +236,15 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	)
 	go pinnedImageSetManager.Run(2, stopCh)
 
+	var mcnScopedInformerStartFunc func(<-chan struct{})
 	if ctrlctx.FeatureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
+		mcnScopedInformer, startFunc := ctrlcommon.NewScopedMachineConfigNodeInformerFromClientBuilder(cb, startOpts.nodeName)
+		mcnScopedInformerStartFunc = startFunc
 		internalReleaseImageManager := internalreleaseimage.New(
 			startOpts.nodeName,
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie(componentName),
 			ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
-			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
+			mcnScopedInformer,
 		)
 		go internalReleaseImageManager.Run(1, stopCh)
 	}
@@ -251,6 +254,9 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	ctrlctx.InformerFactory.Start(stopCh)
 	ctrlctx.OperatorInformerFactory.Start(stopCh)
 	nodeScopedInformerStartFunc(ctrlctx.Stop)
+	if mcnScopedInformerStartFunc != nil {
+		mcnScopedInformerStartFunc(ctrlctx.Stop)
+	}
 	close(ctrlctx.InformersStarted)
 
 	if err := dn.Run(stopCh, exitCh, errCh); err != nil {

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -8,7 +8,9 @@ import (
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	imageinformers "github.com/openshift/client-go/image/informers/externalversions"
 	machineinformersv1beta1 "github.com/openshift/client-go/machine/informers/externalversions"
+	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	mcfginformers "github.com/openshift/client-go/machineconfiguration/informers/externalversions"
+	mcfginformersv1 "github.com/openshift/client-go/machineconfiguration/informers/externalversions/machineconfiguration/v1"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	routeinformers "github.com/openshift/client-go/route/informers/externalversions"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
@@ -208,4 +210,26 @@ func NewScopedNodeInformer(kubeclient kubernetes.Interface, nodeName string) (co
 // instantiated NodeInformer and a start function.
 func NewScopedNodeInformerFromClientBuilder(cb *clients.Builder, nodeName string) (corev1informers.NodeInformer, func(<-chan struct{})) {
 	return NewScopedNodeInformer(cb.KubeClientOrDie("node-scoped-informer"), nodeName)
+}
+
+// Creates a scoped MachineConfigNode informer that only watches the MCN for
+// a single node. Since the daemon only needs its own node's MCN, this avoids
+// caching all MachineConfigNodes cluster-wide. Uses a metadata.name field
+// selector to scope the list/watch to the given node name. Returns the
+// instantiated MachineConfigNodeInformer and a start function.
+func NewScopedMachineConfigNodeInformer(client mcfgclientset.Interface, nodeName string) (mcfginformersv1.MachineConfigNodeInformer, func(<-chan struct{})) {
+	sif := mcfginformers.NewSharedInformerFactoryWithOptions(
+		client,
+		resyncPeriod()(),
+		mcfginformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", nodeName).String()
+		}),
+	)
+
+	return sif.Machineconfiguration().V1().MachineConfigNodes(), sif.Start
+}
+
+// Creates a scoped MachineConfigNode informer from a clients.Builder instance.
+func NewScopedMachineConfigNodeInformerFromClientBuilder(cb *clients.Builder, nodeName string) (mcfginformersv1.MachineConfigNodeInformer, func(<-chan struct{})) {
+	return NewScopedMachineConfigNodeInformer(cb.MachineConfigClientOrDie("mcn-scoped-informer"), nodeName)
 }

--- a/pkg/controller/common/controller_context.go
+++ b/pkg/controller/common/controller_context.go
@@ -59,6 +59,10 @@ type ControllerContext struct {
 	OpenShiftConfigKubeNamespacedInformerFactory        informers.SharedInformerFactory
 	OpenShiftConfigManagedKubeNamespacedInformerFactory informers.SharedInformerFactory
 	OpenShiftKubeAPIServerKubeNamespacedInformerFactory informers.SharedInformerFactory
+	// Scoped informer factory for MCO-specific pods only (namespace + label filtered)
+	// This dramatically reduces memory by only caching machine-config-operator pods
+	// instead of all pods cluster-wide
+	MCOPodInformerFactory                               informers.SharedInformerFactory
 	APIExtInformerFactory                               apiextinformers.SharedInformerFactory
 	ConfigInformerFactory                               configinformers.SharedInformerFactory
 	OperatorInformerFactory                             operatorinformers.SharedInformerFactory
@@ -104,6 +108,17 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder) *Controll
 	)
 	// this is needed to listen for changes in MAO user data secrets to re-apply the ones we define in the MCO (since we manage them)
 	kubeMAOSharedInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod()(), informers.WithNamespace("openshift-machine-api"))
+	// Create scoped informer for MCO pods only (namespace + label filtered)
+	// This dramatically reduces memory overhead by only caching the machine-config-operator pod
+	// instead of all pods cluster-wide (potentially thousands of pods)
+	mcoPodInformer := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		resyncPeriod()(),
+		informers.WithNamespace(MCONamespace),
+		informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
+			opt.LabelSelector = labels.Set{"k8s-app": "machine-config-operator"}.String()
+		}),
+	)
 	imageSharedInformer := imageinformers.NewSharedInformerFactory(imageClient, resyncPeriod()())
 	routeSharedInformer := routeinformers.NewSharedInformerFactory(routeClient, resyncPeriod()())
 
@@ -150,6 +165,7 @@ func CreateControllerContext(ctx context.Context, cb *clients.Builder) *Controll
 		OpenShiftConfigKubeNamespacedInformerFactory:        openShiftConfigKubeNamespacedSharedInformer,
 		OpenShiftKubeAPIServerKubeNamespacedInformerFactory: openShiftKubeAPIServerKubeNamespacedSharedInformer,
 		OpenShiftConfigManagedKubeNamespacedInformerFactory: openShiftConfigManagedKubeNamespacedSharedInformer,
+		MCOPodInformerFactory:                               mcoPodInformer,
 		APIExtInformerFactory:                               apiExtSharedInformer,
 		ConfigInformerFactory:                               configSharedInformer,
 		OperatorInformerFactory:                             operatorSharedInformer,

--- a/pkg/controller/common/layered_node_state.go
+++ b/pkg/controller/common/layered_node_state.go
@@ -19,11 +19,19 @@ import (
 // status.go with this code, then repackage this so that it can be used by any
 // portion of the MCO which needs to interrogate or mutate node state.
 type LayeredNodeState struct {
-	node *corev1.Node
+	node   *corev1.Node
+	copied bool // true if we've already performed the safety DeepCopy
 }
 
-func NewLayeredNodeState(n *corev1.Node) *LayeredNodeState {
-	return &LayeredNodeState{node: n}
+// NewLayeredNodeState creates a LayeredNodeState with copy-on-write semantics.
+// The provided node may be from a lister cache; a DeepCopy is deferred until
+// the first mutation via SetDesiredStateFromPool or
+// SetDesiredStateFromMachineOSConfig. Node() returns the underlying pointer
+// for read-only access; callers must not mutate it directly.
+func NewLayeredNodeState(node *corev1.Node) *LayeredNodeState {
+	return &LayeredNodeState{
+		node: node,
+	}
 }
 
 // Checks if the node is done "working." For a node in both layered and non-layered MCPs, the
@@ -136,42 +144,42 @@ func (l *LayeredNodeState) isImageAnnotationEqualToMachineOSConfig(anno string, 
 
 // Sets the desired MachineConfig annotations from the MachineConfigPool.
 // Deletes any desired image annotations if they exist.
-//
-// Note: This will create a deep copy of the node object first to avoid
-// mutating any underlying caches.
 func (l *LayeredNodeState) SetDesiredStateFromPool(mcp *mcfgv1.MachineConfigPool) {
-	node := l.Node()
+	l.ensureSafeForMutation()
 
-	metav1.SetMetaDataAnnotation(&node.ObjectMeta, daemonconsts.DesiredMachineConfigAnnotationKey, mcp.Spec.Configuration.Name)
-	delete(node.Annotations, daemonconsts.DesiredImageAnnotationKey)
-
-	l.node = node
+	metav1.SetMetaDataAnnotation(&l.node.ObjectMeta, daemonconsts.DesiredMachineConfigAnnotationKey, mcp.Spec.Configuration.Name)
+	delete(l.node.Annotations, daemonconsts.DesiredImageAnnotationKey)
 }
 
 // Sets the desired MachineConfig & image annotations from the MachineOSBuild and
 // MachineOSConfig objects.
-//
-// Note: This will create a deep copy of the node object first to avoid
-// mutating any underlying caches.
-
 func (l *LayeredNodeState) SetDesiredStateFromMachineOSConfig(mosc *mcfgv1.MachineOSConfig, mosb *mcfgv1.MachineOSBuild) {
-	node := l.Node()
+	l.ensureSafeForMutation()
 
-	metav1.SetMetaDataAnnotation(&node.ObjectMeta, daemonconsts.DesiredMachineConfigAnnotationKey, mosb.Spec.MachineConfig.Name)
+	metav1.SetMetaDataAnnotation(&l.node.ObjectMeta, daemonconsts.DesiredMachineConfigAnnotationKey, mosb.Spec.MachineConfig.Name)
 
 	moscs := NewMachineOSConfigState(mosc)
 	if moscs.HasOSImage() {
-		metav1.SetMetaDataAnnotation(&node.ObjectMeta, daemonconsts.DesiredImageAnnotationKey, moscs.GetOSImage())
+		metav1.SetMetaDataAnnotation(&l.node.ObjectMeta, daemonconsts.DesiredImageAnnotationKey, moscs.GetOSImage())
 	} else {
-		delete(node.Annotations, daemonconsts.DesiredImageAnnotationKey)
+		delete(l.node.Annotations, daemonconsts.DesiredImageAnnotationKey)
 	}
-
-	l.node = node
 }
 
-// Returns a deep copy of the underlying node object.
+// Node returns the node object for read-only access. Callers must not mutate
+// the returned pointer directly; use SetDesiredStateFromPool or
+// SetDesiredStateFromMachineOSConfig instead.
 func (l *LayeredNodeState) Node() *corev1.Node {
-	return l.node.DeepCopy()
+	return l.node
+}
+
+// ensureSafeForMutation performs a DeepCopy on the first mutation so that
+// lister-cached nodes are never modified in place.
+func (l *LayeredNodeState) ensureSafeForMutation() {
+	if !l.copied {
+		l.node = l.node.DeepCopy()
+		l.copied = true
+	}
 }
 
 // isNodeDone returns true if the current == desired and the MCD has marked done.

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -324,8 +324,8 @@ func (ctrl *Controller) Run(ctx context.Context, workers int) {
 
 	syncers := []cache.InformerSynced{
 		ctrl.ccListerSynced, ctrl.mcListerSynced, ctrl.mcpListerSynced, ctrl.moscListerSynced,
-		ctrl.mosbListerSynced, ctrl.nodeListerSynced, ctrl.schedulerListerSynced, ctrl.mcopListerSynced,
-		ctrl.infraListerSynced,
+		ctrl.mosbListerSynced, ctrl.nodeListerSynced, ctrl.mcnListerSynced, ctrl.schedulerListerSynced,
+		ctrl.mcopListerSynced, ctrl.infraListerSynced,
 	}
 	// Only wait for the OSImageStream informer to sync if the feature is enabled
 	if ctrl.osStreamsFgEnabled {

--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -31,7 +31,7 @@ func (ctrl *Controller) syncStatusOnly(pool *mcfgv1.MachineConfigPool) error {
 
 	machineConfigStates := []*mcfgv1.MachineConfigNode{}
 	for _, node := range nodes {
-		ms, err := ctrl.client.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		ms, err := ctrl.mcnLister.Get(node.Name)
 		if err != nil {
 			klog.Errorf("Could not find our MachineConfigNode for node. %s: %v", node.Name, err)
 			continue


### PR DESCRIPTION
**- What I did**

In [OCPBUGS-92062](https://redhat.atlassian.net/browse/OCPBUGS-92062), numerous memory usage regressions were identified. The proximate cause was that numerous features were no longer kept behind a FeatureGate. However, the root cause was mostly due to widely-scoped informer configurations. To remedy this, I've done the following:

1. Tightened up the podLister for the NodeController to only look for the MCO pod. Prior to this, it was looking at all pods in all namespaces. This alone should yield a significant reduction in overall memory usage for very large clusters.
2. Added copy-on-write behavior to the LayeredNodeState objects. This will only perform a single deep-copy and only when the object is actually mutated. Otherwise, it will return the original object reference to the caller. I've also added a NewMutableLayeredNodeState() constructor which disables this behavior.
3. Removed the API server calls in NodeController for getting MachineConfigNode objects. Since these are read-only and the NodeController already has a copy of every MachineConfigNode object in memory, we should use them instead of retrieving one from the API server.
4. Although not directly related to the Machine Config Controller, I tightened up the MachineConfigNodeLister in the MCD to scope it only to the node which the MCD is running on. This will ensure that it will only have the actual MachineConfigNode for the current node.

**- How to verify it**

Verifying this outside of the test scenario described in [OCPBUGS-92062](https://redhat.atlassian.net/browse/OCPBUGS-92062) is difficult because we do not (yet) have a good way to enable pprof analysis at runtime and capture it. Therefore, verification should ensure that the objects are being updated as expected. The current E2E test suite should be able to verify this.

**- Description for the changelog**
Reduce memory usage in both the MCC and MCD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced controller startup by wiring additional machine-configuration pod informers for more consistent node/pod state tracking.
  * Added support for scoped machine-configuration node informers when the relevant feature gate is enabled, plus internal release image informer updates.
* **Bug Fixes**
  * Reduced direct API lookups during MachineConfigNode status synchronization by relying on cached data.
  * Improved machine OS/image updating condition handling, including paused-pool behavior.
  * Made node state annotation mutation safer via deferred copy-on-write, and ensured arbiter/master taints are fully cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->