### PR TITLE
OCPBUGS-98316: Fix SHA idempotency test in nmstate-configuration.sh

### DIFF
--- a/templates/common/_base/files/nmstate-configuration.yaml
+++ b/templates/common/_base/files/nmstate-configuration.yaml
@@ -29,7 +29,7 @@ contents:
     if [ -e "$src_path/applied" ]; then
       sha_applied=$(sha256sum "$src_path/applied" | awk '{print $1}')
       sha_config=$(sha256sum "$src_path/$config_file" | awk '{print $1}')
-      if ["$sha_applied"=="$sha_config"]; then
+      if [[ "$sha_applied" == "$sha_config" ]]; then
         echo "Configuration already applied, exiting"
         exit 0
       fi


### PR DESCRIPTION
The applied-vs-config comparison used invalid [ test syntax without spaces, so bash never took the early-exit path and re-ran OVS cleanup on every service start.


Assisted-by: Cursor

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of whether a network configuration has already been applied.
  * Prevented incorrect comparisons that could cause configuration updates to be skipped or reapplied unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->