### PR TITLE
OCPBUGS-98210: Use release payload image for OSImageStream rebuild detection

### DIFF
--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -27,6 +27,12 @@ const (
 	// ReleaseImageVersionAnnotationKey is used to tag the rendered machineconfigs & controller config with the release image version.
 	ReleaseImageVersionAnnotationKey = "machineconfiguration.openshift.io/release-image-version"
 
+	// ReleasePayloadImageAnnotationKey tags the OSImageStream with the release payload image
+	// (ClusterVersion.Status.Desired.Image). Unlike ReleaseImageVersionAnnotationKey (which
+	// tracks the MCO binary hash for version-skew guards), this changes on every upgrade and
+	// is used solely to decide whether the OSImageStream needs rebuilding.
+	ReleasePayloadImageAnnotationKey = "machineconfiguration.openshift.io/release-payload-image"
+
 	// OSImageURLOverriddenKey is used to tag a rendered machineconfig when OSImageURL has been overridden from default using machineconfig
 	OSImageURLOverriddenKey = "machineconfiguration.openshift.io/os-image-url-overridden"
 

--- a/pkg/operator/osimagestream_ocp.go
+++ b/pkg/operator/osimagestream_ocp.go
@@ -13,7 +13,6 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/imageutils"
 	"github.com/openshift/machine-config-operator/pkg/osimagestream"
-	"github.com/openshift/machine-config-operator/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -153,8 +152,8 @@ func (optr *Operator) buildOSImageStream(existingOSImageStream *mcfgv1.OSImageSt
 		klog.Infof("Created OSImageStream with %d available streams, default stream: %s",
 			len(osImageStream.Status.AvailableStreams), osImageStream.Status.DefaultStream)
 	} else {
-		oldVersion := existingOSImageStream.Annotations[ctrlcommon.ReleaseImageVersionAnnotationKey]
-		klog.V(4).Infof("Updating OSImageStream (previous version: %s, new version: %s)", oldVersion, version.Hash)
+		oldPayloadImage := existingOSImageStream.Annotations[ctrlcommon.ReleasePayloadImageAnnotationKey]
+		klog.V(4).Infof("Updating OSImageStream (previous release image: %s, new release image: %s)", oldPayloadImage, image)
 		// Update metadata/spec first (mainly for annotations)
 		// DeepCopy to avoid mutating the shared informer cache
 		desired := existingOSImageStream.DeepCopy()
@@ -240,8 +239,18 @@ func (optr *Operator) isOSImageStreamBuildRequired() (*mcfgv1.OSImageStream, boo
 		return nil, true, err
 	}
 
+	// Get the release payload image to check if it has changed
+	clusterVersion, err := osimagestream.GetClusterVersion(optr.clusterVersionLister)
+	if err != nil {
+		return existingOSImageStream, true, fmt.Errorf("getting cluster version for OSImageStream rebuild check: %w", err)
+	}
+	releaseImage, err := osimagestream.GetReleasePayloadImage(clusterVersion)
+	if err != nil {
+		return existingOSImageStream, true, fmt.Errorf("getting release image for OSImageStream rebuild check: %w", err)
+	}
+
 	// Check if an update is needed
-	if !osImageStreamRequiresRebuild(existingOSImageStream) {
+	if !osImageStreamRequiresRebuild(existingOSImageStream, releaseImage) {
 		klog.V(4).Info("OSImageStream is already up-to-date, skipping sync")
 		return existingOSImageStream, false, nil
 	}
@@ -304,11 +313,14 @@ func (optr *Operator) getExistingOSImageStream() (*mcfgv1.OSImageStream, error) 
 }
 
 // osImageStreamRequiresRebuild checks if the OSImageStream needs to be created or updated.
-// Returns true if osImageStream is nil, if its version annotation doesn't match the current version.
-func osImageStreamRequiresRebuild(osImageStream *mcfgv1.OSImageStream) bool {
+// Returns true if osImageStream is nil, or if its release image annotation doesn't match the
+// current release payload image. This uses the release payload image digest rather than the
+// MCO binary hash so that upgrades are detected even when the MCO image itself hasn't changed
+// (e.g., in CI upgrade jobs where only RHCOS images are rebuilt).
+func osImageStreamRequiresRebuild(osImageStream *mcfgv1.OSImageStream, releaseImage string) bool {
 	if osImageStream == nil {
 		return true
 	}
-	releaseVersion, ok := osImageStream.Annotations[ctrlcommon.ReleaseImageVersionAnnotationKey]
-	return !ok || releaseVersion != version.Hash
+	storedImage, ok := osImageStream.Annotations[ctrlcommon.ReleasePayloadImageAnnotationKey]
+	return !ok || storedImage != releaseImage
 }

--- a/pkg/osimagestream/osimagestream.go
+++ b/pkg/osimagestream/osimagestream.go
@@ -96,11 +96,11 @@ func (f *DefaultStreamSourceFactory) Create(ctx context.Context, sysCtx *types.S
 		return nil, fmt.Errorf("could not find default OSImageStream in the available streams: %w", err)
 	}
 
-	return newOSImageStream(createOptions.ExistingOSImageStream, streams, defaultStream), nil
+	return newOSImageStream(createOptions.ExistingOSImageStream, streams, defaultStream, createOptions.ReleaseImage), nil
 }
 
 // newOSImageStream assembles the OSImageStream CR from the resolved streams, default, and existing spec.
-func newOSImageStream(existing *mcfgv1.OSImageStream, streams []mcfgv1.OSImageStreamSet, defaultStream string) *mcfgv1.OSImageStream {
+func newOSImageStream(existing *mcfgv1.OSImageStream, streams []mcfgv1.OSImageStreamSet, defaultStream, releaseImage string) *mcfgv1.OSImageStream {
 	if existing != nil {
 		defaultStream = existing.Spec.DefaultStream
 	}
@@ -110,6 +110,7 @@ func newOSImageStream(existing *mcfgv1.OSImageStream, streams []mcfgv1.OSImageSt
 			Name: ctrlcommon.ClusterInstanceNameOSImageStream,
 			Annotations: map[string]string{
 				ctrlcommon.ReleaseImageVersionAnnotationKey: version.Hash,
+				ctrlcommon.ReleasePayloadImageAnnotationKey: releaseImage,
 			},
 		},
 		Spec: mcfgv1.OSImageStreamSpec{


### PR DESCRIPTION
The OSImageStream rebuild check compared the CR's annotation against version.Hash (the MCO binary's git commit hash). In CI upgrade jobs where only RHCOS/kubernetes images are rebuilt but the MCO binary is unchanged, this caused the OSImageStream to never be refreshed with the new payload's RHCOS image digests. Nodes would complete the upgrade without actually updating the OS image, leaving them on the old kubelet version.

Replace version.Hash with the release payload image digest (ClusterVersion.Status.Desired.Image) as the rebuild key. The release payload digest changes on every upgrade — including CI jobs where only a subset of payload images are rebuilt — so the OSImageStream is correctly re-inspected and updated with new RHCOS image references.

Will attach Jira once we validate this helps with https://github.com/openshift/kubernetes/pull/2653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OS image stream rebuild decisions now rely on the currently active release payload image digest, ensuring streams rebuild when the installed release changes.
  * During OS image stream creation and updates, the release payload image annotation is set/used consistently, improving alignment between the running release and stored stream metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->