### PR TITLE
Invoke crio dedup if enabled at startup

### DIFF
--- a/templates/common/_base/files/crio-dedup-enabled.yaml
+++ b/templates/common/_base/files/crio-dedup-enabled.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/crio-dedup-enabled.env"
+contents:
+  inline: |
+    CRIO_IMAGE_DEDUP=false

--- a/templates/common/_base/files/crio-dedup.yaml
+++ b/templates/common/_base/files/crio-dedup.yaml
@@ -1,0 +1,37 @@
+mode: 0755
+path: "/usr/local/sbin/crio-dedup.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    set -e
+
+    CRIO_IMAGE_DEDUP_ENABLED=${1:-false}
+
+    # Check if dedup is enabled
+    if [ "$CRIO_IMAGE_DEDUP_ENABLED" != "true" ]; then
+        echo "CRI-O image dedup is not enabled (CRIO_IMAGE_DEDUP=${CRIO_IMAGE_DEDUP_ENABLED}), skipping"
+        exit 0
+    fi
+
+    echo "Starting CRI-O image dedup at $(date)"
+
+    # Check if crio service is already running
+    if systemctl status crio.service >/dev/null 2>&1; then
+        echo "CRI-O service is already running, skipping dedup"
+        exit 0
+    fi
+
+    # Check if crun process is running
+    if pgrep -x crun >/dev/null 2>&1; then
+        echo "crun process is already running, skipping dedup"
+        exit 0
+    fi
+
+    # Run crio dedup (best-effort - do not fail if dedup fails)
+    echo "Running /usr/bin/crio dedup"
+    if /usr/bin/crio dedup --physical-disk-usage; then
+        echo "Finished CRI-O image dedup successfully at $(date)"
+    else
+        echo "Warning: CRI-O image dedup failed at $(date), but continuing"
+    fi
+    exit 0

--- a/templates/common/_base/units/crio-dedup.service.yaml
+++ b/templates/common/_base/units/crio-dedup.service.yaml
@@ -1,0 +1,17 @@
+name: crio-dedup.service
+enabled: true
+contents: |
+  [Unit]
+  Description=CRI-O image deduplication service
+  Wants=network-online.target
+  After=network-online.target firstboot-osupdate.target
+  Before=crio.service
+
+  [Service]
+  # Need oneshot to delay crio
+  Type=oneshot
+  RemainAfterExit=yes
+  EnvironmentFile=/etc/crio-dedup-enabled.env
+  ExecStart=/bin/bash /usr/local/sbin/crio-dedup.sh ${CRIO_IMAGE_DEDUP}
+  [Install]
+  RequiredBy=crio.service

--- a/test/extended-priv/mco.go
+++ b/test/extended-priv/mco.go
@@ -370,3 +370,33 @@ func getCoreDNSWorkerPodCreationTime(oc *exutil.CLI) (string, error) {
 
 	return latestTimestamp, nil
 }
+
+var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator] MCO crio-dedup", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("mco-crio-dedup", exutil.KubeConfigPath())
+
+	g.JustBeforeEach(func() {
+		PreChecks(oc)
+	})
+
+	g.It("[OTP] verify crio-dedup is disabled by default", func() {
+		exutil.By("Get a worker node")
+		node := NewNodeList(oc.AsAdmin()).GetAllLinuxWorkerNodesOrFail()[0]
+		logger.Infof("Testing on node: %s", node.GetName())
+
+		exutil.By("Check that CRIO_IMAGE_DEDUP is set to false in /etc/crio-dedup-enabled.env")
+		envContent, err := node.DebugNodeWithChroot("cat", "/etc/crio-dedup-enabled.env")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to read /etc/crio-dedup-enabled.env")
+		o.Expect(envContent).Should(o.ContainSubstring("CRIO_IMAGE_DEDUP=false"),
+			"Expected CRIO_IMAGE_DEDUP=false in /etc/crio-dedup-enabled.env")
+		logger.Infof("OK! CRIO_IMAGE_DEDUP is set to false")
+
+		exutil.By("Check that crio-dedup.service logs show dedup is not enabled")
+		serviceLogs, err := node.DebugNodeWithChroot("journalctl", "-u", "crio-dedup.service", "--no-pager")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get crio-dedup.service logs")
+		o.Expect(serviceLogs).Should(o.ContainSubstring("CRI-O image dedup is not enabled"),
+			"Expected 'CRI-O image dedup is not enabled' message in crio-dedup.service logs")
+		logger.Infof("OK! crio-dedup.service logs confirm dedup is disabled")
+	})
+})


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Run cri-o dedup at startup if enabled

cc: @asahay19 @haircommander 

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CRI-O image deduplication support that can run during node startup.
  * Introduced an auto-enabled one-shot service that performs physical-disk deduplication when the feature is turned on, and skips cleanly otherwise.
  * Implemented a configuration toggle to control deduplication, with dedup disabled by default.
* **Tests**
  * Added an extended test suite to verify the default behavior and check service logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->