### PR TITLE
MCO-2380: MCO-2381: Expose MachineOSBuild Status Conditions on Paused MachineConfigPools and add E2E Tests for Paused Pool Builds

### DIFF
--- a/pkg/controller/node/status.go
+++ b/pkg/controller/node/status.go
@@ -280,15 +280,30 @@ func (ctrl *Controller) calculateStatus(mcns []*mcfgv1.MachineConfigNode, cconfi
 				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for a new OS image build to start (mosc: %s)", mosc.Name))
 				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
 			default:
-				// Some cases we have an old MOSB object that still exists, we still update MCP
 				mosbState := ctrlcommon.NewMachineOSBuildState(mosb)
 				switch {
-				case mosbState.IsBuilding() || mosbState.IsBuildPrepared():
+				case mosbState.IsBuildPrepared():
+					updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for OS image build to start (mosb: %s)", mosb.Name))
+					apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+				case mosbState.IsBuilding():
 					updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for OS image build to complete (mosb: %s)", mosb.Name))
 					apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+				case mosbState.IsBuildSuccess():
+					// Build succeeded: if nodes still need to apply the image, keep Updating=True.
+					// If allUpdated already cleared Updating above, leave it alone so a fully
+					// converged pool does not get stuck as Updating.
+					if !allUpdated {
+						updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for nodes to apply OS image (mosb: %s)", mosb.Name))
+						apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+					}
 				case mosbState.IsBuildFailure():
-					// Clear updating status when build fails
 					updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", fmt.Sprintf("Pool update stopped due to OS image build failure (mosb: %s)", mosb.Name))
+					apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+				case mosbState.IsBuildInterrupted():
+					updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", fmt.Sprintf("Pool update stopped due to OS image build being interrupted (mosb: %s)", mosb.Name))
+					apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+				case mosbState.IsInInitialState():
+					updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is waiting for OS image build to start (mosb: %s)", mosb.Name))
 					apihelpers.SetMachineConfigPoolCondition(&status, *updating)
 				}
 			}
@@ -296,6 +311,35 @@ func (ctrl *Controller) calculateStatus(mcns []*mcfgv1.MachineConfigNode, cconfi
 			// Pool is degraded due to non-build issues, clear updating status
 			updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", "Pool update paused due to degraded condition")
 			apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+		}
+	} else if mosc != nil && pool.Spec.Paused {
+		// Pool is paused but a background build may still be running or may have failed.
+		// Surface build state so operators can observe progress without unpausing.
+		if mosb == nil {
+			updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is paused; waiting for a new OS image build to start (mosc: %s)", mosc.Name))
+			apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+		} else {
+			mosbState := ctrlcommon.NewMachineOSBuildState(mosb)
+			switch {
+			case mosbState.IsBuildPrepared():
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is paused; OS image build has been prepared but will not rollout (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			case mosbState.IsBuilding():
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is paused; OS image build in progress (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			case mosbState.IsBuildSuccess():
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", fmt.Sprintf("Pool is paused; OS image build completed successfully (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			case mosbState.IsBuildFailure():
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", fmt.Sprintf("Pool is paused; OS image build failed (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			case mosbState.IsBuildInterrupted():
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse, "", fmt.Sprintf("Pool is paused; OS image build was interrupted (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			case mosbState.IsInInitialState():
+				updating := apihelpers.NewMachineConfigPoolCondition(mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue, "", fmt.Sprintf("Pool is paused; OS image build has been created but not yet started (mosb: %s)", mosb.Name))
+				apihelpers.SetMachineConfigPoolCondition(&status, *updating)
+			}
 		}
 	}
 

--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -308,6 +308,8 @@ func TestCalculateStatus(t *testing.T) {
 		nodes                   []*corev1.Node
 		currentConfig           string
 		paused                  bool
+		overrideMosb            bool
+		mosb                    *mcfgv1.MachineOSBuild
 		osStream                mcfgv1.OSImageStreamReference
 		needsOSImageStreamSetup bool
 		initialConditions       []mcfgv1.MachineConfigPoolCondition
@@ -479,6 +481,321 @@ func TestCalculateStatus(t *testing.T) {
 			}
 		},
 	}, {
+		name: "pool paused, mosc exists but no mosb, waiting for build to start",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          nil,
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; waiting for a new OS image build to start (mosc: mosc-1)", condupdating.Message)
+		},
+	},
+		{
+			name: "pool paused, mosc but is in initial state",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			paused:        true,
+			overrideMosb:  true,
+			mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithBuildInitialState().MachineOSBuild(),
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
+				assert.Equal(t, "Pool is paused; OS image build has been created but not yet started (mosb: mosb-1)", condupdating.Message)
+			},
+		},
+		{
+			name: "pool paused, build prepared",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			paused:        true,
+			overrideMosb:  true,
+			mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithBuildPrepared().MachineOSBuild(),
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
+				assert.Equal(t, "Pool is paused; OS image build has been prepared but will not rollout (mosb: mosb-1)", condupdating.Message)
+			},
+		}, {
+			name: "pool paused, build in progress",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			paused:        true,
+			overrideMosb:  true,
+			mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithBuildInProgress().MachineOSBuild(),
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
+				assert.Equal(t, "Pool is paused; OS image build in progress (mosb: mosb-1)", condupdating.Message)
+			},
+		}, {
+			name: "pool paused, build failed",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			paused:        true,
+			overrideMosb:  true,
+			mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithFailedBuild().MachineOSBuild(),
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
+				assert.Equal(t, "Pool is paused; OS image build failed (mosb: mosb-1)", condupdating.Message)
+			},
+		}, {
+			name: "pool paused, build interrupted",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			paused:        true,
+			overrideMosb:  true,
+			mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithInterruptedBuild().MachineOSBuild(),
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
+				assert.Equal(t, "Pool is paused; OS image build was interrupted (mosb: mosb-1)", condupdating.Message)
+			},
+		}, {
+			name: "pool paused, build succeeded",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			paused:        true,
+			overrideMosb:  true,
+			mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithSuccessfulBuild().MachineOSBuild(),
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
+			assert.Equal(t, "Pool is paused; OS image build completed successfully (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, mosc exists but no mosb, waiting for build to start",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          nil,
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for a new OS image build to start (mosc: mosc-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build prepared",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithBuildPrepared().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for OS image build to start (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build in progress",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithBuildInProgress().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for OS image build to complete (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build failed",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithFailedBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool update stopped due to OS image build failure (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build interrupted",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithInterruptedBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool update stopped due to OS image build being interrupted (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build in initial state",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithBuildInitialState().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for OS image build to start (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build succeeded, nodes still applying",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithSuccessfulBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for nodes to apply OS image (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build succeeded, all nodes updated",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithDigestedImagePushspec("registry.host.com/org/repo@sha256:12345").WithSuccessfulBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+			if condupdated == nil {
+				t.Fatal("updated condition not found")
+			}
+			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+			}
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+		},
+	}, {
 		name: "0 nodes updated, 1 node updating, 0 nodes degraded",
 		nodes: []*corev1.Node{
 			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionFalse),
@@ -536,463 +853,463 @@ func TestCalculateStatus(t *testing.T) {
 		},
 	}, {
 		name: "0 nodes updated, 1 node updating, 1 node degraded",
-		nodes: []*corev1.Node{
-			newNodeWithReadyAndDaemonState("node-0", machineConfigV0, machineConfigV1, corev1.ConditionFalse, daemonconsts.MachineConfigDaemonStateDegraded),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-		},
-		currentConfig: machineConfigV1,
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			if got, want := status.MachineCount, int32(3); got != want {
-				t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
-			}
+			nodes: []*corev1.Node{
+				newNodeWithReadyAndDaemonState("node-0", machineConfigV0, machineConfigV1, corev1.ConditionFalse, daemonconsts.MachineConfigDaemonStateDegraded),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				if got, want := status.MachineCount, int32(3); got != want {
+					t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UpdatedMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UpdatedMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.ReadyMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.ReadyMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UnavailableMachineCount, int32(1); got != want {
-				t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UnavailableMachineCount, int32(1); got != want {
+					t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.DegradedMachineCount, int32(1); got != want {
-				t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.DegradedMachineCount, int32(1); got != want {
+					t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
+				}
 
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
 
-			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
-			if condupdating == nil {
-				t.Fatal("updating condition not found")
-			}
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
 
-			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if conddegraded == nil {
-				t.Fatal("updating condition not found")
-			}
+				conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
+				if conddegraded == nil {
+					t.Fatal("updating condition not found")
+				}
 
-			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := conddegraded.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
-			}
-		},
-	}, {
-		name: "1 node updated, 1 node updating, 0 nodes degraded",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionFalse),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-		},
-		currentConfig: machineConfigV1,
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			if got, want := status.MachineCount, int32(3); got != want {
-				t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
-			}
+				if got, want := conddegraded.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+				}
+			},
+		}, {
+			name: "1 node updated, 1 node updating, 0 nodes degraded",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionFalse),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				if got, want := status.MachineCount, int32(3); got != want {
+					t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UpdatedMachineCount, int32(1); got != want {
-				t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UpdatedMachineCount, int32(1); got != want {
+					t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.ReadyMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.ReadyMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UnavailableMachineCount, int32(1); got != want {
-				t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UnavailableMachineCount, int32(1); got != want {
+					t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.DegradedMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.DegradedMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
+				}
 
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
 
-			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
-			if condupdating == nil {
-				t.Fatal("updating condition not found")
-			}
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
 
-			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if conddegraded == nil {
-				t.Fatal("degraded condition not found")
-			}
+				conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
+				if conddegraded == nil {
+					t.Fatal("degraded condition not found")
+				}
 
-			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
-			}
-		},
-	}, {
-		name: "1 node updated, 2 nodes updating, 0 nodes degraded",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
-		},
-		currentConfig: machineConfigV1,
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			if got, want := status.MachineCount, int32(3); got != want {
-				t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
-			}
+				if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+				}
+			},
+		}, {
+			name: "1 node updated, 2 nodes updating, 0 nodes degraded",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				if got, want := status.MachineCount, int32(3); got != want {
+					t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UpdatedMachineCount, int32(1); got != want {
-				t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UpdatedMachineCount, int32(1); got != want {
+					t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.ReadyMachineCount, int32(1); got != want {
-				t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.ReadyMachineCount, int32(1); got != want {
+					t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UnavailableMachineCount, int32(2); got != want {
-				t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UnavailableMachineCount, int32(2); got != want {
+					t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.DegradedMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.DegradedMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
+				}
 
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
 
-			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
-			if condupdating == nil {
-				t.Fatal("updating condition not found")
-			}
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
 
-			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if conddegraded == nil {
-				t.Fatal("degraded condition not found")
-			}
+				conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
+				if conddegraded == nil {
+					t.Fatal("degraded condition not found")
+				}
 
-			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
-			}
-		},
-	}, {
-		name: "3 nodes updated, 0 nodes updating, 0 nodes degraded",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-		},
-		currentConfig: machineConfigV1,
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			if got, want := status.MachineCount, int32(3); got != want {
-				t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
-			}
+				if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+				}
+			},
+		}, {
+			name: "3 nodes updated, 0 nodes updating, 0 nodes degraded",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV1,
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				if got, want := status.MachineCount, int32(3); got != want {
+					t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UpdatedMachineCount, int32(3); got != want {
-				t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UpdatedMachineCount, int32(3); got != want {
+					t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.ReadyMachineCount, int32(3); got != want {
-				t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.ReadyMachineCount, int32(3); got != want {
+					t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UnavailableMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UnavailableMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.DegradedMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.DegradedMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch DegradedMachineCount: got %d want: %d", got, want)
+				}
 
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
 
-			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
-			if condupdating == nil {
-				t.Fatal("updating condition not found")
-			}
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
 
-			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if conddegraded == nil {
-				t.Fatal("degraded condition not found")
-			}
+				conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
+				if conddegraded == nil {
+					t.Fatal("degraded condition not found")
+				}
 
-			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream is empty when OSImageStream CR does not exist",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-		},
-		currentConfig: machineConfigV0,
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			if got, want := status.MachineCount, int32(3); got != want {
-				t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
-			}
+				if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream is empty when OSImageStream CR does not exist",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig: machineConfigV0,
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				if got, want := status.MachineCount, int32(3); got != want {
+					t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UpdatedMachineCount, int32(3); got != want {
-				t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UpdatedMachineCount, int32(3); got != want {
+					t.Fatalf("mismatch UpdatedMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.ReadyMachineCount, int32(3); got != want {
-				t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.ReadyMachineCount, int32(3); got != want {
+					t.Fatalf("mismatch ReadyMachineCount: got %d want: %d", got, want)
+				}
 
-			if got, want := status.UnavailableMachineCount, int32(0); got != want {
-				t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
-			}
+				if got, want := status.UnavailableMachineCount, int32(0); got != want {
+					t.Fatalf("mismatch UnavailableMachineCount: got %d want: %d", got, want)
+				}
 
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
 
-			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
-			if condupdating == nil {
-				t.Fatal("updating condition not found")
-			}
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
 
-			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
+				if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
 
-			// When OSImageStream CR does not exist, status.OSImageStream should be empty
-			if got, want := status.OSImageStream.Name, ""; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - OSImageStream should be empty when CR does not exist", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream status populated when pool updated and osImageURL matches stream",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-		},
-		currentConfig:           machineConfigV0,
-		needsOSImageStreamSetup: true,
-		initialConditions: []mcfgv1.MachineConfigPoolCondition{
-			{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
-			{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
-			{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
-		},
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			// Verify pool is fully updated
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
-			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				// When OSImageStream CR does not exist, status.OSImageStream should be empty
+				if got, want := status.OSImageStream.Name, ""; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - OSImageStream should be empty when CR does not exist", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream status populated when pool updated and osImageURL matches stream",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig:           machineConfigV0,
+			needsOSImageStreamSetup: true,
+			initialConditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
+				{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
+			},
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				// Verify pool is fully updated
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
+				if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if conddegraded == nil {
-				t.Fatal("degraded condition not found")
-			}
-			if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
-			}
+				conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
+				if conddegraded == nil {
+					t.Fatal("degraded condition not found")
+				}
+				if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+				}
 
-			// OSImageStream status should be populated with the matching stream
-			if got, want := status.OSImageStream.Name, "rhel-9"; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream status empty when pool updated but osImageURL doesn't match any stream (override)",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
-		},
-		currentConfig:           machineConfigV1,
-		needsOSImageStreamSetup: true,
-		initialConditions: []mcfgv1.MachineConfigPoolCondition{
-			{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
-			{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
-			{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
-		},
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			// Verify pool is fully updated
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
-			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				// OSImageStream status should be populated with the matching stream
+				if got, want := status.OSImageStream.Name, "rhel-9"; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream status empty when pool updated but osImageURL doesn't match any stream (override)",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV1, machineConfigV1, corev1.ConditionTrue),
+			},
+			currentConfig:           machineConfigV1,
+			needsOSImageStreamSetup: true,
+			initialConditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
+				{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
+			},
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				// Verify pool is fully updated
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
+				if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			// OSImageStream status should be empty (override scenario)
-			if got, want := status.OSImageStream.Name, ""; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty for override scenario", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream status empty when pool is updating",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-		},
-		currentConfig:           machineConfigV1,
-		needsOSImageStreamSetup: true,
-		// No initialConditions - let calculateStatus set them based on node states
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			// Verify pool is updating
-			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
-			if condupdating == nil {
-				t.Fatal("updating condition not found")
-			}
-			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
-			}
+				// OSImageStream status should be empty (override scenario)
+				if got, want := status.OSImageStream.Name, ""; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty for override scenario", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream status empty when pool is updating",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV0, machineConfigV1, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig:           machineConfigV1,
+			needsOSImageStreamSetup: true,
+			// No initialConditions - let calculateStatus set them based on node states
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				// Verify pool is updating
+				condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+				if condupdating == nil {
+					t.Fatal("updating condition not found")
+				}
+				if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+				}
 
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
-			if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
+				if got, want := condupdated.Status, corev1.ConditionFalse; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			// OSImageStream status should be empty when pool is updating
-			if got, want := status.OSImageStream.Name, ""; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty when updating", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream status empty when pool is degraded",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV0, machineConfigV0, "", "", daemonconsts.MachineConfigDaemonStateDegraded, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
-		},
-		currentConfig:           machineConfigV0,
-		needsOSImageStreamSetup: true,
-		initialConditions: []mcfgv1.MachineConfigPoolCondition{
-			{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionFalse},
-			{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
-			{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionTrue},
-		},
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			// Verify pool is degraded
-			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if conddegraded == nil {
-				t.Fatal("degraded condition not found")
-			}
-			if got, want := conddegraded.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
-			}
+				// OSImageStream status should be empty when pool is updating
+				if got, want := status.OSImageStream.Name, ""; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty when updating", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream status empty when pool is degraded",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV0, machineConfigV0, "", "", daemonconsts.MachineConfigDaemonStateDegraded, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV0, machineConfigV0, corev1.ConditionTrue),
+			},
+			currentConfig:           machineConfigV0,
+			needsOSImageStreamSetup: true,
+			initialConditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionFalse},
+				{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionTrue},
+			},
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				// Verify pool is degraded
+				conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
+				if conddegraded == nil {
+					t.Fatal("degraded condition not found")
+				}
+				if got, want := conddegraded.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+				}
 
-			// OSImageStream status should be empty when pool is degraded
-			if got, want := status.OSImageStream.Name, ""; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty when degraded", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream status empty when rendered config has empty osImageURL",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", machineConfigV2, machineConfigV2, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", machineConfigV2, machineConfigV2, corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", machineConfigV2, machineConfigV2, corev1.ConditionTrue),
-		},
-		currentConfig:           machineConfigV2,
-		needsOSImageStreamSetup: true,
-		initialConditions: []mcfgv1.MachineConfigPoolCondition{
-			{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
-			{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
-			{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
-		},
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			// Verify pool is fully updated
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
-			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				// OSImageStream status should be empty when pool is degraded
+				if got, want := status.OSImageStream.Name, ""; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty when degraded", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream status empty when rendered config has empty osImageURL",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", machineConfigV2, machineConfigV2, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", machineConfigV2, machineConfigV2, corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", machineConfigV2, machineConfigV2, corev1.ConditionTrue),
+			},
+			currentConfig:           machineConfigV2,
+			needsOSImageStreamSetup: true,
+			initialConditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
+				{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
+			},
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				// Verify pool is fully updated
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
+				if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			// OSImageStream status should be empty when osImageURL is empty
-			if got, want := status.OSImageStream.Name, ""; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty when osImageURL is empty", got, want)
-			}
-		},
-	}, {
-		name: "OSImageStream status matches second stream when osImageURL matches it",
-		nodes: []*corev1.Node{
-			helpers.NewNodeWithReady("node-0", "rendered-rhel10", "rendered-rhel10", corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-1", "rendered-rhel10", "rendered-rhel10", corev1.ConditionTrue),
-			helpers.NewNodeWithReady("node-2", "rendered-rhel10", "rendered-rhel10", corev1.ConditionTrue),
-		},
-		currentConfig:           "rendered-rhel10",
-		needsOSImageStreamSetup: true,
-		initialConditions: []mcfgv1.MachineConfigPoolCondition{
-			{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
-			{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
-			{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
-		},
-		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
-			// Verify pool is fully updated
-			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
-			if condupdated == nil {
-				t.Fatal("updated condition not found")
-			}
-			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
-				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
-			}
+				// OSImageStream status should be empty when osImageURL is empty
+				if got, want := status.OSImageStream.Name, ""; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q - should be empty when osImageURL is empty", got, want)
+				}
+			},
+		}, {
+			name: "OSImageStream status matches second stream when osImageURL matches it",
+			nodes: []*corev1.Node{
+				helpers.NewNodeWithReady("node-0", "rendered-rhel10", "rendered-rhel10", corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-1", "rendered-rhel10", "rendered-rhel10", corev1.ConditionTrue),
+				helpers.NewNodeWithReady("node-2", "rendered-rhel10", "rendered-rhel10", corev1.ConditionTrue),
+			},
+			currentConfig:           "rendered-rhel10",
+			needsOSImageStreamSetup: true,
+			initialConditions: []mcfgv1.MachineConfigPoolCondition{
+				{Type: mcfgv1.MachineConfigPoolUpdated, Status: corev1.ConditionTrue},
+				{Type: mcfgv1.MachineConfigPoolUpdating, Status: corev1.ConditionFalse},
+				{Type: mcfgv1.MachineConfigPoolDegraded, Status: corev1.ConditionFalse},
+			},
+			verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+				// Verify pool is fully updated
+				condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+				if condupdated == nil {
+					t.Fatal("updated condition not found")
+				}
+				if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+					t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+				}
 
-			// OSImageStream status should match the second stream (rhel-10)
-			if got, want := status.OSImageStream.Name, "rhel-10"; got != want {
-				t.Fatalf("mismatch OSImageStream.Name: got %q want: %q", got, want)
-			}
-		},
-	}}
+				// OSImageStream status should match the second stream (rhel-10)
+				if got, want := status.OSImageStream.Name, "rhel-10"; got != want {
+					t.Fatalf("mismatch OSImageStream.Name: got %q want: %q", got, want)
+				}
+			},
+		}}
 	for idx, test := range tests {
 		idx := idx
 		test := test
@@ -1091,7 +1408,14 @@ func TestCalculateStatus(t *testing.T) {
 				c = f.newController()
 			}
 
-			status := c.calculateStatus([]*mcfgv1.MachineConfigNode{}, nil, pool, test.nodes, nil, nil)
+			var mosc *mcfgv1.MachineOSConfig
+			var mosb *mcfgv1.MachineOSBuild
+			if test.overrideMosb {
+				mosc = helpers.NewMachineOSConfigBuilder("mosc-1").WithCurrentImagePullspec("registry.host.com/org/repo@sha256:12345").MachineOSConfig()
+				mosb = test.mosb
+			}
+
+			status := c.calculateStatus([]*mcfgv1.MachineConfigNode{}, nil, pool, test.nodes, mosc, mosb)
 			test.verify(status, t)
 		})
 	}
@@ -1122,6 +1446,8 @@ func TestCalculateStatusWithImageModeReporting(t *testing.T) {
 		mcns          []*mcfgv1.MachineConfigNode
 		currentConfig string
 		paused        bool
+		overrideMosb  bool
+		mosb          *mcfgv1.MachineOSBuild
 		verify        func(mcfgv1.MachineConfigPoolStatus, *testing.T)
 	}{{
 		name: "0 nodes updated, 0 nodes updating, 0 nodes degraded",
@@ -1289,14 +1615,19 @@ func TestCalculateStatusWithImageModeReporting(t *testing.T) {
 				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
 			}
 
+			// The default MachineOSBuild created by the test driver (below) has no build
+			// conditions set, so it is in its "initial state". A paused pool with a MOSC/MOSB
+			// pair whose build is in its initial state is still considered "Updating" so
+			// operators can see that a build has been created but has not started yet.
 			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
 			if condupdating == nil {
 				t.Fatal("updating condition not found")
 			}
 
-			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
 				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
 			}
+			assert.Equal(t, "Pool is paused; OS image build has been created but not yet started (mosb: mosb-1)", condupdating.Message)
 
 			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
 			if conddegraded == nil {
@@ -1305,6 +1636,394 @@ func TestCalculateStatusWithImageModeReporting(t *testing.T) {
 
 			if got, want := conddegraded.Status, corev1.ConditionFalse; got != want {
 				t.Fatalf("mismatch conddegraded.Status: got %s want: %s", got, want)
+			}
+		},
+	}, {
+		name: "pool paused, mosc exists but no mosb, waiting for build to start",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          nil,
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; waiting for a new OS image build to start (mosc: mosc-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool paused, mosb exists but is in initial state",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithBuildInitialState().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; OS image build has been created but not yet started (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool paused, build prepared",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithBuildPrepared().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; OS image build has been prepared but will not rollout (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool paused, build in progress",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithBuildInProgress().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; OS image build in progress (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool paused, build failed",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithFailedBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; OS image build failed (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool paused, build interrupted",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithInterruptedBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; OS image build was interrupted (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool paused, build succeeded",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		paused:        true,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithSuccessfulBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is paused; OS image build completed successfully (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, mosc exists but no mosb, waiting for build to start",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          nil,
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for a new OS image build to start (mosc: mosc-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build in initial state",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithBuildInitialState().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for OS image build to start (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build prepared",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithBuildPrepared().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for OS image build to start (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build in progress",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithBuildInProgress().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for OS image build to complete (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build failed",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithFailedBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool update stopped due to OS image build failure (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build interrupted",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithInterruptedBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool update stopped due to OS image build being interrupted (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build succeeded, nodes still applying",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV0, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12346", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV0, "registry.host.com/org/repo@sha256:12345", false, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV0,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV0).WithSuccessfulBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
+			}
+			assert.Equal(t, "Pool is waiting for nodes to apply OS image (mosb: mosb-1)", condupdating.Message)
+		},
+	}, {
+		name: "pool not paused, build succeeded, all nodes updated",
+		nodes: []*corev1.Node{
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-0", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-1", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+			helpers.NewNodeWithReadyAndDaemonStateAndImageAnnos("node-2", machineConfigV1, machineConfigV1, "registry.host.com/org/repo@sha256:12345", "registry.host.com/org/repo@sha256:12345", daemonconsts.MachineConfigDaemonStateDone, corev1.ConditionTrue),
+		},
+		mcns: []*mcfgv1.MachineConfigNode{
+			helpers.NewMachineConfigNode("node-0", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-1", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
+		},
+		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithDigestedImagePushspec("registry.host.com/org/repo@sha256:12345").WithSuccessfulBuild().MachineOSBuild(),
+		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
+			condupdated := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdated)
+			if condupdated == nil {
+				t.Fatal("updated condition not found")
+			}
+			if got, want := condupdated.Status, corev1.ConditionTrue; got != want {
+				t.Fatalf("mismatch condupdated.Status: got %s want: %s", got, want)
+			}
+			condupdating := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolUpdating)
+			if condupdating == nil {
+				t.Fatal("updating condition not found")
+			}
+			if got, want := condupdating.Status, corev1.ConditionFalse; got != want {
+				t.Fatalf("mismatch condupdating.Status: got %s want: %s", got, want)
 			}
 		},
 	}, {
@@ -1381,6 +2100,8 @@ func TestCalculateStatusWithImageModeReporting(t *testing.T) {
 			helpers.NewMachineConfigNode("node-2", "worker", machineConfigV1, "registry.host.com/org/repo@sha256:12345", true, false),
 		},
 		currentConfig: machineConfigV1,
+		overrideMosb:  true,
+		mosb:          helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(machineConfigV1).WithDigestedImagePushspec("registry.host.com/org/repo@sha256:12345").WithSuccessfulBuild().MachineOSBuild(),
 		verify: func(status mcfgv1.MachineConfigPoolStatus, t *testing.T) {
 			if got, want := status.MachineCount, int32(3); got != want {
 				t.Fatalf("mismatch MachineCount: got %d want: %d", got, want)
@@ -1517,7 +2238,12 @@ func TestCalculateStatusWithImageModeReporting(t *testing.T) {
 			// For ImageModeStatusReporting tests, we need MachineOSConfig and MachineOSBuild
 			// Use the same image that we set in the MCN Status
 			mosc := helpers.NewMachineOSConfigBuilder("mosc-1").WithCurrentImagePullspec("registry.host.com/org/repo@sha256:12345").MachineOSConfig()
-			mosb := helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(test.currentConfig).MachineOSBuild()
+			var mosb *mcfgv1.MachineOSBuild
+			if test.overrideMosb {
+				mosb = test.mosb
+			} else {
+				mosb = helpers.NewMachineOSBuildBuilder("mosb-1").WithDesiredConfig(test.currentConfig).MachineOSBuild()
+			}
 
 			c := f.newController()
 			status := c.calculateStatus(test.mcns, nil, pool, test.nodes, mosc, mosb)

--- a/test/e2e-ocl-2of2/onclusterlayering_test.go
+++ b/test/e2e-ocl-2of2/onclusterlayering_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -716,6 +717,81 @@ func TestImageBuildDegradedOnFailureAndClearedOnBuildStart(t *testing.T) {
 	t.Logf("All MCP status transitions verified successfully across build failure, success, and subsequent new build")
 }
 
+// TestPausedMCPSurfacesMachineOSBuildStatus verifies that a paused MachineConfigPool
+// surfaces MachineOSBuild progress in its Updating condition and rolls out after unpause.
+func TestPausedMCPSurfacesMachineOSBuildStatus(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cs := framework.NewClientSet("")
+
+	dockerfile, err := ocltesthelper.GetCowsayDockerfileForCluster(t, cs)
+	require.NoError(t, err)
+
+	node := helpers.GetRandomNode(t, cs, "worker")
+	mosc := prepareForOnClusterLayeringTest(t, cs, onClusterLayeringTestOpts{
+		poolName:   layeredMCPName,
+		targetNode: &node,
+		customDockerfiles: map[string]string{
+			layeredMCPName: dockerfile,
+		},
+	})
+
+	setMachineConfigPoolPaused(ctx, t, cs, layeredMCPName, true)
+	t.Cleanup(func() {
+		setMachineConfigPoolPaused(ctx, t, cs, layeredMCPName, false)
+	})
+
+	createMachineOSConfig(t, cs, mosc)
+
+	// waiting/prepared are short-lived transitional messages that the node
+	// controller may skip entirely if it doesn't reconcile during that exact
+	// window (e.g. if the MOSB is already Building by the first reconcile
+	// after pause). Only "in progress" is durable for the life of the build,
+	// so that's the one condition we require here. The others are logged as
+	// a bonus signal if we happen to observe them.
+	var sawWaiting, sawPrepared, sawInProgress bool
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		mcp, err := cs.MachineconfigurationV1Interface.MachineConfigPools().Get(ctx, layeredMCPName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if !mcp.Spec.Paused {
+			return false, fmt.Errorf("expected pool %s to remain paused", layeredMCPName)
+		}
+		// Check for starting conditions
+		cond := apihelpers.GetMachineConfigPoolCondition(mcp.Status, mcfgv1.MachineConfigPoolUpdating)
+		if cond != nil && cond.Status == corev1.ConditionTrue {
+			if strings.Contains(cond.Message, "waiting for a new OS image build to start") {
+				sawWaiting = true
+				assert.Contains(t, cond.Message, mosc.Name)
+			}
+			if strings.Contains(cond.Message, "prepared but will not rollout") {
+				sawPrepared = true
+			}
+			if strings.Contains(cond.Message, "OS image build in progress") {
+				sawInProgress = true
+			}
+		}
+
+		return sawInProgress, nil
+	}))
+	t.Logf("Observed while paused: sawWaiting=%v sawPrepared=%v sawInProgress=%v", sawWaiting, sawPrepared, sawInProgress)
+	assert.True(t, sawInProgress, "MCP should surface build-in-progress while paused")
+
+	mosb := waitForBuildToStartForPoolAndConfig(t, cs, layeredMCPName, mosc.Name)
+
+	finishedBuild := waitForBuildToComplete(t, cs, mosb)
+	imagePullspec := string(finishedBuild.Status.DigestedImagePushSpec)
+
+	updatingCond := waitForMCPUpdatingCondition(ctx, t, cs, layeredMCPName, corev1.ConditionFalse, "OS image build completed successfully")
+	assert.Contains(t, updatingCond.Message, mosb.Name)
+
+	setMachineConfigPoolPaused(ctx, t, cs, layeredMCPName, false)
+
+	require.NoError(t, helpers.WaitForNodeImageChange(t, cs, node, imagePullspec))
+}
+
 // TestCurrentMachineOSBuildAnnotationHandling tests that the node controller correctly uses the
 // current-machine-os-build annotation on the MachineOSConfig to select the correct MOSB when
 // multiple MOSBs exist for the same rendered MachineConfig. This can happen during rapid updates
@@ -1321,6 +1397,45 @@ func waitForJobToReachCondition(ctx context.Context, t *testing.T, cs *framework
 
 		return condFunc(job)
 	}))
+}
+
+func setMachineConfigPoolPaused(ctx context.Context, t *testing.T, cs *framework.ClientSet, poolName string, paused bool) {
+	t.Helper()
+
+	mcp, err := cs.MachineconfigurationV1Interface.MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	mcp.Spec.Paused = paused
+	_, err = cs.MachineconfigurationV1Interface.MachineConfigPools().Update(ctx, mcp, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("MachineConfigPool %s paused=%v", poolName, paused)
+}
+
+func waitForMCPUpdatingCondition(ctx context.Context, t *testing.T, cs *framework.ClientSet, poolName string, expectedStatus corev1.ConditionStatus, messageContains string) *mcfgv1.MachineConfigPoolCondition {
+	t.Helper()
+
+	var condition *mcfgv1.MachineConfigPoolCondition
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		mcp, err := cs.MachineconfigurationV1Interface.MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if !mcp.Spec.Paused {
+			return false, fmt.Errorf("expected pool %s to remain paused", poolName)
+		}
+
+		condition = apihelpers.GetMachineConfigPoolCondition(mcp.Status, mcfgv1.MachineConfigPoolUpdating)
+		if condition == nil || condition.Status != expectedStatus {
+			return false, nil
+		}
+		if messageContains != "" && !strings.Contains(condition.Message, messageContains) {
+			return false, nil
+		}
+		return true, nil
+	}))
+
+	return condition
 }
 
 // waitForImageBuildDegradedCondition waits for the ImageBuildDegraded condition to reach the expected state

--- a/test/helpers/machineosbuildbuilder.go
+++ b/test/helpers/machineosbuildbuilder.go
@@ -98,6 +98,186 @@ func (m *MachineOSBuildBuilder) WithSuccessfulBuild() *MachineOSBuildBuilder {
 	return m
 }
 
+func (m *MachineOSBuildBuilder) WithBuildPrepared() *MachineOSBuildBuilder {
+	m.mosb.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(mcfgv1.MachineOSBuildPrepared),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Prepared",
+			Message: "Build Prepared and Pending",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuilding),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Building",
+			Message: "Image Build In Progress",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildFailed),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Failed",
+			Message: "Build Failed",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildInterrupted),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Interrupted",
+			Message: "Build Interrupted",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildSucceeded),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Ready",
+			Message: "Build Ready",
+		},
+	}
+	return m
+}
+
+func (m *MachineOSBuildBuilder) WithBuildInitialState() *MachineOSBuildBuilder {
+	m.mosb.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(mcfgv1.MachineOSBuildPrepared),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Prepared",
+			Message: "Build Prepared and Pending",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuilding),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Building",
+			Message: "Image Build In Progress",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildFailed),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Failed",
+			Message: "Build Failed",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildInterrupted),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Interrupted",
+			Message: "Build Interrupted",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildSucceeded),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Ready",
+			Message: "Build Ready",
+		},
+	}
+	return m
+}
+
+func (m *MachineOSBuildBuilder) WithBuildInProgress() *MachineOSBuildBuilder {
+	m.mosb.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(mcfgv1.MachineOSBuildPrepared),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Prepared",
+			Message: "Build Prepared and Pending",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuilding),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Building",
+			Message: "Image Build In Progress",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildFailed),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Failed",
+			Message: "Build Failed",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildInterrupted),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Interrupted",
+			Message: "Build Interrupted",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildSucceeded),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Ready",
+			Message: "Build Ready",
+		},
+	}
+	return m
+}
+
+func (m *MachineOSBuildBuilder) WithFailedBuild() *MachineOSBuildBuilder {
+	m.mosb.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(mcfgv1.MachineOSBuildPrepared),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Prepared",
+			Message: "Build Prepared and Pending",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuilding),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Building",
+			Message: "Image Build In Progress",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildFailed),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Failed",
+			Message: "Build Failed",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildInterrupted),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Interrupted",
+			Message: "Build Interrupted",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildSucceeded),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Ready",
+			Message: "Build Ready",
+		},
+	}
+	return m
+}
+
+func (m *MachineOSBuildBuilder) WithInterruptedBuild() *MachineOSBuildBuilder {
+	m.mosb.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(mcfgv1.MachineOSBuildPrepared),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Prepared",
+			Message: "Build Prepared and Pending",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuilding),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Building",
+			Message: "Image Build In Progress",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildFailed),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Failed",
+			Message: "Build Failed",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildInterrupted),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Interrupted",
+			Message: "Build Interrupted",
+		},
+		{
+			Type:    string(mcfgv1.MachineOSBuildSucceeded),
+			Status:  metav1.ConditionFalse,
+			Reason:  "Ready",
+			Message: "Build Ready",
+		},
+	}
+	return m
+}
+
 func (m *MachineOSBuildBuilder) WithAnnotations(annos map[string]string) *MachineOSBuildBuilder {
 	for k, v := range annos {
 		m.mosb.Annotations[k] = v


### PR DESCRIPTION
**- What I did**

- Updated calculateStatus in the node controller to surface MachineOSBuild lifecycle state on paused MachineConfigPools via the Updating condition (initial, prepared, in progress, success, interrupted, and failure)
- Added unit tests in status_test.go covering each paused-pool build phase and expected condition messages
- Added TestPausedMCPSurfacesMachineOSBuildStatus e2e test to verify build status visibility while paused and rollout after unpause
- Extended MachineOSBuildBuilder with WithBuildPrepared, WithBuildInProgress, and WithFailedBuild helpers for unit test fixtures
- Added e2e helpers setMachineConfigPoolPaused and waitForMCPUpdatingCondition
- Refined pool updating explicitly adding the five states specified above and adding unit tests to verify behavior

**- How to verify it**

Run the unit tests:
`go test ./pkg/controller/node/ -run TestCalculateStatusWithImageModeReporting`

or

Run the e2e test (requires a cluster with OCL enabled):
`go test -v ./test/e2e-ocl-2of2/ -run TestPausedMCPSurfacesMachineOSBuildStatus`

Manual verification on a cluster:

1. Pause a pool: oc patch mcp worker --type=merge -p '{"spec":{"paused":true}}'
2. Create or update a MachineOSConfig for that pool
3. Watch the MCP Updating condition: oc get mcp worker -o jsonpath='{.status.conditions[?(@.type=="Updating")].message}'
4. You should see messages like Pool is paused; waiting for a new OS image build to start, ...prepared but will not rollout, ...build in progress, and ...build completed successfully as the build progresses
5. Unpause the pool and confirm nodes roll out to the new image

**- Description for the changelog**
Surface MachineOSBuild status on paused MachineConfigPools and add e2e coverage

[MCO-2380](https://redhat.atlassian.net/browse/MCO-2380)
[MCO-2381](https://redhat.atlassian.net/browse/MCO-2381)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `MachineConfigPoolUpdating` reporting for paused pools, surfacing distinct `MachineOSBuild` lifecycle stages (waiting for build start, prepared, and in progress) with clearer, stage-specific messages.

* **Bug Fixes**
  * Terminal states now transition more accurately when the pool is paused, including correct failure and interruption handling with appropriate completion/failure messaging.

* **Tests**
  * Extended unit tests to cover paused-pool OS image build lifecycle states, including build interrupted.
  * Added an end-to-end test for paused-pool behavior and new test helpers to simulate `MachineOSBuild` condition states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->