### PR TITLE
[release:4.20] OCPBUGS-98096: In OCB to check when a image is removed the old build is triggered again and the MC should start updating directly and no new MOSB should be triggred

### DIFF
--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -147,7 +147,21 @@ func (j *jobImageBuilder) start(ctx context.Context) (*batchv1.Job, error) {
 	}
 
 	if k8serrors.IsAlreadyExists(err) {
-		return j.getBuildJobStrict(ctx)
+		existingJob, getErr := j.getBuildJobStrict(ctx)
+		if getErr != nil {
+			return nil, getErr
+		}
+
+		klog.Infof("Build job %q already exists for MachineOSBuild %q, reusing", existingJob.Name, mosbName)
+
+		if j.mosb != nil {
+			metav1.SetMetaDataAnnotation(&j.mosb.ObjectMeta, constants.JobUIDAnnotationKey, string(existingJob.UID))
+			if _, updateErr := j.mcfgclient.MachineconfigurationV1().MachineOSBuilds().Update(ctx, j.mosb, metav1.UpdateOptions{}); updateErr != nil && !k8serrors.IsNotFound(updateErr) {
+				return nil, fmt.Errorf("could not update MachineOSBuild %s with job UID annotation: %w", mosbName, updateErr)
+			}
+		}
+
+		return existingJob, nil
 	}
 
 	return nil, fmt.Errorf("could not create build job: %w", err)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1353,6 +1353,33 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 		return err
 	}
 
+	osImageURLs, _ := ctrlcommon.GetOSImageURLConfig(ctx, b.kubeclient)
+	targetMosb, err := buildrequest.NewMachineOSBuild(buildrequest.MachineOSBuildOpts{
+		MachineOSConfig:   mosc,
+		MachineConfigPool: mcp,
+		OSImageURLConfig:  osImageURLs,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not generate name for target MOSB: %w", err)
+	}
+
+	// No action needed if the rendered config has not changed AND the annotation
+	// imagestream tag was deleted, in which case we must fall through and rebuild.
+	if oldRendered == newRendered && firstOptIn == targetMosb.Name {
+		existingMosb, getErr := b.machineOSBuildLister.Get(targetMosb.Name)
+		if getErr != nil || !ctrlcommon.NewMachineOSBuildState(existingMosb).IsBuildSuccess() {
+			klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
+			return nil
+		}
+		image := string(existingMosb.Spec.RenderedImagePushSpec)
+		if _, err := b.inspectImage(ctx, image, existingMosb); err == nil {
+			klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
+			return nil
+		}
+		klog.Infof("pool %q: image %q no longer exists despite unchanged config, will rebuild", mcp.Name, image)
+	}
+
 	// This is our trigger point
 	if (oldRendered != newRendered && needsImageRebuild) || firstOptIn == "" {
 		klog.Infof("pool %q: rendered config changed and requires an image rebuild. Verifying if a valid build already exists...", mcp.Name)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1347,13 +1347,16 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 	old := mcp.DeepCopy()
 	old.Spec.Configuration.Name = mcp.Status.Configuration.Name
 	firstOptIn := mosc.Annotations[constants.CurrentMachineOSBuildAnnotationKey]
-	if firstOptIn == "" {
-		return fmt.Errorf("no current build annotation on MachineOSConfig %q", mosc.Name)
-	}
 
 	needsImageRebuild, err := b.reconcileImageRebuild(old, mcp)
 	if err != nil {
 		return err
+	}
+
+	// No action needed if the rendered config has not changed and we have an annotation
+	if oldRendered == newRendered && firstOptIn != "" {
+		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
+		return nil
 	}
 
 	// This is our trigger point

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1353,24 +1353,6 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 		return err
 	}
 
-	osImageURLs, _ := ctrlcommon.GetOSImageURLConfig(ctx, b.kubeclient)
-	targetMosb, err := buildrequest.NewMachineOSBuild(buildrequest.MachineOSBuildOpts{
-		MachineOSConfig:   mosc,
-		MachineConfigPool: mcp,
-		OSImageURLConfig:  osImageURLs,
-	})
-
-	if err != nil {
-		return fmt.Errorf("could not generate name for target MOSB: %w", err)
-	}
-
-	// No action needed if the rendered config has not changed AND the annotation
-	// already points to the expected MOSB for the current MOSC spec.
-	if oldRendered == newRendered && firstOptIn == targetMosb.Name {
-		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
-		return nil
-	}
-
 	// This is our trigger point
 	if (oldRendered != newRendered && needsImageRebuild) || firstOptIn == "" {
 		klog.Infof("pool %q: rendered config changed and requires an image rebuild. Verifying if a valid build already exists...", mcp.Name)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1353,8 +1353,20 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 		return err
 	}
 
-	// No action needed if the rendered config has not changed and we have an annotation
-	if oldRendered == newRendered && firstOptIn != "" {
+	osImageURLs, _ := ctrlcommon.GetOSImageURLConfig(ctx, b.kubeclient)
+	targetMosb, err := buildrequest.NewMachineOSBuild(buildrequest.MachineOSBuildOpts{
+		MachineOSConfig:   mosc,
+		MachineConfigPool: mcp,
+		OSImageURLConfig:  osImageURLs,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not generate name for target MOSB: %w", err)
+	}
+
+	// No action needed if the rendered config has not changed AND the annotation
+	// already points to the expected MOSB for the current MOSC spec.
+	if oldRendered == newRendered && firstOptIn == targetMosb.Name {
 		klog.V(4).Infof("pool %q: Configuration unchanged (%s), no action needed", mcp.Name, oldRendered)
 		return nil
 	}
@@ -1388,8 +1400,10 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 			// 1. Applied MC triggered a MOSB build through `needsImageRebuild`, and it completed, but we are waiting for spec == status in the node update
 			// 2. Current MOSB state is successful, and a deleted MC triggered a MOSB build through `needsImageRebuild`.
 			if mosbState.IsBuildSuccess() {
-				// Next, we should check if the image associated with the MachineOSBuild still exists.
-				info, err := b.inspectImage(ctx, string(existingMosb.Status.DigestedImagePushSpec), existingMosb)
+				// Use the tag URL so that imagestream tag deletion (e.g. `oc tag -d`)
+				// is detected as image-not-found rather than hitting the still-live blob.
+				image := string(existingMosb.Spec.RenderedImagePushSpec)
+				info, err := b.inspectImage(ctx, image, existingMosb)
 				// If the image exists, reuse it.
 				if info != nil && err == nil {
 					klog.Infof("pool %q: Found successful build for target whose image exists. Reusing image.", mcp.Name)
@@ -1405,7 +1419,7 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 				// If we could not inspect the image, we might not have permissions to
 				// do so, or it could be another issue. Either way, we should return an
 				// error here.
-				return fmt.Errorf("could not inspect image %s for MachineOSBuild %s for MachineConfigPool %s: %w", string(existingMosb.Status.DigestedImagePushSpec), existingMosb.Name, mcp.Name, err)
+				return fmt.Errorf("could not inspect image %s for MachineOSBuild %s for MachineConfigPool %s: %w", image, existingMosb.Name, mcp.Name, err)
 			}
 		} else if !k8serrors.IsNotFound(err) {
 			// An actual error occurred (not just "not found"). Return the error.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Manual Backport of https://github.com/openshift/machine-config-operator/pull/6196
