### PR TITLE
fix: nmstate-configuration.sh SHA comparison missing spaces in test brackets

### DIFF
--- a/templates/common/_base/files/nmstate-configuration.yaml
+++ b/templates/common/_base/files/nmstate-configuration.yaml
@@ -29,7 +29,7 @@ contents:
     if [ -e "$src_path/applied" ]; then
       sha_applied=$(sha256sum "$src_path/applied" | awk '{print $1}')
       sha_config=$(sha256sum "$src_path/$config_file" | awk '{print $1}')
-      if ["$sha_applied"=="$sha_config"]; then
+      if [ "$sha_applied" == "$sha_config" ]; then
         echo "Configuration already applied, exiting"
         exit 0
       fi


### PR DESCRIPTION
## Summary

- Fix missing spaces in bash `[ ]` test on line 32 of `nmstate-configuration.sh`
- `if ["$sha_applied"=="$sha_config"]` is interpreted as a command name, not a comparison
- Script falls through to `del-br` + copy on every boot, causing unnecessary network disruption

## Reproducer

```bash
$ sha_applied="abc123"
$ sha_config="abc123"
$ if ["$sha_applied"=="$sha_config"]; then echo "match"; else echo "no match"; fi
bash: [abc123==abc123]: command not found
no match
```

## Impact

Without the fix, `ovs-vsctl del-br br-ex` runs on every boot even when nmstate config has not changed, causing brief network disruption. NetworkManager then rebuilds br-ex from `.nmconnection` files on disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the configuration-detection check so existing nmstate settings are now recognized properly.
  * Prevented unnecessary re-application by ensuring matching configuration hashes trigger the “already applied” path as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->