### PR TITLE
OCPBUGS-96733: Fix kdump-over-SSH failure by inverting OVS/kdump ordering

### DIFF
--- a/templates/common/_base/units/ovs-configuration.service.yaml
+++ b/templates/common/_base/units/ovs-configuration.service.yaml
@@ -2,11 +2,11 @@ name: ovs-configuration.service
 enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else}}false{{end}}
 contents: |
   [Unit]
-  # Kdump will generate it's initramfs based on the running state when kdump.service run
-  # If OVS has already run, the kdump fails to gather a working network config,
-  # which prevent network log exports, sush as SSH.
-  # See https://issues.redhat.com/browse/OCPBUGS-28239
-  After=kdump.service
+  # OVS must finish configuring NM connections before kdump generates its
+  # initramfs, otherwise dracut cannot clone a working network config for
+  # network-based dump targets (SSH, NFS).
+  # See https://issues.redhat.com/browse/OCPBUGS-96733
+  Before=kdump.service
   Description=Configures OVS with proper host networking configuration
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service

--- a/templates/common/azure/units/ovs-configuration.service.yaml
+++ b/templates/common/azure/units/ovs-configuration.service.yaml
@@ -2,11 +2,11 @@ name: ovs-configuration.service
 enabled: {{if eq .NetworkType "OVNKubernetes"}}true{{else}}false{{end}}
 contents: |
   [Unit]
-  # Kdump will generate it's initramfs based on the running state when kdump.service run
-  # If OVS has already run, the kdump fails to gather a working network config,
-  # which prevent network log exports, sush as SSH.
-  # See https://issues.redhat.com/browse/OCPBUGS-28239
-  After=kdump.service
+  # OVS must finish configuring NM connections before kdump generates its
+  # initramfs, otherwise dracut cannot clone a working network config for
+  # network-based dump targets (SSH, NFS).
+  # See https://issues.redhat.com/browse/OCPBUGS-96733
+  Before=kdump.service
   Description=Configures OVS with proper host networking configuration
   # This service is used to move a physical NIC into OVS and reconfigure OVS to use the host IP
   Requires=openvswitch.service


### PR DESCRIPTION
**- What I did**

Inverted the systemd ordering between `ovs-configuration.service` and `kdump.service` from `After=kdump.service` to `Before=kdump.service` in both `_base` and `azure` variants.

The original fix ([OCPBUGS-30239](https://issues.redhat.com/browse/OCPBUGS-30239), PR #4213) added `After=kdump.service` so kdump ran before OVS. In 4.15 and earlier, NM connection profiles were persistent in `/etc/NetworkManager/system-connections/` and survived reboots, so dracut could clone them for network-based dump targets (SSH, NFS).

In 4.16+, NM connections are ephemeral (`save no`, stored in `/run/NetworkManager/system-connections/`) and only exist after `configure-ovs.sh` runs. With the current `After=kdump.service` ordering, kdump starts first but dracut cannot find the NM connections it needs to clone:

```
dracut: Failed to clone
Failed to install the .nmconnection for enp1s0
kdump: mkdumprd: failed to make kdump initrd
```

Changing to `Before=kdump.service` ensures OVS finishes setting up NM connections before kdump's dracut tries to clone them.

This is safe because:
- `Before=` only establishes ordering — it does NOT create a dependency
- If `kdump.service` is disabled (default on OpenShift): `Before=kdump.service` is a no-op, OVS starts immediately with no waiting
- If `kdump.service` fails: OVS is unaffected (already finished), no coupling exists
- No `Requires=`, `BindsTo=`, or `PartOf=` between the two units

**- How to verify it**

Tested on OCP 4.18.30 with kdump configured for SSH export to a remote server:

| Test | ovs-configuration.service | Dracut Rebuild | Result |
|------|--------------------------|---------------|--------|
| `After=kdump.service` (current) | kdump first | Yes | PASS (connections persisted from previous boot) |
| No ordering (removed) | Parallel | Yes (forced) | PASS (but theoretical race window) |
| **`Before=kdump.service` (this fix)** | **OVS first** | **Yes (forced)** | **PASS — zero race, guaranteed sequential** |
| kdump disabled (default) | OVS only | N/A | **PASS — OVS starts immediately, no waiting** |

Boot ordering with `Before=kdump.service`:
```
09:55:40.873  ovs-configuration START
09:55:45.943  ovs-configuration END     (5s)
09:55:46.037  kdump START               (94ms after OVS finished)
09:56:25.461  kdump END                 (39s, full dracut rebuild)
```

To reproduce manually:
1. Add `crashkernel=256M` kernel arg: `rpm-ostree kargs --append='crashkernel=256M'`
2. Configure `/etc/kdump.conf` for SSH target
3. Enable kdump: `systemctl enable kdump`
4. Apply the fix by editing `/etc/systemd/system/ovs-configuration.service`: change `After=kdump.service` to `Before=kdump.service`
5. Remove cached initramfs: `rm -f /var/lib/kdump/initramfs-*.img`
6. Reboot and verify `systemctl status kdump` shows `[OK]`

**- Description for the changelog**

Fix kdump-over-SSH failure on 4.16+ by inverting OVS/kdump systemd ordering so OVS configures NM connections before kdump's dracut clones them.
