### PR TITLE
MCO-2416: add Polarion OCP-88940 Apply password only if changes exist

### DIFF
--- a/test/extended-priv/mco_password.go
+++ b/test/extended-priv/mco_password.go
@@ -422,6 +422,103 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		checkAuthorizedKeyInNode(mcp.GetCoreOsNodesOrFail()[0], append(initialKeys, key))
 		logger.Infof("OK!\n")
 	})
+
+	// https://issues.redhat.com/browse/OCPBUGS-83830
+	g.It("[PolarionID:88940][OTP] Apply password only if changes exist [Disruptive]", func() {
+		var (
+			mcName   = "tc-88940-core-password-hash-change"
+			silentOC = oc.AsAdmin()
+
+			password1     = exutil.GetRandomString()
+			passwordHash1 = OrFail[string](getHashPasswd(password1))
+			password2     = password1 + "-2"
+			passwordHash2 = OrFail[string](getHashPasswd(password2))
+
+			_, sshPubKey = GenerateSSHKeyPairOrFail()
+
+			passwordConfiguredMsg = "Password has been configured"
+			expectedReboot        = false
+		)
+		silentOC.NotShowInfo()
+
+		allCoreos := mcp.GetCoreOsNodesOrFail()
+		if len(allCoreos) == 0 {
+			logger.Infof("No CoreOs nodes are configured in the pool %s. We use master pool for testing", mcp.GetName())
+			mcp = mMcp
+			allCoreos = mcp.GetCoreOsNodesOrFail()
+		}
+
+		node := allCoreos[0]
+		mcc := NewController(oc.AsAdmin()).IgnoreLogsBeforeNowOrFail()
+		startTime := node.GetDateOrFail()
+		o.Expect(node.IgnoreEventsBeforeNow()).NotTo(o.HaveOccurred(),
+			"Error getting the latest event in node %s", node.GetName())
+
+		exutil.By("Apply MC with passwordHash for core user")
+		pwdUser := ign32PaswdUser{Name: user, PasswordHash: passwordHash1}
+		mc := NewMachineConfig(silentOC, mcName, mcp.GetName())
+		mc.parameters = []string{fmt.Sprintf(`PWDUSERS=[%s]`, MarshalOrFail(pwdUser))}
+		mc.skipWaitForMcp = true
+
+		defer mc.DeleteWithWait()
+		mc.create()
+		mcp.waitForComplete()
+		logger.Infof("OK!\n")
+
+		exutil.By("Check MCD logs to verify 'Password has been configured' is logged")
+		mcdLogs, err := node.GetMCDaemonLogs("")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCD logs for node %s", node.GetName())
+		initialPasswordCount := strings.Count(mcdLogs, passwordConfiguredMsg)
+		o.Expect(initialPasswordCount).To(o.BeNumerically(">", 0),
+			"Expected '%s' in MCD logs after initial password application on node %s", passwordConfiguredMsg, node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Check that drain and reboot are skipped for password-only change")
+		checkDrainAction(expectedReboot, node, mcc)
+		checkRebootAction(expectedReboot, node, startTime)
+		logger.Infof("OK!\n")
+
+		exutil.By("Update the passwordHash in MC")
+		patchErr := mc.Patch("json",
+			fmt.Sprintf(`[{ "op": "replace", "path": "/spec/config/passwd/users/0/passwordHash", "value": "%s"}]`, passwordHash2))
+		o.Expect(patchErr).NotTo(o.HaveOccurred(),
+			"Error patching mc %s to update the 'core' user password", mc.GetName())
+		mcp.waitForComplete()
+		logger.Infof("OK!\n")
+
+		exutil.By("Check MCD logs to verify 'Password has been configured' is logged again after hash change")
+		mcdLogs, err = node.GetMCDaemonLogs("")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCD logs for node %s", node.GetName())
+		updatedPasswordCount := strings.Count(mcdLogs, passwordConfiguredMsg)
+		o.Expect(updatedPasswordCount).To(o.BeNumerically(">", initialPasswordCount),
+			"Expected a new '%s' log entry after password hash change on node %s", passwordConfiguredMsg, node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Add SSH key to MC without changing the password hash")
+		pwdUserWithSSH := ign32PaswdUser{Name: user, PasswordHash: passwordHash2, SSHAuthorizedKeys: []string{strings.TrimSpace(sshPubKey)}}
+		patchErr = mc.Patch("json",
+			fmt.Sprintf(`[{ "op": "replace", "path": "/spec/config/passwd/users", "value": [%s]}]`, MarshalOrFail(pwdUserWithSSH)))
+		o.Expect(patchErr).NotTo(o.HaveOccurred(),
+			"Error patching mc %s to add SSH key", mc.GetName())
+		mcp.waitForComplete()
+		logger.Infof("OK!\n")
+
+		exutil.By("Check MCD logs to verify 'Password has been configured' is NOT logged for SSH-only change")
+		mcdLogs, err = node.GetMCDaemonLogs("")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCD logs for node %s", node.GetName())
+		finalPasswordCount := strings.Count(mcdLogs, passwordConfiguredMsg)
+		o.Expect(finalPasswordCount).To(o.Equal(updatedPasswordCount),
+			"'%s' should NOT appear in MCD logs when only SSH keys are added (no password hash change) on node %s",
+			passwordConfiguredMsg, node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Check events to make sure that drain and reboot events were not triggered")
+		nodeEvents, eErr := node.GetEvents()
+		o.Expect(eErr).ShouldNot(o.HaveOccurred(), "Error getting events for node %s", node.GetName())
+		o.Expect(nodeEvents).NotTo(HaveEventsSequence("Drain"), "Error, a Drain event was triggered but it shouldn't")
+		o.Expect(nodeEvents).NotTo(HaveEventsSequence("Reboot"), "Error, a Reboot event was triggered but it shouldn't")
+		logger.Infof("OK!\n")
+	})
 })
 
 // getPasswdValidator returns the commands that need to be executed in an interactive expect shell to validate that a user can login

--- a/test/extended-priv/mco_password.go
+++ b/test/extended-priv/mco_password.go
@@ -436,19 +436,12 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 			_, sshPubKey = GenerateSSHKeyPairOrFail()
 
-			passwordConfiguredMsg = "Password has been configured"
+			passwdConfigLogMsg = "Password has been configured"
 			expectedReboot        = false
 		)
 		silentOC.NotShowInfo()
 
-		allCoreos := mcp.GetCoreOsNodesOrFail()
-		if len(allCoreos) == 0 {
-			logger.Infof("No CoreOs nodes are configured in the pool %s. We use master pool for testing", mcp.GetName())
-			mcp = mMcp
-			allCoreos = mcp.GetCoreOsNodesOrFail()
-		}
-
-		node := allCoreos[0]
+		node := mcp.GetSortedNodesOrFail()[0]
 		mcc := NewController(oc.AsAdmin()).IgnoreLogsBeforeNowOrFail()
 		startTime := node.GetDateOrFail()
 		o.Expect(node.IgnoreEventsBeforeNow()).NotTo(o.HaveOccurred(),
@@ -468,9 +461,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		exutil.By("Check MCD logs to verify 'Password has been configured' is logged")
 		mcdLogs, err := node.GetMCDaemonLogs("")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCD logs for node %s", node.GetName())
-		initialPasswordCount := strings.Count(mcdLogs, passwordConfiguredMsg)
+		initialPasswordCount := strings.Count(mcdLogs, passwdConfigLogMsg)
 		o.Expect(initialPasswordCount).To(o.BeNumerically(">", 0),
-			"Expected '%s' in MCD logs after initial password application on node %s", passwordConfiguredMsg, node.GetName())
+			"Expected '%s' in MCD logs after initial password application on node %s", passwdConfigLogMsg, node.GetName())
 		logger.Infof("OK!\n")
 
 		exutil.By("Check that drain and reboot are skipped for password-only change")
@@ -489,9 +482,16 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		exutil.By("Check MCD logs to verify 'Password has been configured' is logged again after hash change")
 		mcdLogs, err = node.GetMCDaemonLogs("")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCD logs for node %s", node.GetName())
-		updatedPasswordCount := strings.Count(mcdLogs, passwordConfiguredMsg)
+		updatedPasswordCount := strings.Count(mcdLogs, passwdConfigLogMsg)
 		o.Expect(updatedPasswordCount).To(o.BeNumerically(">", initialPasswordCount),
-			"Expected a new '%s' log entry after password hash change on node %s", passwordConfiguredMsg, node.GetName())
+			"Expected a new '%s' log entry after password hash change on node %s", passwdConfigLogMsg, node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Get currently configured authorized keys before adding new SSH key")
+		currentMc, err := mcp.GetConfiguredMachineConfig()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the current configuration for %s pool", mcp.GetName())
+		initialKeys, err := currentMc.GetAuthorizedKeysByUserAsList("core")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the current authorizedkeys for user 'core' in %s pool", mcp.GetName())
 		logger.Infof("OK!\n")
 
 		exutil.By("Add SSH key to MC without changing the password hash")
@@ -503,13 +503,17 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		mcp.waitForComplete()
 		logger.Infof("OK!\n")
 
+		exutil.By("Verify that the SSH key was correctly applied to the node")
+		checkAuthorizedKeyInNode(node, append(initialKeys, strings.TrimSpace(sshPubKey)))
+		logger.Infof("OK!\n")
+
 		exutil.By("Check MCD logs to verify 'Password has been configured' is NOT logged for SSH-only change")
 		mcdLogs, err = node.GetMCDaemonLogs("")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting MCD logs for node %s", node.GetName())
-		finalPasswordCount := strings.Count(mcdLogs, passwordConfiguredMsg)
+		finalPasswordCount := strings.Count(mcdLogs, passwdConfigLogMsg)
 		o.Expect(finalPasswordCount).To(o.Equal(updatedPasswordCount),
 			"'%s' should NOT appear in MCD logs when only SSH keys are added (no password hash change) on node %s",
-			passwordConfiguredMsg, node.GetName())
+			passwdConfigLogMsg, node.GetName())
 		logger.Infof("OK!\n")
 
 		exutil.By("Check events to make sure that drain and reboot events were not triggered")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

  Added e2e test OCP-88940 to verify that MCD applies password usermod only when the password hash actually changes (OCPBUGS-83830).

  The test covers:
  1. Apply a MachineConfig with passwordHash for the core user → verify "Password has been configured" appears in MCD logs
  2. Update the passwordHash to a different value → verify "Password has been configured" appears again
  3. Add an SSH key without changing the password hash → verify "Password has been configured" does not appear (the key assertion for the bug fix)
  4. Verify no drain or reboot events are triggered throughout

**- How to verify it**

  make machine-config-tests-ext
  ./_output/linux/amd64/machine-config-tests-ext list | grep 88940

  Run on a cluster:
  ./_output/linux/amd64/machine-config-tests-ext run --test "PolarionID:88940"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add e2e test OCP-88940 validating MCD only runs password usermod when the hash changes, not on unrelated passwd section updates like SSH key additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that password configuration is applied only when the password hash changes.
  * Confirmed that unrelated SSH key updates do not reapply the password or trigger unnecessary drain and reboot actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->