### PR TITLE
OCPBUGS-63152: use IPFamilies template for wait-for-node-ip

### DIFF
--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -197,6 +197,74 @@ func TestSkipMissing(t *testing.T) {
 	}
 }
 
+func TestWaitForNodeIPScriptIPFamilies(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(templateDir, "common/_base/files/wait-for-node-ip.yaml")
+	templateData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+
+	const (
+		primaryBind = "cat /run/nodeip-configuration/primary-ip"
+		ipv4Bind    = "cat /run/nodeip-configuration/ipv4"
+		ipv6Bind    = "cat /run/nodeip-configuration/ipv6"
+	)
+
+	cases := []struct {
+		families     mcfgv1.IPFamiliesType
+		wantIPv4Bind bool
+		wantIPv6Bind bool
+	}{
+		{
+			families:     mcfgv1.IPFamiliesIPv4,
+			wantIPv4Bind: true,
+			wantIPv6Bind: false,
+		},
+		{
+			families:     mcfgv1.IPFamiliesIPv6,
+			wantIPv4Bind: false,
+			wantIPv6Bind: true,
+		},
+		{
+			families:     mcfgv1.IPFamiliesDualStack,
+			wantIPv4Bind: true,
+			wantIPv6Bind: true,
+		},
+		{
+			families:     mcfgv1.IPFamiliesDualStackIPv6Primary,
+			wantIPv4Bind: true,
+			wantIPv6Bind: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.families), func(t *testing.T) {
+			t.Parallel()
+			config := &mcfgv1.ControllerConfig{
+				Spec: mcfgv1.ControllerConfigSpec{
+					IPFamilies: tc.families,
+				},
+			}
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, path, templateData)
+			if err != nil {
+				t.Fatalf("renderTemplate: %v", err)
+			}
+			out := string(got)
+			if !strings.Contains(out, primaryBind) {
+				t.Fatalf("primary-ip bind block missing\n%s", out)
+			}
+			if strings.Contains(out, ipv4Bind) != tc.wantIPv4Bind {
+				t.Fatalf("ipv4 bind block: got %v want %v\n%s", strings.Contains(out, ipv4Bind), tc.wantIPv4Bind, out)
+			}
+			if strings.Contains(out, ipv6Bind) != tc.wantIPv6Bind {
+				t.Fatalf("ipv6 bind block: got %v want %v\n%s", strings.Contains(out, ipv6Bind), tc.wantIPv6Bind, out)
+			}
+		})
+	}
+}
+
 const templateDir = "../../../templates"
 
 var (

--- a/templates/common/_base/files/wait-for-node-ip.yaml
+++ b/templates/common/_base/files/wait-for-node-ip.yaml
@@ -36,19 +36,21 @@ contents:
     fi
     wait_for_ip_bind "${ip}"
 
-    # Do not fail below because we don't know if we run on primary-v4 or primary-v6 platform.
-    # We only want to make sure that if nodeip-configuration detected an IP address, the
-    # address is usable.
+    # Family-specific checks follow ControllerConfig IPFamilies (network.config serviceNetwork; same as kubelet --node-ip).
+    # Skip the opposite family on single-stack clusters; dual-stack runs both.
+{{- if ne .IPFamilies "IPv6" }}
     ip=$(cat /run/nodeip-configuration/ipv4 || echo "")
     if [[ "${ip}" == "" ]]; then
       echo "No ipv4 to bind was found"
     else
       wait_for_ip_bind "${ip}"
     fi
-
+{{- end }}
+{{- if ne .IPFamilies "IPv4" }}
     ip=$(cat /run/nodeip-configuration/ipv6 || echo "")
     if [[ "${ip}" == "" ]]; then
       echo "No ipv6 to bind was found"
     else
       wait_for_ip_bind "${ip}"
     fi
+{{- end }}

--- a/templates/common/_base/files/wait-for-node-ip.yaml
+++ b/templates/common/_base/files/wait-for-node-ip.yaml
@@ -42,6 +42,7 @@ contents:
     ip=$(cat /run/nodeip-configuration/ipv4 || echo "")
     if [[ "${ip}" == "" ]]; then
       echo "No ipv4 to bind was found"
+      exit 1
     else
       wait_for_ip_bind "${ip}"
     fi
@@ -50,6 +51,7 @@ contents:
     ip=$(cat /run/nodeip-configuration/ipv6 || echo "")
     if [[ "${ip}" == "" ]]; then
       echo "No ipv6 to bind was found"
+      exit 1
     else
       wait_for_ip_bind "${ip}"
     fi


### PR DESCRIPTION
See if we can use the kubelet dualstack node-ip templating info to help with wait-for-node-ip.sh.

If kubelet is not trying to bind to an IPv6 address, then we don't need to wait for the IPv6 address?

Cursor AI assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node IP binding checks now respect the configured IP family.
  * Single-stack environments validate only the applicable IPv4 or IPv6 address.
  * Dual-stack environments continue to validate both address families.
  * Missing required addresses now cause validation to fail.
  * Existing primary IP binding behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->